### PR TITLE
Support for hyphenated Oracle schemas

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
@@ -119,7 +119,7 @@ public class OracleDatabase extends AbstractDatabase {
         String escapedIndexName = indexName;
         if (schemaName != null)
         {
-            escapedIndexName = schemaName + "." + escapedIndexName;
+            escapedIndexName = escapeDatabaseObject(schemaName) + "." + escapedIndexName;
         }
         return escapedIndexName;
     }


### PR DESCRIPTION
The fix in the link below was merged into master.

https://github.com/liquibase/liquibase/pull/56

It would be nice if it were also included in the next release of 2.0
