### PR TITLE
bug on GenerateChangeLog command line

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -772,7 +772,7 @@ public class Main {
                 CommandLineUtils.doDiffToChangeLog(changeLogFile, createReferenceDatabaseFromCommandParams(commandParams), database, diffOutputControl);
                 return;
             } else if ("generateChangeLog".equalsIgnoreCase(command)) {
-                CommandLineUtils.doGenerateChangeLog(changeLogFile, database, defaultSchemaName, defaultCatalogName, StringUtils.trimToNull(diffTypes), StringUtils.trimToNull(changeSetAuthor), StringUtils.trimToNull(changeSetContext), StringUtils.trimToNull(dataOutputDirectory), diffOutputControl);
+                CommandLineUtils.doGenerateChangeLog(changeLogFile, database, defaultCatalogName, defaultSchemaName, StringUtils.trimToNull(diffTypes), StringUtils.trimToNull(changeSetAuthor), StringUtils.trimToNull(changeSetContext), StringUtils.trimToNull(dataOutputDirectory), diffOutputControl);
                 return;
             }
 


### PR DESCRIPTION
call to CommandLineUtils.doGenerateChangeLog had parameters defaultCatalogName, defaultSchemaName swapped
