### PR TITLE
When using the system property

### DIFF
--- a/liquibase-core/src/main/java/liquibase/configuration/ConfigurationProperty.java
+++ b/liquibase-core/src/main/java/liquibase/configuration/ConfigurationProperty.java
@@ -95,6 +95,8 @@ public class ConfigurationProperty {
                 return Integer.valueOf((String) value);
             } else if (type.equals(BigDecimal.class)) {
                 return new BigDecimal((String) value);
+            } else if (type.equals(Long.class)) {
+            	return new Long((String) value);
             } else {
                 throw new UnexpectedLiquibaseException("Cannot parse property "+type.getSimpleName()+" to a "+type.getSimpleName());
             }


### PR DESCRIPTION
"liquibase.changeLogLockWaitTimeInMinutes" an
UnexpectedLiquibaseException is raised as the
ConfigurationProperty.valueOf( Object ) method is unaware of how to
handle the Long object type.
