### PR TITLE
CORE-1663: Support replaceIfExists for createView on H2

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateViewGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateViewGenerator.java
@@ -29,7 +29,7 @@ public class CreateViewGenerator extends AbstractSqlGenerator<CreateViewStatemen
         validationErrors.checkRequiredField("selectQuery", createViewStatement.getSelectQuery());
 
         if (createViewStatement.isReplaceIfExists()) {
-            validationErrors.checkDisallowedField("replaceIfExists", createViewStatement.isReplaceIfExists(), database, HsqlDatabase.class, H2Database.class, DB2Database.class, CacheDatabase.class, DerbyDatabase.class, SybaseASADatabase.class, InformixDatabase.class);
+            validationErrors.checkDisallowedField("replaceIfExists", createViewStatement.isReplaceIfExists(), database, HsqlDatabase.class, DB2Database.class, CacheDatabase.class, DerbyDatabase.class, SybaseASADatabase.class, InformixDatabase.class);
         }
 
         return validationErrors;

--- a/liquibase-core/src/test/java/liquibase/change/ChangeParameterMetaDataTest.java
+++ b/liquibase-core/src/test/java/liquibase/change/ChangeParameterMetaDataTest.java
@@ -162,7 +162,7 @@ public class ChangeParameterMetaDataTest {
 
         ChangeParameterMetaData replaceIfExists  = ChangeFactory.getInstance().getChangeMetaData(new CreateViewChange()).getParameters().get("replaceIfExists");
         assertSetsEqual(new String[]{}, replaceIfExists.analyzeRequiredDatabases(new String[]{ChangeParameterMetaData.COMPUTE}));
-        assertSetsEqual(new String[]{"sybase","mssql","postgresql","firebird","oracle","sqlite","maxdb","mysql"}, replaceIfExists.analyzeSupportedDatabases(new String[]{ChangeParameterMetaData.COMPUTE}));
+        assertSetsEqual(new String[]{"sybase","mssql","postgresql","firebird","oracle","sqlite","maxdb","mysql","h2"}, replaceIfExists.analyzeSupportedDatabases(new String[]{ChangeParameterMetaData.COMPUTE}));
     }
 
 


### PR DESCRIPTION
H2 supports CREATE OR REPLACE VIEW, so we can simply use the default case.

H2 documentation: http://www.h2database.com/html/grammar.html#create_view
