### PR TITLE
CORE-1014 CORE-1153 CORE-1057 Added support for next value from a sequence for inserts

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/ColumnConfig.java
+++ b/liquibase-core/src/main/java/liquibase/change/ColumnConfig.java
@@ -8,6 +8,7 @@ import java.util.Locale;
 
 import liquibase.database.structure.Column;
 import liquibase.statement.DatabaseFunction;
+import liquibase.statement.SequenceFunction;
 import liquibase.util.ISODateFormat;
 
 /**
@@ -25,6 +26,7 @@ public class ColumnConfig {
     private String valueBlob;
     private String valueClob;
     private DatabaseFunction valueComputed;
+    private SequenceFunction valueSequenceNext;
 
     private String defaultValue;
     private Number defaultValueNumeric;
@@ -168,6 +170,14 @@ public class ColumnConfig {
         return this;
     }
 
+    public SequenceFunction getValueSequenceNext() {
+        return valueSequenceNext;
+    }
+
+    public void setValueSequenceNext(final SequenceFunction valueSequenceNext) {
+        this.valueSequenceNext = valueSequenceNext;
+    }
+
     public Date getValueDate() {
         return valueDate;
     }
@@ -204,6 +214,8 @@ public class ColumnConfig {
             return getValueDate();
         } else if (getValueComputed() != null) {
             return getValueComputed();
+        } else if (getValueSequenceNext() != null) {
+            return getValueSequenceNext();
         }
         return null;
     }

--- a/liquibase-core/src/main/java/liquibase/change/core/AddAutoIncrementChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/AddAutoIncrementChange.java
@@ -9,6 +9,7 @@ import liquibase.change.DatabaseChangeProperty;
 import liquibase.database.Database;
 import liquibase.database.core.PostgresDatabase;
 import liquibase.statement.DatabaseFunction;
+import liquibase.statement.SequenceFunction;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.AddAutoIncrementStatement;
 import liquibase.statement.core.AddDefaultValueStatement;
@@ -97,7 +98,7 @@ public class AddAutoIncrementChange extends AbstractChange {
             return new SqlStatement[]{
                     new CreateSequenceStatement(catalogName, schemaName, sequenceName),
                     new SetNullableStatement(catalogName, schemaName, getTableName(), getColumnName(), null, false),
-                    new AddDefaultValueStatement(catalogName, schemaName, getTableName(), getColumnName(), getColumnDataType(), new DatabaseFunction("NEXTVAL('"+sequenceName+"')")),
+                    new AddDefaultValueStatement(catalogName, schemaName, getTableName(), getColumnName(), getColumnDataType(), new SequenceFunction(sequenceName)),
             };
         }
 

--- a/liquibase-core/src/main/java/liquibase/database/Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/Database.java
@@ -102,6 +102,13 @@ public interface Database extends DatabaseObject, PrioritizedService {
 
     void setCurrentDateTimeFunction(String function);
 
+    /**
+     * Return the constructed next value expression for this sequence
+     * @param sequenceName sequence name
+     * @return The next value expression for this sequence
+     */
+    String generateSequenceNextValueFunction(String sequenceName);
+
 
     String getLineComment();
 
@@ -287,4 +294,13 @@ public interface Database extends DatabaseObject, PrioritizedService {
     boolean isFunction(String string);
 
     int getDataTypeMaxParameters(String dataTypeName);
+
+    /**
+     * Types like int4 in postgres cannot have a modifier. e.g. int4(10)
+     * Checks whether the type is allowed to have a modifier
+     *
+     * @param typeName type name
+     * @return Whether data type can have a modifier
+     */
+    boolean dataTypeIsNotModifiable(String typeName);
 }

