### PR TITLE
Add maven support for hibernate integration

### DIFF
--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
@@ -1,9 +1,12 @@
 package org.liquibase.maven.plugins;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.*;
 
 import liquibase.*;
@@ -370,6 +373,26 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
         }
         catch (MalformedURLException e) {
             throw new MojoExecutionException("Failed to create artifact classloader", e);
+        }
+    }
+
+    /**
+     * Returns an isolated classloader.
+     *
+     * @return ClassLoader
+     * @noinspection unchecked
+     */
+    protected ClassLoader getClassLoaderIncludingProjectClasspath() throws MojoExecutionException {
+        try {
+            List classpathElements = project.getCompileClasspathElements();
+            classpathElements.add(project.getBuild().getOutputDirectory());
+            URL urls[] = new URL[classpathElements.size()];
+            for (int i = 0; i < classpathElements.size(); ++i) {
+                urls[i] = new File((String) classpathElements.get(i)).toURL();
+            }
+            return new URLClassLoader(urls, this.getClass().getClassLoader());
+        } catch (Exception e) {
+            throw new MojoExecutionException("Failed to create project classloader", e);
         }
     }
 

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseDatabaseDiff.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseDatabaseDiff.java
@@ -8,6 +8,7 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import liquibase.Liquibase;
 import liquibase.database.Database;
+import liquibase.exception.DatabaseException;
 import liquibase.exception.LiquibaseException;
 import liquibase.integration.commandline.CommandLineUtils;
 
@@ -87,7 +88,7 @@ public class LiquibaseDatabaseDiff extends AbstractLiquibaseChangeLogMojo {
             referenceUsername = referenceInfo.getUserName();
             referencePassword = referenceInfo.getPassword();
         }
-        
+
         super.execute();
     }
 
@@ -95,7 +96,7 @@ public class LiquibaseDatabaseDiff extends AbstractLiquibaseChangeLogMojo {
     protected void performLiquibaseTask(Liquibase liquibase) throws LiquibaseException {
         ClassLoader cl = null;
         try {
-            cl = getMavenArtifactClassLoader();
+            cl = getClassLoaderIncludingProjectClasspath();
             Thread.currentThread().setContextClassLoader(cl);
         }
         catch (MojoExecutionException e) {


### PR DESCRIPTION
Include the target project's compile-time dependencies and build output in the classloader used to perform the database diff in the liquibase:diff mojo. These are required when the project is using hibernate annotations.
