### PR TITLE
CORE-1160: MSSQL doesn't support DROP TABLE CASCADE

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/AbstractDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractDatabase.java
@@ -667,7 +667,6 @@ public abstract class AbstractDatabase implements Database {
     public boolean supportsDropTableCascadeConstraints() {
          return (this instanceof DerbyDatabase
                  || this instanceof DB2Database
-                 || this instanceof MSSQLDatabase
                  || this instanceof FirebirdDatabase
                  || this instanceof SQLiteDatabase
                  || this instanceof SybaseDatabase


### PR DESCRIPTION
I didn't find the "cascade" keyword in the drop table syntax of MS SQL. So I guess MS SQL doesn't support cascade.
