### PR TITLE
CORE-2325 Improve the merge conflict resolution between CORE-2325 and CORE-2318

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/LiquibaseDataType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/LiquibaseDataType.java
@@ -136,8 +136,6 @@ public abstract class LiquibaseDataType implements PrioritizedService {
             return null;
         } else if (value instanceof DatabaseFunction) {
             return functionToSql((DatabaseFunction) value, database);
-        } else if (value instanceof BigDecimal) {
-            return formatNumber(((BigDecimal) value).toPlainString());
         } else if (value instanceof Number) {
             return numberToSql((Number) value, database);
         }
@@ -149,7 +147,13 @@ public abstract class LiquibaseDataType implements PrioritizedService {
     }
 
     protected String numberToSql(Number number, Database database) {
-        return number == null ? null : formatNumber(number.toString());
+        if (number == null) {
+            return null;
+        }
+        if (number instanceof BigDecimal) {
+            return formatNumber(((BigDecimal) number).toPlainString());
+        }
+        return formatNumber(number.toString());
     }
 
     protected String otherToSql(Object value, Database database) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/UUIDType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/UUIDType.java
@@ -8,7 +8,6 @@ import liquibase.datatype.DataTypeInfo;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.LiquibaseDataType;
 import liquibase.exception.DatabaseException;
-import liquibase.statement.DatabaseFunction;
 
 @DataTypeInfo(name = "uuid", aliases = { "uniqueidentifier", "java.util.UUID" }, minParameters = 0, maxParameters = 0, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class UUIDType extends LiquibaseDataType {
@@ -44,7 +43,7 @@ public class UUIDType extends LiquibaseDataType {
             return null;
         }
         if (database instanceof MSSQLDatabase) {
-			 return (value instanceof DatabaseFunction) ? database.generateDatabaseFunctionValue((DatabaseFunction) value) : "'" + value.toString().toUpperCase(Locale.ENGLISH) + "'";
+            return "'" + value.toString().toUpperCase(Locale.ENGLISH) + "'";
         }
         return super.otherToSql(value, database);
     }


### PR DESCRIPTION
I had a slightly different idea of how to handle the merge conflict between CORE-2325 and CORE-2318. This should make behavior more predictable if someone later overrides LiquibaseDataType#numberToSql(Number, Database). The code in UUIDType#otherToSql(Object, Database) was also able to be simplified due to the inheriting the necessary code to handle a DatabaseFunction from LiquibaseDataType#objectToSql(Object, Database).