### PR TITLE
Output a delimiter command for MySQL client.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/AbstractSQLChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/AbstractSQLChange.java
@@ -28,6 +28,7 @@ public abstract class AbstractSQLChange extends AbstractChange implements DbmsTa
 
     private boolean stripComments;
     private boolean splitStatements;
+    private boolean outputDelimiter;
     private String endDelimiter;
     private String sql;
     private String dbms;
@@ -159,6 +160,21 @@ public abstract class AbstractSQLChange extends AbstractChange implements DbmsTa
         this.endDelimiter = endDelimiter;
     }
 
+    @DatabaseChangeProperty(since = "3.4",
+            description = "Whether to output a delimiter statement in updateSQL/rollbackSQL",
+            supportsDatabase = "mysql")
+    public Boolean isOutputDelimiter() {
+        return outputDelimiter;
+    }
+
+    public void setOutputDelimiter(Boolean outputDelimiter) {
+        if (outputDelimiter == null) {
+            this.outputDelimiter = false;
+        } else {
+            this.outputDelimiter = outputDelimiter;
+        }
+    }
+
     /**
      * Calculates the checksum based on the contained SQL.
      *
@@ -235,7 +251,9 @@ public abstract class AbstractSQLChange extends AbstractChange implements DbmsTa
                 escapedStatement = statement;
             }
 
-            returnStatements.add(new RawSqlStatement(escapedStatement, getEndDelimiter()));
+            RawSqlStatement rawStatement = new RawSqlStatement(escapedStatement, getEndDelimiter());
+            rawStatement.setOutputDelimiter(isOutputDelimiter());
+            returnStatements.add(rawStatement);
         }
 
         return returnStatements.toArray(new SqlStatement[returnStatements.size()]);

--- a/liquibase-core/src/main/java/liquibase/change/AbstractSQLChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/AbstractSQLChange.java
@@ -160,7 +160,7 @@ public abstract class AbstractSQLChange extends AbstractChange implements DbmsTa
         this.endDelimiter = endDelimiter;
     }
 
-    @DatabaseChangeProperty(since = "3.4",
+    @DatabaseChangeProperty(since = "4.0",
             description = "Whether to output a delimiter statement in updateSQL/rollbackSQL",
             supportsDatabase = "mysql")
     public Boolean isOutputDelimiter() {

--- a/liquibase-core/src/main/java/liquibase/executor/LoggingExecutor.java
+++ b/liquibase-core/src/main/java/liquibase/executor/LoggingExecutor.java
@@ -109,8 +109,10 @@ public class LoggingExecutor extends AbstractExecutor {
 
                 String endDelimiter = ";";
                 String potentialDelimiter = null;
+                boolean outputDelimiter = false;
                 if (sql instanceof RawSqlStatement) {
                     potentialDelimiter = ((RawSqlStatement) sql).getEndDelimiter();
+                    outputDelimiter = ((RawSqlStatement) sql).isOutputDelimiter();
                 } else if (sql instanceof CreateProcedureStatement) {
                     potentialDelimiter = ((CreateProcedureStatement) sql).getEndDelimiter();
                 }
@@ -129,16 +131,12 @@ public class LoggingExecutor extends AbstractExecutor {
 
 
                 boolean resetMySqlDelimiter = false;
-
-                if (database instanceof MySQLDatabase
-                        && endDelimiter.toLowerCase(Locale.ROOT).startsWith("delimiter")) {
-                    endDelimiter = endDelimiter.substring("delimiter".length());
-
+                if (outputDelimiter == true && database instanceof MySQLDatabase
+                        && !";".equals(endDelimiter)) {
+                    resetMySqlDelimiter = true;
                     output.write("delimiter ");
                     output.write(endDelimiter);
                     output.write(StreamUtil.getLineSeparator());
-
-                    resetMySqlDelimiter = true;
                 }
 
                 //remove trailing "/"

--- a/liquibase-core/src/main/java/liquibase/statement/core/RawSqlStatement.java
+++ b/liquibase-core/src/main/java/liquibase/statement/core/RawSqlStatement.java
@@ -6,6 +6,7 @@ public class RawSqlStatement extends AbstractSqlStatement {
 
     private String sql;
     private String endDelimiter  = ";";
+    private boolean outputDelimiter;
 
 
     public RawSqlStatement(String sql) {
@@ -25,6 +26,14 @@ public class RawSqlStatement extends AbstractSqlStatement {
 
     public String getEndDelimiter() {
         return endDelimiter.replace("\\r","\r").replace("\\n","\n");
+    }
+
+    public boolean isOutputDelimiter() {
+        return outputDelimiter;
+    }
+
+    public void setOutputDelimiter(boolean outputDelimiter) {
+        this.outputDelimiter = outputDelimiter;
     }
 
     @Override

--- a/liquibase-core/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.0.xsd
+++ b/liquibase-core/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.0.xsd
@@ -1075,6 +1075,7 @@
             <xsd:attribute name="splitStatements" type="booleanExp"/>
             <xsd:attribute name="endDelimiter" type="xsd:string"/>
             <xsd:attribute name="dbms" type="xsd:string"/>
+            <xsd:attribute name="outputDelimiter" type="booleanExp"/>
         </xsd:complexType>
     </xsd:element>
 

--- a/liquibase-core/src/test/groovy/liquibase/serializer/core/string/StringChangeLogSerializerTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/serializer/core/string/StringChangeLogSerializerTest.groovy
@@ -225,14 +225,17 @@ public class StringChangeLogSerializerTest extends Specification {
 
         then:
         new StringChangeLogSerializer().serialize(change, false) == "sqlFile:[\n" +
+                "    outputDelimiter=\"false\"\n" +
                 "    splitStatements=\"true\"\n" +
-                "    stripComments=\"false\"\n]"
+                "    stripComments=\"false\"\n" +
+                "]"
 
         when:
         change.setPath("PATH/TO/File.txt");
 
         then:
         new StringChangeLogSerializer().serialize(change, false) == "sqlFile:[\n" +
+                "    outputDelimiter=\"false\"\n" +
                 "    path=\"PATH/TO/File.txt\"\n" +
                 "    splitStatements=\"true\"\n" +
                 "    stripComments=\"false\"\n" +
@@ -245,13 +248,16 @@ public class StringChangeLogSerializerTest extends Specification {
 
         then:
         new StringChangeLogSerializer().serialize(change, false) == "sql:[\n" +
+                "    outputDelimiter=\"false\"\n" +
                 "    splitStatements=\"true\"\n" +
-                "    stripComments=\"false\"\n]"
+                "    stripComments=\"false\"\n" +
+                "]"
 
         when:
         change.setSql("some SQL Here");
         then:
         new StringChangeLogSerializer().serialize(change, false) == "sql:[\n" +
+                "    outputDelimiter=\"false\"\n" +
                 "    splitStatements=\"true\"\n" +
                 "    sql=\"some SQL Here\"\n" +
                 "    stripComments=\"false\"\n" +

--- a/liquibase-core/src/test/groovy/liquibase/serializer/core/string/StringChangeLogSerializerTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/serializer/core/string/StringChangeLogSerializerTest.groovy
@@ -264,6 +264,29 @@ public class StringChangeLogSerializerTest extends Specification {
                 "]"
     }
 
+    def serialized_rawSql_outputDelimiter() {
+        when:
+        RawSQLChange change = new RawSQLChange();
+        change.setOutputDelimiter(true);
+
+        then:
+        new StringChangeLogSerializer().serialize(change, false) == "sql:[\n" +
+                "    outputDelimiter=\"true\"\n" +
+                "    splitStatements=\"true\"\n" +
+                "    stripComments=\"false\"\n" +
+                "]"
+
+        when:
+        change.setSql("some SQL Here");
+        then:
+        new StringChangeLogSerializer().serialize(change, false) == "sql:[\n" +
+                "    outputDelimiter=\"true\"\n" +
+                "    splitStatements=\"true\"\n" +
+                "    sql=\"some SQL Here\"\n" +
+                "    stripComments=\"false\"\n" +
+                "]"
+    }
+
     @Unroll("#featureName: #change.class.name")
     def "general field serialization check"() throws Exception {
         expect:

--- a/liquibase-core/src/test/java/liquibase/executor/LoggingExecutorTest.java
+++ b/liquibase-core/src/test/java/liquibase/executor/LoggingExecutorTest.java
@@ -1,0 +1,60 @@
+package liquibase.executor;
+
+import java.io.StringWriter;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import liquibase.change.core.RawSQLChange;
+import liquibase.database.core.MySQLDatabase;
+import liquibase.exception.DatabaseException;
+import liquibase.util.StreamUtil;
+
+public class LoggingExecutorTest {
+
+    @Test
+    public void outputDelimiterTrue() throws DatabaseException {
+        StringWriter output = new StringWriter();
+        MySQLDatabase database = new MySQLDatabase();
+        LoggingExecutor executor = new LoggingExecutor(null, output, database);
+
+        RawSQLChange change = new RawSQLChange("CREATE PROCEDURE x (a int)\n" +
+                "        BEGIN\n" +
+                "          DECLARE b int;\n" +
+                "        END//");
+        change.setEndDelimiter("//");
+        change.setOutputDelimiter(true);
+
+        executor.execute(change);
+
+        Assert.assertEquals("delimiter //" + StreamUtil.getLineSeparator() +
+                "CREATE PROCEDURE x (a int)" + StreamUtil.getLineSeparator() +
+                "        BEGIN" + StreamUtil.getLineSeparator() +
+                "          DECLARE b int;" + StreamUtil.getLineSeparator() +
+                "        END//" + StreamUtil.getLineSeparator() +
+                "delimiter ;" + StreamUtil.getLineSeparator()
+                + StreamUtil.getLineSeparator() + StreamUtil.getLineSeparator(), output.toString());
+    }
+
+    @Test
+    public void outputDelimiterFalse() throws DatabaseException {
+        StringWriter output = new StringWriter();
+        MySQLDatabase database = new MySQLDatabase();
+        LoggingExecutor executor = new LoggingExecutor(null, output, database);
+
+        RawSQLChange change = new RawSQLChange("CREATE PROCEDURE x (a int)\n" +
+                "        BEGIN\n" +
+                "          DECLARE b int;\n" +
+                "        END//");
+        change.setEndDelimiter("//");
+        change.setOutputDelimiter(false);
+
+        executor.execute(change);
+
+        Assert.assertEquals("CREATE PROCEDURE x (a int)" + StreamUtil.getLineSeparator() +
+                "        BEGIN" + StreamUtil.getLineSeparator() +
+                "          DECLARE b int;" + StreamUtil.getLineSeparator() +
+                "        END//" + StreamUtil.getLineSeparator() +
+                StreamUtil.getLineSeparator(), output.toString());
+    }
+}


### PR DESCRIPTION
This behavior can be triggered with `outputDelimiter="true"` for SQL changes.
This allows for generating SQL via outputSQL that can be used
directly with the MySQL command line tool.

The following example changeset:

```
<changeSet id="1" author="a">
    <sql endDelimiter="//" splitStatements="false" outputDelimiter="true">
        CREATE PROCEDURE x (a int)
        BEGIN
          DECLARE b int;
        END//
    </sql>
</changeSet>
```

Will produce the following SQL:

```
--  Changeset test-changelog.xml::1::a
delimiter //
CREATE PROCEDURE x (a int)
        BEGIN
          DECLARE b int;
        END//
delimiter ;
```

I've chosen now the name `outputDelimiter`. Let me know, if this is ok or whether I should change it.

Thanks!

