### PR TITLE
CORE-2274 Changing change log parameter from FileResource to String

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/ant/AbstractChangeLogBasedTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/AbstractChangeLogBasedTask.java
@@ -10,7 +10,7 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 
 public abstract class AbstractChangeLogBasedTask extends BaseLiquibaseTask {
-    private FileResource changeLogFile;
+    private String changeLogFile;
     private String contexts;
     private LabelExpression labels;
     private FileResource outputFile;
@@ -34,11 +34,11 @@ public abstract class AbstractChangeLogBasedTask extends BaseLiquibaseTask {
      * @return The change log file resource.
      */
     @Override
-    public FileResource getChangeLogFile() {
+    public String getChangeLogFile() {
         return changeLogFile;
     }
 
-    public void setChangeLogFile(FileResource changeLogFile) {
+    public void setChangeLogFile(String changeLogFile) {
         this.changeLogFile = changeLogFile;
     }
 

--- a/liquibase-core/src/main/java/liquibase/integration/ant/BaseLiquibaseTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/BaseLiquibaseTask.java
@@ -68,8 +68,7 @@ public abstract class BaseLiquibaseTask extends Task {
         try {
             ResourceAccessor resourceAccessor = createResourceAccessor(classLoader);
             database = createDatabaseFromType(databaseType);
-            String changeLogFilePath = getChangeLogFilePath();
-            liquibase = new Liquibase(changeLogFilePath, resourceAccessor, database);
+            liquibase = new Liquibase(getChangeLogFile(), resourceAccessor, database);
             if(changeLogParameters != null) {
                 changeLogParameters.applyParameters(liquibase);
             }
@@ -107,7 +106,7 @@ public abstract class BaseLiquibaseTask extends Task {
      * @return Returns null in this implementation. Subclasses that need a change log should implement.
      * @see AbstractChangeLogBasedTask#getChangeLogFile()
      */
-    protected FileResource getChangeLogFile() {
+    protected String getChangeLogFile() {
         return null;
     }
 
@@ -146,16 +145,6 @@ public abstract class BaseLiquibaseTask extends Task {
         FileSystemResourceAccessor fileSystemResourceAccessor = new FileSystemResourceAccessor();
         ClassLoaderResourceAccessor classLoaderResourceAccessor = new ClassLoaderResourceAccessor(classLoader);
         return new CompositeResourceAccessor(fileSystemResourceAccessor, classLoaderResourceAccessor);
-    }
-
-    /**
-     * Convenience method to get the change log file path from the change log file resource if it exists.
-     *
-     * @return The change log file path string.
-     */
-    private String getChangeLogFilePath() {
-        FileResource changeLogFile = getChangeLogFile();
-        return (changeLogFile != null) ? changeLogFile.toString() : null;
     }
 
     /**
@@ -318,7 +307,7 @@ public abstract class BaseLiquibaseTask extends Task {
         getDatabaseType().setPassword(password);
     }
 
-    public void setChangeLogFile(FileResource changeLogFile) {
+    public void setChangeLogFile(String changeLogFile) {
         // This method is deprecated. Use child implementation.
     }
 

--- a/liquibase-core/src/main/java/liquibase/integration/ant/DBDocTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/DBDocTask.java
@@ -9,7 +9,7 @@ import java.io.File;
 
 public class DBDocTask extends BaseLiquibaseTask {
     private FileResource outputDirectory;
-    private FileResource changeLog;
+    private String changeLog;
     private String contexts;
 
     @Override
@@ -50,7 +50,7 @@ public class DBDocTask extends BaseLiquibaseTask {
     }
 
     @Override
-    protected FileResource getChangeLogFile() {
+    protected String getChangeLogFile() {
         return changeLog;
     }
 
@@ -62,7 +62,7 @@ public class DBDocTask extends BaseLiquibaseTask {
         this.outputDirectory = outputDirectory;
     }
 
-    public void setChangeLogFile(FileResource changeLog) {
+    public void setChangeLogFile(String changeLog) {
         this.changeLog = changeLog;
     }
 


### PR DESCRIPTION
When the Ant tasks were refactored the change log parameter because an Ant ```FileResource``` object. This means change logs can only be located on the file system. This negates the usefulness of the ```ResourceAccessor``` interface in Liquibase.
I have converted the change log parameter back to a ```String``` and am letting the ```ResourceAccessor``` handle the locating and reading of the file.
This fixes CORE-2274.