### PR TITLE
CORE-209 do not generate lock table creation twice when producing an SQL file

### DIFF
--- a/liquibase-core/src/main/java/liquibase/lockservice/StandardLockService.java
+++ b/liquibase-core/src/main/java/liquibase/lockservice/StandardLockService.java
@@ -77,7 +77,7 @@ public class StandardLockService implements LockService {
 
         boolean createdTable = false;
         Executor executor = ExecutorService.getInstance().getExecutor(database);
-        if (!hasDatabaseChangeLogLockTable()) {
+        if (!hasDatabaseChangeLogLockTable && !hasDatabaseChangeLogLockTable()) {
 
             executor.comment("Create Database Lock Table");
             executor.execute(new CreateDatabaseChangeLogLockTableStatement());


### PR DESCRIPTION
When generating an SQL file with updateSQL or changelogSyncSQL on a database that has no LB Metatables, the create and initialize statements for the lock table are generated twice to the resulting file.
The check for hasDatabaseChangeLogLockTable is not done in hasDatabaseChangeLogLockTable() as listLocks() would e. g. also be affected.
