### PR TITLE
fix some regexes that used \r or \n instead of \\r and \\n

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/AbstractSQLChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/AbstractSQLChange.java
@@ -207,7 +207,7 @@ public abstract class AbstractSQLChange extends AbstractChange implements DbmsTa
         String processedSQL = normalizeLineEndings(sql);
         for (String statement : StringUtils.processMutliLineSQL(processedSQL, isStripComments(), isSplitStatements(), getEndDelimiter())) {
             if (database instanceof MSSQLDatabase) {
-                 statement = statement.replaceAll("\n", "\r\n");
+                 statement = statement.replaceAll("\\n", "\r\n");
              }
 
             String escapedStatement = statement;

--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
@@ -259,7 +259,7 @@ public class ChangeSet implements Conditional, LiquibaseSerializable {
             executor.comment("Changeset " + toString(false));
             if (StringUtils.trimToNull(getComments()) != null) {
                 String comments = getComments();
-                String[] lines = comments.split("\n");
+                String[] lines = comments.split("\\n");
                 for (int i = 0; i < lines.length; i++) {
                     if (i > 0) {
                         lines[i] = database.getLineComment() + " " + lines[i];

--- a/liquibase-core/src/main/java/liquibase/database/core/H2Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/H2Database.java
@@ -97,7 +97,7 @@ public class H2Database extends AbstractJdbcDatabase {
     public String getViewDefinition(CatalogAndSchema schema, String name) throws DatabaseException {
         String definition = super.getViewDefinition(schema, name);
         if (!definition.startsWith("SELECT")) {
-            definition = definition.replaceFirst(".*?\n", ""); //some h2 versions return "create view....as\nselect
+            definition = definition.replaceFirst(".*?\\n", ""); //some h2 versions return "create view....as\nselect
         }
 
         definition = definition.replaceFirst("/\\*.*",""); //sometimes includes comments at the end

--- a/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
@@ -308,7 +308,7 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
         }
         String definition = sb.toString();
 
-        String finalDef =definition.replaceAll("\r\n", "\n");
+        String finalDef =definition.replaceAll("\\r\\n", "\n");
         finalDef = INITIAL_COMMENT_PATTERN.matcher(finalDef).replaceFirst("").trim(); //handle views that start with '/****** Script for XYZ command from SSMS  ******/'
         finalDef = CREATE_VIEW_AS_PATTERN.matcher(finalDef).replaceFirst("").trim();
 

--- a/liquibase-core/src/main/java/liquibase/util/StringUtils.java
+++ b/liquibase-core/src/main/java/liquibase/util/StringUtils.java
@@ -65,10 +65,10 @@ public class StringUtils {
      */
     public static String[] splitSQL(String multiLineSQL, String endDelimiter) {
         if (endDelimiter == null) {
-            endDelimiter = ";\\s*\n|;$|\n[gG][oO]\\s*\n|\n[Gg][oO]\\s*$";
+            endDelimiter = ";\\s*\\n|;$|\\n[gG][oO]\\s*\\n|\\n[Gg][oO]\\s*$";
         } else {
             if (endDelimiter.equalsIgnoreCase("go")) {
-                endDelimiter = "\n[gG][oO]\\s*\n|\n[Gg][oO]\\s*$";
+                endDelimiter = "\\n[gG][oO]\\s*\\n|\\n[Gg][oO]\\s*$";
             }
         }
         String[] initialSplit = multiLineSQL.split(endDelimiter);
@@ -92,7 +92,7 @@ public class StringUtils {
      * @return The String without the comments in
      */
     public static String stripComments(String multiLineSQL) {
-        String strippedSingleLines = Pattern.compile("\\s*\\-\\-.*\n").matcher(multiLineSQL).replaceAll("\n");
+        String strippedSingleLines = Pattern.compile("\\s*\\-\\-.*\\n").matcher(multiLineSQL).replaceAll("\n");
         strippedSingleLines = Pattern.compile("\\s*\\-\\-.*$").matcher(strippedSingleLines).replaceAll("\n");
         return Pattern.compile("/\\*.*?\\*/", Pattern.DOTALL).matcher(strippedSingleLines).replaceAll("").trim();
     }


### PR DESCRIPTION
It works with the single-backslash variant, but it is not clean.
In a regex the \r and \n should be correctly escaped and given to the regex engine.
This is e. g. also important if you use an IDE that lets you edit regexes "after the string escaping" like IntelliJ IDEA.
