### PR TITLE
MSSQL-Server in Version 10 does not support DropTableCascadeConstraints

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
@@ -229,7 +229,7 @@ public class MSSQLDatabase extends AbstractDatabase {
     @Override
     public boolean supportsDropTableCascadeConstraints() {
         try {
-            return this.getDatabaseMajorVersion() >= 10;
+            return this.getDatabaseMajorVersion() > 10;
         } catch (DatabaseException e) {
             return true;
         }


### PR DESCRIPTION
We use MSSQL-Server in version 10. It does not support DropTableCascadeConstraints as we get an Exception when calling Liquibase.dropAll. 
I changed the version check so that it only returns true if the version is greater than 10. 
I didn't check, if MSSQL-Server in a version greater than 10 does support DropTableCascadeConstraints. 
