### PR TITLE
BOM aware file reader

### DIFF
--- a/liquibase-core/src/main/java/liquibase/resource/UtfBomAwareReader.java
+++ b/liquibase-core/src/main/java/liquibase/resource/UtfBomAwareReader.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PushbackInputStream;
 import java.io.Reader;
+import java.nio.charset.Charset;
 
 /**
  * Reader that tries to identify the encoding by looking at the BOM. If no BOM
@@ -25,6 +26,11 @@ public class UtfBomAwareReader extends Reader {
 	private InputStreamReader is = null;
 	private String defaultCharsetName;
 
+	public UtfBomAwareReader(InputStream in) {
+		pis = new PushbackInputStream(in, 4);
+		this.defaultCharsetName = Charset.defaultCharset().name();
+	}
+	
 	public UtfBomAwareReader(InputStream in, String defaultCharsetName) {
 		pis = new PushbackInputStream(in, 4);
 		if (defaultCharsetName == null)

--- a/liquibase-core/src/test/java/liquibase/resource/UtfBomAwareReaderTest.java
+++ b/liquibase-core/src/test/java/liquibase/resource/UtfBomAwareReaderTest.java
@@ -130,6 +130,15 @@ public class UtfBomAwareReaderTest {
 		assertData();
 	}
 
+	@Test
+	public void testWithNoDefault() throws IOException {
+		reader = new UtfBomAwareReader(prepareStream(0x00, 0x00, 0xFE, 0xFF,
+				0x00, 0x00, 0x00, 0x61, 0x00, 0x00, 0x00, 0x62, 0x00, 0x00,
+				0x00, 0x63));
+		assertEncoding("UTF-32BE", Charset.defaultCharset().toString());
+		assertData();
+	}
+	
 	private void assertData() throws IOException {
 		assertEquals("abc", new BufferedReader(reader).readLine());
 		assertEmpty();
@@ -140,10 +149,14 @@ public class UtfBomAwareReaderTest {
 	}
 
 	private void assertEncoding(String expectedCharsetName) throws IOException {
+		assertEncoding(expectedCharsetName, "ISO8859_1");
+	}
+
+	private void assertEncoding(String expectedCharsetName, String expectedDefault) throws IOException {
 		String canonicalCharsetName = Charset.forName(reader.getEncoding())
 				.toString();
 
 		assertEquals(expectedCharsetName, canonicalCharsetName);
-		assertEquals("ISO8859_1", reader.getDefaultEncoding());
+		assertEquals(expectedDefault, reader.getDefaultEncoding());
 	}
 }

--- a/liquibase-core/src/test/java/liquibase/util/StreamUtilTest.java
+++ b/liquibase-core/src/test/java/liquibase/util/StreamUtilTest.java
@@ -1,6 +1,8 @@
 package liquibase.util;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.fail;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -9,20 +11,69 @@ import java.io.StringReader;
 
 public class StreamUtilTest {
 
-    @Test
-    public void testGetStreamContents() throws IOException {
-        byte[] contents = "TEST2".getBytes();
-        ByteArrayInputStream stream = new ByteArrayInputStream(contents);
-        String result = StreamUtil.getStreamContents(stream);
-        assertEquals("TEST2", result);
-    }
+	@Test
+	public void testGetStreamContents() throws IOException {
+		byte[] contents = "TEST2".getBytes();
+		ByteArrayInputStream stream = new ByteArrayInputStream(contents);
+		String result = StreamUtil.getStreamContents(stream);
+		assertEquals("TEST2", result);
+	}
 
-    @Test
-    public void testGetReaderContents() throws IOException {
-        String contents = "TEST";
-        StringReader reader = new StringReader(contents);
-        String result = StreamUtil.getReaderContents(reader);
-        assertEquals(contents, result);
-    }
+	@Test
+	public void testGetReaderContents() throws IOException {
+		String contents = "TEST";
+		StringReader reader = new StringReader(contents);
+		String result = StreamUtil.getReaderContents(reader);
+		assertEquals(contents, result);
+	}
+
+	@Test
+	public void testWithBomNoEncodingGiven() throws IOException {
+		String contents = "abc";
+		ByteArrayInputStream bais = new ByteArrayInputStream(new byte[] {
+				(byte) 0xEF, (byte) 0xBB, (byte) 0xBF, 0x61, 0x62, 0x63 });
+
+		assertEquals(contents, StreamUtil.getStreamContents(bais));
+	}
+
+	@Test
+	public void testWithBomCorrectEncodingGiven() throws IOException {
+		String contents = "abc";
+		ByteArrayInputStream bais = new ByteArrayInputStream(new byte[] {
+				(byte) 0xEF, (byte) 0xBB, (byte) 0xBF, 0x61, 0x62, 0x63 });
+
+		assertEquals(contents, StreamUtil.getStreamContents(bais, "UTF8"));
+	}
+
+	@Test
+	public void testWithoutBomUtf8() throws IOException {
+		String contents = "abc";
+		ByteArrayInputStream bais = new ByteArrayInputStream(new byte[] { 0x61,
+				0x62, 0x63 });
+
+		assertEquals(contents, StreamUtil.getStreamContents(bais, "UTF8"));
+	}
+
+	@Test
+	public void testWithoutBomLatin1() throws IOException {
+		String contents = "abc";
+		ByteArrayInputStream bais = new ByteArrayInputStream(new byte[] { 0x61,
+				0x62, 0x63 });
+
+		assertEquals(contents, StreamUtil.getStreamContents(bais, "Latin1"));
+	}
+	
+	@Test
+	public void testWithBomWrongEncodingGiven() throws IOException {
+		ByteArrayInputStream bais = new ByteArrayInputStream(new byte[] {
+				(byte) 0xEF, (byte) 0xBB, (byte) 0xBF, 0x61, 0x62, 0x63 });
+
+		try {
+			StreamUtil.getStreamContents(bais, "UTF-16BE");
+			fail("Should have thrown an IllegalArgumentException");
+		} catch (IllegalArgumentException e) {
+			assertTrue(e.getMessage().contains("UTF-16BE"));
+		}
+	}
 
 }


### PR DESCRIPTION
Hi! 
This patch adds a BOM aware reader to stream utils. The reader correctly parses UTF BOM's and strips them away before passing the file data to liquibase. It also checks that the  BOM it finds is matching the encoding given in the changelog file. 

Context: We are using lots of custom SQL files here and some MS editors will generate UTF-16 with BOM or UTF-8 with BOM. This would then give incorrect SQL statements. With this patch, which we tried for some time on a previous version of master those issues are solved. If no BOM is present liquibase behaves exactly like before.

I added some tests to check the behavior. However, I was not able to run the full suite with changes currently happening on master. I assumed this was already known to you.

I hope this helps, feel free to ask for more information or tests if need be.
