### PR TITLE
Always grab the hostname from InetAddress.getLocalHost().getHostName()

### DIFF
--- a/liquibase-cdi/src/main/java/liquibase/integration/cdi/CDILiquibase.java
+++ b/liquibase-cdi/src/main/java/liquibase/integration/cdi/CDILiquibase.java
@@ -95,7 +95,7 @@ public class CDILiquibase implements Extension {
         log.info("Booting Liquibase " + LiquibaseUtil.getBuildVersion());
         String hostName;
         try {
-            hostName = NetUtil.getLocalHost().getHostName();
+            hostName = NetUtil.getLocalHostName();
         } catch (Exception e) {
             log.warning("Cannot find hostname: " + e.getMessage());
             log.debug("", e);

--- a/liquibase-core/src/main/java/liquibase/integration/servlet/LiquibaseServletListener.java
+++ b/liquibase-core/src/main/java/liquibase/integration/servlet/LiquibaseServletListener.java
@@ -86,7 +86,7 @@ public class LiquibaseServletListener implements ServletContextListener {
     public void contextInitialized(ServletContextEvent servletContextEvent) {
         ServletContext servletContext = servletContextEvent.getServletContext();
         try {
-            this.hostName = NetUtil.getLocalHost().getHostName();
+            this.hostName = NetUtil.getLocalHostName();
         }
         catch (Exception e) {
             servletContext.log("Cannot find hostname: " + e.getMessage());

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/LockDatabaseChangeLogGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/LockDatabaseChangeLogGenerator.java
@@ -11,7 +11,6 @@ import liquibase.statement.core.LockDatabaseChangeLogStatement;
 import liquibase.statement.core.UpdateStatement;
 import liquibase.util.NetUtil;
 
-import java.net.InetAddress;
 import java.sql.Timestamp;
 
 public class LockDatabaseChangeLogGenerator extends AbstractSqlGenerator<LockDatabaseChangeLogStatement> {
@@ -25,11 +24,9 @@ public class LockDatabaseChangeLogGenerator extends AbstractSqlGenerator<LockDat
     protected static String hostaddress;
 
     static {
-        InetAddress localHost;
         try {
-            localHost = NetUtil.getLocalHost();
-            hostname = localHost.getHostName();
-            hostaddress = localHost.getHostAddress();
+            hostname = NetUtil.getLocalHostName();
+            hostaddress = NetUtil.getLocalHostAddress();
         } catch (Exception e) {
             throw new UnexpectedLiquibaseException(e);
         }

--- a/liquibase-core/src/main/java/liquibase/util/NetUtil.java
+++ b/liquibase-core/src/main/java/liquibase/util/NetUtil.java
@@ -11,14 +11,14 @@ public class NetUtil {
     /**
      * Smarter way to get localhost than InetAddress.getLocalHost.  See http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4665037
      */
-    public static InetAddress getLocalHost() throws UnknownHostException, SocketException {
+    public static String getLocalHostAddress() throws UnknownHostException, SocketException {
         // Windows Vista returns the IPv6 InetAddress using this method, which is not
         // particularly useful as it has no name or useful address, just "0:0:0:0:0:0:0:1".
         // That is why windows should be treated differently to linux/unix and use the
         // default way of getting the localhost.
         String osName = System.getProperty("os.name");
         if (osName != null && osName.toLowerCase().contains("windows")) {
-            return InetAddress.getLocalHost();
+            return InetAddress.getLocalHost().getHostAddress();
         }
       
         InetAddress lch = null;
@@ -34,7 +34,10 @@ public class NetUtil {
             lch = ie.nextElement();
             if (!lch.isLoopbackAddress()) break;
         }
-        return lch;
+        return lch == null ? null : lch.getHostAddress();
     }
 
+    public static String getLocalHostName() throws UnknownHostException, SocketException {
+        return InetAddress.getLocalHost().getHostName();
+    }
 }


### PR DESCRIPTION
The previous code would always trigger a reverse DNS lookup.  If the
workstation/server is not configured with a valid DNS name, the reverse
DNS lookup would timeout.  This would cause liquibase to hang for 10-15
seconds on some systems.  This behaviour was noticed on Linux systems.
