### PR TITLE
CORE-1943 - Handle Error: InetAddress.getLocalHost().getHostName() UnknownHostException

### DIFF
--- a/liquibase-core/src/main/java/liquibase/util/NetUtil.java
+++ b/liquibase-core/src/main/java/liquibase/util/NetUtil.java
@@ -11,16 +11,16 @@ public class NetUtil {
     /**
      * Smarter way to get localhost than InetAddress.getLocalHost.  See http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4665037
      */
-    public static String getLocalHostAddress() throws UnknownHostException, SocketException {
+    private static InetAddress getLocalHost() throws UnknownHostException, SocketException {
         // Windows Vista returns the IPv6 InetAddress using this method, which is not
         // particularly useful as it has no name or useful address, just "0:0:0:0:0:0:0:1".
         // That is why windows should be treated differently to linux/unix and use the
         // default way of getting the localhost.
         String osName = System.getProperty("os.name");
         if (osName != null && osName.toLowerCase().contains("windows")) {
-            return InetAddress.getLocalHost().getHostAddress();
+            return InetAddress.getLocalHost();
         }
-      
+
         InetAddress lch = null;
         Enumeration<NetworkInterface> e = NetworkInterface.getNetworkInterfaces();
 
@@ -34,10 +34,28 @@ public class NetUtil {
             lch = ie.nextElement();
             if (!lch.isLoopbackAddress()) break;
         }
-        return lch == null ? null : lch.getHostAddress();
+        return lch == null ? null : lch;
     }
 
-    public static String getLocalHostName() throws UnknownHostException, SocketException {
-        return InetAddress.getLocalHost().getHostName();
+    /**
+     * Returns Local Host IP Address
+     * @return local Host IP address
+     * @throws UnknownHostException
+     * @throws SocketException
+     */
+    public static String getLocalHostAddress() throws UnknownHostException, SocketException {
+        return getLocalHost().getHostAddress();
     }
+
+    /**
+     * Returns Local Host Name
+     * @return local Host Name
+     * @throws UnknownHostException
+     * @throws SocketException
+     */
+    public static String getLocalHostName() throws UnknownHostException, SocketException {
+        return getLocalHost().getHostName();
+    }
+
+
 }


### PR DESCRIPTION
CORE-1943 - Handle Error: InetAddress.getLocalHost().getHostName() UnknownHostException results in NoClassDefFoundError - Use 'Smarter' way to get localhost for local host name as well as local host address.  (Basically same approach as 2.0.2 functionality, which worked)