### PR TITLE
Be more conservative with regular expressions in stripComments.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/util/StringUtils.java
+++ b/liquibase-core/src/main/java/liquibase/util/StringUtils.java
@@ -78,8 +78,8 @@ public class StringUtils {
      * @return The String without the comments in
      */
     public static String stripComments(String multiLineSQL) {
-        String strippedSingleLines = Pattern.compile("(.*?)\\s*\\-\\-.*\n").matcher(multiLineSQL).replaceAll("$1\n");
-        strippedSingleLines = Pattern.compile("(.*?)\\s*\\-\\-.*$").matcher(strippedSingleLines).replaceAll("$1\n");
+        String strippedSingleLines = Pattern.compile("\\s*\\-\\-.*\n").matcher(multiLineSQL).replaceAll("\n");
+        strippedSingleLines = Pattern.compile("\\s*\\-\\-.*$").matcher(strippedSingleLines).replaceAll("\n");
         return Pattern.compile("/\\*.*?\\*/", Pattern.DOTALL).matcher(strippedSingleLines).replaceAll("").trim();
     }
 

--- a/liquibase-core/src/test/java/liquibase/util/StringUtilsTest.java
+++ b/liquibase-core/src/test/java/liquibase/util/StringUtilsTest.java
@@ -65,6 +65,22 @@ public class StringUtilsTest {
     }
     
     @Test
+    public void singleLongLineNoFollowOnLine() {
+        StringBuilder sqlBuilder = new StringBuilder();
+        for (int i = 0; i < 10000; ++i)
+            sqlBuilder.append(" A");
+        String sql = sqlBuilder.toString();
+        String comment = " -- with comment\n";
+        String totalLine=sql + comment ;
+        long start = System.currentTimeMillis();
+        String result = StringUtils.stripComments(totalLine);
+        long end = System.currentTimeMillis();
+        
+        assertEquals(sql.trim(),result);
+        assertTrue("Did not complete within 1 second", end - start <= 1000);
+    }
+    
+    @Test
     public void singleLineMultipleComments() {
         String sql = "Some text" ;
         String comment = " -- with comment";


### PR DESCRIPTION
Starting with a non-greedy universal match causes Java's regular expression engine to try to match zero characters followed by the rest of the pattern, then 1 character followed by the rest of the pattern, and so on until it finds a match. Since comments must appear at the _end_ of input, this ensures that the regex engine does a maximal amount of work before eliminating a comment. For queries of a "reasonable" size, this isn't an issue, but a 10 or 20
kilocharacter query is large enough to cause comment removal to take over a second.

Since the replacement removes the trailing part of the match outright, I've rewritten the filter regexes to do so directly, rather than by replacing the trailing part with the preceding universal group, and removed the universal group match. This permits the regex engine to skip from whitespace to whitespace without evaluating all the intervening bytes, and avoids
backtracking entirely.

This bit my day job, in real life, on queries that insert entire PNG images via hex-encoded strings. While this is an unreasonable query, it's not an _unrealistic_ query. We worked around the problem by disabling stripComments, but fixing the regex will improve overall performance.
