### PR TITLE
Add ability to set dbms for raw sql changes.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/AbstractChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/AbstractChange.java
@@ -29,6 +29,8 @@ import java.lang.reflect.Method;
  */
 public abstract class AbstractChange implements Change {
 
+    private String dbms;
+
     private ChangeMetaData changeMetaData;
 
     private ResourceAccessor resourceAccessor;
@@ -236,6 +238,14 @@ public abstract class AbstractChange implements Change {
         return true;
     }
 
+    public boolean includes(final Database database) {
+        if (dbms == null || dbms.trim().isEmpty()) {
+            return true;
+        }
+        List<String> dbmsList = StringUtils.splitAndTrim(dbms, ",");
+        return dbmsList.contains(database.getShortName());
+    }
+
     /**
      * Implementation delegates logic to the {@link liquibase.sqlgenerator.SqlGenerator#warn(liquibase.statement.SqlStatement, liquibase.database.Database, liquibase.sqlgenerator.SqlGeneratorChain)} method on the {@link SqlStatement} objects returned by {@link #generateStatements }.
      * If a generated statement is not supported for the given database, no warning will be added since that is a validation error.
@@ -401,6 +411,18 @@ public abstract class AbstractChange implements Change {
         }
 
         return affectedObjects;
+    }
+
+    /**
+     * @return A comma separated list of dbms' that this change will be run for. Will run for all dbms' if empty or null.
+     */
+    @DatabaseChangeProperty(since = "3.0", exampleValue = "h2, oracle")
+    public String getDbms() {
+        return dbms;
+    }
+
+    public void setDbms(final String dbms) {
+        this.dbms = dbms;
     }
 
     public Set<String> getSerializableFields() {

--- a/liquibase-core/src/main/java/liquibase/change/Change.java
+++ b/liquibase-core/src/main/java/liquibase/change/Change.java
@@ -58,6 +58,11 @@ public interface Change extends LiquibaseSerializable {
     boolean supports(Database database);
 
     /**
+     * @return Whether this change should run for the specified database
+     */
+    boolean includes(Database database);
+
+    /**
      * Generates warnings based on the configured Change instance. Warnings do not stop changelog execution, but are passed along to the end user for reference.
      * Can return null or an empty Warnings object when there are no warnings.
      */

--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
@@ -333,8 +333,12 @@ public class ChangeSet implements Conditional, LiquibaseSerializable {
 
                 log.debug("Reading ChangeSet: " + toString());
                 for (Change change : getChanges()) {
-                    database.executeStatements(change, databaseChangeLog, sqlVisitors);
-                    log.debug(change.getConfirmationMessage());
+                    if (change.includes(database)) {
+                        database.executeStatements(change, databaseChangeLog, sqlVisitors);
+                        log.debug(change.getConfirmationMessage());
+                    } else {
+                        log.debug("Change " + change.getSerializedObjectName() + " not included for database " + database.getShortName());
+                    }
                 }
 
                 if (runInTransaction) {

--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.0.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.0.xsd
@@ -309,10 +309,14 @@
         <xsd:attribute name="valueSequenceCurrent" type="xsd:string" />
     </xsd:attributeGroup>
 
+    <xsd:attributeGroup name="tableNameAttribute">
+      <xsd:attribute name="catalogName" type="xsd:string" />
+      <xsd:attribute name="schemaName" type="xsd:string" />
+      <xsd:attribute name="tableName" type="xsd:string" use="required" />
+    </xsd:attributeGroup>
+
 	<xsd:attributeGroup name="dropTableAttributes">
-        <xsd:attribute name="catalogName" type="xsd:string" />
-		<xsd:attribute name="schemaName" type="xsd:string" />
-		<xsd:attribute name="tableName" type="xsd:string" use="required" />
+        <xsd:attributeGroup ref="tableNameAttribute" />
 		<xsd:attribute name="cascadeConstraints" type="booleanExp" />
 	</xsd:attributeGroup>
 
@@ -330,12 +334,6 @@
 		<xsd:attribute name="schemaName" type="xsd:string" />
 		<xsd:attribute name="oldViewName" type="xsd:string" use="required" />
 		<xsd:attribute name="newViewName" type="xsd:string" use="required" />
-	</xsd:attributeGroup>
-
-	<xsd:attributeGroup name="tableNameAttribute">
-        <xsd:attribute name="catalogName" type="xsd:string" />
-        <xsd:attribute name="schemaName" type="xsd:string" />
-		<xsd:attribute name="tableName" type="xsd:string" use="required" />
 	</xsd:attributeGroup>
 
 	<xsd:attributeGroup name="renameColumnAttributes">
@@ -379,9 +377,7 @@
 
 	<xsd:element name="addPrimaryKey">
 		<xsd:complexType>
-            <xsd:attribute name="catalogName" type="xsd:string" />
-			<xsd:attribute name="schemaName" type="xsd:string" />
-			<xsd:attribute name="tableName" type="xsd:string" use="required" />
+            <xsd:attributeGroup ref="tableNameAttribute" />
 			<xsd:attribute name="columnNames" type="xsd:string"
 				use="required" />
 			<xsd:attribute name="constraintName" type="xsd:string" />
@@ -391,18 +387,14 @@
 
 	<xsd:element name="dropPrimaryKey">
 		<xsd:complexType>
-            <xsd:attribute name="catalogName" type="xsd:string" />
-			<xsd:attribute name="schemaName" type="xsd:string" />
-			<xsd:attribute name="tableName" type="xsd:string" use="required" />
+            <xsd:attributeGroup ref="tableNameAttribute" />
 			<xsd:attribute name="constraintName" type="xsd:string" />
 		</xsd:complexType>
 	</xsd:element>
 
 	<xsd:element name="addUniqueConstraint">
 		<xsd:complexType>
-            <xsd:attribute name="catalogName" type="xsd:string" />
-			<xsd:attribute name="schemaName" type="xsd:string" />
-			<xsd:attribute name="tableName" type="xsd:string" use="required" />
+            <xsd:attributeGroup ref="tableNameAttribute" />
 			<xsd:attribute name="columnNames" type="xsd:string"
 				use="required" />
 			<xsd:attribute name="constraintName" type="xsd:string" />
@@ -415,9 +407,7 @@
 
 	<xsd:element name="dropUniqueConstraint">
 		<xsd:complexType>
-            <xsd:attribute name="catalogName" type="xsd:string" />
-			<xsd:attribute name="schemaName" type="xsd:string" />
-			<xsd:attribute name="tableName" type="xsd:string" use="required" />
+            <xsd:attributeGroup ref="tableNameAttribute" />
 			<xsd:attribute name="constraintName" type="xsd:string" />
 			<xsd:attribute name="uniqueColumns" type="xsd:string" />
 		</xsd:complexType>
@@ -425,9 +415,7 @@
 
 	<xsd:element name="modifyDataType">
 		<xsd:complexType>
-            <xsd:attribute name="catalogName" type="xsd:string" />
-			<xsd:attribute name="schemaName" type="xsd:string" />
-			<xsd:attribute name="tableName" type="xsd:string" use="required" />
+            <xsd:attributeGroup ref="tableNameAttribute" />
 			<xsd:attribute name="columnName" type="xsd:string" use="required" />
 			<xsd:attribute name="newDataType" type="xsd:string" use="required" />
 		</xsd:complexType>
@@ -454,9 +442,7 @@
 
 	<xsd:element name="addAutoIncrement">
 		<xsd:complexType>
-            <xsd:attribute name="catalogName" type="xsd:string" />
-			<xsd:attribute name="schemaName" type="xsd:string" />
-			<xsd:attribute name="tableName" type="xsd:string" use="required" />
+            <xsd:attributeGroup ref="tableNameAttribute" />
 			<xsd:attribute name="columnName" type="xsd:string" use="required" />
 			<xsd:attribute name="columnDataType" type="xsd:string" />
 			<xsd:attribute name="startWith" type="xsd:long" />
@@ -466,9 +452,7 @@
 
 	<xsd:element name="addDefaultValue">
 		<xsd:complexType>
-            <xsd:attribute name="catalogName" type="xsd:string" />
-			<xsd:attribute name="schemaName" type="xsd:string" />
-			<xsd:attribute name="tableName" type="xsd:string" use="required" />
+            <xsd:attributeGroup ref="tableNameAttribute" />
 			<xsd:attribute name="columnName" type="xsd:string" use="required" />
 			<xsd:attribute name="columnDataType" type="xsd:string" />
 			<xsd:attribute name="defaultValue" type="xsd:string" />
@@ -482,9 +466,7 @@
 
 	<xsd:element name="dropDefaultValue">
 		<xsd:complexType>
-            <xsd:attribute name="catalogName" type="xsd:string" />
-			<xsd:attribute name="schemaName" type="xsd:string" />
-			<xsd:attribute name="tableName" type="xsd:string" use="required" />
+            <xsd:attributeGroup ref="tableNameAttribute" />
 			<xsd:attribute name="columnName" type="xsd:string" use="required" />
 			<xsd:attribute name="columnDataType" type="xsd:string" />
 		</xsd:complexType>
@@ -507,9 +489,7 @@
 					</xsd:complexType>
 				</xsd:element>
 			</xsd:sequence>
-            <xsd:attribute name="catalogName" type="xsd:string" />
-			<xsd:attribute name="schemaName" type="xsd:string" />
-			<xsd:attribute name="tableName" type="xsd:string" use="required" />
+            <xsd:attributeGroup ref="tableNameAttribute" />
 			<xsd:attribute name="file" type="xsd:string" />
 			<xsd:attribute name="encoding" type="xsd:string" default="UTF-8"/>
 			<xsd:attribute name="separator" type="xsd:string" default=","/>
@@ -534,9 +514,7 @@
 					</xsd:complexType>
 				</xsd:element>
 			</xsd:sequence>
-            <xsd:attribute name="catalogName" type="xsd:string" />
-			<xsd:attribute name="schemaName" type="xsd:string" />
-			<xsd:attribute name="tableName" type="xsd:string" use="required" />
+            <xsd:attributeGroup ref="tableNameAttribute" />
 			<xsd:attribute name="file" type="xsd:string" />
 			<xsd:attribute name="encoding" type="xsd:string" default="UTF-8"/>
 			<xsd:attribute name="primaryKey" type="xsd:string" use="required" />
@@ -579,9 +557,7 @@
 	</xsd:attributeGroup>
 
 	<xsd:attributeGroup name="addNotNullConstraintAttrib">
-        <xsd:attribute name="catalogName" type="xsd:string" />
-		<xsd:attribute name="schemaName" type="xsd:string" />
-		<xsd:attribute name="tableName" type="xsd:string" use="required" />
+        <xsd:attributeGroup ref="tableNameAttribute" />
 		<xsd:attribute name="columnName" type="xsd:string" use="required" />
 		<xsd:attribute name="defaultNullValue" type="xsd:string" />
 		<xsd:attribute name="columnDataType" type="xsd:string" />
@@ -916,6 +892,7 @@
 			<xsd:attribute name="stripComments" type="booleanExp" />
 			<xsd:attribute name="splitStatements" type="booleanExp" />
 			<xsd:attribute name="endDelimiter" type="xsd:string" />
+            <xsd:attribute name="dbms" type="xsd:string" />
 		</xsd:complexType>
 	</xsd:element>
 
@@ -948,7 +925,8 @@
 			<xsd:attribute name="splitStatements" type="booleanExp" />
 			<xsd:attribute name="encoding" type="xsd:string" default="UTF-8"/>
 			<xsd:attribute name="endDelimiter" type="xsd:string" />
-            <xsd:attribute name="relativeToChangelogFile" type="booleanExp" />            
+            <xsd:attribute name="relativeToChangelogFile" type="booleanExp" />
+            <xsd:attribute name="dbms" type="xsd:string" />
 		</xsd:complexType>
 	</xsd:element>
 

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
@@ -200,11 +200,15 @@ public abstract class AbstractIntegrationTest {
     }
 
     protected void runCompleteChangeLog() throws Exception {
-        Liquibase liquibase = createLiquibase(completeChangeLog);
+        runChangeLog(completeChangeLog);
+    }
+
+    protected void runChangeLog(String changelogFile) throws Exception {
+        Liquibase liquibase = createLiquibase(changelogFile);
         clearDatabase(liquibase);
 
         //run again to test changelog testing logic
-        liquibase = createLiquibase(completeChangeLog);
+        liquibase = createLiquibase(changelogFile);
         try {
             liquibase.update(this.contexts);
         } catch (ValidationFailedException e) {

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/h2/H2IntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/h2/H2IntegrationTest.java
@@ -12,8 +12,11 @@ import org.junit.Test;
 
 public class H2IntegrationTest extends AbstractIntegrationTest {
 
+    private final String changeSpecifyDbmsChangeLog;
+
     public H2IntegrationTest() throws Exception {
         super("h2", "jdbc:h2:mem:liquibase");
+        this.changeSpecifyDbmsChangeLog = "changelogs/h2/complete/change.specify.dbms.changelog.xml";
     }
 
     @Test
@@ -50,6 +53,11 @@ public class H2IntegrationTest extends AbstractIntegrationTest {
         runCompleteChangeLog();
         DatabaseSnapshot snapshot = SnapshotGeneratorFactory.getInstance().createSnapshot(getDatabase().getDefaultSchema(), getDatabase(), new SnapshotControl());
         System.out.println(snapshot);
+    }
+
+    @Test
+    public void canSpecifyDbmsForIndividualChanges() throws Exception {
+        runChangeLog(changeSpecifyDbmsChangeLog);
     }
 
     //    @Test

--- a/liquibase-integration-tests/src/test/resources/changelogs/h2/complete/change.specify.dbms.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/h2/complete/change.specify.dbms.changelog.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+  <preConditions>
+    <dbms type="h2"/>
+  </preConditions>
+
+  <changeSet id="1" author="dbiggs">
+    <createTable tableName="testChangeDbms">
+      <column name="sampleColumn" type="varchar(50)"/>
+    </createTable>
+    <!-- sql will cause error if it was run -->
+    <sql dbms="oracle">select * from tableThatDoesNotExist</sql>
+    <insert tableName="testChangeDbms" dbms="h2">
+      <column name="sampleColumn" value="testValue"/>
+    </insert>
+  </changeSet>
+
+  <changeSet id="2" author="dbiggs">
+    <preConditions>
+      <sqlCheck expectedResult="1">select count(*) from testChangeDbms</sqlCheck>
+    </preConditions>
+  </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Currently, you can only specify database names at the changeset level.
This commit extends that functionality for individual changes.
Useful for creating more compact change logs.

I'm not fully comfortable with the practive of injecting variables into a changelog from java.
If that is possible, I can move my integration test to common.tests.changelog and pass in the current
database short name so that the testing can be used for all databases.

Currently only testing using H2 but since this feature is just liquibase based it should work fine with
all databases.
