### PR TITLE
Use ReflectionToStringBuilder to implement toString on all SQL Statements

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -1202,7 +1202,7 @@ public abstract class AbstractJdbcDatabase implements Database {
             if (statement.skipOnUnsupported() && !SqlGeneratorFactory.getInstance().supports(statement, this)) {
                 continue;
             }
-            LogFactory.getLogger().debug("Executing Statement: " + statement.getClass().getName());
+            LogFactory.getLogger().debug("Executing Statement: " + statement);
             ExecutorService.getInstance().getExecutor(this).execute(statement, sqlVisitors);
         }
     }

--- a/liquibase-core/src/main/java/liquibase/statement/AbstractSqlStatement.java
+++ b/liquibase-core/src/main/java/liquibase/statement/AbstractSqlStatement.java
@@ -1,9 +1,18 @@
 package liquibase.statement;
 
+import org.apache.commons.lang.builder.ReflectionToStringBuilder;
+
 public abstract class AbstractSqlStatement implements SqlStatement {
 
     @Override
     public boolean skipOnUnsupported() {
         return false;
     }
+
+    @Override
+    public String toString() {
+      return ReflectionToStringBuilder.toString(this);
+    }
+    
+    
 }


### PR DESCRIPTION
.. so that when exceptions happen the user gets decent feedback.

This way, when some SQL exception happens rather than a stack trace that looks like this:

```
liquibase.exception.RollbackFailedException: liquibase.exception.RollbackFailedException: Error executing custom SQL [liquibase.statement.core.DeleteStatement@509d1fe1]
```

We will instad get more details on the statement, like this:

```
liquibase.exception.RollbackFailedException: liquibase.exception.RollbackFailedException: Error executing custom SQL [liquibase.statement.core.DeleteStatement@509d1fe1 catalogName=null schemaName=null tableName="someTable"]
```
