### PR TITLE
CORE-2320 MinGW (Git Bash) support for shell

### DIFF
--- a/liquibase-core/src/main/resources/dist/liquibase
+++ b/liquibase-core/src/main/resources/dist/liquibase
@@ -36,12 +36,17 @@ if [ -f /usr/bin/cygpath ]; then
     CP="$CP;$i"
   done
 else
+  if [[ $(uname) = MINGW* ]]; then
+    CP_SEPARATOR=";"
+  else
+    CP_SEPARATOR=":"
+  fi
   CP=.
   for i in "$LIQUIBASE_HOME"/liquibase*.jar; do
-    CP="$CP":"$i"
+    CP="$CP""$CP_SEPARATOR""$i"
   done
   for i in "$LIQUIBASE_HOME"/lib/*.jar; do
-    CP="$CP":"$i"
+    CP="$CP""$CP_SEPARATOR""$i"
   done
 fi
 


### PR DESCRIPTION
MinGW should use semicolon for classpath separation.