### PR TITLE
CORE-1045: resolving transitive dependencies for liquibase-maven-plugin

### DIFF
--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/MavenUtils.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/MavenUtils.java
@@ -41,8 +41,8 @@ public class MavenUtils {
       log.info("Loading artfacts into URLClassLoader");
     }
     Set<URL> urls = new HashSet<URL>();
-
-    Set dependencies = project.getDependencyArtifacts();
+    // Find project dependencies, including the transitive ones.
+    Set dependencies = project.getArtifacts();
 	if (dependencies != null && !dependencies.isEmpty()) {
 		for (Iterator it = dependencies.iterator(); it.hasNext();) {
 			addArtifact(urls, (Artifact) it.next(), log, verbose);


### PR DESCRIPTION
This is the same as [this](https://github.com/liquibase/liquibase/pull/72), but for 2_0_x instead of master.

I wasn't able to test the fix with 3.0.0-SNAPSHOT but it works ok on 2.0.6-SNAPSHOT.
