### PR TITLE
CORE-2298: HSQL not allowed to add defaultValueComputed for datetime columns.  Added method to HsqlDatabase to check for conditions under which computed values are allowed.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
@@ -11,14 +11,19 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 public class HsqlDatabase extends AbstractJdbcDatabase {
     private static String START_CONCAT = "CONCAT(";
     private static String END_CONCAT = ")";
     private static String SEP_CONCAT = ", ";
-
+    private static String[] SUPPORTED_DEFAULT_VALUE_COMPUTED_LIST = {"CURRENT_DATE", "CURRENT_TIME", "CURRENT_TIMESTAMP", "TODAY", "NOW"};
+    
     private Boolean oracleSyntax;
 
     public HsqlDatabase() {
@@ -66,6 +71,18 @@ public class HsqlDatabase extends AbstractJdbcDatabase {
     @Override
     public boolean supportsSequences() {
         return true;
+    }
+    
+    /**
+     * Checks to see if the string is an acceptable computed value for HSQL
+     *    "datetime" columns are the only columns for which HSQL supports computer values.
+     *
+     * @param columnType String of the column's data type
+     * @param defaultValue String to be checked for valid valueComputed in HSQL
+     * @return boolean True if the string represents a function supported by HSQL for default values
+     */
+    public static boolean supportsDefaultValueComputed(String columnType, String defaultValue){
+    	return "datetime".equals(columnType) ? Arrays.asList(SUPPORTED_DEFAULT_VALUE_COMPUTED_LIST).contains(defaultValue) : false;
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
@@ -11,15 +11,23 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 
 public class HsqlDatabase extends AbstractJdbcDatabase {
     private static String START_CONCAT = "CONCAT(";
     private static String END_CONCAT = ")";
     private static String SEP_CONCAT = ", ";
-    private static String[] SUPPORTED_DEFAULT_VALUE_COMPUTED_LIST = {"CURRENT_DATE", "CURRENT_TIME", "CURRENT_TIMESTAMP", "TODAY", "NOW"};
-    
+    private static final Map<String, HashSet<String>> SUPPORTED_DEFAULT_VALUE_COMPUTED_MAP;
+    static {
+        Map<String, HashSet<String>> tempMap = new HashMap<String, HashSet<String>>();
+        tempMap.put("datetime", new HashSet<String>(Arrays.asList("CURRENT_DATE", "CURRENT_TIME", "CURRENT_TIMESTAMP", "TODAY", "NOW")));
+        SUPPORTED_DEFAULT_VALUE_COMPUTED_MAP = Collections.unmodifiableMap(tempMap);
+    }
     private Boolean oracleSyntax;
 
     public HsqlDatabase() {
@@ -78,7 +86,8 @@ public class HsqlDatabase extends AbstractJdbcDatabase {
      * @return boolean True if the string represents a function supported by HSQL for default values
      */
     public static boolean supportsDefaultValueComputed(String columnType, String defaultValue){
-    	return "datetime".equals(columnType) ? Arrays.asList(SUPPORTED_DEFAULT_VALUE_COMPUTED_LIST).contains(defaultValue) : false;
+    	HashSet<String> possibleComputedValues = SUPPORTED_DEFAULT_VALUE_COMPUTED_MAP.get(columnType);
+    	return (possibleComputedValues!=null) ? possibleComputedValues.contains(defaultValue) : false;
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
@@ -87,7 +87,7 @@ public class HsqlDatabase extends AbstractJdbcDatabase {
      */
     public static boolean supportsDefaultValueComputed(String columnType, String defaultValue){
     	HashSet<String> possibleComputedValues = SUPPORTED_DEFAULT_VALUE_COMPUTED_MAP.get(columnType);
-    	return (possibleComputedValues!=null) ? possibleComputedValues.contains(defaultValue) : false;
+    	return (possibleComputedValues!=null) && possibleComputedValues.contains(defaultValue);
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
@@ -18,7 +18,8 @@ public class HsqlDatabase extends AbstractJdbcDatabase {
     private static String START_CONCAT = "CONCAT(";
     private static String END_CONCAT = ")";
     private static String SEP_CONCAT = ", ";
-
+    private static String[] SUPPORTED_DEFAULT_VALUE_COMPUTED_LIST = {"CURRENT_DATE", "CURRENT_TIME", "CURRENT_TIMESTAMP", "TODAY", "NOW"};
+    
     private Boolean oracleSyntax;
 
     public HsqlDatabase() {
@@ -66,6 +67,18 @@ public class HsqlDatabase extends AbstractJdbcDatabase {
     @Override
     public boolean supportsSequences() {
         return true;
+    }
+    
+    /**
+     * Checks to see if the string is an acceptable computed value for HSQL
+     *    "datetime" columns are the only columns for which HSQL supports computer values.
+     *
+     * @param columnType String of the column's data type
+     * @param defaultValue String to be checked for valid valueComputed in HSQL
+     * @return boolean True if the string represents a function supported by HSQL for default values
+     */
+    public static boolean supportsDefaultValueComputed(String columnType, String defaultValue){
+    	return "datetime".equals(columnType) ? Arrays.asList(SUPPORTED_DEFAULT_VALUE_COMPUTED_LIST).contains(defaultValue) : false;
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
@@ -11,19 +11,14 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 public class HsqlDatabase extends AbstractJdbcDatabase {
     private static String START_CONCAT = "CONCAT(";
     private static String END_CONCAT = ")";
     private static String SEP_CONCAT = ", ";
-    private static String[] SUPPORTED_DEFAULT_VALUE_COMPUTED_LIST = {"CURRENT_DATE", "CURRENT_TIME", "CURRENT_TIMESTAMP", "TODAY", "NOW"};
-    
+
     private Boolean oracleSyntax;
 
     public HsqlDatabase() {
@@ -71,18 +66,6 @@ public class HsqlDatabase extends AbstractJdbcDatabase {
     @Override
     public boolean supportsSequences() {
         return true;
-    }
-    
-    /**
-     * Checks to see if the string is an acceptable computed value for HSQL
-     *    "datetime" columns are the only columns for which HSQL supports computer values.
-     *
-     * @param columnType String of the column's data type
-     * @param defaultValue String to be checked for valid valueComputed in HSQL
-     * @return boolean True if the string represents a function supported by HSQL for default values
-     */
-    public static boolean supportsDefaultValueComputed(String columnType, String defaultValue){
-    	return "datetime".equals(columnType) ? Arrays.asList(SUPPORTED_DEFAULT_VALUE_COMPUTED_LIST).contains(defaultValue) : false;
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddDefaultValueGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddDefaultValueGenerator.java
@@ -36,7 +36,7 @@ public class AddDefaultValueGenerator extends AbstractSqlGenerator<AddDefaultVal
         if (database instanceof HsqlDatabase) {
             if (defaultValue instanceof SequenceNextValueFunction) {
                 validationErrors.addError("Database " + database.getShortName() + " does not support adding sequence-based default values");
-            } else if (defaultValue instanceof DatabaseFunction && !HsqlDatabase.supportsDefaultValueComputed(addDefaultValueStatement.getColumnDataType(),defaultValue.toString())) {
+            } else if (defaultValue instanceof DatabaseFunction) {
                 validationErrors.addError("Database " + database.getShortName() + " does not support adding function-based default values");
             }
         }

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddDefaultValueGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddDefaultValueGenerator.java
@@ -36,7 +36,7 @@ public class AddDefaultValueGenerator extends AbstractSqlGenerator<AddDefaultVal
         if (database instanceof HsqlDatabase) {
             if (defaultValue instanceof SequenceNextValueFunction) {
                 validationErrors.addError("Database " + database.getShortName() + " does not support adding sequence-based default values");
-            } else if (defaultValue instanceof DatabaseFunction) {
+            } else if (defaultValue instanceof DatabaseFunction && !HsqlDatabase.supportsDefaultValueComputed(addDefaultValueStatement.getColumnDataType(),defaultValue.toString())) {
                 validationErrors.addError("Database " + database.getShortName() + " does not support adding function-based default values");
             }
         }


### PR DESCRIPTION
According to the HSQL documentation (http://www.hsqldb.org/doc/guide/ch09.html#columnDef-entry), there are several types of computed default values allowed for datetime columns.  This update adds a funciton to the HsqlDatabase class to check if a computed value function is allowed given the column data type, and uses this function in the AddDefaultValueGenerator to allow certain computed values.