### PR TITLE
contextGroup element added to schema

### DIFF
--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.2.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.2.xsd
@@ -85,18 +85,93 @@
 	<xsd:element name="databaseChangeLog">
 		<xsd:complexType>
 			<xsd:sequence>
-				<xsd:element name="property" minOccurs="0" maxOccurs="unbounded">
-					<xsd:complexType>
-						<xsd:attribute name="file" type="xsd:string" />
-						<xsd:attribute name="name" type="xsd:string" />
-						<xsd:attribute name="value" type="xsd:string" />
-						<xsd:attribute name="dbms" type="xsd:string" />
-						<xsd:attribute name="context" type="xsd:string" />
+				<xsd:element ref="property" minOccurs="0" maxOccurs="unbounded" />
+
+				<xsd:element ref="preConditions" minOccurs="0"
+					maxOccurs="1" />
+				
+				<xsd:choice minOccurs="0" maxOccurs="unbounded">
+					<xsd:element ref="changeSet" minOccurs="0" maxOccurs="unbounded" />
+						
+
+					<!-- include -->
+					<xsd:element ref="include" minOccurs="0" maxOccurs="unbounded" />
+				
+					<xsd:element ref="includeAll" minOccurs="0" maxOccurs="unbounded" />
+					
+					<xsd:element name="contextGroup" minOccurs="0" maxOccurs="unbounded">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element ref="property" minOccurs="0" maxOccurs="unbounded" />
+
+								<xsd:element ref="preConditions" minOccurs="0"
+									maxOccurs="1" />
+				
+								<xsd:choice minOccurs="0" maxOccurs="unbounded">
+									<xsd:element ref="changeSet" minOccurs="0" maxOccurs="unbounded" />
+										
+				
+									<!-- include -->
+									<xsd:element ref="include" minOccurs="0" maxOccurs="unbounded" />
+								
+									<xsd:element ref="includeAll" minOccurs="0" maxOccurs="unbounded" />
+								</xsd:choice>
+							</xsd:sequence>
+							<xsd:attribute name="context" type="xsd:string" use="required"/>
+						</xsd:complexType>
+					</xsd:element>
+				</xsd:choice>
+			</xsd:sequence>
+			<xsd:attributeGroup ref="changeLogAttributes" />
+			<xsd:anyAttribute namespace="##other" />
+		</xsd:complexType>
+	</xsd:element>
+	
+	<xsd:element name="property">
+		<xsd:complexType>
+			<xsd:attribute name="file" type="xsd:string" />
+			<xsd:attribute name="name" type="xsd:string" />
+			<xsd:attribute name="value" type="xsd:string" />
+			<xsd:attribute name="dbms" type="xsd:string" />
+			<xsd:attribute name="context" type="xsd:string" />
+		</xsd:complexType>
+	</xsd:element>
+	
+	<xsd:element name="preConditions">
+		<xsd:complexType>
+			<xsd:choice>
+				<xsd:group ref="PreConditionChildren" maxOccurs="unbounded" />
+			</xsd:choice>
+			<xsd:attribute name="onFailMessage" type="xsd:string" />
+			<xsd:attribute name="onErrorMessage" type="xsd:string" />
+			<xsd:attribute name="onFail"
+				type="onChangeLogPreconditionErrorOrFail" />
+			<xsd:attribute name="onError"
+				type="onChangeLogPreconditionErrorOrFail" />
+			<xsd:attribute name="onSqlOutput"
+				type="onChangeLogPreconditionOnSqlOutput" />
+		</xsd:complexType>
+	</xsd:element>
+	
+	<xsd:element name="changeSet">
+		<xsd:complexType>
+			<xsd:sequence>
+				<xsd:element name="validCheckSum" minOccurs="0"
+					maxOccurs="unbounded">
+					<xsd:complexType mixed="true">
+						<xsd:sequence>
+							<xsd:element ref="comment" minOccurs="0"
+								maxOccurs="1" />
+						</xsd:sequence>
 					</xsd:complexType>
 				</xsd:element>
