### PR TITLE
Update AbstractLogger to add default implementations of Logger interface

### DIFF
--- a/liquibase-core/src/main/java/liquibase/logging/core/AbstractLogger.java
+++ b/liquibase-core/src/main/java/liquibase/logging/core/AbstractLogger.java
@@ -1,11 +1,15 @@
 package liquibase.logging.core;
 
+import liquibase.changelog.ChangeSet;
+import liquibase.changelog.DatabaseChangeLog;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.logging.LogLevel;
 import liquibase.logging.Logger;
 
-public abstract class AbstractLogger  implements Logger {
+public abstract class AbstractLogger implements Logger {
     private LogLevel logLevel;
+    private DatabaseChangeLog databaseChangeLog;
+    private ChangeSet changeSet;
 
     @Override
     public LogLevel getLogLevel() {
@@ -33,8 +37,31 @@ public abstract class AbstractLogger  implements Logger {
         }
     }
 
+    protected String buildMessage(String message) {
+        StringBuilder msg = new StringBuilder();
+        if(databaseChangeLog != null) {
+            msg.append(databaseChangeLog.getFilePath()).append(": ");
+        }
+        if(changeSet != null) {
+            String changeSetName = changeSet.toString(false);
+            msg.append(changeSetName.replace(changeSetName + "::", "")).append(": ");
+        }
+        msg.append(message);
+        return msg.toString();
+    }
+
     @Override
     public void setLogLevel(LogLevel level) {
         this.logLevel = level;
+    }
+
+    @Override
+    public void setChangeLog(DatabaseChangeLog databaseChangeLog) {
+        this.databaseChangeLog = databaseChangeLog;
+    }
+
+    @Override
+    public void setChangeSet(ChangeSet changeSet) {
+        this.changeSet = changeSet;
     }
 }

--- a/liquibase-core/src/main/java/liquibase/logging/core/DefaultLogger.java
+++ b/liquibase-core/src/main/java/liquibase/logging/core/DefaultLogger.java
@@ -1,7 +1,5 @@
 package liquibase.logging.core;
 
-import liquibase.changelog.ChangeSet;
-import liquibase.changelog.DatabaseChangeLog;
 import liquibase.configuration.LiquibaseConfiguration;
 import liquibase.logging.LogLevel;
 import liquibase.util.StringUtils;
@@ -10,16 +8,12 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.text.DateFormat;
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
 
 public class DefaultLogger extends AbstractLogger {
 
     private String name = "liquibase";
     private PrintStream err = System.err;
-    private String changeLogName = null;
-    private String changeSetName = null;
 
     public DefaultLogger() {
     }
@@ -75,16 +69,7 @@ public class DefaultLogger extends AbstractLogger {
             return;
         }
 
-        List<String> description = new ArrayList<String>();
-        description.add(name);
-        if (changeLogName != null) {
-            description.add(changeLogName);
-        }
-        if (changeSetName != null) {
-            description.add(changeSetName.replace(changeLogName+"::", ""));
-        }
-
-        err.println(logLevel + " " + DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT).format(new Date()) + ":" + StringUtils.join(description, ": ") + ": " + message);
+        err.println(logLevel + " " + DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT).format(new Date()) + ": " + name + ": " + buildMessage(message));
     }
 
     @Override
@@ -139,19 +124,5 @@ public class DefaultLogger extends AbstractLogger {
             e.printStackTrace(err);
         }
 
-    }
-
-    @Override
-    public void setChangeLog(DatabaseChangeLog databaseChangeLog) {
-      if (databaseChangeLog == null) {
-        changeLogName = null;
-      } else {
-        changeLogName  = databaseChangeLog.getFilePath();
-      }
-    }
-
-    @Override
-    public void setChangeSet(ChangeSet changeSet) {
-      changeSetName = (changeSet == null ? null : changeSet.toString(false));
     }
 }


### PR DESCRIPTION
A while back the Liquibase `Logger` interface added a couple of new methods to set a `DatabaseChangeLog` and `ChangeSet` to the Logger. In that change the `DefaultLogger` class was updated to implement these new methods but the `AbstractLogger` did not provide a default implementation. This caused a breaking interface change that required all implementers of the `Logger` interface, regardless if they extended the `AbstractLogger`, to update their code.
I have added a default implementation of these methods to the `AbstractLogger` class as well as a convenience method for building a log message based on these methods. This way all implementers can benefit from a common format for log messages.
