### PR TITLE
Correcting 'drop index' query when a schemaName is supplied, for PostgreSQL database

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/PostgresDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/PostgresDatabase.java
@@ -293,6 +293,13 @@ public class PostgresDatabase extends AbstractDatabase {
 
     @Override
     public String escapeIndexName(String catalogName,String schemaName, String indexName) {
-        return escapeDatabaseObject(indexName);
+    	String escapedSchema = escapeDatabaseObject(schemaName);
+    	String escapedIndex;
+    	if (escapedSchema == null) {
+    		escapedIndex = escapeDatabaseObject(indexName);
+    	} else {
+    		escapedIndex = escapedSchema + "." + escapeDatabaseObject(indexName);
+    	}
+        return escapedIndex;
     }
 }

--- a/liquibase-core/src/test/java/liquibase/database/core/PostgresDatabaseTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/core/PostgresDatabaseTest.java
@@ -73,5 +73,16 @@ public class PostgresDatabaseTest extends AbstractDatabaseTest {
         Database database = getDatabase();
         assertEquals("\"schemaName\".\"tableName\"", database.escapeTableName("catalogName", "schemaName", "tableName"));
     }
-
+    
+    @Test
+    public void escapeIndexName_noSchema() {
+        Database database = getDatabase();
+        assertEquals("\"indexName\"", database.escapeIndexName(null, null, "indexName"));
+    }
+    
+    @Test
+    public void escapeIndexName_withSchema() {
+    	 Database database = getDatabase();
+    	 assertEquals("\"schemaName\".\"indexName\"", database.escapeIndexName("catalogName", "schemaName", "indexName"));
+	}
 }


### PR DESCRIPTION
Previously, for PostgreSQL database, drop index generated queries didn't show schema, even though one was supplied. This was a source of error.

That Pull Request, https://github.com/liquibase/liquibase/pull/4 , solved the problem, but it seems this bug reappear after some refactoring.
