### PR TITLE
fix for using in fat jars

### DIFF
--- a/liquibase-core/src/main/java/liquibase/servicelocator/DefaultPackageScanClassResolver.java
+++ b/liquibase-core/src/main/java/liquibase/servicelocator/DefaultPackageScanClassResolver.java
@@ -383,7 +383,7 @@ public class DefaultPackageScanClassResolver implements PackageScanClassResolver
             JarEntry entry;
             while ((entry = jarStream.getNextJarEntry()) != null) {
                 String name = entry.getName();
-                if (name != null) {
+                if (name != null && name.contains(parent)) {
                     name = name.trim();
                     if (!entry.isDirectory() && name.endsWith(".class")) {
                         loadClass(name, loader);


### PR DESCRIPTION
Fix for creating a fat jar where classes have no package (see example below). Also should speed up loading of fat jars in general.

http://search.maven.org/#search|ga|1|luaj-jse
