### PR TITLE
CORE-1247 - [Sqlite] bad syntax in create table statements with single

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/IntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/IntType.java
@@ -39,6 +39,9 @@ public class IntType extends LiquibaseDataType {
         if (database instanceof MSSQLDatabase || database instanceof HsqlDatabase || database instanceof FirebirdDatabase) {
             return new DatabaseDataType("INT");
         }
+        if (database instanceof SQLiteDatabase ) {
+        	return new DatabaseDataType("INTEGER");
+        }
         return super.toDatabaseDataType(database);
 
         //sqllite

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateTableGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateTableGenerator.java
@@ -92,7 +92,7 @@ public class CreateTableGenerator extends AbstractSqlGenerator<CreateTableStatem
                     buffer.append(" CONSTRAINT ");
                     buffer.append(database.escapeConstraintName(pkName));
                 }
-                buffer.append(" PRIMARY KEY AUTOINCREMENT");
+                buffer.append(" PRIMARY KEY");
             }
 
             // for the serial data type in postgres, there should be no default value


### PR DESCRIPTION
Create table with autoincrement primary key column syntax fixed on SQLite.
Also use of INTEGER as data type instead of INT in order to avoid syntax error defining PRIMARY KEY with type different from INTEGER.
