### PR TITLE
Checking the connection before attempting rollback 

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
@@ -55,7 +55,9 @@ public class ValidatingVisitor implements ChangeSetVisitor {
             errorPreconditions.addAll(e.getErrorPreconditions());
         } finally {
             try {
-                database.rollback();
+                if (database.getConnection() != null) {
+                    database.rollback();
+                }
             } catch (DatabaseException e) {
                 LogFactory.getLogger().warning("Error rolling back after precondition check", e);
             }


### PR DESCRIPTION
Checking the connection before attempting rollback  allows for validating the log file while not connected.
