### PR TITLE
Allow commandLine interface to share configuration file with application...

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -65,6 +65,7 @@ public class Main {
     protected String driverPropertiesFile;
     protected Boolean promptForNonLocalDatabase = null;
     protected Boolean includeSystemClasspath;
+    protected Boolean strict = Boolean.TRUE;
     protected String defaultsFile = "liquibase.properties";
 
     protected String diffTypes;
@@ -409,6 +410,9 @@ public class Main {
     protected void parsePropertiesFile(InputStream propertiesInputStream) throws IOException, CommandLineParsingException {
         Properties props = new Properties();
         props.load(propertiesInputStream);
+        if(props.containsKey("strict")){
+            strict = Boolean.valueOf(props.getProperty("strict"));
+        }
 
         for (Map.Entry entry : props.entrySet()) {
             try {
@@ -429,6 +433,12 @@ public class Main {
                             field.set(this, value);
                         }
                     }
+                }
+            } catch (NoSuchFieldException nsfe){
+                if(strict){
+                    throw new CommandLineParsingException("Unknown parameter: '" + entry.getKey() + "'");
+                } else {
+                    LogFactory.getInstance().getLog().info("Ignored parameter: " + entry.getKey());
                 }
             } catch (Exception e) {
                 throw new CommandLineParsingException("Unknown parameter: '" + entry.getKey() + "'");

--- a/liquibase-core/src/test/java/liquibase/integration/commandline/MainTest.java
+++ b/liquibase-core/src/test/java/liquibase/integration/commandline/MainTest.java
@@ -229,6 +229,59 @@ public class MainTest {
     }
 
     @Test
+    public void propertiesFileParsingShouldIgnoreUnknownArgumentsIfStrictFalseIsInFile() throws Exception {
+        Main cli = new Main();
+
+        Properties props = new Properties();
+        props.setProperty("driver", "DRIVER");
+        props.setProperty("unknown.property", "UnknownValue");
+        props.setProperty("strict", "false");
+
+        ByteArrayOutputStream propFile = new ByteArrayOutputStream();
+        props.store(propFile, "");
+
+        cli.parsePropertiesFile(new ByteArrayInputStream(propFile.toByteArray()));
+
+        assertEquals("DRIVER", cli.driver);
+
+    }
+
+    @Test
+    public void propertiesFileParsingShouldIgnoreUnknownArgumentsIfStrictModeIsFalse() throws Exception {
+        Main cli = new Main();
+        String[] args = new String[]{"--strict=false"};
+
+        cli.parseOptions(args);
+        Properties props = new Properties();
+        props.setProperty("driver", "DRIVER");
+        props.setProperty("unknown.property", "UnknownValue");
+
+        ByteArrayOutputStream propFile = new ByteArrayOutputStream();
+        props.store(propFile, "");
+
+        cli.parsePropertiesFile(new ByteArrayInputStream(propFile.toByteArray()));
+
+        assertEquals("DRIVER", cli.driver);
+
+    }
+
+    @Test(expected = CommandLineParsingException.class)
+    public void propertiesFileParsingShouldFailOnUnknownArgumentsIfStrictMode() throws Exception {
+        Main cli = new Main();
+
+        Properties props = new Properties();
+        props.setProperty("driver", "DRIVER");
+        props.setProperty("unknown.property", "UnknownValue");
+        props.setProperty("strict", "true");
+
+        ByteArrayOutputStream propFile = new ByteArrayOutputStream();
+        props.store(propFile, "");
+
+        cli.parsePropertiesFile(new ByteArrayInputStream(propFile.toByteArray()));
+
+    }
+
+    @Test
     public void applyDefaults() {
         Main cli = new Main();
 


### PR DESCRIPTION
.... Removes need to duplicate properties in a specific file for Liquibase.

When using the commandline interface its quite likely that you have the configuration of the application at hand. But that can not be used at the moment, as parsing of the properties file fails on any unknown parameter. 
So at present you'd need to specify the database connection parameters in two files, one for liquibase and one for the application, which makes configuration management a little more difficult than necessary.

Allowing non-strict parsing is one way to solve this (using a liquibase. prefix would be another, but thats more intrusive).
