### PR TITLE
make the check sum generation of sql and sqlFile changes independent of the default encoding which is different on different OS

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/AbstractSQLChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/AbstractSQLChange.java
@@ -169,7 +169,7 @@ public abstract class AbstractSQLChange extends AbstractChange implements DbmsTa
             }
 
             if (sql != null) {
-                stream = new ByteArrayInputStream(sql.getBytes());
+                stream = new ByteArrayInputStream(sql.getBytes("UTF-8"));
             }
 
             return CheckSum.compute(new NormalizingStream(this.getEndDelimiter(), this.isSplitStatements(), this.isStripComments(), stream), false);


### PR DESCRIPTION
If you have some non-ascii characters in your sql or sqlFile change that are checksum relevant, the generated checksum depends on the default encoding. This means you get different checksums if you run liquibase on windows (iso-8859-1) or linux (utf-8).
I even got different results on windows when running from the commandline and from within idea as idea seems to set the default charset of the VM it runs to utf-8.
With this change UTF-8 is always used to translate the characters to bytes and thus the checksum is os independent.
