### PR TITLE
Fixes for Hsqldb Integration tests and CORE-1229

### DIFF
--- a/liquibase-core/liquibase-core.iml
+++ b/liquibase-core/liquibase-core.iml
@@ -48,7 +48,7 @@
     <orderEntry type="library" scope="PROVIDED" name="Maven: javax.annotation:jsr250-api:1.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: javax.inject:javax.inject:1" level="project" />
     <orderEntry type="library" name="Maven: org.jboss.weld.se:weld-se:1.1.8.Final" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: hsqldb:hsqldb:1.8.0.7" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.hsqldb:hsqldb:2.2.9" level="project" />
   </component>
 </module>
 

--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -76,7 +76,7 @@
         </dependency>
 
         <dependency>
-            <groupId>hsqldb</groupId>
+            <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
         </dependency>
 

--- a/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -95,6 +95,8 @@ public abstract class AbstractJdbcDatabase implements Database {
 
     protected BigInteger defaultAutoIncrementStartWith = BigInteger.ONE;
     protected BigInteger defaultAutoIncrementBy = BigInteger.ONE;
+    // most databases either lowercase or uppercase unuqoted objects such as table and column names.
+    protected Boolean unquotedObjectsAreUppercased = null;
 
     protected AbstractJdbcDatabase() {
         this.dateFunctions.add(new DatabaseFunction(getCurrentDateTimeFunction()));
@@ -276,7 +278,14 @@ public abstract class AbstractJdbcDatabase implements Database {
     }
 
     public String correctObjectName(String objectName, Class<? extends DatabaseObject> objectType) {
-        return objectName;
+        if (unquotedObjectsAreUppercased == null || objectName == null ||
+                (objectName.startsWith("\"") && objectName.endsWith("\""))) {
+            return objectName;
+        } else if (unquotedObjectsAreUppercased == Boolean.TRUE) {
+            return objectName.toUpperCase();
+        } else {
+            return objectName.toLowerCase();
+        }
     }
 
     public CatalogAndSchema getDefaultSchema() {
@@ -315,11 +324,11 @@ public abstract class AbstractJdbcDatabase implements Database {
     }
 
     public void setDefaultCatalogName(String defaultCatalogName) {
-        this.defaultCatalogName = defaultCatalogName;
+        this.defaultCatalogName = correctObjectName(defaultCatalogName, Catalog.class);
     }
 
     public void setDefaultSchemaName(String schemaName) {
-        this.defaultSchemaName = schemaName;
+        this.defaultSchemaName = correctObjectName(schemaName, Schema.class);
     }
 
     /**

--- a/liquibase-core/src/main/java/liquibase/database/core/H2Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/H2Database.java
@@ -23,8 +23,9 @@ public class H2Database extends AbstractJdbcDatabase {
     private static String SEP_CONCAT = ", ";
 
     public H2Database() {
-        this.dateFunctions.add(new DatabaseFunction("CURRENT_TIMESTAMP()"));
-        sequenceNextValueFunction = "nextval('%s')";
+        super.dateFunctions.add(new DatabaseFunction("CURRENT_TIMESTAMP()"));
+        super.sequenceNextValueFunction = "nextval('%s')";
+        super.unquotedObjectsAreUppercased = Boolean.TRUE;
     }
 
     public String getShortName() {
@@ -53,14 +54,6 @@ public class H2Database extends AbstractJdbcDatabase {
 
     public boolean isCorrectDatabaseImplementation(DatabaseConnection conn) throws DatabaseException {
         return "H2".equals(conn.getDatabaseProductName());
-    }
-
-    @Override
-    public String correctObjectName(String objectName, Class<? extends DatabaseObject> objectType) {
-        if (objectName == null) {
-            return null;
-        }
-        return objectName.toUpperCase();
     }
 
     //    public void dropDatabaseObjects(String schema) throws DatabaseException {

--- a/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
@@ -25,6 +25,7 @@ public class HsqlDatabase extends AbstractJdbcDatabase {
     	super();
     	super.defaultAutoIncrementStartWith = BigInteger.ZERO;
         super.sequenceNextValueFunction = "NEXT VALUE FOR %s";
+        super.unquotedObjectsAreUppercased = Boolean.TRUE;
     }
     
     public boolean isCorrectDatabaseImplementation(DatabaseConnection conn) throws DatabaseException {
@@ -54,11 +55,6 @@ public class HsqlDatabase extends AbstractJdbcDatabase {
 
     public String getShortName() {
         return "hsqldb";
-    }
-
-    @Override
-    public String correctObjectName(String objectName, Class<? extends DatabaseObject> objectType) {
-        return objectName.toUpperCase();
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
@@ -35,18 +35,11 @@ public class OracleDatabase extends AbstractJdbcDatabase {
         dateFunctions.add(new DatabaseFunction("SYSTIMESTAMP"));
         dateFunctions.add(new DatabaseFunction("CURRENT_TIMESTAMP"));
         super.sequenceNextValueFunction = "%s.nextval";
+        super.unquotedObjectsAreUppercased = Boolean.TRUE;
     }
 
     public int getPriority() {
         return PRIORITY_DEFAULT;
-    }
-
-    @Override
-    public String correctObjectName(String objectName, Class<? extends DatabaseObject> objectType) {
-        if (objectName == null) {
-            return null;
-        }
-        return objectName.toUpperCase();
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/datatype/core/BigIntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/BigIntType.java
@@ -31,7 +31,8 @@ public class BigIntType extends LiquibaseDataType {
         if (database instanceof OracleDatabase) {
             return new DatabaseDataType("NUMBER", 38,0);
         }
-        if (database instanceof DB2Database || database instanceof DerbyDatabase || database instanceof MSSQLDatabase) {
+        if (database instanceof DB2Database || database instanceof DerbyDatabase
+                || database instanceof MSSQLDatabase || database instanceof HsqlDatabase) {
             return new DatabaseDataType("BIGINT");
         }
         if (database instanceof PostgresDatabase) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/BooleanType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/BooleanType.java
@@ -27,6 +27,8 @@ public class BooleanType extends LiquibaseDataType {
             return new DatabaseDataType("BIT");
         } else if (database instanceof DerbyDatabase) {
             return new DatabaseDataType("SMALLINT");
+        } else if (database instanceof HsqlDatabase) {
+            return new DatabaseDataType("BOOLEAN");
         }
 
         return super.toDatabaseDataType(database);

--- a/liquibase-core/src/main/java/liquibase/datatype/core/DoubleType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/DoubleType.java
@@ -13,7 +13,7 @@ public class DoubleType  extends LiquibaseDataType {
         if (database instanceof MSSQLDatabase) {
             return new DatabaseDataType("FLOAT");
         }
-        if (database instanceof DB2Database || database instanceof DerbyDatabase) {
+        if (database instanceof DB2Database || database instanceof DerbyDatabase || database instanceof HsqlDatabase) {
             return new DatabaseDataType("DOUBLE");
         }
         if (database instanceof OracleDatabase) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/IntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/IntType.java
@@ -36,7 +36,7 @@ public class IntType extends LiquibaseDataType {
                 return new DatabaseDataType("SERIAL");
             }
         }
-        if (database instanceof MSSQLDatabase) {
+        if (database instanceof MSSQLDatabase || database instanceof HsqlDatabase) {
             return new DatabaseDataType("INT");
         }
         return super.toDatabaseDataType(database);

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
@@ -3,6 +3,7 @@ package liquibase.snapshot.jvm;
 import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.Database;
 import liquibase.database.core.DB2Database;
+import liquibase.database.core.HsqlDatabase;
 import liquibase.database.core.MSSQLDatabase;
 import liquibase.database.core.MySQLDatabase;
 import liquibase.database.core.OracleDatabase;
@@ -80,7 +81,7 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
 
     protected List<Map> listConstraints(Table table, Database database, Schema schema) throws DatabaseException {
         String sql = null;
-        if (database instanceof MySQLDatabase) {
+        if (database instanceof MySQLDatabase || database instanceof HsqlDatabase) {
             sql = "select CONSTRAINT_NAME " +
                     "from information_schema.table_constraints " +
                     "where constraint_schema='" + database.correctObjectName(schema.getCatalogName(), Catalog.class) + "' " +
@@ -123,7 +124,7 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
         String name = example.getName();
 
         String sql = null;
-        if (database instanceof MySQLDatabase) {
+        if (database instanceof MySQLDatabase || database instanceof HsqlDatabase) {
             sql = "select const.CONSTRAINT_NAME, COLUMN_NAME " +
                     "from information_schema.table_constraints const " +
                     "join information_schema.key_column_usage col " +

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/GetViewDefinitionGeneratorHsql.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/GetViewDefinitionGeneratorHsql.java
@@ -25,7 +25,7 @@ public class GetViewDefinitionGeneratorHsql extends GetViewDefinitionGenerator {
         CatalogAndSchema schema = database.correctSchema(new CatalogAndSchema(statement.getCatalogName(), statement.getSchemaName()));
 
         return new Sql[] {
-                    new UnparsedSql("SELECT VIEW_DEFINITION FROM INFORMATION_SCHEMA.SYSTEM_VIEWS WHERE TABLE_NAME = '" + statement.getViewName() + "' AND TABLE_SCHEMA='" + schema.getSchemaName() + "'")
+                    new UnparsedSql("SELECT VIEW_DEFINITION FROM INFORMATION_SCHEMA.VIEWS WHERE TABLE_NAME = '" + statement.getViewName() + "' AND TABLE_SCHEMA='" + schema.getSchemaName() + "'")
             };
     }
 }

--- a/liquibase-core/src/main/java/liquibase/structure/AbstractDatabaseObject.java
+++ b/liquibase-core/src/main/java/liquibase/structure/AbstractDatabaseObject.java
@@ -20,6 +20,9 @@ public abstract class AbstractDatabaseObject implements DatabaseObject {
     }
 
     public void setSnapshotId(UUID snapshotId) {
+        if (snapshotId == null) {
+            throw new UnexpectedLiquibaseException("Must be a non null uuid");
+        }
         if (this.snapshotId != null) {
             throw new UnexpectedLiquibaseException("snapshotId already set");
         }

--- a/liquibase-core/src/test/java/liquibase/integration/cdi/CDITestProducer.java
+++ b/liquibase-core/src/test/java/liquibase/integration/cdi/CDITestProducer.java
@@ -3,7 +3,7 @@ package liquibase.integration.cdi;
 import liquibase.integration.cdi.annotations.LiquibaseType;
 import liquibase.resource.ClassLoaderResourceAccessor;
 import liquibase.resource.ResourceAccessor;
-import org.hsqldb.jdbc.jdbcDataSource;
+import org.hsqldb.jdbc.JDBCDataSource;
 import org.jboss.weld.resources.ClassLoaderResourceLoader;
 
 import javax.enterprise.inject.Produces;
@@ -30,7 +30,7 @@ public class CDITestProducer {
 
     @Produces @LiquibaseType
     public DataSource createDataSource() throws SQLException {
-        jdbcDataSource ds = new jdbcDataSource();
+        JDBCDataSource ds = new JDBCDataSource();
         ds.setDatabase("jdbc:hsqldb:mem:test");
         ds.setUser("sa");
         ds.setPassword("");

--- a/liquibase-integration-tests/liquibase-integration-tests.iml
+++ b/liquibase-integration-tests/liquibase-integration-tests.iml
@@ -32,7 +32,7 @@
     <orderEntry type="module" module-name="liquibase-ext-change" scope="TEST" />
     <orderEntry type="module" module-name="liquibase-ext-changewithnestedtags" scope="TEST" />
     <orderEntry type="module" module-name="liquibase-ext-sqlgenerator" scope="TEST" />
-    <orderEntry type="library" scope="TEST" name="Maven: hsqldb:hsqldb:1.8.0.7" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.hsqldb:hsqldb:2.2.9" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.apache.derby:derby:10.2.2.0" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.apache.maven.shared:maven-verifier:1.2" level="project" />
   </component>

--- a/liquibase-integration-tests/pom.xml
+++ b/liquibase-integration-tests/pom.xml
@@ -74,7 +74,7 @@
         </dependency>
         <!-- JDBC drivers -->
         <dependency>
-            <groupId>hsqldb</groupId>
+            <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
         </dependency>
         <dependency>

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
@@ -213,7 +213,7 @@ public abstract class AbstractIntegrationTest {
 
     protected CatalogAndSchema[] getSchemasToDrop() throws DatabaseException {
         return new CatalogAndSchema[]{
-                new CatalogAndSchema(null, "liquibaseb".toUpperCase()),
+                new CatalogAndSchema(null, database.correctObjectName("liquibaseb", Schema.class)),
                 new CatalogAndSchema(null, database.getDefaultSchemaName())
         };
     }

--- a/liquibase-integration-tests/src/test/resources/changelogs/common/common.tests.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/common/common.tests.changelog.xml
@@ -484,7 +484,7 @@
             <column name="id" type="int">
                 <constraints primaryKey="true"/>
             </column>
-            <column name="ref" type="int">
+            <column name="referee" type="int">
                 <constraints foreignKeyName="fk_reftest" references="createtablenamedpk(id)"/>
             </column>
         </createTable>

--- a/liquibase-integration-tests/src/test/resources/changelogs/hsqldb/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/hsqldb/complete/root.changelog.xml
@@ -319,7 +319,7 @@
     </changeSet>
 
     <changeSet id="61" author="nvoxland">
-        <createTable tableName="user">
+        <createTable tableName="sampleUser">
             <column name="id" type="int"/>
             <column name="user" type="int"/>
         </createTable>

--- a/liquibase.ipr
+++ b/liquibase.ipr
@@ -494,17 +494,6 @@
         <root url="jar://$MAVEN_REPOSITORY$/doxia/doxia-sink-api/1.0-alpha-4/doxia-sink-api-1.0-alpha-4-sources.jar!/" />
       </SOURCES>
     </library>
-    <library name="Maven: hsqldb:hsqldb:1.8.0.7">
-      <CLASSES>
-        <root url="jar://$MAVEN_REPOSITORY$/hsqldb/hsqldb/1.8.0.7/hsqldb-1.8.0.7.jar!/" />
-      </CLASSES>
-      <JAVADOC>
-        <root url="jar://$MAVEN_REPOSITORY$/hsqldb/hsqldb/1.8.0.7/hsqldb-1.8.0.7-javadoc.jar!/" />
-      </JAVADOC>
-      <SOURCES>
-        <root url="jar://$MAVEN_REPOSITORY$/hsqldb/hsqldb/1.8.0.7/hsqldb-1.8.0.7-sources.jar!/" />
-      </SOURCES>
-    </library>
     <library name="Maven: javax.annotation:jsr250-api:1.0">
       <CLASSES>
         <root url="jar://$MAVEN_REPOSITORY$/javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar!/" />
@@ -888,6 +877,17 @@
       </JAVADOC>
       <SOURCES>
         <root url="jar://$MAVEN_REPOSITORY$/org/easymock/easymockclassextension/2.5.2/easymockclassextension-2.5.2-sources.jar!/" />
+      </SOURCES>
+    </library>
+    <library name="Maven: org.hsqldb:hsqldb:2.2.9">
+      <CLASSES>
+        <root url="jar://$MAVEN_REPOSITORY$/org/hsqldb/hsqldb/2.2.9/hsqldb-2.2.9.jar!/" />
+      </CLASSES>
+      <JAVADOC>
+        <root url="jar://$MAVEN_REPOSITORY$/org/hsqldb/hsqldb/2.2.9/hsqldb-2.2.9-javadoc.jar!/" />
+      </JAVADOC>
+      <SOURCES>
+        <root url="jar://$MAVEN_REPOSITORY$/org/hsqldb/hsqldb/2.2.9/hsqldb-2.2.9-sources.jar!/" />
       </SOURCES>
     </library>
     <library name="Maven: org.javassist:javassist:3.17.1-GA">

--- a/pom.xml
+++ b/pom.xml
@@ -166,9 +166,9 @@
 
             <!-- JDBC drivers -->
             <dependency>
-                <groupId>hsqldb</groupId>
+                <groupId>org.hsqldb</groupId>
                 <artifactId>hsqldb</artifactId>
-                <version>1.8.0.7</version>
+                <version>2.2.9</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
Added fix suggested for Holger Willebrandt for GetViewDefinitionGeneratorHsql.
Tested and it works fine now.

Revved hsqldb to version 2.2.9
This version adheres to the sql standards.
It contains a TABLE_CONSTRAINTS table in the information_schema.
Added checks for HsqlDatabase to Int, Double, BigInt and Boolean toDatabaseType methods.
Sizes were being incorrectly appended. E.g. boolean(0);

Fixed bug with setting defaultSchemaName.
The default schema name that is set should be corrected by the implementing database.
E.g. setting 'liquibaseb' as the default schema name for Hsqldb is actually setting 'LIQUBASEB' as the defualt schema name.
This difference means that snapshot checks fail to realize that the DatabaseChangeLogLock table already exists.

Modified the correctObjectName method in AbstractJdbcDatabase.
Based on a conditional property unquotedObjectsAreUppercased, unquoted objects are either uppercased or lowercased.
This reflects typical database handling. Quoted objects don't have their case changed in any database that I've worked with.
