### PR TITLE
CORE-2234: columnExists precondition speedup by relying on SQL parser in DB

### DIFF
--- a/liquibase-core/src/main/java/liquibase/precondition/core/ColumnExistsPrecondition.java
+++ b/liquibase-core/src/main/java/liquibase/precondition/core/ColumnExistsPrecondition.java
@@ -1,8 +1,14 @@
 package liquibase.precondition.core;
 
+import static java.lang.String.format;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+
 import liquibase.changelog.DatabaseChangeLog;
 import liquibase.changelog.ChangeSet;
 import liquibase.database.Database;
+import liquibase.database.jvm.JdbcConnection;
 import liquibase.precondition.AbstractPrecondition;
 import liquibase.snapshot.SnapshotGeneratorFactory;
 import liquibase.structure.core.Column;
@@ -10,6 +16,7 @@ import liquibase.structure.core.Schema;
 import liquibase.exception.*;
 import liquibase.precondition.Precondition;
 import liquibase.structure.core.Table;
+import liquibase.util.JdbcUtils;
 import liquibase.util.StringUtils;
 
 public class ColumnExistsPrecondition extends AbstractPrecondition {
@@ -67,6 +74,15 @@ public class ColumnExistsPrecondition extends AbstractPrecondition {
 
     @Override
     public void check(Database database, DatabaseChangeLog changeLog, ChangeSet changeSet) throws PreconditionFailedException, PreconditionErrorException {
+		if (canCheckFast(database)) {
+			checkFast(database, changeLog);
+
+		} else {
+			checkUsingSnapshot(database, changeLog, changeSet);
+		}
+	}
+
+    private void checkUsingSnapshot(Database database, DatabaseChangeLog changeLog, ChangeSet changeSet) throws PreconditionFailedException, PreconditionErrorException {
         Column example = new Column();
         if (StringUtils.trimToNull(getTableName()) != null) {
             example.setRelation(new Table().setName(database.correctObjectName(getTableName(), Table.class)).setSchema(new Schema(getCatalogName(), getSchemaName())));
@@ -81,6 +97,64 @@ public class ColumnExistsPrecondition extends AbstractPrecondition {
             throw new PreconditionErrorException(e, changeLog, this);
         }
     }
+
+	private boolean canCheckFast(Database database) {
+		if (getCatalogName() != null)
+			return false;
+
+		if (!(database.getConnection() instanceof JdbcConnection))
+			return false;
+
+		if (getColumnName() == null)
+			return false;
+
+		if (!getColumnName().matches("(?i)[a-z][a-z_0-9]*"))
+			return false;
+
+		if (!(getSchemaName() != null || database.getDefaultSchemaName() != null)) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private void checkFast(Database database, DatabaseChangeLog changeLog)
+			throws PreconditionFailedException, PreconditionErrorException {
+
+		Statement statement = null;
+		try {
+			statement = ((JdbcConnection) database.getConnection())
+					.createStatement();
+
+			String schemaName = getSchemaName();
+			if (schemaName == null) {
+				schemaName = database.getDefaultSchemaName();
+			}
+			String tableName = getTableName();
+			String columnName = getColumnName();
+
+			try {
+				String sql = format("select t.%s from %s.%s t where 0=1",
+						columnName, schemaName, tableName);
+				statement.executeQuery(sql).close();
+
+				// column exists
+				return;
+
+			} catch (SQLException e) {
+				// column or table does not exist
+				throw new PreconditionFailedException(format(
+						"Column %s.%s.%s does not exist", schemaName,
+						tableName, columnName), changeLog, this);
+			}
+
+		} catch (DatabaseException e) {
+			throw new PreconditionErrorException(e, changeLog, this);
+
+		} finally {
+			JdbcUtils.closeStatement(statement);
+		}
+	}
 
     @Override
     public String getName() {


### PR DESCRIPTION
Speed up columnExists precondition by delegating work to SQL parser of the
database. Instead of inspecting database metadata (which can be slow when
many tables/columns exist in the db), check that the column can be selected
from the table.