### PR TITLE
Added close to prepared statement

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/InsertDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/InsertDataChange.java
@@ -203,7 +203,14 @@ public class InsertDataChange extends AbstractChange implements ChangeWithColumn
                 stmt.execute();
             } catch(SQLException e) {
                 throw new DatabaseException(e);
-            }
+            } finally {
+            	// make sure database resources are released
+            	try {
+                	stmt.close();
+                } catch(SQLException e) {
+                	throw new DatabaseException(e);
+				}
+			}
         }
 
         public boolean skipOnUnsupported() {


### PR DESCRIPTION
PreparedStatement object returned from PreparedStatementFactory was not being closed, so database resources are not being released; this caused problems when working with a large Oracle database with thousands of records being added.
