### PR TITLE
CORE-829: Embedded Derby shutdown does not work with Maven

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/DerbyDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/DerbyDatabase.java
@@ -1,13 +1,14 @@
 package liquibase.database.core;
 
+import java.lang.reflect.Method;
+import java.sql.Driver;
+import java.sql.SQLException;
+
 import liquibase.database.AbstractDatabase;
 import liquibase.database.DatabaseConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.logging.LogFactory;
 import liquibase.logging.Logger;
-
-import java.lang.reflect.Method;
-import java.sql.Driver;
 
 public class DerbyDatabase extends AbstractDatabase {
 
@@ -108,9 +109,22 @@ public class DerbyDatabase extends AbstractDatabase {
                 }
                 LogFactory.getLogger().info("Shutting down derby connection: " + url);
                 // this cleans up the lock files in the embedded derby database folder
-                ((Driver) Class.forName(driverName).newInstance()).connect(url, null);
+                ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+                Driver driver = (Driver) contextClassLoader.loadClass(driverName).newInstance();
+                driver.connect(url, null);
             } catch (Exception e) {
-                LogFactory.getLogger().severe("Error closing derby cleanly", e);
+                if (e instanceof SQLException) {
+                    String state = ((SQLException) e).getSQLState();
+                    if ("XJ015".equals(state) || "08006".equals(state)) {
+                        // "The XJ015 error (successful shutdown of the Derby engine) and the 08006 
+                        // error (successful shutdown of a single database) are the only exceptions 
+                        // thrown by Derby that might indicate that an operation succeeded. All other 
+                        // exceptions indicate that an operation failed."
+                        // See http://db.apache.org/derby/docs/dev/getstart/rwwdactivity3.html
+                        return;
+                    }
+                }
+                throw new DatabaseException("Error closing derby cleanly", e);
             }
         }
     }


### PR DESCRIPTION
Hi,

this fixes the issue during the shutdown of the Derby database. The following two problems has been fixed:
1) The Derby driver failed to load, because an incorrect class loader was used.
2) Derby throws an Exception even if the shutdown is successful. It is necessary to check the error code in order to find out whether the operation succeeded or not.

Please pull this fix.

Cheers,
Stepan
