### PR TITLE
Fixes for running H2 and Hsql integration tests.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/H2Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/H2Database.java
@@ -23,6 +23,7 @@ public class H2Database extends AbstractJdbcDatabase {
     private static String SEP_CONCAT = ", ";
 
     public H2Database() {
+        super.unquotedObjectsAreUppercased=true;
         super.setCurrentDateTimeFunction("NOW()");
         super.sequenceNextValueFunction = "nextval('%s')";
         this.dateFunctions.add(new DatabaseFunction("CURRENT_TIMESTAMP()"));

--- a/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
@@ -22,7 +22,8 @@ public class HsqlDatabase extends AbstractJdbcDatabase {
     private static String SEP_CONCAT = ", ";
 
     public HsqlDatabase() {
-    	super.setCurrentDateTimeFunction("NOW");
+    	super.unquotedObjectsAreUppercased=true;
+        super.setCurrentDateTimeFunction("NOW");
         super.sequenceNextValueFunction = "NEXT VALUE FOR %s";
     	super.defaultAutoIncrementStartWith = BigInteger.ZERO;
         super.sequenceCurrentValueFunction = "CURRVAL('%s')";

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/UpdateGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/UpdateGenerator.java
@@ -62,9 +62,8 @@ public class UpdateGenerator extends AbstractSqlGenerator<UpdateStatement> {
             } else {
                 sqlString = DataTypeFactory.getInstance().getFalseBooleanValue(database);
             }
-        } else if (newValue instanceof DatabaseFunction
-                && DatabaseFunction.CURRENT_DATE_TIME_PLACE_HOLDER.equalsIgnoreCase(newValue.toString())) {
-            sqlString = database.getCurrentDateTimeFunction();
+        } else if (newValue instanceof DatabaseFunction) {
+            sqlString = database.generateDatabaseFunctionValue((DatabaseFunction) newValue);
         } else {
             sqlString = newValue.toString();
         }

--- a/liquibase-core/src/main/java/liquibase/structure/core/Column.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/Column.java
@@ -77,7 +77,8 @@ public class Column extends AbstractDatabaseObject {
     }
 
     public boolean isAutoIncrement() {
-        return (Boolean) getAttribute("autoIncrement", Boolean.class);
+        Boolean isAutoIncrement = getAttribute("autoIncrement", Boolean.class);
+        return isAutoIncrement != null && isAutoIncrement;
     }
 
     public AutoIncrementInformation getAutoIncrementInformation() {

--- a/liquibase-core/src/main/java/liquibase/util/ISODateFormat.java
+++ b/liquibase-core/src/main/java/liquibase/util/ISODateFormat.java
@@ -10,11 +10,13 @@ public class ISODateFormat {
     private SimpleDateFormat dateTimeFormat = new SimpleDateFormat(DATE_TIME_FORMAT_STRING);
     private SimpleDateFormat dateTimeFormatWithDecimal = new SimpleDateFormat(DATE_TIME_FORMAT_STRING_WITH_DECIMAL);
     private SimpleDateFormat dateTimeFormatWithSpace = new SimpleDateFormat(DATE_TIME_FORMAT_STRING_WITH_SPACE);
+    private SimpleDateFormat dateTimeFormatWithSpaceAndDecimal = new SimpleDateFormat(DATE_TIME_FORMAT_STRING_WITH_SPACE_AND_DECIMAL);
     private SimpleDateFormat timeFormat = new SimpleDateFormat("HH:mm:ss");
     private SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
     private static final String DATE_TIME_FORMAT_STRING = "yyyy-MM-dd'T'HH:mm:ss";
     private static final String DATE_TIME_FORMAT_STRING_WITH_SPACE = "yyyy-MM-dd HH:mm:ss";
     private static final String DATE_TIME_FORMAT_STRING_WITH_DECIMAL = "yyyy-MM-dd'T'HH:mm:ss.S";
+    private static final String DATE_TIME_FORMAT_STRING_WITH_SPACE_AND_DECIMAL = "yyyy-MM-dd HH:mm:ss.S";
 
 
     public String format(java.sql.Date date) {
@@ -44,9 +46,11 @@ public class ISODateFormat {
     public Date parse(String dateAsString) throws ParseException {
         SimpleDateFormat dateTimeFormat = this.dateTimeFormat;
 
-        if (dateAsString.indexOf('.') >= 0) {
+        if (dateAsString.contains(".") && dateAsString.contains(" ")) {
+            dateTimeFormat = this.dateTimeFormatWithSpaceAndDecimal;
+        } else if (dateAsString.contains(".")) {
             dateTimeFormat = this.dateTimeFormatWithDecimal;
-        } else if (dateAsString.indexOf(' ') >= 0) {
+        } else if (dateAsString.contains(" ")) {
             dateTimeFormat = this.dateTimeFormatWithSpace;
         }
 


### PR DESCRIPTION
Set value for unquotedObjectsAreUppercased to true for H2 and Hsql.
Added new date time format for a date string with both a space and a dot.
For H2, A timestamp was getitng converted into a date string that did not match
any of the existing ones.
