### PR TITLE
Fixed Oracle update error - unquoted reserved word

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
@@ -3,6 +3,7 @@ package liquibase.database.core;
 import liquibase.CatalogAndSchema;
 import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.DatabaseConnection;
+import liquibase.database.ObjectQuotingStrategy;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.logging.LogFactory;
@@ -55,12 +56,24 @@ public class OracleDatabase extends AbstractJdbcDatabase {
             method.invoke(sqlConn, true);
 
             reservedWords.addAll(Arrays.asList(sqlConn.getMetaData().getSQLKeywords().toUpperCase().split(",\\s*")));
-            reservedWords.addAll(Arrays.asList("USER", "SESSION","RESOURCE", "START", "SIZE")); //more reserved words not returned by driver
+            reservedWords.addAll(Arrays.asList("USER", "SESSION","RESOURCE", "START", "SIZE", "PASSWORD")); //more reserved words not returned by driver
         } catch (Exception e) {
             LogFactory.getLogger().info("Could not set remarks reporting on OracleDatabase: " + e.getMessage());
             ; //cannot set it. That is OK
         }
         super.setConnection(conn);
+    }
+
+    @Override
+    public String escapeObjectName(String objectName, Class<? extends DatabaseObject> objectType) {
+        if (objectName != null) {
+            if (objectName.contains("-") || startsWithNumeric(objectName) || isReservedWord(objectName)) {
+                return quotingStartCharacter + objectName + quotingEndCharacter;
+            } else if (quotingStrategy == ObjectQuotingStrategy.QUOTE_ALL_OBJECTS) {
+                return quotingStartCharacter + objectName + quotingEndCharacter;
+            }
+        }
+        return objectName;
     }
 
     public String getShortName() {


### PR DESCRIPTION
Hi there,
Even if I've added "PASSWORD" reserved word I still have [that error](https://github.com/liquibase/liquibase/pull/154)  - 

> _Caused by: liquibase.exception.DatabaseException: java.sql.SQLSyntaxErrorException: ORA-00904: "PASSWORD": invalid identifier
>     at liquibase.snapshot.jvm.ColumnSnapshotGenerator.snapshotObject(ColumnSnapshotGenerator.java:58)
>     at liquibase.snapshot.jvm.JdbcSnapshotGenerator.snapshot(JdbcSnapshotGenerator.java:59)
>     at liquibase.snapshot.SnapshotGeneratorChain.snapshot(SnapshotGeneratorChain.java:42)
>     at liquibase.snapshot.DatabaseSnapshot.include(DatabaseSnapshot.java:75)
>     at liquibase.snapshot.DatabaseSnapshot.replaceObject(DatabaseSnapshot.java:144)
>     at liquibase.snapshot.DatabaseSnapshot.includeNestedObjects(DatabaseSnapshot.java:107)
>     at liquibase.snapshot.DatabaseSnapshot.include(DatabaseSnapshot.java:94)
>     at liquibase.snapshot.DatabaseSnapshot.replaceObject(DatabaseSnapshot.java:144)
>     at liquibase.snapshot.DatabaseSnapshot.replaceObject(DatabaseSnapshot.java:157)
>     at liquibase.snapshot.DatabaseSnapshot.includeNestedObjects(DatabaseSnapshot.java:107)
>     at liquibase.snapshot.DatabaseSnapshot.include(DatabaseSnapshot.java:94)
>     at liquibase.snapshot.DatabaseSnapshot.replaceObject(DatabaseSnapshot.java:124)
>     at liquibase.snapshot.DatabaseSnapshot.includeNestedObjects(DatabaseSnapshot.java:107)
>     at liquibase.snapshot.DatabaseSnapshot.include(DatabaseSnapshot.java:94)
>     at liquibase.snapshot.SnapshotGeneratorFactory.createSnapshot(SnapshotGeneratorFactory.java:128)
>     at liquibase.snapshot.SnapshotGeneratorFactory.createSnapshot(SnapshotGeneratorFactory.java:139)
>     at liquibase.snapshot.SnapshotGeneratorFactory.getDatabaseChangeLogTable(SnapshotGeneratorFactory.java:146)
>     at liquibase.database.AbstractJdbcDatabase.checkDatabaseChangeLogTable(AbstractJdbcDatabase.java:619)
>     ... 5 more
> Caused by: java.sql.SQLSyntaxErrorException: ORA-00904: "PASSWORD": invalid identifier
>     at oracle.jdbc.driver.T4CTTIoer.processError(T4CTTIoer.java:452)
>     at oracle.jdbc.driver.T4CTTIoer.processError(T4CTTIoer.java:400)
>     at oracle.jdbc.driver.T4C8Oall.processError(T4C8Oall.java:884)
>     at oracle.jdbc.driver.T4CTTIfun.receive(T4CTTIfun.java:471)
>     at oracle.jdbc.driver.T4CTTIfun.doRPC(T4CTTIfun.java:199)
>     at oracle.jdbc.driver.T4C8Oall.doOALL(T4C8Oall.java:535)
>     at oracle.jdbc.driver.T4CStatement.doOall8(T4CStatement.java:197)
>     at oracle.jdbc.driver.T4CStatement.executeForDescribe(T4CStatement.java:1165)
>     at oracle.jdbc.driver.OracleStatement.executeMaybeDescribe(OracleStatement.java:1444)
>     at oracle.jdbc.driver.OracleStatement.doExecuteWithTimeout(OracleStatement.java:1662)
>     at oracle.jdbc.driver.OracleStatement.executeQuery(OracleStatement.java:1958)
>     at oracle.jdbc.driver.OracleStatementWrapper.executeQuery(OracleStatementWrapper.java:1695)
>     at liquibase.snapshot.jvm.ColumnSnapshotGenerator.readColumn(ColumnSnapshotGenerator.java:137)
>     at liquibase.snapshot.jvm.ColumnSnapshotGenerator.snapshotObject(ColumnSnapshotGenerator.java:53)
>     ... 22 more_

I'll try to explain the reason why I've override that method.
In parent method _quotingStrategy_ is always equals _ObjectQuotingStrategy.LEGACY_
#### Parent method:

``` java
    public String escapeObjectName(String objectName, Class<? extends DatabaseObject> objectType) {
        if (objectName == null || quotingStrategy == ObjectQuotingStrategy.LEGACY) {
            return objectName;
        } else if (objectName.contains("-") || startsWithNumeric(objectName) || isReservedWord(objectName)) {
            return quotingStartCharacter + objectName + quotingEndCharacter;
        } else if (quotingStrategy == ObjectQuotingStrategy.QUOTE_ALL_OBJECTS) {
            return quotingStartCharacter + objectName + quotingEndCharacter;
        }
        return objectName;
    }
```

Then it just doesn't try to check reserved words.
I've changed this behaviour in Oracle implementation:
#### Oracle method:

``` java
 public String escapeObjectName(String objectName, Class<? extends DatabaseObject> objectType) {
     if (objectName != null) {
         if (objectName.contains("-") || startsWithNumeric(objectName) || isReservedWord(objectName)) {
             return quotingStartCharacter + objectName + quotingEndCharacter;
         } else if (quotingStrategy == ObjectQuotingStrategy.QUOTE_ALL_OBJECTS) {
             return quotingStartCharacter + objectName + quotingEndCharacter;
         }
     }
     return objectName;
 }
```

and this fixed the problem.
