### PR TITLE
Add the outputDefaultSchema flag to the ant task.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/ant/BaseLiquibaseTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/BaseLiquibaseTask.java
@@ -418,10 +418,6 @@ public abstract class BaseLiquibaseTask extends Task {
         this.outputDefaultSchema = outputDefaultSchema;
     }
 
-    public String getLogLevel() {
-        return LogFactory.getLogger().getLogLevel().name();
-    }
-
     public boolean isOutputDefaultCatalog() {
         return outputDefaultCatalog;
     }
@@ -433,6 +429,10 @@ public abstract class BaseLiquibaseTask extends Task {
      */
     public void setOutputDefaultCatalog(boolean outputDefaultCatalog) {
         this.outputDefaultCatalog = outputDefaultCatalog;
+    }
+
+    public String getLogLevel() {
+        return LogFactory.getLogger().getLogLevel().name();
     }
 
     public void setLogLevel(String level) {


### PR DESCRIPTION
This fixes [CORE-1758](https://liquibase.jira.com/browse/CORE-1758). Adds the outputDefaultSchema flag to the ant task. This maintains parity with the maven plugin and command line client. The value of the flag defaults to true based on the default found in AbstractJdbcDatabase.
