### PR TITLE
Only use JdbcSnapshotGenerators on AbstractJdbcDatabases.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/JdbcSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/JdbcSnapshotGenerator.java
@@ -36,13 +36,15 @@ public abstract class JdbcSnapshotGenerator implements SnapshotGenerator {
     }
 
     public int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
-        if (defaultFor != null && defaultFor.isAssignableFrom(objectType)) {
-            return PRIORITY_DEFAULT;
-        }
-        if (addsTo() != null) {
-            for (Class<? extends DatabaseObject> type : addsTo()) {
-                if (type.isAssignableFrom(objectType)) {
-                    return PRIORITY_ADDITIONAL;
+        if (database instanceof AbstractJdbcDatabase) {
+            if (defaultFor != null && defaultFor.isAssignableFrom(objectType)) {
+                return PRIORITY_DEFAULT;
+            }
+            if (addsTo() != null) {
+                for (Class<? extends DatabaseObject> type : addsTo()) {
+                    if (type.isAssignableFrom(objectType)) {
+                        return PRIORITY_ADDITIONAL;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Working on updating liquibase-hibernate to Liquibase 3.x, but the new snapshot framework is a bit too eager. Added a guard so it doesn't try to run the snapshot generators against unsupported databases.
