### PR TITLE
MySQL CreateTableGenerator workaround

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/DatabaseDataType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/DatabaseDataType.java
@@ -39,6 +39,28 @@ public class DatabaseDataType {
     public boolean isAutoIncrement() {
         return type.equalsIgnoreCase("serial") || type.equalsIgnoreCase("bigserial");
     }
+    
+    /**
+     * Mainly for MySQL. Temporal defaults need to be quoted Strings 
+     * on table creation if they are of a literal date
+     * @return true if timestamp, date, datetime, year datatype
+     */
+    public boolean isTemporal() {
+        return type.equalsIgnoreCase("timestamp") 
+            || type.equalsIgnoreCase("datetime")
+            || type.equalsIgnoreCase("date")
+            || type.equalsIgnoreCase("time")
+            || type.equalsIgnoreCase("year");
+    }
+    
+    
+    /**
+     * Mainly for MySQL. default Enumerations should be quoted
+     * @return true if enumeration
+     */
+    public boolean isEnumeration(){
+        return type.toLowerCase().startsWith("enum");
+    }
 
     public String toSql() {
         return toString();

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateTableGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateTableGenerator.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import liquibase.statement.DatabaseFunction;
 
 public class CreateTableGenerator extends AbstractSqlGenerator<CreateTableStatement> {
 


### PR DESCRIPTION
Workaround for https://liquibase.jira.com/browse/CORE-1374.  This is probably not the best long term solution, but this will ensure the default dates/times that are actual dates and times (`1970-01-01 00:00:00`) will get passed as strings.  Currently, they are coming across as DatabaseFunction and thus go unquoted. Actual DatabaseFunctions, e.g. `CURRENT_TIMESTAMP` and `NOW()` will still get passed as functions. Same thing  with the `ENUM` datatype. 

It should be noted that this workaround  is to make the values that are generated in my generated changelog work. 

Also `ENUM`s are not properly parsed in the generated changelog for MySQL.  Should be `enum('Y','N')` gets parsed as `enum(2)`, which will fail on table creation.  But I see that is addressed in https://liquibase.jira.com/browse/CORE-1224.

Unrelated quick question:
Are there any plans to change the changelog generation order so that indexing happens before foreign key and unique constraints?  Currently I have to edit my 26k+ line generated file by hand to get the order right.



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-74) by [Unito](https://www.unito.io/learn-more)
