### PR TITLE
Allow the creation of snaphots of non-Jdbc based databases

### DIFF
--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/JdbcSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/JdbcSnapshotGenerator.java
@@ -36,18 +36,18 @@ public abstract class JdbcSnapshotGenerator implements SnapshotGenerator {
     }
 
     public int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
-	if(database instanceof AbstractJdbcDatabase) {
-	        if (defaultFor != null && defaultFor.isAssignableFrom(objectType)) {
-	            return PRIORITY_DEFAULT;
-	        }
-	        if (addsTo() != null) {
-	            for (Class<? extends DatabaseObject> type : addsTo()) {
-	                if (type.isAssignableFrom(objectType)) {
-	                    return PRIORITY_ADDITIONAL;
-	                }
-	            }
-	        }
-	}
+        if(database instanceof AbstractJdbcDatabase) {
+            if (defaultFor != null && defaultFor.isAssignableFrom(objectType)) {
+                return PRIORITY_DEFAULT;
+            }
+            if (addsTo() != null) {
+                for (Class<? extends DatabaseObject> type : addsTo()) {
+                    if (type.isAssignableFrom(objectType)) {
+                        return PRIORITY_ADDITIONAL;
+                    }
+                }
+            }
+        }
         return PRIORITY_NONE;
 
     }
@@ -57,7 +57,7 @@ public abstract class JdbcSnapshotGenerator implements SnapshotGenerator {
     }
 
     public Class<? extends DatabaseObject> defaultFor() {
-	return defaultFor;
+        return defaultFor;
     }
 
     public DatabaseObject snapshot(DatabaseObject example, DatabaseSnapshot snapshot, SnapshotGeneratorChain chain) throws DatabaseException, InvalidExampleException {


### PR DESCRIPTION
I'd like to create an extension for database diffs with JPA-annotated classes.
Currently most of the subclasses of `JdbcSnapshotGenerator` heavily depend on the database being an `AbstractJdbcDatabase`.

I want to create a Database-Class for the JPA-annotated classes which is not a subclass of `AbstractJdbcDatabase`. But since all subclasses have a priority > 0 they are considered as snapshot generators and then fail with exceptions.
