### PR TITLE
Added feature that allows preconditions to be disabled.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -61,6 +61,7 @@ public class Main {
     protected String driverPropertiesFile;
     protected Boolean promptForNonLocalDatabase = null;
     protected Boolean includeSystemClasspath;
+    protected Boolean disablePreconditions = Boolean.FALSE;
     protected String defaultsFile = "liquibase.properties";
 
     protected String diffTypes;
@@ -810,6 +811,9 @@ public class Main {
 
 
             Liquibase liquibase = new Liquibase(changeLogFile, fileOpener, database);
+            if (disablePreconditions) {
+                liquibase.disablePreconditions();
+            }
             liquibase.setCurrentDateTimeFunction(currentDateTimeFunction);
             for (Map.Entry<String, Object> entry : changeLogParameters.entrySet()) {
                 liquibase.setChangeLogParameter(entry.getKey(), entry.getValue());

--- a/liquibase-core/src/main/java/liquibase/integration/spring/SpringLiquibase.java
+++ b/liquibase-core/src/main/java/liquibase/integration/spring/SpringLiquibase.java
@@ -72,6 +72,8 @@ import org.springframework.core.io.ResourceLoader;
  */
 public class SpringLiquibase implements InitializingBean, BeanNameAware, ResourceLoaderAware {
 
+    private boolean disablePreConditions = false;
+
     public class SpringResourceOpener implements ResourceAccessor {
 
         private String parentFile;
@@ -344,7 +346,10 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
 
 	protected Liquibase createLiquibase(Connection c) throws LiquibaseException {
 		Liquibase liquibase = new Liquibase(getChangeLog(), createResourceOpener(), createDatabase(c));
-        liquibase.setIgnoreClasspathPrefix(isIgnoreClasspathPrefix());
+		liquibase.setIgnoreClasspathPrefix(isIgnoreClasspathPrefix());
+		if (disablePreConditions) {
+			liquibase.disablePreconditions();
+		}
 		if (parameters != null) {
 			for (Map.Entry<String, String> entry : parameters.entrySet()) {
 				liquibase.setChangeLogParameter(entry.getKey(), entry.getValue());
@@ -413,6 +418,10 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
 
 	public void setRollbackFile(File rollbackFile) {
 		this.rollbackFile = rollbackFile;
+    }
+
+    public void setDisablePreConditions(boolean disablePreConditions) {
+        this.disablePreConditions = disablePreConditions;
     }
 
     public boolean isIgnoreClasspathPrefix() {

--- a/liquibase-core/src/test/java/liquibase/integration/commandline/MainTest.java
+++ b/liquibase-core/src/test/java/liquibase/integration/commandline/MainTest.java
@@ -37,6 +37,7 @@ public class MainTest {
                 "--classpath=CLASSPATH;CLASSPATH2",
                 "--contexts=CONTEXT1,CONTEXT2",
                 "--promptForNonLocalDatabase=true",
+                "--disablePreconditions=true",
                 "update",
         };
 
@@ -51,6 +52,7 @@ public class MainTest {
         assertEquals("CLASSPATH;CLASSPATH2", cli.classpath);
         assertEquals("CONTEXT1,CONTEXT2", cli.contexts);
         assertEquals(Boolean.TRUE, cli.promptForNonLocalDatabase);
+        assertEquals(Boolean.TRUE, cli.disablePreconditions);
         assertEquals("update", cli.command);
     }
 
@@ -58,6 +60,7 @@ public class MainTest {
     public void falseBooleanParameters() throws Exception {
         String[] args = new String[]{
                 "--promptForNonLocalDatabase=false",
+                "--disablePreconditions=false",
                 "update",
         };
 
@@ -65,6 +68,21 @@ public class MainTest {
         cli.parseOptions(args);
 
         assertEquals(Boolean.FALSE, cli.promptForNonLocalDatabase);
+        assertEquals(Boolean.FALSE, cli.disablePreconditions);
+        assertEquals("update", cli.command);
+
+    }
+
+    @Test
+    public void disablePreconditionsShouldBeSetToFalseByDefault() throws Exception {
+        String[] args = new String[]{
+                "update",
+        };
+
+        Main cli = new Main();
+        cli.parseOptions(args);
+
+        assertEquals(Boolean.FALSE, cli.disablePreconditions);
         assertEquals("update", cli.command);
 
     }
@@ -87,12 +105,14 @@ public class MainTest {
     public void trueBooleanParameters() throws Exception {
         String[] args = new String[]{
                 "--promptForNonLocalDatabase=true",
+                "--disablePreconditions=true",
                 "update",
         };
 
         Main cli = new Main();
         cli.parseOptions(args);
 
+        assertEquals(Boolean.TRUE, cli.disablePreconditions);
         assertEquals(Boolean.TRUE, cli.promptForNonLocalDatabase);
         assertEquals("update", cli.command);
 


### PR DESCRIPTION
Added a flag that allows you to disable preconditions for all changesets.

This is useful when you want to run the changesets in development or testing where the data may not match the expected preconditions.

