### PR TITLE
Ignore eclipse project files.  Reorganize and document intent.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,26 @@
-/target
-/.project
-/.settings
+# ignore maven target dir
+target
+
+# ignore eclipse project files
+.project
+.settings
+.classpath
+
+# ignore netbeans project files
 *nb-configuration.xml
-/.classpath
+
+# ignore select intellij IDEA files
 /.idea/workspace.xml
+liquibase.iws
+
+# ignore build outputs
 /out
 /bin
-liquibase.integrationtest.local.properties
 /liquibase
+
+# ignore local configuration
+liquibase.integrationtest.local.properties
+
+# ignore logs
 /derby.log
-/liquibase-core/target/
-/liquibase-integration-tests/target/
-/liquibase-maven-plugin/target/
-/liquibase-osgi/target/
+


### PR DESCRIPTION
After reorganizing the .gitignore file I do not have eclipse or intellij project files cluttering up status.
I hope it helps others.

I went from:

``` git
# Untracked files:
#   (use "git add <file>..." to include in what will be committed)
#
#   liquibase-core/.classpath
#   liquibase-core/.project
#   liquibase-core/.settings/
#   liquibase-integration-tests/.classpath
#   liquibase-integration-tests/.project
#   liquibase-integration-tests/.settings/
#   liquibase-maven-plugin/.classpath
#   liquibase-maven-plugin/.project
#   liquibase-maven-plugin/.settings/
#   liquibase-osgi/.classpath
#   liquibase-osgi/.project
#   liquibase-osgi/.settings/
#   liquibase.iws
#   samples/
```

to pretty clean
