### PR TITLE
Fix for CORE-936 - DropAllForeignKeys throws exception on PostgreSQL

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/FindForeignKeyConstraintsGeneratorPostgres.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/FindForeignKeyConstraintsGeneratorPostgres.java
@@ -30,11 +30,11 @@ public class FindForeignKeyConstraintsGeneratorPostgres extends AbstractSqlGener
          StringBuilder sb = new StringBuilder();
 
             sb.append("SELECT ");
-            sb.append("FK.TABLE_NAME as K_Table, ");
-            sb.append("CU.COLUMN_NAME as FK_Column, ");
-            sb.append("PK.TABLE_NAME as PK_Table, ");
-            sb.append("PT.COLUMN_NAME as PK_Column,");
-            sb.append("C.CONSTRAINT_NAME as Constraint_Name ");
+            sb.append("FK.TABLE_NAME as \"").append(FindForeignKeyConstraintsStatement.RESULT_COLUMN_BASE_TABLE_NAME).append("\", ");
+            sb.append("CU.COLUMN_NAME as \"").append(FindForeignKeyConstraintsStatement.RESULT_COLUMN_BASE_TABLE_COLUMN_NAME).append("\", ");
+            sb.append("PK.TABLE_NAME as \"").append(FindForeignKeyConstraintsStatement.RESULT_COLUMN_FOREIGN_TABLE_NAME).append("\", ");
+            sb.append("PT.COLUMN_NAME as \"").append(FindForeignKeyConstraintsStatement.RESULT_COLUMN_FOREIGN_COLUMN_NAME).append("\", ");
+            sb.append("C.CONSTRAINT_NAME as \"").append(FindForeignKeyConstraintsStatement.RESULT_COLUMN_CONSTRAINT_NAME).append("\" ");
             sb.append("FROM       INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS C ");
             sb.append("INNER JOIN  INFORMATION_SCHEMA.TABLE_CONSTRAINTS FK ON C.CONSTRAINT_NAME = FK.CONSTRAINT_NAME ");
             sb.append("INNER JOIN      INFORMATION_SCHEMA.TABLE_CONSTRAINTS PK ON C.UNIQUE_CONSTRAINT_NAME = PK.CONSTRAINT_NAME ");


### PR DESCRIPTION
The query in FindForeignKeyConstraintsGeneratorPostgres.java did not use the constants defined for the column names, hence the DropAllForeignKeyRequests.java code NPE'd when trying to retrieve the query results.

I modified FindForeignKeyConstraintsGeneratorPostgres.java to use the correct constants when generating the SQL query.
