### PR TITLE
CORE-2153

### DIFF
--- a/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -316,7 +316,7 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                             "DATA_DEFAULT, NUM_DISTINCT, LOW_VALUE, HIGH_VALUE, DENSITY, NUM_NULLS, " +
                             "NUM_BUCKETS, LAST_ANALYZED, SAMPLE_SIZE, CHARACTER_SET_NAME, " +
                             "CHAR_COL_DECL_LENGTH, GLOBAL_STATS, USER_STATS, AVG_COL_LEN, CHAR_LENGTH, " +
-                            "CHAR_USED, V80_FMT_IMAGE, DATA_UPGRADED, HISTOGRAM\n" +
+                            "CHAR_USED, V80_FMT_IMAGE, DATA_UPGRADED\n" +
                             "FROM ALL_TAB_COLUMNS c " +
                             "JOIN ALL_COL_COMMENTS cc USING ( OWNER, TABLE_NAME, COLUMN_NAME ) " +
                             "WHERE OWNER='"+((AbstractJdbcDatabase) database).getJdbcSchemaName(catalogAndSchema)+"'";


### PR DESCRIPTION
column ALL_TAB_COLS.HISTOGRAM is not used and doesn't exist with Oracle 9
refers to https://liquibase.jira.com/browse/CORE-2153
