### PR TITLE
Fixes CORE-1987

### DIFF
--- a/liquibase-core/src/main/java/liquibase/diff/compare/CompareControl.java
+++ b/liquibase-core/src/main/java/liquibase/diff/compare/CompareControl.java
@@ -39,7 +39,11 @@ public class CompareControl {
     }
 
     public CompareControl(SchemaComparison[] schemaComparison, String compareTypes) {
-        this.schemaComparisons = schemaComparison;
+        if (schemaComparison != null && schemaComparison.length > 0) {
+            this.schemaComparisons = schemaComparison;
+        } else {
+            this.schemaComparisons = new SchemaComparison[]{new SchemaComparison(new CatalogAndSchema(null, null), new CatalogAndSchema(null, null))};
+        }
         setTypes(DatabaseObjectFactory.getInstance().parseTypes(compareTypes));
     }
 


### PR DESCRIPTION
Fixes CORE-1987 "mvn liquibase:diff" does not find any differences between databases

It makes sure schemaComparison isn't empty
