### PR TITLE
Make createProcedure Change honor the procedureText Attribute

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/CreateProcedureChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/CreateProcedureChange.java
@@ -121,7 +121,7 @@ public class CreateProcedureChange extends AbstractChange implements DbmsTargete
         this.procedureText = procedureText;
     }
 
-    @DatabaseChangeProperty(isChangeProperty = false)
+    @DatabaseChangeProperty
     public String getProcedureText() {
         return procedureText;
     }


### PR DESCRIPTION
The DatabaseChangeProperty metadata for
CreateProcedureChange.getProcedureText contained 'isChangeProperty =
false' which effectively made it unusable.

The problem is so obvious, that it looks like beeing intentional.
On the other hand it effectively disables a documented feature, gives a nonsensical error message, and there is no hint (neither a comment in the code nor something that I colud find in the issue tracker or via google), so it might as well be a simple oversight.