### PR TITLE
URLs connection caching is turned off.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/spring/SpringLiquibase.java
+++ b/liquibase-core/src/main/java/liquibase/integration/spring/SpringLiquibase.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URLConnection;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.*;
@@ -106,7 +107,9 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
                 return null;
             }
             for (Resource resource : resources) {
-                returnSet.add(resource.getURL().openStream());
+            	URLConnection connection = resource.getURL().openConnection();
+            	connection.setUseCaches(false);
+            	returnSet.add(connection.getInputStream());
             }
 
             return returnSet;

--- a/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
@@ -39,7 +39,9 @@ public class ClassLoaderResourceAccessor extends AbstractResourceAccessor {
                 continue;
             }
             seenUrls.add(url.toExternalForm());
-            InputStream resourceAsStream = url.openStream();
+            URLConnection connection = url.openConnection();
+            connection.setUseCaches(false);
+            InputStream resourceAsStream = connection.getInputStream();
             if (resourceAsStream != null) {
                 returnSet.add(resourceAsStream);
             }

--- a/liquibase-core/src/main/java/liquibase/util/LiquibaseUtil.java
+++ b/liquibase-core/src/main/java/liquibase/util/LiquibaseUtil.java
@@ -3,6 +3,7 @@ package liquibase.util;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.net.URLConnection;
 import java.util.Properties;
 
 public class LiquibaseUtil {
@@ -15,7 +16,9 @@ public class LiquibaseUtil {
         InputStream in = null;
         try {
             if (buildInfoFile != null) {
-                in = buildInfoFile.openStream();
+            	URLConnection connection = buildInfoFile.openConnection();
+            	connection.setUseCaches(false);
+                in = connection.getInputStream();
                 buildInfo.load(in);
                 String o = (String) buildInfo.get("build.version");
 


### PR DESCRIPTION
URL's cache results in FileNotFoundException for the case when jar was changed and liquibase tried to reread any file from this jar.
For example it happens when web application in Jetty 9 is stopped, jar file from WEB-INF/lib is replaced with new one and application is started back again. I got this problem with jetty-maven-plugin when it tried to apply changes I made in IDE to running web application (liquibase was configured as Spring bean).