### PR TITLE
CORE-2130 workaround fetchSize exception for oracle jdbc driver

### DIFF
--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingDataExternalFileChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingDataExternalFileChangeGenerator.java
@@ -4,6 +4,7 @@ import liquibase.change.Change;
 import liquibase.change.core.LoadDataChange;
 import liquibase.change.core.LoadDataColumnConfig;
 import liquibase.database.Database;
+import liquibase.database.core.OracleDatabase;
 import liquibase.database.core.PostgresDatabase;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.diff.output.DiffOutputControl;
@@ -59,7 +60,7 @@ public class MissingDataExternalFileChangeGenerator extends MissingDataChangeGen
             String sql = "SELECT * FROM " + referenceDatabase.escapeTableName(table.getSchema().getCatalogName(), table.getSchema().getName(), table.getName());
 
             stmt = ((JdbcConnection) referenceDatabase.getConnection()).createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
-            if (!(referenceDatabase instanceof PostgresDatabase)) {
+            if (!(referenceDatabase instanceof PostgresDatabase || referenceDatabase instanceof OracleDatabase)) {
                 stmt.setFetchSize(Integer.MIN_VALUE);
             }
             rs = stmt.executeQuery(sql);


### PR DESCRIPTION
Fix for CORE-2130. Setting fetchSize to zero instead of Integer.MIN_VALUE might as well fix the issue. But I guess somebody had a reason to use negative values instead of 0 and I can't test with any other jdbc driver.

Note that lots of tests fail on my box, but that's with and without my fix. So I couldn't run the whole testsuite.
