### PR TITLE
Added flag to databaseChangeLog to allow skipping of checksum validation...

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -21,6 +21,8 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
     private String physicalFilePath;
     private String logicalFilePath;
 
+    private boolean skipChecksumValidation = false;
+
     private List<ChangeSet> changeSets = new ArrayList<ChangeSet>();
     private ChangeLogParameters changeLogParameters;
 
@@ -79,6 +81,17 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
     @Override
     public String toString() {
         return getFilePath();
+    }
+
+    /**
+     * @return Whether validation of a changeset should occur
+     */
+    public boolean isSkipChecksumValidation() {
+        return skipChecksumValidation;
+    }
+
+    public void setSkipChecksumValidation(boolean skipChecksumValidation) {
+        this.skipChecksumValidation = skipChecksumValidation;
     }
 
     public int compareTo(DatabaseChangeLog o) {

--- a/liquibase-core/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
@@ -103,7 +103,7 @@ public class ValidatingVisitor implements ChangeSetVisitor {
             }
         }
 
-        if(ranChangeSet != null){
+        if(!databaseChangeLog.isSkipChecksumValidation() && ranChangeSet != null){
             if (!changeSet.isCheckSumValid(ranChangeSet.getLastCheckSum())) {
                 if (!changeSet.shouldRunOnChange()) {
                     invalidMD5Sums.add(changeSet);

--- a/liquibase-core/src/main/java/liquibase/parser/core/xml/XMLChangeLogSAXHandler.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/xml/XMLChangeLogSAXHandler.java
@@ -135,6 +135,8 @@ class XMLChangeLogSAXHandler extends DefaultHandler {
 				}
 				databaseChangeLog.setLogicalFilePath(atts
 						.getValue("logicalFilePath"));
+                databaseChangeLog.setSkipChecksumValidation(Boolean.TRUE.toString()
+                        .equalsIgnoreCase(atts.getValue("skipChecksumValidation")));
 			} else if ("include".equals(qName)) {
 				String fileName = atts.getValue("file");
 				fileName = fileName.replace('\\', '/');

--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.0.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.0.xsd
@@ -228,6 +228,7 @@
 	<!-- Attributes for changeSet -->
 	<xsd:attributeGroup name="changeLogAttributes">
 		<xsd:attribute name="logicalFilePath" type="xsd:string" />
+        <xsd:attribute name="skipChecksumValidation"  type="xsd:boolean" />
 	</xsd:attributeGroup>
 
 	<!-- Attributes for changeSet -->

--- a/liquibase-integration-tests/src/test/resources/changelogs/common/skipChecksumValidation/invalid.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/common/skipChecksumValidation/invalid.changelog.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- similar to updated.changelog.xml but with no skipping of checksum validation -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd"
+        logicalFilePath="original.changelog.xml">
+
+    <changeSet id="sample1" author="dbiggs">
+        <createTable tableName="dataTypeTest">
+            <column name="id" type="int" />
+            <column name="dateCol" type="date"/>
+            <column name="timeCol" type="time"/>
+            <column name="dateTimeCol" type="dateTime"/>
+            <column name="bigintcol" type="bigint"/>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="sample2" author="dbiggs">
+        <insert tableName="dataTypeTest">
+            <column name="id" valueNumeric="1"/>
+            <column name="dateCol" valueDate="2007-08-09"/>
+            <column name="timeCol" valueDate="13:14:15"/>
+            <column name="dateTimeCol" valueDate="2007-08-09T13:14:15"/>
+            <!-- updated value for bigintcol to 12 -->
+            <column name="bigintcol" valueNumeric="9"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>

--- a/liquibase-integration-tests/src/test/resources/changelogs/common/skipChecksumValidation/original.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/common/skipChecksumValidation/original.changelog.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd"
+        logicalFilePath="original.changelog.xml">
+
+    <changeSet id="sample1" author="dbiggs">
+        <createTable tableName="dataTypeTest">
+            <column name="id" type="int" />
+            <column name="dateCol" type="date"/>
+            <column name="timeCol" type="time"/>
+            <column name="dateTimeCol" type="dateTime"/>
+            <column name="bigintcol" type="bigint"/>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="sample2" author="dbiggs">
+        <insert tableName="dataTypeTest">
+            <column name="id" valueNumeric="1"/>
+            <column name="dateCol" valueDate="2007-08-09"/>
+            <column name="timeCol" valueDate="13:14:15"/>
+            <column name="dateTimeCol" valueDate="2007-08-09T13:14:15"/>
+            <column name="bigintcol" valueNumeric="6"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>

--- a/liquibase-integration-tests/src/test/resources/changelogs/common/skipChecksumValidation/updated.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/common/skipChecksumValidation/updated.changelog.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd"
+        logicalFilePath="original.changelog.xml"
+        skipChecksumValidation="true">
+
+    <changeSet id="sample1" author="dbiggs">
+        <createTable tableName="dataTypeTest" schemaName="">
+            <column name="id" type="int" />
+            <column name="dateCol" type="date"/>
+            <column name="timeCol" type="time"/>
+            <column name="dateTimeCol" type="dateTime"/>
+            <column name="bigintcol" type="bigint"/>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="sample2" author="dbiggs">
+        <insert tableName="dataTypeTest">
+            <column name="id" valueNumeric="1"/>
+            <column name="dateCol" valueDate="2007-08-09"/>
+            <column name="timeCol" valueDate="13:14:15"/>
+            <column name="dateTimeCol" valueDate="2007-08-09T13:14:15"/>
+            <!-- updated value for bigintcol to 9 -->
+            <column name="bigintcol" valueNumeric="9"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
....

Currently, there's no way to make improvements to old changesets without breaking users who have already ran those change sets. This approach allows the ability to skip validation for a change log.

This is a rework of my first attempt at this.
My first approach was too coarse grained, it removed the validation of the actual
changes in a changeset. This approach just prevents the validation of checksums for
changesets that have already ran.

Added integration test for the new functionality.
Tested using H2IntegrationTests.



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-127) by [Unito](https://www.unito.io/learn-more)
