### PR TITLE
Add LongVarcharType

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/ClobType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/ClobType.java
@@ -6,11 +6,11 @@ import liquibase.datatype.DataTypeInfo;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.LiquibaseDataType;
 
-@DataTypeInfo(name="clob", aliases = {"longvarchar", "text", "longtext", "java.sql.Types.LONGVARCHAR", "java.sql.Types.CLOB"}, minParameters = 0, maxParameters = 0, priority = LiquibaseDataType.PRIORITY_DEFAULT)
+@DataTypeInfo(name="clob", aliases = {"text", "longtext", "java.sql.Types.CLOB"}, minParameters = 0, maxParameters = 0, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class ClobType extends LiquibaseDataType {
     @Override
     public DatabaseDataType toDatabaseDataType(Database database) {
-        if (database instanceof CacheDatabase || database instanceof H2Database || database instanceof HsqlDatabase) {
+        if (database instanceof CacheDatabase) {
             return new DatabaseDataType("LONGVARCHAR");
         }   else if (database instanceof FirebirdDatabase) {
             return new DatabaseDataType("BLOB SUB_TYPE TEXT");
@@ -22,8 +22,7 @@ public class ClobType extends LiquibaseDataType {
             return new DatabaseDataType("LONGTEXT");
         } else if (database instanceof PostgresDatabase || database instanceof SQLiteDatabase || database instanceof SybaseDatabase) {
             return new DatabaseDataType("TEXT");
-        }
-        if (database instanceof OracleDatabase) {
+        } else if (database instanceof OracleDatabase || database instanceof H2Database || database instanceof HsqlDatabase) {
             return new DatabaseDataType("CLOB");
         }
         return super.toDatabaseDataType(database);

--- a/liquibase-core/src/main/java/liquibase/datatype/core/LongVarcharType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/LongVarcharType.java
@@ -1,0 +1,22 @@
+package liquibase.datatype.core;
+
+import liquibase.database.Database;
+import liquibase.database.core.H2Database;
+import liquibase.database.core.HsqlDatabase;
+import liquibase.datatype.DataTypeInfo;
+import liquibase.datatype.DatabaseDataType;
+import liquibase.datatype.LiquibaseDataType;
+
+@DataTypeInfo(name="longvarchar", aliases = {"java.sql.Types.LONGVARCHAR"}, minParameters = 0, maxParameters = 0, priority = LiquibaseDataType.PRIORITY_DEFAULT)
+
+public class LongVarcharType extends ClobType {
+
+    @Override
+    public DatabaseDataType toDatabaseDataType(Database database) {
+        if (database instanceof H2Database || database instanceof HsqlDatabase) {
+            return new DatabaseDataType("LONGVARCHAR");
+        } else {
+            return super.toDatabaseDataType(database);
+        }
+    }
+}

--- a/liquibase-integration-tests/src/test/resources/changelogs/common/common.tests.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/common/common.tests.changelog.xml
@@ -263,6 +263,7 @@
             <column name="uuidColumn" type="uuid"/>
             <column name="blobColumn" type="blob"/>
             <column name="clobColumn" type="clob"/>
+            <column name="longVarcharColumn" type="longvarchar"/>
             <column name="dateColumn" type="date"/>
             <column name="timeColumn" type="time"/>
             <column name="datetimeColumn" type="datetime"/>


### PR DESCRIPTION
Currently both H2 and Hsqldb have their datatype set to LongVarchar for Clob even though both databases support the CLOB datatype.

Now longvarchar is only used if explicitly set.

Added test to common.changelog.xml for Longvarchar type.
