### PR TITLE
Align method signature of conflicting String[] and String.. declaration

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/Database.java
@@ -144,7 +144,7 @@ public interface Database extends PrioritizedService {
 
     boolean hasDatabaseChangeLogLockTable() throws DatabaseException;
 
-    void checkDatabaseChangeLogTable(boolean updateExistingNullChecksums, DatabaseChangeLog databaseChangeLog, String[] contexts) throws DatabaseException;
+    void checkDatabaseChangeLogTable(boolean updateExistingNullChecksums, DatabaseChangeLog databaseChangeLog, String... contexts) throws DatabaseException;
 
     void checkDatabaseChangeLogLockTable() throws DatabaseException;
 

--- a/liquibase-core/src/test/java/liquibase/database/core/MockDatabase.java
+++ b/liquibase-core/src/test/java/liquibase/database/core/MockDatabase.java
@@ -436,7 +436,7 @@ public class MockDatabase implements Database {
     }
 
     @Override
-    public void checkDatabaseChangeLogTable(boolean updateExistingNullChecksums, DatabaseChangeLog databaseChangeLog, String[] contexts) throws DatabaseException {
+    public void checkDatabaseChangeLogTable(boolean updateExistingNullChecksums, DatabaseChangeLog databaseChangeLog, String... contexts) throws DatabaseException {
         ;
     }
 


### PR DESCRIPTION
Under JDK 1.8 this conflict causes unresolvable compiler warnings even in your own, derived classes not touching those methods at all.

 java: checkDatabaseChangeLogTable() in liquibase.database.AbstractJdbcDatabase
       implements checkDatabaseChangeLogTable(...,java.lang.String[]) in
       liquibase.database.Database; overridden method has no '...'
