### PR TITLE
Add Support for Pivotal's SqlFire database to Liquibase. 

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/DerbyDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/DerbyDatabase.java
@@ -46,7 +46,11 @@ public class DerbyDatabase extends AbstractJdbcDatabase {
         // CORE-1230 - don't shutdown derby network server
         if (url.startsWith("jdbc:derby://")) {
             return "org.apache.derby.jdbc.ClientDriver";
-        } else if (url.startsWith("jdbc:derby") || url.startsWith("java:derby")) {
+        }
+        else if (url.startsWith("jdbc:sqlfire://")) {
+            return "com.vmware.sqlfire.jdbc.ClientDriver";
+        }
+        else if (url.startsWith("jdbc:derby") || url.startsWith("java:derby")) {
             return "org.apache.derby.jdbc.EmbeddedDriver";
         }
         return null;

--- a/liquibase-core/src/test/java/liquibase/database/core/DerbyDatabaseTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/core/DerbyDatabaseTest.java
@@ -7,6 +7,7 @@ public class DerbyDatabaseTest extends TestCase {
     public void testGetDefaultDriver() {
         Database database = new DerbyDatabase();
 
+        assertEquals("com.vmware.sqlfire.jdbc.ClientDriver", database.getDefaultDriver("jdbc:sqlfire://localhost:1527/"));
         assertEquals("org.apache.derby.jdbc.EmbeddedDriver", database.getDefaultDriver("java:derby:liquibase;create=true"));
 
         assertNull(database.getDefaultDriver("jdbc:oracle://localhost;databaseName=liquibase"));


### PR DESCRIPTION
SqlFire uses an Apache Derby port to provide it's sql interface. The adds additional option in the getDefaultDriver method for SqlFire. This avoids a nullpointer exception being thrown in the DerbyDatabase close method.

Please also see http://forum.liquibase.org/topic/support-for-vfabric-sqlfire-database
