### PR TITLE
Fix for CORE-955

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/ModifyDataTypeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/ModifyDataTypeGenerator.java
@@ -13,17 +13,6 @@ import liquibase.sql.UnparsedSql;
 
 public class ModifyDataTypeGenerator extends AbstractSqlGenerator<ModifyDataTypeStatement> {
 
-    @Override
-    public Warnings warn(ModifyDataTypeStatement modifyDataTypeStatement, Database database, SqlGeneratorChain sqlGeneratorChain) {
-        Warnings warnings = super.warn(modifyDataTypeStatement, database, sqlGeneratorChain);
-
-        if (database instanceof MySQLDatabase && !modifyDataTypeStatement.getNewDataType().toLowerCase().contains("varchar")) {
-            warnings.addWarning("modifyDataType will lose primary key/autoincrement/not null settings for mysql.  Use <sql> and re-specify all configuration if this is the case");
-        }
-
-        return warnings;
-    }
-
     public ValidationErrors validate(ModifyDataTypeStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
         ValidationErrors validationErrors = new ValidationErrors();
         validationErrors.checkRequiredField("tableName", statement.getTableName());
@@ -56,7 +45,6 @@ public class ModifyDataTypeGenerator extends AbstractSqlGenerator<ModifyDataType
     private String getModifyString(Database database) {
         if (database instanceof SybaseASADatabase
                 || database instanceof SybaseDatabase
-                || database instanceof MySQLDatabase
                 || database instanceof OracleDatabase
                 || database instanceof MaxDBDatabase
                 || database instanceof InformixDatabase
@@ -78,7 +66,6 @@ public class ModifyDataTypeGenerator extends AbstractSqlGenerator<ModifyDataType
         } else if (database instanceof SybaseASADatabase
                 || database instanceof SybaseDatabase
                 || database instanceof MSSQLDatabase
-                || database instanceof MySQLDatabase
                 || database instanceof HsqlDatabase
                 || database instanceof H2Database
                 || database instanceof CacheDatabase

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/ModifyDataTypeGeneratorMySQL.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/ModifyDataTypeGeneratorMySQL.java
@@ -1,0 +1,84 @@
+package liquibase.sqlgenerator.core;
+
+import java.util.HashSet;
+
+import liquibase.database.Database;
+import liquibase.database.structure.Column;
+import liquibase.database.typeconversion.TypeConverterFactory;
+import liquibase.diff.DiffStatusListener;
+import liquibase.exception.DatabaseException;
+import liquibase.exception.UnexpectedLiquibaseException;
+import liquibase.snapshot.DatabaseSnapshot;
+import liquibase.snapshot.DatabaseSnapshotGenerator;
+import liquibase.snapshot.DatabaseSnapshotGeneratorFactory;
+import liquibase.sql.Sql;
+import liquibase.sql.UnparsedSql;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.statement.core.ModifyDataTypeStatement;
+
+public class ModifyDataTypeGeneratorMySQL extends ModifyDataTypeGenerator {
+
+    @Override
+    public int getPriority() {
+        return PRIORITY_DATABASE;
+    }
+
+    /**
+     * Generate MySQL-specific modify statement.
+     *
+     * @param statement Statement instance
+     * @param database Database instance
+     * @param sqlGeneratorChain SqlGeneratorChain instance
+     * @return SQL statement array
+     */
+    public Sql[] generateSql(ModifyDataTypeStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+
+        // Main alter statement
+        String alterTable = "ALTER TABLE " + database.escapeTableName(statement.getSchemaName(), statement.getTableName()) + " MODIFY ";
+
+        // Add column name
+        alterTable += database.escapeColumnName(statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " ";
+
+        // Add column type
+        alterTable += TypeConverterFactory.getInstance().findTypeConverter(database).getDataType(statement.getNewDataType(), false);
+
+        // Get column information to avoid inadvertently removing default value, null-ability, uniqueness, etc.
+        DatabaseSnapshotGeneratorFactory factory = DatabaseSnapshotGeneratorFactory.getInstance();
+        DatabaseSnapshotGenerator generator = factory.getGenerator(database);
+        DatabaseSnapshot snapshot = null;
+        try {
+            snapshot = generator.createSnapshot(database, statement.getSchemaName(), new HashSet<DiffStatusListener>());
+        } catch (DatabaseException e) {
+            throw new UnexpectedLiquibaseException("Error retrieving database snapshot", e);
+        }
+
+        Column col = null;
+        try {
+            col = snapshot.getColumn(statement.getTableName(), statement.getColumnName());
+        } catch (NullPointerException e) {
+            throw new UnexpectedLiquibaseException("Error retrieving database snapshot", e);
+        }
+
+        if (!col.isNullable()) {
+            alterTable += " NOT NULL";
+        }
+
+        if (col.getDefaultValue() != null) {
+            alterTable += " DEFAULT " + col.getDefaultValue();
+        }
+
+        if (col.isAutoIncrement()) {
+            alterTable += " AUTO INCREMENT";
+        }
+
+        if (col.isUnique()) {
+            alterTable += " UNIQUE";
+        }
+
+        if (col.isPrimaryKey()) {
+            alterTable += " PRIMARY KEY";
+        }
+
+        return new Sql[]{new UnparsedSql(alterTable)};
+    }
+}


### PR DESCRIPTION
Added liquibase.sqlgenerator.core.ModifyDataTypeGeneratorMySQL to fix CORE-955 "Supress "modifyDataType will lose primary key settings for mysql" warning if changelog says it is ok". ModifyDataTypeGeneratorMySQL uses a DatabaseSnapshot to determine what properties the column has, and add them to the alter statement so the correct properties are maintained, not lost.
