### PR TITLE
Set system properties earlier

### DIFF
--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
@@ -283,6 +283,8 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
             }
         }
 
+        processSystemProperties();
+
         LiquibaseConfiguration liquibaseConfiguration = LiquibaseConfiguration.getInstance();
 
         if (!liquibaseConfiguration.getConfiguration(GlobalConfiguration.class).getShouldRun()) {
@@ -294,8 +296,6 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
             getLog().warn("Liquibase skipped due to maven configuration");
             return;
         }
-
-        processSystemProperties();
 
         ClassLoader artifactClassLoader = getMavenArtifactClassLoader();
         configureFieldsAndValues(getFileOpener(artifactClassLoader));


### PR DESCRIPTION
Ensure provided system properties is read and written to System before initialisation of the configuration instance. This change enables you to provide, for example, liquibase.databaseChangeLogTableName inside the configuration\systemProperties tag of your plugin configuration.
