### PR TITLE
CORE-1721 HSQL doesn't respect the QUOTE_ALL_OBJECTS flag.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
@@ -438,14 +438,4 @@ public class HsqlDatabase extends AbstractJdbcDatabase {
     public boolean isCaseSensitive() {
         return false;
     }
-
-    @Override
-    public String escapeObjectName(String objectName, Class<? extends DatabaseObject> objectType) {
-        if (objectName != null) {
-            if (isReservedWord(objectName.toUpperCase())) {
-                return "\""+objectName.toUpperCase()+"\"";
-            }
-        }
-        return objectName;
-    }
 }

--- a/liquibase-core/src/test/java/liquibase/database/core/HsqlDatabaseTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/core/HsqlDatabaseTest.java
@@ -2,6 +2,8 @@ package liquibase.database.core;
 
 import junit.framework.TestCase;
 import liquibase.database.Database;
+import liquibase.database.ObjectQuotingStrategy;
+import liquibase.structure.core.Table;
 
 public class HsqlDatabaseTest extends TestCase {
     public void testGetDefaultDriver() {
@@ -23,4 +25,17 @@ public class HsqlDatabaseTest extends TestCase {
         assertNull(database.getConcatSql((String[]) null));
     }
 
+    /**
+     * Verifies that {@link HsqlDatabase#escapeObjectName(String, Class)}
+     * respects the value of {@link HsqlDatabase#getObjectQuotingStrategy()}.
+     */
+    public void testEscapeObjectName() {
+        Database databaseWithDefaultQuoting = new HsqlDatabase();
+        databaseWithDefaultQuoting.setObjectQuotingStrategy(ObjectQuotingStrategy.LEGACY);
+        assertEquals("Test", databaseWithDefaultQuoting.escapeObjectName("Test", Table.class));
+        
+        Database databaseWithAllQuoting = new HsqlDatabase();
+        databaseWithAllQuoting.setObjectQuotingStrategy(ObjectQuotingStrategy.QUOTE_ALL_OBJECTS);
+        assertEquals("\"Test\"", databaseWithAllQuoting.escapeObjectName("Test", Table.class));
+    }
 }

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/minimumRequiredIsValidSql/loadData/hsqldb.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/minimumRequiredIsValidSql/loadData/hsqldb.sql
@@ -5,5 +5,5 @@
 -- ], ]
 -- Change Parameter: file=com/example/users.csv
 -- Change Parameter: tableName=person
-INSERT INTO person (username,  fullname) VALUES ('nvoxland', ' Nathan Voxland');
-INSERT INTO person (username,  fullname) VALUES ('bob', ' Bob Bobson');
+INSERT INTO person (username, fullname) VALUES ('nvoxland', ' Nathan Voxland');
+INSERT INTO person (username, fullname) VALUES ('bob', ' Bob Bobson');


### PR DESCRIPTION
Just removed the HsqlDatabase.escapeObjectName(...) override, as the
superclass' implementation is more complete. Aside from fixing this bug, the
only functional change should be that object names that match DB-reserved words
are no longer always uppercased, which looks like it was a bug, too (though one
hidden by this one).
