### PR TITLE
CORE-2014 applyToRollback attribute of modifySql not respected when rollback element included in changeset

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -1190,10 +1190,10 @@ public abstract class AbstractJdbcDatabase implements Database {
     }
 
     /*
-     * Executes the statements passed as argument to a target {@link Database}
+     * Executes the statements passed
      *
      * @param statements an array containing the SQL statements to be issued
-     * @param database the target {@link Database}
+     * @param sqlVisitors a list of {@link SqlVisitor} objects to be applied to the executed statements
      * @throws DatabaseException if there were problems issuing the statements
      */
     @Override
@@ -1219,17 +1219,14 @@ public abstract class AbstractJdbcDatabase implements Database {
     }
 
     @Override
-    public void executeRollbackStatements(final Change change, final List<SqlVisitor> sqlVisitors) throws LiquibaseException, RollbackImpossibleException {
-        SqlStatement[] statements = change.generateRollbackStatements(this);
-        List<SqlVisitor> rollbackVisitors = new ArrayList<SqlVisitor>();
-        if (sqlVisitors != null) {
-            for (SqlVisitor visitor : sqlVisitors) {
-                if (visitor.isApplyToRollback()) {
-                    rollbackVisitors.add(visitor);
-                }
-            }
-        }
-        execute(statements, rollbackVisitors);
+    public void executeRollbackStatements(final SqlStatement[] statements, final List<SqlVisitor> sqlVisitors) throws LiquibaseException, RollbackImpossibleException {
+        execute(statements, filterRollbackVisitors(sqlVisitors));
+    }
+    
+    @Override
+    public void executeRollbackStatements(final Change change, final List<SqlVisitor> sqlVisitors) throws LiquibaseException, RollbackImpossibleException {        
+        final SqlStatement[] statements = change.generateRollbackStatements(this);
+        executeRollbackStatements(statements, sqlVisitors);
     }
 
     @Override
@@ -1242,6 +1239,22 @@ public abstract class AbstractJdbcDatabase implements Database {
         }
     }
 
+    /**
+     * Takes a list of SqlVisitors and returns a new list with only the SqlVisitors set to apply to rollbacks
+     */
+    protected List<SqlVisitor> filterRollbackVisitors(final List<SqlVisitor> visitors) {
+        final List<SqlVisitor> rollbackVisitors = new ArrayList<SqlVisitor>();
+        if (visitors != null) {
+            for (SqlVisitor visitor : visitors) {
+               if (visitor.isApplyToRollback()) {
+                   rollbackVisitors.add(visitor);
+               }
+            }
+        }
+        
+        return rollbackVisitors;
+    }
+    
     @Override
     public List<DatabaseFunction> getDateFunctions() {
         return dateFunctions;

--- a/liquibase-core/src/main/java/liquibase/database/Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/Database.java
@@ -246,6 +246,7 @@ public interface Database extends PrioritizedService {
     void saveStatements(Change change, List<SqlVisitor> sqlVisitors, Writer writer) throws IOException, StatementNotSupportedOnDatabaseException, LiquibaseException;
 
     void executeRollbackStatements(Change change, List<SqlVisitor> sqlVisitors) throws LiquibaseException, RollbackImpossibleException;
+    void executeRollbackStatements(SqlStatement[] statements, List<SqlVisitor> sqlVisitors) throws LiquibaseException, RollbackImpossibleException;
 
     void saveRollbackStatement(Change change, List<SqlVisitor> sqlVisitors, Writer writer) throws IOException, RollbackImpossibleException, StatementNotSupportedOnDatabaseException, LiquibaseException;
 

--- a/liquibase-core/src/main/java/liquibase/sdk/database/MockDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/sdk/database/MockDatabase.java
@@ -538,6 +538,11 @@ public class MockDatabase implements Database, InternalDatabase {
     }
 
     @Override
+    public void executeRollbackStatements(final SqlStatement[] statements, final List<SqlVisitor> sqlVisitors) throws LiquibaseException, RollbackImpossibleException {
+        ;
+    }
+    
+    @Override
     public void saveRollbackStatement(final Change change, final List<SqlVisitor> sqlVisitors, final Writer writer) throws IOException, RollbackImpossibleException, StatementNotSupportedOnDatabaseException, LiquibaseException {
         ;
     }


### PR DESCRIPTION
modifySql attribute applyToRollback is ignored when specific rollback steps are included in a changeset.  Modified behavior of Rollback to ensure that with either custom rollback steps or automatically generated rollback statements, modifySql elements are not applied to the rollback SQL if the applyToRollback is false.

This included refactoring small amounts of the ChangeSet.java and AbstractJdbcDatabase.java file to centralize the Rollback statement execution code.  Rather than call the ExecutorService.execute method in the ChangeSet.java file when dealing with custom SQL rollback steps, a new overload of executeRollbackStatements in AbstractJdbcDatabase.java is called which takes the list of custom statements to execute.  Then, filtering of the SqlVisitors is done consistently both for custom rollback steps and automatically generated ones.
