### PR TITLE
CORE-1768 Fixed dropAll issue when using Oracle spatial.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
@@ -255,6 +255,9 @@ public class OracleDatabase extends AbstractJdbcDatabase {
                 return true;
             } else if (example.getName().startsWith("SYS_IOT_OVER")) { //oracle system table
                 return true;
+            } else if ((example.getName().startsWith("MDRT_") || example.getName().startsWith("MDRS_")) && example.getName().endsWith("$")) {
+                // CORE-1768 - Oracle creates these for spatial indices and will remove them when the index is removed.
+                return true;
             } else if (example.getName().startsWith("MLOG$_")) { //Created by materliaized view logs for every table that is part of a materialized view. Not available for DDL operations.
                 return true;
             } else if (example.getName().startsWith("RUPD$_")) { //Created by materialized view log tables using primary keys. Not available for DDL operations.


### PR DESCRIPTION
This is a very minor change that fixes dropAll when using Oracle Spatial. JIRA issue here https://liquibase.jira.com/browse/CORE-1768.