### PR TITLE
Escape references schema - which may contain illegal characters

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateTableGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateTableGenerator.java
@@ -2,6 +2,7 @@ package liquibase.sqlgenerator.core;
 
 import liquibase.database.Database;
 import liquibase.database.core.*;
+import liquibase.database.structure.Schema;
 import liquibase.exception.ValidationErrors;
 import liquibase.logging.LogFactory;
 import liquibase.sql.Sql;
@@ -163,7 +164,7 @@ public class CreateTableGenerator extends AbstractSqlGenerator<CreateTableStatem
         	}
             String referencesString = fkConstraint.getReferences();
             if (!referencesString.contains(".") && database.getDefaultSchemaName() != null) {
-                referencesString = database.getDefaultSchemaName()+"."+referencesString;
+                referencesString = database.escapeDatabaseObject(database.getDefaultSchemaName(), Schema.class)+"."+referencesString;
             }
             buffer.append(" FOREIGN KEY (")
                     .append(database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), fkConstraint.getColumn()))

--- a/liquibase-core/src/test/java/liquibase/sqlgenerator/core/CreateTableGeneratorTest.java
+++ b/liquibase-core/src/test/java/liquibase/sqlgenerator/core/CreateTableGeneratorTest.java
@@ -22,6 +22,7 @@ import liquibase.datatype.core.IntType;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.AbstractSqlGeneratorTest;
 import liquibase.statement.AutoIncrementConstraint;
+import liquibase.statement.ForeignKeyConstraint;
 import liquibase.statement.core.CreateTableStatement;
 import liquibase.test.TestContext;
 
@@ -914,5 +915,15 @@ public class CreateTableGeneratorTest extends AbstractSqlGeneratorTest<CreateTab
     			assertEquals("CREATE TABLE [CATALOG_NAME].[SCHEMA_NAME].[TABLE_NAME] ([COLUMN1_NAME] BIGINT IDENTITY NULL)", generatedSql[0].toSql());
     		}
     	}
-    } 
+    }
+
+    @Test
+    public void createReferencesSchemaEscaped() throws Exception {
+        Database database = new PostgresDatabase();
+        database.setDefaultSchemaName("my-schema");
+        CreateTableStatement statement = new CreateTableStatement(CATALOG_NAME, SCHEMA_NAME, TABLE_NAME);
+        statement.addColumnConstraint(new ForeignKeyConstraint("fk_test_parent", TABLE_NAME + "(id)").setColumn("id"));
+        Sql[] generatedSql = this.generatorUnderTest.generateSql(statement, database, null);
+        assertEquals("CREATE TABLE SCHEMA_NAME.TABLE_NAME (, CONSTRAINT fk_test_parent FOREIGN KEY (id) REFERENCES \"my-schema\".TABLE_NAME(id))", generatedSql[0].toSql());
+    }
 }


### PR DESCRIPTION
We're seeing this in Liquibase against MySQL. It appears that the newer version of Liquibase might avoid this by always returning null in MySQLDatabase, but it should be escaped just in case.
