### PR TITLE
Fixed bugs with foreign keys

### DIFF
--- a/liquibase-core/src/main/java/liquibase/diff/compare/core/ForeignKeyComparator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/compare/core/ForeignKeyComparator.java
@@ -38,6 +38,13 @@ public class ForeignKeyComparator implements DatabaseObjectComparator {
             columnsTheSame = StringUtils.trimToEmpty(((ForeignKey) databaseObject1).getForeignKeyColumns()).equals(StringUtils.trimToEmpty(((ForeignKey) databaseObject2).getForeignKeyColumns())) &&
                     StringUtils.trimToEmpty(((ForeignKey) databaseObject1).getPrimaryKeyColumns()).equals(StringUtils.trimToEmpty(((ForeignKey) databaseObject2).getPrimaryKeyColumns()));
         } else {
+            if (((ForeignKey) databaseObject1).getForeignKeyColumns()== null || ((ForeignKey) databaseObject2).getForeignKeyColumns() == null) {
+              if (((ForeignKey) databaseObject1).getForeignKeyColumns() == ((ForeignKey) databaseObject2).getForeignKeyColumns()) {
+                return true;
+              } else {
+                return false;
+              }
+            }
             columnsTheSame = ((ForeignKey) databaseObject1).getForeignKeyColumns().equalsIgnoreCase(((ForeignKey) databaseObject2).getForeignKeyColumns()) &&
                     ((ForeignKey) databaseObject1).getPrimaryKeyColumns().equalsIgnoreCase(((ForeignKey) databaseObject2).getPrimaryKeyColumns());
 


### PR DESCRIPTION
[1] Composite foreign key generation now works
(ForeignKeySnaphotGenerator.java)

https://liquibase.jira.com/browse/CORE-548

[2] - Crash since NullPointerException on generateChangeLog in
ForeignKeyComparator.java.