-
 				<xsd:element name="preConditions" minOccurs="0"
 					maxOccurs="1">
+                                <xsd:annotation>
+                                    <xsd:appinfo>
+                                        <xsd:documentation>onChangeLogPreconditionOnSqlOutput determines what should happen when evaluating this precondition in updateSQL mode.  TEST: Run precondition, FAIL: Fail precondition, IGNORE: Skip precondition check [DEFAULT]</xsd:documentation>
+                                    </xsd:appinfo>
+                                </xsd:annotation>
 					<xsd:complexType>
 						<xsd:choice>
 							<xsd:group ref="PreConditionChildren" maxOccurs="unbounded" />
@@ -104,92 +179,51 @@
 						<xsd:attribute name="onFailMessage" type="xsd:string" />
 						<xsd:attribute name="onErrorMessage" type="xsd:string" />
 						<xsd:attribute name="onFail"
-							type="onChangeLogPreconditionErrorOrFail" />
+							type="onChangeSetPreconditionErrorOrFail" />
 						<xsd:attribute name="onError"
-							type="onChangeLogPreconditionErrorOrFail" />
+							type="onChangeSetPreconditionErrorOrFail" />
 						<xsd:attribute name="onSqlOutput"
 							type="onChangeLogPreconditionOnSqlOutput" />
 					</xsd:complexType>
 				</xsd:element>
-
-				<xsd:choice minOccurs="0" maxOccurs="unbounded">
-					<xsd:element name="changeSet" minOccurs="0" maxOccurs="unbounded">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="validCheckSum" minOccurs="0"
-									maxOccurs="unbounded">
-									<xsd:complexType mixed="true">
-										<xsd:sequence>
-											<xsd:element ref="comment" minOccurs="0"
-												maxOccurs="1" />
-										</xsd:sequence>
-									</xsd:complexType>
-								</xsd:element>
-								<xsd:element name="preConditions" minOccurs="0"
-									maxOccurs="1">
-                                    <xsd:annotation>
-                                        <xsd:appinfo>
-                                            <xsd:documentation>onChangeLogPreconditionOnSqlOutput determines what should happen when evaluating this precondition in updateSQL mode.  TEST: Run precondition, FAIL: Fail precondition, IGNORE: Skip precondition check [DEFAULT]</xsd:documentation>
-                                        </xsd:appinfo>
-                                    </xsd:annotation>
-									<xsd:complexType>
-										<xsd:choice>
-											<xsd:group ref="PreConditionChildren" maxOccurs="unbounded" />
-										</xsd:choice>
-										<xsd:attribute name="onFailMessage" type="xsd:string" />
-										<xsd:attribute name="onErrorMessage" type="xsd:string" />
-										<xsd:attribute name="onFail"
-											type="onChangeSetPreconditionErrorOrFail" />
-										<xsd:attribute name="onError"
-											type="onChangeSetPreconditionErrorOrFail" />
-										<xsd:attribute name="onSqlOutput"
-											type="onChangeLogPreconditionOnSqlOutput" />
-									</xsd:complexType>
-								</xsd:element>
-								<xsd:choice>
-									<xsd:element ref="tagDatabase" maxOccurs="1" />
-									<xsd:group ref="changeSetChildren" minOccurs="0"
-										maxOccurs="unbounded" />
-								</xsd:choice>
-
-								<xsd:element name="modifySql" minOccurs="0"
-									maxOccurs="unbounded">
-									<xsd:complexType>
-										<xsd:choice>
-											<xsd:group ref="modifySqlChildren" minOccurs="1"
-												maxOccurs="unbounded" />
-										</xsd:choice>
-										<xsd:attribute name="dbms" type="xsd:string" />
-										<xsd:attribute name="context" type="xsd:string" />
-										<xsd:attribute name="applyToRollback" type="booleanExp" />
-									</xsd:complexType>
-								</xsd:element>
-
-							</xsd:sequence>
-							<xsd:attributeGroup ref="changeSetAttributes" />
-							<xsd:anyAttribute namespace="##other" />
-						</xsd:complexType>
-					</xsd:element>
-
-					<!-- include -->
-					<xsd:element name="include" minOccurs="0" maxOccurs="unbounded">
-						<xsd:complexType>
-							<xsd:attribute name="file" type="xsd:string" use="required" />
-							<xsd:attribute name="relativeToChangelogFile" type="booleanExp" />
-							<xsd:anyAttribute namespace="##other" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="includeAll" minOccurs="0" maxOccurs="unbounded">
-						<xsd:complexType>
-							<xsd:attribute name="path" type="xsd:string" use="required" />
-							<xsd:attribute name="relativeToChangelogFile" type="booleanExp" />
-                            <xsd:attribute name="filter" type="xsd:string" />
-							<xsd:anyAttribute namespace="##other" />
-						</xsd:complexType>
-					</xsd:element>
+				<xsd:choice>
+					<xsd:element ref="tagDatabase" maxOccurs="1" />
+					<xsd:group ref="changeSetChildren" minOccurs="0"
+						maxOccurs="unbounded" />
 				</xsd:choice>
