### PR TITLE
Support for relative paths in valueBlobFile and valueClobFile attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ liquibase.integrationtest.local.properties
 /derby.log
 /.idea
 *.iml
+.DS_Store

--- a/liquibase-core/src/main/java/liquibase/change/ColumnConfig.java
+++ b/liquibase-core/src/main/java/liquibase/change/ColumnConfig.java
@@ -1,12 +1,5 @@
 package liquibase.change;
 
-import liquibase.statement.DatabaseFunction;
-import liquibase.statement.SequenceCurrentValueFunction;
-import liquibase.statement.SequenceNextValueFunction;
-import liquibase.structure.core.Column;
-import liquibase.structure.core.Table;
-import liquibase.util.ISODateFormat;
-
 import java.math.BigInteger;
 import java.text.NumberFormat;
 import java.text.ParseException;
@@ -17,8 +10,14 @@ import java.util.Set;
 
 import liquibase.serializer.LiquibaseSerializable;
 import liquibase.serializer.ReflectionSerializer;
-import liquibase.structure.core.*;
 import liquibase.statement.DatabaseFunction;
+import liquibase.statement.SequenceCurrentValueFunction;
+import liquibase.statement.SequenceNextValueFunction;
+import liquibase.structure.core.Column;
+import liquibase.structure.core.ForeignKey;
+import liquibase.structure.core.PrimaryKey;
+import liquibase.structure.core.Table;
+import liquibase.structure.core.UniqueConstraint;
 import liquibase.util.ISODateFormat;
 import liquibase.util.StringUtils;
 
