### PR TITLE
Bug Fix: InsertOrUpdateGeneratorPostgres

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/InsertOrUpdateGeneratorPostgres.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/InsertOrUpdateGeneratorPostgres.java
@@ -35,8 +35,17 @@ public class InsertOrUpdateGeneratorPostgres extends InsertOrUpdateGenerator {
 					sqlGeneratorChain));
 		} catch (LiquibaseException e) {
 			// do a select statement instead
+			/*
 			generatedSql.append("select * from " + database.escapeTableName(insertOrUpdateStatement.getCatalogName(), insertOrUpdateStatement.getSchemaName(), insertOrUpdateStatement.getTableName()) + " WHERE " +
 					getWhereClause(insertOrUpdateStatement, database) + "\n");
+			*/
+
+			// The above code results in an invalid pl/pgsql statement as the select is not being stored.
+			// The perform keyword can be used here as an alternative as it does not return a value.
+			// Additionally the statement is not being terminated correctly, it is missing a semi-colon.
+			generatedSql.append("perform * from "
+					+ database.escapeTableName(insertOrUpdateStatement.getCatalogName(), insertOrUpdateStatement.getSchemaName(),
+							insertOrUpdateStatement.getTableName()) + " WHERE " + getWhereClause(insertOrUpdateStatement, database) + ";\n");
 		}
 		generatedSql.append("IF not found THEN\n");
 		generatedSql.append(getInsertStatement(insertOrUpdateStatement,


### PR DESCRIPTION
When updating a basic two-column many-to-many relationship table the statement generated by the InsertOrUpdateGeneratorPostgres incorrectly uses the SELECT keyword which causes in the pl/pgsql statement to fail.

This change uses the PERFORM keyword instead to ensure that a result is not returned.

Also, the statement was not being terminated with a semi-colon which was also an issue.
