### PR TITLE
Optimed MD5 calculation to be blockwise as bytewise operation is slow

### DIFF
--- a/liquibase-core/src/main/java/liquibase/util/MD5Util.java
+++ b/liquibase-core/src/main/java/liquibase/util/MD5Util.java
@@ -45,8 +45,9 @@ public class MD5Util {
             digest = MessageDigest.getInstance("MD5");
 
             DigestInputStream digestStream = new DigestInputStream(stream, digest);
-            while (digestStream.read() != -1) {
-                ; //digest is updating
+            byte[] buf = new byte[20480];
+            while (digestStream.read(buf) != -1) {
+                ; // digest is updating
             }
         } catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
I've been working with quite big files and found that the bytewise operation on IOStreams is quite slow. I here submit a block wise operation on IOStreams.

I submit this for both master and the 2.x branch; it would be nice if there would be a release of the 2.x branch at some time (despite the new version 3.0)

Br Alexander.
