### PR TITLE
CORE-2325 Liquibase - New versions break DB create

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/LiquibaseDataType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/LiquibaseDataType.java
@@ -122,13 +122,25 @@ public abstract class LiquibaseDataType implements PrioritizedService {
         if (value == null || value.toString().equalsIgnoreCase("null")) {
             return null;
         } else if (value instanceof DatabaseFunction) {
-            return database.generateDatabaseFunctionValue((DatabaseFunction) value);
+            return functionToSql((DatabaseFunction) value, database);
         } else if (value instanceof Number) {
-            return formatNumber(value.toString());
+            return numberToSql((Number) value, database);
         }
-        return value.toString();
+        return otherToSql(value, database);
     }
-    
+
+    protected String functionToSql(DatabaseFunction function, Database database) {
+        return function == null ? null : database.generateDatabaseFunctionValue(function);
+    }
+
+    protected String numberToSql(Number number, Database database) {
+        return number == null ? null : formatNumber(number.toString());
+    }
+
+    protected String otherToSql(Object value, Database database) {
+        return value == null ? null : value.toString();
+    }
+
     public Object sqlToObject(String value, Database database) {
         return value;
     }

--- a/liquibase-core/src/main/java/liquibase/datatype/core/UUIDType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/UUIDType.java
@@ -1,5 +1,7 @@
 package liquibase.datatype.core;
 
+import java.util.Locale;
+
 import liquibase.database.Database;
 import liquibase.database.core.*;
 import liquibase.datatype.DataTypeInfo;
@@ -33,10 +35,13 @@ public class UUIDType extends LiquibaseDataType {
     }
 
     @Override
-    public String objectToSql(Object value, Database database) {
-        if (database instanceof MSSQLDatabase) {
-            return "'"+value+"'";
+    protected String otherToSql(Object value, Database database) {
+        if (value == null) {
+            return null;
         }
-        return super.objectToSql(value, database);
+        if (database instanceof MSSQLDatabase) {
+            return "'" + value.toString().toUpperCase(Locale.ENGLISH) + "'";
+        }
+        return super.otherToSql(value, database);
     }
 }

--- a/liquibase-core/src/main/java/liquibase/datatype/core/UUIDType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/UUIDType.java
@@ -9,7 +9,7 @@ import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.LiquibaseDataType;
 import liquibase.exception.DatabaseException;
 
-@DataTypeInfo(name="uuid", aliases = {"uniqueidentifier"}, minParameters = 0, maxParameters = 0, priority = LiquibaseDataType.PRIORITY_DEFAULT)
+@DataTypeInfo(name = "uuid", aliases = { "uniqueidentifier", "java.util.UUID" }, minParameters = 0, maxParameters = 0, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class UUIDType extends LiquibaseDataType {
     @Override
     public DatabaseDataType toDatabaseDataType(Database database) {

--- a/liquibase-core/src/test/groovy/liquibase/datatype/core/UUIDTypeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/core/UUIDTypeTest.groovy
@@ -1,0 +1,31 @@
+package liquibase.datatype.core
+
+import liquibase.database.core.*
+import liquibase.sdk.database.MockDatabase
+import liquibase.statement.DatabaseFunction
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class UUIDTypeTest extends Specification {
+    @Unroll("#featureName: #object for #database")
+    def "objectToSql"() {
+        when:
+        def type = new UUIDType()
+
+        then:
+        type.objectToSql(object, database) == expectedSql
+
+        where:
+        object                                                  | database            | expectedSql
+        null                                                    | new MockDatabase()  | null
+        "NULL"                                                  | new MockDatabase()  | null
+        "DFD8E505-0BB7-4D3E-B341-AD17190D8C9E"                  | new MockDatabase()  | "DFD8E505-0BB7-4D3E-B341-AD17190D8C9E"
+        UUID.fromString("dfd8e505-0bb7-4d3e-b341-ad17190d8c9e") | new MockDatabase()  | "dfd8e505-0bb7-4d3e-b341-ad17190d8c9e"
+        null                                                    | new MSSQLDatabase() | null
+        "NULL"                                                  | new MSSQLDatabase() | null
+        new DatabaseFunction("NEWID()")                         | new MSSQLDatabase() | "NEWID()"
+        new DatabaseFunction("NEWSEQUENTIALID()")               | new MSSQLDatabase() | "NEWSEQUENTIALID()"
+        "DFD8E505-0BB7-4D3E-B341-AD17190D8C9E"                  | new MSSQLDatabase() | "'DFD8E505-0BB7-4D3E-B341-AD17190D8C9E'"
+        UUID.fromString("dfd8e505-0bb7-4d3e-b341-ad17190d8c9e") | new MSSQLDatabase() | "'DFD8E505-0BB7-4D3E-B341-AD17190D8C9E'"
+    }
+}


### PR DESCRIPTION
[CORE-2325](https://liquibase.jira.com/browse/CORE-2325) Liquibase - New versions break DB create

Fixed UUIDType.objectToSql(), added a test case for UUIDType, added infrastructure for piecewise override of LiquibaseDataType.objectToSql(), added support for converting java.util.UUID