### PR TITLE
CORE-1219. Removed empty DatabaseException catch blocks in LockService

### DIFF
--- a/liquibase-core/src/main/java/liquibase/lockservice/LockService.java
+++ b/liquibase-core/src/main/java/liquibase/lockservice/LockService.java
@@ -53,7 +53,7 @@ public class LockService {
         return hasChangeLogLock;
     }
 
-    public void waitForLock() throws LockException {
+    public void waitForLock() throws LockException, DatabaseException {
 
         boolean locked = false;
         long timeToGiveUp = new Date().getTime() + changeLogLockWaitTime;
@@ -82,7 +82,8 @@ public class LockService {
         }
     }
 
-    public boolean acquireLock() throws LockException {
+    public boolean acquireLock() throws DatabaseException, LockException
+    {
         if (hasChangeLogLock) {
             return true;
         }
@@ -95,7 +96,8 @@ public class LockService {
 
             Boolean locked = (Boolean) ExecutorService.getInstance().getExecutor(database).queryForObject(new SelectFromDatabaseChangeLogLockStatement("LOCKED"), Boolean.class);
 
-            if (locked) {
+            if (locked)
+            {
                 return false;
             } else {
 
@@ -117,19 +119,15 @@ public class LockService {
                 database.setCanCacheLiquibaseTableInfo(true);
                 return true;
             }
-        } catch (Exception e) {
-            throw new LockException(e);
-        } finally {
-            try {
-                database.rollback();
-            } catch (DatabaseException e) {
-                ;
-            }
+        }
+        finally
+        {
+            database.rollback();
         }
 
     }
 
-    public void releaseLock() throws LockException {
+    public void releaseLock() throws DatabaseException, LockException {
         Executor executor = ExecutorService.getInstance().getExecutor(database);
         try {
             if (database.hasDatabaseChangeLogLockTable()) {
@@ -148,18 +146,14 @@ public class LockService {
 
                 LogFactory.getLogger().info("Successfully released change log lock");
             }
-        } catch (Exception e) {
-            throw new LockException(e);
-        } finally {
-            try {
-                database.rollback();
-            } catch (DatabaseException e) {
-                ;
-            }
+        }
+        finally
+        {
+            database.rollback();
         }
     }
 
-    public DatabaseChangeLogLock[] listLocks() throws LockException {
+    public DatabaseChangeLogLock[] listLocks() throws DatabaseException {
         try {
             if (!database.hasDatabaseChangeLogLockTable()) {
                 return new DatabaseChangeLogLock[0];
@@ -181,8 +175,10 @@ public class LockService {
                 }
             }
             return allLocks.toArray(new DatabaseChangeLogLock[allLocks.size()]);
-        } catch (Exception e) {
-            throw new LockException(e);
+        }
+        finally
+        {
+            database.rollback(); //Rollback to make sure any database explicitly imposed lock from the above SELECT statement gets released. CORE-1219 incident.
         }
     }
 

--- a/liquibase-core/src/test/java/liquibase/lockservice/LockServiceTest.java
+++ b/liquibase-core/src/test/java/liquibase/lockservice/LockServiceTest.java
@@ -301,6 +301,9 @@ public class LockServiceTest {
         expect(executor.queryForObject(isA(SelectFromDatabaseChangeLogLockStatement.class), eq(Boolean.class))).andReturn(true).anyTimes();
         expect(database.hasDatabaseChangeLogLockTable()).andReturn(true);
 
+        database.rollback();
+        expectLastCall().times(1);
+
         List<Map> resultList = new ArrayList<Map>();
         Map<String, Object> result = new HashMap<String, Object>();
         result.put("ID", 1);
@@ -337,6 +340,9 @@ public class LockServiceTest {
         expect(executor.queryForObject(isA(SelectFromDatabaseChangeLogLockStatement.class), eq(Boolean.class))).andReturn(true).anyTimes();
         expect(database.hasDatabaseChangeLogLockTable()).andReturn(true);
 
+        database.rollback();
+        expectLastCall().times(1);
+
         List<Map> resultList = new ArrayList<Map>();
 
         expect(executor.queryForList(isA(SelectFromDatabaseChangeLogLockStatement.class))).andReturn(resultList);
@@ -357,6 +363,9 @@ public class LockServiceTest {
         Database database = createMock(Database.class);
 
         expect(database.hasDatabaseChangeLogLockTable()).andReturn(false);
+
+        database.rollback();
+        expectLastCall().times(1);
 
         replay(database);
 


### PR DESCRIPTION
Removed empty DatabaseException catch blocks around database.rollback() calls in the LockService, which were believed to hide the real cause of the problem described in the incident. Initially, it was thought that no databse.rollback() was being called, thus leaving the Oracle lock hanging. However, the code inspection revealed that database.rollback() must have been called (as it was alreay in the finally blocks); however, it must have failed for some reason, and this reason was not reported due to empty DatabaseException catch blocks.
