### PR TITLE
CORE-2299 - Add capability to ignore missing or empty folder with includeAll

### DIFF
--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.3.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.3.xsd
@@ -184,6 +184,7 @@
 					<xsd:element name="includeAll" minOccurs="0" maxOccurs="unbounded">
 						<xsd:complexType>
 							<xsd:attribute name="path" type="xsd:string" use="required" />
+                            <xsd:attribute name="ignoreMissingOrEmptyDirectory" type="booleanExp" default="false" />
 							<xsd:attribute name="relativeToChangelogFile" type="booleanExp" />
                             <xsd:attribute name="filter" type="xsd:string" />
 							<xsd:anyAttribute namespace="##other" />

--- a/liquibase-core/src/test/groovy/liquibase/changelog/DatabaseChangeLogTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/changelog/DatabaseChangeLogTest.groovy
@@ -2,12 +2,13 @@ package liquibase.changelog
 
 import liquibase.change.core.CreateTableChange
 import liquibase.change.core.RawSQLChange
+import liquibase.exception.SetupException
 import liquibase.parser.core.ParsedNode
 import liquibase.precondition.core.OrPrecondition
 import liquibase.precondition.core.PreconditionContainer
 import liquibase.precondition.core.RunningAsPrecondition
-import liquibase.sdk.supplier.resource.ResourceSupplier
 import liquibase.sdk.resource.MockResourceAccessor
+import liquibase.sdk.supplier.resource.ResourceSupplier
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -198,12 +199,44 @@ create view sql_view as select * from sql_table;'''
                 "com/example/not/fileX.sql": "file X",
         ])
         def changeLogFile = new DatabaseChangeLog("com/example/root.xml")
-        changeLogFile.includeAll("com/example/children", false, null, changeLogFile.getStandardChangeLogComparator(), resourceAccessor)
+        changeLogFile.includeAll("com/example/children", false, null, false, changeLogFile.getStandardChangeLogComparator(), resourceAccessor)
 
         then:
         changeLogFile.changeSets.collect { it.filePath } == [ "com/example/children/file1.sql",
                                                               "com/example/children/file2.sql",
                                                               "com/example/children/file3.sql" ]
+    }
+
+    def "includeAll throws exception when directory not found"() {
+        when:
+        def resourceAccessor = new MockResourceAccessor([
+                "com/example/children/file2.sql": "file 2",
+                "com/example/children/file3.sql": "file 3",
+                "com/example/children/file1.sql": "file 1",
+                "com/example/not/fileX.sql": "file X",
+        ])
+        def changeLogFile = new DatabaseChangeLog("com/example/root.xml")
+        changeLogFile.includeAll("com/example/missing", false, null, false, changeLogFile.getStandardChangeLogComparator(), resourceAccessor)
+
+        then:
+        SetupException e = thrown()
+        assert e.getMessage().startsWith("Could not find directory or directory was empty for includeAll '");
+
+    }
+
+    def "includeAll throws no exception when directory not found and ignoreMissingEmptyDirectory is true"() {
+        when:
+        def resourceAccessor = new MockResourceAccessor([
+                "com/example/children/file2.sql": "file 2",
+                "com/example/children/file3.sql": "file 3",
+                "com/example/children/file1.sql": "file 1",
+                "com/example/not/fileX.sql": "file X",
+        ])
+        def changeLogFile = new DatabaseChangeLog("com/example/root.xml")
+        changeLogFile.includeAll("com/example/missing", false, null, true, changeLogFile.getStandardChangeLogComparator(), resourceAccessor)
+        then:
+        changeLogFile.changeSets.collect {it.filePath } == []
+
     }
 
 }


### PR DESCRIPTION
CORE-2299 - Add capability to ignore missing or empty folder with includeAll - Add new 'ignoreMissingOrEmptyDirectory' attribute to 'includeAll'.  Default false.