### PR TITLE
CORE-2196 Adding root cause message to the build exception

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/ant/AbstractDatabaseDiffTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/AbstractDatabaseDiffTask.java
@@ -35,7 +35,7 @@ public abstract class AbstractDatabaseDiffTask extends BaseLiquibaseTask {
             referenceSnapshot = snapshotGeneratorFactory.createSnapshot(referenceDatabase.getDefaultSchema(),
                     referenceDatabase, new SnapshotControl(referenceDatabase, diffTypes));
         } catch (LiquibaseException e) {
-            throw new BuildException("Unable to create a DatabaseSnapshot.", e);
+            throw new BuildException("Unable to create a DatabaseSnapshot. " + e.toString(), e);
         }
 
         CompareControl compareControl = new CompareControl(schemaComparisons, referenceSnapshot.getSnapshotControl().getTypesToInclude());
@@ -43,7 +43,7 @@ public abstract class AbstractDatabaseDiffTask extends BaseLiquibaseTask {
         try {
             return liquibase.diff(referenceDatabase, targetDatabase, compareControl);
         } catch (LiquibaseException e) {
-            throw new BuildException("Unable to diff databases.", e);
+            throw new BuildException("Unable to diff databases. " + e.toString(), e);
         }
     }
 

--- a/liquibase-core/src/main/java/liquibase/integration/ant/BaseLiquibaseTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/BaseLiquibaseTask.java
@@ -82,7 +82,7 @@ public abstract class BaseLiquibaseTask extends Task {
                 executeWithLiquibaseClassloader();
             }
         } catch (LiquibaseException e) {
-            throw new BuildException("Unable to initialize Liquibase.", e);
+            throw new BuildException("Unable to initialize Liquibase. " + e.toString(), e);
         } finally {
             closeDatabase(database);
             classLoader.resetThreadContextLoader();

--- a/liquibase-core/src/main/java/liquibase/integration/ant/ChangeLogSyncTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/ChangeLogSyncTask.java
@@ -30,7 +30,7 @@ public class ChangeLogSyncTask extends AbstractChangeLogBasedTask {
         } catch (IOException e) {
             throw new BuildException("Unable to generate sync SQL. Error creating output writer.", e);
         } catch (LiquibaseException e) {
-            throw new BuildException("Unable to sync change log.", e);
+            throw new BuildException("Unable to sync change log. " + e.toString(), e);
         } finally {
             FileUtils.close(writer);
         }

--- a/liquibase-core/src/main/java/liquibase/integration/ant/DBDocTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/DBDocTask.java
@@ -33,7 +33,7 @@ public class DBDocTask extends BaseLiquibaseTask {
                 liquibase.generateDocumentation(outputDirectory.toString());
             }
         } catch (LiquibaseException e) {
-            throw new BuildException("Liquibase encountered an error while creating database documentation.", e);
+            throw new BuildException("Liquibase encountered an error while creating database documentation. " + e.toString(), e);
         }
     }
 

--- a/liquibase-core/src/main/java/liquibase/integration/ant/DatabaseRollbackFutureTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/DatabaseRollbackFutureTask.java
@@ -15,7 +15,7 @@ public class DatabaseRollbackFutureTask extends AbstractChangeLogBasedTask {
         try {
             liquibase.futureRollbackSQL(null, new Contexts(getContexts()), getLabels(), getOutputFileWriter());
         } catch (LiquibaseException e) {
-            throw new BuildException("Unable to generate future rollback SQL.", e);
+            throw new BuildException("Unable to generate future rollback SQL. " + e.toString(), e);
         } catch (IOException e) {
             throw new BuildException("Unable to generate future rollback SQL. Error creating output writer.", e);
         }

--- a/liquibase-core/src/main/java/liquibase/integration/ant/DatabaseRollbackTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/DatabaseRollbackTask.java
@@ -54,7 +54,7 @@ public class DatabaseRollbackTask extends AbstractChangeLogBasedTask {
                 throw new BuildException("Unable to rollback database. No count, tag, or date set.");
             }
         } catch (LiquibaseException e) {
-            throw new BuildException("Unable to rollback database.", e);
+            throw new BuildException("Unable to rollback database. " + e.toString(), e);
         } catch (UnsupportedEncodingException e) {
             throw new BuildException("Unable to generate rollback SQL. Encoding [" + getOutputEncoding() + "] is not supported.", e);
         } catch (IOException e) {

--- a/liquibase-core/src/main/java/liquibase/integration/ant/DatabaseUpdateTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/DatabaseUpdateTask.java
@@ -34,7 +34,7 @@ public class DatabaseUpdateTask extends AbstractChangeLogBasedTask {
                 liquibase.update(new Contexts(getContexts()), getLabels());
             }
         } catch (LiquibaseException e) {
-            throw new BuildException("Unable to update database.", e);
+            throw new BuildException("Unable to update database. " + e.toString(), e);
         } catch (UnsupportedEncodingException e) {
             throw new BuildException("Unable to generate update SQL. Encoding [" + getOutputEncoding() + "] is not supported.", e);
         } catch (IOException e) {

--- a/liquibase-core/src/main/java/liquibase/integration/ant/DatabaseUpdateTestingRollbackTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/DatabaseUpdateTestingRollbackTask.java
@@ -21,7 +21,7 @@ public class DatabaseUpdateTestingRollbackTask extends AbstractChangeLogBasedTas
             }
             liquibase.updateTestingRollback(new Contexts(getContexts()), getLabels());
         } catch (LiquibaseException e) {
-            throw new BuildException("Unable to update database with a rollback test.", e);
+            throw new BuildException("Unable to update database with a rollback test. " + e.toString(), e);
         }
     }
 

