### PR TITLE
Add commons-lang dependency as non-optional

### DIFF
--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -43,6 +43,13 @@
         </dependency>
 
         <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.4</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>compile</scope>


### PR DESCRIPTION
The maven plugin is failing, as commons-lang is available transitively via velocity, but this dependency is optional, so commons-lang was missing if liquibase is used without velocity.

This just adds commons-lang as a explicit dependency.
