### PR TITLE
Bug fix

### DIFF
--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/SchemaSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/SchemaSnapshotGenerator.java
@@ -69,7 +69,7 @@ public class SchemaSnapshotGenerator extends JdbcSnapshotGenerator {
 
                     Catalog catalog = new Catalog(schemaFromJdbcInfo.getCatalogName());
 
-                    Schema schema = new Schema(catalog, schemaFromJdbcInfo.getSchemaName());
+                    Schema schema = new Schema(catalog, tableSchema);
                     if (DatabaseObjectComparatorFactory.getInstance().isSameObject(schema, example, database)) {
                         if (match == null) {
                             match = schema;


### PR DESCRIPTION
An error showed up with our DB2 iSeries database that caused liquibase to think there were multiple schemas with the same name.  Making the proposed change fixed the error.

@nvoxland, you appear to be the primary maintainer for this code--you may consider making this change.
