### PR TITLE
Fix for CORE-1957 Using VARCHAR2 column type fails for Hsqldb running in...

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
@@ -1,9 +1,7 @@
 package liquibase.database.core;
 
-import liquibase.CatalogAndSchema;
 import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.DatabaseConnection;
-import liquibase.structure.DatabaseObject;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.DateParseException;
 import liquibase.util.ISODateFormat;
@@ -20,6 +18,8 @@ public class HsqlDatabase extends AbstractJdbcDatabase {
     private static String START_CONCAT = "CONCAT(";
     private static String END_CONCAT = ")";
     private static String SEP_CONCAT = ", ";
+
+    private Boolean oracleSyntax;
 
     public HsqlDatabase() {
     	super.unquotedObjectsAreUppercased=true;
@@ -455,5 +455,26 @@ public class HsqlDatabase extends AbstractJdbcDatabase {
     @Override
     public boolean isCaseSensitive() {
         return false;
+    }
+    
+    @Override
+    public void setConnection(DatabaseConnection conn) {
+        oracleSyntax = null;
+        super.setConnection(conn);
+    }
+
+    public boolean isUsingOracleSyntax() {
+        if (oracleSyntax == null) {
+            oracleSyntax = Boolean.FALSE;
+            if (getConnection() != null && getConnection().getURL() != null) {
+                for (String str : getConnection().getURL().split(";")) {
+                    if (str.contains("sql.syntax_ora") && str.contains("=")) {
+                        oracleSyntax = Boolean.valueOf(str.split("=")[1].trim());
+                        break;
+                    }
+                }
+            }
+        }
+        return oracleSyntax;
     }
 }

--- a/liquibase-core/src/main/java/liquibase/datatype/core/VarcharType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/VarcharType.java
@@ -1,6 +1,7 @@
 package liquibase.datatype.core;
 
 import liquibase.database.Database;
+import liquibase.database.core.HsqlDatabase;
 import liquibase.database.core.InformixDatabase;
 import liquibase.database.core.MSSQLDatabase;
 import liquibase.database.core.OracleDatabase;
@@ -13,7 +14,8 @@ public class VarcharType extends CharType {
 
     @Override
     public DatabaseDataType toDatabaseDataType(Database database) {
-        if (database instanceof OracleDatabase) {
+        if (database instanceof OracleDatabase
+                || (database instanceof HsqlDatabase && ((HsqlDatabase) database).isUsingOracleSyntax())) {
             return new DatabaseDataType("VARCHAR2", getParameters());
         }
 

--- a/liquibase-core/src/test/java/liquibase/database/core/HsqlDatabaseTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/core/HsqlDatabaseTest.java
@@ -1,7 +1,10 @@
 package liquibase.database.core;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import junit.framework.TestCase;
 import liquibase.database.Database;
+import liquibase.database.DatabaseConnection;
 import liquibase.database.ObjectQuotingStrategy;
 import liquibase.structure.core.Table;
 
@@ -37,5 +40,21 @@ public class HsqlDatabaseTest extends TestCase {
         Database databaseWithAllQuoting = new HsqlDatabase();
         databaseWithAllQuoting.setObjectQuotingStrategy(ObjectQuotingStrategy.QUOTE_ALL_OBJECTS);
         assertEquals("\"Test\"", databaseWithAllQuoting.escapeObjectName("Test", Table.class));
+    }
+    
+    public void testUsingOracleSyntax()  {
+        HsqlDatabase database = new HsqlDatabase();
+        DatabaseConnection conn = mock(DatabaseConnection.class);
+        when(conn.getURL()).thenReturn("jdbc:hsqldb:mem:testdb;sql.syntax_ora=true;sql.enforce_names=true");
+        database.setConnection(conn );
+        assertTrue("Using oracle syntax", database.isUsingOracleSyntax());
+    }
+
+    public void testNotUsingOracleSyntax()  {
+        HsqlDatabase database = new HsqlDatabase();
+        DatabaseConnection conn = mock(DatabaseConnection.class);
+        when(conn.getURL()).thenReturn("jdbc:hsqldb:mem:testdb");
+        database.setConnection(conn );
+        assertFalse("Using oracle syntax", database.isUsingOracleSyntax());
     }
 }

--- a/liquibase-core/src/test/java/liquibase/datatype/core/VarcharTypeTest.java
+++ b/liquibase-core/src/test/java/liquibase/datatype/core/VarcharTypeTest.java
@@ -1,0 +1,32 @@
+package liquibase.datatype.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import liquibase.database.core.HsqlDatabase;
+import liquibase.datatype.DatabaseDataType;
+
+import org.junit.Test;
+
+public class VarcharTypeTest {
+
+    @Test
+    public void varchar2ForHsqldbInOracleSyntaxMode() {
+        VarcharType type = new VarcharType();
+        HsqlDatabase hsqlDatabase = mock(HsqlDatabase.class);
+        when(hsqlDatabase.isUsingOracleSyntax()).thenReturn(true);
+        DatabaseDataType databaseDataType = type.toDatabaseDataType(hsqlDatabase);
+        assertEquals("VARCHAR2", databaseDataType.getType().toUpperCase());
+    }
+
+    @Test
+    public void varcharForHsqldbNotInOracleSyntaxMode() {
+        VarcharType type = new VarcharType();
+        HsqlDatabase hsqlDatabase = mock(HsqlDatabase.class);
+        when(hsqlDatabase.isUsingOracleSyntax()).thenReturn(false);
+        DatabaseDataType databaseDataType = type.toDatabaseDataType(hsqlDatabase);
+        assertEquals("VARCHAR", databaseDataType.getType().toUpperCase());
+    }
+
+}


### PR DESCRIPTION
This is a fix for <a href="https://liquibase.jira.com/browse/CORE-1957">CORE-1957, Using VARCHAR2 column type fails for Hsqldb running in oracle syntax mode</a>, that hopefully can be incorporated into the 3.2.1 release. 

Some unit tests have been added and all other tests in liquibase-core are running fine.
