### PR TITLE
Add property for excluding databases from changesets.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
@@ -74,7 +74,7 @@ public class FormattedSqlChangeLogParser implements ChangeLogParser {
             Pattern runAlwaysPattern = Pattern.compile(".*runAlways:(\\w+).*", Pattern.CASE_INSENSITIVE);
             Pattern contextPattern = Pattern.compile(".*context:([\\w,]+).*", Pattern.CASE_INSENSITIVE);
             Pattern runInTransactionPattern = Pattern.compile(".*runInTransaction:(\\w+).*", Pattern.CASE_INSENSITIVE);
-            Pattern dbmsPattern = Pattern.compile(".*dbms:(\\w+).*", Pattern.CASE_INSENSITIVE);
+            Pattern dbmsPattern = Pattern.compile(".*dbms:([\\w!]+).*", Pattern.CASE_INSENSITIVE);
             Pattern failOnErrorPattern = Pattern.compile(".*failOnError:(\\w+).*", Pattern.CASE_INSENSITIVE);
             Pattern onFailPattern = Pattern.compile(".*onFail:(\\w+).*", Pattern.CASE_INSENSITIVE);
             Pattern onErrorPattern = Pattern.compile(".*onError:(\\w+).*", Pattern.CASE_INSENSITIVE);

--- a/liquibase-core/src/test/java/liquibase/changelog/filter/DbmsChangeSetFilterTest.java
+++ b/liquibase-core/src/test/java/liquibase/changelog/filter/DbmsChangeSetFilterTest.java
@@ -25,6 +25,7 @@ public class DbmsChangeSetFilterTest  {
         assertTrue(filter.accepts(new ChangeSet(null, null, false, false, null,null, "mysql, oracle")));
         assertFalse(filter.accepts(new ChangeSet(null, null, false, false, null,null, "oracle")));
         assertTrue(filter.accepts(new ChangeSet(null, null, false, false, null, null, null)));
+        assertFalse(filter.accepts(new ChangeSet(null, null, false, false, null,null, "h2,!mysql")));
     }
 
 //    @Test

--- a/liquibase-core/src/test/java/liquibase/sqlgenerator/core/MarkChangeSetRanGeneratorTest.java
+++ b/liquibase-core/src/test/java/liquibase/sqlgenerator/core/MarkChangeSetRanGeneratorTest.java
@@ -18,6 +18,7 @@ public class MarkChangeSetRanGeneratorTest extends AbstractSqlGeneratorTest<Mark
         super(new MarkChangeSetRanGenerator());
     }
 
+    @Override
     protected MarkChangeSetRanStatement createSampleSqlStatement() {
         return new MarkChangeSetRanStatement(new ChangeSet("1", "a", false, false, "c", null, null), ChangeSet.ExecType.EXECUTED);
     }

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
@@ -200,11 +200,15 @@ public abstract class AbstractIntegrationTest {
     }
 
     protected void runCompleteChangeLog() throws Exception {
-        Liquibase liquibase = createLiquibase(completeChangeLog);
+        runChangeLogFile(completeChangeLog);
+    }
+
+    protected void runChangeLogFile(String changeLogFile) throws Exception {
+        Liquibase liquibase = createLiquibase(changeLogFile);
         clearDatabase(liquibase);
 
         //run again to test changelog testing logic
-        liquibase = createLiquibase(completeChangeLog);
+        liquibase = createLiquibase(changeLogFile);
         try {
             liquibase.update(this.contexts);
         } catch (ValidationFailedException e) {

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/h2/H2IntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/h2/H2IntegrationTest.java
@@ -12,8 +12,12 @@ import org.junit.Test;
 
 public class H2IntegrationTest extends AbstractIntegrationTest {
 
+    private final String dbmsExcludeChangelog;
+
     public H2IntegrationTest() throws Exception {
         super("h2", "jdbc:h2:mem:liquibase");
+
+        this.dbmsExcludeChangelog = "changelogs/h2/complete/dbms.exclude.changelog.xml";
     }
 
     @Test
@@ -50,6 +54,11 @@ public class H2IntegrationTest extends AbstractIntegrationTest {
         runCompleteChangeLog();
         DatabaseSnapshot snapshot = SnapshotGeneratorFactory.getInstance().createSnapshot(getDatabase().getDefaultSchema(), getDatabase(), new SnapshotControl());
         System.out.println(snapshot);
+    }
+
+    @Test
+    public void h2IsExcludedFromRunningChangeset() throws Exception {
+        runChangeLogFile(dbmsExcludeChangelog);
     }
 
     //    @Test

--- a/liquibase-integration-tests/src/test/resources/changelogs/h2/complete/dbms.exclude.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/h2/complete/dbms.exclude.changelog.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+  <preConditions>
+    <dbms type="h2"/>
+  </preConditions>
+
+  <changeSet id="1" author="dbiggs" dbms="!oracle">
+    <createTable tableName="testDbmsExclude">
+      <column name="sampleField" type="varchar(50)"/>
+    </createTable>
+  </changeSet>
+
+  <changeSet id="2" author="dbiggs" dbms="!h2">
+    <comment>Should never be executed by h2</comment>
+    <dropTable tableName="testDbmsExclude" />
+  </changeSet>
+
+  <changeSet id="3" author="dbiggs">
+    <preConditions>
+      <tableExists tableName="testDbmsExclude" />
+    </preConditions>
+  </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
Similar to the dbms property for a changeset, sometimes it is easier
to just specify what databases shouldn't run a changeset.
Use property dbmsExclude to specify a list of databases that shouldn't
run a changeset.
