### PR TITLE
Fix CORE-2178 Use correct database collation

### DIFF
--- a/liquibase-core/src/test/java/liquibase/database/core/MSSQLDatabaseTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/core/MSSQLDatabaseTest.java
@@ -81,6 +81,7 @@ public class MSSQLDatabaseTest extends AbstractJdbcDatabaseTest {
 		expect(connection.getConnectionUserName()).andReturn("user").anyTimes();
 		expect(connection.getURL()).andReturn("URL").anyTimes();
 		expect(connection.getAutoCommit()).andReturn(getDatabase().getAutoCommitMode()).anyTimes();
+    expect(connection.getCatalog()).andReturn("catalog").anyTimes();
 
 		Connection sqlConnection = createMock(Connection.class);
 		Statement statement = createMock(Statement.class);
@@ -89,7 +90,7 @@ public class MSSQLDatabaseTest extends AbstractJdbcDatabaseTest {
 
 		expect(connection.getUnderlyingConnection()).andReturn(sqlConnection).anyTimes();
 		expect( sqlConnection.createStatement()).andReturn(statement);
-		expect( statement.executeQuery("SELECT CONVERT(varchar(100), SERVERPROPERTY('COLLATION'))")).andReturn(resultSet);
+		expect( statement.executeQuery("SELECT CONVERT(varchar(100), DATABASEPROPERTYEX('catalog', 'COLLATION'))")).andReturn(resultSet);
 		expect( resultSet.next() ).andReturn(true);
 		expect( resultSet.getMetaData() ).andReturn(metadata);
 		expect( metadata.getColumnCount() ).andReturn(1);


### PR DESCRIPTION
Fixes CORE-2178: https://liquibase.jira.com/browse/CORE-2178

MSSQLDatabase.isCaseSensitive() uses the system collation rather than the database collation to determine whether or not the database is case-sensitive. That is fixed by checking DATABASEPROPERTYEX(<catalog>, 'collation').

Also, MSSQLDatabase.getdbcSchemaName() always converts to lower case. That causes a false negative on a case-sensitive database when checking to see if the lock table exists.

I am not nearly familiar enough to understand the full impact of this change, but it does seem to fix the problem we are having on SQL Server 2012.