### PR TITLE
CORE-2041 HsqlDatabase should emit uppercase names when quoting reserved...

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
@@ -4,6 +4,7 @@ import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.DatabaseConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.DateParseException;
+import liquibase.structure.DatabaseObject;
 import liquibase.util.ISODateFormat;
 
 import java.math.BigInteger;
@@ -454,7 +455,16 @@ public class HsqlDatabase extends AbstractJdbcDatabase {
     public boolean isCaseSensitive() {
         return false;
     }
-    
+
+    @Override
+    public String quoteObject(String objectName, Class<? extends DatabaseObject> objectType) {
+        String quoted = super.quoteObject(objectName, objectType);
+        if (isReservedWord(objectName)) {
+            quoted = quoted.toUpperCase();
+        }
+        return quoted;
+    }
+
     @Override
     public void setConnection(DatabaseConnection conn) {
         oracleSyntax = null;

--- a/liquibase-core/src/test/java/liquibase/database/core/HsqlDatabaseTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/core/HsqlDatabaseTest.java
@@ -6,7 +6,7 @@ import junit.framework.TestCase;
 import liquibase.database.Database;
 import liquibase.database.DatabaseConnection;
 import liquibase.database.ObjectQuotingStrategy;
-import liquibase.structure.core.Table;
+import liquibase.structure.core.*;
 
 public class HsqlDatabaseTest extends TestCase {
     public void testGetDefaultDriver() {
@@ -40,6 +40,23 @@ public class HsqlDatabaseTest extends TestCase {
         Database databaseWithAllQuoting = new HsqlDatabase();
         databaseWithAllQuoting.setObjectQuotingStrategy(ObjectQuotingStrategy.QUOTE_ALL_OBJECTS);
         assertEquals("\"Test\"", databaseWithAllQuoting.escapeObjectName("Test", Table.class));
+    }
+
+    /**
+     * Verifies that {@link HsqlDatabase#escapeObjectName(String, Class)} quoted object names are emitted in uppercase.
+     */
+    public void testEscapeObjectNameWithReservedWord() {
+        Database databaseWithDefaultQuoting = new HsqlDatabase();
+        databaseWithDefaultQuoting.setObjectQuotingStrategy(ObjectQuotingStrategy.LEGACY);
+
+        assertEquals("\"USER\"", databaseWithDefaultQuoting.escapeObjectName("user", Table.class));
+        assertEquals("\"VALUE\"", databaseWithDefaultQuoting.escapeObjectName("value", Column.class));
+
+        Database databaseWithAllQuoting = new HsqlDatabase();
+        databaseWithAllQuoting.setObjectQuotingStrategy(ObjectQuotingStrategy.QUOTE_ALL_OBJECTS);
+
+        assertEquals("\"USER\"", databaseWithAllQuoting.escapeObjectName("user", Table.class));
+        assertEquals("\"test\"", databaseWithAllQuoting.escapeObjectName("test", Table.class));
     }
     
     public void testUsingOracleSyntax()  {


### PR DESCRIPTION
... words.  Otherwise, the database will end up not being case insensitive on queries.
