### PR TITLE
Mark backing index for primary key as handled as well.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/H2Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/H2Database.java
@@ -231,4 +231,8 @@ public class H2Database extends AbstractJdbcDatabase {
         return false;
     }
 
+    @Override
+    protected String getAutoIncrementClause() {
+        return "AUTO_INCREMENT";
+    }
 }

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingTableChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingTableChangeGenerator.java
@@ -76,17 +76,12 @@ public class MissingTableChangeGenerator implements MissingObjectChangeGenerator
                     constraintsConfig.setPrimaryKeyName(primaryKey.getName());
                 }
                 control.setAlreadyHandledMissing(primaryKey);
+                control.setAlreadyHandledMissing(primaryKey.getBackingIndex());
             } else if (column.isNullable() != null && !column.isNullable()) {
                 constraintsConfig = new ConstraintsConfig();
                 constraintsConfig.setNullable(false);
             }
 
-//                if (column.isUnique()) {
-//					if (constraintsConfig == null) {
-//						constraintsConfig = new ConstraintsConfig();
-//					}
-//					constraintsConfig.setUnique(true);
-//				}
             if (constraintsConfig != null) {
                 columnConfig.setConstraints(constraintsConfig);
             }

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/pgsql/PostgreSQLIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/pgsql/PostgreSQLIntegrationTest.java
@@ -8,10 +8,4 @@ public class PostgreSQLIntegrationTest extends AbstractIntegrationTest {
     public PostgreSQLIntegrationTest() throws Exception {
         super("pgsql", "jdbc:postgresql://"+ getDatabaseServerHostname("PostgreSQL") +"/liquibase");
     }
-
-    @Override
-    @Test
-    public void testRunChangeLog() throws Exception {
-        super.testRunChangeLog();    //To change body of overridden methods use File | Settings | File Templates.
-    }
 }


### PR DESCRIPTION
In MissingTableChangeGenerator, auto increment primary keys are handled.
The backing index for the primary key should be handled as well.
Use AUTO_INCREMENT as the auto increment clause for H2.
The IDENTITY clause does not allow a constraint name to be specified when used for creating a table.
Removed redundant code from PostgreSQLIntegrationTest.
