### PR TITLE
Added support for multiple DBMS values in formatted SQL changelogs.

### DIFF
--- a/liquibase-core/DEV_NOTES.txt
+++ b/liquibase-core/DEV_NOTES.txt
@@ -14,3 +14,7 @@ Kept existing interfaces for the most part for backwards compatibility, but need
 
  - liquibase.DbmsSet
  TODO: Need to do somethign like liquibase.Context but for dbms usage
+ 
+Features:
+- liquibase.parser.core.formattedsql.FormattedSqlChangeLogParser
+Added support for multiple DBMS values in formatted SQL changelogs. Use comma separated values without spaces, e.g. "dbms:oracle,h2".

--- a/liquibase-core/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
@@ -83,7 +83,7 @@ public class FormattedSqlChangeLogParser implements ChangeLogParser {
             Pattern runAlwaysPattern = Pattern.compile(".*runAlways:(\\w+).*", Pattern.CASE_INSENSITIVE);
             Pattern contextPattern = Pattern.compile(".*context:(\\S*).*", Pattern.CASE_INSENSITIVE);
             Pattern runInTransactionPattern = Pattern.compile(".*runInTransaction:(\\w+).*", Pattern.CASE_INSENSITIVE);
-            Pattern dbmsPattern = Pattern.compile(".*dbms:([\\w!]+).*", Pattern.CASE_INSENSITIVE);
+            Pattern dbmsPattern = Pattern.compile(".*dbms:([^,][\\w!,]+).*", Pattern.CASE_INSENSITIVE);
             Pattern failOnErrorPattern = Pattern.compile(".*failOnError:(\\w+).*", Pattern.CASE_INSENSITIVE);
             Pattern onFailPattern = Pattern.compile(".*onFail:(\\w+).*", Pattern.CASE_INSENSITIVE);
             Pattern onErrorPattern = Pattern.compile(".*onError:(\\w+).*", Pattern.CASE_INSENSITIVE);

--- a/liquibase-core/src/test/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.java
+++ b/liquibase-core/src/test/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.java
@@ -238,6 +238,45 @@ public class FormattedSqlChangeLogParserTest {
 
     }
 
+    @Test
+    public void parse_multipleDbms() throws Exception {
+        // Happy day scenarios
+    	String changeLogWithMultipleDbms = "--liquibase formatted sql\n\n"+
+                "--changeset John Doe:12345 dbms:db2,db2i\n" +
+                "create table test (id int);\n";
+
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithMultipleDbms).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor());
+        assertEquals(2, changeLog.getChangeSets().get(0).getDbmsSet().size());
+        assertTrue(changeLog.getChangeSets().get(0).getDbmsSet().contains("db2"));
+        assertTrue(changeLog.getChangeSets().get(0).getDbmsSet().contains("db2i"));
+        
+        // Sad night scenarios
+        String changeLogWithInvalidMultipleDbms = "--liquibase formatted sql\n\n"+
+                "--changeset John Doe:12345 dbms:db2, db2i\n" +
+                "create table test (id int);\n";
+
+        DatabaseChangeLog invalidChangeLog = new MockFormattedSqlChangeLogParser(changeLogWithInvalidMultipleDbms).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor());
+        assertEquals(1, invalidChangeLog.getChangeSets().get(0).getDbmsSet().size());
+        assertTrue(invalidChangeLog.getChangeSets().get(0).getDbmsSet().contains("db2"));
+        assertFalse(invalidChangeLog.getChangeSets().get(0).getDbmsSet().contains("db2i"));
+
+        changeLogWithInvalidMultipleDbms = "--liquibase formatted sql\n\n"+
+                "--changeset John Doe:12345 dbms:db2,\n" +
+                "create table test (id int);\n";
+
+        invalidChangeLog = new MockFormattedSqlChangeLogParser(changeLogWithInvalidMultipleDbms).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor());
+        assertEquals(1, invalidChangeLog.getChangeSets().get(0).getDbmsSet().size());
+        assertTrue(invalidChangeLog.getChangeSets().get(0).getDbmsSet().contains("db2"));
+        assertFalse(invalidChangeLog.getChangeSets().get(0).getDbmsSet().contains("db2i"));
+        
+        changeLogWithInvalidMultipleDbms = "--liquibase formatted sql\n\n"+
+                "--changeset John Doe:12345 dbms:,db2,\n" +
+                "create table test (id int);\n";
+
+        invalidChangeLog = new MockFormattedSqlChangeLogParser(changeLogWithInvalidMultipleDbms).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor());
+        assertEquals(null, invalidChangeLog.getChangeSets().get(0).getDbmsSet());
+    }
+    
     private static class MockFormattedSqlChangeLogParser extends FormattedSqlChangeLogParser {
         private String changeLog;
 


### PR DESCRIPTION
Formatted SQL files only allow a single DBMS to be used, due to the regular expression used. I've modified the regex to support multiple values, separated by commas. Note that values cannot have spaces between them, just commas.

Example:
--changeset John Doe:12345 dbms:db2,db2i
