### PR TITLE
Bug fix in Ant task database type dropping connection props when used as reference.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/ant/type/DatabaseType.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/type/DatabaseType.java
@@ -69,6 +69,7 @@ public class DatabaseType extends DataType {
             if(password != null && !password.isEmpty()) {
                 connectionProps.setProperty(PASSWORD, password);
             }
+            ConnectionProperties connectionProperties = getConnectionProperties();
             if(connectionProperties != null) {
                 connectionProps.putAll(connectionProperties.buildProperties());
             }
@@ -204,6 +205,10 @@ public class DatabaseType extends DataType {
 
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    public ConnectionProperties getConnectionProperties() {
+        return isReference() ? ((DatabaseType) getCheckedRef()).getConnectionProperties() : connectionProperties;
     }
 
     public void addConnectionProperties(ConnectionProperties connectionProperties) {


### PR DESCRIPTION
I found a bug in the new Ant tasks where a `<database>` type created with connection properties then referenced in a task were not adding the properties to the JDBC connection as intended. This is because the `DatabaseType` class was not calling a accessor method that would check to see if the type was a reference.
I have updated the `DatabaseType` to use a new accessor method that makes it more consistent with all of the other fields in the class.
