### PR TITLE
CORE-1243: On loadDataChange exception and failOnError is null/true rethrow ule.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
@@ -175,9 +175,10 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
                 if (getChangeSet() != null && getChangeSet().getFailOnError() != null && !getChangeSet().getFailOnError()) {
                     Logger log = LogFactory.getLogger();
                     log.info("Change set " + getChangeSet().toString(false) + " failed, but failOnError was false.  Error: " + ule.getMessage());        
+                    return new SqlStatement[0];
+                } else {
+                    throw ule;
                 }
-
-            return new SqlStatement[0];
         } finally {
 			if (null != reader) {
 				try {


### PR DESCRIPTION
I ran into an issue where my liquibase changelog/changeset was running successfully, but was not really populating all the data due to an issue matching my CSV file up with the columns. I figured out that the exception was being shallowed by the catch block and fixed it.
