### PR TITLE
warn and exit if command is generateChangeLog but no changeLogFile is supplied

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -342,7 +342,8 @@ public class Main {
                 || "status".equalsIgnoreCase(command)
                 || "validate".equalsIgnoreCase(command)
                 || "changeLogSync".equalsIgnoreCase(command)
-                || "changeLogSyncSql".equalsIgnoreCase(command);
+                || "changeLogSyncSql".equalsIgnoreCase(command)
+                || "generateChangeLog".equalsIgnoreCase(command);
     }
 
     private boolean isCommand(String arg) {


### PR DESCRIPTION
I was using the command line incorrectly (specifying command and then options) but my incorrect usage resulted in a null pointer exception rather than a helpful message. This fixes that.
