### PR TITLE
CORE-2321 Liquibase tag command tags too much, CORE-842

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/TagDatabaseChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/TagDatabaseChange.java
@@ -1,14 +1,13 @@
 package liquibase.change.core;
 
 import liquibase.change.*;
-import liquibase.changelog.ChangeLogHistoryService;
 import liquibase.changelog.ChangeLogHistoryServiceFactory;
 import liquibase.database.Database;
 import liquibase.exception.DatabaseException;
-import liquibase.executor.ExecutorService;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.sqlgenerator.core.MarkChangeSetRanGenerator;
 import liquibase.statement.SqlStatement;
-import liquibase.statement.core.RawSqlStatement;
-import liquibase.statement.core.TagDatabaseStatement;
+import liquibase.statement.core.MarkChangeSetRanStatement;
 
 @DatabaseChange(name="tagDatabase", description = "Applies a tag to the database for future rollback", priority = ChangeMetaData.PRIORITY_DEFAULT, since = "1.6")
 public class TagDatabaseChange extends AbstractChange {
@@ -24,11 +23,13 @@ public class TagDatabaseChange extends AbstractChange {
         this.tag = tag;
     }
 
+    /**
+     * {@inheritDoc}
+     * @see MarkChangeSetRanGenerator#generateSql(MarkChangeSetRanStatement, Database, SqlGeneratorChain)
+     */
     @Override
     public SqlStatement[] generateStatements(Database database) {
-        return new SqlStatement[] {
-                new TagDatabaseStatement(tag)
-        };
+        return new SqlStatement[0];
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/DeleteGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/DeleteGenerator.java
@@ -24,8 +24,8 @@ public class DeleteGenerator extends AbstractSqlGenerator<DeleteStatement> {
     public Sql[] generateSql(DeleteStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
         StringBuffer sql = new StringBuffer("DELETE FROM " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()));
 
-        if (statement.getWhereClause() != null) {
-            String fixedWhereClause = " WHERE " + statement.getWhereClause();
+        if (statement.getWhere() != null) {
+            String fixedWhereClause = "WHERE " + statement.getWhere();
             for (String columnName : statement.getWhereColumnNames()) {
                 if (columnName == null) {
                     continue;

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/MarkChangeSetRanGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/MarkChangeSetRanGenerator.java
@@ -18,6 +18,7 @@ import liquibase.statement.SqlStatement;
 import liquibase.statement.core.InsertStatement;
 import liquibase.statement.core.MarkChangeSetRanStatement;
 import liquibase.statement.core.UpdateStatement;
+import liquibase.structure.core.Column;
 import liquibase.util.LiquibaseUtil;
 import liquibase.util.StringUtils;
 
@@ -46,7 +47,9 @@ public class MarkChangeSetRanGenerator extends AbstractSqlGenerator<MarkChangeSe
                         .addNewColumnValue("DATEEXECUTED", new DatabaseFunction(dateValue))
                         .addNewColumnValue("MD5SUM", changeSet.generateCheckSum().toString())
                         .addNewColumnValue("EXECTYPE", statement.getExecType().value)
-                        .setWhereClause("ID=? AND AUTHOR=? AND FILENAME=?")
+                        .setWhereClause(database.escapeObjectName("ID", Column.class) + " = ? " +
+                                "AND " + database.escapeObjectName("AUTHOR", Column.class) + " = ? " +
+                                "AND " + database.escapeObjectName("FILENAME", Column.class) + " = ?")
                         .addWhereParameters(changeSet.getId(), changeSet.getAuthor(), changeSet.getFilePath());
             } else {
                 runStatement = new InsertStatement(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogTableName())

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/RemoveChangeSetRanStatusGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/RemoveChangeSetRanStatusGenerator.java
@@ -4,11 +4,11 @@ import liquibase.changelog.ChangeSet;
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
 import liquibase.sql.Sql;
-import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.SqlGeneratorFactory;
 import liquibase.statement.core.DeleteStatement;
 import liquibase.statement.core.RemoveChangeSetRanStatusStatement;
+import liquibase.structure.core.Column;
 
 public class RemoveChangeSetRanStatusGenerator extends AbstractSqlGenerator<RemoveChangeSetRanStatusStatement> {
 
@@ -24,7 +24,9 @@ public class RemoveChangeSetRanStatusGenerator extends AbstractSqlGenerator<Remo
         ChangeSet changeSet = statement.getChangeSet();
 
         return SqlGeneratorFactory.getInstance().generateSql(new DeleteStatement(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogTableName())
-                .setWhereClause("ID=? AND AUTHOR=? AND FILENAME=?")
+                .setWhere(database.escapeObjectName("ID", Column.class) + " = ? " +
+                        "AND " + database.escapeObjectName("AUTHOR", Column.class) + " = ? " +
+                        "AND " + database.escapeObjectName("FILENAME", Column.class) + " = ?")
                 .addWhereParameters(changeSet.getId(), changeSet.getAuthor(), changeSet.getFilePath())
                 , database);
     }

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/TagDatabaseGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/TagDatabaseGenerator.java
@@ -12,6 +12,7 @@ import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.SqlGeneratorFactory;
 import liquibase.statement.core.TagDatabaseStatement;
 import liquibase.statement.core.UpdateStatement;
+import liquibase.structure.core.Column;
 
 public class TagDatabaseGenerator extends AbstractSqlGenerator<TagDatabaseStatement> {
 
@@ -78,11 +79,11 @@ public class TagDatabaseGenerator extends AbstractSqlGenerator<TagDatabaseStatem
             };
         } else {
             updateStatement.setWhereClause(
-                    "DATEEXECUTED = (" +
-                        "SELECT MAX(DATEEXECUTED) " +
+                    database.escapeObjectName("DATEEXECUTED", Column.class) + " = (" +
+                        "SELECT MAX(" + database.escapeObjectName("DATEEXECUTED", Column.class) + ") " +
                         "FROM " + tableNameEscaped +
                     ") " +
-                    "AND TAG IS NULL");
+                    "AND " + database.escapeObjectName("TAG", Column.class) + " IS NULL");
         }
 
         return SqlGeneratorFactory.getInstance().generateSql(updateStatement, database);

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/TagDatabaseGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/TagDatabaseGenerator.java
@@ -3,13 +3,13 @@ package liquibase.sqlgenerator.core;
 import liquibase.database.Database;
 import liquibase.database.core.InformixDatabase;
 import liquibase.database.core.MySQLDatabase;
+import liquibase.datatype.DataTypeFactory;
+import liquibase.exception.DatabaseException;
 import liquibase.exception.ValidationErrors;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
-import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.SqlGeneratorFactory;
-import liquibase.statement.SqlStatement;
 import liquibase.statement.core.TagDatabaseStatement;
 import liquibase.statement.core.UpdateStatement;
 
@@ -24,32 +24,61 @@ public class TagDatabaseGenerator extends AbstractSqlGenerator<TagDatabaseStatem
 
     @Override
     public Sql[] generateSql(TagDatabaseStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
-    	String liquibaseSchema = null;
-   		liquibaseSchema = database.getLiquibaseSchemaName();
-        UpdateStatement updateStatement = new UpdateStatement(database.getLiquibaseCatalogName(), liquibaseSchema, database.getDatabaseChangeLogTableName());
+        UpdateStatement updateStatement = new UpdateStatement(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogTableName());
         updateStatement.addNewColumnValue("TAG", statement.getTag());
+        String tableNameEscaped = database.escapeTableName(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogTableName());
+        String tagEscaped = DataTypeFactory.getInstance().fromObject(statement.getTag(), database).objectToSql(statement.getTag(), database);
         if (database instanceof MySQLDatabase) {
             try {
-                long version = Long.parseLong(database.getDatabaseProductVersion().substring(0, 1));
-
-                if (version < 5) {
-                    return new Sql[]{
-                            new UnparsedSql("UPDATE "+database.escapeTableName(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogTableName())+" C LEFT JOIN (SELECT MAX(DATEEXECUTED) as MAXDATE FROM (SELECT DATEEXECUTED FROM `DATABASECHANGELOG`) AS X) D ON C.DATEEXECUTED = D.MAXDATE SET C.TAG = '" + statement.getTag() + "' WHERE D.MAXDATE IS NOT NULL")
+                if (database.getDatabaseMajorVersion() < 5) {
+                    return new Sql[] {
+                        new UnparsedSql(
+                                "UPDATE " + tableNameEscaped + " C " +
+                                "LEFT JOIN (" +
+                                    "SELECT MAX(DATEEXECUTED) as MAXDATE " +
+                                    "FROM (" +
+                                        "SELECT DATEEXECUTED " +
+                                        "FROM " + tableNameEscaped +
+                                    ") AS X" +
+                                ") AS D " +
+                                "ON C.DATEEXECUTED = D.MAXDATE " +
+                                "SET C.TAG = " + tagEscaped + " " +
+                                "WHERE D.MAXDATE IS NOT NULL")
                     };
                 }
-
-            } catch (Throwable e) {
-                ; //assume it is version 5
+            } catch (DatabaseException e) {
+                //assume it is version 5 or greater
             }
-            updateStatement.setWhereClause("DATEEXECUTED = (SELECT MAX(DATEEXECUTED) FROM (SELECT DATEEXECUTED FROM " + database.escapeTableName(database.getLiquibaseCatalogName(), liquibaseSchema, database.getDatabaseChangeLogTableName()) + ") AS X)");
+            updateStatement.setWhereClause(
+                    "DATEEXECUTED = (" +
+                        "SELECT MAX(DATEEXECUTED) " +
+                        "FROM (" +
+                            "SELECT DATEEXECUTED " +
+                            "FROM " + tableNameEscaped +
+                        ") AS X" +
+                    ")");
         } else if (database instanceof InformixDatabase) {
-            return new Sql[]{
-                    new UnparsedSql("SELECT MAX(dateexecuted) max_date FROM " + database.escapeTableName(database.getLiquibaseCatalogName(), liquibaseSchema, database.getDatabaseChangeLogTableName()) + " INTO TEMP max_date_temp WITH NO LOG"),
-                    new UnparsedSql("UPDATE "+database.escapeTableName(database.getLiquibaseCatalogName(), liquibaseSchema, database.getDatabaseChangeLogTableName())+" SET TAG = '"+statement.getTag()+"' WHERE DATEEXECUTED = (SELECT max_date FROM max_date_temp);"),
-                    new UnparsedSql("DROP TABLE max_date_temp;")
+            return new Sql[] {
+                    new UnparsedSql(
+                            "SELECT MAX(dateexecuted) max_date " +
+                            "FROM " + tableNameEscaped + " " +
+                            "INTO TEMP max_date_temp WITH NO LOG"),
+                    new UnparsedSql(
+                            "UPDATE " + tableNameEscaped + " " +
+                            "SET TAG = " + tagEscaped + " " +
+                            "WHERE DATEEXECUTED = (" +
+                                "SELECT max_date " +
+                                "FROM max_date_temp" +
+                            ");"),
+                    new UnparsedSql(
+                            "DROP TABLE max_date_temp;")
             };
         } else {
-            updateStatement.setWhereClause("DATEEXECUTED = (SELECT MAX(DATEEXECUTED) FROM " + database.escapeTableName(database.getLiquibaseCatalogName(), liquibaseSchema, database.getDatabaseChangeLogTableName()) + ")");
+            updateStatement.setWhereClause(
+                    "DATEEXECUTED = (" +
+                        "SELECT MAX(DATEEXECUTED) " +
+                        "FROM " + tableNameEscaped +
+                    ")");
         }
 
         return SqlGeneratorFactory.getInstance().generateSql(updateStatement, database);

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/TagDatabaseGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/TagDatabaseGenerator.java
@@ -43,7 +43,8 @@ public class TagDatabaseGenerator extends AbstractSqlGenerator<TagDatabaseStatem
                                 ") AS D " +
                                 "ON C.DATEEXECUTED = D.MAXDATE " +
                                 "SET C.TAG = " + tagEscaped + " " +
-                                "WHERE D.MAXDATE IS NOT NULL")
+                                "WHERE D.MAXDATE IS NOT NULL " +
+                                "AND C.TAG IS NULL")
                     };
                 }
             } catch (DatabaseException e) {
@@ -56,7 +57,8 @@ public class TagDatabaseGenerator extends AbstractSqlGenerator<TagDatabaseStatem
                             "SELECT DATEEXECUTED " +
                             "FROM " + tableNameEscaped +
                         ") AS X" +
-                    ")");
+                    ") " +
+                    "AND TAG IS NULL");
         } else if (database instanceof InformixDatabase) {
             return new Sql[] {
                     new UnparsedSql(
@@ -69,7 +71,8 @@ public class TagDatabaseGenerator extends AbstractSqlGenerator<TagDatabaseStatem
                             "WHERE DATEEXECUTED = (" +
                                 "SELECT max_date " +
                                 "FROM max_date_temp" +
-                            ");"),
+                            ") " +
+                            "AND tag IS NULL;"),
                     new UnparsedSql(
                             "DROP TABLE max_date_temp;")
             };
@@ -78,7 +81,8 @@ public class TagDatabaseGenerator extends AbstractSqlGenerator<TagDatabaseStatem
                     "DATEEXECUTED = (" +
                         "SELECT MAX(DATEEXECUTED) " +
                         "FROM " + tableNameEscaped +
-                    ")");
+                    ") " +
+                    "AND TAG IS NULL");
         }
 
         return SqlGeneratorFactory.getInstance().generateSql(updateStatement, database);

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/UpdateChangeSetChecksumGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/UpdateChangeSetChecksumGenerator.java
@@ -9,6 +9,7 @@ import liquibase.sqlgenerator.SqlGeneratorFactory;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.UpdateChangeSetChecksumStatement;
 import liquibase.statement.core.UpdateStatement;
