### PR TITLE
Path for relativeToChangelogFile=true fix.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/SQLFileChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/SQLFileChange.java
@@ -111,7 +111,7 @@ public class SQLFileChange extends AbstractSQLChange {
      */
     private boolean loadFromFileSystem(String file) throws SetupException {
         if (relativeToChangelogFile != null && relativeToChangelogFile) {
-            file = getChangeSet().getFilePath().replaceFirst("/[^/]*$","")+"/"+file;
+            file = getChangeSet().getFilePath().replaceFirst("[^/]*$","")+file;
         }
 
         InputStream fis = null;
@@ -149,7 +149,7 @@ public class SQLFileChange extends AbstractSQLChange {
      */
     private boolean loadFromClasspath(String file) throws SetupException {
         if (relativeToChangelogFile != null && relativeToChangelogFile) {
-            file = getChangeSet().getFilePath().replaceFirst("/[^/]*$","")+"/"+file;
+            file = getChangeSet().getFilePath().replaceFirst("[^/]*$","")+file;
         }
 
         InputStream in = null;


### PR DESCRIPTION
When sqlFile has relativeToChangelogFile=true option, liquibase failed when run from the same directory where changelog.xml was located, prepending changelog files' name to sqlFile path.

This simple change corrects getting files' path.
