### PR TITLE
CORE-2217 Add DataTypeFactory support for delimited data type names, improve resolution of MSSQL data types

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -1480,4 +1480,9 @@ public abstract class AbstractJdbcDatabase implements Database {
     public String escapeDataTypeName(String dataTypeName) {
         return dataTypeName;
     }
+
+    @Override
+    public String unescapeDataTypeName(String dataTypeName) {
+        return dataTypeName;
+    }
 }

--- a/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -69,6 +69,7 @@ public abstract class AbstractJdbcDatabase implements Database {
     protected String sequenceCurrentValueFunction;
     protected String quotingStartCharacter = "\"";
     protected String quotingEndCharacter = "\"";
+    protected String quotingEndReplacement = "\"\"";
 
     // List of Database native functions.
     protected List<DatabaseFunction> dateFunctions = new ArrayList<DatabaseFunction>();
@@ -972,7 +973,13 @@ public abstract class AbstractJdbcDatabase implements Database {
     }
 
     public String quoteObject(final String objectName, final Class<? extends DatabaseObject> objectType) {
-        return quotingStartCharacter + escapeStringForDatabase(objectName) + quotingEndCharacter;
+        if (objectName == null) {
+            return null;
+        }
+
+        return quotingStartCharacter
+                + objectName.replace(quotingEndCharacter, quotingEndReplacement)
+                + quotingEndCharacter;
     }
 
     @Override
@@ -1467,5 +1474,10 @@ public abstract class AbstractJdbcDatabase implements Database {
     @Override
 	public String getSystemSchema(){
     	return "information_schema";
+    }
+
+    @Override
+    public String escapeDataTypeName(String dataTypeName) {
+        return dataTypeName;
     }
 }

--- a/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -1485,4 +1485,9 @@ public abstract class AbstractJdbcDatabase implements Database {
     public String unescapeDataTypeName(String dataTypeName) {
         return dataTypeName;
     }
+
+    @Override
+    public String unescapeDataTypeString(String dataTypeString) {
+        return dataTypeString;
+    }
 }

--- a/liquibase-core/src/main/java/liquibase/database/Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/Database.java
@@ -334,5 +334,7 @@ public interface Database extends PrioritizedService {
     public String getSystemSchema();
 
     public void addReservedWords(Collection<String> words);
+
+    String escapeDataTypeName(String dataTypeName);
 }
 

--- a/liquibase-core/src/main/java/liquibase/database/Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/Database.java
@@ -336,5 +336,7 @@ public interface Database extends PrioritizedService {
     public void addReservedWords(Collection<String> words);
 
     String escapeDataTypeName(String dataTypeName);
+
+    String unescapeDataTypeName(String dataTypeName);
 }
 

--- a/liquibase-core/src/main/java/liquibase/database/Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/Database.java
@@ -338,5 +338,7 @@ public interface Database extends PrioritizedService {
     String escapeDataTypeName(String dataTypeName);
 
     String unescapeDataTypeName(String dataTypeName);
+
+    String unescapeDataTypeString(String dataTypeString);
 }
 

--- a/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
@@ -8,7 +8,6 @@ import liquibase.database.DatabaseConnection;
 import liquibase.database.OfflineConnection;
 import liquibase.statement.core.RawSqlStatement;
 import liquibase.structure.DatabaseObject;
-import liquibase.structure.core.DataType;
 import liquibase.structure.core.Index;
 import liquibase.structure.core.Schema;
 import liquibase.structure.core.Table;
@@ -418,12 +417,12 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
     @Override
     public String escapeDataTypeName(String dataTypeName) {
         int indexOfPeriod = dataTypeName.indexOf('.');
-        
+
         if (indexOfPeriod < 0) {
             if (!dataTypeName.startsWith(quotingStartCharacter)) {
                 dataTypeName = escapeObjectName(dataTypeName, DatabaseObject.class);
             }
-            
+
             return dataTypeName;
         }
 
@@ -438,5 +437,29 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
         }
 
         return schemaName + "." + dataTypeName;
+    }
+
+    public String unescapeDataTypeName(String dataTypeName) {
+         int indexOfPeriod = dataTypeName.indexOf('.');
+
+         if (indexOfPeriod < 0) {
+             if (dataTypeName.matches("\\[[^]\\[]++\\]")) {
+                 dataTypeName = dataTypeName.substring(1, dataTypeName.length() - 1);
+             }
+
+             return dataTypeName;
+         }
+
+         String schemaName = dataTypeName.substring(0, indexOfPeriod);
+         if (schemaName.matches("\\[[^]\\[]++\\]")) {
+             schemaName = schemaName.substring(1, schemaName.length() - 1);
+         }
+
+         dataTypeName = dataTypeName.substring(indexOfPeriod + 1, dataTypeName.length());
+         if (dataTypeName.matches("\\[[^]\\[]++\\]")) {
+             dataTypeName = dataTypeName.substring(1, dataTypeName.length() - 1);
+         }
+
+         return schemaName + "." + dataTypeName;
     }
 }

--- a/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
@@ -421,7 +421,7 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
         
         if (indexOfPeriod < 0) {
             if (!dataTypeName.startsWith(quotingStartCharacter)) {
-                dataTypeName = escapeObjectName(dataTypeName, DataType.class);
+                dataTypeName = escapeObjectName(dataTypeName, DatabaseObject.class);
             }
             
             return dataTypeName;
@@ -434,7 +434,7 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
 
         dataTypeName = dataTypeName.substring(indexOfPeriod + 1, dataTypeName.length());
         if (!dataTypeName.startsWith(quotingStartCharacter)) {
-            dataTypeName = escapeObjectName(dataTypeName, DataType.class);
+            dataTypeName = escapeObjectName(dataTypeName, DatabaseObject.class);
         }
 
         return schemaName + "." + dataTypeName;

--- a/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
@@ -462,4 +462,14 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
 
          return schemaName + "." + dataTypeName;
     }
+
+    public String unescapeDataTypeString(String dataTypeString) {
+        int indexOfLeftParen = dataTypeString.indexOf('(');
+        if (indexOfLeftParen < 0) {
+            return unescapeDataTypeName(dataTypeString);
+        }
+
+        return unescapeDataTypeName(dataTypeString.substring(0, indexOfLeftParen))
+                + dataTypeString.substring(indexOfLeftParen);
+    }
 }

--- a/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
@@ -439,6 +439,7 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
         return schemaName + "." + dataTypeName;
     }
 
+    @Override
     public String unescapeDataTypeName(String dataTypeName) {
          int indexOfPeriod = dataTypeName.indexOf('.');
 
@@ -463,6 +464,7 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
          return schemaName + "." + dataTypeName;
     }
 
