### PR TITLE
CORE-1158 HSQL escaped identifier names to upper case

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
@@ -134,7 +134,8 @@ public class HsqlDatabase extends AbstractDatabase {
     public String escapeDatabaseObject(String objectName) {
     	if (objectName != null) {
             if (keywords.contains(objectName.toUpperCase())) {
-                return "\""+objectName+"\"";
+                // CORE-1158 HSQL always uses upper case identifiers
+                return "\""+objectName.toUpperCase()+"\"";
             }
     	}
         return objectName;


### PR DESCRIPTION
Hi,
here is a patch for CORE-1158. I think turning the objectName to upper case is ok. The HSQLDB documentation says that it uses always upper case for identifiers. So quoted identifiers should be converted to upper case.

I'm wondering why HSQLDB doesn't converted quoted identifers :-/

I've fixed it in 2_0_x branch in case of a last bugfix release for 2.0 and because the ticket is marked for 2.0.6 in Jira.

I've rebased this branch on the current 2_0_x sources.

Kind regards
Norman
