### PR TITLE
Fix null dereference

### DIFF
--- a/liquibase-core/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-core/src/main/java/liquibase/Liquibase.java
@@ -1018,7 +1018,7 @@ public class Liquibase {
 
     public void generateChangeLog(CatalogAndSchema catalogAndSchema, DiffToChangeLog changeLogWriter, PrintStream outputStream, Class<? extends DatabaseObject>... snapshotTypes) throws DatabaseException, IOException, ParserConfigurationException {
         Set<Class<? extends DatabaseObject>> finalCompareTypes = null;
-        if (snapshotTypes != null || snapshotTypes.length > 0) {
+        if (snapshotTypes != null && snapshotTypes.length > 0) {
             finalCompareTypes = new HashSet<Class<? extends DatabaseObject>>(Arrays.asList(snapshotTypes));
         }
 


### PR DESCRIPTION
I found a possible null dereference because my IDE marked it as warning. I think the intention was to use `&&` instead of `||`, please have a look if it makes sense!
