### PR TITLE
fix CORE-892 - generateChangeLog on MySQL with Views

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/MySQLDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MySQLDatabase.java
@@ -108,7 +108,12 @@ public class MySQLDatabase extends AbstractDatabase {
     @Override
     protected String getDefaultDatabaseSchemaName() throws DatabaseException {
 //        return super.getDefaultDatabaseSchemaName().replaceFirst("\\@.*","");
-            return getConnection().getCatalog();
+        String catalog = getConnection().getCatalog();
+        // catalog is empty if jdbc url doesn't contain a database
+        if (catalog == null || catalog.trim().length() == 0) {
+            return getDefaultSchemaName();
+        }
+        return catalog;
     }
 
     @Override


### PR DESCRIPTION
this time with correct jira issue number.

on mysql connection.getCatalog() is empty if no database is given in jdbc
url. so views can't be found because no schema is defined
