### PR TITLE
Retry loading resource if it starts with a slash

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/commandline/CommandLineResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/CommandLineResourceAccessor.java
@@ -26,7 +26,14 @@ public class CommandLineResourceAccessor implements ResourceAccessor {
     public InputStream getResourceAsStream(String file) throws IOException {
         URL resource = loader.getResource(file);
         if (resource == null) {
-            throw new IOException(file + " could not be found");
+            // One more try. People are often confused about leading
+            // slashes in resource paths...
+            if (file.startsWith("/")) {
+                resource = loader.getResource(file.substring(1));
+            }
+            if (resource == null) {
+                throw new IOException(file + " could not be found");
+            }
         }
         return resource.openStream();
     }


### PR DESCRIPTION
Resource names starting with a slash indicate that people
are confused about how Liquibase loads included files, and
that's ok - they shouldn't have to think about it. In case
files are written with a slash, this patch retries the
load without the leading slash.