--- a/liquibase-core/src/main/java/liquibase/database/core/DB2Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/DB2Database.java
@@ -15,6 +15,12 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 
 public class DB2Database extends AbstractDatabase {
+
+    public DB2Database() {
+        super();
+        super.sequenceNextValueFunction = "nextval for %s";
+    }
+
     private String defaultSchemaName;
 
     public boolean isCorrectDatabaseImplementation(DatabaseConnection conn) throws DatabaseException {

--- a/liquibase-core/src/main/java/liquibase/database/core/DerbyDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/DerbyDatabase.java
@@ -25,6 +25,7 @@ public class DerbyDatabase extends AbstractDatabase {
 
     public DerbyDatabase() {
         determineDriverVersion();
+        super.sequenceNextValueFunction = "NEXT VALUE FOR %s";
     }
 
     public boolean isCorrectDatabaseImplementation(DatabaseConnection conn) throws DatabaseException {

--- a/liquibase-core/src/main/java/liquibase/database/core/FirebirdDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/FirebirdDatabase.java
@@ -12,6 +12,11 @@ import liquibase.exception.DatabaseException;
  */
 public class FirebirdDatabase extends AbstractDatabase {
 
+    public FirebirdDatabase() {
+        super();
+        super.sequenceNextValueFunction = "NEXT VALUE FOR %s";
+    }
+
     public boolean isCorrectDatabaseImplementation(DatabaseConnection conn) throws DatabaseException {
         return conn.getDatabaseProductName().startsWith("Firebird");
     }

--- a/liquibase-core/src/main/java/liquibase/database/core/H2Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/H2Database.java
@@ -24,6 +24,7 @@ public class H2Database extends AbstractDatabase {
 
     public H2Database() {
         this.dateFunctions.add(new DatabaseFunction("CURRENT_TIMESTAMP()"));
+        sequenceNextValueFunction = "nextval('%s')";
     }
 
     public String getShortName() {

--- a/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
@@ -24,6 +24,7 @@ public class HsqlDatabase extends AbstractDatabase {
     public HsqlDatabase() {
     	super();
     	super.defaultAutoIncrementStartWith = BigInteger.ZERO;
+        super.sequenceNextValueFunction = "NEXT VALUE FOR %s";
     }
     
     public boolean isCorrectDatabaseImplementation(DatabaseConnection conn) throws DatabaseException {

--- a/liquibase-core/src/main/java/liquibase/database/core/InformixDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/InformixDatabase.java
@@ -92,6 +92,7 @@ public class InformixDatabase extends AbstractDatabase {
 
 		systemTablesAndViews.add("sysdomains");
 		systemTablesAndViews.add("sysindexes");
+        super.sequenceNextValueFunction = "%s.NEXTVAL";
 	}
 
 	@Override

--- a/liquibase-core/src/main/java/liquibase/database/core/MaxDBDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MaxDBDatabase.java
@@ -80,6 +80,8 @@ public class MaxDBDatabase extends AbstractDatabase {
         systemTablesAndViews.add("TRANSACTIONS");
         systemTablesAndViews.add("UNLOADEDSTATEMENTS");
         systemTablesAndViews.add("VERSION");
+        super.sequenceNextValueFunction = "%s.NEXTVAL";
+
     }
 
     public int getPriority() {

--- a/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
@@ -31,6 +31,7 @@ public class OracleDatabase extends AbstractDatabase {
 		dateFunctions.add(new DatabaseFunction("SYSDATE"));
 		dateFunctions.add(new DatabaseFunction("SYSTIMESTAMP"));
         dateFunctions.add(new DatabaseFunction("CURRENT_TIMESTAMP"));
+        super.sequenceNextValueFunction = "%s.nextval)";
 	}
 
 	public int getPriority() {

--- a/liquibase-core/src/main/java/liquibase/database/core/PostgresDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/PostgresDatabase.java
@@ -12,6 +12,7 @@ import liquibase.logging.LogFactory;
 import liquibase.statement.core.RawSqlStatement;
 
 import java.math.BigInteger;
+import java.sql.Types;
 import java.util.*;
 
 /**
@@ -28,7 +29,8 @@ public class PostgresDatabase extends AbstractDatabase {
 
     public PostgresDatabase() {
         reservedWords.addAll(Arrays.asList("USER", "LIKE", "GROUP", "DATE", "ALL"));
-
+        super.sequenceNextValueFunction = "NEXTVAL('%s')";
+        super.unmodifiableDataTypes.addAll(Arrays.asList("bool", "int4", "int8", "float4", "float8", "numeric", "bigserial", "serial", "bytea", "timestamptz"));
 //        systemTablesAndViews.add("pg_logdir_ls");
 //        systemTablesAndViews.add("administrable_role_authorizations");
 //        systemTablesAndViews.add("applicable_roles");
@@ -114,11 +116,6 @@ public class PostgresDatabase extends AbstractDatabase {
 
     public boolean supportsInitiallyDeferrableColumns() {
         return true;
-    }
-
-    @Override
-    public String correctObjectName(String objectName, Class<? extends DatabaseObject> objectType) {
-        return objectName.toLowerCase();
     }
 
     public boolean isCorrectDatabaseImplementation(DatabaseConnection conn) throws DatabaseException {
@@ -289,13 +286,14 @@ public class PostgresDatabase extends AbstractDatabase {
         return searchPaths;
     }
 
+    @Override
+    protected String doGetDefaultSchemaName() {
+        return "public";
+    }
 
     private boolean catalogExists(String catalogName) throws DatabaseException {
-        if (catalogName != null) {
-            return runExistsQuery("select count(*) from information_schema.schemata where catalog_name='" + catalogName + "'");
-        } else {
-            return false;
-        }
+        return catalogName != null && runExistsQuery(
+                "select count(*) from information_schema.schemata where catalog_name='" + catalogName + "'");
     }
 
     private boolean schemaExists(String schemaName) throws DatabaseException {

--- a/liquibase-core/src/main/java/liquibase/database/structure/Sequence.java
+++ b/liquibase-core/src/main/java/liquibase/database/structure/Sequence.java
@@ -13,8 +13,9 @@ public class Sequence extends DatabaseObjectImpl implements Comparable<Sequence>
         return name;
     }
 
-    public void setName(String name) {
+    public Sequence setName(String name) {
         this.name = name;
+        return this;
     }
 
 

--- a/liquibase-core/src/main/java/liquibase/datatype/DataTypeFactory.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/DataTypeFactory.java
@@ -125,12 +125,17 @@ public class DataTypeFactory {
             }
         }
 
+        /*
+        The block below seems logically incomplete.
+        It will always end up putting the second word after the entire type name
+        e.g. character varying will become CHARACTER VARYING varying
+
         //try to something like "int(11) unsigned" or int unsigned but not "varchar(11 bytes)"
         String lookingForAdditionalInfo = dataTypeDefinition;
         lookingForAdditionalInfo = lookingForAdditionalInfo.replaceFirst("\\(.*\\)", "");
         if (lookingForAdditionalInfo.contains(" ")) {
             liquibaseDataType.setAdditionalInformation(lookingForAdditionalInfo.split(" ", 2)[1]);
-        }
+        }*/
 
         if (dataTypeDefinition.matches(".*\\{.*")) {
             String paramStrings = dataTypeDefinition.replaceFirst(".*?\\{", "").replaceFirst("\\}.*", "");

--- a/liquibase-core/src/main/java/liquibase/datatype/DatabaseDataType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/DatabaseDataType.java
@@ -5,7 +5,7 @@ import liquibase.util.StringUtils;
 public class DatabaseDataType {
 
     private String type;
-    
+
     public DatabaseDataType(String type) {
         this.type = type;
     }
@@ -32,6 +32,14 @@ public class DatabaseDataType {
         }
     }
 
+    /**
+     * Mainly for postgres, check if the column is a serial data type.
+     * @return Whether the type is serial
+     */
+    public boolean isSerialDataType() {
+        return type.equalsIgnoreCase("serial") || type.equalsIgnoreCase("bigserial");
+    }
+
     public String toSql() {
         return toString();
     }
@@ -40,4 +48,13 @@ public class DatabaseDataType {
     public String toString() {
         return type;
     }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(final String type) {
+        this.type = type;
+    }
+
 }

--- a/liquibase-core/src/main/java/liquibase/datatype/LiquibaseDataType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/LiquibaseDataType.java
@@ -3,7 +3,7 @@ package liquibase.datatype;
 import liquibase.database.Database;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.servicelocator.PrioritizedService;
-import liquibase.statement.DatabaseFunction;
+import liquibase.statement.SequenceFunction;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -107,6 +107,8 @@ public abstract class LiquibaseDataType implements PrioritizedService {
     public String objectToSql(Object value, Database database) {
         if (value == null || value.toString().equalsIgnoreCase("null")) {
             return null;
+        } else if (value instanceof SequenceFunction) {
+            return database.generateSequenceNextValueFunction(value.toString());
         } else if (isCurrentDateTimeFunction(value.toString(), database)) {
             return database.getCurrentDateTimeFunction();
         }

--- a/liquibase-core/src/main/java/liquibase/datatype/core/CharType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/CharType.java
@@ -12,7 +12,14 @@ public class CharType extends LiquibaseDataType {
         if (value == null || value.toString().equalsIgnoreCase("null")) {
             return null;
         }
-        return "'"+value+"'";
+        String val = String.valueOf(value);
+        // postgres type character varying gets identified as a char type
+        // simple sanity check to avoid double quoting a value
+        if (val.startsWith("'")) {
+            return val;
+        } else {
+            return "'"+val+"'";
+        }
     }
 
 }

--- a/liquibase-core/src/main/java/liquibase/datatype/core/NumberType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/NumberType.java
@@ -10,7 +10,8 @@ import liquibase.datatype.LiquibaseDataType;
 public class NumberType extends LiquibaseDataType {
     @Override
     public DatabaseDataType toDatabaseDataType(Database database) {
-        if (database instanceof MySQLDatabase || database instanceof DB2Database|| database instanceof MSSQLDatabase || database instanceof HsqlDatabase || database instanceof DerbyDatabase) {
+        if (database instanceof MySQLDatabase || database instanceof DB2Database|| database instanceof MSSQLDatabase
+                || database instanceof HsqlDatabase || database instanceof DerbyDatabase || database instanceof PostgresDatabase) {
             return new DatabaseDataType("numeric", getParameters());
         }
         return super.toDatabaseDataType(database);

--- a/liquibase-core/src/main/java/liquibase/executor/jvm/JdbcExecutor.java
+++ b/liquibase-core/src/main/java/liquibase/executor/jvm/JdbcExecutor.java
@@ -216,7 +216,7 @@ public class JdbcExecutor extends AbstractExecutor implements Executor {
                 if (sqlToExecute.length != 1) {
                     throw new DatabaseException("Cannot call update on Statement that returns back multiple Sql objects");
                 }
-                log.debug("Executing UPDATE database command: "+sqlToExecute[0]);                
+                log.debug("Executing UPDATE database command: "+sqlToExecute[0]);
                 return stmt.executeUpdate(sqlToExecute[0]);
             }
 

--- a/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
@@ -276,6 +276,9 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
         if (columnConfig.getValueComputed() != null) {
             element.setAttribute("valueComputed", columnConfig.getValueComputed().toString());
         }
+        if (columnConfig.getValueSequenceNext() != null) {
+            element.setAttribute("valueSequenceNext", columnConfig.getValueSequenceNext().toString());
+        }
         if (StringUtils.trimToNull(columnConfig.getRemarks()) != null) {
             element.setAttribute("remarks", columnConfig.getRemarks());
         }

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/DerbyDatabaseSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/DerbyDatabaseSnapshotGenerator.java
@@ -20,10 +20,10 @@ public class DerbyDatabaseSnapshotGenerator extends JdbcDatabaseSnapshotGenerato
     }
 
     @Override
-    protected Object readDefaultValue(Map<String, Object> columnMetadataResultSet, Column columnInfo, Database database) throws SQLException, DatabaseException {
+    protected Object readDefaultValue(Map<String, String> columnMetadataResultSet, Column columnInfo, Database database) throws SQLException, DatabaseException {
         Object val = columnMetadataResultSet.get("COLUMN_DEF");
 
-        if (val instanceof String && "GENERATED_BY_DEFAULT".equals(val)) {
+        if ("GENERATED_BY_DEFAULT".equals(val)) {
             return null;
         }
         return super.readDefaultValue(columnMetadataResultSet, columnInfo, database);

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/H2DatabaseSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/H2DatabaseSnapshotGenerator.java
@@ -22,7 +22,7 @@ public class H2DatabaseSnapshotGenerator extends JdbcDatabaseSnapshotGenerator {
     }
 
     @Override
-    protected Object readDefaultValue(Map<String, Object> columnMetadataResultSet, Column columnInfo, Database database) throws SQLException, DatabaseException {
+    protected Object readDefaultValue(Map<String, String> columnMetadataResultSet, Column columnInfo, Database database) throws SQLException, DatabaseException {
         Object defaultValue = super.readDefaultValue(columnMetadataResultSet, columnInfo, database);
         if (defaultValue != null && defaultValue instanceof DatabaseFunction && ((DatabaseFunction) defaultValue).getValue().startsWith("NEXT VALUE FOR ")) {
             columnInfo.setAutoIncrement(true);

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/InformixDatabaseSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/InformixDatabaseSnapshotGenerator.java
@@ -37,11 +37,11 @@ public class InformixDatabaseSnapshotGenerator extends JdbcDatabaseSnapshotGener
     }
 
     @Override
-    protected DataType readDataType(Map<String, Object> rs, Column column, Database database) throws SQLException {
+    protected DataType readDataType(Map<String, String> rs, Column column, Database database) throws SQLException {
         // See http://publib.boulder.ibm.com/infocenter/idshelp/v115/topic/com.ibm.sqlr.doc/sqlr07.htm
-        String typeName = ((String) rs.get("TYPE_NAME")).toUpperCase();
+        String typeName = rs.get("TYPE_NAME").toUpperCase();
         if ("DATETIME".equals(typeName) || "INTERVAL".equals(typeName)) {
-            int collength = (Integer) rs.get("COLUMN_SIZE");
+            int collength = Integer.valueOf(rs.get("COLUMN_SIZE"));
             //int positions = collength / 256;
             int firstQualifierType = (collength % 256) / 16;
             int lastQualifierType = (collength % 256) % 16;

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/MSSQLDatabaseSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/MSSQLDatabaseSnapshotGenerator.java
@@ -39,15 +39,12 @@ public class MSSQLDatabaseSnapshotGenerator extends JdbcDatabaseSnapshotGenerato
     }
 
     @Override
-    protected Object readDefaultValue(Map<String, Object> columnMetadataResultSet, Column columnInfo, Database database) throws SQLException, DatabaseException {
-        Object defaultValue = columnMetadataResultSet.get("COLUMN_DEF");
+    protected Object readDefaultValue(Map<String, String> columnMetadataResultSet, Column columnInfo, Database database) throws SQLException, DatabaseException {
+        String defaultValue = columnMetadataResultSet.get("COLUMN_DEF");
 
-        if (defaultValue != null && defaultValue instanceof String) {
-            String newValue = null;
-            if (defaultValue.equals("(NULL)")) {
-                newValue = null;
-            }
-            columnMetadataResultSet.put("COLUMN_DEF", newValue);
+        // todo: decide if we were handling anything else here
+        if (defaultValue.equals("(NULL)")) {
+            columnMetadataResultSet.put("COLUMN_DEF", null);
         }
         return super.readDefaultValue(columnMetadataResultSet, columnInfo, database);
     }

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddDefaultValueGeneratorPostgres.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddDefaultValueGeneratorPostgres.java
@@ -1,0 +1,61 @@
+package liquibase.sqlgenerator.core;
+
+import liquibase.database.Database;
+import liquibase.database.core.OracleDatabase;
+import liquibase.database.core.PostgresDatabase;
+import liquibase.database.structure.Column;
+import liquibase.database.structure.Schema;
+import liquibase.database.structure.Sequence;
+import liquibase.database.structure.Table;
+import liquibase.datatype.DataTypeFactory;
+import liquibase.sql.Sql;
+import liquibase.sql.UnparsedSql;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.statement.SequenceFunction;
+import liquibase.statement.core.AddDefaultValueStatement;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Adds functionality for setting the sequence to be owned by the column with the default value
+ */
+public class AddDefaultValueGeneratorPostgres extends AddDefaultValueGenerator {
+
+    @Override
+    public int getPriority() {
+        return PRIORITY_DATABASE;
+    }
+
+    @Override
+    public boolean supports(AddDefaultValueStatement statement, Database database) {
+        return database instanceof PostgresDatabase;
+    }
+
+    @Override
+    public Sql[] generateSql(final AddDefaultValueStatement statement, final Database database,
+                             final SqlGeneratorChain sqlGeneratorChain) {
+
+        if (!(statement.getDefaultValue() instanceof SequenceFunction)) {
+            return super.generateSql(statement, database, sqlGeneratorChain);
+        }
+
+        List<Sql> commands = new ArrayList<Sql>(Arrays.asList(super.generateSql(statement, database, sqlGeneratorChain)));
+        // for postgres, we need to also set the sequence to be owned by this table for true serial like functionality.
+        // this will allow a drop table cascade to remove the sequence as well.
+        SequenceFunction sequenceFunction = (SequenceFunction) statement.getDefaultValue();
+
+        Sql alterSequenceOwner = new UnparsedSql("ALTER SEQUENCE " + database.escapeSequenceName(statement.getCatalogName(),
+                statement.getSchemaName(), sequenceFunction.getValue()) + " OWNED BY " +
+                database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + "."
+                + database.escapeDatabaseObject(statement.getColumnName(), Column.class),
+                new Column()
+                        .setRelation(new Table(statement.getTableName()).setSchema(new Schema(statement.getCatalogName(), statement.getSchemaName())))
+                        .setName(statement.getColumnName()),
+                new Sequence()
+                        .setName(sequenceFunction.getValue()));
+        commands.add(alterSequenceOwner);
+        return commands.toArray(new Sql[commands.size()]);
+    }
+}

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateIndexGeneratorPostgres.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateIndexGeneratorPostgres.java
@@ -50,8 +50,8 @@ public class CreateIndexGeneratorPostgres extends CreateIndexGenerator {
 	    buffer.append("INDEX ");
 
 	    if (statement.getIndexName() != null) {
-            String indexSchema = statement.getTableSchemaName();
-            buffer.append(database.escapeIndexName(null, indexSchema, statement.getIndexName())).append(" ");
+            // for postgres setting the schema name for the index name is invalid
+            buffer.append(database.escapeDatabaseObject(statement.getIndexName(), Index.class)).append(" ");
 	    }
 	    buffer.append("ON ");
 	    buffer.append(database.escapeTableName(statement.getTableCatalogName(), statement.getTableSchemaName(), statement.getTableName())).append("(");

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/InsertGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/InsertGenerator.java
@@ -6,6 +6,7 @@ import liquibase.exception.ValidationErrors;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.statement.SequenceFunction;
 import liquibase.statement.core.InsertStatement;
 
 import java.util.Date;
@@ -48,7 +49,10 @@ public class InsertGenerator extends AbstractSqlGenerator<InsertStatement> {
                 } else {
                     sql.append(DataTypeFactory.getInstance().getFalseBooleanValue(database));
                 }
-            } else {
+            } else if (newValue instanceof SequenceFunction) {
+                sql.append(database.generateSequenceNextValueFunction(newValue.toString()));
+            }
+            else {
                 sql.append(newValue);
             }
             sql.append(", ");

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/SelectSequencesGeneratorPostgres.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/SelectSequencesGeneratorPostgres.java
@@ -35,9 +35,10 @@ public class SelectSequencesGeneratorPostgres extends AbstractSqlGenerator<Selec
                 "WHERE relkind='S' " +
                 "AND pg_class.relnamespace = pg_namespace.oid " +
                 "AND nspname = '" + schema.getName() + "' " +
-                "AND 'nextval(''" + (schema == null ? "" : schema + ".") + "'||relname||'''::regclass)' not in (select adsrc from pg_attrdef where adsrc is not null) " +
-                "AND 'nextval(''" + (schema == null ? "" : schema + ".") + "\"'||relname||'\"''::regclass)' not in (select adsrc from pg_attrdef where adsrc is not null) " +
-                "AND 'nextval('''||relname||'''::regclass)' not in (select adsrc from pg_attrdef where adsrc is not null)")
+                "AND 'nextval(''" + schema + "." + "'||relname||'''::regclass)' not in (select adsrc from pg_attrdef where adsrc is not null) " +
+                "AND 'nextval(''" + schema + "." + "\"'||relname||'\"''::regclass)' not in (select adsrc from pg_attrdef where adsrc is not null) " +
+                "AND 'nextval('''||relname||'''::regclass)' not in (select adsrc from pg_attrdef where adsrc is not null)" +
+                "AND 'nextval(''\"'||relname||'\"''::regclass)' not in (select adsrc from pg_attrdef where adsrc is not null)")
             };
     }
 }

--- a/liquibase-core/src/main/java/liquibase/statement/SequenceFunction.java
+++ b/liquibase-core/src/main/java/liquibase/statement/SequenceFunction.java
@@ -1,0 +1,37 @@
+package liquibase.statement;
+
+/**
+ * Represents a function for getting the next value from a sequence
+ */
+public class SequenceFunction {
+
+    private String value;
+
+    public SequenceFunction(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return getValue();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof SequenceFunction) {
+            return this.toString().equals(obj.toString());
+        } else {
+            return super.equals(obj);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return this.toString().hashCode();
+    }
+
+}

--- a/liquibase-core/src/main/java/liquibase/util/NumberUtils.java
+++ b/liquibase-core/src/main/java/liquibase/util/NumberUtils.java
@@ -193,4 +193,16 @@ public abstract class NumberUtils {
 		return (negative ? result.negate() : result);
 	}
 
+    /**
+     * Convenience method for converting a string to an Integer object
+     * @param value string value
+     * @return Null if the value is null, otherwise the converted integer
+     */
+    public static Integer readInteger(String value) {
+        if (value == null) {
+            return null;
+        }
+        return Integer.valueOf(value);
+    }
+
 }

--- a/liquibase-core/src/main/java/liquibase/util/ObjectUtil.java
+++ b/liquibase-core/src/main/java/liquibase/util/ObjectUtil.java
@@ -8,6 +8,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import liquibase.statement.DatabaseFunction;
+import liquibase.statement.SequenceFunction;
 
 public class ObjectUtil {
 
@@ -56,6 +57,9 @@ public class ObjectUtil {
                         return;
                     } else if (parameterType.equals(DatabaseFunction.class)) {
                         method.invoke(object, new DatabaseFunction(propertyValue));
+                        return;
+                    } else if (parameterType.equals(SequenceFunction.class)) {
+                        method.invoke(object, new SequenceFunction(propertyValue));
                         return;
                     }
                 }

--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-2.0.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-2.0.xsd
@@ -263,6 +263,7 @@
 		<xsd:attribute name="valueBoolean" type="xsd:string" />
 		<xsd:attribute name="valueDate" type="xsd:string" />
 		<xsd:attribute name="valueComputed" type="xsd:string" />
+        <xsd:attribute name="valueSequenceNext" type="xsd:string" />
 		<xsd:attribute name="defaultValue" type="xsd:string" />
 		<xsd:attribute name="defaultValueNumeric" type="xsd:string" />
 		<xsd:attribute name="defaultValueDate" type="xsd:string" />

--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.0.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.0.xsd
@@ -267,6 +267,7 @@
 		<xsd:attribute name="valueBoolean" type="xsd:string" />
 		<xsd:attribute name="valueDate" type="xsd:string" />
 		<xsd:attribute name="valueComputed" type="xsd:string" />
+        <xsd:attribute name="valueSequenceNext" type="xsd:string" />
         <xsd:attribute name="valueBlob" type="xsd:string"/>
         <xsd:attribute name="valueClob" type="xsd:string"/>
 		<xsd:attribute name="defaultValue" type="xsd:string" />

--- a/liquibase-core/src/test/java/liquibase/database/core/MockDatabase.java
+++ b/liquibase-core/src/test/java/liquibase/database/core/MockDatabase.java
@@ -198,6 +198,10 @@ public class MockDatabase implements Database {
     public void setCurrentDateTimeFunction(String function) {
     }
 
+    public String generateSequenceNextValueFunction(final String sequenceName) {
+        return "NEXTVAL('" + sequenceName + "')";
+    }
+
     public String getLineComment() {
         return null;
     }
@@ -535,5 +539,9 @@ public class MockDatabase implements Database {
 
     public int getDataTypeMaxParameters(String dataTypeName) {
         return 2;
+    }
+
+    public boolean dataTypeIsNotModifiable(final String typeName) {
+        return true;
     }
 }

--- a/liquibase-core/src/test/java/liquibase/serializer/core/string/StringChangeLogSerializerTest.java
+++ b/liquibase-core/src/test/java/liquibase/serializer/core/string/StringChangeLogSerializerTest.java
@@ -35,6 +35,7 @@ import liquibase.resource.ClassLoaderResourceAccessor;
 import liquibase.resource.ResourceAccessor;
 import liquibase.statement.DatabaseFunction;
 
+import liquibase.statement.SequenceFunction;
 import org.junit.Test;
 
 public class StringChangeLogSerializerTest {
@@ -295,6 +296,8 @@ public class StringChangeLogSerializerTest {
                 field.set(object, createColumnConfig());
             } else if (field.getType().equals(DatabaseFunction.class)) {
                 field.set(object, createDatabaseFunction());
+            } else if (field.getType().equals(SequenceFunction.class)) {
+                field.set(object, createSequenceFunction());
             } else if (field.getType().equals(ConstraintsConfig.class)) {
                 field.set(object, createConstraintsConfig());
             } else if (field.getType().getName().equals("liquibase.change.custom.CustomChange")) {
@@ -390,6 +393,12 @@ public class StringChangeLogSerializerTest {
 
     private DatabaseFunction createDatabaseFunction() throws Exception {
         DatabaseFunction function = new DatabaseFunction("FUNCTION_HERE");
+        setFields(function);
+        return function;
+    }
+
+    private SequenceFunction createSequenceFunction() throws Exception {
+        SequenceFunction function = new SequenceFunction("SEQUENCE_NAME");
         setFields(function);
         return function;
     }

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
@@ -113,7 +113,8 @@ public abstract class AbstractIntegrationTest {
             database.checkDatabaseChangeLogLockTable();
 
             if (database.getConnection() != null) {
-                ((JdbcConnection) database.getConnection()).getUnderlyingConnection().createStatement().executeUpdate("drop table "+database.getDatabaseChangeLogLockTableName());
+                String dropTableCommand = "drop table " + database.escapeTableName(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(),database.getDatabaseChangeLogLockTableName());
+                ((JdbcConnection) database.getConnection()).getUnderlyingConnection().createStatement().executeUpdate(dropTableCommand);
                 database.commit();
             }
 
@@ -201,7 +202,7 @@ public abstract class AbstractIntegrationTest {
 
     protected Schema[] getSchemasToDrop() throws DatabaseException {
         return new Schema[]{
-                new Schema(new Catalog(null), "liquibaseb".toUpperCase()),
+                new Schema(new Catalog(null), database.escapeDatabaseObject("liquibaseb", Schema.class)),
                 new Schema(new Catalog(null), database.getDefaultSchemaName())
         };
     }
@@ -415,6 +416,7 @@ public abstract class AbstractIntegrationTest {
             } finally {
                 output.close();
             }
+
 
             Liquibase liquibase = createLiquibase(tempFile.getName());
             clearDatabase(liquibase);
@@ -828,6 +830,9 @@ public abstract class AbstractIntegrationTest {
 
     @Test
     public void invalidIncludeDoesntBreakLiquibase() throws Exception{
+        if (database == null) {
+            return;
+        }
         Liquibase liquibase = createLiquibase(invalidReferenceChangeLog);
         try {
             liquibase.update(null);
@@ -841,6 +846,9 @@ public abstract class AbstractIntegrationTest {
 
     @Test
     public void contextsWithHyphensWorkInFormattedSql() throws Exception {
+        if (database == null) {
+            return;
+        }
         Liquibase liquibase = createLiquibase("changelogs/common/sqlstyle/formatted.changelog.sql");
         liquibase.update("hyphen-context-using-sql,camelCaseContextUsingSql");
 

--- a/liquibase-integration-tests/src/test/resources/changelogs/common/common.tests.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/common/common.tests.changelog.xml
@@ -162,7 +162,7 @@
         </createIndex>
     </changeSet>
 
-    <changeSet id="hasIndexPrecondition" author="nvoxland" dbms="oracle,mssql,mysql,h2,hsql,pgsql"> <!-- can check with or without table name, derby doesn't work with just column names -->
+    <changeSet id="hasIndexPrecondition" author="nvoxland" dbms="oracle,mssql,mysql,h2,hsql,postgresql"> <!-- can check with or without table name, derby doesn't work with just column names -->
         <preConditions>
             <indexExists indexName="idx_compoundtest"/>
             <indexExists tableName="compoundIndexTest" indexName="idx_compoundtest"/>
@@ -875,5 +875,21 @@
     </changeSet>
     <changeSet id="createOrReplaceVieworks-3" author="nvoxland" dbms="mssql,oracle">
         <sql>select * from replace_view_test</sql>
+    </changeSet>
+
+    <!-- should work for all databases but only tested on h2 and psotgres for now -->
+    <changeSet id="insertRecordWithSequence" author="dbiggs" dbms="postgresql, h2">
+      <createTable tableName="insertTest">
+        <column name="id" type="int">
+          <constraints primaryKey="true"/>
+        </column>
+        <column name="stringValue" type="varchar(10)" />
+      </createTable>
+      <createSequence sequenceName="insertTest_seq" />
+
+      <insert tableName="insertTest">
+        <column name="id" valueSequenceNext="insertTest_seq" />
+        <column name="stringValue" value="test value" />
+      </insert>
     </changeSet>
 </databaseChangeLog>

--- a/liquibase-integration-tests/src/test/resources/changelogs/pgsql/rollback/rollbackable.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/pgsql/rollback/rollbackable.changelog.xml
@@ -105,7 +105,7 @@
     <changeSet id="14" author="nvoxland">
         <addLookupTable
             existingTableName="publication" existingColumnName="isbn"
-            newTableName="isbn" newColumnName="code"/>
+            newTableName="isbn" newColumnName="code" newColumnDataType="varchar(50)"/>
     </changeSet>
 
     <changeSet id="15" author="nvoxland">


### PR DESCRIPTION
Added field valueSequenceNext to ColumnConfig. Value for field is a sequence name.
Added string to AbstractDatabase to represent the next value database syntax.
Added setting of this value from Databases that support sequences.
I used google to get the next value syntax for each database.
The only databases that I have tested though are h2, derby, hsql and postgresql.
Added changeset to common.tests.changelog.xml to test using the next value from a sequence on insert.

Added several fixes to get the postgres integration tests to run.
Overrode doGetDefaultSchema to always return 'public' I'm not sure how this was working for other people?

Removed overriding of correctObjectName for postgres. Postgres supports mixed case so lowercasing all objects
is incorrect. This caused the precondition integration test for the compound index to break.

in JdbcDatabaseSnapshotGenerator, I removed the logic for converting the result set according to the types list.
Now it just loops through the result set and adds each column to the map.
For my postgres database, this had one more field than was in the actual result set thus causing an index out of bounds exception.
The comment about the data type in the result set being incorrect is true.
Instead I always read out the value as a string and convert it when needed to an Integer Object.
I also changed the method used to get the column name from getColumnName to getColumnLabel.
For H2, COLUMN_SIZE was not present, instead the name was CHARACTER_MAX_LENGTH.
The label values appear to be correct for all the databases I've tested.

For SelectSequencesGeneratorPostgres, I added a clause to exclude non lowercase sequences that are owned by a column.

I added Postgres as a database that can support cascade drop. This means that when dropping a table with a serial type,
the sequence for the serial type is also removed.

For AddDefaultValueGeneratorPostgres, the sequence that is added should be owned by the column that it is now the default value for.
This is to make it consistent with the serial datatype in postgres. Otherwise, when doing a drop table cascade for that table, the
sequence will not be deleted.

Added a concept of data types that can't be modified to AbstractDatabase. For postgres types like int4, they should never be converted to
int4(10). This was happening for the database export / import tests.

Removed code that added the second word of a datatype as additional information.
E.g. character varying would be converted to CHARACTER VARYING varying.
The comment mentioned that it was for types like int unsigned but it looked like it would turn that into INT UNSIGNED unsigned as well.
