### PR TITLE
allow determining boolean value from integer

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/BooleanType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/BooleanType.java
@@ -70,6 +70,12 @@ public class BooleanType extends LiquibaseDataType {
             } else {
                 returnValue = this.getFalseBooleanValue(database);
             }
+        } else if (value instanceof Integer) {
+            if (1 == value) {
+                returnValue = this.getTrueBooleanValue(database);
+            } else {
+                returnValue = this.getFalseBooleanValue(database);
+            }
         } else if (value instanceof DatabaseFunction) {
             return ((DatabaseFunction) value).toString();
         } else if (((Boolean) value)) {


### PR DESCRIPTION
when generating a schema diff I encountered a java.lang.Integer cannot be cast to java.lang.Boolean error. Some of the fields in my schema were TINYINTs. After applying this patch, it worked, so I decided to contribute it back to see if it helps.

Please let me know if I misunderstood something.