+    @Override
     public String unescapeDataTypeString(String dataTypeString) {
         int indexOfLeftParen = dataTypeString.indexOf('(');
         if (indexOfLeftParen < 0) {

--- a/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
@@ -33,6 +33,8 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
 
     private static Pattern CREATE_VIEW_AS_PATTERN = Pattern.compile("(?im)^\\s*(CREATE|ALTER)\\s+VIEW\\s+(\\S+)\\s+?AS\\s*", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
+	protected String quotingEndReplacement = "]]";
+
     @Override
     public String getShortName() {
         return "mssql";
@@ -365,4 +367,64 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
             return caseSensitive.booleanValue();
         }
     }
+
+    @Override
+    public int getDataTypeMaxParameters(String dataTypeName) {
+        if ("bigint".equalsIgnoreCase(dataTypeName)
+                || "bit".equalsIgnoreCase(dataTypeName)
+                || "date".equalsIgnoreCase(dataTypeName)
+                || "datetime".equalsIgnoreCase(dataTypeName)
+                || "geography".equalsIgnoreCase(dataTypeName)
+                || "geometry".equalsIgnoreCase(dataTypeName)
+                || "hierarchyid".equalsIgnoreCase(dataTypeName)
+                || "image".equalsIgnoreCase(dataTypeName)
+                || "int".equalsIgnoreCase(dataTypeName)
+                || "money".equalsIgnoreCase(dataTypeName)
+                || "ntext".equalsIgnoreCase(dataTypeName)
+                || "real".equalsIgnoreCase(dataTypeName)
+                || "smalldatetime".equalsIgnoreCase(dataTypeName)
+                || "smallint".equalsIgnoreCase(dataTypeName)
+                || "smallmoney".equalsIgnoreCase(dataTypeName)
+                || "text".equalsIgnoreCase(dataTypeName)
+                || "timestamp".equalsIgnoreCase(dataTypeName)
+                || "tinyint".equalsIgnoreCase(dataTypeName)
+                || "rowversion".equalsIgnoreCase(dataTypeName)
+                || "sql_variant".equalsIgnoreCase(dataTypeName)
+                || "uniqueidentifier".equalsIgnoreCase(dataTypeName)) {
+
+            return 0;
+        }
+
+        if ("binary".equalsIgnoreCase(dataTypeName)
+                || "char".equalsIgnoreCase(dataTypeName)
+                || "datetime2".equalsIgnoreCase(dataTypeName)
+                || "datetimeoffset".equalsIgnoreCase(dataTypeName)
+                || "float".equalsIgnoreCase(dataTypeName)
+                || "nchar".equalsIgnoreCase(dataTypeName)
+                || "nvarchar".equalsIgnoreCase(dataTypeName)
+                || "time".equalsIgnoreCase(dataTypeName)
+                || "varbinary".equalsIgnoreCase(dataTypeName)
+                || "varchar".equalsIgnoreCase(dataTypeName)
+                || "xml".equalsIgnoreCase(dataTypeName)) {
+
+            return 1;
+        }
+
+        return 2;
+    }
+
+	/**
+	 *
+	 * @param identifier
+	 * @return
+	 */
+	public String delimitIdentifier(String identifier) {
+		if (identifier == null) {
+			return null;
+		}
+
+		return quotingStartCharacter
+				+ identifier.replace(quotingEndCharacter, quotingEndReplacement)
+				+ quotingEndCharacter;
+	}
 }

--- a/liquibase-core/src/main/java/liquibase/datatype/DataTypeFactory.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/DataTypeFactory.java
@@ -95,15 +95,23 @@ public class DataTypeFactory {
     public LiquibaseDataType fromDescription(String dataTypeDefinition, Database database) {
         String dataTypeName = dataTypeDefinition;
         if (dataTypeName.matches(".+\\(.*\\).*")) {
-            dataTypeName = dataTypeDefinition.replaceFirst("\\s*\\(.*\\)", "");
+            dataTypeName = dataTypeName.replaceFirst("\\s*\\(.*\\)", "");
         }
         if (dataTypeName.matches(".+\\{.*")) {
             dataTypeName = dataTypeName.replaceFirst("\\s*\\{.*", "");
         }
-        boolean primaryKey = false;
+        boolean autoIncrement = false;
         if (dataTypeName.endsWith(" identity")) {
             dataTypeName = dataTypeName.replaceFirst(" identity$", "");
-            primaryKey = true;
+            autoIncrement = true;
+        }
+        // unquote delimited identifiers
+        if (dataTypeName.matches("\"[^\"]++\"") // surrounded with double quotes
+                || dataTypeName.matches("\\[[^]\\[]++\\]") // surrounded with square brackets (a la mssql)
+                || dataTypeName.matches("`[^`]++`") // surrounded with backticks (a la mysql)
+                || dataTypeName.matches("'[^']++'")) { // surrounded with single quotes
+
+            dataTypeName = dataTypeName.substring(1, dataTypeName.length() - 1);
         }
 
         String additionalInfo = null;
@@ -185,10 +193,10 @@ public class DataTypeFactory {
             }
         }
 
-        if (primaryKey && liquibaseDataType instanceof IntType) {
+        if (autoIncrement && liquibaseDataType instanceof IntType) {
             ((IntType) liquibaseDataType).setAutoIncrement(true);
         }
-        if (primaryKey && liquibaseDataType instanceof BigIntType) {
+        if (autoIncrement && liquibaseDataType instanceof BigIntType) {
             ((BigIntType) liquibaseDataType).setAutoIncrement(true);
         }
 

--- a/liquibase-core/src/main/java/liquibase/datatype/LiquibaseDataType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/LiquibaseDataType.java
@@ -9,7 +9,6 @@ import liquibase.statement.DatabaseFunction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 
 /**
  * Object representing a data type, instead of a plain string. It will be returned by
@@ -113,10 +112,7 @@ public abstract class LiquibaseDataType implements PrioritizedService {
 
     public DatabaseDataType toDatabaseDataType(Database database) {
         if (database instanceof MSSQLDatabase) {
-            String name = getName();
-            if (name.matches("(?i)[a-z0-9]+")) {
-            	name = ((MSSQLDatabase) database).delimitIdentifier(name.toLowerCase(Locale.ENGLISH));
-            }
+            String name = database.escapeDataTypeName(getName());
             int dataTypeMaxParameters = database.getDataTypeMaxParameters(getName());
             Object[] parameters = getParameters();
             if (dataTypeMaxParameters < parameters.length) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/BigIntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/BigIntType.java
@@ -32,8 +32,11 @@ public class BigIntType extends LiquibaseDataType {
         if (database instanceof OracleDatabase) {
             return new DatabaseDataType("NUMBER", 38,0);
         }
+        if (database instanceof MSSQLDatabase) {
+            return new DatabaseDataType("[bigint]");
+        }
         if (database instanceof DB2Database || database instanceof DerbyDatabase
-                || database instanceof MSSQLDatabase || database instanceof HsqlDatabase || database instanceof FirebirdDatabase || database instanceof MySQLDatabase) {
+                || database instanceof HsqlDatabase || database instanceof FirebirdDatabase || database instanceof MySQLDatabase) {
             return new DatabaseDataType("BIGINT");
         }
         if (database instanceof PostgresDatabase) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/BigIntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/BigIntType.java
@@ -33,7 +33,7 @@ public class BigIntType extends LiquibaseDataType {
             return new DatabaseDataType("NUMBER", 38,0);
         }
         if (database instanceof MSSQLDatabase) {
-            return new DatabaseDataType("[bigint]");
+            return new DatabaseDataType(database.escapeDataTypeName("bigint"));
         }
         if (database instanceof DB2Database || database instanceof DerbyDatabase
                 || database instanceof HsqlDatabase || database instanceof FirebirdDatabase || database instanceof MySQLDatabase) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/BlobType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/BlobType.java
@@ -2,7 +2,6 @@ package liquibase.datatype.core;
 
 import java.math.BigInteger;
 import java.util.Arrays;
-import java.util.Locale;
 
 import liquibase.database.Database;
 import liquibase.database.core.*;
@@ -39,7 +38,7 @@ public class BlobType extends LiquibaseDataType {
                 } else if (parameters.length > 1) {
                     parameters = Arrays.copyOfRange(parameters, 0, 1);
                 }
-                return new DatabaseDataType("[varbinary]", parameters);
+                return new DatabaseDataType(database.escapeDataTypeName("varbinary"), parameters);
             }
             if (originalDefinition.equalsIgnoreCase("binary")
                     || originalDefinition.equals("[binary]")
@@ -51,12 +50,12 @@ public class BlobType extends LiquibaseDataType {
                 } else if (parameters.length > 1) {
                     parameters = Arrays.copyOfRange(parameters, 0, 1);
                 }
-                return new DatabaseDataType("[binary]", parameters);
+                return new DatabaseDataType(database.escapeDataTypeName("binary"), parameters);
             }
             if (originalDefinition.equalsIgnoreCase("image")
                     || originalDefinition.equals("[image]")) {
 
-                return new DatabaseDataType("[image]");
+                return new DatabaseDataType(database.escapeDataTypeName("image"));
             }
             boolean max = true;
             if (parameters.length > 0) {
@@ -67,17 +66,17 @@ public class BlobType extends LiquibaseDataType {
             if (max) {
                 try {
                     if (database.getDatabaseMajorVersion() <= 8) { //2000 or earlier
-                        return new DatabaseDataType("[image]");
+                        return new DatabaseDataType(database.escapeDataTypeName("image"));
                     }
                 } catch (DatabaseException ignore) {
                 } //assuming it is a newer version
 
-                return new DatabaseDataType("[varbinary]", "MAX");
+                return new DatabaseDataType(database.escapeDataTypeName("varbinary"), "MAX");
             }
             if (parameters.length > 1) {
                 parameters = Arrays.copyOfRange(parameters, 0, 1);
             }
-            return new DatabaseDataType("[varbinary]", parameters);
+            return new DatabaseDataType(database.escapeDataTypeName("varbinary"), parameters);
         }
         if (database instanceof MySQLDatabase) {
             if (originalDefinition.toLowerCase().startsWith("blob") || originalDefinition.equals("java.sql.Types.BLOB")) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/BlobType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/BlobType.java
@@ -11,7 +11,7 @@ import liquibase.datatype.LiquibaseDataType;
 import liquibase.exception.DatabaseException;
 import liquibase.util.StringUtils;
 
-@DataTypeInfo(name="blob", aliases = {"longblob", "longvarbinary", "java.sql.Types.BLOB", "java.sql.Types.LONGBLOB", "java.sql.Types.LONGVARBINARY", "java.sql.Types.VARBINARY", "java.sql.Types.BINARY", "varbinary", "binary", "image"}, minParameters = 0, maxParameters = 1, priority = LiquibaseDataType.PRIORITY_DEFAULT)
+@DataTypeInfo(name = "blob", aliases = { "longblob", "longvarbinary", "java.sql.Types.BLOB", "java.sql.Types.LONGBLOB", "java.sql.Types.LONGVARBINARY", "java.sql.Types.VARBINARY", "java.sql.Types.BINARY", "varbinary", "binary", "image", "tinyblob", "mediumblob" }, minParameters = 0, maxParameters = 1, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class BlobType extends LiquibaseDataType {
 
     @Override
@@ -83,6 +83,10 @@ public class BlobType extends LiquibaseDataType {
                 return new DatabaseDataType("BLOB");
             } else if (originalDefinition.toLowerCase().startsWith("varbinary") || originalDefinition.equals("java.sql.Types.VARBINARY")) {
                 return new DatabaseDataType("VARBINARY", getParameters());
+            } else if (originalDefinition.toLowerCase().startsWith("tinyblob")) {
+                return new DatabaseDataType("TINYBLOB");
+            } else if (originalDefinition.toLowerCase().startsWith("mediumblob")) {
+                return new DatabaseDataType("MEDIUMBLOB");
             } else {
                 return new DatabaseDataType("LONGBLOB");
             }

--- a/liquibase-core/src/main/java/liquibase/datatype/core/BooleanType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/BooleanType.java
@@ -28,7 +28,7 @@ public class BooleanType extends LiquibaseDataType {
         if (database instanceof DB2Database || database instanceof FirebirdDatabase) {
             return new DatabaseDataType("SMALLINT");
         } else if (database instanceof MSSQLDatabase) {
-            return new DatabaseDataType("[bit]");
+            return new DatabaseDataType(database.escapeDataTypeName("bit"));
         } else if (database instanceof MySQLDatabase) {
             if (originalDefinition.toLowerCase().startsWith("bit")) {
                 return new DatabaseDataType("BIT", getParameters());

--- a/liquibase-core/src/main/java/liquibase/datatype/core/BooleanType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/BooleanType.java
@@ -17,18 +17,20 @@ import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.LiquibaseDataType;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.statement.DatabaseFunction;
+import liquibase.util.StringUtils;
 
 @DataTypeInfo(name = "boolean", aliases = {"java.sql.Types.BOOLEAN", "java.lang.Boolean", "bit"}, minParameters = 0, maxParameters = 0, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class BooleanType extends LiquibaseDataType {
 
     @Override
     public DatabaseDataType toDatabaseDataType(Database database) {
+        String originalDefinition = StringUtils.trimToEmpty(getRawDefinition());
         if (database instanceof DB2Database || database instanceof FirebirdDatabase) {
             return new DatabaseDataType("SMALLINT");
         } else if (database instanceof MSSQLDatabase) {
-            return new DatabaseDataType("BIT");
+            return new DatabaseDataType("[bit]");
         } else if (database instanceof MySQLDatabase) {
-            if (getRawDefinition().toLowerCase().startsWith("bit")) {
+            if (originalDefinition.toLowerCase().startsWith("bit")) {
                 return new DatabaseDataType("BIT", getParameters());
             }
             return new DatabaseDataType("BIT", 1);

--- a/liquibase-core/src/main/java/liquibase/datatype/core/CharType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/CharType.java
@@ -1,15 +1,40 @@
 package liquibase.datatype.core;
 
+import java.math.BigInteger;
+import java.util.Arrays;
+
 import liquibase.database.Database;
 import liquibase.database.core.MSSQLDatabase;
 import liquibase.database.core.PostgresDatabase;
 import liquibase.datatype.DataTypeInfo;
+import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.LiquibaseDataType;
 import liquibase.statement.DatabaseFunction;
 import liquibase.util.StringUtils;
 
 @DataTypeInfo(name="char", aliases = "java.sql.Types.CHAR", minParameters = 0, maxParameters = 1, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class CharType extends LiquibaseDataType {
+    @Override
+    public DatabaseDataType toDatabaseDataType(Database database) {
+        if (database instanceof MSSQLDatabase) {
+            Object[] parameters = getParameters();
+            if (parameters.length > 0) {
+                String param1 = parameters[0].toString();
+                if (!param1.matches("\\d+")
+                        || new BigInteger(param1).compareTo(BigInteger.valueOf(8000)) > 0) {
+
+                    return new DatabaseDataType("[char]", 8000); 
+                }
+            }
+            if (parameters.length == 0) {
+                parameters = new Object[] { 1 };
+            } else if (parameters.length > 1) {
+                parameters = Arrays.copyOfRange(parameters, 0, 1);
+            }
+            return new DatabaseDataType("[char]", parameters);
+        }
+        return super.toDatabaseDataType(database);
+    }
 
     @Override
     public String objectToSql(Object value, Database database) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/CharType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/CharType.java
@@ -23,7 +23,7 @@ public class CharType extends LiquibaseDataType {
                 if (!param1.matches("\\d+")
                         || new BigInteger(param1).compareTo(BigInteger.valueOf(8000)) > 0) {
 
-                    return new DatabaseDataType("[char]", 8000); 
+                    return new DatabaseDataType(database.escapeDataTypeName("char"), 8000);
                 }
             }
             if (parameters.length == 0) {
@@ -31,7 +31,7 @@ public class CharType extends LiquibaseDataType {
             } else if (parameters.length > 1) {
                 parameters = Arrays.copyOfRange(parameters, 0, 1);
             }
-            return new DatabaseDataType("[char]", parameters);
+            return new DatabaseDataType(database.escapeDataTypeName("char"), parameters);
         }
         return super.toDatabaseDataType(database);
     }

--- a/liquibase-core/src/main/java/liquibase/datatype/core/ClobType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/ClobType.java
@@ -47,12 +47,12 @@ public class ClobType extends LiquibaseDataType {
             if (originalDefinition.equalsIgnoreCase("text")
                     || originalDefinition.equals("[text]")) {
 
-                return new DatabaseDataType("[text]");
+                return new DatabaseDataType(database.escapeDataTypeName("text"));
             }
             if (originalDefinition.equalsIgnoreCase("ntext")
                     || originalDefinition.equals("[ntext]")) {
 
-                return new DatabaseDataType("[ntext]");
+                return new DatabaseDataType(database.escapeDataTypeName("ntext"));
             }
             Object[] parameters = getParameters();
             boolean max = true;
@@ -64,16 +64,16 @@ public class ClobType extends LiquibaseDataType {
             if (max) {
                 try {
                     if (database.getDatabaseMajorVersion() <= 8) { //2000 or earlier
-                        return new DatabaseDataType("[ntext]");
+                        return new DatabaseDataType(database.escapeDataTypeName("ntext"));
                     }
                 } catch (DatabaseException ignore) { } //assuming it is a newer version
 
-                return new DatabaseDataType("[nvarchar]", "MAX");
+                return new DatabaseDataType(database.escapeDataTypeName("nvarchar"), "MAX");
             }
             if (parameters.length > 1) {
                 parameters = Arrays.copyOfRange(parameters, 0, 1);
             }
-            return new DatabaseDataType("[nvarchar]", parameters);
+            return new DatabaseDataType(database.escapeDataTypeName("nvarchar"), parameters);
         } else if (database instanceof MySQLDatabase) {
             if (originalDefinition.toLowerCase().startsWith("text")) {
                 return new DatabaseDataType("TEXT");

--- a/liquibase-core/src/main/java/liquibase/datatype/core/CurrencyType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/CurrencyType.java
@@ -18,9 +18,9 @@ public class CurrencyType  extends LiquibaseDataType {
             if (originalDefinition.equalsIgnoreCase("smallmoney")
                     || originalDefinition.equals("[smallmoney]")) {
 
-                return new DatabaseDataType("[smallmoney]");
+                return new DatabaseDataType(database.escapeDataTypeName("smallmoney"));
             }
-            return new DatabaseDataType("[money]");
+            return new DatabaseDataType(database.escapeDataTypeName("money"));
         }
         if (database instanceof InformixDatabase || database instanceof SybaseASADatabase || database instanceof SybaseDatabase) {
             return new DatabaseDataType("MONEY");

--- a/liquibase-core/src/main/java/liquibase/datatype/core/CurrencyType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/CurrencyType.java
@@ -5,14 +5,24 @@ import liquibase.database.core.*;
 import liquibase.datatype.DataTypeInfo;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.LiquibaseDataType;
+import liquibase.util.StringUtils;
 
 
-@DataTypeInfo(name="currency", aliases = "money", minParameters = 0, maxParameters = 0, priority = LiquibaseDataType.PRIORITY_DEFAULT)
+@DataTypeInfo(name="currency", aliases = {"money", "smallmoney"}, minParameters = 0, maxParameters = 0, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class CurrencyType  extends LiquibaseDataType {
 
     @Override
     public DatabaseDataType toDatabaseDataType(Database database) {
-        if (database instanceof InformixDatabase || database instanceof MSSQLDatabase || database instanceof SybaseASADatabase || database instanceof SybaseDatabase) {
+        String originalDefinition = StringUtils.trimToEmpty(getRawDefinition());
+        if (database instanceof MSSQLDatabase) {
+            if (originalDefinition.equalsIgnoreCase("smallmoney")
+                    || originalDefinition.equals("[smallmoney]")) {
+
+                return new DatabaseDataType("[smallmoney]");
+            }
+            return new DatabaseDataType("[money]");
+        }
+        if (database instanceof InformixDatabase || database instanceof SybaseASADatabase || database instanceof SybaseDatabase) {
             return new DatabaseDataType("MONEY");
         }
         if (database instanceof OracleDatabase) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/DateTimeType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/DateTimeType.java
@@ -40,7 +40,7 @@ public class DateTimeType extends LiquibaseDataType {
             if (originalDefinition.equalsIgnoreCase("smalldatetime")
                     || originalDefinition.equals("[smalldatetime]")) {
 
-                return new DatabaseDataType("[smalldatetime]");
+                return new DatabaseDataType(database.escapeDataTypeName("smalldatetime"));
             } else if (originalDefinition.equalsIgnoreCase("datetime2")
                     || originalDefinition.equals("[datetime2]")
                     || originalDefinition.matches("(?i)datetime2\\s*\\(.+")
@@ -48,7 +48,7 @@ public class DateTimeType extends LiquibaseDataType {
 
                 try {
                     if (database.getDatabaseMajorVersion() <= 9) { //2005 or earlier
-                        return new DatabaseDataType("[datetime]");
+                        return new DatabaseDataType(database.escapeDataTypeName("datetime"));
                     }
                 } catch (DatabaseException ignore) { } //assuming it is a newer version
 
@@ -57,9 +57,9 @@ public class DateTimeType extends LiquibaseDataType {
                 } else if (parameters.length > 1) {
                     parameters = Arrays.copyOfRange(parameters, 0, 1);
                 }
-                return new DatabaseDataType("[datetime2]", parameters);
+                return new DatabaseDataType(database.escapeDataTypeName("datetime2"), parameters);
             }
-            return new DatabaseDataType("[datetime]");
+            return new DatabaseDataType(database.escapeDataTypeName("datetime"));
         }
         if (database instanceof InformixDatabase) {
 

--- a/liquibase-core/src/main/java/liquibase/datatype/core/DateTimeType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/DateTimeType.java
@@ -8,19 +8,21 @@ import liquibase.statement.DatabaseFunction;
 import liquibase.database.Database;
 import liquibase.exception.DatabaseException;
 import liquibase.logging.LogFactory;
+import liquibase.util.StringUtils;
 
 import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 
 @DataTypeInfo(name = "datetime", aliases = {"java.sql.Types.DATETIME", "java.util.Date", "smalldatetime", "datetime2"}, minParameters = 0, maxParameters = 1, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class DateTimeType extends LiquibaseDataType {
 
     @Override
     public DatabaseDataType toDatabaseDataType(Database database) {
+        String originalDefinition = StringUtils.trimToEmpty(getRawDefinition());
         boolean allowFractional = supportsFractionalDigits(database);
-
         if (database instanceof DB2Database
                 || database instanceof DerbyDatabase
                 || database instanceof FirebirdDatabase
@@ -34,11 +36,30 @@ public class DateTimeType extends LiquibaseDataType {
         }
 
         if (database instanceof MSSQLDatabase) {
-            if ((getParameters().length > 0 && "16".equals(getParameters()[0])) || "SMALLDATETIME".equalsIgnoreCase(getRawDefinition())) {
-                   return new DatabaseDataType("SMALLDATETIME");
-            } else if (getRawDefinition().toLowerCase().startsWith("datetime2")) {
-                return new DatabaseDataType(getRawDefinition());
+            Object[] parameters = getParameters();
+            if (originalDefinition.equalsIgnoreCase("smalldatetime")
+                    || originalDefinition.equals("[smalldatetime]")) {
+
+                return new DatabaseDataType("[smalldatetime]");
+            } else if (originalDefinition.equalsIgnoreCase("datetime2")
+                    || originalDefinition.equals("[datetime2]")
+                    || originalDefinition.matches("(?i)datetime2\\s*\\(.+")
+                    || originalDefinition.matches("\\[datetime2\\]\\s*\\(.+")) {
+
+                try {
+                    if (database.getDatabaseMajorVersion() <= 9) { //2005 or earlier
+                        return new DatabaseDataType("[datetime]");
+                    }
+                } catch (DatabaseException ignore) { } //assuming it is a newer version
+
+                if (parameters.length == 0) {
+                    parameters = new Object[] { 7 };
+                } else if (parameters.length > 1) {
+                    parameters = Arrays.copyOfRange(parameters, 0, 1);
+                }
+                return new DatabaseDataType("[datetime2]", parameters);
             }
+            return new DatabaseDataType("[datetime]");
         }
         if (database instanceof InformixDatabase) {
 
@@ -68,13 +89,13 @@ public class DateTimeType extends LiquibaseDataType {
 
           // From changelog to the database
           if (getAdditionalInformation() != null && getAdditionalInformation().length() > 0) {
-            return new DatabaseDataType(getRawDefinition());
+            return new DatabaseDataType(originalDefinition);
           }
 
           return new DatabaseDataType("DATETIME YEAR TO FRACTION", 5);
         }
         if (database instanceof PostgresDatabase) {
-            String rawDefinition = getRawDefinition().toLowerCase();
+            String rawDefinition = originalDefinition.toLowerCase();
             Object[] params = getParameters();
             if (rawDefinition.contains("tz") || rawDefinition.contains("with time zone")) {
                 if (params.length == 0 || !allowFractional) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/DateType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/DateType.java
@@ -19,10 +19,10 @@ public class DateType extends LiquibaseDataType {
         if (database instanceof MSSQLDatabase) {
             try {
                 if (database.getDatabaseMajorVersion() <= 9) { //2005 or earlier
-                    return new DatabaseDataType("SMALLDATETIME");
+                    return new DatabaseDataType("[datetime]");
                 }
             } catch (DatabaseException ignore) { } //assuming it is a newer version
-
+            return new DatabaseDataType("[date]");
         }
         return new DatabaseDataType(getName());
     }

--- a/liquibase-core/src/main/java/liquibase/datatype/core/DateType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/DateType.java
@@ -19,10 +19,10 @@ public class DateType extends LiquibaseDataType {
         if (database instanceof MSSQLDatabase) {
             try {
                 if (database.getDatabaseMajorVersion() <= 9) { //2005 or earlier
-                    return new DatabaseDataType("[datetime]");
+                    return new DatabaseDataType(database.escapeDataTypeName("datetime"));
                 }
             } catch (DatabaseException ignore) { } //assuming it is a newer version
-            return new DatabaseDataType("[date]");
+            return new DatabaseDataType(database.escapeDataTypeName("date"));
         }
         return new DatabaseDataType(getName());
     }

--- a/liquibase-core/src/main/java/liquibase/datatype/core/DecimalType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/DecimalType.java
@@ -1,5 +1,7 @@
 package liquibase.datatype.core;
 
+import java.util.Arrays;
+
 import liquibase.database.Database;
 import liquibase.database.core.*;
 import liquibase.datatype.DataTypeInfo;
@@ -21,6 +23,17 @@ public class DecimalType  extends LiquibaseDataType {
 
   @Override
   public DatabaseDataType toDatabaseDataType(Database database) {
+    if (database instanceof MSSQLDatabase) {
+      Object[] parameters = getParameters();
+      if (parameters.length == 0) {
+        parameters = new Object[] { 18, 0 };
+      } else if (parameters.length == 1) {
+        parameters = new Object[] { parameters[0], 0 };
+      } else if (parameters.length > 2) {
+        parameters = Arrays.copyOfRange(parameters, 0, 2);
+      }
+      return new DatabaseDataType("[decimal]", parameters);
+    }
     if (database instanceof InformixDatabase) {
 
       if(getParameters() != null && getParameters().length == 2) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/DecimalType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/DecimalType.java
@@ -32,7 +32,7 @@ public class DecimalType  extends LiquibaseDataType {
       } else if (parameters.length > 2) {
         parameters = Arrays.copyOfRange(parameters, 0, 2);
       }
-      return new DatabaseDataType("[decimal]", parameters);
+      return new DatabaseDataType(database.escapeDataTypeName("decimal"), parameters);
     }
     if (database instanceof InformixDatabase) {
 

--- a/liquibase-core/src/main/java/liquibase/datatype/core/DoubleType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/DoubleType.java
@@ -11,7 +11,7 @@ public class DoubleType  extends LiquibaseDataType {
     @Override
     public DatabaseDataType toDatabaseDataType(Database database) {
         if (database instanceof MSSQLDatabase) {
-            return new DatabaseDataType("[float](53)");
+            return new DatabaseDataType(database.escapeDataTypeName("float"), 53);
         }
         if (database instanceof MySQLDatabase) {
             return new DatabaseDataType("DOUBLE", getParameters());

--- a/liquibase-core/src/main/java/liquibase/datatype/core/DoubleType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/DoubleType.java
@@ -11,9 +11,8 @@ public class DoubleType  extends LiquibaseDataType {
     @Override
     public DatabaseDataType toDatabaseDataType(Database database) {
         if (database instanceof MSSQLDatabase) {
-            return new DatabaseDataType("FLOAT");
+            return new DatabaseDataType("[float](53)");
         }
-
         if (database instanceof MySQLDatabase) {
             return new DatabaseDataType("DOUBLE", getParameters());
         }

--- a/liquibase-core/src/main/java/liquibase/datatype/core/FloatType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/FloatType.java
@@ -1,19 +1,39 @@
 package liquibase.datatype.core;
 
+import java.util.Arrays;
+
 import liquibase.database.Database;
-import liquibase.database.core.DB2Database;
-import liquibase.database.core.DerbyDatabase;
 import liquibase.database.core.FirebirdDatabase;
 import liquibase.database.core.InformixDatabase;
+import liquibase.database.core.MSSQLDatabase;
 import liquibase.datatype.DataTypeInfo;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.LiquibaseDataType;
+import liquibase.util.StringUtils;
 
-@DataTypeInfo(name="float", aliases = {"java.sql.Types.FLOAT","java.lang.Float"}, minParameters = 0, maxParameters = 2, priority = LiquibaseDataType.PRIORITY_DEFAULT)
+@DataTypeInfo(name="float", aliases = {"java.sql.Types.FLOAT", "java.lang.Float", "real", "java.sql.Types.REAL"}, minParameters = 0, maxParameters = 2, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class FloatType  extends LiquibaseDataType {
 
     @Override
     public DatabaseDataType toDatabaseDataType(Database database) {
+        String originalDefinition = StringUtils.trimToEmpty(getRawDefinition());
+        if (database instanceof MSSQLDatabase) {
+            if ("real".equalsIgnoreCase(originalDefinition)
+                    || "[real]".equals(originalDefinition)
+                    || "java.lang.Float".equals(originalDefinition)
+                    || "java.sql.Types.REAL".equals(originalDefinition)) {
+
+                return new DatabaseDataType("[real]");
+            }
+            Object[] parameters = getParameters();
+            if (parameters.length == 0) {
+                parameters = new Object[] { 53 };
+            }
+            else if (parameters.length > 1) {
+                parameters = Arrays.copyOfRange(parameters, 0, 1);
+            }
+            return new DatabaseDataType("[float]", parameters);
+        }
         if (database instanceof FirebirdDatabase || database instanceof InformixDatabase) {
             return new DatabaseDataType("FLOAT");
         }

--- a/liquibase-core/src/main/java/liquibase/datatype/core/FloatType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/FloatType.java
@@ -3,9 +3,7 @@ package liquibase.datatype.core;
 import java.util.Arrays;
 
 import liquibase.database.Database;
-import liquibase.database.core.FirebirdDatabase;
-import liquibase.database.core.InformixDatabase;
-import liquibase.database.core.MSSQLDatabase;
+import liquibase.database.core.*;
 import liquibase.datatype.DataTypeInfo;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.LiquibaseDataType;
@@ -33,6 +31,11 @@ public class FloatType  extends LiquibaseDataType {
                 parameters = Arrays.copyOfRange(parameters, 0, 1);
             }
             return new DatabaseDataType(database.escapeDataTypeName("float"), parameters);
+        }
+        if (database instanceof MySQLDatabase || database instanceof DB2Database) {
+            if (originalDefinition.equalsIgnoreCase("REAL")) {
+                return new DatabaseDataType("REAL");
+            }
         }
         if (database instanceof FirebirdDatabase || database instanceof InformixDatabase) {
             return new DatabaseDataType("FLOAT");

--- a/liquibase-core/src/main/java/liquibase/datatype/core/FloatType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/FloatType.java
@@ -23,7 +23,7 @@ public class FloatType  extends LiquibaseDataType {
                     || "java.lang.Float".equals(originalDefinition)
                     || "java.sql.Types.REAL".equals(originalDefinition)) {
 
-                return new DatabaseDataType("[real]");
+                return new DatabaseDataType(database.escapeDataTypeName("real"));
             }
             Object[] parameters = getParameters();
             if (parameters.length == 0) {
@@ -32,7 +32,7 @@ public class FloatType  extends LiquibaseDataType {
             else if (parameters.length > 1) {
                 parameters = Arrays.copyOfRange(parameters, 0, 1);
             }
-            return new DatabaseDataType("[float]", parameters);
+            return new DatabaseDataType(database.escapeDataTypeName("float"), parameters);
         }
         if (database instanceof FirebirdDatabase || database instanceof InformixDatabase) {
             return new DatabaseDataType("FLOAT");

--- a/liquibase-core/src/main/java/liquibase/datatype/core/IntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/IntType.java
@@ -37,7 +37,10 @@ public class IntType extends LiquibaseDataType {
                 return new DatabaseDataType("SERIAL");
             }
         }
-        if (database instanceof MSSQLDatabase || database instanceof HsqlDatabase || database instanceof FirebirdDatabase || database instanceof InformixDatabase  || database instanceof MySQLDatabase) {
+        if (database instanceof MSSQLDatabase) {
+            return new DatabaseDataType("[int]");
+        }
+        if (database instanceof HsqlDatabase || database instanceof FirebirdDatabase || database instanceof InformixDatabase  || database instanceof MySQLDatabase) {
             return new DatabaseDataType("INT");
         }
         if (database instanceof SQLiteDatabase) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/IntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/IntType.java
@@ -38,7 +38,7 @@ public class IntType extends LiquibaseDataType {
             }
         }
         if (database instanceof MSSQLDatabase) {
-            return new DatabaseDataType("[int]");
+            return new DatabaseDataType(database.escapeDataTypeName("int"));
         }
         if (database instanceof HsqlDatabase || database instanceof FirebirdDatabase || database instanceof InformixDatabase  || database instanceof MySQLDatabase) {
             return new DatabaseDataType("INT");

--- a/liquibase-core/src/main/java/liquibase/datatype/core/MediumIntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/MediumIntType.java
@@ -23,7 +23,7 @@ public class MediumIntType extends LiquibaseDataType {
     @Override
     public DatabaseDataType toDatabaseDataType(Database database) {
         if (database instanceof MSSQLDatabase) {
-            return new DatabaseDataType("[int]");
+            return new DatabaseDataType(database.escapeDataTypeName("int"));
         }
         if (database instanceof DB2Database || database instanceof DerbyDatabase || database instanceof FirebirdDatabase || database instanceof MySQLDatabase) {
             return new DatabaseDataType("MEDIUMINT"); //always smallint regardless of parameters passed

--- a/liquibase-core/src/main/java/liquibase/datatype/core/MediumIntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/MediumIntType.java
@@ -22,7 +22,10 @@ public class MediumIntType extends LiquibaseDataType {
 
     @Override
     public DatabaseDataType toDatabaseDataType(Database database) {
-        if (database instanceof DB2Database || database instanceof DerbyDatabase || database instanceof FirebirdDatabase || database instanceof MSSQLDatabase || database instanceof MySQLDatabase) {
+        if (database instanceof MSSQLDatabase) {
+            return new DatabaseDataType("[int]");
+        }
+        if (database instanceof DB2Database || database instanceof DerbyDatabase || database instanceof FirebirdDatabase || database instanceof MySQLDatabase) {
             return new DatabaseDataType("MEDIUMINT"); //always smallint regardless of parameters passed
         }
         return super.toDatabaseDataType(database);

--- a/liquibase-core/src/main/java/liquibase/datatype/core/NCharType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/NCharType.java
@@ -1,7 +1,11 @@
 package liquibase.datatype.core;
 
+import java.math.BigInteger;
+import java.util.Arrays;
+
 import liquibase.database.Database;
 import liquibase.database.core.HsqlDatabase;
+import liquibase.database.core.MSSQLDatabase;
 import liquibase.database.core.OracleDatabase;
 import liquibase.datatype.DataTypeInfo;
 import liquibase.datatype.DatabaseDataType;
@@ -17,6 +21,23 @@ public class NCharType extends CharType {
         }
         if (database instanceof OracleDatabase) {
             return new DatabaseDataType("NCHAR", getParameters());
+        }
+        if (database instanceof MSSQLDatabase) {
+            Object[] parameters = getParameters();
+            if (parameters.length > 0) {
+                String param1 = parameters[0].toString();
+                if (!param1.matches("\\d+")
+                        || new BigInteger(param1).compareTo(BigInteger.valueOf(4000)) > 0) {
+
+                    return new DatabaseDataType("[nchar]", 4000);
+                }
+            }
+            if (parameters.length == 0) {
+              parameters = new Object[] { 1 };
+            } else if (parameters.length > 1) {
+                parameters = Arrays.copyOfRange(parameters, 0, 1);
+            }
+            return new DatabaseDataType("[nchar]", parameters);
         }
         return super.toDatabaseDataType(database);
     }

--- a/liquibase-core/src/main/java/liquibase/datatype/core/NCharType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/NCharType.java
@@ -29,7 +29,7 @@ public class NCharType extends CharType {
                 if (!param1.matches("\\d+")
                         || new BigInteger(param1).compareTo(BigInteger.valueOf(4000)) > 0) {
 
-                    return new DatabaseDataType("[nchar]", 4000);
+                    return new DatabaseDataType(database.escapeDataTypeName("nchar"), 4000);
                 }
             }
             if (parameters.length == 0) {
@@ -37,7 +37,7 @@ public class NCharType extends CharType {
             } else if (parameters.length > 1) {
                 parameters = Arrays.copyOfRange(parameters, 0, 1);
             }
-            return new DatabaseDataType("[nchar]", parameters);
+            return new DatabaseDataType(database.escapeDataTypeName("nchar"), parameters);
         }
         return super.toDatabaseDataType(database);
     }

--- a/liquibase-core/src/main/java/liquibase/datatype/core/NVarcharType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/NVarcharType.java
@@ -33,11 +33,11 @@ public class NVarcharType extends CharType {
 
                     try {
                         if (database.getDatabaseMajorVersion() <= 8) { //2000 or earlier
-                            return new DatabaseDataType("[nvarchar]", "4000");
+                            return new DatabaseDataType(database.escapeDataTypeName("nvarchar"), "4000");
                         }
                     } catch (DatabaseException ignore) { } //assuming it is a newer version
 
-                    return new DatabaseDataType("[nvarchar]", "MAX");
+                    return new DatabaseDataType(database.escapeDataTypeName("nvarchar"), "MAX");
                 }
             }
             if (parameters.length == 0) {
@@ -45,7 +45,7 @@ public class NVarcharType extends CharType {
             } else if (parameters.length > 1) {
                 parameters = Arrays.copyOfRange(parameters, 0, 1);
             }
-            return new DatabaseDataType("[nvarchar]", parameters);
+            return new DatabaseDataType(database.escapeDataTypeName("nvarchar"), parameters);
         }
         return super.toDatabaseDataType(database);
     }

--- a/liquibase-core/src/main/java/liquibase/datatype/core/NVarcharType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/NVarcharType.java
@@ -1,32 +1,51 @@
 package liquibase.datatype.core;
 
+import java.math.BigInteger;
+import java.util.Arrays;
+
 import liquibase.database.Database;
 import liquibase.database.core.*;
 import liquibase.datatype.DataTypeInfo;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.LiquibaseDataType;
+import liquibase.exception.DatabaseException;
 
 @DataTypeInfo(name="nvarchar", aliases = {"java.sql.Types.NVARCHAR", "nvarchar2"}, minParameters = 0, maxParameters = 1, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class NVarcharType extends CharType {
 
     @Override
     public DatabaseDataType toDatabaseDataType(Database database) {
-        if (database instanceof HsqlDatabase || database instanceof PostgresDatabase|| database instanceof DerbyDatabase) {
+        if (database instanceof HsqlDatabase
+                || database instanceof PostgresDatabase
+                || database instanceof DerbyDatabase) {
+
             return new DatabaseDataType("VARCHAR", getParameters());
         }
         if (database instanceof OracleDatabase) {
             return new DatabaseDataType("NVARCHAR2", getParameters());
         }
         if (database instanceof MSSQLDatabase) {
-            if (getParameters() != null && getParameters().length > 0) {
-                Object param1 = getParameters()[0];
-                if (param1.toString().matches("\\d+")) {
-                    if (Long.valueOf(param1.toString()) > 8000) {
-                        return new DatabaseDataType("NVARCHAR", "MAX");
-                    }
+            Object[] parameters = getParameters();
+            if (parameters.length > 0) {
+                String param1 = parameters[0].toString();
+                if (!param1.matches("\\d+")
+                        || new BigInteger(param1).compareTo(BigInteger.valueOf(4000L)) > 0) {
+
+                    try {
+                        if (database.getDatabaseMajorVersion() <= 8) { //2000 or earlier
+                            return new DatabaseDataType("[nvarchar]", "4000");
+                        }
+                    } catch (DatabaseException ignore) { } //assuming it is a newer version
+
+                    return new DatabaseDataType("[nvarchar]", "MAX");
                 }
             }
-            return new DatabaseDataType("NVARCHAR", getParameters());
+            if (parameters.length == 0) {
+                parameters = new Object[] { 1 };
+            } else if (parameters.length > 1) {
+                parameters = Arrays.copyOfRange(parameters, 0, 1);
+            }
+            return new DatabaseDataType("[nvarchar]", parameters);
         }
         return super.toDatabaseDataType(database);
     }

--- a/liquibase-core/src/main/java/liquibase/datatype/core/NumberType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/NumberType.java
@@ -32,7 +32,7 @@ public class NumberType extends LiquibaseDataType {
             } else if (parameters.length > 2) {
                 parameters = Arrays.copyOfRange(parameters, 0, 2);
             }
-            return new DatabaseDataType("[numeric]", parameters);
+            return new DatabaseDataType(database.escapeDataTypeName("numeric"), parameters);
         } else if (database instanceof MySQLDatabase
                 || database instanceof DB2Database
                 || database instanceof HsqlDatabase

--- a/liquibase-core/src/main/java/liquibase/datatype/core/NumberType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/NumberType.java
@@ -1,5 +1,7 @@
 package liquibase.datatype.core;
 
+import java.util.Arrays;
+
 import liquibase.database.Database;
 import liquibase.database.core.*;
 import liquibase.datatype.DataTypeInfo;
@@ -21,9 +23,18 @@ public class NumberType extends LiquibaseDataType {
 
     @Override
     public DatabaseDataType toDatabaseDataType(Database database) {
-        if (database instanceof MySQLDatabase
+        if (database instanceof MSSQLDatabase) {
+            Object[] parameters = getParameters();
+            if (parameters.length == 0) {
+                parameters = new Object[] { 18, 0 };
+            } else if (parameters.length == 1) {
+                parameters = new Object[] { parameters[0], 0 };
+            } else if (parameters.length > 2) {
+                parameters = Arrays.copyOfRange(parameters, 0, 2);
+            }
+            return new DatabaseDataType("[numeric]", parameters);
+        } else if (database instanceof MySQLDatabase
                 || database instanceof DB2Database
-                || database instanceof MSSQLDatabase
                 || database instanceof HsqlDatabase
                 || database instanceof DerbyDatabase
                 || database instanceof FirebirdDatabase

--- a/liquibase-core/src/main/java/liquibase/datatype/core/SmallIntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/SmallIntType.java
@@ -22,7 +22,10 @@ public class SmallIntType extends LiquibaseDataType {
 
     @Override
     public DatabaseDataType toDatabaseDataType(Database database) {
-        if (database instanceof DB2Database || database instanceof DerbyDatabase || database instanceof FirebirdDatabase || database instanceof MSSQLDatabase || database instanceof PostgresDatabase || database instanceof InformixDatabase || database instanceof MySQLDatabase) {
+        if (database instanceof MSSQLDatabase) {
+            return new DatabaseDataType("[smallint]"); //always smallint regardless of parameters passed
+        }
+        if (database instanceof DB2Database || database instanceof DerbyDatabase || database instanceof FirebirdDatabase || database instanceof PostgresDatabase || database instanceof InformixDatabase || database instanceof MySQLDatabase) {
             return new DatabaseDataType("SMALLINT"); //always smallint regardless of parameters passed
         }
 

--- a/liquibase-core/src/main/java/liquibase/datatype/core/SmallIntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/SmallIntType.java
@@ -23,7 +23,7 @@ public class SmallIntType extends LiquibaseDataType {
     @Override
     public DatabaseDataType toDatabaseDataType(Database database) {
         if (database instanceof MSSQLDatabase) {
-            return new DatabaseDataType("[smallint]"); //always smallint regardless of parameters passed
+            return new DatabaseDataType(database.escapeDataTypeName("smallint")); //always smallint regardless of parameters passed
         }
         if (database instanceof DB2Database || database instanceof DerbyDatabase || database instanceof FirebirdDatabase || database instanceof PostgresDatabase || database instanceof InformixDatabase || database instanceof MySQLDatabase) {
             return new DatabaseDataType("SMALLINT"); //always smallint regardless of parameters passed

--- a/liquibase-core/src/main/java/liquibase/datatype/core/TimeType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/TimeType.java
@@ -27,7 +27,7 @@ public class TimeType  extends LiquibaseDataType {
             Object[] parameters = getParameters();
             try {
                 if (database.getDatabaseMajorVersion() <= 9) {
-                    return new DatabaseDataType("[datetime]");
+                    return new DatabaseDataType(database.escapeDataTypeName("datetime"));
                 }
             } catch (DatabaseException e) {
                 //assume greater than sql 2008 and TIME will work
@@ -37,7 +37,7 @@ public class TimeType  extends LiquibaseDataType {
             } else if (parameters.length > 1) {
                 parameters = Arrays.copyOfRange(parameters, 0, 1);
             }
-            return new DatabaseDataType("[time]", parameters);
+            return new DatabaseDataType(database.escapeDataTypeName("time"), parameters);
         }
 
         if (database instanceof MySQLDatabase) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/TimestampType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/TimestampType.java
@@ -21,7 +21,7 @@ public class TimestampType extends DateTimeType {
             return super.toDatabaseDataType(database);
         }
         if (database instanceof MSSQLDatabase) {
-            return new DatabaseDataType("[datetime]");
+            return new DatabaseDataType(database.escapeDataTypeName("datetime"));
         }
         return super.toDatabaseDataType(database);
     }

--- a/liquibase-core/src/main/java/liquibase/datatype/core/TimestampType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/TimestampType.java
@@ -6,20 +6,22 @@ import liquibase.database.core.MySQLDatabase;
 import liquibase.datatype.DataTypeInfo;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.LiquibaseDataType;
+import liquibase.util.StringUtils;
 
 @DataTypeInfo(name = "timestamp", aliases = {"java.sql.Types.TIMESTAMP", "java.sql.Timestamp", "timestamptz"}, minParameters = 0, maxParameters = 1, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class TimestampType extends DateTimeType {
 
     @Override
     public DatabaseDataType toDatabaseDataType(Database database) {
+        String originalDefinition = StringUtils.trimToEmpty(getRawDefinition());
         if (database instanceof MySQLDatabase) {
-            if (getRawDefinition().contains(" ")) {
+            if (originalDefinition.contains(" ")) {
                 return new DatabaseDataType(getRawDefinition());
             }
             return super.toDatabaseDataType(database);
         }
         if (database instanceof MSSQLDatabase) {
-            return new DatabaseDataType("DATETIME");
+            return new DatabaseDataType("[datetime]");
         }
         return super.toDatabaseDataType(database);
     }

--- a/liquibase-core/src/main/java/liquibase/datatype/core/TinyIntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/TinyIntType.java
@@ -24,7 +24,7 @@ public class TinyIntType  extends LiquibaseDataType {
     @Override
     public DatabaseDataType toDatabaseDataType(Database database) {
         if (database instanceof MSSQLDatabase) {
-            return new DatabaseDataType("[tinyint]");
+            return new DatabaseDataType(database.escapeDataTypeName("tinyint"));
         }
         if (database instanceof DerbyDatabase || database instanceof PostgresDatabase || database instanceof FirebirdDatabase) {
             return new DatabaseDataType("SMALLINT");

--- a/liquibase-core/src/main/java/liquibase/datatype/core/TinyIntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/TinyIntType.java
@@ -23,10 +23,13 @@ public class TinyIntType  extends LiquibaseDataType {
 
     @Override
     public DatabaseDataType toDatabaseDataType(Database database) {
+        if (database instanceof MSSQLDatabase) {
+            return new DatabaseDataType("[tinyint]");
+        }
         if (database instanceof DerbyDatabase || database instanceof PostgresDatabase || database instanceof FirebirdDatabase) {
             return new DatabaseDataType("SMALLINT");
         }
-        if (database instanceof MSSQLDatabase || database instanceof MySQLDatabase) {
+        if (database instanceof MySQLDatabase) {
             return new DatabaseDataType("TINYINT");
         }
         if (database instanceof OracleDatabase) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/UUIDType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/UUIDType.java
@@ -21,7 +21,10 @@ public class UUIDType extends LiquibaseDataType {
             // fall back
         }
 
-        if (database instanceof MSSQLDatabase || database instanceof SybaseASADatabase || database instanceof SybaseDatabase) {
+        if (database instanceof MSSQLDatabase) {
+            return new DatabaseDataType("[uniqueidentifier]");
+        }
+        if (database instanceof SybaseASADatabase || database instanceof SybaseDatabase) {
             return new DatabaseDataType("UNIQUEIDENTIFIER");
         }
         if (database instanceof OracleDatabase) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/UUIDType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/UUIDType.java
@@ -22,7 +22,7 @@ public class UUIDType extends LiquibaseDataType {
         }
 
         if (database instanceof MSSQLDatabase) {
-            return new DatabaseDataType("[uniqueidentifier]");
+            return new DatabaseDataType(database.escapeDataTypeName("uniqueidentifier"));
         }
         if (database instanceof SybaseASADatabase || database instanceof SybaseDatabase) {
             return new DatabaseDataType("UNIQUEIDENTIFIER");

--- a/liquibase-core/src/main/java/liquibase/datatype/core/UnknownType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/UnknownType.java
@@ -10,7 +10,7 @@ import liquibase.datatype.LiquibaseDataType;
 import liquibase.statement.DatabaseFunction;
 
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.Locale;
 
 public class UnknownType extends LiquibaseDataType {
 
@@ -49,17 +49,15 @@ public class UnknownType extends LiquibaseDataType {
             parameters = new Object[0];
         }
 
-        if (database instanceof MSSQLDatabase && (
-                getName().equalsIgnoreCase("REAL")
-                || getName().equalsIgnoreCase("XML")
-                || getName().equalsIgnoreCase("HIERARCHYID")
-                || getName().equalsIgnoreCase("DATETIMEOFFSET")
-                || getName().equalsIgnoreCase("IMAGE")
-                || getName().equalsIgnoreCase("NTEXT")
-                || getName().equalsIgnoreCase("SYSNAME")
-                || getName().equalsIgnoreCase("SMALLMONEY")
-        )) {
-            parameters = new Object[0];
+        if (database instanceof MSSQLDatabase) {
+            String name = getName();
+            if (name.matches("(?i)[a-z0-9]+")) {
+            	name = ((MSSQLDatabase) database).delimitIdentifier(name.toLowerCase(Locale.ENGLISH));
+            }
+            if (dataTypeMaxParameters < parameters.length) {
+                parameters = Arrays.copyOfRange(parameters, 0, dataTypeMaxParameters);
+            }
+            return new DatabaseDataType(name, parameters);
         }
 
         if (database instanceof OracleDatabase) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/UnknownType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/UnknownType.java
@@ -10,7 +10,6 @@ import liquibase.datatype.LiquibaseDataType;
 import liquibase.statement.DatabaseFunction;
 
 import java.util.Arrays;
-import java.util.Locale;
 
 public class UnknownType extends LiquibaseDataType {
 
@@ -50,10 +49,7 @@ public class UnknownType extends LiquibaseDataType {
         }
 
         if (database instanceof MSSQLDatabase) {
-            String name = getName();
-            if (name.matches("(?i)[a-z0-9]+")) {
-            	name = ((MSSQLDatabase) database).delimitIdentifier(name.toLowerCase(Locale.ENGLISH));
-            }
+            String name = database.escapeDataTypeName(getName());
             if (dataTypeMaxParameters < parameters.length) {
                 parameters = Arrays.copyOfRange(parameters, 0, dataTypeMaxParameters);
             }

--- a/liquibase-core/src/main/java/liquibase/datatype/core/UnknownType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/UnknownType.java
@@ -1,10 +1,7 @@
 package liquibase.datatype.core;
 
 import liquibase.database.Database;
-import liquibase.database.core.DB2Database;
-import liquibase.database.core.MSSQLDatabase;
-import liquibase.database.core.MySQLDatabase;
-import liquibase.database.core.OracleDatabase;
+import liquibase.database.core.*;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.LiquibaseDataType;
 import liquibase.statement.DatabaseFunction;
@@ -34,17 +31,7 @@ public class UnknownType extends LiquibaseDataType {
             dataTypeMaxParameters = database.getDataTypeMaxParameters(getName());
         }
         Object[] parameters = getParameters();
-        if (database instanceof MySQLDatabase && (
-                getName().equalsIgnoreCase("TINYBLOB")
-                        || getName().equalsIgnoreCase("MEDIUMBLOB")
-                        || getName().equalsIgnoreCase("TINYTEXT")
-                        || getName().equalsIgnoreCase("MEDIUMTEXT")
-                        || getName().equalsIgnoreCase("REAL")
-        )) {
-            parameters = new Object[0];
-        }
-
-        if (database instanceof DB2Database && (getName().equalsIgnoreCase("REAL") || getName().equalsIgnoreCase("XML"))) {
+        if (database instanceof DB2Database && getName().equalsIgnoreCase("XML")) {
             parameters = new Object[0];
         }
 
@@ -58,7 +45,6 @@ public class UnknownType extends LiquibaseDataType {
 
         if (database instanceof OracleDatabase) {
             if (getName().equalsIgnoreCase("LONG")
-                    || getName().equalsIgnoreCase("NCLOB")
                     || getName().equalsIgnoreCase("BFILE")
                     || getName().equalsIgnoreCase("ROWID")
                     || getName().equalsIgnoreCase("XMLTYPE")

--- a/liquibase-core/src/main/java/liquibase/datatype/core/VarcharType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/VarcharType.java
@@ -36,11 +36,11 @@ public class VarcharType extends CharType {
 
                     try {
                         if (database.getDatabaseMajorVersion() <= 8) { //2000 or earlier
-                            return new DatabaseDataType("[varchar]", "8000");
+                            return new DatabaseDataType(database.escapeDataTypeName("varchar"), "8000");
                         }
                     } catch (DatabaseException ignore) { } //assuming it is a newer version
 
-                    return new DatabaseDataType("[varchar]", "MAX");
+                    return new DatabaseDataType(database.escapeDataTypeName("varchar"), "MAX");
                 }
             }
             if (parameters.length == 0) {
@@ -48,7 +48,7 @@ public class VarcharType extends CharType {
             } else if (parameters.length > 1) {
                 parameters = Arrays.copyOfRange(parameters, 0, 1);
             }
-            return new DatabaseDataType("[varchar]", parameters);
+            return new DatabaseDataType(database.escapeDataTypeName("varchar"), parameters);
         }
 
         return super.toDatabaseDataType(database);

--- a/liquibase-core/src/main/java/liquibase/datatype/core/VarcharType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/VarcharType.java
@@ -1,5 +1,8 @@
 package liquibase.datatype.core;
 
+import java.math.BigInteger;
+import java.util.Arrays;
+
 import liquibase.database.Database;
 import liquibase.database.core.HsqlDatabase;
 import liquibase.database.core.InformixDatabase;
@@ -8,6 +11,7 @@ import liquibase.database.core.OracleDatabase;
 import liquibase.datatype.DataTypeInfo;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.LiquibaseDataType;
+import liquibase.exception.DatabaseException;
 
 @DataTypeInfo(name="varchar", aliases = {"java.sql.Types.VARCHAR", "java.lang.String", "varchar2", "character varying"}, minParameters = 0, maxParameters = 1, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class VarcharType extends CharType {
@@ -24,15 +28,27 @@ public class VarcharType extends CharType {
         }
 
         if (database instanceof MSSQLDatabase) {
-            if (getParameters() != null && getParameters().length > 0) {
-                Object param1 = getParameters()[0];
-                if (param1.toString().matches("\\d+")) {
-                    if (Long.valueOf(param1.toString()) > 8000) {
-                        return new DatabaseDataType("VARCHAR", "MAX");
-                    }
+            Object[] parameters = getParameters();
+            if (parameters.length > 0) {
+                String param1 = parameters[0].toString();
+                if (!param1.matches("\\d+")
+                        || new BigInteger(param1).compareTo(BigInteger.valueOf(8000L)) > 0) {
+
+                    try {
+                        if (database.getDatabaseMajorVersion() <= 8) { //2000 or earlier
+                            return new DatabaseDataType("[varchar]", "8000");
+                        }
+                    } catch (DatabaseException ignore) { } //assuming it is a newer version
+
+                    return new DatabaseDataType("[varchar]", "MAX");
                 }
             }
-            return new DatabaseDataType("VARCHAR", getParameters());
+            if (parameters.length == 0) {
+                parameters = new Object[] { 1 };
+            } else if (parameters.length > 1) {
+                parameters = Arrays.copyOfRange(parameters, 0, 1);
+            }
+            return new DatabaseDataType("[varchar]", parameters);
         }
 
         return super.toDatabaseDataType(database);

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingTableChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingTableChangeGenerator.java
@@ -6,6 +6,7 @@ import liquibase.change.ConstraintsConfig;
 import liquibase.change.core.CreateTableChange;
 import liquibase.database.Database;
 import liquibase.database.core.InformixDatabase;
+import liquibase.database.core.MSSQLDatabase;
 import liquibase.database.core.MySQLDatabase;
 import liquibase.datatype.DataTypeFactory;
 import liquibase.datatype.DatabaseDataType;
@@ -68,7 +69,11 @@ public class MissingTableChangeGenerator implements MissingObjectChangeGenerator
             columnConfig.setName(column.getName());
             LiquibaseDataType ldt = DataTypeFactory.getInstance().from(column.getType(), comparisonDatabase);
             DatabaseDataType ddt = ldt.toDatabaseDataType(referenceDatabase);
-            columnConfig.setType(ddt.toString());
+            String typeString = ddt.toString();
+            if (referenceDatabase instanceof MSSQLDatabase) {
+                typeString = typeString.replace("[", "").replace("]", "");
+            }
+            columnConfig.setType(typeString);
 
             if (column.isAutoIncrement()) {
                 columnConfig.setAutoIncrement(true);

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingTableChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingTableChangeGenerator.java
@@ -71,7 +71,7 @@ public class MissingTableChangeGenerator implements MissingObjectChangeGenerator
             DatabaseDataType ddt = ldt.toDatabaseDataType(referenceDatabase);
             String typeString = ddt.toString();
             if (referenceDatabase instanceof MSSQLDatabase) {
-                typeString = referenceDatabase.unescapeDataTypeName(typeString);
+                typeString = referenceDatabase.unescapeDataTypeString(typeString);
             }
             columnConfig.setType(typeString);
 

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingTableChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingTableChangeGenerator.java
@@ -71,7 +71,7 @@ public class MissingTableChangeGenerator implements MissingObjectChangeGenerator
             DatabaseDataType ddt = ldt.toDatabaseDataType(referenceDatabase);
             String typeString = ddt.toString();
             if (referenceDatabase instanceof MSSQLDatabase) {
-                typeString = typeString.replace("[", "").replace("]", "");
+                typeString = referenceDatabase.unescapeDataTypeName(typeString);
             }
             columnConfig.setType(typeString);
 

--- a/liquibase-core/src/main/java/liquibase/sdk/database/MockDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/sdk/database/MockDatabase.java
@@ -762,4 +762,9 @@ public class MockDatabase implements Database, InternalDatabase {
     public String escapeDataTypeName(String dataTypeName) {
         return dataTypeName;
     }
+
+    @Override
+    public String unescapeDataTypeName(String dataTypeName) {
+        return dataTypeName;
+    }
 }

--- a/liquibase-core/src/main/java/liquibase/sdk/database/MockDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/sdk/database/MockDatabase.java
@@ -757,4 +757,9 @@ public class MockDatabase implements Database, InternalDatabase {
     public String toString() {
         return "Mock database";
     }
+
+    @Override
+    public String escapeDataTypeName(String dataTypeName) {
+        return dataTypeName;
+    }
 }

--- a/liquibase-core/src/main/java/liquibase/sdk/database/MockDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/sdk/database/MockDatabase.java
@@ -767,4 +767,9 @@ public class MockDatabase implements Database, InternalDatabase {
     public String unescapeDataTypeName(String dataTypeName) {
         return dataTypeName;
     }
+
+    @Override
+    public String unescapeDataTypeString(String dataTypeString) {
+        return dataTypeString;
+    }
 }

--- a/liquibase-core/src/main/java/liquibase/structure/core/DataType.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/DataType.java
@@ -1,14 +1,9 @@
 package liquibase.structure.core;
 
-import liquibase.parser.core.ParsedNode;
-import liquibase.parser.core.ParsedNodeException;
-import liquibase.resource.ResourceAccessor;
-import liquibase.serializer.AbstractLiquibaseSerializable;
-import liquibase.util.ObjectUtil;
+import liquibase.structure.AbstractDatabaseObject;
+import liquibase.structure.DatabaseObject;
 
-import java.util.Set;
-
-public class DataType extends AbstractLiquibaseSerializable {
+public class DataType extends AbstractDatabaseObject {
 
     private String typeName;
 
@@ -133,5 +128,26 @@ public class DataType extends AbstractLiquibaseSerializable {
     @Override
     public String getSerializedObjectNamespace() {
         return STANDARD_SNAPSHOT_NAMESPACE;
+    }
+
+    public DatabaseObject[] getContainingObjects() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return getAttribute("name", String.class);
+    }
+
+    @Override
+    public DataType setName(String name) {
+        setAttribute("name", name);
+        typeName = name;
+        return this;
+    }
+
+    @Override
+    public Schema getSchema() {
+        return null;
     }
 }

--- a/liquibase-core/src/main/java/liquibase/structure/core/DataType.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/DataType.java
@@ -1,8 +1,6 @@
 package liquibase.structure.core;
 
 import liquibase.serializer.AbstractLiquibaseSerializable;
-import liquibase.structure.AbstractDatabaseObject;
-import liquibase.structure.DatabaseObject;
 
 public class DataType extends AbstractLiquibaseSerializable {
 

--- a/liquibase-core/src/main/java/liquibase/structure/core/DataType.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/DataType.java
@@ -1,9 +1,10 @@
 package liquibase.structure.core;
 
+import liquibase.serializer.AbstractLiquibaseSerializable;
 import liquibase.structure.AbstractDatabaseObject;
 import liquibase.structure.DatabaseObject;
 
-public class DataType extends AbstractDatabaseObject {
+public class DataType extends AbstractLiquibaseSerializable {
 
     private String typeName;
 
@@ -128,26 +129,5 @@ public class DataType extends AbstractDatabaseObject {
     @Override
     public String getSerializedObjectNamespace() {
         return STANDARD_SNAPSHOT_NAMESPACE;
-    }
-
-    public DatabaseObject[] getContainingObjects() {
-        return null;
-    }
-
-    @Override
-    public String getName() {
-        return getAttribute("name", String.class);
-    }
-
-    @Override
-    public DataType setName(String name) {
-        setAttribute("name", name);
-        typeName = name;
-        return this;
-    }
-
-    @Override
-    public Schema getSchema() {
-        return null;
     }
 }

--- a/liquibase-core/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
@@ -1,30 +1,8 @@
 package liquibase.datatype
 
 import liquibase.database.DatabaseFactory
-import liquibase.database.core.MSSQLDatabase;
-import liquibase.datatype.core.BigIntType
-import liquibase.datatype.core.BlobType
-import liquibase.datatype.core.BooleanType
-import liquibase.datatype.core.CharType
-import liquibase.datatype.core.ClobType
-import liquibase.datatype.core.CurrencyType
-import liquibase.datatype.core.DateTimeType
-import liquibase.datatype.core.DateType
-import liquibase.datatype.core.DecimalType
-import liquibase.datatype.core.DoubleType
-import liquibase.datatype.core.FloatType;
-import liquibase.datatype.core.IntType
-import liquibase.datatype.core.MediumIntType
-import liquibase.datatype.core.NCharType
-import liquibase.datatype.core.NVarcharType
-import liquibase.datatype.core.NumberType
-import liquibase.datatype.core.SmallIntType
-import liquibase.datatype.core.TimeType
-import liquibase.datatype.core.TimestampType
-import liquibase.datatype.core.TinyIntType
-import liquibase.datatype.core.UUIDType
-import liquibase.datatype.core.UnknownType;
-import liquibase.datatype.core.VarcharType
+import liquibase.database.core.*
+import liquibase.datatype.core.*
 import liquibase.sdk.database.MockDatabase
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -57,6 +35,7 @@ public class DataTypeFactoryTest extends Specification {
         "serial8"                                            | new MockDatabase()    | "BIGINT"                                             | BigIntType    | true
         "int4"                                               | new MockDatabase()    | "INT"                                                | IntType       | false
         "serial4"                                            | new MockDatabase()    | "INT"                                                | IntType       | true
+        "real"                                               | new DB2Database()     | "REAL"                                               | FloatType     | false
         "bigint"                                             | new MSSQLDatabase()   | "[bigint]"                                           | BigIntType    | false
         "[bigint]"                                           | new MSSQLDatabase()   | "[bigint]"                                           | BigIntType    | false
         "binary"                                             | new MSSQLDatabase()   | "[binary](1)"                                        | BlobType      | false
@@ -71,7 +50,7 @@ public class DataTypeFactoryTest extends Specification {
         "[char]"                                             | new MSSQLDatabase()   | "[char](1)"                                          | CharType      | false
         "char(8000)"                                         | new MSSQLDatabase()   | "[char](8000)"                                       | CharType      | false
         "[char](8000)"                                       | new MSSQLDatabase()   | "[char](8000)"                                       | CharType      | false
-        "clob"                                               | new MSSQLDatabase()   | "[nvarchar](MAX)"                                    | ClobType      | false
+        "clob"                                               | new MSSQLDatabase()   | "[varchar](MAX)"                                     | ClobType      | false
         "currency"                                           | new MSSQLDatabase()   | "[money]"                                            | CurrencyType  | false
         "date"                                               | new MSSQLDatabase()   | "[date]"                                             | DateType      | false
         "[date]"                                             | new MSSQLDatabase()   | "[date]"                                             | DateType      | false
@@ -104,6 +83,7 @@ public class DataTypeFactoryTest extends Specification {
         "[nchar]"                                            | new MSSQLDatabase()   | "[nchar](1)"                                         | NCharType     | false
         "nchar(4000)"                                        | new MSSQLDatabase()   | "[nchar](4000)"                                      | NCharType     | false
         "[nchar](4000)"                                      | new MSSQLDatabase()   | "[nchar](4000)"                                      | NCharType     | false
+        "nclob"                                              | new MSSQLDatabase()   | "[nvarchar](MAX)"                                    | ClobType      | false
         "ntext"                                              | new MSSQLDatabase()   | "[ntext]"                                            | ClobType      | false
         "[ntext]"                                            | new MSSQLDatabase()   | "[ntext]"                                            | ClobType      | false
         "number"                                             | new MSSQLDatabase()   | "[numeric](18, 0)"                                   | NumberType    | false
@@ -167,5 +147,11 @@ public class DataTypeFactoryTest extends Specification {
         "MySchema.[MyUDT]"                                   | new MSSQLDatabase()   | "[MySchema].[MyUDT]"                                 | UnknownType   | false
         "[MySchema].MyUDT"                                   | new MSSQLDatabase()   | "[MySchema].[MyUDT]"                                 | UnknownType   | false
         "[MySchema].[MyUDT]"                                 | new MSSQLDatabase()   | "[MySchema].[MyUDT]"                                 | UnknownType   | false
+        "tinyblob"                                           | new MySQLDatabase()   | "TINYBLOB"                                           | BlobType      | false
+        "tinytext"                                           | new MySQLDatabase()   | "TINYTEXT"                                           | ClobType      | false
+        "mediumblob"                                         | new MySQLDatabase()   | "MEDIUMBLOB"                                         | BlobType      | false
+        "mediumtext"                                         | new MySQLDatabase()   | "MEDIUMTEXT"                                         | ClobType      | false
+        "real"                                               | new MySQLDatabase()   | "REAL"                                               | FloatType     | false
+        "nclob"                                              | new OracleDatabase()  | "NCLOB"                                              | ClobType      | false
     }
 }

--- a/liquibase-core/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
@@ -163,5 +163,9 @@ public class DataTypeFactoryTest extends Specification {
         "[xml](CONTENT [MySchema].[MyXmlSchemaCollection])"  | new MSSQLDatabase()   | "[xml](CONTENT [MySchema].[MyXmlSchemaCollection])"  | UnknownType   | false
         "xml(DOCUMENT [MySchema].[MyXmlSchemaCollection])"   | new MSSQLDatabase()   | "[xml](DOCUMENT [MySchema].[MyXmlSchemaCollection])" | UnknownType   | false
         "[xml](DOCUMENT [MySchema].[MyXmlSchemaCollection])" | new MSSQLDatabase()   | "[xml](DOCUMENT [MySchema].[MyXmlSchemaCollection])" | UnknownType   | false
+        "MySchema.MyUDT"                                     | new MSSQLDatabase()   | "[MySchema].[MyUDT]"                                 | UnknownType   | false
+        "MySchema.[MyUDT]"                                   | new MSSQLDatabase()   | "[MySchema].[MyUDT]"                                 | UnknownType   | false
+        "[MySchema].MyUDT"                                   | new MSSQLDatabase()   | "[MySchema].[MyUDT]"                                 | UnknownType   | false
+        "[MySchema].[MyUDT]"                                 | new MSSQLDatabase()   | "[MySchema].[MyUDT]"                                 | UnknownType   | false
     }
 }

--- a/liquibase-core/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
@@ -1,43 +1,167 @@
-package liquibase.datatype;
+package liquibase.datatype
 
-import liquibase.database.core.H2Database
-import liquibase.datatype.core.BigIntType;
-import liquibase.datatype.core.IntType;
+import liquibase.database.DatabaseFactory
+import liquibase.database.core.MSSQLDatabase;
+import liquibase.datatype.core.BigIntType
+import liquibase.datatype.core.BlobType
+import liquibase.datatype.core.BooleanType
+import liquibase.datatype.core.CharType
+import liquibase.datatype.core.ClobType
+import liquibase.datatype.core.CurrencyType
+import liquibase.datatype.core.DateTimeType
+import liquibase.datatype.core.DateType
+import liquibase.datatype.core.DecimalType
+import liquibase.datatype.core.DoubleType
+import liquibase.datatype.core.FloatType;
+import liquibase.datatype.core.IntType
+import liquibase.datatype.core.MediumIntType
+import liquibase.datatype.core.NCharType
+import liquibase.datatype.core.NVarcharType
+import liquibase.datatype.core.NumberType
+import liquibase.datatype.core.SmallIntType
+import liquibase.datatype.core.TimeType
+import liquibase.datatype.core.TimestampType
+import liquibase.datatype.core.TinyIntType
+import liquibase.datatype.core.UUIDType
+import liquibase.datatype.core.UnknownType;
 import liquibase.datatype.core.VarcharType
-import liquibase.sdk.database.MockDatabase;
-import org.junit.Test
+import liquibase.sdk.database.MockDatabase
 import spock.lang.Specification
-import spock.lang.Unroll;
-
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
+import spock.lang.Unroll
 
 public class DataTypeFactoryTest extends Specification {
 
-    @Unroll("#featureName: #liquibaseString")
-    public void parse() throws Exception {
+    @Unroll("#featureName: #liquibaseString for #database")
+    public void fromDescription() throws Exception {
         when:
-        def parsed = DataTypeFactory.getInstance().fromDescription(liquibaseString, new MockDatabase())
-        if (databaseString == null) {
-            databaseString = liquibaseString
-        }
+        def liquibaseType = DataTypeFactory.getInstance().fromDescription(liquibaseString, database)
+        def databaseType = liquibaseType.toDatabaseDataType(database)
+        def autoIncrement = (liquibaseType instanceof IntType && ((IntType) liquibaseType).isAutoIncrement()) \
+                || (liquibaseType instanceof BigIntType && ((BigIntType) liquibaseType).isAutoIncrement())
 
         then:
-        expectedType.getName() == parsed.getClass().getName()
-        databaseString == parsed.toString()
+        databaseString == databaseType.toString()
+        expectedType == liquibaseType.getClass()
+        expectedAutoIncrement == autoIncrement
 
         where:
-        liquibaseString                           | databaseString | expectedType      | isAutoIncrement
-        "int"                                     | null           | IntType.class     | false
-        "varchar(255)"                            | null           | VarcharType.class | false
-        "int{autoIncrement:true}"                 | "int"          | IntType.class     | true
-        "int{autoIncrement:false}"                | "int"          | IntType.class     | true
-        "int{}"                                   | "int"          | IntType.class     | false
-        "varchar COLLATE Latin1_General_BIN"      | null           | VarcharType.class | false
-        "varchar(255) COLLATE Latin1_General_BIN" | null           | VarcharType.class | false
-        "character varying(256)"                  | "varchar(256)" | VarcharType.class | false
-        "serial8"                                 | "bigint"       | BigIntType        | true
-        "int4"                                    | "int"          | IntType.class     | false
-        "serial4"                                 | "int"          | IntType.class     | true
+        liquibaseString                                      | database              | databaseString                                       | expectedType  | expectedAutoIncrement
+        "int"                                                | new MockDatabase()    | "INT"                                                | IntType       | false
+        "varchar(255)"                                       | new MockDatabase()    | "VARCHAR(255)"                                       | VarcharType   | false
+        "int{autoIncrement:true}"                            | new MockDatabase()    | "INT"                                                | IntType       | true
+        "int{autoIncrement:false}"                           | new MockDatabase()    | "INT"                                                | IntType       | false
+        "int{}"                                              | new MockDatabase()    | "INT"                                                | IntType       | false
+        "varchar COLLATE Latin1_General_BIN"                 | new MockDatabase()    | "VARCHAR COLLATE Latin1_General_BIN"                 | VarcharType   | false
+        "varchar(255) COLLATE Latin1_General_BIN"            | new MockDatabase()    | "VARCHAR(255) COLLATE Latin1_General_BIN"            | VarcharType   | false
+        "character varying(256)"                             | new MockDatabase()    | "VARCHAR(256)"                                       | VarcharType   | false
+        "serial8"                                            | new MockDatabase()    | "BIGINT"                                             | BigIntType    | true
+        "int4"                                               | new MockDatabase()    | "INT"                                                | IntType       | false
+        "serial4"                                            | new MockDatabase()    | "INT"                                                | IntType       | true
+        "bigint"                                             | new MSSQLDatabase()   | "[bigint]"                                           | BigIntType    | false
+        "[bigint]"                                           | new MSSQLDatabase()   | "[bigint]"                                           | BigIntType    | false
+        "binary"                                             | new MSSQLDatabase()   | "[binary](1)"                                        | BlobType      | false
+        "[binary]"                                           | new MSSQLDatabase()   | "[binary](1)"                                        | BlobType      | false
+        "binary(8000)"                                       | new MSSQLDatabase()   | "[binary](8000)"                                     | BlobType      | false
+        "[binary](8000)"                                     | new MSSQLDatabase()   | "[binary](8000)"                                     | BlobType      | false
+        "bit"                                                | new MSSQLDatabase()   | "[bit]"                                              | BooleanType   | false
+        "[bit]"                                              | new MSSQLDatabase()   | "[bit]"                                              | BooleanType   | false
+        "blob"                                               | new MSSQLDatabase()   | "[varbinary](MAX)"                                   | BlobType      | false
+        "boolean"                                            | new MSSQLDatabase()   | "[bit]"                                              | BooleanType   | false
+        "char"                                               | new MSSQLDatabase()   | "[char](1)"                                          | CharType      | false
+        "[char]"                                             | new MSSQLDatabase()   | "[char](1)"                                          | CharType      | false
+        "char(8000)"                                         | new MSSQLDatabase()   | "[char](8000)"                                       | CharType      | false
+        "[char](8000)"                                       | new MSSQLDatabase()   | "[char](8000)"                                       | CharType      | false
+        "clob"                                               | new MSSQLDatabase()   | "[nvarchar](MAX)"                                    | ClobType      | false
+        "currency"                                           | new MSSQLDatabase()   | "[money]"                                            | CurrencyType  | false
+        "date"                                               | new MSSQLDatabase()   | "[date]"                                             | DateType      | false
+        "[date]"                                             | new MSSQLDatabase()   | "[date]"                                             | DateType      | false
+        "datetime"                                           | new MSSQLDatabase()   | "[datetime]"                                         | DateTimeType  | false
+        "[datetime]"                                         | new MSSQLDatabase()   | "[datetime]"                                         | DateTimeType  | false
+        "datetime2"                                          | new MSSQLDatabase()   | "[datetime2](7)"                                     | DateTimeType  | false
+        "[datetime2]"                                        | new MSSQLDatabase()   | "[datetime2](7)"                                     | DateTimeType  | false
+        "datetime2(6)"                                       | new MSSQLDatabase()   | "[datetime2](6)"                                     | DateTimeType  | false
+        "[datetime2](6)"                                     | new MSSQLDatabase()   | "[datetime2](6)"                                     | DateTimeType  | false
+        "decimal"                                            | new MSSQLDatabase()   | "[decimal](18, 0)"                                   | DecimalType   | false
+        "[decimal]"                                          | new MSSQLDatabase()   | "[decimal](18, 0)"                                   | DecimalType   | false
+        "decimal(19)"                                        | new MSSQLDatabase()   | "[decimal](19, 0)"                                   | DecimalType   | false
+        "[decimal](19)"                                      | new MSSQLDatabase()   | "[decimal](19, 0)"                                   | DecimalType   | false
+        "decimal(19, 2)"                                     | new MSSQLDatabase()   | "[decimal](19, 2)"                                   | DecimalType   | false
+        "[decimal](19, 2)"                                   | new MSSQLDatabase()   | "[decimal](19, 2)"                                   | DecimalType   | false
+        "double"                                             | new MSSQLDatabase()   | "[float](53)"                                        | DoubleType    | false
+        "float"                                              | new MSSQLDatabase()   | "[float](53)"                                        | FloatType     | false
+        "[float]"                                            | new MSSQLDatabase()   | "[float](53)"                                        | FloatType     | false
+        "float(53)"                                          | new MSSQLDatabase()   | "[float](53)"                                        | FloatType     | false
+        "[float](53)"                                        | new MSSQLDatabase()   | "[float](53)"                                        | FloatType     | false
+        "image"                                              | new MSSQLDatabase()   | "[image]"                                            | BlobType      | false
+        "[image]"                                            | new MSSQLDatabase()   | "[image]"                                            | BlobType      | false
+        "int"                                                | new MSSQLDatabase()   | "[int]"                                              | IntType       | false
+        "[int]"                                              | new MSSQLDatabase()   | "[int]"                                              | IntType       | false
+        "integer"                                            | new MSSQLDatabase()   | "[int]"                                              | IntType       | false
+        "mediumint"                                          | new MSSQLDatabase()   | "[int]"                                              | MediumIntType | false
+        "money"                                              | new MSSQLDatabase()   | "[money]"                                            | CurrencyType  | false
+        "[money]"                                            | new MSSQLDatabase()   | "[money]"                                            | CurrencyType  | false
+        "nchar"                                              | new MSSQLDatabase()   | "[nchar](1)"                                         | NCharType     | false
+        "[nchar]"                                            | new MSSQLDatabase()   | "[nchar](1)"                                         | NCharType     | false
+        "nchar(4000)"                                        | new MSSQLDatabase()   | "[nchar](4000)"                                      | NCharType     | false
+        "[nchar](4000)"                                      | new MSSQLDatabase()   | "[nchar](4000)"                                      | NCharType     | false
+        "ntext"                                              | new MSSQLDatabase()   | "[ntext]"                                            | ClobType      | false
+        "[ntext]"                                            | new MSSQLDatabase()   | "[ntext]"                                            | ClobType      | false
+        "number"                                             | new MSSQLDatabase()   | "[numeric](18, 0)"                                   | NumberType    | false
+        "numeric"                                            | new MSSQLDatabase()   | "[numeric](18, 0)"                                   | NumberType    | false
+        "[numeric]"                                          | new MSSQLDatabase()   | "[numeric](18, 0)"                                   | NumberType    | false
+        "numeric(19)"                                        | new MSSQLDatabase()   | "[numeric](19, 0)"                                   | NumberType    | false
+        "[numeric](19)"                                      | new MSSQLDatabase()   | "[numeric](19, 0)"                                   | NumberType    | false
+        "numeric(19, 2)"                                     | new MSSQLDatabase()   | "[numeric](19, 2)"                                   | NumberType    | false
+        "[numeric](19, 2)"                                   | new MSSQLDatabase()   | "[numeric](19, 2)"                                   | NumberType    | false
+        "nvarchar"                                           | new MSSQLDatabase()   | "[nvarchar](1)"                                      | NVarcharType  | false
+        "[nvarchar]"                                         | new MSSQLDatabase()   | "[nvarchar](1)"                                      | NVarcharType  | false
+        "nvarchar(4000)"                                     | new MSSQLDatabase()   | "[nvarchar](4000)"                                   | NVarcharType  | false
+        "[nvarchar](4000)"                                   | new MSSQLDatabase()   | "[nvarchar](4000)"                                   | NVarcharType  | false
+        "nvarchar(MAX)"                                      | new MSSQLDatabase()   | "[nvarchar](MAX)"                                    | NVarcharType  | false
+        "[nvarchar](MAX)"                                    | new MSSQLDatabase()   | "[nvarchar](MAX)"                                    | NVarcharType  | false
+        "real"                                               | new MSSQLDatabase()   | "[real]"                                             | FloatType     | false
+        "[real]"                                             | new MSSQLDatabase()   | "[real]"                                             | FloatType     | false
+        "smalldatetime"                                      | new MSSQLDatabase()   | "[smalldatetime]"                                    | DateTimeType  | false
+        "[smalldatetime]"                                    | new MSSQLDatabase()   | "[smalldatetime]"                                    | DateTimeType  | false
+        "smallint"                                           | new MSSQLDatabase()   | "[smallint]"                                         | SmallIntType  | false
+        "[smallint]"                                         | new MSSQLDatabase()   | "[smallint]"                                         | SmallIntType  | false
+        "smallmoney"                                         | new MSSQLDatabase()   | "[smallmoney]"                                       | CurrencyType  | false
+        "[smallmoney]"                                       | new MSSQLDatabase()   | "[smallmoney]"                                       | CurrencyType  | false
+        "text"                                               | new MSSQLDatabase()   | "[text]"                                             | ClobType      | false
+        "[text]"                                             | new MSSQLDatabase()   | "[text]"                                             | ClobType      | false
+        "time"                                               | new MSSQLDatabase()   | "[time](7)"                                          | TimeType      | false
+        "[time]"                                             | new MSSQLDatabase()   | "[time](7)"                                          | TimeType      | false
+        "time(6)"                                            | new MSSQLDatabase()   | "[time](6)"                                          | TimeType      | false
+        "[time](6)"                                          | new MSSQLDatabase()   | "[time](6)"                                          | TimeType      | false
+        "timestamp"                                          | new MSSQLDatabase()   | "[datetime]"                                         | TimestampType | false
+        "tinyint"                                            | new MSSQLDatabase()   | "[tinyint]"                                          | TinyIntType   | false
+        "[tinyint]"                                          | new MSSQLDatabase()   | "[tinyint]"                                          | TinyIntType   | false
+        "uniqueidentifier"                                   | new MSSQLDatabase()   | "[uniqueidentifier]"                                 | UUIDType      | false
+        "[uniqueidentifier]"                                 | new MSSQLDatabase()   | "[uniqueidentifier]"                                 | UUIDType      | false
+        "uuid"                                               | new MSSQLDatabase()   | "[uniqueidentifier]"                                 | UUIDType      | false
+        "varbinary"                                          | new MSSQLDatabase()   | "[varbinary](1)"                                     | BlobType      | false
+        "[varbinary]"                                        | new MSSQLDatabase()   | "[varbinary](1)"                                     | BlobType      | false
+        "varbinary(8000)"                                    | new MSSQLDatabase()   | "[varbinary](8000)"                                  | BlobType      | false
+        "[varbinary](8000)"                                  | new MSSQLDatabase()   | "[varbinary](8000)"                                  | BlobType      | false
+        "varbinary(MAX)"                                     | new MSSQLDatabase()   | "[varbinary](MAX)"                                   | BlobType      | false
+        "[varbinary](MAX)"                                   | new MSSQLDatabase()   | "[varbinary](MAX)"                                   | BlobType      | false
+        "varchar"                                            | new MSSQLDatabase()   | "[varchar](1)"                                       | VarcharType   | false
+        "[varchar]"                                          | new MSSQLDatabase()   | "[varchar](1)"                                       | VarcharType   | false
+        "varchar(8000)"                                      | new MSSQLDatabase()   | "[varchar](8000)"                                    | VarcharType   | false
+        "[varchar](8000)"                                    | new MSSQLDatabase()   | "[varchar](8000)"                                    | VarcharType   | false
+        "varchar(MAX)"                                       | new MSSQLDatabase()   | "[varchar](MAX)"                                     | VarcharType   | false
+        "[varchar](MAX)"                                     | new MSSQLDatabase()   | "[varchar](MAX)"                                     | VarcharType   | false
+        "xml"                                                | new MSSQLDatabase()   | "[xml]"                                              | UnknownType   | false
+        "[xml]"                                              | new MSSQLDatabase()   | "[xml]"                                              | UnknownType   | false
+        "xml(CONTENT)"                                       | new MSSQLDatabase()   | "[xml](CONTENT)"                                     | UnknownType   | false
+        "[xml](CONTENT)"                                     | new MSSQLDatabase()   | "[xml](CONTENT)"                                     | UnknownType   | false
+        "xml(DOCUMENT)"                                      | new MSSQLDatabase()   | "[xml](DOCUMENT)"                                    | UnknownType   | false
+        "[xml](DOCUMENT)"                                    | new MSSQLDatabase()   | "[xml](DOCUMENT)"                                    | UnknownType   | false
+        "xml([MySchema].[MyXmlSchemaCollection])"            | new MSSQLDatabase()   | "[xml]([MySchema].[MyXmlSchemaCollection])"          | UnknownType   | false
+        "[xml]([MySchema].[MyXmlSchemaCollection])"          | new MSSQLDatabase()   | "[xml]([MySchema].[MyXmlSchemaCollection])"          | UnknownType   | false
+        "xml(CONTENT [MySchema].[MyXmlSchemaCollection])"    | new MSSQLDatabase()   | "[xml](CONTENT [MySchema].[MyXmlSchemaCollection])"  | UnknownType   | false
+        "[xml](CONTENT [MySchema].[MyXmlSchemaCollection])"  | new MSSQLDatabase()   | "[xml](CONTENT [MySchema].[MyXmlSchemaCollection])"  | UnknownType   | false
+        "xml(DOCUMENT [MySchema].[MyXmlSchemaCollection])"   | new MSSQLDatabase()   | "[xml](DOCUMENT [MySchema].[MyXmlSchemaCollection])" | UnknownType   | false
+        "[xml](DOCUMENT [MySchema].[MyXmlSchemaCollection])" | new MSSQLDatabase()   | "[xml](DOCUMENT [MySchema].[MyXmlSchemaCollection])" | UnknownType   | false
     }
 }

--- a/liquibase-core/src/test/groovy/liquibase/datatype/core/CharTypeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/core/CharTypeTest.groovy
@@ -27,8 +27,9 @@ class CharTypeTest extends Specification {
         [13]         | new HsqlDatabase()     | "CHAR(13)"
         [13]         | new PostgresDatabase() | "CHAR(13)"
         [13]         | new OracleDatabase()   | "CHAR(13)"
-        [13]         | new MSSQLDatabase()    | "CHAR(13)"
-        [2147483647] | new MSSQLDatabase()    | "CHAR(2147483647)"
+        []           | new MSSQLDatabase()    | "[char](1)"
+        [13]         | new MSSQLDatabase()    | "[char](13)"
+        [2147483647] | new MSSQLDatabase()    | "[char](8000)"
         [13]         | new MySQLDatabase()    | "CHAR(13)"
     }
 

--- a/liquibase-core/src/test/groovy/liquibase/datatype/core/DoubleTypeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/core/DoubleTypeTest.groovy
@@ -27,11 +27,11 @@ class DoubleTypeTest extends Specification {
         where:
         params | database               | expected
         [22]   | new MySQLDatabase()    | "DOUBLE(22)"
-        [7,3]   | new MySQLDatabase()    | "DOUBLE(7, 3)"
+        [7, 3] | new MySQLDatabase()    | "DOUBLE(7, 3)"
         [22]   | new DB2Database()      | "DOUBLE"
         [22]   | new DerbyDatabase()    | "DOUBLE"
         [22]   | new HsqlDatabase()     | "DOUBLE"
-        [22]   | new MSSQLDatabase()    | "FLOAT"
+        [22]   | new MSSQLDatabase()    | "[float](53)"
         [22]   | new PostgresDatabase() | "DOUBLE PRECISION"
         [22]   | new InformixDatabase() | "DOUBLE PRECISION"
         []     | new OracleDatabase()   | "FLOAT(24)"

--- a/liquibase-core/src/test/groovy/liquibase/datatype/core/NVarcharTypeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/core/NVarcharTypeTest.groovy
@@ -23,8 +23,9 @@ class NVarcharTypeTest extends Specification {
         [13]         | new HsqlDatabase()     | "VARCHAR(13)"
         [13]         | new PostgresDatabase() | "VARCHAR(13)"
         [13]         | new OracleDatabase()   | "NVARCHAR2(13)"
-        [13]         | new MSSQLDatabase()    | "NVARCHAR(13)"
-        [2147483647] | new MSSQLDatabase()    | "NVARCHAR(MAX)"
+        []           | new MSSQLDatabase()    | "[nvarchar](1)"
+        [13]         | new MSSQLDatabase()    | "[nvarchar](13)"
+        [2147483647] | new MSSQLDatabase()    | "[nvarchar](MAX)"
         [13]         | new MySQLDatabase()    | "NVARCHAR(13)"
     }
 

--- a/liquibase-core/src/test/groovy/liquibase/datatype/core/VarcharTypeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/core/VarcharTypeTest.groovy
@@ -33,8 +33,9 @@ class VarcharTypeTest extends Specification {
         [13]         | new HsqlDatabase()     | true              | "VARCHAR2(13)"
         [13]         | new PostgresDatabase() | false             | "VARCHAR(13)"
         [13]         | new OracleDatabase()   | false             | "VARCHAR2(13)"
-        [13]         | new MSSQLDatabase()    | false             | "VARCHAR(13)"
-        [2147483647] | new MSSQLDatabase()    | false             | "VARCHAR(MAX)"
+        []           | new MSSQLDatabase()    | false             | "[varchar](1)"
+        [13]         | new MSSQLDatabase()    | false             | "[varchar](13)"
+        [2147483647] | new MSSQLDatabase()    | false             | "[varchar](MAX)"
         [13]         | new MySQLDatabase()    | false             | "VARCHAR(13)"
     }
 }

--- a/liquibase-core/src/test/java/liquibase/database/core/MSSQLDatabaseTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/core/MSSQLDatabaseTest.java
@@ -137,4 +137,13 @@ public class MSSQLDatabaseTest extends AbstractJdbcDatabaseTest {
         assertEquals("MySchema.MyUDT", database.unescapeDataTypeName("[MySchema].MyUDT"));
         assertEquals("MySchema.MyUDT", database.unescapeDataTypeName("[MySchema].[MyUDT]"));
     }
+
+    @Test
+    public void testUnescapeDataTypeString() {
+        Database database = getDatabase();
+        assertEquals("int", database.unescapeDataTypeString("int"));
+        assertEquals("int", database.unescapeDataTypeString("[int]"));
+        assertEquals("decimal(19, 2)", database.unescapeDataTypeString("decimal(19, 2)"));
+        assertEquals("decimal(19, 2)", database.unescapeDataTypeString("[decimal](19, 2)"));
+    }
 }

--- a/liquibase-core/src/test/java/liquibase/database/core/MSSQLDatabaseTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/core/MSSQLDatabaseTest.java
@@ -119,4 +119,22 @@ public class MSSQLDatabaseTest extends AbstractJdbcDatabaseTest {
     	Database database =getADatabaseWithCollation("Latin1_General_CS_AI");    	
     	assertTrue( "Should be case sensitive", database.isCaseSensitive() );
     }
+
+    @Test
+    public void testEscapeDataTypeName() {
+        Database database = getDatabase();
+        assertEquals("[MySchema].[MyUDT]", database.escapeDataTypeName("MySchema.MyUDT"));
+        assertEquals("[MySchema].[MyUDT]", database.escapeDataTypeName("MySchema.[MyUDT]"));
+        assertEquals("[MySchema].[MyUDT]", database.escapeDataTypeName("[MySchema].MyUDT"));
+        assertEquals("[MySchema].[MyUDT]", database.escapeDataTypeName("[MySchema].[MyUDT]"));
+    }
+
+    @Test
+    public void testUnescapeDataTypeName() {
+        Database database = getDatabase();
+        assertEquals("MySchema.MyUDT", database.unescapeDataTypeName("MySchema.MyUDT"));
+        assertEquals("MySchema.MyUDT", database.unescapeDataTypeName("MySchema.[MyUDT]"));
+        assertEquals("MySchema.MyUDT", database.unescapeDataTypeName("[MySchema].MyUDT"));
+        assertEquals("MySchema.MyUDT", database.unescapeDataTypeName("[MySchema].[MyUDT]"));
+    }
 }

--- a/liquibase-core/src/test/java/liquibase/sqlgenerator/core/CreateTableGeneratorTest.java
+++ b/liquibase-core/src/test/java/liquibase/sqlgenerator/core/CreateTableGeneratorTest.java
@@ -597,7 +597,7 @@ public class CreateTableGeneratorTest extends AbstractSqlGeneratorTest<CreateTab
 	    		
 	    		Sql[] generatedSql = this.generatorUnderTest.generateSql(statement, database, null);
 
-    			assertEquals("Error on "+database, "CREATE TABLE [SCHEMA_NAME].[TABLE_NAME] ([COLUMN1_NAME] BIGINT IDENTITY (1, 1) NOT NULL)", generatedSql[0].toSql());
+    			assertEquals("Error on "+database, "CREATE TABLE [SCHEMA_NAME].[TABLE_NAME] ([COLUMN1_NAME] [bigint] IDENTITY (1, 1) NOT NULL)", generatedSql[0].toSql());
     		}
     	}
     }
@@ -618,7 +618,7 @@ public class CreateTableGeneratorTest extends AbstractSqlGeneratorTest<CreateTab
 
 	    		Sql[] generatedSql = this.generatorUnderTest.generateSql(statement, database, null);
 
-    			assertEquals("CREATE TABLE [SCHEMA_NAME].[TABLE_NAME] ([COLUMN1_NAME] BIGINT IDENTITY (0, 1) NOT NULL)", generatedSql[0].toSql());
+    			assertEquals("CREATE TABLE [SCHEMA_NAME].[TABLE_NAME] ([COLUMN1_NAME] [bigint] IDENTITY (0, 1) NOT NULL)", generatedSql[0].toSql());
     		}
     	}
     }
@@ -639,7 +639,7 @@ public class CreateTableGeneratorTest extends AbstractSqlGeneratorTest<CreateTab
 
 	    		Sql[] generatedSql = this.generatorUnderTest.generateSql(statement, database, null);
 
-				assertEquals("CREATE TABLE [SCHEMA_NAME].[TABLE_NAME] ([COLUMN1_NAME] BIGINT IDENTITY (0, 10) NOT NULL)", generatedSql[0].toSql());
+				assertEquals("CREATE TABLE [SCHEMA_NAME].[TABLE_NAME] ([COLUMN1_NAME] [bigint] IDENTITY (0, 10) NOT NULL)", generatedSql[0].toSql());
     		}
     	}
     }


### PR DESCRIPTION
[CORE-2217](https://liquibase.jira.com/browse/CORE-2217) Add DataTypeFactory support for delimited data type names, improve resolution of MSSQL data types

Rebased off of master (3.4.x)

See [PR#364](https://github.com/liquibase/liquibase/pull/364) which was based off of 3.3.x.