### PR TITLE
Fix NPE in ChangeLogSyncVisitor when no ChangeLogSyncListener is given

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/visitor/ChangeLogSyncVisitor.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/visitor/ChangeLogSyncVisitor.java
@@ -30,6 +30,8 @@ public class ChangeLogSyncVisitor implements ChangeSetVisitor {
     @Override
     public void visit(ChangeSet changeSet, DatabaseChangeLog databaseChangeLog, Database database, Set<ChangeSetFilterResult> filterResults) throws LiquibaseException {
         this.database.markChangeSetExecStatus(changeSet, ChangeSet.ExecType.EXECUTED);
-        listener.markedRan(changeSet, databaseChangeLog, database);
+        if(listener != null) {
+            listener.markedRan(changeSet, databaseChangeLog, database);
+        }
     }
 }

--- a/liquibase-core/src/test/java/liquibase/changelog/visitor/ChangeLogSyncVisitorTest.java
+++ b/liquibase-core/src/test/java/liquibase/changelog/visitor/ChangeLogSyncVisitorTest.java
@@ -1,0 +1,43 @@
+package liquibase.changelog.visitor;
+
+import liquibase.changelog.ChangeSet;
+import liquibase.changelog.DatabaseChangeLog;
+import liquibase.changelog.filter.ChangeSetFilterResult;
+import liquibase.database.Database;
+import liquibase.exception.LiquibaseException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class ChangeLogSyncVisitorTest {
+    private ChangeSet changeSet;
+    private DatabaseChangeLog databaseChangeLog;
+
+    @Before
+    public void setUp() {
+        changeSet = new ChangeSet("1", "testAuthor", false, false, "path/changelog", null, null, null);
+        databaseChangeLog = new DatabaseChangeLog();
+    }
+
+    @Test
+    public void testVisitDatabaseConstructor() throws LiquibaseException {
+        Database mockDatabase = mock(Database.class);
+        ChangeLogSyncVisitor visitor = new ChangeLogSyncVisitor(mockDatabase);
+        visitor.visit(changeSet, databaseChangeLog, mockDatabase, Collections.<ChangeSetFilterResult>emptySet());
+        verify(mockDatabase).markChangeSetExecStatus(changeSet, ChangeSet.ExecType.EXECUTED);
+    }
+
+    @Test
+    public void testVisitListenerConstructor() throws LiquibaseException {
+        Database mockDatabase = mock(Database.class);
+        ChangeLogSyncListener mockListener = mock(ChangeLogSyncListener.class);
+        ChangeLogSyncVisitor visitor = new ChangeLogSyncVisitor(mockDatabase, mockListener);
+        visitor.visit(changeSet, databaseChangeLog, mockDatabase, Collections.<ChangeSetFilterResult>emptySet());
+        verify(mockDatabase).markChangeSetExecStatus(changeSet, ChangeSet.ExecType.EXECUTED);
+        verify(mockListener).markedRan(changeSet, databaseChangeLog, mockDatabase);
+    }
+}


### PR DESCRIPTION
I encountered this NPE while I was writing integration tests for the MarkNextChangeSetRan Ant task. Since the visitor has two constructors, one with a listener argument and one without, the listener is an optional argument and can't be relied upon to be a non-null reference. The visit method was always expecting a listener reference to exist causing the NPE.
To fix I wrapped the listener usage in a null check. I wrote a couple of unit tests to recreate the exception and then fixed the issue and verified the tests passed.
