### PR TITLE
Fixed relative CLOB file path bug

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/InsertDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/InsertDataChange.java
@@ -90,7 +90,7 @@ public class InsertDataChange extends AbstractChange implements ChangeWithColumn
 
         if (needsPreparedStatement) {
             return new SqlStatement[] {
-                    new InsertExecutablePreparedStatement(database, catalogName, schemaName, tableName, columns, getChangeSet())
+                    new InsertExecutablePreparedStatement(database, catalogName, schemaName, tableName, columns, getChangeSet(), this.getResourceAccessor())
             };
         }
 

--- a/liquibase-core/src/main/java/liquibase/change/core/UpdateDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/UpdateDataChange.java
@@ -52,7 +52,7 @@ public class UpdateDataChange extends AbstractModifyDataChange implements Change
         }
 
         if (needsPreparedStatement) {
-            UpdateExecutablePreparedStatement statement = new UpdateExecutablePreparedStatement(database, catalogName, schemaName, tableName, columns, getChangeSet());
+            UpdateExecutablePreparedStatement statement = new UpdateExecutablePreparedStatement(database, catalogName, schemaName, tableName, columns, getChangeSet(), this.getResourceAccessor());
             
             statement.setWhereClause(where);
             

--- a/liquibase-core/src/main/java/liquibase/statement/InsertExecutablePreparedStatement.java
+++ b/liquibase-core/src/main/java/liquibase/statement/InsertExecutablePreparedStatement.java
@@ -6,14 +6,15 @@ import java.util.List;
 import liquibase.change.ColumnConfig;
 import liquibase.changelog.ChangeSet;
 import liquibase.database.Database;
+import liquibase.resource.ResourceAccessor;
 
 /**
  * Handles INSERT Execution
  */
 public class InsertExecutablePreparedStatement extends ExecutablePreparedStatementBase {
 	
-	public InsertExecutablePreparedStatement(Database database, String catalogName, String schemaName, String tableName, List<ColumnConfig> columns, ChangeSet changeSet) {
-		super(database, catalogName, schemaName, tableName, columns, changeSet);
+	public InsertExecutablePreparedStatement(Database database, String catalogName, String schemaName, String tableName, List<ColumnConfig> columns, ChangeSet changeSet, ResourceAccessor resourceAccessor) {
+		super(database, catalogName, schemaName, tableName, columns, changeSet, resourceAccessor);
 	}
 
 	@Override

--- a/liquibase-core/src/main/java/liquibase/statement/UpdateExecutablePreparedStatement.java
+++ b/liquibase-core/src/main/java/liquibase/statement/UpdateExecutablePreparedStatement.java
@@ -8,6 +8,7 @@ import liquibase.change.ColumnConfig;
 import liquibase.changelog.ChangeSet;
 import liquibase.database.Database;
 import liquibase.datatype.DataTypeFactory;
+import liquibase.resource.ResourceAccessor;
 import liquibase.structure.core.Column;
 
 public class UpdateExecutablePreparedStatement extends ExecutablePreparedStatementBase {
@@ -17,8 +18,8 @@ public class UpdateExecutablePreparedStatement extends ExecutablePreparedStateme
     private List<String> whereColumnNames = new ArrayList<String>();
     private List<Object> whereParameters = new ArrayList<Object>();
 
-	public UpdateExecutablePreparedStatement(Database database, String catalogName, String schemaName, String tableName, List<ColumnConfig> columns, ChangeSet changeSet) {
-		super(database, catalogName, schemaName, tableName, columns, changeSet);
+	public UpdateExecutablePreparedStatement(Database database, String catalogName, String schemaName, String tableName, List<ColumnConfig> columns, ChangeSet changeSet, ResourceAccessor resourceAccessor) {
+		super(database, catalogName, schemaName, tableName, columns, changeSet, resourceAccessor);
 	}
 
 	@Override

--- a/liquibase-core/src/test/java/liquibase/statement/ExecutablePreparedStatementTest.java
+++ b/liquibase-core/src/test/java/liquibase/statement/ExecutablePreparedStatementTest.java
@@ -22,6 +22,10 @@ import liquibase.database.PreparedStatementFactory;
 import liquibase.database.core.MockDatabase;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import liquibase.resource.CompositeResourceAccessor;
+import liquibase.resource.FileSystemResourceAccessor;
+import liquibase.resource.ResourceAccessor;
 
 import org.easymock.Capture;
 import org.easymock.IAnswer;
@@ -73,7 +77,7 @@ public class ExecutablePreparedStatementTest {
 		
 		InsertExecutablePreparedStatement statement =
 				new InsertExecutablePreparedStatement(
-						new MockDatabase(), "catalog", "schema", "table", columns, changeSet);
+						new MockDatabase(), "catalog", "schema", "table", columns, changeSet, createResourceAccessor());
 		
 		PreparedStatement stmt = createMock(PreparedStatement.class);
 
@@ -147,7 +151,7 @@ public class ExecutablePreparedStatementTest {
 		InsertExecutablePreparedStatement statement =
 				new InsertExecutablePreparedStatement(
 						new MockDatabase(),
-						"catalog", "schema", "table", columns, changeSet);
+						"catalog", "schema", "table", columns, changeSet, createResourceAccessor());
 		
 		PreparedStatement stmt = createMock(PreparedStatement.class);
 
@@ -173,5 +177,18 @@ public class ExecutablePreparedStatementTest {
 		replay(connection);
 		
 		statement.execute(new PreparedStatementFactory(connection));
+	}
+	
+	/**
+	 * Create a test context resource accessor.
+	 * @return
+	 */
+	private ResourceAccessor createResourceAccessor() {
+		ResourceAccessor resourceAccessor = new CompositeResourceAccessor(
+				new ClassLoaderResourceAccessor(),
+				new FileSystemResourceAccessor(),
+				new ClassLoaderResourceAccessor(Thread.currentThread().getContextClassLoader()));
+		
+		return resourceAccessor;
 	}
 }


### PR DESCRIPTION
Resolving path by changeLog.getPhysicalFilePath rather than by using changeSet.getFilePath

This makes the behavior consistent with the lookup of change logs in change log imports. I've also adapted the mocks in the unit tests.

Additionally, I've created an integration test in the liquibase-maven-plugin module, but I'll submit this in a separate pull request as it uses a Derby in memory DB and I'm not sure if you'd want to have this in your tests.
