### PR TITLE
Removing "-p (prompt)" from commandline help text

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -490,7 +490,7 @@ public class Main {
         stream.println("Required Parameters:");
         stream.println(" --changeLogFile=<path and filename>        Migration file");
         stream.println(" --username=<value>                         Database username");
-        stream.println(" --password=<value>  | -p (prompt)          Database password");
+        stream.println(" --password=<value>                         Database password");
         stream.println(" --url=<value>                              Database URL");
         stream.println("");
         stream.println("Optional Parameters:");
@@ -522,7 +522,7 @@ public class Main {
         stream.println("");
         stream.println("Required Diff Parameters:");
         stream.println(" --referenceUsername=<value>                Reference Database username");
-        stream.println(" --referencePassword=<value> | -rp (prompt) Reference Database password");
+        stream.println(" --referencePassword=<value>                Reference Database password");
         stream.println(" --referenceUrl=<value>                     Reference Database URL");
         stream.println("");
         stream.println("Optional Diff Parameters:");


### PR DESCRIPTION
The commandline help text still says the -p argument for password prompting is available, despite that option being removed.
