### PR TITLE
CORE-1376 - Allowing 400 characters for changelog filenames

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateDatabaseChangeLogTableGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateDatabaseChangeLogTableGenerator.java
@@ -55,6 +55,6 @@ public class CreateDatabaseChangeLogTableGenerator extends AbstractSqlGenerator<
     }
 
     protected String getFilenameColumnSize() {
-        return "200";
+        return "400";
     }
 }


### PR DESCRIPTION
Fix for Jira issue CORE-1376: databasechangelog.filename column is too short