+
+				<xsd:element name="modifySql" minOccurs="0"
+					maxOccurs="unbounded">
+					<xsd:complexType>
+						<xsd:choice>
+							<xsd:group ref="modifySqlChildren" minOccurs="1"
+								maxOccurs="unbounded" />
+						</xsd:choice>
+						<xsd:attribute name="dbms" type="xsd:string" />
+						<xsd:attribute name="context" type="xsd:string" />
+						<xsd:attribute name="applyToRollback" type="booleanExp" />
+					</xsd:complexType>
+				</xsd:element>
+
 			</xsd:sequence>
-			<xsd:attributeGroup ref="changeLogAttributes" />
+			<xsd:attributeGroup ref="changeSetAttributes" />
+			<xsd:anyAttribute namespace="##other" />
+		</xsd:complexType>
+	</xsd:element>
+	
+	<xsd:element name="include">
+		<xsd:complexType>
+			<xsd:attribute name="file" type="xsd:string" use="required" />
+			<xsd:attribute name="relativeToChangelogFile" type="booleanExp" />
+			<xsd:anyAttribute namespace="##other" />
+		</xsd:complexType>
+	</xsd:element>
+	
+	<xsd:element name="includeAll">
+		<xsd:complexType>
+			<xsd:attribute name="path" type="xsd:string" use="required" />
+			<xsd:attribute name="relativeToChangelogFile" type="booleanExp" />
+                        <xsd:attribute name="filter" type="xsd:string" />
 			<xsd:anyAttribute namespace="##other" />
 		</xsd:complexType>
 	</xsd:element>

--- a/liquibase-core/src/test/java/liquibase/parser/core/xml/XMLChangeLogSAXParserTest.java
+++ b/liquibase-core/src/test/java/liquibase/parser/core/xml/XMLChangeLogSAXParserTest.java
@@ -1,5 +1,14 @@
 package liquibase.parser.core.xml;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import liquibase.Contexts;
 import liquibase.change.AddColumnConfig;
 import liquibase.change.Change;
 import liquibase.change.ChangeFactory;
@@ -17,12 +26,9 @@ import liquibase.exception.ChangeLogParseException;
 import liquibase.precondition.core.OrPrecondition;
 import liquibase.precondition.core.PreconditionContainer;
 import liquibase.test.JUnitResourceAccessor;
