### PR TITLE
Added system property "liquibase.env" to support multiple instances

### DIFF
--- a/liquibase-core/DEV_NOTES.txt
+++ b/liquibase-core/DEV_NOTES.txt
@@ -18,3 +18,6 @@ Kept existing interfaces for the most part for backwards compatibility, but need
 Features:
 - liquibase.parser.core.formattedsql.FormattedSqlChangeLogParser
 Added support for multiple DBMS values in formatted SQL changelogs. Use comma separated values without spaces, e.g. "dbms:oracle,h2".
+
+Added system property "liquibase.env" to support multiple instances running on a single host, keeping a separation of instances by including an environment 
+name. The LOCKEDBY column when the system property is set will include the liquibase.env value, separated by a #. e.g. localhost#server1 (127.0.0.1)

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/LockDatabaseChangeLogGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/LockDatabaseChangeLogGenerator.java
@@ -22,6 +22,7 @@ public class LockDatabaseChangeLogGenerator extends AbstractSqlGenerator<LockDat
 
     protected static final String hostname;
     protected static final String hostaddress;
+    protected static final String environment = System.getProperty( "liquibase.env" ) == null ? "" : "#" + System.getProperty( "liquibase.env" );
 
     static {
         try {
@@ -37,14 +38,14 @@ public class LockDatabaseChangeLogGenerator extends AbstractSqlGenerator<LockDat
     	String liquibaseSchema = database.getLiquibaseSchemaName();
         String liquibaseCatalog = database.getLiquibaseCatalogName();
 
-
+        
 
         UpdateStatement updateStatement = new UpdateStatement(liquibaseCatalog, liquibaseSchema, database.getDatabaseChangeLogLockTableName());
         updateStatement.addNewColumnValue("LOCKED", true);
         updateStatement.addNewColumnValue("LOCKGRANTED", new Timestamp(new java.util.Date().getTime()));
-        updateStatement.addNewColumnValue("LOCKEDBY", hostname + " (" + hostaddress + ")");
+        updateStatement.addNewColumnValue("LOCKEDBY", hostname + environment + " (" + hostaddress + ")");
         updateStatement.setWhereClause(database.escapeColumnName(liquibaseCatalog, liquibaseSchema, database.getDatabaseChangeLogTableName(), "ID") + " = 1 AND " + database.escapeColumnName(liquibaseCatalog, liquibaseSchema, database.getDatabaseChangeLogTableName(), "LOCKED") + " = "+ DataTypeFactory.getInstance().fromDescription("boolean").objectToSql(false, database));
-
+        
         return SqlGeneratorFactory.getInstance().generateSql(updateStatement, database);
 
     }


### PR DESCRIPTION
running on a single host, keeping a separation of instances by including
an environment name. The LOCKEDBY column when the system property is set
will include the liquibase.env value, separated by a #. e.g.
localhost#server1 (127.0.0.1)
