### PR TITLE
Overloading the generateChangeLog method to add a ChangeLogSerializer argument

### DIFF
--- a/liquibase-core/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-core/src/main/java/liquibase/Liquibase.java
@@ -35,6 +35,7 @@ import liquibase.logging.Logger;
 import liquibase.parser.ChangeLogParser;
 import liquibase.parser.ChangeLogParserFactory;
 import liquibase.resource.ResourceAccessor;
+import liquibase.serializer.ChangeLogSerializer;
 import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.InvalidExampleException;
 import liquibase.snapshot.SnapshotControl;
@@ -1053,8 +1054,11 @@ public class Liquibase {
         return ignoreClasspathPrefix;
     }
 
-
     public void generateChangeLog(CatalogAndSchema catalogAndSchema, DiffToChangeLog changeLogWriter, PrintStream outputStream, Class<? extends DatabaseObject>... snapshotTypes) throws DatabaseException, IOException, ParserConfigurationException {
+        generateChangeLog(catalogAndSchema, changeLogWriter, outputStream, null, snapshotTypes);
+    }
+
+    public void generateChangeLog(CatalogAndSchema catalogAndSchema, DiffToChangeLog changeLogWriter, PrintStream outputStream, ChangeLogSerializer changeLogSerializer, Class<? extends DatabaseObject>... snapshotTypes) throws DatabaseException, IOException, ParserConfigurationException {
         Set<Class<? extends DatabaseObject>> finalCompareTypes = null;
         if (snapshotTypes != null && snapshotTypes.length > 0) {
             finalCompareTypes = new HashSet<Class<? extends DatabaseObject>>(Arrays.asList(snapshotTypes));
@@ -1071,7 +1075,11 @@ public class Liquibase {
 
             changeLogWriter.setDiffResult(diffResult);
 
-            changeLogWriter.print(outputStream);
+            if(changeLogSerializer != null) {
+                changeLogWriter.print(outputStream, changeLogSerializer);
+            } else {
+                changeLogWriter.print(outputStream);
+            }
         } catch (InvalidExampleException e) {
             throw new UnexpectedLiquibaseException(e);
         }


### PR DESCRIPTION
I have overloaded the `generateChangeLog()` method in the `Liquibase` facade class to take an additional argument of `ChangeLogSerializer`. This allows the caller to explicitly specify which serializer they want to use rather than relying on the output file type extension.
This will be very useful in situations in areas like ant tasks and maven plugins where the plugin will have ways for the user to specify multiple outputs. For me, I am working on enhancing the generate change log ant task to output multiple change logs formats.
