### PR TITLE
Fixed bug that Servlet listener wrongly handle LiquibaseServletListener.LIQUIBASE_PARAMETER

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/servlet/LiquibaseServletListener.java
+++ b/liquibase-core/src/main/java/liquibase/integration/servlet/LiquibaseServletListener.java
@@ -230,7 +230,7 @@ public class LiquibaseServletListener implements ServletContextListener {
             while (initParameters.hasMoreElements()) {
                 String name = initParameters.nextElement().trim();
                 if (name.startsWith(LIQUIBASE_PARAMETER + ".")) {
-                    liquibase.setChangeLogParameter(name.substring(LIQUIBASE_PARAMETER.length()), servletValueContainer.getValue(name));
+                    liquibase.setChangeLogParameter(name.substring(LIQUIBASE_PARAMETER.length() + 1), servletValueContainer.getValue(name));
                 }
             }
 


### PR DESCRIPTION
There is a bug that a dot remains as parameter name prefix