### PR TITLE
Making it possible to use JaCoCo instead of Emma by ignoring synthetic fields

### DIFF
--- a/liquibase-core/src/main/java/liquibase/serializer/core/string/StringChangeLogSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/string/StringChangeLogSerializer.java
@@ -59,7 +59,7 @@ public class StringChangeLogSerializer implements ChangeLogSerializer {
                     if (field.getName().equals("serialVersionUID")) {
                         continue;
                     }
-                    if (field.getName().equals("$VRc")) { //from emma
+                    if (field.isSynthetic() || field.getName().equals("$VRc")) { //from emma
                         continue;
                     }
                     if (field.getName().equals("serialVersionUID")) {

--- a/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
@@ -151,7 +151,7 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
                 if (field.getName().equals("serialVersionUID")) {
                     continue;
                 }
-                if (field.getName().equals("$VRc")) { //from emma
+                if (field.isSynthetic() || field.getName().equals("$VRc")) { //from emma
                     continue;
                 }
 
@@ -188,7 +188,7 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
                 if (field.getName().equals("serialVersionUID")) {
                     continue;
                 }
-                if (field.getName().equals("$VRc")) { //from emma
+                if (field.isSynthetic() || field.getName().equals("$VRc")) { //from emma
                     continue;
                 }
                 

--- a/liquibase-core/src/test/java/liquibase/change/AbstractChangeTest.java
+++ b/liquibase-core/src/test/java/liquibase/change/AbstractChangeTest.java
@@ -52,7 +52,7 @@ public abstract class AbstractChangeTest {
         Map<String, String> seenCheckSums = new HashMap<String, String>();
         for (Field field : change.getClass().getDeclaredFields()) {
             field.setAccessible(true);
-            if (field.getName().startsWith("$VR") || field.getName().equals("serialVersionUID")) {
+            if (field.isSynthetic() || field.getName().startsWith("$VR") || field.getName().equals("serialVersionUID")) {
                 //code coverage related
             } else if (field.getName().equals("associatedWith")) {
                 //currently not used

--- a/liquibase-core/src/test/java/liquibase/serializer/core/string/StringChangeLogSerializerTest.java
+++ b/liquibase-core/src/test/java/liquibase/serializer/core/string/StringChangeLogSerializerTest.java
@@ -267,7 +267,7 @@ public class StringChangeLogSerializerTest {
                 continue;
             }
             field.setAccessible(true);
-            if (field.getType().getName().equals("[[Z")) {
+            if (field.isSynthetic() || field.getType().getName().equals("[[Z")) {
                 //nothing, from emma
             } else if (field.getName().equals("serialVersionUID")) {
                 //nothing

--- a/liquibase-core/src/test/java/liquibase/statement/core/SelectFromDatabaseChangeLogStatementTest.java
+++ b/liquibase-core/src/test/java/liquibase/statement/core/SelectFromDatabaseChangeLogStatementTest.java
@@ -3,6 +3,6 @@ package liquibase.statement.core;
 public class SelectFromDatabaseChangeLogStatementTest extends AbstractSqStatementTest<SelectFromDatabaseChangeLogStatement> {
     @Override
     protected SelectFromDatabaseChangeLogStatement createStatementUnderTest() {
-        return new SelectFromDatabaseChangeLogStatement(null);
+        return new SelectFromDatabaseChangeLogStatement((String[])null);
     }
 }


### PR DESCRIPTION
Making it possible to use JaCoCo instead of Emma by ignoring synthetic fields
