### PR TITLE
User-submitted feature: escaped changeLog params

### DIFF
--- a/liquibase-core/src/test/java/liquibase/changelog/ChangeLogParametersTest.java
+++ b/liquibase-core/src/test/java/liquibase/changelog/ChangeLogParametersTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.*;
 import liquibase.database.core.H2Database;
 
 import java.util.Arrays;
+import static java.lang.String.format;
 
 
 public class ChangeLogParametersTest {
@@ -18,6 +19,30 @@ public class ChangeLogParametersTest {
         changeLogParameters.set("doubleSet", "newValue");
 
         assertEquals("re-setting a param should not overwrite the value (like how ant works)", "originalValue", changeLogParameters.getValue("doubleSet"));
+    }
+
+    @Test 
+    public void getParameterValue_escaped_simple() {
+        ChangeLogParameters changeLogParameters = new ChangeLogParameters(true);
+        
+        String expanded = changeLogParameters.expandExpressions("${:user.name}");
+        assertEquals("${user.name}", expanded);
+    }
+
+    @Test 
+    public void getParameterValue_escaped_and_undescaped() {
+        ChangeLogParameters changeLogParameters = new ChangeLogParameters(true);
+        
+        String expanded = changeLogParameters.expandExpressions("${user.name} != ${:user.name}");
+        assertEquals(format("%s != ${user.name}", changeLogParameters.getValue("user.name")), expanded);
+    }
+        
+    @Test 
+    public void getParameterValue_escaped_complex() {
+        ChangeLogParameters changeLogParameters = new ChangeLogParameters(true);
+        
+        String expanded = changeLogParameters.expandExpressions("${user.name} != ${:user.name} but does equal ${user.name}");
+        assertEquals(format("%s != ${user.name} but does equal %s", changeLogParameters.getValue("user.name"), changeLogParameters.getValue("user.name")), expanded);
     }
 
     @Test


### PR DESCRIPTION
This patch implements a mechanism to escape changeLog params, by including a colon before the param name that is meant to be a literal.

For, example: `${:user.name}` will not be interpreted and will expand to `${user.name}`.

This should be 100% backwards compatible, and can only be enabled via a system property: `-Dliquibase.enableEscaping=true`.

When I first cloned my fork (i.e. before any local changes) I tried running the entire test suite. Several tests failed. As such, I've only ran `liquibase.changelog.ChangeLogParametersTest` as part of this submission.
