### PR TITLE
Added an "unexpectedChangeSets" command.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/RanChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/RanChangeSet.java
@@ -103,6 +103,11 @@ public class RanChangeSet {
         return result;
     }
 
+    @Override
+    public String toString() {
+        return getChangeLog() + "::" + getId() + "::" + getAuthor();
+    }
+
     public boolean isSameAs(ChangeSet changeSet) {
         return this.getChangeLog().replace('\\', '/').equalsIgnoreCase(changeSet.getFilePath().replace('\\', '/'))
                 && this.getId().equalsIgnoreCase(changeSet.getId())

--- a/liquibase-core/src/main/java/liquibase/changelog/visitor/ExpectedChangesVisitor.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/visitor/ExpectedChangesVisitor.java
@@ -1,0 +1,40 @@
+package liquibase.changelog.visitor;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+import liquibase.changelog.ChangeSet;
+import liquibase.changelog.DatabaseChangeLog;
+import liquibase.changelog.RanChangeSet;
+import liquibase.database.Database;
+import liquibase.exception.LiquibaseException;
+
+public class ExpectedChangesVisitor implements ChangeSetVisitor {
+    private final LinkedHashSet<RanChangeSet> unexpectedChangeSets;
+
+    public ExpectedChangesVisitor(List<RanChangeSet> ranChangeSetList) {
+        this.unexpectedChangeSets = new LinkedHashSet<RanChangeSet>(ranChangeSetList);
+    }
+
+    public Direction getDirection() {
+        return ChangeSetVisitor.Direction.FORWARD;
+    }
+
+    public void visit(ChangeSet changeSet,
+            DatabaseChangeLog databaseChangeLog,
+            Database database) throws LiquibaseException {
+        for (Iterator<RanChangeSet> i = unexpectedChangeSets.iterator(); i.hasNext(); ) {
+            RanChangeSet ranChangeSet = i.next();
+            if (ranChangeSet.isSameAs(changeSet)) {
+                i.remove();
+            }
+        }
+    }
+
+    public Collection<RanChangeSet> getUnexpectedChangeSets() {
+        return unexpectedChangeSets;
+    }
+
+}

--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -242,7 +242,8 @@ public class Main {
             if (commandParams.size() > 0 && commandParams.iterator().next().startsWith("-")) {
                 messages.add("unexpected command parameters: "+commandParams);
             }
-        } else if ("status".equalsIgnoreCase(command)) {
+        } else if ("status".equalsIgnoreCase(command)
+                || "unexpectedChangeSets".equalsIgnoreCase(command)) {
             if (commandParams.size() > 0 && !commandParams.iterator().next().equalsIgnoreCase("--verbose")) {
                 messages.add("unexpected command parameters: "+commandParams);
             }
@@ -288,6 +289,7 @@ public class Main {
                 || "dropAll".equalsIgnoreCase(arg)
                 || "releaseLocks".equalsIgnoreCase(arg)
                 || "status".equalsIgnoreCase(arg)
+                || "unexpectedChangeSets".equalsIgnoreCase(arg)
                 || "validate".equalsIgnoreCase(arg)
                 || "help".equalsIgnoreCase(arg)
                 || "diff".equalsIgnoreCase(arg)
@@ -420,6 +422,9 @@ public class Main {
         stream.println("Maintenance Commands");
         stream.println(" tag <tag string>          'Tags' the current database state for future rollback");
         stream.println(" status [--verbose]        Outputs count (list if --verbose) of unrun changesets");
+        stream.println(" unexpectedChangeSets [--verbose]");
+        stream.println("                           Outputs count (list if --verbose) of changesets run");
+        stream.println("                           in the database that do not exist in the changelog.");
         stream.println(" validate                  Checks changelog for errors");
         stream.println(" clearCheckSums            Removes all saved checksums from database log.");
         stream.println("                           Useful for 'MD5Sum Check Failed' errors");
@@ -749,6 +754,14 @@ public class Main {
                     runVerbose = true;
                 }
                 liquibase.reportStatus(runVerbose, contexts, getOutputWriter());
+                return;
+            } else if ("unexpectedChangeSets".equalsIgnoreCase(command)) {
+                boolean runVerbose = false;
+
+                if (commandParams.contains("--verbose")) {
+                    runVerbose = true;
+                }
+                liquibase.reportUnexpectedChangeSets(runVerbose, contexts, getOutputWriter());
                 return;
             } else if ("validate".equalsIgnoreCase(command)) {
                 try {


### PR DESCRIPTION
A changeset is "unexpected" if it does not exist in the passed changelog (after processing includes and so on). This command lists "unexpected" changesets that have been executed on the target database.

This pull request is based on the liquibase-2.0.3 tag, but applies cleanly to master as of 20333bb46657ad7663e1050b693b5ddf657159c1.

My day job would like a command line this both for auditing and for working with old versions of their app -- it's nice to be able to verify that the checked out DB scripts actually correspond with the state of the database.
