### PR TITLE
debugging issue finding xsd via resource-accessor

### DIFF
--- a/liquibase-core/src/main/java/liquibase/parser/core/xml/LiquibaseEntityResolver.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/xml/LiquibaseEntityResolver.java
@@ -71,14 +71,17 @@ public class LiquibaseEntityResolver implements EntityResolver2 {
             }
             String xsdFile = namespaceDetails.getLocalPath(systemId);
             try {
+              System.err.println("Looking for " + xsdFile + " for " + systemId);
                 InputStream resourceAsStream = resourceAccessor.getResourceAsStream(xsdFile);
-
-                if (resourceAccessor == null) {
+                System.err.println("Tried " + resourceAccessor + " and got " + resourceAsStream);
+                if (resourceAsStream == null) {
                     if (Thread.currentThread().getContextClassLoader() != null) {
                         resourceAsStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(xsdFile);
+                        System.err.println("Tried thread context classloader and got " + resourceAsStream);
                     }
                     if (resourceAsStream == null) {
                         resourceAsStream = this.getClass().getClassLoader().getResourceAsStream(xsdFile);
+                        System.err.println("Tried lb classloader and got " + resourceAsStream);
                     }
                 }
                 if (resourceAsStream == null) {
@@ -89,6 +92,7 @@ public class LiquibaseEntityResolver implements EntityResolver2 {
                 source.setSystemId(systemId);
                 return source;
             } catch (Exception ex) {
+                ex.printStackTrace();
                 return null; // We don't have the schema, try the network
             }
         }

--- a/liquibase-core/src/main/java/liquibase/resource/CompositeResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/CompositeResourceAccessor.java
@@ -5,7 +5,6 @@ import liquibase.util.StringUtils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.*;
 
 /**


### PR DESCRIPTION
I thought line 76 looked off, but I'm not sure it was my problem.
I've found that the xsd schemaLocation hint must be there because the SAX parser is looking for the xsd's explicitly, not asking the entity resolver for them per namespace URI.
