### PR TITLE
CORE-54 Fixed order of Mojo system properties processing.

### DIFF
--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
@@ -283,6 +283,8 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
             }
         }
 
+        processSystemProperties();
+
         LiquibaseConfiguration liquibaseConfiguration = LiquibaseConfiguration.getInstance();
 
         if (!liquibaseConfiguration.getConfiguration(GlobalConfiguration.class).getShouldRun()) {
@@ -294,8 +296,6 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
             getLog().warn("Liquibase skipped due to maven configuration");
             return;
         }
-
-        processSystemProperties();
 
         ClassLoader artifactClassLoader = getMavenArtifactClassLoader();
         configureFieldsAndValues(getFileOpener(artifactClassLoader));


### PR DESCRIPTION
Corrected the relative position of system properties processing and config initialization in the Maven plugin so system properties in the POM configuration will override defaults again.

Recycled [CORE-54](https://liquibase.jira.com/browse/CORE-54) since technically system properties weren't supported in 3.2.x, and the issue seemed to be in need of cleanup.