+
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.List;
-
-import static org.junit.Assert.*;
 
 public class XMLChangeLogSAXParserTest {
 
@@ -126,6 +132,39 @@ public class XMLChangeLogSAXParserTest {
         assertEquals("table", exChg.getTableName());
         assertEquals("column", exChg.getColumnName());
 
+    }
+    
+    @Test
+    public void contextGroupChangeLog() throws Exception {
+    	DatabaseChangeLog changeLog = new XMLChangeLogSAXParser().parse("liquibase/parser/core/xml/contextGroupChangeLog.xml", new ChangeLogParameters(), new JUnitResourceAccessor());
+    	
+    	//Changeset 1
+    	ChangeSet changeSet = changeLog.getChangeSets().get(0);
+    	Contexts contexts = changeSet.getContexts();
+    	assertEquals("Expected 2 contexts",2,contexts.size());
+    	for (String context : contexts) {
+    		assertTrue("Expected either context1 or context3", "context1".equals(context) || "context3".equals(context));
+    	}
+    	
+    	//Changeset 2
+    	changeSet = changeLog.getChangeSets().get(1);
+    	contexts = changeSet.getContexts();
+    	assertEquals("Expected 2 contexts",2,contexts.size());
+    	for (String context : contexts) {
+    		assertTrue("Expected either context1 or context3", "context1".equals(context) || "context3".equals(context));
+    	}
+    	
+    	//Changeset 3 different contextGroup and nested context
+    	changeSet = changeLog.getChangeSets().get(2);
+    	contexts = changeSet.getContexts();
+    	assertEquals("Expected 2 contexts",2,contexts.size());
+    	for (String context : contexts) {
+    		assertTrue("Expected context2 or context4", "context2".equals(context) || "context4".equals(context));
+    	}
+    	
+    	// change 4
+        changeSet = changeLog.getChangeSets().get(3);
+        assertTrue("Expected no contexts", changeSet.getContexts().isEmpty());
     }
 
     @Test

--- a/liquibase-core/src/test/resources/liquibase/parser/core/xml/contextGroupChangeLog.xml
+++ b/liquibase-core/src/test/resources/liquibase/parser/core/xml/contextGroupChangeLog.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog src/main/resources/liquibase/parser/core/xml/dbchangelog-3.2.xsd">
+
+	<contextGroup context="context1,context3">
+		<changeSet id="1" author="macton">
+			<createTable tableName="person">
+				<column name="id" type="int">
+					<constraints primaryKey="true" nullable="false" />
+				</column>
+				<column name="firstname" type="varchar(50)" />
+				<column name="lastname" type="varchar(50)">
+					<constraints nullable="false" />
+				</column>
+			</createTable>
+		</changeSet>
+
+		<changeSet id="2" author="macton" runAlways="true"
+			runOnChange="true">
+			<comment>Testing add column</comment>
+			<addColumn tableName="person">
+				<column name="username" type="varchar(255)" />
+			</addColumn>
+			<addColumn tableName="person">
+				<column name="hireDate" type="date" />
+			</addColumn>
+			<rollback>
+				alter table person drop column username;
+				alter table person drop column hireDate;
+			</rollback>
+		</changeSet>
+	</contextGroup>
+
+	<contextGroup context="context2">
+		<changeSet id="3" author="bob" context="context4" runAlways="false"
+			runOnChange="false">
+			<createTable tableName="company">
+				<column name="id" type="int">
+					<constraints primaryKey="true" nullable="false" />
+				</column>
+				<column name="name" type="varchar(50)" />
+			</createTable>
+		</changeSet>
+	</contextGroup>
+	
+	<changeSet id="4" author="jim">
+		<createTable tableName="account">
+			<column name="id" type="int">
+				<constraints primaryKey="true" nullable="false" />
+			</column>
+			<column name="type" type="varchar(75)" />
+		</createTable>
+	</changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
This new element allows grouping of databaseChangeLog child elements
 under a single context(s). This is mainly useful for grouping
 multiple changeSets under a single context without the need of
 copy / pasting the context multiple times.

We are using liquibase in conjunction with Maven and an internal maven plugin to generate migration and rollback scripts for our DBA's to use during deployments. These scripts are tied to a certain release using the context attribute. We prefer to use multiple changeSets in order to maintain the perception of atomic migrations. However, it is tedious and error prone to copy / paste the appropriate context in order for the plugin to pull in the correct scripts. 

I wanted to contribute this tag back to the community as I can see others benefiting if they are using Liquibase in a similar setup. 