### PR TITLE
CORE-1866 - Filtering changelog list by includeAll tag is not working

### DIFF
--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.0.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.0.xsd
@@ -183,7 +183,7 @@
 						<xsd:complexType>
 							<xsd:attribute name="path" type="xsd:string" use="required" />
 							<xsd:attribute name="relativeToChangelogFile" type="booleanExp" />
-                            <xsd:attribute name="filter" type="xsd:string" />
+                            <xsd:attribute name="resourceFilter" type="xsd:string" />
 							<xsd:anyAttribute namespace="##other" />
 						</xsd:complexType>
 					</xsd:element>

--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.1.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.1.xsd
@@ -183,7 +183,7 @@
 						<xsd:complexType>
 							<xsd:attribute name="path" type="xsd:string" use="required" />
 							<xsd:attribute name="relativeToChangelogFile" type="booleanExp" />
-                            <xsd:attribute name="filter" type="xsd:string" />
+                            <xsd:attribute name="resourceFilter" type="xsd:string" />
 							<xsd:anyAttribute namespace="##other" />
 						</xsd:complexType>
 					</xsd:element>

--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.2.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.2.xsd
@@ -183,7 +183,7 @@
 						<xsd:complexType>
 							<xsd:attribute name="path" type="xsd:string" use="required" />
 							<xsd:attribute name="relativeToChangelogFile" type="booleanExp" />
-                            <xsd:attribute name="filter" type="xsd:string" />
+                            <xsd:attribute name="resourceFilter" type="xsd:string" />
 							<xsd:anyAttribute namespace="##other" />
 						</xsd:complexType>
 					</xsd:element>

--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.3.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.3.xsd
@@ -185,7 +185,7 @@
 						<xsd:complexType>
 							<xsd:attribute name="path" type="xsd:string" use="required" />
 							<xsd:attribute name="relativeToChangelogFile" type="booleanExp" />
-                            <xsd:attribute name="filter" type="xsd:string" />
+                            <xsd:attribute name="resourceFilter" type="xsd:string" />
 							<xsd:anyAttribute namespace="##other" />
 						</xsd:complexType>
 					</xsd:element>


### PR DESCRIPTION
CORE-1866 - Filtering changelog list by includeAll tag is not working - fix bad "filter" entry in xsd's to be "resourceFilter" to match Java code.