### PR TITLE
Added comment support for FormattedSqlChangeLogs

### DIFF
--- a/liquibase-core/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
@@ -78,6 +78,7 @@ public class FormattedSqlChangeLogParser implements ChangeLogParser {
             Pattern stripCommentsPattern = Pattern.compile(".*stripComments:(\\w+).*", Pattern.CASE_INSENSITIVE);
             Pattern splitStatementsPattern = Pattern.compile(".*splitStatements:(\\w+).*", Pattern.CASE_INSENSITIVE);
             Pattern endDelimiterPattern = Pattern.compile(".*endDelimiter:(\\S*).*", Pattern.CASE_INSENSITIVE);
+            Pattern commentPattern = Pattern.compile("\\-\\-[\\s]*comment: (.*)", Pattern.CASE_INSENSITIVE);
 
             Pattern runOnChangePattern = Pattern.compile(".*runOnChange:(\\w+).*", Pattern.CASE_INSENSITIVE);
             Pattern runAlwaysPattern = Pattern.compile(".*runAlways:(\\w+).*", Pattern.CASE_INSENSITIVE);
@@ -151,10 +152,16 @@ public class FormattedSqlChangeLogParser implements ChangeLogParser {
                     currentRollbackSql = new StringBuffer();
                 } else {
                     if (changeSet != null) {
+                        Matcher commentMatcher = commentPattern.matcher(line);
                         Matcher rollbackMatcher = rollbackPattern.matcher(line);
                         Matcher preconditionsMatcher = preconditionsPattern.matcher(line);
                         Matcher preconditionMatcher = preconditionPattern.matcher(line);
-                        if (rollbackMatcher.matches()) {
+
+                        if (commentMatcher.matches()) {
+                            if (commentMatcher.groupCount() == 1) {
+                                changeSet.setComments(commentMatcher.group(1));
+                            }
+                        } else if (rollbackMatcher.matches()) {
                             if (rollbackMatcher.groupCount() == 1) {
                                 currentRollbackSql.append(rollbackMatcher.group(1)).append("\n");
                             }

--- a/liquibase-core/src/test/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.java
+++ b/liquibase-core/src/test/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.java
@@ -53,6 +53,7 @@ public class FormattedSqlChangeLogParserTest {
             ");\n" +
             "--rollback drop table ${tablename};\n" +
             "-- changeset mysql:1\n" +
+            "-- comment: this is a comment\n" +
             "create table mysql_boo (\n" +
             "  id int primary key\n" +
             ");\n" +
@@ -236,6 +237,20 @@ public class FormattedSqlChangeLogParserTest {
         assertEquals("John Doe", changeLog.getChangeSets().get(0).getAuthor());
         assertEquals("12345", changeLog.getChangeSets().get(0).getId());
 
+    }
+
+    @Test
+    public void parse_withComment() throws Exception {
+        String changeLogWithComment = "--liquibase formatted sql\n\n"+
+            "--changeset JohnDoe:12345\n" +
+            "--comment: This is a test comment\n" +
+            "create table test (id int);\n";
+
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithComment).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor());
+        assertEquals(1, changeLog.getChangeSets().size());
+        assertEquals("JohnDoe", changeLog.getChangeSets().get(0).getAuthor());
+        assertEquals("12345", changeLog.getChangeSets().get(0).getId());
+        assertEquals("This is a test comment", changeLog.getChangeSets().get(0).getComments());
     }
 
     @Test


### PR DESCRIPTION
This patch adds comment support for FormattedSqlChangeLogs, similar to <comment> for XML
A unit test is included.

Syntax example:

``` sql
--changeset nvoxland:2
--comment: insert some test data
insert into test1 (id, name) values (1, ‘name 1′);
insert into test1 (id, name) values (2, ‘name 2′);
```
