### PR TITLE
Handle timestamp precision

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/TimestampType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/TimestampType.java
@@ -16,7 +16,7 @@ public class TimestampType extends DateTimeType {
             if (getRawDefinition().contains(" ")) {
                 return new DatabaseDataType(getRawDefinition());
             }
-            return new DatabaseDataType("TIMESTAMP");
+            return super.toDatabaseDataType(database);
         }
         if (database instanceof MSSQLDatabase) {
             return new DatabaseDataType("DATETIME");


### PR DESCRIPTION
The current handling for TIMESTAMP precision handling really doesn't do a good job.

In the case of MySQL, the code simply ignores any precision specified and the version check is simply wrong (would fail for 6.x.x or 5.7.x).

In case of PostgreSQL, also the precision is simply ignored.

Related at least to the following issues:
* https://liquibase.jira.com/browse/CORE-1424