--- a/liquibase-core/src/main/java/liquibase/integration/ant/DiffDatabaseTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/DiffDatabaseTask.java
@@ -26,7 +26,7 @@ public class DiffDatabaseTask extends AbstractDatabaseDiffTask {
             log("Writing diff report " + outputFile.toString(), Project.MSG_INFO);
             diffReport.print();
         } catch (DatabaseException e) {
-            throw new BuildException("Unable to make diff report.", e);
+            throw new BuildException("Unable to make diff report. " + e.toString(), e);
         } catch (UnsupportedEncodingException e) {
             throw new BuildException("Unable to make diff report. Encoding [" + outputEncoding + "] is not supported.", e);
         } catch (IOException e) {

--- a/liquibase-core/src/main/java/liquibase/integration/ant/DiffDatabaseToChangeLogTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/DiffDatabaseToChangeLogTask.java
@@ -48,7 +48,7 @@ public class DiffDatabaseToChangeLogTask extends AbstractDatabaseDiffTask {
             } catch (ParserConfigurationException e) {
                 throw new BuildException("Unable to diff databases to change log file. Error configuring parser.", e);
             } catch (DatabaseException e) {
-                throw new BuildException("Unable to diff databases to change log file.", e);
+                throw new BuildException("Unable to diff databases to change log file. " + e.toString(), e);
             } finally {
                 FileUtils.close(printStream);
             }

--- a/liquibase-core/src/main/java/liquibase/integration/ant/DropAllTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/DropAllTask.java
@@ -28,7 +28,7 @@ public class DropAllTask extends BaseLiquibaseTask {
                 liquibase.dropAll();
             }
         } catch (LiquibaseException e) {
-            throw new BuildException("Unable to drop all objects from database.", e);
+            throw new BuildException("Unable to drop all objects from database. " + e.toString(), e);
         }
     }
 

--- a/liquibase-core/src/main/java/liquibase/integration/ant/GenerateChangeLogTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/GenerateChangeLogTask.java
@@ -54,7 +54,7 @@ public class GenerateChangeLogTask extends BaseLiquibaseTask {
             } catch (ParserConfigurationException e) {
                 throw new BuildException("Unable to generate a change log. Error configuring parser.", e);
             } catch (DatabaseException e) {
-                throw new BuildException("Unable to generate a change log.", e);
+                throw new BuildException("Unable to generate a change log. " + e.toString(), e);
             } finally {
                 FileUtils.close(printStream);
             }

--- a/liquibase-core/src/main/java/liquibase/integration/ant/MarkNextChangeSetRanTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/MarkNextChangeSetRanTask.java
@@ -24,7 +24,7 @@ public class MarkNextChangeSetRanTask extends AbstractChangeLogBasedTask {
                 liquibase.markNextChangeSetRan(new Contexts(getContexts()), getLabels());
             }
         } catch (LiquibaseException e) {
-            throw new BuildException("Unable to mark next changeset as ran.", e);
+            throw new BuildException("Unable to mark next changeset as ran. " + e.toString(), e);
         } catch (IOException e) {
             throw new BuildException("Unable to mark next changeset as ran. Error creating output writer.", e);
         } finally {

--- a/liquibase-core/src/main/java/liquibase/integration/ant/TagDatabaseTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/TagDatabaseTask.java
@@ -14,7 +14,7 @@ public class TagDatabaseTask extends BaseLiquibaseTask {
         try {
             liquibase.tag(tag);
         } catch (LiquibaseException e) {
-            throw new BuildException("Unable to tag database.", e);
+            throw new BuildException("Unable to tag database. " + e.toString(), e);
         }
     }
 

--- a/liquibase-core/src/main/java/liquibase/integration/ant/type/DatabaseType.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/type/DatabaseType.java
@@ -122,9 +122,9 @@ public class DatabaseType extends DataType {
 
             return database;
         } catch (SQLException e) {
-            throw new BuildException("Unable to create Liquibase database instance. A JDBC error occurred.", e);
+            throw new BuildException("Unable to create Liquibase database instance. A JDBC error occurred. " + e.toString(), e);
         } catch (DatabaseException e) {
-            throw new BuildException("Unable to create Liquibase database instance.", e);
+            throw new BuildException("Unable to create Liquibase database instance. " + e.toString(), e);
         }
     }
 


### PR DESCRIPTION
I am adding the output of the root cause exception to the corresponding Ant BuildException to give more context about the error. Before the Ant task refactoring, there were no custom messages when BuildException was through which resulted in the root cause message being the only message. Once more messages were added, the root cause message was lost.
This should fix CORE-2196.