### PR TITLE
Fix for CORE-1251

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/H2Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/H2Database.java
@@ -144,9 +144,8 @@ public class H2Database extends AbstractJdbcDatabase {
         return true;
     }
 
-
     @Override
-    public String getDefaultSchemaName() {
+    protected String doGetDefaultSchemaName() {
         return "PUBLIC";
     }
 


### PR DESCRIPTION
Overide doGetDefaultSchmea instead of getDefaultSchema so an alternative default schema can actually be set.
