### PR TITLE
Index drop in PostgreSQL 8.4

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/DropIndexGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/DropIndexGenerator.java
@@ -44,7 +44,9 @@ public class DropIndexGenerator extends AbstractSqlGenerator<DropIndexStatement>
             return new Sql[] {new UnparsedSql("DROP INDEX " + database.escapeIndexName(null, statement.getIndexName()) + " ON " + database.escapeTableName(schemaName, statement.getTableName())) };
         } else if (database instanceof MSSQLDatabase) {
             return new Sql[] {new UnparsedSql("DROP INDEX " + database.escapeTableName(schemaName, statement.getTableName()) + "." + database.escapeIndexName(null, statement.getIndexName())) };
-        }
+        } else if (database instanceof PostgresDatabase) {
+			return new Sql[]{new UnparsedSql("DROP INDEX " + schemaName + "." + statement.getIndexName())};
+		}
 
         return new Sql[] {new UnparsedSql("DROP INDEX " + database.escapeIndexName(schemaName, statement.getIndexName())) };
     }

--- a/liquibase-core/src/test/java/liquibase/sqlgenerator/core/DropIndexGeneratorTest.java
+++ b/liquibase-core/src/test/java/liquibase/sqlgenerator/core/DropIndexGeneratorTest.java
@@ -1,6 +1,20 @@
 package liquibase.sqlgenerator.core;
 
-public abstract class DropIndexGeneratorTest {
+import liquibase.database.Database;
+import liquibase.database.core.PostgresDatabase;
+import liquibase.sql.Sql;
+import liquibase.sql.UnparsedSql;
+import liquibase.sqlgenerator.SqlGenerator;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.statement.core.DropIndexStatement;
+import org.junit.Test;
+
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import static junit.framework.Assert.assertEquals;
+
+public class DropIndexGeneratorTest {
 //    @Test
 //    public void execute_defaultSchema() throws Exception {
 //        new DatabaseTestTemplate().testOnAvailableDatabases(
@@ -36,4 +50,15 @@ public abstract class DropIndexGeneratorTest {
 ////                });
 ////    }
 
+
+	@Test
+	public void shouldDropIndexInPostgreSQL() throws Exception {
+		DropIndexGenerator dropIndexGenerator = new DropIndexGenerator();
+		DropIndexStatement statement = new DropIndexStatement("indexName", "defaultSchema", "aTable", null);
+		Database database = new PostgresDatabase();
+		SortedSet<SqlGenerator> sqlGenerators = new TreeSet<SqlGenerator>();
+		SqlGeneratorChain sqlGenerationChain = new SqlGeneratorChain(sqlGenerators);
+		Sql[] sqls = dropIndexGenerator.generateSql(statement, database, sqlGenerationChain);
+		assertEquals("DROP INDEX defaultSchema.indexName", sqls[0].toSql());
+	}
 }


### PR DESCRIPTION
The default drop index in PostgreSQL 8.4 wasn't working.

It should be something like this:

DROP INDEX schema_name.index_name;

Please review it and accept our pull request.

@JoseRibeiro
@mvlbarcelos
