### PR TITLE
basics of implementing checkConstraint

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/CreateTableChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/CreateTableChange.java
@@ -86,6 +86,10 @@ public class CreateTableChange extends AbstractChange implements ChangeWithColum
                 if (constraints.isNullable() != null && !constraints.isNullable()) {
                     statement.addColumnConstraint(new NotNullConstraint(column.getName()));
                 }
+                
+                if(constraints.getCheckConstraint() != null) {
+                    statement.addColumnConstraint(new CheckConstraint(column.getName(), constraints.getCheckConstraint()));
+                }
 
                 if (constraints.getReferences() != null ||
                         (constraints.getReferencedTableName() != null && constraints.getReferencedColumnNames() != null)) {

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateTableGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateTableGenerator.java
@@ -10,6 +10,7 @@ import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.statement.AutoIncrementConstraint;
+import liquibase.statement.CheckConstraint;
 import liquibase.statement.ForeignKeyConstraint;
 import liquibase.statement.SequenceNextValueFunction;
 import liquibase.statement.UniqueConstraint;
@@ -151,6 +152,23 @@ public class CreateTableGenerator extends AbstractSqlGenerator<CreateTableStatem
 
             if (database instanceof InformixDatabase && isSinglePrimaryKeyColumn && isPrimaryKeyColumn) {
                 //buffer.append(" PRIMARY KEY");
+            }
+            
+            if(!statement.getCheckConstraints().isEmpty()) {
+                CheckConstraint checkConstraint = null;
+                // find matching check constraint
+                for (CheckConstraint currentCheckConstraint : statement.getCheckConstraints()) {
+                    if (column.equals(currentCheckConstraint.getColumnName())) {
+                        checkConstraint = currentCheckConstraint;
+                        break;
+                    }
+                }
+                // act on it
+                if(checkConstraint != null) {
+                    buffer.append(" CHECK(");
+                    buffer.append(checkConstraint.getConstraint());
+                    buffer.append(")");
+                }
             }
 
             if(statement.getColumnRemarks(column) != null){

--- a/liquibase-core/src/main/java/liquibase/statement/CheckConstraint.java
+++ b/liquibase-core/src/main/java/liquibase/statement/CheckConstraint.java
@@ -1,0 +1,32 @@
+package liquibase.statement;
+
+public class CheckConstraint implements ColumnConstraint {
+    private String columnName;
+    private String constraint;
+
+    public CheckConstraint() {
+    }
+
+    public CheckConstraint(String columnName, String constraint) {
+        setColumnName(columnName);
+        setConstraint(constraint);
+    }
+
+
+    public void setConstraint(String constraint) {
+        this.constraint = constraint;
+    }
+
+    public String getConstraint() {
+        return constraint;
+    }
+
+    public String getColumnName() {
+        return columnName;
+    }
+
+    public CheckConstraint setColumnName(String columnName) {
+        this.columnName = columnName;
+        return this;
+    }
+}

--- a/liquibase-core/src/main/java/liquibase/statement/core/CreateTableStatement.java
+++ b/liquibase-core/src/main/java/liquibase/statement/core/CreateTableStatement.java
@@ -21,6 +21,7 @@ public class CreateTableStatement extends AbstractSqlStatement {
     private Set<String> notNullColumns = new HashSet<String>();
     private Set<ForeignKeyConstraint> foreignKeyConstraints = new HashSet<ForeignKeyConstraint>();
     private Set<UniqueConstraint> uniqueConstraints = new HashSet<UniqueConstraint>();
+    private Set<CheckConstraint> checkConstraints = new HashSet<CheckConstraint>();
 
 
     public CreateTableStatement(String catalogName, String schemaName, String tableName) {
@@ -192,6 +193,15 @@ public class CreateTableStatement extends AbstractSqlStatement {
     public CreateTableStatement addColumnConstraint(AutoIncrementConstraint autoIncrementConstraint) {
         getAutoIncrementConstraints().add(autoIncrementConstraint);
         return this;
+    }
+    
+    public CreateTableStatement addColumnConstraint(CheckConstraint checkConstraint) {
+        getCheckConstraints().add(checkConstraint);
+        return this;
+    }
+    
+    public Set<CheckConstraint> getCheckConstraints() {
+        return checkConstraints;
     }
 
     public Set<AutoIncrementConstraint> getAutoIncrementConstraints() {

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
@@ -43,6 +43,7 @@ import liquibase.util.FileUtil;
 import liquibase.util.RegexMatcher;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -53,6 +54,7 @@ import java.util.*;
 
 import static junit.framework.Assert.*;
 import static org.junit.Assert.assertFalse;
+import static org.hamcrest.CoreMatchers.*;
 
 /**
  * Base class for all database integration tests.  There is an AbstractIntegrationTest subclass for each supported database.
@@ -944,6 +946,22 @@ public abstract class AbstractIntegrationTest {
         assertFalse("the scheame name '"+schemaName+"' should be ignored\n\n"+outputResult, outputResult.contains(schemaName+"."));
 //        System.out.println("expected    : " + expected);
 //        System.out.println("outputResult: " + outputResult);
+    }
+    
+    @Test
+    public void testCheckConstraintOnColumn() throws Exception {
+        StringWriter output = new StringWriter();
+        Liquibase liquibase = createLiquibase(includedChangeLog);
+        clearDatabase(liquibase);
+
+        liquibase = createLiquibase("changelogs/common/checkConstraint.tests.changelog.xml");
+        liquibase.update(new Contexts(), output);
+
+        String outputResult = output.getBuffer().toString();
+        assertNotNull(outputResult);
+        String expected = "colors VARCHAR(50) NOT NULL CHECK(colors IN ('red', 'green', 'blue'))";
+        Assert.assertThat(outputResult, containsString(expected));
+        
     }
 
     @Test

--- a/liquibase-integration-tests/src/test/resources/changelogs/common/checkConstraint.tests.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/common/checkConstraint.tests.changelog.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <changeSet id="checkConstraint-basic" author="the-alchemist">
+        <createTable tableName="checkConstraint_table">
+            <column name="id" type="int">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="colors" type="varchar(50)">
+                <constraints nullable="false" checkConstraint="colors IN ('red', 'green', 'blue')"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
Not sure if this is the right way to do it, but I tried to follow the coding style already present.  Included basics of unit test.

Tested the resulting SQL against PostgreSQL, which I believe uses the fairly standard CHECK syntax.

NOTE: MySQL doesn't support CHECK constraint, but they are [silently ignored](http://dev.mysql.com/doc/refman/5.5/en/create-table.html).  So I'm not sure if database checks are necessary at all.   [MS Access seems to support them](https://msdn.microsoft.com/en-us/library/aa140015%28office.10%29.aspx#acintsql_ddlconst) albeit with some restrictions.  [SQLite supports CHECK constraints too](https://www.sqlite.org/lang_createtable.html).

