### PR TITLE
CORE-549 relativeToChangelogFile for loadData, loadUpdateData, sqlFile

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
@@ -39,10 +39,10 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
     private String schemaName;
     private String tableName;
     private String file;
+    private Boolean relativeToChangelogFile;
     private String encoding = null;
     private String separator = liquibase.util.csv.opencsv.CSVReader.DEFAULT_SEPARATOR + "";
 	private String quotchar = liquibase.util.csv.opencsv.CSVReader.DEFAULT_QUOTE_CHARACTER + "";
-
 
     private List<LoadDataColumnConfig> columns = new ArrayList<LoadDataColumnConfig>();
 
@@ -92,6 +92,14 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
 
     public void setFile(String file) {
         this.file = file;
+    }
+
+    public Boolean isRelativeToChangelogFile() {
+        return relativeToChangelogFile;
+    }
+
+    public void setRelativeToChangelogFile(Boolean relativeToChangelogFile) {
+        this.relativeToChangelogFile = relativeToChangelogFile;
     }
 
     @DatabaseChangeProperty(exampleValue = "UTF-8", description = "Encoding of the CSV file (defaults to UTF-8)")
@@ -250,7 +258,7 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
         if (resourceAccessor == null) {
             throw new UnexpectedLiquibaseException("No file resourceAccessor specified for "+getFile());
         }
-        InputStream stream = StreamUtil.singleInputStream(getFile(), resourceAccessor);
+        InputStream stream = StreamUtil.openStream(file, isRelativeToChangelogFile(), getChangeSet(), resourceAccessor);
         if (stream == null) {
             return null;
         }
@@ -310,7 +318,7 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
     public CheckSum generateCheckSum() {
         InputStream stream = null;
         try {
-            stream = StreamUtil.singleInputStream(getFile(), getResourceAccessor());
+            stream = StreamUtil.openStream(file, isRelativeToChangelogFile(), getChangeSet(), getResourceAccessor());
             if (stream == null) {
                 throw new UnexpectedLiquibaseException(getFile() + " could not be found");
             }

--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.3.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.3.xsd
@@ -512,6 +512,7 @@
 			</xsd:sequence>
             <xsd:attributeGroup ref="tableNameAttribute" />
 			<xsd:attribute name="file" type="xsd:string" />
+			<xsd:attribute name="relativeToChangelogFile" type="booleanExp" />
 			<xsd:attribute name="encoding" type="xsd:string" default="UTF-8"/>
 			<xsd:attribute name="separator" type="xsd:string" default=","/>
 			<xsd:attribute name="quotchar" type="xsd:string" default="&quot;"/>
@@ -537,6 +538,7 @@
 			</xsd:sequence>
             <xsd:attributeGroup ref="tableNameAttribute" />
 			<xsd:attribute name="file" type="xsd:string" />
+			<xsd:attribute name="relativeToChangelogFile" type="booleanExp" />
 			<xsd:attribute name="encoding" type="xsd:string" default="UTF-8"/>
 			<xsd:attribute name="primaryKey" type="xsd:string" use="required" />
 			<xsd:attribute name="separator" type="xsd:string" default=","/>

--- a/liquibase-core/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
@@ -2,6 +2,7 @@ package liquibase.change.core
 
 import liquibase.change.ChangeStatus
 import liquibase.change.StandardChangeTest;
+import liquibase.changelog.ChangeSet;
 import liquibase.sdk.database.MockDatabase
 import liquibase.parser.core.ParsedNodeException;
 import liquibase.resource.ClassLoaderResourceAccessor
@@ -179,5 +180,37 @@ public class LoadDataChangeTest extends StandardChangeTest {
 
         change.columns[1].name == "new_col"
         change.columns[1].header == "new_col_header"
+    }
+
+    def "relativeToChangelogFile works"() throws Exception {
+        when:
+        ChangeSet changeSet = new ChangeSet(null, null, true, false,
+                                            "liquibase/change/fakeChangeSet.xml",
+                                            null, null, false, null, null);
+
+        LoadDataChange relativeChange = new LoadDataChange();
+
+        relativeChange.setSchemaName("SCHEMA_NAME");
+        relativeChange.setTableName("TABLE_NAME");
+        relativeChange.setRelativeToChangelogFile(Boolean.TRUE);
+        relativeChange.setChangeSet(changeSet);
+        relativeChange.setFile("core/sample.data1.csv");
+        relativeChange.setResourceAccessor(new ClassLoaderResourceAccessor());
+
+        SqlStatement[] relativeStatements = relativeChange.generateStatements(new MockDatabase());
+
+        LoadUpdateDataChange nonRelativeChange = new LoadUpdateDataChange();
+        nonRelativeChange.setSchemaName("SCHEMA_NAME");
+        nonRelativeChange.setTableName("TABLE_NAME");
+        nonRelativeChange.setChangeSet(changeSet);
+        nonRelativeChange.setFile("liquibase/change/core/sample.data1.csv");
+        nonRelativeChange.setResourceAccessor(new ClassLoaderResourceAccessor());
+
+        SqlStatement[] nonRelativeStatements = nonRelativeChange.generateStatements(new MockDatabase());
+
+        then:
+        assert relativeStatements != null
+        assert nonRelativeStatements != null
+        assert relativeStatements.size() == nonRelativeStatements.size()
     }
 }


### PR DESCRIPTION
Add support for the relativeToChangelogFile attribute in loadData and
loadUpdateData.
