### PR TITLE
CORE-898 fixing issue that it is impossible to include extensions on Preconditions in an xsd validated xml changelog

### DIFF
--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-2.0.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-2.0.xsd
@@ -1061,6 +1061,8 @@
 				<xsd:element ref="sqlCheck" maxOccurs="unbounded" />
 				<xsd:element ref="changeLogPropertyDefined" maxOccurs="unbounded" />
 				<xsd:element ref="customPrecondition" maxOccurs="unbounded" />
+				<xsd:any namespace="##other" processContents="lax" minOccurs="0"
+					maxOccurs="unbounded" />
 			</xsd:choice>
 		</xsd:sequence>
 

--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.0.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.0.xsd
@@ -1134,6 +1134,8 @@
 				<xsd:element ref="changeLogPropertyDefined" maxOccurs="unbounded" />
                 <xsd:element ref="expectedQuotingStrategy" maxOccurs="unbounded" />
 				<xsd:element ref="customPrecondition" maxOccurs="unbounded" />
+				<xsd:any namespace="##other" processContents="lax" minOccurs="0"
+					maxOccurs="unbounded" />
 			</xsd:choice>
 		</xsd:sequence>
 


### PR DESCRIPTION
CORE-898 - fixing missing xdd entries to allow extensions on precondions in xml. CORE-898 was wrongly closed, it was not fixed

This should be updated in the xsds accessible from:

http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd
http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd
