### PR TITLE
Remove an unused import preventing compile with OpenJDK.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/cdi/CDILiquibaseConfig.java
+++ b/liquibase-core/src/main/java/liquibase/integration/cdi/CDILiquibaseConfig.java
@@ -1,6 +1,5 @@
 package liquibase.integration.cdi;
 
-import com.sun.xml.internal.ws.util.QNameMap;
 import liquibase.resource.ResourceAccessor;
 
 import java.util.Map;


### PR DESCRIPTION
Import can't be resolved if using OpenJDK, but turns out it was unused
anyhow.
