### PR TITLE
Overwrite lock wait time with (optional) system property

### DIFF
--- a/liquibase-core/src/main/java/liquibase/lockservice/LockServiceImpl.java
+++ b/liquibase-core/src/main/java/liquibase/lockservice/LockServiceImpl.java
@@ -24,8 +24,20 @@ public class LockServiceImpl implements LockService {
 
     private boolean hasChangeLogLock = false;
 
+    public static final String LOCK_WAIT_TIME_SYSTEM_PROPERTY = "liquibase.changeLogLockWaitTimeInMinutes";
+    
     private long changeLogLockWaitTime = 1000 * 60 * 5;  //default to 5 mins
     private long changeLogLocRecheckTime = 1000 * 10;  //default to every 10 seconds
+
+
+    {
+        try {
+			changeLogLockWaitTime = 1000 * 60 * Long.parseLong(System.getProperty(LOCK_WAIT_TIME_SYSTEM_PROPERTY));
+			LogFactory.getLogger().info("lockWaitTime change to: " + changeLogLockWaitTime);
+		} catch (NumberFormatException e) {
+			// was non or not valid configuration, we will keep the standard value
+		}
+    }
 
     public LockServiceImpl() {
     }


### PR DESCRIPTION
Very useful/necessary if you have long running migrations (>5 min) in a cluster. Only one node performs the migration, other nodes are waiting and then end in a time out. Setting the system property e.g. liquibase.changeLogLockWaitTimeInMinutes=15 will increase wait time before the timeout kicks in.
