### PR TITLE
Context null check

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/filter/ContextChangeSetFilter.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/filter/ContextChangeSetFilter.java
@@ -27,7 +27,7 @@ public class ContextChangeSetFilter implements ChangeSetFilter {
         }
         changeSet.getSqlVisitors().removeAll(visitorsToRemove);
 
-        if (contexts.isEmpty()) {
+        if (contexts == null || contexts.isEmpty()) {
             return new ChangeSetFilterResult(true, "No runtime context specified, all contexts will run", this.getClass());
         }
 

--- a/liquibase-core/src/test/java/liquibase/changelog/filter/ContextChangeSetFilterTest.java
+++ b/liquibase-core/src/test/java/liquibase/changelog/filter/ContextChangeSetFilterTest.java
@@ -58,6 +58,14 @@ public class ContextChangeSetFilterTest {
         assertTrue(filter.accepts(new ChangeSet(null, null, false, false, null, null, null, null)).isAccepted());
     }
 
+    @Test public void reallyNullContexts(){
+      ContextChangeSetFilter filter = new ContextChangeSetFilter(null);
+
+      assertTrue(filter.accepts(new ChangeSet(null, null, false, false, null, "test1", null, null)).isAccepted());
+      assertTrue(filter.accepts(new ChangeSet(null, null, false, false, null, "test1, test2", null, null)).isAccepted());
+      assertTrue(filter.accepts(new ChangeSet(null, null, false, false, null, null, null, null)).isAccepted());
+    }
+    
     @Test
     public void nullListContexts() {
         ContextChangeSetFilter filter = new ContextChangeSetFilter();

--- a/liquibase-core/src/test/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.java
+++ b/liquibase-core/src/test/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.java
@@ -136,7 +136,7 @@ public class FormattedSqlChangeLogParserTest {
         assertTrue(changeLog.getChangeSets().get(1).isAlwaysRun());
         assertTrue(changeLog.getChangeSets().get(1).isRunOnChange());
         assertFalse(changeLog.getChangeSets().get(1).isRunInTransaction());
-        assertEquals("y", changeLog.getChangeSets().get(1).getContexts().toString());
+        assertEquals("(y)", changeLog.getChangeSets().get(1).getContexts().toString());
         assertEquals("mysql", StringUtils.join(changeLog.getChangeSets().get(1).getDbmsSet(), ","));
         assertEquals(1, changeLog.getChangeSets().get(1).getRollBackChanges().length);
         assertEquals("delete from table1;\n" +


### PR DESCRIPTION
This is a unit test that reproduces the problem we were seeing, a fix to make the test pass, as well as a fix to another unit test that broke locally that seems to be related to the Contexts change. 
