### PR TITLE
Removed System.out debug statements

### DIFF
--- a/liquibase-core/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
+++ b/liquibase-core/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
@@ -251,8 +251,6 @@ public abstract class ExecutablePreparedStatementBase implements ExecutablePrepa
 		//  Most of this method were copy-pasted from XMLChangeLogSAXHandler#handleIncludedChangeLog()
 		
 		String relativeBaseFileName = changeSet.getChangeLog().getPhysicalFilePath();
-		System.out.println("relativeBaseFileName: " + relativeBaseFileName);
-		System.out.println(new File(".").getAbsolutePath());
 		
 		// workaround for FilenameUtils.normalize() returning null for relative paths like ../conf/liquibase.xml
 		String tempFile = FilenameUtils.concat(FilenameUtils.getFullPath(relativeBaseFileName), fileName);


### PR DESCRIPTION
Cosmetic change, but we have a lot of data files and this kind of pollutes the log...
I probably forgot to remove them when I made the relative path fix :-(
