### PR TITLE
CORE-2009 Fixing regression where the AntClassLoader parentFirst setting

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/ant/BaseLiquibaseTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/BaseLiquibaseTask.java
@@ -62,7 +62,6 @@ public abstract class BaseLiquibaseTask extends Task {
         log("Starting Liquibase.", Project.MSG_INFO);
         classLoader = getProject().createClassLoader(classpath);
         classLoader.setParent(this.getClass().getClassLoader());
-        classLoader.setParentFirst(false);
         classLoader.setThreadContextLoader();
         validateParameters();
         Database database = null;


### PR DESCRIPTION
The refactoring of the ant tasks introduced a regression in regards to the creation of the `AntClassLoader`. The `parentFirst` flag was set to false when it should remain set to the default value. This should fix the issues found in CORE-2009. I recommend this go in a 3.3.1 release.
