### PR TITLE
Fixes for running Oracle Integration tests.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/ChangeWithColumns.java
+++ b/liquibase-core/src/main/java/liquibase/change/ChangeWithColumns.java
@@ -15,6 +15,6 @@ public interface ChangeWithColumns<T extends ColumnConfig> {
     /**
      * Return all the {@link ColumnConfig} objects defined for this {@link Change }
      */
-    public List<T> getColumn();
+    public List<T> getColumns();
 
 }

--- a/liquibase-core/src/main/java/liquibase/change/core/AddColumnChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/AddColumnChange.java
@@ -60,7 +60,7 @@ public class AddColumnChange extends AbstractChange implements ChangeWithColumns
     }
 
     @DatabaseChangeProperty(requiredForDatabase = "all", description = "Column constraint and foreign key information. Setting the \"defaultValue\" attribute will specify a default value for the column. Setting the \"value\" attribute will set all rows existing to the specified value without modifying the column default.")
-    public List<ColumnConfig> getColumn() {
+    public List<ColumnConfig> getColumns() {
         return column;
     }
 
@@ -89,7 +89,7 @@ public class AddColumnChange extends AbstractChange implements ChangeWithColumns
 
         List<SqlStatement> sql = new ArrayList<SqlStatement>();
 
-        for (ColumnConfig column : getColumn()) {
+        for (ColumnConfig column : getColumns()) {
             Set<ColumnConstraint> constraints = new HashSet<ColumnConstraint>();
             ConstraintsConfig constraintsConfig =column.getConstraints();
             if (constraintsConfig != null) {
@@ -134,7 +134,7 @@ public class AddColumnChange extends AbstractChange implements ChangeWithColumns
             }
         }
 
-      for (ColumnConfig column : getColumn()) {
+      for (ColumnConfig column : getColumns()) {
           String columnRemarks = StringUtils.trimToNull(column.getRemarks());
           if (columnRemarks != null) {
               SetColumnRemarksStatement remarksStatement = new SetColumnRemarksStatement(catalogName, schemaName, tableName, column.getName(), columnRemarks);

--- a/liquibase-core/src/main/java/liquibase/change/core/CreateIndexChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/CreateIndexChange.java
@@ -59,7 +59,7 @@ public class CreateIndexChange extends AbstractChange implements ChangeWithColum
     }
 
     @DatabaseChangeProperty(requiredForDatabase = "all", mustEqualExisting = "index.column", description = "Column(s) to add to the index")
-    public List<ColumnConfig> getColumn() {
+    public List<ColumnConfig> getColumns() {
         if (columns == null) {
             return new ArrayList<ColumnConfig>();
         }
@@ -86,7 +86,7 @@ public class CreateIndexChange extends AbstractChange implements ChangeWithColum
 
     public SqlStatement[] generateStatements(Database database) {
         List<String> columns = new ArrayList<String>();
-        for (ColumnConfig column : getColumn()) {
+        for (ColumnConfig column : getColumns()) {
             columns.add(column.getName());
         }
 
@@ -98,7 +98,7 @@ public class CreateIndexChange extends AbstractChange implements ChangeWithColum
 					    getTableName(),
 					    this.isUnique(),
 					    getAssociatedWith(),
-					    columns.toArray(new String[getColumn().size()]))
+					    columns.toArray(new String[getColumns().size()]))
 					    .setTablespace(getTablespace())
 	    };
     }

--- a/liquibase-core/src/main/java/liquibase/change/core/CreateTableChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/CreateTableChange.java
@@ -29,13 +29,14 @@ public class CreateTableChange extends AbstractChange implements ChangeWithColum
     private String remarks;
 
     public CreateTableChange() {
+        super();
         columns = new ArrayList<ColumnConfig>();
     }
 
     public SqlStatement[] generateStatements(Database database) {
 
         CreateTableStatement statement = new CreateTableStatement(getCatalogName(), getSchemaName(), getTableName());
-        for (ColumnConfig column : getColumn()) {
+        for (ColumnConfig column : getColumns()) {
             ConstraintsConfig constraints = column.getConstraints();
             boolean isAutoIncrement = column.isAutoIncrement() != null && column.isAutoIncrement();
 
@@ -94,7 +95,7 @@ public class CreateTableChange extends AbstractChange implements ChangeWithColum
             }
         }
 
-        for (ColumnConfig column : getColumn()) {
+        for (ColumnConfig column : getColumns()) {
             String columnRemarks = StringUtils.trimToNull(column.getRemarks());
             if (columnRemarks != null) {
                 SetColumnRemarksStatement remarksStatement = new SetColumnRemarksStatement(catalogName, schemaName, tableName, column.getName(), columnRemarks);
@@ -120,7 +121,7 @@ public class CreateTableChange extends AbstractChange implements ChangeWithColum
     }
 
     @DatabaseChangeProperty(requiredForDatabase = "all")
-    public List<ColumnConfig> getColumn() {
+    public List<ColumnConfig> getColumns() {
         if (columns == null) {
             return new ArrayList<ColumnConfig>();
         }
@@ -181,4 +182,6 @@ public class CreateTableChange extends AbstractChange implements ChangeWithColum
     public String getConfirmationMessage() {
         return "Table " + tableName + " created";
     }
+
+
 }

--- a/liquibase-core/src/main/java/liquibase/change/core/InsertDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/InsertDataChange.java
@@ -52,7 +52,7 @@ public class InsertDataChange extends AbstractChange implements ChangeWithColumn
     }
 
     @DatabaseChangeProperty(requiredForDatabase = "all", mustEqualExisting = "table.column", description = "Data to insert into columns")
-    public List<ColumnConfig> getColumn() {
+    public List<ColumnConfig> getColumns() {
         return columns;
     }
 

--- a/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
@@ -113,7 +113,7 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
     }
 
     @DatabaseChangeProperty(description = "Defines how the data should be loaded.")
-    public List<LoadDataColumnConfig> getColumn() {
+    public List<LoadDataColumnConfig> getColumns() {
         return columns;
     }
 

--- a/liquibase-core/src/main/java/liquibase/change/core/UpdateDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/UpdateDataChange.java
@@ -51,7 +51,7 @@ public class UpdateDataChange extends AbstractChange implements ChangeWithColumn
     }
 
     @DatabaseChangeProperty(requiredForDatabase = "all", description = "Data to update")
-    public List<ColumnConfig> getColumn() {
+    public List<ColumnConfig> getColumns() {
         return columns;
     }
 

--- a/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
@@ -30,6 +30,7 @@ public class OracleDatabase extends AbstractJdbcDatabase {
     private Set<String> reservedWords = new HashSet<String>();
 
     public OracleDatabase() {
+        super.unquotedObjectsAreUppercased=true;
         super.setCurrentDateTimeFunction("SYSTIMESTAMP");
         // Setting list of Oracle's native functions
         dateFunctions.add(new DatabaseFunction("SYSDATE"));

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/DiffToChangeLog.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/DiffToChangeLog.java
@@ -137,7 +137,7 @@ public class DiffToChangeLog {
                 }
                 String objectName = object.getName();
                 Database targetDatabase = diffResult.getReferenceSnapshot().getDatabase();
-                if (!objectName.equals(targetDatabase.correctObjectName(objectName, object.getClass()))) {
+                if (objectName != null && !objectName.equals(targetDatabase.correctObjectName(objectName, object.getClass()))) {
                     quotingStrategy = ObjectQuotingStrategy.QUOTE_ALL_OBJECTS;
                 }
                 Change[] changes = changeGeneratorFactory.fixMissing(object, diffOutputControl, diffResult.getReferenceSnapshot().getDatabase(), diffResult.getComparisonSnapshot().getDatabase());
@@ -155,7 +155,7 @@ public class DiffToChangeLog {
                 if (!diffResult.getComparisonSnapshot().getDatabase().isLiquibaseObject(object) && !diffResult.getComparisonSnapshot().getDatabase().isSystemObject(object)) {
                     String objectName = object.getName();
                     Database targetDatabase = diffResult.getReferenceSnapshot().getDatabase();
-                    if (!objectName.equals(targetDatabase.correctObjectName(objectName, object.getClass()))) {
+                    if (objectName != null && !objectName.equals(targetDatabase.correctObjectName(objectName, object.getClass()))) {
                         quotingStrategy = ObjectQuotingStrategy.QUOTE_ALL_OBJECTS;
                     }
                     addToChangeSets(changes, changeSets, quotingStrategy);

--- a/liquibase-core/src/main/java/liquibase/parser/core/xml/XMLChangeLogSAXHandler.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/xml/XMLChangeLogSAXHandler.java
@@ -404,7 +404,7 @@ class XMLChangeLogSAXHandler extends DefaultHandler {
 				}
 				ColumnConfig lastColumn = null;
                 if (change instanceof ChangeWithColumns) {
-                    List<ColumnConfig> columns = ((ChangeWithColumns) change).getColumn();
+                    List<ColumnConfig> columns = ((ChangeWithColumns) change).getColumns();
                     if (columns != null && columns.size() > 0) {
                         lastColumn = columns.get(columns.size() - 1);
                     }
@@ -624,10 +624,10 @@ class XMLChangeLogSAXHandler extends DefaultHandler {
 			} else if (change != null && qName.equals("column")
 					&& textString != null) {
 				if (change instanceof InsertDataChange) {
-					List<ColumnConfig> columns = ((InsertDataChange) change).getColumn();
+					List<ColumnConfig> columns = ((InsertDataChange) change).getColumns();
 					columns.get(columns.size() - 1).setValue(textString);
 				} else if (change instanceof UpdateDataChange) {
-					List<ColumnConfig> columns = ((UpdateDataChange) change).getColumn();
+					List<ColumnConfig> columns = ((UpdateDataChange) change).getColumns();
 					columns.get(columns.size() - 1).setValue(textString);
 				} else {
 					throw new RuntimeException("Unexpected column with text: " + textString);

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/MarkChangeSetRanGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/MarkChangeSetRanGenerator.java
@@ -79,7 +79,7 @@ public class MarkChangeSetRanGenerator extends AbstractSqlGenerator<MarkChangeSe
     }
 
     private String limitSize(String string) {
-        int maxLength = 255;
+        int maxLength = 250;
         if (string.length() > maxLength) {
             return string.substring(0, maxLength - 3) + "...";
         }

--- a/liquibase-core/src/test/java/liquibase/change/core/AddColumnChangeTest.java
+++ b/liquibase-core/src/test/java/liquibase/change/core/AddColumnChangeTest.java
@@ -38,13 +38,13 @@ public class AddColumnChangeTest extends StandardChangeTest {
     @Test
     public void addColumn() throws Exception {
         AddColumnChange change = new AddColumnChange();
-        assertEquals(0, change.getColumn().size());
+        assertEquals(0, change.getColumns().size());
 
         change.addColumn(new ColumnConfig().setName("a"));
-        assertEquals(1, change.getColumn().size());
+        assertEquals(1, change.getColumns().size());
 
         change.addColumn(new ColumnConfig().setName("b"));
-        assertEquals(2, change.getColumn().size());
+        assertEquals(2, change.getColumns().size());
     }
 
     @Test
@@ -53,19 +53,19 @@ public class AddColumnChangeTest extends StandardChangeTest {
         ColumnConfig columnB = new ColumnConfig().setName("b");
 
         AddColumnChange change = new AddColumnChange();
-        assertEquals(0, change.getColumn().size());
+        assertEquals(0, change.getColumns().size());
 
         change.removeColumn(columnA);
-        assertEquals(0, change.getColumn().size());
+        assertEquals(0, change.getColumns().size());
 
         change.addColumn(columnA);
-        assertEquals(1, change.getColumn().size());
+        assertEquals(1, change.getColumns().size());
 
         change.removeColumn(columnB);
-        assertEquals(1, change.getColumn().size());
+        assertEquals(1, change.getColumns().size());
 
         change.removeColumn(columnA);
-        assertEquals(0, change.getColumn().size());
+        assertEquals(0, change.getColumns().size());
     }
 
     @Override

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
@@ -7,6 +7,7 @@ import liquibase.changelog.ChangeSet;
 import liquibase.database.Database;
 import liquibase.database.DatabaseConnection;
 import liquibase.database.DatabaseFactory;
+import liquibase.database.ObjectQuotingStrategy;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.diff.compare.CompareControl;
 import liquibase.diff.output.report.DiffToReport;
@@ -898,8 +899,11 @@ public abstract class AbstractIntegrationTest {
         if (database == null) {
             return;
         }
+        database.setObjectQuotingStrategy(ObjectQuotingStrategy.QUOTE_ALL_OBJECTS);
         Liquibase liquibase = createLiquibase(objectQuotingStrategyChangeLog);
+        clearDatabase(liquibase);
         liquibase.update(contexts);
+        clearDatabase(liquibase);
     }
 
 //   @Test

--- a/liquibase-integration-tests/src/test/resources/changelogs/common/common.tests.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/common/common.tests.changelog.xml
@@ -934,8 +934,8 @@
 
   </changeSet>
 
-  <!-- should work for all databases but only tested on h2, oracle and psotgres for now -->
-  <changeSet id="AddSequenceNextValueAsDefault" author="dbiggs" dbms="postgresql, h2, oracle">
+  <!-- should work for all databases but only tested on h2 and psotgres for now, oracle actually does not support sequences as default values -->
+  <changeSet id="AddSequenceNextValueAsDefault" author="dbiggs" dbms="postgresql, h2">
     <createSequence sequenceName="tableDefault_seq" />
     <createTable tableName="insertWithDefaultSeq">
       <column name="id" type="int" defaultValueSequenceNext="tableDefault_seq">


### PR DESCRIPTION
Added null checks for object name.
Oracle doesn't support setting a sequence as a default value so removed oracle from that test.
After the Diff refactoring, CreateTableChange is not having its columns serialized.
Added overridden methods to CreateTableChange to return columns as a serializable field.
There might be a more elegant way to do this. It looks like I should have a getter and setter
for columns to be picked up automatically as a serilizable value.

I also encountered weird behavior with Oracle whereby an overly long description was correctly
limited to 255 characters but was for some reason being treated as 259 characters by oracle.
This thus resulted in a constraint violation as the length was then too long for the description.
Bit of a hack but I lowered the description length to 250 and that seems to work.
