### PR TITLE
CORE-1669: Returning the defaultCatalogName if it is not null.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/DB2Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/DB2Database.java
@@ -71,7 +71,7 @@ public class DB2Database extends AbstractJdbcDatabase {
     public String getDefaultCatalogName() {
 
         if (defaultCatalogName != null) {
-            return defaultSchemaName;
+            return defaultCatalogName;
         }
 
         if (defaultSchemaName != null) {


### PR DESCRIPTION
Fix for Jira issue CORE-1669
