### PR TITLE
CORE-1088: Derby fails to create databasechangelog tables

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/typeconversion/core/DerbyTypeConverter.java
+++ b/liquibase-core/src/main/java/liquibase/database/typeconversion/core/DerbyTypeConverter.java
@@ -35,6 +35,11 @@ public class DerbyTypeConverter  extends AbstractTypeConverter {
     }
 
     @Override
+    public BooleanType getBooleanType() {
+        return new BooleanType.NumericBooleanType("SMALLINT");
+    }
+
+    @Override
     public DateTimeType getDateTimeType() {
         return new DateTimeType("TIMESTAMP");
     }


### PR DESCRIPTION
Hey,

this fixes the problem with creation of the DatabaseChangeLog table on the Derby database. Without this fix is Liquibase with Derby virtually unusable. BTW, the reporter of the issue CORE-1088 suggested the very same fix.

Cheers,
Stepan
