### PR TITLE
Added option "updateable" to the column tag.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
@@ -174,7 +174,7 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
 
                     Object value = line[i];
 
-                    ColumnConfig columnConfig = getColumnConfig(i, headers[i].trim());
+                    LoadDataColumnConfig columnConfig = getColumnConfig(i, headers[i].trim());
                     if (columnConfig != null) {
                         columnName = columnConfig.getName();
 
@@ -212,8 +212,11 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
                         columnName = ((AbstractJdbcDatabase) database).quoteObject(columnName, Column.class);
                     }
 
-
                     insertStatement.addColumnValue(columnName, value);
+                    
+                    if (columnConfig.isUpdateable() == null || columnConfig.isUpdateable()) {
+                    	insertStatement.addColumnUpdateValue(columnName, value);
+                    }
                 }
                 statements.add(insertStatement);
             }
@@ -280,7 +283,7 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
         return new InsertStatement(catalogName, schemaName,tableName);
     }
 
-    protected ColumnConfig getColumnConfig(int index, String header) {
+    protected LoadDataColumnConfig getColumnConfig(int index, String header) {
         for (LoadDataColumnConfig config : columns) {
             if (config.getIndex() != null && config.getIndex().equals(index)) {
                 return config;

--- a/liquibase-core/src/main/java/liquibase/change/core/LoadDataColumnConfig.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/LoadDataColumnConfig.java
@@ -9,6 +9,7 @@ public class LoadDataColumnConfig extends ColumnConfig {
 
     private Integer index;
     private String header;
+    private Boolean updateable;
 
    public Integer getIndex() {
         return index;
@@ -25,12 +26,24 @@ public class LoadDataColumnConfig extends ColumnConfig {
     public void setHeader(String header) {
         this.header = header;
     }
+    
+    /**
+     * Returns true if this Column should be updated. Returns null if update hasn't been explicitly assigned.
+     */  
+	public Boolean isUpdateable() {
+		return updateable;
+	}
+
+	public void setUpdateable(Boolean updateable) {
+		this.updateable = updateable;
+	}
 
     @Override
     public void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException {
         super.load(parsedNode, resourceAccessor);
         this.index = parsedNode.getChildValue(null, "index", Integer.class);
         this.header = parsedNode.getChildValue(null, "header", String.class);
+        this.updateable = parsedNode.getChildValue(null, "updateable", Boolean.class);
     }
 
 

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/InsertOrUpdateGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/InsertOrUpdateGenerator.java
@@ -103,10 +103,10 @@ public abstract class InsertOrUpdateGenerator extends AbstractSqlGenerator<Inser
 
         String[] pkFields=insertOrUpdateStatement.getPrimaryKey().split(",");
         HashSet<String> hashPkFields = new HashSet<String>(Arrays.asList(pkFields));
-        for(String columnKey:insertOrUpdateStatement.getColumnValues().keySet())
+        for(String columnKey:insertOrUpdateStatement.getColumnUpdateValues().keySet())
         {
             if (!hashPkFields.contains(columnKey)) {
-                updateStatement.addNewColumnValue(columnKey,insertOrUpdateStatement.getColumnValue(columnKey));
+                updateStatement.addNewColumnValue(columnKey,insertOrUpdateStatement.getColumnUpdateValue(columnKey));
             }
         }
         // this isn't very elegant but the code fails above without any columns to update

--- a/liquibase-core/src/main/java/liquibase/statement/core/InsertStatement.java
+++ b/liquibase-core/src/main/java/liquibase/statement/core/InsertStatement.java
@@ -11,6 +11,7 @@ public class InsertStatement extends AbstractSqlStatement {
     private String schemaName;
     private String tableName;
     private Map<String, Object> columnValues = new LinkedHashMap<String, Object>();
+    private Map<String, Object> columnUpdateValues = new LinkedHashMap<String, Object>();
 
     public InsertStatement(String catalogName, String schemaName, String tableName) {
         this.catalogName = catalogName;
@@ -46,5 +47,23 @@ public class InsertStatement extends AbstractSqlStatement {
     
     public InsertStatement addColumn(ColumnConfig columnConfig) {
     	return addColumnValue(columnConfig.getName(), columnConfig.getValueObject());
+    }
+    
+    public InsertStatement addColumnUpdateValue(String columnName, Object newValue) {
+    	columnUpdateValues.put(columnName, newValue);
+
+        return this;
+    }
+
+    public Object getColumnUpdateValue(String columnName) {
+        return columnUpdateValues.get(columnName);
+    }
+
+    public Map<String, Object> getColumnUpdateValues() {
+        return columnUpdateValues;
+    }
+    
+    public InsertStatement addColumnUpdate(ColumnConfig columnConfig) {
+    	return addColumnUpdateValue(columnConfig.getName(), columnConfig.getValueObject());
     }
 }

--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.2.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.2.xsd
@@ -296,7 +296,7 @@
 		<xsd:attribute name="startWith" type="xsd:long" />
 		<xsd:attribute name="incrementBy" type="xsd:long" />
 		<xsd:attribute name="remarks" type="xsd:string" />
-        <xsd:attribute name="encoding" type="xsd:string">
+        <xsd:attribute name="encoding" type="xsd:string">       
             <xsd:annotation>
                 <xsd:appinfo>
                     <xsd:documentation>
@@ -524,6 +524,7 @@
 						<xsd:attribute name="header" type="xsd:string" />
 						<xsd:attribute name="name" type="xsd:string" />
 						<xsd:attribute name="type" type="xsd:string" />
+						<xsd:attribute name="updateable" type="booleanExp" default="true"/>
 						<xsd:attribute name="defaultValue" type="xsd:string" />
 						<xsd:attribute name="defaultValueNumeric" type="xsd:string" />
 						<xsd:attribute name="defaultValueDate" type="xsd:string" />

--- a/liquibase-core/src/test/java/liquibase/sqlgenerator/core/InsertOrUpdateGeneratorMSSQLTest.java
+++ b/liquibase-core/src/test/java/liquibase/sqlgenerator/core/InsertOrUpdateGeneratorMSSQLTest.java
@@ -88,7 +88,7 @@ public class InsertOrUpdateGeneratorMSSQLTest {
          MSSQLDatabase database = new MSSQLDatabase();
 
          InsertOrUpdateStatement statement = new InsertOrUpdateStatement("mycatalog", "myschema","mytable","pk_col1");
-         statement.addColumnValue("col2","value2");
+         statement.addColumnUpdateValue("col2","value2");
 
          String where = "1 = 1";
 

--- a/liquibase-core/src/test/java/liquibase/sqlgenerator/core/InsertOrUpdateGeneratorOracleTest.java
+++ b/liquibase-core/src/test/java/liquibase/sqlgenerator/core/InsertOrUpdateGeneratorOracleTest.java
@@ -17,6 +17,8 @@ public class InsertOrUpdateGeneratorOracleTest {
         InsertOrUpdateStatement statement = new InsertOrUpdateStatement("mycatalog", "myschema","mytable","pk_col1");
         statement.addColumnValue("pk_col1","value1");
         statement.addColumnValue("col2","value2");
+        statement.addColumnUpdateValue("pk_col1","value1");
+        statement.addColumnUpdateValue("col2","value2");
         Sql[] sql = generator.generateSql( statement, database,  null);
         String theSql = sql[0].toSql();
         assertTrue(theSql.contains("INSERT INTO mycatalog.mytable (pk_col1, col2) VALUES ('value1', 'value2');"));


### PR DESCRIPTION
Added option "updateable" to the column tag. This option allows you to not include a column in the update script. Default value = "true".



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-84) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 4.2.0
