### PR TITLE
Fix DATABASECHANGELOG/DATABASECHANGELOGLOCK re-creation.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
@@ -212,7 +212,7 @@ public class OracleDatabase extends AbstractJdbcDatabase {
                 return true;
             }
         }else if (isSystemObject(example.getSchema())) {
-            return true;
+            return !example.getName().startsWith("DATABASECHANGELOG");
         }
         if (example instanceof Catalog) {
             if (("SYSTEM".equals(example.getName()) || "SYS".equals(example.getName()) || "CTXSYS".equals(example.getName()) || "XDB".equals(example.getName()))) {


### PR DESCRIPTION
When running as SYSTEM user, the LQB table checks were always considered
as system objects, thus leading to a new creation attempt, bound to fail.
