### PR TITLE
fixed configuration fail of maven goal liquibase:diff.

### DIFF
--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseDatabaseDiff.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseDatabaseDiff.java
@@ -110,11 +110,13 @@ public class LiquibaseDatabaseDiff extends AbstractLiquibaseChangeLogMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        AuthenticationInfo referenceInfo = wagonManager.getAuthenticationInfo(referenceServer);
-        if (referenceInfo != null) {
-            referenceUsername = referenceInfo.getUserName();
-            referencePassword = referenceInfo.getPassword();
-        }
+    	if(referenceServer!=null) {
+    		AuthenticationInfo referenceInfo = wagonManager.getAuthenticationInfo(referenceServer);
+    		if (referenceInfo != null) {
+    			referenceUsername = referenceInfo.getUserName();
+    			referencePassword = referenceInfo.getPassword();
+    		}
+    	}
 
         super.execute();
     }


### PR DESCRIPTION
fixed configuration fail of maven goal liquibase:diff. 
If referenceServer not configured, configured valued of referenceUsername and referencePassword in pom.xml always ignored.

WagonManager.getAuthenticationInfo() return empty AuthentiationInfo when parameter referenceServer is null, and the configured values are overwriten with empty values of the AuthenticaitonInfo.
