### PR TITLE
CORE-2318 Add support for converting BigDecimal objects to a SQL string via DataTypeFactory

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/LiquibaseDataType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/LiquibaseDataType.java
@@ -5,6 +5,7 @@ import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.servicelocator.PrioritizedService;
 import liquibase.statement.DatabaseFunction;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -123,6 +124,8 @@ public abstract class LiquibaseDataType implements PrioritizedService {
             return null;
         } else if (value instanceof DatabaseFunction) {
             return database.generateDatabaseFunctionValue((DatabaseFunction) value);
+        } else if (value instanceof BigDecimal) {
+            return formatNumber(((BigDecimal) value).toPlainString());
         } else if (value instanceof Number) {
             return formatNumber(value.toString());
         }

--- a/liquibase-core/src/main/java/liquibase/datatype/core/DecimalType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/DecimalType.java
@@ -6,7 +6,7 @@ import liquibase.datatype.DataTypeInfo;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.LiquibaseDataType;
 
-@DataTypeInfo(name="decimal", aliases = "java.sql.Types.DECIMAL" , minParameters = 0, maxParameters = 2, priority = LiquibaseDataType.PRIORITY_DEFAULT)
+@DataTypeInfo(name = "decimal", aliases = { "java.sql.Types.DECIMAL", "java.math.BigDecimal" }, minParameters = 0, maxParameters = 2, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class DecimalType  extends LiquibaseDataType {
 
     private boolean autoIncrement;

--- a/liquibase-core/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
@@ -35,4 +35,27 @@ public class DataTypeFactoryTest extends Specification {
         "int4"                                               | new MockDatabase()    | "INT"                                                | IntType       | false
         "serial4"                                            | new MockDatabase()    | "INT"                                                | IntType       | true
     }
+
+    @Unroll("#featureName: #object for #database")
+    public void fromObject() throws Exception {
+        when:
+        def liquibaseType = DataTypeFactory.getInstance().fromObject(object, database)
+
+        then:
+        liquibaseType.objectToSql(object, database) == expectedSql
+        liquibaseType.getClass() == expectedType
+
+        where:
+        object                       | database           | expectedType | expectedSql
+        Integer.valueOf("10000000")  | new MockDatabase() | IntType      | "10000000"
+        Long.valueOf("10000000")     | new MockDatabase() | BigIntType   | "10000000"
+        new BigInteger("10000000")   | new MockDatabase() | BigIntType   | "10000000"
+        Float.valueOf("10000000.0")  | new MockDatabase() | FloatType    | "1.0E7"
+        Float.valueOf("10000000.1")  | new MockDatabase() | FloatType    | "1.0E7"
+        Double.valueOf("10000000.0") | new MockDatabase() | DoubleType   | "1.0E7"
+        Double.valueOf("10000000.1") | new MockDatabase() | DoubleType   | "1.00000001E7"
+        new BigDecimal("10000000.0") | new MockDatabase() | DecimalType  | "10000000"
+        new BigDecimal("10000000.1") | new MockDatabase() | DecimalType  | "10000000.1"
+        "10000000"                   | new MockDatabase() | VarcharType  | "'10000000'"
+    }
 }


### PR DESCRIPTION
[CORE-2318](https://liquibase.jira.com/browse/CORE-2318) Add support for converting BigDecimal objects to a SQL string via DataTypeFactory