### PR TITLE
Use PreparedStatement for UpdateDataChange for a CLOB column (CORE-2069)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/UpdateDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/UpdateDataChange.java
@@ -46,7 +46,8 @@ public class UpdateDataChange extends AbstractModifyDataChange implements Change
             if (column.getValueBlobFile() != null) {
                 needsPreparedStatement = true;
             }
-            if (column.getValueClobFile() != null) {
+            if (column.getValueClobFile() != null
+                || (column.getType() != null && column.getType().equalsIgnoreCase("CLOB"))) {
                 needsPreparedStatement = true;
             }
         }


### PR DESCRIPTION
Use a prepared statement for a clob column type rather than a standard SQL statement.  This is to prevent a 4000 character Oracle error when using large values for columns.
