### PR TITLE
CORE-2124 - Add JDBC driver properties file parameter to Maven plugin

### DIFF
--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
@@ -268,6 +268,13 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
      */
     protected String changelogSchemaName;
 
+    /**
+     * Location of a properties file containing JDBC connection properties for use by the driver.
+     *
+     * @parameter
+     */
+    private File driverPropertiesFile;
+
 
     protected Writer getOutputWriter(final File outputFile) throws IOException {
         if (outputFileEncoding==null) {
@@ -318,6 +325,7 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
         Database database = null;
         try {
             String dbPassword = emptyPassword || password == null ? "" : password;
+            String driverPropsFile = (driverPropertiesFile == null) ? null : driverPropertiesFile.getAbsolutePath();
             database = CommandLineUtils.createDatabaseObject(artifactClassLoader,
                     url,
                     username,
@@ -328,7 +336,7 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
                     outputDefaultCatalog,
                     outputDefaultSchema,
                     databaseClass,
-                    null,
+                    driverPropsFile,
                     propertyProviderClass,
                     changelogCatalogName,
                     changelogSchemaName);


### PR DESCRIPTION
To fix CORE-2124 I have added a new Maven parameter called `driverPropertiesFile`. This is an optional parameter and is used to specify a file containing JDBC connection properties that might be needed for a specific database (like Oracle).