@@ -36,6 +35,7 @@ public class ColumnConfig implements LiquibaseSerializable {
     private Boolean valueBoolean;
     private String valueBlobFile;
     private String valueClobFile;
+    private String encoding;
     private DatabaseFunction valueComputed;
     private SequenceNextValueFunction valueSequenceNext;
     private SequenceCurrentValueFunction valueSequenceCurrent;
@@ -52,7 +52,6 @@ public class ColumnConfig implements LiquibaseSerializable {
     private BigInteger startWith;
     private BigInteger incrementBy;
     private String remarks;
-
 
     /**
      * Create a ColumnConfig object based on a {@link Column} snapshot.
@@ -347,6 +346,18 @@ public class ColumnConfig implements LiquibaseSerializable {
         return this;
     }
 
+    /**
+     * Return encoding of a file, referenced via {@link #valueClobFile}.
+     */
+    public String getEncoding() {
+        return encoding;
+    }
+    
+    public ColumnConfig setEncoding(String encoding) {
+        this.encoding = encoding;
+        return this;
+    }
+    
     /**
      * Return the value from whatever setValue* function was called. Will return null if none were set.
      */

--- a/liquibase-core/src/main/java/liquibase/change/core/InsertDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/InsertDataChange.java
@@ -90,7 +90,7 @@ public class InsertDataChange extends AbstractChange implements ChangeWithColumn
 
         if (needsPreparedStatement) {
             return new SqlStatement[] {
-                    new InsertExecutablePreparedStatement(database, catalogName, schemaName, tableName, columns)
+                    new InsertExecutablePreparedStatement(database, getChangeSet(), catalogName, schemaName, tableName, columns)
             };
         }
 

--- a/liquibase-core/src/main/java/liquibase/change/core/UpdateDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/UpdateDataChange.java
@@ -53,7 +53,7 @@ public class UpdateDataChange extends AbstractModifyDataChange implements Change
 
         if (needsPreparedStatement) {
             return new SqlStatement[] {
-                    new UpdateExecutablePreparedStatement(database, catalogName, schemaName, tableName, columns)
+                    new UpdateExecutablePreparedStatement(database, getChangeSet(), catalogName, schemaName, tableName, columns)
             };
         }
     	

--- a/liquibase-core/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
+++ b/liquibase-core/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
@@ -4,9 +4,10 @@ import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
+import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.PreparedStatement;
@@ -15,20 +16,31 @@ import java.util.ArrayList;
 import java.util.List;
 
 import liquibase.change.ColumnConfig;
+import liquibase.changelog.ChangeSet;
 import liquibase.database.Database;
 import liquibase.database.PreparedStatementFactory;
 import liquibase.exception.DatabaseException;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import liquibase.resource.CompositeResourceAccessor;
+import liquibase.resource.FileSystemResourceAccessor;
+import liquibase.resource.ResourceAccessor;
+import liquibase.resource.UtfBomAwareReader;
+import liquibase.util.StreamUtil;
+import liquibase.util.StringUtils;
+import liquibase.util.file.FilenameUtils;
 
 public abstract class ExecutablePreparedStatementBase implements ExecutablePreparedStatement {
 
+	private ChangeSet changeSet;
 	protected Database database;
 	private String catalogName;
 	private String schemaName;
 	private String tableName;
 	private List<ColumnConfig> columns;
 
-	protected ExecutablePreparedStatementBase(Database database, String catalogName, String schemaName, String tableName, List<ColumnConfig> columns) {
+	protected ExecutablePreparedStatementBase(Database database, ChangeSet changeSet, String catalogName, String schemaName, String tableName, List<ColumnConfig> columns) {
 		this.database = database;
+		this.changeSet = changeSet;
 		this.catalogName = catalogName;
 		this.schemaName = schemaName;
 		this.tableName = tableName;
@@ -84,34 +96,139 @@ public abstract class ExecutablePreparedStatementBase implements ExecutablePrepa
 		    }
 		} else if(col.getValueDate() != null) {
 		    stmt.setDate(i, new java.sql.Date(col.getValueDate().getTime()));
+		} else if (col.getValueBlobFile() != null) {
+			try {
+				LOBContent<InputStream> lob = toBinaryStream(col.getValueBlobFile());
+				stmt.setBinaryStream(i, lob.content, lob.length);
+			} catch (IOException e) {
+				throw new DatabaseException(e.getMessage(), e); // wrap
+			}
+		} else if(col.getValueClobFile() != null) {
+			try {
+				LOBContent<Reader> lob = toCharacterStream(col.getValueClobFile(), col.getEncoding());
+				stmt.setCharacterStream(i, lob.content, lob.length);
+			}
+			catch (IOException e) {
+				throw new DatabaseException(e.getMessage(), e); // wrap
+			}
 		} else {
-	    String valueBlobFileName = col.getValueBlobFile();
-	    if (valueBlobFileName != null) {
-		        try {
-		    File file = new File(valueBlobFileName);
-		    InputStream in;
-		    if (file.exists()) {
-		        in = new FileInputStream(file);
-		    } else {
-			in = getClass().getResourceAsStream(valueBlobFileName);
-		    }
-		    stmt.setBinaryStream(i, new BufferedInputStream(in),
-		    	(int) file.length());
-		        } catch (FileNotFoundException e) {
-		            throw new DatabaseException(e.getMessage(), e); // wrap
-		        }
-		    } else if(col.getValueClobFile() != null) {
-		        try {
-		            File file = new File(col.getValueClobFile());
-		            stmt.setCharacterStream(i, new BufferedReader(new FileReader(file)), (int) file.length());
-		        } catch(FileNotFoundException e) {
-		            throw new DatabaseException(e.getMessage(), e); // wrap
-		        }
-		    } else {
-		    	// NULL values might intentionally be set into a change, we must also add them to the prepared statement  
-		    	stmt.setNull(i, java.sql.Types.NULL);
-		    }
+			// NULL values might intentionally be set into a change, we must also add them to the prepared statement  
+			stmt.setNull(i, java.sql.Types.NULL);
 		}
+	}
+
+	private class LOBContent<T> {
+		private final T content;
+		private final long length;
+		
+		LOBContent(T content, long length) {
+			this.content = content;
+			this.length = length;
+		}
+	}
+
+	private LOBContent<InputStream> toBinaryStream(String valueLobFile) throws DatabaseException, IOException
+	{
+		InputStream in = getResourceAsStream(valueLobFile);
+		
+		if (in == null) {
+			throw new DatabaseException("BLOB resource not found: " + valueLobFile);
+		}
+		
+		if (in instanceof FileInputStream) {
+			return new LOBContent<InputStream>(createStream(in), ((FileInputStream) in).getChannel().size());
+		}
+		
+		in = createStream(in);
+		
+		final int IN_MEMORY_THRESHOLD = 100000;
+		
+		if (in.markSupported()) {
+			in.mark(IN_MEMORY_THRESHOLD);
+		}
+		
+		long length = StreamUtil.getContentLength(in);
+		
+		if (in.markSupported() && length <= IN_MEMORY_THRESHOLD) {
+			in.reset();
+		} else {
+			in = createStream(getResourceAsStream(valueLobFile));
+		}
+		
+		return new LOBContent<InputStream>(in, length);
+	}
+
+	private InputStream createStream(InputStream in) {
+		return (in instanceof BufferedInputStream) ? in : new BufferedInputStream(in);
+	}
+	
+	private LOBContent<Reader> toCharacterStream(String valueLobFile, String encoding) throws IOException, DatabaseException
+	{
+		InputStream in = getResourceAsStream(valueLobFile);
+		
+		if (in == null) {
+			throw new DatabaseException("CLOB resource not found: " + valueLobFile);
+		}
+		
+		final int IN_MEMORY_THRESHOLD = 100000;
+		
+		Reader reader = createReader(in, encoding);
+		
+		if (reader.markSupported()) {
+			reader.mark(IN_MEMORY_THRESHOLD);
+		}
+		
+		long length = StreamUtil.getContentLength(reader);
+		
+		if (reader.markSupported() && length <= IN_MEMORY_THRESHOLD) {
+			reader.reset();
+		} else {
+			reader = createReader(getResourceAsStream(valueLobFile), encoding);
+		}
+		
+		return new LOBContent<Reader>(reader, length);
+	}
+
+	@SuppressWarnings("resource")
+	private Reader createReader(InputStream in, String encoding) throws UnsupportedEncodingException {
+		return new BufferedReader(
+				StringUtils.trimToNull(encoding) == null
+					? new UtfBomAwareReader(in)
+					: new UtfBomAwareReader(in, encoding));
+	}
+	
+	protected InputStream getResourceAsStream(String valueLobFile) throws IOException {
+		//  The same lookup logic that is in LiquibaseServletListener#executeUpdate()
+		
+		Thread currentThread = Thread.currentThread();
+		ClassLoader contextClassLoader = currentThread.getContextClassLoader();
+		ResourceAccessor threadClFO = new ClassLoaderResourceAccessor(contextClassLoader);
+
+		ResourceAccessor clFO = new ClassLoaderResourceAccessor();
+		ResourceAccessor fsFO = new FileSystemResourceAccessor();
+		
+		ResourceAccessor accessor = new CompositeResourceAccessor(clFO, fsFO, threadClFO);
+		
+		String fileName = getFileName(valueLobFile);
+		
+		InputStream in = accessor.getResourceAsStream(fileName);
+		return in;
+	}
+
+	protected String getFileName(String fileName) {
+		//  Most of this method were copy-pasted from XMLChangeLogSAXHandler#handleIncludedChangeLog()
+		
+		String relativeBaseFileName = changeSet.getFilePath();
+		
+		// workaround for FilenameUtils.normalize() returning null for relative paths like ../conf/liquibase.xml
+		String tempFile = FilenameUtils.concat(FilenameUtils.getFullPath(relativeBaseFileName), fileName);
+		if (tempFile != null && new File(tempFile).exists() == true) {
+			fileName = tempFile;
+		} else {
+			fileName = FilenameUtils.getFullPath(relativeBaseFileName) + fileName;
+		}
+		
+		return fileName;
 	}
 
 	@Override

--- a/liquibase-core/src/main/java/liquibase/statement/InsertExecutablePreparedStatement.java
+++ b/liquibase-core/src/main/java/liquibase/statement/InsertExecutablePreparedStatement.java
@@ -4,6 +4,7 @@ package liquibase.statement;
 import java.util.List;
 
 import liquibase.change.ColumnConfig;
+import liquibase.changelog.ChangeSet;
 import liquibase.database.Database;
 
 /**
@@ -11,8 +12,8 @@ import liquibase.database.Database;
  */
 public class InsertExecutablePreparedStatement extends ExecutablePreparedStatementBase {
 	
-	public InsertExecutablePreparedStatement(Database database, String catalogName, String schemaName, String tableName, List<ColumnConfig> columns) {
-		super(database, catalogName, schemaName, tableName, columns);
+	public InsertExecutablePreparedStatement(Database database, ChangeSet changeSet, String catalogName, String schemaName, String tableName, List<ColumnConfig> columns) {
+		super(database, changeSet, catalogName, schemaName, tableName, columns);
 	}
 
 	@Override

--- a/liquibase-core/src/main/java/liquibase/statement/UpdateExecutablePreparedStatement.java
+++ b/liquibase-core/src/main/java/liquibase/statement/UpdateExecutablePreparedStatement.java
@@ -3,12 +3,13 @@ package liquibase.statement;
 import java.util.List;
 
 import liquibase.change.ColumnConfig;
+import liquibase.changelog.ChangeSet;
 import liquibase.database.Database;
 
 public class UpdateExecutablePreparedStatement extends ExecutablePreparedStatementBase {
 
-	public UpdateExecutablePreparedStatement(Database database, String catalogName, String schemaName, String tableName, List<ColumnConfig> columns) {
-		super(database, catalogName, schemaName, tableName, columns);
+	public UpdateExecutablePreparedStatement(Database database, ChangeSet changeSet, String catalogName, String schemaName, String tableName, List<ColumnConfig> columns) {
+		super(database, changeSet, catalogName, schemaName, tableName, columns);
 	}
 
 	@Override

--- a/liquibase-core/src/main/java/liquibase/util/StreamUtil.java
+++ b/liquibase-core/src/main/java/liquibase/util/StreamUtil.java
@@ -95,4 +95,28 @@ public class StreamUtil {
             r = inputStream.read(bytes);
         }
     }
+
+    public static long getContentLength(InputStream in) throws IOException
+    {
+        long length = 0;
+        byte[] buf = new byte[4096];
+        int bytesRead = in.read(buf);
+        while (bytesRead > 0) {
+            length += bytesRead;
+            bytesRead = in.read(buf);
+        }
+        return length;
+    }
+
+    public static long getContentLength(Reader reader) throws IOException
+    {
+        long length = 0;
+        char[] buf = new char[2048];
+        int charsRead = reader.read(buf);
+        while (charsRead > 0) {
+            length += charsRead;
+            charsRead = reader.read(buf);
+        }
+        return length;
+    }
 }

--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.1.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.1.xsd
@@ -296,6 +296,15 @@
 		<xsd:attribute name="startWith" type="xsd:long" />
 		<xsd:attribute name="incrementBy" type="xsd:long" />
 		<xsd:attribute name="remarks" type="xsd:string" />
+        <xsd:attribute name="encoding" type="xsd:string">
+            <xsd:annotation>
+                <xsd:appinfo>
+                    <xsd:documentation>
+                        Used with valueClobFile to specify file encoding explicitly.
+                    </xsd:documentation>
+                </xsd:appinfo>
+            </xsd:annotation>
+        </xsd:attribute>
 	</xsd:attributeGroup>
 
     <xsd:complexType name="columnType" mixed="true">

--- a/liquibase-core/src/test/java/liquibase/statement/ExecutablePreparedStatementTest.java
+++ b/liquibase-core/src/test/java/liquibase/statement/ExecutablePreparedStatementTest.java
@@ -1,0 +1,167 @@
+package liquibase.statement;
+
+import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.classextension.EasyMock.createMock;
+import static org.easymock.classextension.EasyMock.replay;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.Reader;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+
+import liquibase.change.ColumnConfig;
+import liquibase.changelog.ChangeSet;
+import liquibase.database.PreparedStatementFactory;
+import liquibase.database.core.MockDatabase;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.DatabaseException;
+
+import org.easymock.Capture;
+import org.easymock.IAnswer;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ExecutablePreparedStatementTest {
+
+	@Test
+	public void testValueBlobFileFromClassLoader() throws DatabaseException, SQLException {
+		ColumnConfig columnConfig = new ColumnConfig();
+		
+		String valueBlobFile = "../unicode-file.txt";
+		columnConfig.setValueBlobFile(valueBlobFile);
+		
+		List<ColumnConfig> columns = Arrays.asList(columnConfig);
+		
+		ChangeSet changeSet = createMock(ChangeSet.class);
+		expect(changeSet.getFilePath()).andReturn("liquibase/util/foo/");
+		replay(changeSet);
+		
+		assertSetBinaryStream(columns, changeSet);
+	}
+
+	@Test
+	public void testValueBlobFileFromFile() throws DatabaseException, SQLException {
+		ColumnConfig columnConfig = new ColumnConfig();
+		
+		String valueBlobFile = "unicode-file.txt";
+		columnConfig.setValueBlobFile(valueBlobFile);
+		
+		List<ColumnConfig> columns = Arrays.asList(columnConfig);
+		
+		ChangeSet changeSet = createMock(ChangeSet.class);
+		expect(changeSet.getFilePath()).andReturn("src/test/resources/liquibase/util/");
+		replay(changeSet);
+		
+		assertSetBinaryStream(columns, changeSet);
+	}
+
+	protected void assertSetBinaryStream(List<ColumnConfig> columns, ChangeSet changeSet)
+			throws SQLException, DatabaseException {
+		
+		InsertExecutablePreparedStatement statement =
+				new InsertExecutablePreparedStatement(
+						new MockDatabase(),
+						changeSet,
+						"catalog", "schema", "table", columns);
+		
+		PreparedStatement stmt = createMock(PreparedStatement.class);
+
+		final Capture<Integer> index = new Capture<Integer>();
+		final Capture<InputStream> in = new Capture<InputStream>();
+		final Capture<Long> length = new Capture<Long>();
+		stmt.setBinaryStream(capture(index), capture(in), capture(length));
+		expectLastCall().andAnswer(new IAnswer<Object>() {
+			@Override
+			public Object answer() throws Throwable {
+				Assert.assertEquals(new Integer(1), index.getValue());
+				Assert.assertNotNull(in.getValue());
+				Assert.assertTrue(in.getValue() instanceof BufferedInputStream);
+				Assert.assertEquals(new Long(50), length.getValue());
+				return null;
+			}
+		});
+		expect(stmt.execute()).andReturn(true);
+		replay(stmt);
+		
+		JdbcConnection connection = createMock(JdbcConnection.class);
+		expect(connection.prepareStatement("INSERT INTO schema.table(null) VALUES(?)")).andReturn(stmt);
+		replay(connection);
+		
+		statement.execute(new PreparedStatementFactory(connection));
+	}
+
+	@Test
+	public void testValueClobFileFromClassLoader() throws DatabaseException, SQLException {
+		ColumnConfig columnConfig = new ColumnConfig();
+		
+		String valueClobFile = "unicode-file.txt";
+		columnConfig.setValueClobFile(valueClobFile);
+		columnConfig.setEncoding("UTF-8");
+		
+		List<ColumnConfig> columns = Arrays.asList(columnConfig);
+		
+		ChangeSet changeSet = createMock(ChangeSet.class);
+		expect(changeSet.getFilePath()).andReturn("liquibase/util/");
+		replay(changeSet);
+		
+		assertSetCharacterStream(columns, changeSet);
+	}
+
+	@Test
+	public void testValueClobFileFromFile() throws DatabaseException, SQLException {
+		ColumnConfig columnConfig = new ColumnConfig();
+		
+		String valueClobFile = "unicode-file.txt";
+		columnConfig.setValueClobFile(valueClobFile);
+		columnConfig.setEncoding("UTF-8");
+		
+		List<ColumnConfig> columns = Arrays.asList(columnConfig);
+		
+		ChangeSet changeSet = createMock(ChangeSet.class);
+		expect(changeSet.getFilePath()).andReturn("src/test/resources/liquibase/util/");
+		replay(changeSet);
+		
+		assertSetCharacterStream(columns, changeSet);
+	}
+
+	protected void assertSetCharacterStream(List<ColumnConfig> columns, ChangeSet changeSet)
+			throws SQLException, DatabaseException {
+		
+		InsertExecutablePreparedStatement statement =
+				new InsertExecutablePreparedStatement(
+						new MockDatabase(),
+						changeSet,
+						"catalog", "schema", "table", columns);
+		
+		PreparedStatement stmt = createMock(PreparedStatement.class);
+
+		final Capture<Integer> index = new Capture<Integer>();
+		final Capture<Reader> reader = new Capture<Reader>();
+		final Capture<Long> length = new Capture<Long>();
+		stmt.setCharacterStream(capture(index), capture(reader), capture(length));
+		expectLastCall().andAnswer(new IAnswer<Object>() {
+			@Override
+			public Object answer() throws Throwable {
+				Assert.assertEquals(new Integer(1), index.getValue());
+				Assert.assertNotNull(reader.getValue());
+				Assert.assertTrue(reader.getValue() instanceof BufferedReader);
+				Assert.assertEquals(new Long(39), length.getValue());
+				return null;
+			}
+		});
+		expect(stmt.execute()).andReturn(true);
+		replay(stmt);
+		
+		JdbcConnection connection = createMock(JdbcConnection.class);
+		expect(connection.prepareStatement("INSERT INTO schema.table(null) VALUES(?)")).andReturn(stmt);
+		replay(connection);
+		
+		statement.execute(new PreparedStatementFactory(connection));
+	}
+}

--- a/liquibase-core/src/test/java/liquibase/util/StreamUtilTest.java
+++ b/liquibase-core/src/test/java/liquibase/util/StreamUtilTest.java
@@ -1,13 +1,16 @@
 package liquibase.util;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.Assert.fail;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.StringReader;
+
+import org.junit.Test;
 
 public class StreamUtilTest {
 
@@ -75,5 +78,13 @@ public class StreamUtilTest {
 			assertTrue(e.getMessage().contains("UTF-16BE"));
 		}
 	}
-
+	
+	@Test
+	public void testContentLength() throws IOException {
+		InputStream in = getClass().getResourceAsStream("/liquibase/util/unicode-file.txt");
+		assertEquals(50, StreamUtil.getContentLength(in));
+		
+		in = getClass().getResourceAsStream("/liquibase/util/unicode-file.txt");
+		assertEquals(39, StreamUtil.getContentLength(new InputStreamReader(in, "UTF-8")));
+	}
 }

--- a/liquibase-core/src/test/resources/liquibase/util/unicode-file.txt
+++ b/liquibase-core/src/test/resources/liquibase/util/unicode-file.txt
@@ -1,0 +1,2 @@
+File with Unicode chars.
+Файл с Юникод.


### PR DESCRIPTION
This PR allows valueBlobFile and valueClobFile contain relative paths.
Paths may be relative to current change log file.

Also previous implementation doesn't allowed to load CLOB content from classpath resources, this patch fixes this.

Previous implementation of loading BLOBs from classpath might not working as expected, because it used value of `file.length()` of non-existing files, which is 0L, by passing it to http://docs.oracle.com/javase/6/docs/api/java/sql/PreparedStatement.html#setBinaryStream(int,%20java.io.InputStream,%20int).
I couldn't find any tests for this in liquibase, but I think that some JDBC drivers might not support 0L as value of length (or might simply take 0 bytes, i.e. nothing, from the stream).

What I did in this PR is copied the LOBs from streams into memory entirely to calculate the length, which may not work good by the means of memory consumption for really large files. Another way may be to use http://docs.oracle.com/javase/6/docs/api/java/sql/PreparedStatement.html#setBinaryStream(int,%20java.io.InputStream) without length parameter, but this requires Java 6 and JDBC 4.
