### PR TITLE
do a RESTART WITH for postgresql's SERIAL

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateTableGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateTableGenerator.java
@@ -131,7 +131,7 @@ public class CreateTableGenerator extends AbstractSqlGenerator<CreateTableStatem
                     if( autoIncrementConstraint.getStartWith() != null ){
 	                    if (database instanceof PostgresDatabase) {
 	                        String sequenceName = statement.getTableName()+"_"+column+"_seq";
-	                        additionalSql.add(new UnparsedSql("alter sequence "+database.escapeSequenceName(statement.getCatalogName(), statement.getSchemaName(), sequenceName)+" start with "+autoIncrementConstraint.getStartWith(), new Sequence().setName(sequenceName).setSchema(statement.getCatalogName(), statement.getSchemaName())));
+	                        additionalSql.add(new UnparsedSql("alter sequence "+database.escapeSequenceName(statement.getCatalogName(), statement.getSchemaName(), sequenceName)+" restart with "+autoIncrementConstraint.getStartWith(), new Sequence().setName(sequenceName).setSchema(statement.getCatalogName(), statement.getSchemaName())));
 	                    }else if(database instanceof MySQLDatabase){
 	                    	mysqlTableOptionStartWith = autoIncrementConstraint.getStartWith();
 	                    }


### PR DESCRIPTION
I get the impression a {{RESTART}} would be preferable on PostgreSQL, because {{START}} doesn't really do what we want.

