### PR TITLE
CORE-1045: transitive dependencies in liquibase-maven-plugin

### DIFF
--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/MavenUtils.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/MavenUtils.java
@@ -41,8 +41,8 @@ public class MavenUtils {
       log.info("Loading artfacts into URLClassLoader");
     }
     Set<URL> urls = new HashSet<URL>();
-
-    Set dependencies = project.getDependencyArtifacts();
+    // Find project dependencies, including the transitive ones.
+    Set dependencies = project.getArtifacts();
 	if (dependencies != null && !dependencies.isEmpty()) {
 		for (Iterator it = dependencies.iterator(); it.hasNext();) {
 			addArtifact(urls, (Artifact) it.next(), log, verbose);


### PR DESCRIPTION
Hello! This is a fix for CORE-1045 bug.
The problem was that previously,  liquibase-maven-plugin resolved only the direct dependencies. 

Now, with this pull, liquibase-maven-plugin should be able to track down transitive dependencies.

I've tested it with the sample artifacts found on https://liquibase.jira.com/browse/CORE-1045
Let me know if you have some advices or anything else.
