### PR TITLE
Add a "tagExists" command to the liquibase commandline

### DIFF
--- a/liquibase-core/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-core/src/main/java/liquibase/Liquibase.java
@@ -771,6 +771,17 @@ public class Liquibase {
         }
     }
 
+    public boolean tagExists(String tagString) throws LiquibaseException {
+        LockService lockService = LockServiceFactory.getInstance().getLockService(database);
+        lockService.waitForLock();
+
+        try {
+            checkLiquibaseTables(false, null, new Contexts(), new LabelExpression());
+            return getDatabase().doesTagExist(tagString);
+        } finally {
+            lockService.releaseLock();
+        }
+    }
 
     public void updateTestingRollback(String contexts) throws LiquibaseException {
         updateTestingRollback(new Contexts(contexts), new LabelExpression());

--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -274,7 +274,8 @@ public class Main {
             || "rollbackCountSQL".equalsIgnoreCase(command)
             || "calculateCheckSum".equalsIgnoreCase(command)
             || "dbDoc".equalsIgnoreCase(command)
-            || "tag".equalsIgnoreCase(command)) {
+            || "tag".equalsIgnoreCase(command)
+            || "tagExists".equalsIgnoreCase(command)) {
 
             if (commandParams.size() > 0 && commandParams.iterator().next().startsWith("-")) {
                 messages.add("unexpected command parameters: "+commandParams);
@@ -368,6 +369,7 @@ public class Main {
                 || "futureRollbackCountSQL".equalsIgnoreCase(arg)
                 || "updateTestingRollback".equalsIgnoreCase(arg)
                 || "tag".equalsIgnoreCase(arg)
+                || "tagExists".equalsIgnoreCase(arg)
                 || "listLocks".equalsIgnoreCase(arg)
                 || "dropAll".equalsIgnoreCase(arg)
                 || "releaseLocks".equalsIgnoreCase(arg)
@@ -523,6 +525,7 @@ public class Main {
         stream.println("");
         stream.println("Maintenance Commands");
         stream.println(" tag <tag string>          'Tags' the current database state for future rollback");
+        stream.println(" tagExists <tag string>    Checks whether the given tag is already existing");
         stream.println(" status [--verbose]        Outputs count (list if --verbose) of unrun changesets");
         stream.println(" unexpectedChangeSets [--verbose]");
         stream.println("                           Outputs count (list if --verbose) of changesets run");
@@ -990,6 +993,15 @@ public class Main {
             } else if ("tag".equalsIgnoreCase(command)) {
                 liquibase.tag(commandParams.iterator().next());
                 System.err.println("Successfully tagged " + liquibase.getDatabase().getConnection().getConnectionUserName() + "@" + liquibase.getDatabase().getConnection().getURL());
+                return;
+            } else if ("tagExists".equalsIgnoreCase(command)) {
+                String tag = commandParams.iterator().next();
+                boolean exists = liquibase.tagExists(tag);
+                if (exists) {
+                    System.err.println("The tag " + tag + " already exists in " + liquibase.getDatabase().getConnection().getConnectionUserName() + "@" + liquibase.getDatabase().getConnection().getURL());
+                } else {
+                    System.err.println("The tag " + tag + " does not exist in " + liquibase.getDatabase().getConnection().getConnectionUserName() + "@" + liquibase.getDatabase().getConnection().getURL());
+                }
                 return;
             } else if ("dropAll".equals(command)) {
                 liquibase.dropAll();


### PR DESCRIPTION
 This allows for checking whether a given tag already exists. It is
needed in order to write a idempotent tag/update script and to prevent
accidentally overriding an already existing tag.

It also enhances the offline database to support tagging.