+import liquibase.structure.core.Column;
 
 public class UpdateChangeSetChecksumGenerator extends AbstractSqlGenerator<UpdateChangeSetChecksumStatement> {
     @Override
@@ -26,9 +27,9 @@ public class UpdateChangeSetChecksumGenerator extends AbstractSqlGenerator<Updat
         SqlStatement runStatement = null;
         runStatement = new UpdateStatement(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogTableName())
                 .addNewColumnValue("MD5SUM", changeSet.generateCheckSum().toString())
-                .setWhereClause(database.escapeColumnName(null, null, null, "ID") + " = ? " +
-                        "AND " + database.escapeColumnName(null, null, null, "AUTHOR") + " = ? " +
-                        "AND " + database.escapeColumnName(null, null, null, "FILENAME") + " = ?")
+                .setWhereClause(database.escapeObjectName("ID", Column.class) + " = ? " +
+                        "AND " + database.escapeObjectName("AUTHOR", Column.class) + " = ? " +
+                        "AND " + database.escapeObjectName("FILENAME", Column.class) + " = ?")
                 .addWhereParameters(changeSet.getId(), changeSet.getAuthor(), changeSet.getFilePath());
 
         return SqlGeneratorFactory.getInstance().generateSql(runStatement, database);

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/UpdateChangeSetChecksumGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/UpdateChangeSetChecksumGenerator.java
@@ -1,11 +1,9 @@
 package liquibase.sqlgenerator.core;
 
 import liquibase.changelog.ChangeSet;
-import liquibase.changelog.RanChangeSet;
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
 import liquibase.sql.Sql;
-import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.SqlGeneratorFactory;
 import liquibase.statement.SqlStatement;
@@ -28,7 +26,9 @@ public class UpdateChangeSetChecksumGenerator extends AbstractSqlGenerator<Updat
         SqlStatement runStatement = null;
         runStatement = new UpdateStatement(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogTableName())
                 .addNewColumnValue("MD5SUM", changeSet.generateCheckSum().toString())
-                .setWhereClause("ID=? AND AUTHOR=? AND FILENAME=?")
+                .setWhereClause(database.escapeColumnName(null, null, null, "ID") + " = ? " +
+                        "AND " + database.escapeColumnName(null, null, null, "AUTHOR") + " = ? " +
+                        "AND " + database.escapeColumnName(null, null, null, "FILENAME") + " = ?")
                 .addWhereParameters(changeSet.getId(), changeSet.getAuthor(), changeSet.getFilePath());
 
         return SqlGeneratorFactory.getInstance().generateSql(runStatement, database);


### PR DESCRIPTION
[CORE-2321](https://liquibase.jira.com/browse/CORE-2321) Liquibase tag command tags too much

I've tested this with Microsoft SQL Server 2008 R2 using DATEEXECUTED with data type date (no hours, minutes, seconds, or fractional seconds).