### PR TITLE
Add updateOnly flag to loadUpdateData

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/LoadUpdateDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/LoadUpdateDataChange.java
@@ -23,6 +23,7 @@ import java.util.List;
         priority = ChangeMetaData.PRIORITY_DEFAULT, appliesTo = "table", since = "2.0")
 public class LoadUpdateDataChange extends LoadDataChange {
     private String primaryKey;
+    private Boolean updateOnly = Boolean.FALSE;
 
     @Override
     @DatabaseChangeProperty(description = "Name of the table to insert or update data in", requiredForDatabase = "all")
@@ -39,9 +40,21 @@ public class LoadUpdateDataChange extends LoadDataChange {
         return primaryKey;
     }
 
-    @Override
+    @DatabaseChangeProperty(description = "Whether records with no matching database record should be ignored", since = "3.3" )
+    public Boolean getUpdateOnly() {
+    	if ( updateOnly == null ) {
+    		return false;
+    	}
+		return updateOnly;
+	}
+
+	public void setUpdateOnly(Boolean updateOnly) {
+		this.updateOnly = updateOnly;
+	}
+
+	@Override
     protected InsertStatement createStatement(String catalogName, String schemaName, String tableName) {
-        return new InsertOrUpdateStatement(catalogName, schemaName, tableName, this.primaryKey);
+        return new InsertOrUpdateStatement(catalogName, schemaName, tableName, this.primaryKey, this.updateOnly);
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/InsertOrUpdateGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/InsertOrUpdateGenerator.java
@@ -129,22 +129,26 @@ public abstract class InsertOrUpdateGenerator extends AbstractSqlGenerator<Inser
     public Sql[] generateSql(InsertOrUpdateStatement insertOrUpdateStatement, Database database, SqlGeneratorChain sqlGeneratorChain) {
         StringBuffer completeSql = new StringBuffer();
         String whereClause = getWhereClause(insertOrUpdateStatement, database);
-
-        completeSql.append( getRecordCheck(insertOrUpdateStatement, database, whereClause));
-
-        completeSql.append(getInsertStatement(insertOrUpdateStatement, database, sqlGeneratorChain));
-
+        if ( !insertOrUpdateStatement.getUpdateOnly() ) {
+	        completeSql.append( getRecordCheck(insertOrUpdateStatement, database, whereClause));
+	
+	        completeSql.append(getInsertStatement(insertOrUpdateStatement, database, sqlGeneratorChain));
+        }
         try {
         	
             String updateStatement = getUpdateStatement(insertOrUpdateStatement,database,whereClause,sqlGeneratorChain);
             
-            completeSql.append(getElse(database));
+            if ( !insertOrUpdateStatement.getUpdateOnly() ) {
+            	completeSql.append(getElse(database));
+            }
 
             completeSql.append(updateStatement);
             
         } catch (LiquibaseException e) {}
 
-        completeSql.append(getPostUpdateStatements(database));
+        if ( !insertOrUpdateStatement.getUpdateOnly() ) {
+        	completeSql.append(getPostUpdateStatements(database));
+        }
 
         return new Sql[]{
                 new UnparsedSql(completeSql.toString(), "", getAffectedTable(insertOrUpdateStatement))

--- a/liquibase-core/src/main/java/liquibase/statement/core/InsertOrUpdateStatement.java
+++ b/liquibase-core/src/main/java/liquibase/statement/core/InsertOrUpdateStatement.java
@@ -1,15 +1,34 @@
 package liquibase.statement.core;
 
+import liquibase.change.DatabaseChangeProperty;
+
 public class InsertOrUpdateStatement extends InsertStatement {
     private String primaryKey;
-
+    private Boolean updateOnly = Boolean.FALSE;
 
     public InsertOrUpdateStatement(String catalogName, String schemaName, String tableName, String primaryKey) {
         super(catalogName, schemaName, tableName);
         this.primaryKey = primaryKey ;
     }
 
+    public InsertOrUpdateStatement(String catalogName, String schemaName, String tableName, String primaryKey, boolean updateOnly ) {
+        this(catalogName, schemaName, tableName,primaryKey);
+        this.updateOnly = updateOnly;
+    }
+    
     public String getPrimaryKey() {
         return primaryKey;
     }
+
+    @DatabaseChangeProperty(description = "Whether records with no matching database record should be ignored")
+    public Boolean getUpdateOnly() {
+    	if ( updateOnly == null ) {
+    		return false;
+    	}
+		return updateOnly;
+	}
+
+	public void setUpdateOnly(Boolean updateOnly) {
+		this.updateOnly = updateOnly;
+	}
 }

--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.3.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.3.xsd
@@ -540,6 +540,7 @@
 			<xsd:attribute name="file" type="xsd:string" />
 			<xsd:attribute name="encoding" type="xsd:string" default="UTF-8"/>
 			<xsd:attribute name="primaryKey" type="xsd:string" use="required" />
+			<xsd:attribute name="updateOnly" type="xsd:boolean" default="false" />
 			<xsd:attribute name="separator" type="xsd:string" default=","/>
 			<xsd:attribute name="quotchar" type="xsd:string" default="&quot;"/>
 		</xsd:complexType>

--- a/liquibase-core/src/test/java/liquibase/sqlgenerator/core/InsertOrUpdateGeneratorOracleTest.java
+++ b/liquibase-core/src/test/java/liquibase/sqlgenerator/core/InsertOrUpdateGeneratorOracleTest.java
@@ -1,11 +1,13 @@
 package liquibase.sqlgenerator.core;
 
-import org.junit.Test;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
-import liquibase.statement.core.InsertOrUpdateStatement;
 import liquibase.database.core.OracleDatabase;
 import liquibase.sql.Sql;
-import static junit.framework.Assert.assertTrue;
+import liquibase.statement.core.InsertOrUpdateStatement;
+
+import org.junit.Test;
 
 
 public class InsertOrUpdateGeneratorOracleTest {
@@ -72,4 +74,21 @@ END;*/
 
     }
 
+    @Test
+    public void testUpdateOnlyFlag(){
+        OracleDatabase database = new OracleDatabase();
+        InsertOrUpdateGeneratorOracle generator = new InsertOrUpdateGeneratorOracle();
+        InsertOrUpdateStatement statement = new InsertOrUpdateStatement("mycatalog", "myschema","mytable","pk_col1", true);
+        statement.addColumnValue("pk_col1","value1");
+        statement.addColumnValue("col2","value2");
+        Sql[] sql = generator.generateSql( statement, database,  null);
+        String theSql = sql[0].toSql();
+        assertFalse("should not have had insert statement",theSql.contains("INSERT INTO mycatalog.mytable (pk_col1, col2) VALUES ('value1', 'value2');"));
+        assertTrue("missing update statement", theSql.contains("UPDATE mycatalog.mytable"));
+        String[] sqlLines = theSql.split("\n");
+        int lineToCheck = 0;
+        assertEquals("UPDATE mycatalog.mytable SET col2 = 'value2' WHERE pk_col1 = 'value1';",sqlLines[lineToCheck].trim());
+        lineToCheck++;
+        assertEquals( "Wrong number of lines", 1, sqlLines.length);
+    }
 }

--- a/liquibase-core/src/test/java/liquibase/statement/core/InsertOrUpdateStatementTest.java
+++ b/liquibase-core/src/test/java/liquibase/statement/core/InsertOrUpdateStatementTest.java
@@ -10,6 +10,13 @@ public class InsertOrUpdateStatementTest extends InsertStatementTest {
         String primaryKey = "PRIMARYKEY";
         InsertOrUpdateStatement statement = new InsertOrUpdateStatement("CATALOG", "SCHEMA","TABLE", primaryKey);
         assertEquals(primaryKey,statement.getPrimaryKey());
+        assertEquals(Boolean.FALSE,statement.getUpdateOnly());
     }
 
+    @Test
+    public void setUpdateOnly(){
+        String primaryKey = "PRIMARYKEY";
+        InsertOrUpdateStatement statement = new InsertOrUpdateStatement("CATALOG", "SCHEMA","TABLE", primaryKey, true);
+        assertEquals(Boolean.TRUE,statement.getUpdateOnly());
+    }
 }


### PR DESCRIPTION
Adding updateOnly flag to loadUpdateData for cases where we want to _only_ update existing records.  This allows the use of the tag in a way that only columns we need will be updated and prevents failures if a record is unexpectly absent from the target database. (Due to insufficient fields in the input file.)
