### PR TITLE
Added current date time placeholder function name.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -96,11 +96,6 @@ public abstract class AbstractJdbcDatabase implements Database {
     protected BigInteger defaultAutoIncrementStartWith = BigInteger.ONE;
     protected BigInteger defaultAutoIncrementBy = BigInteger.ONE;
 
-    protected AbstractJdbcDatabase() {
-        this.dateFunctions.add(new DatabaseFunction(getCurrentDateTimeFunction()));
-        this.sequenceNextValueFunction = "NEXTVAL('%s')";
-    }
-
     public String getName() {
         return toString();
     }
@@ -355,6 +350,7 @@ public abstract class AbstractJdbcDatabase implements Database {
     public void setCurrentDateTimeFunction(String function) {
         if (function != null) {
             this.currentDateTimeFunction = function;
+            this.dateFunctions.add(new DatabaseFunction(function));
         }
     }
 
@@ -1385,5 +1381,9 @@ public abstract class AbstractJdbcDatabase implements Database {
 
     public boolean dataTypeIsNotModifiable(final String typeName) {
         return unmodifiableDataTypes.contains(typeName.toLowerCase());
+    }
+
+    public String getCurrentDateTimeFunction() {
+        return currentDateTimeFunction;
     }
 }

--- a/liquibase-core/src/main/java/liquibase/database/core/CacheDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/CacheDatabase.java
@@ -8,14 +8,8 @@ import liquibase.exception.DatabaseException;
 public class CacheDatabase extends AbstractJdbcDatabase {
     public static final String PRODUCT_NAME = "cache";
 
-
-
-    public String getCurrentDateTimeFunction() {
-        if (currentDateTimeFunction != null) {
-            return currentDateTimeFunction;
-        }
-
-        return "SYSDATE";
+    public CacheDatabase() {
+        super.setCurrentDateTimeFunction("SYSDATE");
     }
 
     public String getDefaultDriver(String url) {

--- a/liquibase-core/src/main/java/liquibase/database/core/DB2Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/DB2Database.java
@@ -19,6 +19,7 @@ public class DB2Database extends AbstractJdbcDatabase {
     private String defaultSchemaName;
 
     public DB2Database() {
+        super.setCurrentDateTimeFunction("CURRENT TIMESTAMP");
         super.sequenceNextValueFunction = "nextval for %s";
     }
     
@@ -100,14 +101,6 @@ public class DB2Database extends AbstractJdbcDatabase {
 
     public boolean supportsInitiallyDeferrableColumns() {
         return false;
-    }
-
-    public String getCurrentDateTimeFunction() {
-        if (currentDateTimeFunction != null) {
-            return currentDateTimeFunction;
-        }
-
-        return "CURRENT TIMESTAMP";
     }
 
     /**

--- a/liquibase-core/src/main/java/liquibase/database/core/DerbyDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/DerbyDatabase.java
@@ -22,8 +22,9 @@ public class DerbyDatabase extends AbstractJdbcDatabase {
     protected int driverVersionMinor;
 
     public DerbyDatabase() {
-        determineDriverVersion();
+        super.setCurrentDateTimeFunction("CURRENT_TIMESTAMP");
         super.sequenceNextValueFunction = "NEXT VALUE FOR %s";
+        determineDriverVersion();
     }
 
     public boolean isCorrectDatabaseImplementation(DatabaseConnection conn) throws DatabaseException {
@@ -72,14 +73,6 @@ public class DerbyDatabase extends AbstractJdbcDatabase {
 
     public boolean supportsInitiallyDeferrableColumns() {
         return false;
-    }
-
-    public String getCurrentDateTimeFunction() {
-        if (currentDateTimeFunction != null) {
-            return currentDateTimeFunction;
-        }
-
-        return "CURRENT_TIMESTAMP";
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/database/core/FirebirdDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/FirebirdDatabase.java
@@ -14,8 +14,8 @@ import liquibase.structure.core.Table;
 public class FirebirdDatabase extends AbstractJdbcDatabase {
 
     public FirebirdDatabase() {
-        super();
-        super.sequenceNextValueFunction = "NEXT VALUE FOR %s";
+        super.setCurrentDateTimeFunction("CURRENT_TIMESTAMP");
+        super.sequenceNextValueFunction="NEXT VALUE FOR %s";
     }
 
     public boolean isCorrectDatabaseImplementation(DatabaseConnection conn) throws DatabaseException {
@@ -53,14 +53,6 @@ public class FirebirdDatabase extends AbstractJdbcDatabase {
 
     public boolean supportsInitiallyDeferrableColumns() {
         return false;
-    }
-
-    public String getCurrentDateTimeFunction() {
-        if (currentDateTimeFunction != null) {
-            return currentDateTimeFunction;
-        }
-
-        return "CURRENT_TIMESTAMP";
     }
 
     public boolean supportsTablespaces() {

--- a/liquibase-core/src/main/java/liquibase/database/core/H2Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/H2Database.java
@@ -23,8 +23,9 @@ public class H2Database extends AbstractJdbcDatabase {
     private static String SEP_CONCAT = ", ";
 
     public H2Database() {
+        super.setCurrentDateTimeFunction("NOW()");
+        super.sequenceNextValueFunction = "nextval('%s')";
         this.dateFunctions.add(new DatabaseFunction("CURRENT_TIMESTAMP()"));
-        sequenceNextValueFunction = "nextval('%s')";
     }
 
     public String getShortName() {
@@ -245,14 +246,6 @@ public class H2Database extends AbstractJdbcDatabase {
 
     public boolean supportsInitiallyDeferrableColumns() {
         return false;
-    }
-
-    public String getCurrentDateTimeFunction() {
-        if (currentDateTimeFunction != null) {
-            return currentDateTimeFunction;
-        }
-
-        return "NOW()";
     }
 
 }

--- a/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
@@ -22,9 +22,9 @@ public class HsqlDatabase extends AbstractJdbcDatabase {
     private static String SEP_CONCAT = ", ";
 
     public HsqlDatabase() {
-    	super();
-    	super.defaultAutoIncrementStartWith = BigInteger.ZERO;
+    	super.setCurrentDateTimeFunction("NOW");
         super.sequenceNextValueFunction = "NEXT VALUE FOR %s";
+    	super.defaultAutoIncrementStartWith = BigInteger.ZERO;
     }
     
     public boolean isCorrectDatabaseImplementation(DatabaseConnection conn) throws DatabaseException {
@@ -80,14 +80,6 @@ public class HsqlDatabase extends AbstractJdbcDatabase {
         return "PUBLIC";
     }
 
-    public String getCurrentDateTimeFunction() {
-        if (currentDateTimeFunction != null) {
-            return currentDateTimeFunction;
-        }
-
-        return "NOW";
-    }
-    
     @Override
     public String getConcatSql(String... values) {
         if (values == null) {

--- a/liquibase-core/src/main/java/liquibase/database/core/InformixDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/InformixDatabase.java
@@ -46,8 +46,9 @@ public class InformixDatabase extends AbstractJdbcDatabase {
     		Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
 	public InformixDatabase() {
-		super();
-		systemTablesAndViews.add("systables");
+        super.setCurrentDateTimeFunction("CURRENT " + DATETIME_FIELD_QUALIFIER);
+        super.sequenceNextValueFunction = "%s.NEXTVAL";
+        systemTablesAndViews.add("systables");
 		systemTablesAndViews.add("syscolumns");
 		systemTablesAndViews.add("sysindices");
 		systemTablesAndViews.add("systabauth");
@@ -110,7 +111,6 @@ public class InformixDatabase extends AbstractJdbcDatabase {
 
 		systemTablesAndViews.add("sysdomains");
 		systemTablesAndViews.add("sysindexes");
-        super.sequenceNextValueFunction = "%s.NEXTVAL";
 	}
 
 	@Override
@@ -152,14 +152,6 @@ public class InformixDatabase extends AbstractJdbcDatabase {
 		}
     }
 	
-	public String getCurrentDateTimeFunction() {
-        if (currentDateTimeFunction != null) {
-            return currentDateTimeFunction;
-        }
-
-		return "CURRENT " + DATETIME_FIELD_QUALIFIER;
-	}
-
 	public String getDefaultDriver(String url) {
 		if (url.startsWith("jdbc:informix-sqli")) {
 			return "com.informix.jdbc.IfxDriver";

--- a/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
@@ -37,6 +37,7 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
     }
 
     public MSSQLDatabase() {
+        super.setCurrentDateTimeFunction("GETDATE()");
         setDefaultSchemaName("dbo");
 
         systemTablesAndViews.add("syscolumns");
@@ -104,14 +105,6 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
             return "net.sourceforge.jtds.jdbc.Driver";
         }
         return null;
-    }
-
-    public String getCurrentDateTimeFunction() {
-        if (currentDateTimeFunction != null) {
-            return currentDateTimeFunction;
-        }
-
-        return "GETDATE()";
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/database/core/MaxDBDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MaxDBDatabase.java
@@ -18,7 +18,8 @@ public class MaxDBDatabase extends AbstractJdbcDatabase {
     protected Set<String> systemTablesAndViews = new HashSet<String>();
 
     public MaxDBDatabase() {
-        super();
+        super.setCurrentDateTimeFunction("TIMESTAMP");
+        super.sequenceNextValueFunction="%s.NEXTVAL";
         systemTablesAndViews.add("---");
 
         systemTablesAndViews.add("ACTIVECONFIGURATION");
@@ -82,7 +83,6 @@ public class MaxDBDatabase extends AbstractJdbcDatabase {
         systemTablesAndViews.add("TRANSACTIONS");
         systemTablesAndViews.add("UNLOADEDSTATEMENTS");
         systemTablesAndViews.add("VERSION");
-        super.sequenceNextValueFunction = "%s.NEXTVAL";
 
     }
 
@@ -126,14 +126,6 @@ public class MaxDBDatabase extends AbstractJdbcDatabase {
             return "com.sap.dbtech.jdbc.DriverSapDB";
         }
         return null;
-    }
-
-    public String getCurrentDateTimeFunction() {
-        if (currentDateTimeFunction != null) {
-            return currentDateTimeFunction;
-        }
-
-        return "TIMESTAMP";
     }
 
 

--- a/liquibase-core/src/main/java/liquibase/database/core/MySQLDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MySQLDatabase.java
@@ -18,6 +18,10 @@ import liquibase.statement.core.RawSqlStatement;
 public class MySQLDatabase extends AbstractJdbcDatabase {
     public static final String PRODUCT_NAME = "MySQL";
 
+    public MySQLDatabase() {
+        super.setCurrentDateTimeFunction("NOW()");
+    }
+
     public String getShortName() {
         return "mysql";
     }
@@ -72,14 +76,6 @@ public class MySQLDatabase extends AbstractJdbcDatabase {
 
     public boolean supportsInitiallyDeferrableColumns() {
         return false;
-    }
-
-    public String getCurrentDateTimeFunction() {
-        if (currentDateTimeFunction != null) {
-            return currentDateTimeFunction;
-        }
-
-        return "NOW()";
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
@@ -30,6 +30,7 @@ public class OracleDatabase extends AbstractJdbcDatabase {
     private Set<String> reservedWords = new HashSet<String>();
 
     public OracleDatabase() {
+        super.setCurrentDateTimeFunction("SYSTIMESTAMP");
         // Setting list of Oracle's native functions
         dateFunctions.add(new DatabaseFunction("SYSDATE"));
         dateFunctions.add(new DatabaseFunction("SYSTIMESTAMP"));
@@ -156,13 +157,6 @@ public class OracleDatabase extends AbstractJdbcDatabase {
             return "oracle.jdbc.OracleDriver";
         }
         return null;
-    }
-
-    public String getCurrentDateTimeFunction() {
-        if (currentDateTimeFunction != null) {
-            return currentDateTimeFunction;
-        }
-        return "SYSTIMESTAMP";
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/database/core/PostgresDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/PostgresDatabase.java
@@ -28,6 +28,7 @@ public class PostgresDatabase extends AbstractJdbcDatabase {
     private Set<String> reservedWords = new HashSet<String>();
 
     public PostgresDatabase() {
+        super.setCurrentDateTimeFunction("NOW()");
         reservedWords.addAll(Arrays.asList("USER", "LIKE", "GROUP", "DATE", "ALL"));
         super.sequenceNextValueFunction = "NEXTVAL('%s')";
         super.unmodifiableDataTypes.addAll(Arrays.asList("bool", "int4", "int8", "float4", "float8", "numeric", "bigserial", "serial", "bytea", "timestamptz"));
@@ -137,14 +138,6 @@ public class PostgresDatabase extends AbstractJdbcDatabase {
     @Override
     public boolean supportsSequences() {
         return true;
-    }
-
-    public String getCurrentDateTimeFunction() {
-        if (currentDateTimeFunction != null) {
-            return currentDateTimeFunction;
-        }
-
-        return "NOW()";
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/database/core/SQLiteDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/SQLiteDatabase.java
@@ -28,16 +28,11 @@ public class SQLiteDatabase extends AbstractJdbcDatabase {
         systemTables.add("sqlite_sequence");
     }
 
-    public static final String PRODUCT_NAME = "SQLite";
-
-    public String getCurrentDateTimeFunction() {
-        if (currentDateTimeFunction != null) {
-            return currentDateTimeFunction;
-        }
-        
-        return "CURRENT_TIMESTAMP";
+    public SQLiteDatabase() {
+        super.setCurrentDateTimeFunction("CURRENT_TIMESTAMP");
     }
 
+    public static final String PRODUCT_NAME = "SQLite";
 
     public String getDefaultDriver(String url) {
         if (url.startsWith("jdbc:sqlite:")) {
@@ -58,7 +53,7 @@ public class SQLiteDatabase extends AbstractJdbcDatabase {
 
     @Override
     protected String getDefaultDatabaseProductName() {
-        return "SQLite";
+        return PRODUCT_NAME;
     }
 
     public Integer getDefaultPort() {
@@ -67,7 +62,7 @@ public class SQLiteDatabase extends AbstractJdbcDatabase {
 
     public boolean isCorrectDatabaseImplementation(DatabaseConnection conn)
             throws DatabaseException {
-        return "SQLite".equalsIgnoreCase(conn.getDatabaseProductName());
+        return PRODUCT_NAME.equalsIgnoreCase(conn.getDatabaseProductName());
     }
 
     public boolean supportsInitiallyDeferrableColumns() {

--- a/liquibase-core/src/main/java/liquibase/database/core/SybaseASADatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/SybaseASADatabase.java
@@ -122,23 +122,13 @@ public class SybaseASADatabase extends AbstractJdbcDatabase {
 	 */
 	public SybaseASADatabase() {
 		super();
+        super.setCurrentDateTimeFunction("now()");
 	}
 
     public int getPriority() {
         return PRIORITY_DEFAULT;
     }
     
-	/* (non-Javadoc)
-	 * @see liquibase.database.Database#getCurrentDateTimeFunction()
-	 */
-	public String getCurrentDateTimeFunction() {
-        if (currentDateTimeFunction != null) {
-            return currentDateTimeFunction;
-        }
-        
-		return "now()";
-	}
-
 	/* (non-Javadoc)
 	 * @see liquibase.database.Database#getDefaultDriver(java.lang.String)
 	 */

--- a/liquibase-core/src/main/java/liquibase/database/core/SybaseDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/SybaseDatabase.java
@@ -24,15 +24,12 @@ public class SybaseDatabase extends AbstractJdbcDatabase {
     public static final String PRODUCT_NAME = "Adaptive Server Enterprise";
     protected Set<String> systemTablesAndViews = new HashSet<String>();
 
-    public String getProductName() {
-        return "Sybase SQL Server";
-    }
-
     public String getShortName() {
         return "sybase";
     }
 
     public SybaseDatabase() {
+        super.setCurrentDateTimeFunction("GETDATE()");
         systemTablesAndViews.add("syscolumns");
         systemTablesAndViews.add("syscomments");
         systemTablesAndViews.add("sysdepends");
@@ -107,7 +104,7 @@ public class SybaseDatabase extends AbstractJdbcDatabase {
     // package private to facilitate testing
     boolean isSybaseProductName(String dbProductName) {
         return
-                "Adaptive Server Enterprise".equals(dbProductName)
+                PRODUCT_NAME.equals(dbProductName)
                 || "Sybase SQL Server".equals(dbProductName)
                 || "sql server".equals(dbProductName)
                 || "ASE".equals(dbProductName);
@@ -120,14 +117,6 @@ public class SybaseDatabase extends AbstractJdbcDatabase {
             return "net.sourceforge.jtds.jdbc.Driver";
         }
         return null;
-    }
-
-    public String getCurrentDateTimeFunction() {
-        if (currentDateTimeFunction != null) {
-            return currentDateTimeFunction;
-        }
-        
-        return "GETDATE()";
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/datatype/LiquibaseDataType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/LiquibaseDataType.java
@@ -3,6 +3,7 @@ package liquibase.datatype;
 import liquibase.database.Database;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.servicelocator.PrioritizedService;
+import liquibase.statement.DatabaseFunction;
 import liquibase.statement.SequenceFunction;
 
 import java.util.ArrayList;
@@ -166,7 +167,7 @@ public abstract class LiquibaseDataType implements PrioritizedService {
 
     protected boolean isCurrentDateTimeFunction(String string, Database database) {
         return string.toLowerCase().startsWith("current_timestamp")
-                || string.toLowerCase().startsWith("current_datetime")
+                || string.toLowerCase().startsWith(DatabaseFunction.CURRENT_DATE_TIME_PLACE_HOLDER)
                 || database.getCurrentDateTimeFunction().equalsIgnoreCase(string);
     }
 }

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/InsertGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/InsertGenerator.java
@@ -6,6 +6,7 @@ import liquibase.exception.ValidationErrors;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.statement.DatabaseFunction;
 import liquibase.statement.SequenceFunction;
 import liquibase.statement.core.InsertStatement;
 
@@ -51,6 +52,9 @@ public class InsertGenerator extends AbstractSqlGenerator<InsertStatement> {
                 }
             } else if (newValue instanceof SequenceFunction) {
                 sql.append(database.generateSequenceNextValueFunction(newValue.toString()));
+            } else if (newValue instanceof DatabaseFunction
+                    && DatabaseFunction.CURRENT_DATE_TIME_PLACE_HOLDER.equalsIgnoreCase(newValue.toString())) {
+                sql.append(database.getCurrentDateTimeFunction());
             }
             else {
                 sql.append(newValue);

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/UpdateGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/UpdateGenerator.java
@@ -6,6 +6,7 @@ import liquibase.exception.ValidationErrors;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.statement.DatabaseFunction;
 import liquibase.statement.core.UpdateStatement;
 
 import java.util.Date;
@@ -61,6 +62,9 @@ public class UpdateGenerator extends AbstractSqlGenerator<UpdateStatement> {
             } else {
                 sqlString = DataTypeFactory.getInstance().getFalseBooleanValue(database);
             }
+        } else if (newValue instanceof DatabaseFunction
+                && DatabaseFunction.CURRENT_DATE_TIME_PLACE_HOLDER.equalsIgnoreCase(newValue.toString())) {
+            sqlString = database.getCurrentDateTimeFunction();
         } else {
             sqlString = newValue.toString();
         }

--- a/liquibase-core/src/main/java/liquibase/statement/DatabaseFunction.java
+++ b/liquibase-core/src/main/java/liquibase/statement/DatabaseFunction.java
@@ -2,6 +2,12 @@ package liquibase.statement;
 
 public class DatabaseFunction {
 
+    /**
+     * String value used for comparison. If a function matches this value then it should be replaces by the
+     * real current timestamp function.
+     */
+    public static final String CURRENT_DATE_TIME_PLACE_HOLDER = "current_datetime";
+
     private String value;
 
     public DatabaseFunction(String value) {

--- a/liquibase-core/src/main/java/liquibase/structure/core/Column.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/Column.java
@@ -11,7 +11,7 @@ public class Column extends AbstractDatabaseObject {
     }
 
     public Relation getRelation() {
-        return (Relation) getAttribute("relation", Relation.class);
+        return getAttribute("relation", Relation.class);
     }
 
     public DatabaseObject[] getContainingObjects() {
@@ -36,7 +36,7 @@ public class Column extends AbstractDatabaseObject {
     }
 
 	public String getName() {
-        return (String) getAttribute("name", String.class);
+        return getAttribute("name", String.class);
     }
 
     public Column setName(String name) {
@@ -46,7 +46,7 @@ public class Column extends AbstractDatabaseObject {
     }
 
     public Boolean isNullable() {
-        return (Boolean) getAttribute("nullable", Boolean.class);
+        return getAttribute("nullable", Boolean.class);
     }
 
     public Column setNullable(Boolean nullable) {
@@ -57,7 +57,7 @@ public class Column extends AbstractDatabaseObject {
 
 
     public DataType getType() {
-        return (DataType) getAttribute("type", DataType.class);
+        return getAttribute("type", DataType.class);
     }
 
     public Column setType(DataType type) {
@@ -77,7 +77,7 @@ public class Column extends AbstractDatabaseObject {
     }
 
     public boolean isAutoIncrement() {
-        return (Boolean) getAttribute("autoIncrement", Boolean.class);
+        return getAttribute("autoIncrement", Boolean.class);
     }
 
     public void setAutoIncrement(boolean autoIncrement) {
@@ -153,45 +153,8 @@ public class Column extends AbstractDatabaseObject {
         return this;
     }
 
-    public boolean isDataTypeDifferent(Column otherColumn) {
-        if (!this.isCertainDataType() || !otherColumn.isCertainDataType()) {
-            return false;
-        } else {
-            return !this.getType().equals(otherColumn.getType());
-        }
-    }
-
-    @SuppressWarnings({"SimplifiableIfStatement"})
-    public boolean isNullabilityDifferent(Column otherColumn) {
-        if (this.isNullable() == null && otherColumn.isNullable() == null) {
-            return false;
-        }
-        if (this.isNullable() == null && otherColumn.isNullable() != null) {
-            return true;
-        }
-        if (this.isNullable() != null && otherColumn.isNullable() == null) {
-            return true;
-        }
-        return !this.isNullable().equals(otherColumn.isNullable());
-    }
-
-    public boolean isDifferent(Column otherColumn) {
-        return isDataTypeDifferent(otherColumn) || isNullabilityDifferent(otherColumn);
-    }
-
-
-    public boolean isCertainDataType() {
-        return (Boolean) getAttribute("certainDataType", Boolean.class);
-    }
-
-    public Column setCertainDataType(boolean certainDataType) {
-        setAttribute("certainDataType", certainDataType);
-
-        return this;
-    }
-
     public String getRemarks() {
-        return (String) getAttribute("remarks", String.class);
+        return getAttribute("remarks", String.class);
     }
 
     public Column setRemarks(String remarks) {

--- a/liquibase-integration-tests/src/test/resources/changelogs/common/common.tests.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/common/common.tests.changelog.xml
@@ -78,6 +78,14 @@
             <column name="dateTimeCol" valueDate="2007-08-09T13:14:15"/>
             <column name="bigintcol" valueNumeric="2"/>
         </insert>
+        <insert tableName="dataTypeTest">
+          <column name="id" valueNumeric="2"/>
+          <column name="dateCol" valueDate="current_datetime"/>
+          <column name="timeCol" valueComputed="current_datetime"/>
+          <column name="dateTimeCol" valueDate="current_datetime"/>
+          <column name="bigintcol" valueNumeric="2"/>
+        </insert>
+
     </changeSet>
 
     <changeSet id="defaultValueTest-1" author="nvoxland">
@@ -104,7 +112,7 @@
         <addDefaultValue tableName="defaultValueTest" columnName="timeA" defaultValueDate="14:15:16" columnDataType="time" />
         <addDefaultValue tableName="defaultValueTest" columnName="datetimeA" defaultValueDate="2007-08-09T10:11:12" columnDataType="datetime" />
         <addDefaultValue tableName="defaultValueTest" columnName="datetimeB" defaultValueDate="2007-08-09 10:11:12" columnDataType="datetime" />
-        <addDefaultValue tableName="defaultValueTest" columnName="computedDate" defaultValueComputed="CURRENT_TIMESTAMP()" columnDataType="datetime" />
+        <addDefaultValue tableName="defaultValueTest" columnName="computedDate" defaultValueComputed="current_datetime" columnDataType="datetime" />
 
         <insert tableName="defaultValueTest">
             <column name="id" valueNumeric="1"/>
@@ -375,6 +383,11 @@
             <column name="intCol" valueNumeric="12"/>
             <where>id=2</where>
         </update>
+
+      <update tableName="updateTest">
+        <column name="dateCol" valueComputed="current_datetime"/>
+        <where>id=2</where>
+      </update>
 
     </changeSet>
 


### PR DESCRIPTION
If the function name is matched in UpdateGenerator or InsertGenerator, the value is replaced with the real current datetime.
Using current_datetime as the placeholder.
Updated test xml with an example.
Either valueComputed or valueDate can be used to set the value.

Removed redundant castings in Column.java and unused methods.
