### PR TITLE
Rollback of a column with a default value

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/AddColumnChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/AddColumnChange.java
@@ -150,6 +150,7 @@ public class AddColumnChange extends AbstractChange implements ChangeWithColumns
                 DropDefaultValueChange dropChange = new DropDefaultValueChange();
                 dropChange.setTableName(getTableName());
                 dropChange.setColumnName(aColumn.getName());
+                dropChange.setSchemaName(getSchemaName());
 
                 inverses.add(dropChange);
             }

--- a/liquibase-core/src/test/java/liquibase/change/core/AddColumnChangeTest.java
+++ b/liquibase-core/src/test/java/liquibase/change/core/AddColumnChangeTest.java
@@ -393,6 +393,41 @@ public class AddColumnChangeTest extends AbstractChangeTest {
     }
 
     @Test
+    public void createInverses_defaultValue() throws Exception {
+        AddColumnChange refactoring = new AddColumnChange();
+        refactoring.setSchemaName("SCHEMA");
+        refactoring.setTableName("TAB");
+        ColumnConfig column = new ColumnConfig();
+        column.setName("NEWCOL");
+        column.setType("TYP");
+        column.setDefaultValue("DEFAULT");
+
+        ConstraintsConfig constraints = new ConstraintsConfig();
+        constraints.setNullable(Boolean.FALSE);
+        constraints.setPrimaryKey(Boolean.TRUE);
+        column.setAutoIncrement(Boolean.TRUE);
+
+        column.setConstraints(constraints);
+
+        refactoring.addColumn(column);
+
+        testInverseOnAll(refactoring, new InverseValidator() {
+            public void validate(Change[] changes) {
+                assertEquals(2, changes.length);
+                assertTrue(changes[0] instanceof DropDefaultValueChange);
+                assertEquals("TAB", ((DropDefaultValueChange) changes[0]).getTableName());
+                assertEquals("NEWCOL", ((DropDefaultValueChange) changes[0]).getColumnName());
+                assertEquals("SCHEMA", ((DropDefaultValueChange) changes[0]).getSchemaName());
+
+                assertTrue(changes[1] instanceof DropColumnChange);
+                assertEquals("TAB", ((DropColumnChange) changes[1]).getTableName());
+                assertEquals("NEWCOL", ((DropColumnChange) changes[1]).getColumnName());
+                assertEquals("SCHEMA", ((DropColumnChange) changes[1]).getSchemaName());
+            }
+        });
+    }
+
+    @Test
     public void createInverses_multiColumn() throws Exception {
         AddColumnChange refactoring = new AddColumnChange();
         refactoring.setSchemaName("SCHEMA");


### PR DESCRIPTION
Attempting to rollback a column with a default value was failing. The schema was not being added to the DropDefaultValue call.

Additionally, added a test to AddColumnChangeTest to assert that the schema was added.
