### PR TITLE
CORE-419 Add support for descending key columns on indexes, unique constraints and primary keys

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/ColumnConfig.java
+++ b/liquibase-core/src/main/java/liquibase/change/ColumnConfig.java
@@ -54,6 +54,7 @@ public class ColumnConfig extends AbstractLiquibaseSerializable {
     private BigInteger startWith;
     private BigInteger incrementBy;
     private String remarks;
+    private Boolean descending;
 
     /**
      * Create a ColumnConfig object based on a {@link Column} snapshot.
@@ -728,6 +729,15 @@ public class ColumnConfig extends AbstractLiquibaseSerializable {
         return this;
     }
 
+    public Boolean getDescending() {
+        return descending;
+    }
+
+    public ColumnConfig setDescending(Boolean descending) {
+        this.descending = descending;
+        return this;
+    }
+
     @Override
     public String getSerializedObjectName() {
         return "column";
@@ -763,6 +773,7 @@ public class ColumnConfig extends AbstractLiquibaseSerializable {
         startWith = parsedNode.getChildValue(null, "startWith", BigInteger.class);
         incrementBy = parsedNode.getChildValue(null, "incrementBy", BigInteger.class);
         remarks = parsedNode.getChildValue(null, "remarks", String.class);
+        descending = parsedNode.getChildValue(null, "descending", Boolean.class);
 
 
         value = parsedNode.getChildValue(null, "value", String.class);
@@ -840,14 +851,29 @@ public class ColumnConfig extends AbstractLiquibaseSerializable {
 
     }
 
+    public static ColumnConfig fromName(String name) {
+        name = name.trim();
+        Boolean descending = null;
+        if (name.matches("(?i).*\\s+DESC")) {
+            name = name.replaceFirst("(?i)\\s+DESC$", "");
+            descending = true;
+        } else if (name.matches("(?i).*\\s+ASC")) {
+            name = name.replaceFirst("(?i)\\s+ASC$", "");
+            descending = false;
+        }
+        return new ColumnConfig()
+                .setName(name)
+                .setDescending(descending);
+    }
+
     public static ColumnConfig[] arrayFromNames(String names) {
         if (names == null) {
             return null;
         }
         List<String> nameArray = StringUtils.splitAndTrim(names, ",");
         ColumnConfig[] returnArray = new ColumnConfig[nameArray.size()];
-        for (int i=0; i<nameArray.size(); i++) {
-            returnArray[i] = new ColumnConfig().setName(nameArray.get(i));
+        for (int i = 0; i < nameArray.size(); i++) {
+            returnArray[i] = fromName(nameArray.get(i));
         }
         return returnArray;
     }

--- a/liquibase-core/src/main/java/liquibase/change/ColumnConfig.java
+++ b/liquibase-core/src/main/java/liquibase/change/ColumnConfig.java
@@ -62,7 +62,8 @@ public class ColumnConfig extends AbstractLiquibaseSerializable {
      */
     public ColumnConfig(Column columnSnapshot) {
         setName(columnSnapshot.getName());
-        setComputed(columnSnapshot.getComputed());
+        setComputed(columnSnapshot.getComputed() != null && columnSnapshot.getComputed() ? Boolean.TRUE : null);
+        setDescending(columnSnapshot.getDescending() != null && columnSnapshot.getDescending() ? Boolean.TRUE : null);
         if (columnSnapshot.getType() != null) {
             setType(columnSnapshot.getType().toString());
         }

--- a/liquibase-core/src/main/java/liquibase/change/core/AddPrimaryKeyChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/AddPrimaryKeyChange.java
@@ -9,7 +9,6 @@ import liquibase.statement.core.AddPrimaryKeyStatement;
 import liquibase.statement.core.ReorganizeTableStatement;
 import liquibase.structure.core.Column;
 import liquibase.structure.core.PrimaryKey;
-import liquibase.structure.core.Table;
 
 /**
  * Creates a primary key out of an existing column or set of columns.

--- a/liquibase-core/src/main/java/liquibase/change/core/AddUniqueConstraintChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/AddUniqueConstraintChange.java
@@ -173,12 +173,7 @@ public class AddUniqueConstraintChange extends AbstractChange {
     public ChangeStatus checkStatus(Database database) {
         ChangeStatus result = new ChangeStatus();
         try {
-            String[] columnNames = getColumnNames().split("\\s+,\\s+");
-            Column[] columns = new Column[columnNames.length];
-            for (int i=0; i<columnNames.length; i++) {
-                columns[i] = new Column(columnNames[i]);
-            }
-            UniqueConstraint example = new UniqueConstraint(getConstraintName(), getCatalogName(), getSchemaName(), getTableName(), columns);
+            UniqueConstraint example = new UniqueConstraint(getConstraintName(), getCatalogName(), getSchemaName(), getTableName(), Column.arrayFromNames(getColumnNames()));
 
             UniqueConstraint snapshot = SnapshotGeneratorFactory.getInstance().createSnapshot(example, database);
             result.assertComplete(snapshot != null, "Unique constraint does not exist");

--- a/liquibase-core/src/main/java/liquibase/change/core/CreateIndexChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/CreateIndexChange.java
@@ -2,8 +2,6 @@ package liquibase.change.core;
 
 import liquibase.change.*;
 import liquibase.database.Database;
-import liquibase.parser.core.ParsedNode;
-import liquibase.parser.core.ParsedNodeException;
 import liquibase.snapshot.SnapshotGeneratorFactory;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.CreateIndexStatement;

--- a/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -1021,15 +1021,24 @@ public abstract class AbstractJdbcDatabase implements Database {
 
     @Override
     public String escapeColumnNameList(final String columnNames) {
-        StringBuffer sb = new StringBuffer();
-        for (String columnName : columnNames.split(",")) {
+        StringBuilder sb = new StringBuilder();
+        for (String columnName : StringUtils.splitAndTrim(columnNames, ",")) {
             if (sb.length() > 0) {
                 sb.append(", ");
             }
-            sb.append(escapeObjectName(columnName.trim(), Column.class));
+            boolean descending = false;
+            if (columnName.matches("(?i).*\\s+DESC")) {
+                columnName = columnName.replaceFirst("(?i)\\s+DESC$", "");
+                descending = true;
+            } else if (columnName.matches("(?i).*\\s+ASC")) {
+                columnName = columnName.replaceFirst("(?i)\\s+ASC$", "");
+            }
+            sb.append(escapeObjectName(columnName, Column.class));
+            if (descending) {
+                sb.append(" DESC");
+            }
         }
         return sb.toString();
-
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingIndexChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingIndexChangeGenerator.java
@@ -50,9 +50,9 @@ public class MissingIndexChangeGenerator implements MissingObjectChangeGenerator
             change.setSchemaName(index.getTable().getSchema().getName());
         }
         change.setIndexName(index.getName());
-        change.setUnique(index.isUnique());
+        change.setUnique(index.isUnique() != null && index.isUnique() ? Boolean.TRUE : null);
         change.setAssociatedWith(index.getAssociatedWithAsString());
-        change.setClustered(index.getClustered());
+        change.setClustered(index.getClustered() != null && index.getClustered() ? Boolean.TRUE : null);
 
 //        if (index.getAssociatedWith().contains(Index.MARK_PRIMARY_KEY) || index.getAssociatedWith().contains(Index.MARK_FOREIGN_KEY) || index.getAssociatedWith().contains(Index.MARK_UNIQUE_CONSTRAINT)) {
 //            continue;

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingUniqueConstraintChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingUniqueConstraintChangeGenerator.java
@@ -60,9 +60,9 @@ public class MissingUniqueConstraintChangeGenerator implements MissingObjectChan
         }
         change.setConstraintName(uc.getName());
         change.setColumnNames(uc.getColumnNames());
-        change.setDeferrable(uc.isDeferrable());
-        change.setInitiallyDeferred(uc.isInitiallyDeferred());
-        change.setDisabled(uc.isDisabled());
+        change.setDeferrable(uc.isDeferrable() ? Boolean.TRUE : null);
+        change.setInitiallyDeferred(uc.isInitiallyDeferred() ? Boolean.TRUE : null);
+        change.setDisabled(uc.isDisabled() ? Boolean.TRUE : null);
 
         if (comparisonDatabase instanceof OracleDatabase) {
             Index backingIndex = uc.getBackingIndex();

--- a/liquibase-core/src/main/java/liquibase/snapshot/DatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/DatabaseSnapshot.java
@@ -222,6 +222,15 @@ public abstract class DatabaseSnapshot implements LiquibaseSerializable {
 
     private void includeNestedObjects(DatabaseObject object) throws DatabaseException, InvalidExampleException, InstantiationException, IllegalAccessException {
         for (String field : new HashSet<String>(object.getAttributes())) {
+            if (object.getClass() == Index.class && field.equals("columns")) {
+                continue;
+            }
+            if (object.getClass() == PrimaryKey.class && field.equals("columns")) {
+                continue;
+            }
+            if (object.getClass() == UniqueConstraint.class && field.equals("columns")) {
+                continue;
+            }
             Object fieldValue = object.getAttribute(field, Object.class);
             Object newFieldValue = replaceObject(fieldValue);
             if (newFieldValue == null) { //sometimes an object references a non-snapshotted object. Leave it with the unsnapshotted example

--- a/liquibase-core/src/main/java/liquibase/snapshot/DatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/DatabaseSnapshot.java
@@ -20,9 +20,6 @@ import liquibase.util.ObjectUtil;
 import java.sql.Timestamp;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 public abstract class DatabaseSnapshot implements LiquibaseSerializable {
 

--- a/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -5,14 +5,10 @@ import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.Database;
 import liquibase.database.core.*;
 import liquibase.database.jvm.JdbcConnection;
-import liquibase.diff.compare.DatabaseObjectComparator;
-import liquibase.diff.compare.DatabaseObjectComparatorFactory;
 import liquibase.exception.DatabaseException;
-import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.logging.LogFactory;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.*;
-import liquibase.util.StringUtils;
 
 import java.sql.*;
 import java.util.*;
@@ -170,12 +166,25 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                     CatalogAndSchema catalogAndSchema = new CatalogAndSchema(catalogName, schemaName).customize(database);
                     if (database instanceof OracleDatabase) {
                         //oracle getIndexInfo is buggy and slow.  See Issue 1824548 and http://forums.oracle.com/forums/thread.jspa?messageID=578383&#578383
-                        String sql = "SELECT c.INDEX_NAME, 3 AS TYPE, c.TABLE_NAME, c.COLUMN_NAME, c.COLUMN_POSITION AS ORDINAL_POSITION, e.COLUMN_EXPRESSION AS FILTER_CONDITION, case I.UNIQUENESS when 'UNIQUE' then 0 else 1 end as NON_UNIQUE " +
+                        String sql =
+                                "SELECT " +
+                                    "c.INDEX_NAME, " +
+                                    "3 AS TYPE, " +
+                                    "c.TABLE_NAME, " +
+                                    "c.COLUMN_NAME, " +
+                                    "c.COLUMN_POSITION AS ORDINAL_POSITION, " +
+                                    "e.COLUMN_EXPRESSION AS FILTER_CONDITION, " +
+                                    "CASE I.UNIQUENESS WHEN 'UNIQUE' THEN 0 ELSE 1 END AS NON_UNIQUE, " +
+                                    "CASE c.DESCEND WHEN 'Y' THEN 'D' WHEN 'N' THEN 'A' END AS ASC_OR_DESC " +
                                 "FROM ALL_IND_COLUMNS c " +
-                                "JOIN ALL_INDEXES i on i.index_name = c.index_name " +
-                                "LEFT JOIN all_ind_expressions e on (e.column_position = c.column_position AND e.index_name = c.index_name) " +
-                                "WHERE c.TABLE_OWNER='" + database.correctObjectName(catalogAndSchema.getCatalogName(), Schema.class) + "' " +
-                                "AND i.OWNER=c.TABLE_OWNER";
+                                "JOIN ALL_INDEXES i " +
+                                "ON i.index_name = c.index_name " +
+                                "LEFT JOIN all_ind_expressions e " +
+                                "ON e.column_position = c.column_position " +
+                                "AND e.index_name = c.index_name " +
+                                "WHERE c.TABLE_OWNER = '" + database.correctObjectName(catalogAndSchema.getCatalogName(), Schema.class) + "' " +
+                                "AND i.OWNER = c.TABLE_OWNER";
+
                         if (!bulkFetch && tableName != null) {
                             sql += " AND c.TABLE_NAME='" + database.correctObjectName(tableName, Table.class) + "'";
                         }
@@ -459,24 +468,98 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                 @Override
                 public List<CachedRow> fastFetchQuery() throws SQLException {
                     CatalogAndSchema catalogAndSchema = new CatalogAndSchema(catalogName, schemaName).customize(database);
-
-                    if (table == null) {
-                        try {
-                            List<CachedRow> foundPks = new ArrayList<CachedRow>();
+                    try {
+                        List<CachedRow> foundPks = new ArrayList<CachedRow>();
+                        if (table == null) {
                             List<CachedRow> tables = CachingDatabaseMetaData.this.getTables(catalogName, schemaName, null);
                             for (CachedRow table : tables) {
-                                List<CachedRow> pkInfo = extract(databaseMetaData.getPrimaryKeys(((AbstractJdbcDatabase) database).getJdbcCatalogName(catalogAndSchema), ((AbstractJdbcDatabase) database).getJdbcSchemaName(catalogAndSchema), table.getString("TABLE_NAME")));
+                                List<CachedRow> pkInfo = getPkInfo(schemaName, catalogAndSchema, table.getString("TABLE_NAME"));
                                 if (pkInfo != null) {
                                     foundPks.addAll(pkInfo);
                                 }
                             }
                             return foundPks;
-                        } catch (DatabaseException e) {
-                            throw new SQLException(e);
+                        } else {
+                            List<CachedRow> pkInfo = getPkInfo(schemaName, catalogAndSchema, table);
+                            if (pkInfo != null) {
+                                foundPks.addAll(pkInfo);
+                            }
                         }
-                    } else {
-                        return extract(databaseMetaData.getPrimaryKeys(((AbstractJdbcDatabase) database).getJdbcCatalogName(catalogAndSchema), ((AbstractJdbcDatabase) database).getJdbcSchemaName(catalogAndSchema), table));
+                        return foundPks;
+                    } catch (DatabaseException e) {
+                        throw new SQLException(e);
                     }
+                }
+
+                private List<CachedRow> getPkInfo(String schemaName, CatalogAndSchema catalogAndSchema, String tableName) throws DatabaseException, SQLException {
+                    List<CachedRow> pkInfo;
+                    if (database instanceof MSSQLDatabase && database.getDatabaseMajorVersion() >= 8) {
+                        String sql;
+                        if (database.getDatabaseMajorVersion() >= 9) {
+                            sql =
+                                    "SELECT " +
+                                        "DB_NAME() AS [TABLE_CAT], " +
+                                        "[s].[name] AS [TABLE_SCHEM], " +
+                                        "[t].[name] AS [TABLE_NAME], " +
+                                        "[c].[name] AS [COLUMN_NAME], " +
+                                        "CASE [ic].[is_descending_key] WHEN 0 THEN N'A' WHEN 1 THEN N'D' END AS [ASC_OR_DESC], " +
+                                        "[ic].[key_ordinal] AS [KEY_SEQ], " +
+                                        "[kc].[name] AS [PK_NAME] " +
+                                    "FROM [sys].[schemas] AS [s] " +
+                                    "INNER JOIN [sys].[tables] AS [t] " +
+                                    "ON [t].[schema_id] = [s].[schema_id] " +
+                                    "INNER JOIN [sys].[key_constraints] AS [kc] " +
+                                    "ON [kc].[parent_object_id] = [t].[object_id] " +
+                                    "INNER JOIN [sys].[indexes] AS [i] " +
+                                    "ON [i].[object_id] = [kc].[parent_object_id] " +
+                                    "AND [i].[index_id] = [kc].[unique_index_id] " +
+                                    "INNER JOIN [sys].[index_columns] AS [ic] " +
+                                    "ON [ic].[object_id] = [i].[object_id] " +
+                                    "AND [ic].[index_id] = [i].[index_id] " +
+                                    "INNER JOIN [sys].[columns] AS [c] " +
+                                    "ON [c].[object_id] = [ic].[object_id] " +
+                                    "AND [c].[column_id] = [ic].[column_id] " +
+                                    "WHERE [s].[name] = N'" + database.escapeStringForDatabase(database.correctObjectName(schemaName, Schema.class)) + "' " +
+                                    "AND [t].[name] = N'" + database.escapeStringForDatabase(database.correctObjectName(tableName, Table.class)) + "' " +
+                                    "AND [kc].[type] = 'PK' " +
+                                    "AND [ic].[key_ordinal] > 0 " +
+                                    "ORDER BY " +
+                                        "[ic].[key_ordinal]";
+                        } else {
+                            sql =
+                                    "SELECT " +
+                                        "DB_NAME() AS [TABLE_CAT], " +
+                                        "[s].[name] AS [TABLE_SCHEM], " +
+                                        "[t].[name] AS [TABLE_NAME], " +
+                                        "[c].[name] AS [COLUMN_NAME], " +
+                                        "CASE INDEXKEY_PROPERTY([ic].[id], [ic].[indid], [ic].[keyno], 'IsDescending') WHEN 0 THEN N'A' WHEN 1 THEN N'D' END AS [ASC_OR_DESC], " +
+                                        "[ic].[keyno] AS [KEY_SEQ], " +
+                                        "[kc].[name] AS [PK_NAME] " +
+                                    "FROM [dbo].[sysusers] AS [s] " +
+                                    "INNER JOIN [dbo].[sysobjects] AS [t] " +
+                                    "ON [t].[uid] = [s].[uid] " +
+                                    "INNER JOIN [dbo].[sysobjects] AS [kc] " +
+                                    "ON [kc].[parent_obj] = [t].[id] " +
+                                    "INNER JOIN [dbo].[sysindexes] AS [i] " +
+                                    "ON [i].[id] = [kc].[parent_obj] " +
+                                    "AND [i].[name] = [kc].[name] " +
+                                    "INNER JOIN [dbo].[sysindexkeys] AS [ic] " +
+                                    "ON [ic].[id] = [i].[id] " +
+                                    "AND [ic].[indid] = [i].[indid] " +
+                                    "INNER JOIN [dbo].[syscolumns] AS [c] " +
+                                    "ON [c].[id] = [ic].[id] " +
+                                    "AND [c].[colid] = [ic].[colid] " +
+                                    "WHERE [s].[name] =  N'" + database.escapeStringForDatabase(database.correctObjectName(schemaName, Schema.class)) + "' " +
+                                    "AND [t].[name] = N'" + database.escapeStringForDatabase(database.correctObjectName(tableName, Table.class)) + "' " +
+                                    "AND [kc].[xtype] = 'PK' " +
+                                    "ORDER BY " +
+                                        "[ic].[keyno]";
+                        }
+                        pkInfo = executeAndExtract(sql, database);
+                    } else {
+                        pkInfo = extract(databaseMetaData.getPrimaryKeys(((AbstractJdbcDatabase) database).getJdbcCatalogName(catalogAndSchema), ((AbstractJdbcDatabase) database).getJdbcSchemaName(catalogAndSchema), tableName));
+                    }
+                    return pkInfo;
                 }
 
                 @Override
@@ -557,11 +640,16 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                             sql += " and table_name='" + database.correctObjectName(tableName, Table.class) + "'";
                         }
                     } else if (database instanceof MSSQLDatabase) {
-                        sql = "select CONSTRAINT_NAME, TABLE_NAME from INFORMATION_SCHEMA.TABLE_CONSTRAINTS "
-                                + "where CONSTRAINT_TYPE = 'Unique' "
-                                + "and CONSTRAINT_SCHEMA='" + jdbcSchemaName + "'";
+                        sql =
+                                "SELECT " +
+                                    "[TC].[CONSTRAINT_NAME], " +
+                                    "[TC].[TABLE_NAME] " +
+                                "FROM [INFORMATION_SCHEMA].[TABLE_CONSTRAINTS] AS [TC] " +
+                                "WHERE [TC].[CONSTRAINT_TYPE] = 'UNIQUE' " +
+                                "AND [TC].[CONSTRAINT_CATALOG] = N'" + database.escapeStringForDatabase(jdbcCatalogName) + "' " +
+                                "AND [TC].[CONSTRAINT_SCHEMA] = N'" + database.escapeStringForDatabase(jdbcSchemaName) + "'";
                         if (tableName != null) {
-                            sql += " and TABLE_NAME='" + database.correctObjectName(tableName, Table.class) + "'";
+                            sql += " AND [TC].[TABLE_NAME] = N'" + database.escapeStringForDatabase(database.correctObjectName(tableName, Table.class)) + "'";
                         }
                     } else if (database instanceof OracleDatabase) {
                         sql = "select uc.constraint_name, uc.table_name,uc.status,uc.deferrable,uc.deferred,ui.tablespace_name, ui.index_name, ui.owner as INDEX_CATALOG from all_constraints uc, all_indexes ui "

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/IndexSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/IndexSnapshotGenerator.java
@@ -170,7 +170,9 @@ public class IndexSnapshotGenerator extends JdbcSnapshotGenerator {
 
                         foundIndexes.put(indexName, index);
                     }
-                    index.addColumn(new Column(row.getString("COLUMN_NAME")).setRelation(index.getTable()));
+                    String ascOrDesc = row.getString("ASC_OR_DESC");
+                    Boolean descending = "D".equals(ascOrDesc) ? Boolean.TRUE : "A".equals(ascOrDesc) ? Boolean.FALSE : null;
+                    index.addColumn(new Column(row.getString("COLUMN_NAME")).setComputed(false).setDescending(descending).setRelation(index.getTable()));
                 }
 
                 for (Index exampleIndex : foundIndexes.values()) {
@@ -301,7 +303,9 @@ public class IndexSnapshotGenerator extends JdbcSnapshotGenerator {
                     returnIndex.getColumns().add(null);
                 }
                 if (definition == null) {
-                    returnIndex.getColumns().set(position - 1, new Column(columnName).setComputed(false).setRelation(returnIndex.getTable()));
+                    String ascOrDesc = row.getString("ASC_OR_DESC");
+                    Boolean descending = "D".equals(ascOrDesc) ? Boolean.TRUE : "A".equals(ascOrDesc) ? Boolean.FALSE : null;
+                    returnIndex.getColumns().set(position - 1, new Column(columnName).setDescending(descending).setRelation(returnIndex.getTable()));
                 } else {
                     returnIndex.getColumns().set(position - 1, new Column().setRelation(returnIndex.getTable()).setName(definition, true));
                 }

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/PrimaryKeySnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/PrimaryKeySnapshotGenerator.java
@@ -14,7 +14,6 @@ import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.*;
 
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.List;
 
 public class PrimaryKeySnapshotGenerator extends JdbcSnapshotGenerator {
@@ -56,7 +55,9 @@ public class PrimaryKeySnapshotGenerator extends JdbcSnapshotGenerator {
                     position = (short) (position + 1);
                 }
 
-                returnKey.addColumn(position - 1, new Column(columnName).setRelation(((PrimaryKey) example).getTable()));
+                String ascOrDesc = row.getString("ASC_OR_DESC");
+                Boolean descending = "D".equals(ascOrDesc) ? Boolean.TRUE : "A".equals(ascOrDesc) ? Boolean.FALSE : null;
+                returnKey.addColumn(position - 1, new Column(columnName).setDescending(descending).setRelation(((PrimaryKey) example).getTable()));
             }
 
             if (returnKey != null) {

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateIndexGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateIndexGenerator.java
@@ -106,6 +106,9 @@ public class CreateIndexGenerator extends AbstractSqlGenerator<CreateIndexStatem
                     buffer.append(database.escapeColumnName(statement.getTableCatalogName(), statement.getTableSchemaName(), statement.getTableName(), column.getName()));
                 }
             }
+            if (column.getDescending() != null && column.getDescending()) {
+                buffer.append(" DESC");
+            }
             if (iterator.hasNext()) {
 			    buffer.append(", ");
 		    }

--- a/liquibase-core/src/main/java/liquibase/statement/core/AddUniqueConstraintStatement.java
+++ b/liquibase-core/src/main/java/liquibase/statement/core/AddUniqueConstraintStatement.java
@@ -49,9 +49,10 @@ public class AddUniqueConstraintStatement extends AbstractSqlStatement {
         return StringUtils.join(columns, ", ", new StringUtils.StringUtilsFormatter<ColumnConfig>() {
             @Override
             public String toString(ColumnConfig obj) {
-                return obj.getName();
+                return obj.getName() + (obj.getDescending() != null && obj.getDescending() ? " DESC" : "");
             }
-        });    }
+        });
+    }
 
     public String getConstraintName() {
         return constraintName;

--- a/liquibase-core/src/main/java/liquibase/structure/core/Column.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/Column.java
@@ -174,17 +174,17 @@ public class Column extends AbstractDatabaseObject {
         if (includeRelation) {
             return toString();
         } else {
-            return getName();
+            return getName() + (getDescending() != null && getDescending() ? " DESC" : "");
         }
     }
 
     @Override
     public String toString() {
         if (getRelation() == null) {
-            return getName();
+            return getName() + (getDescending() != null && getDescending() ? " DESC" : "");
         } else {
             String tableOrViewName = getRelation().getName();
-            return tableOrViewName + "." + getName();
+            return tableOrViewName + "." + getName() + (getDescending() != null && getDescending() ? " DESC" : "");
         }
     }
 

--- a/liquibase-core/src/main/java/liquibase/structure/core/Column.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/Column.java
@@ -2,28 +2,22 @@ package liquibase.structure.core;
 
 import liquibase.change.ColumnConfig;
 import liquibase.change.ConstraintsConfig;
-import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.parser.core.ParsedNode;
 import liquibase.parser.core.ParsedNodeException;
 import liquibase.resource.ResourceAccessor;
 import liquibase.structure.AbstractDatabaseObject;
 import liquibase.structure.DatabaseObject;
-import liquibase.util.ISODateFormat;
 import liquibase.util.StringUtils;
 
-import java.lang.reflect.InvocationTargetException;
 import java.math.BigInteger;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class Column extends AbstractDatabaseObject {
 
     private String name;
     private Boolean computed;
+    private Boolean descending;
 
     public Column() {
     }
@@ -43,6 +37,7 @@ public class Column extends AbstractDatabaseObject {
 
     public Column(ColumnConfig columnConfig) {
         setName(columnConfig.getName());
+        setDescending(columnConfig.getDescending());
         setType(new DataType(columnConfig.getType()));
 
         if (columnConfig.getDefaultValue() != null) {
@@ -164,6 +159,16 @@ public class Column extends AbstractDatabaseObject {
         setAttribute("autoIncrementInformation", autoIncrementInformation);
     }
 
+    public Boolean getDescending() {
+        return descending;
+    }
+
+    public Column setDescending(Boolean descending) {
+        this.descending = descending;
+        setAttribute("descending", descending);
+
+        return this;
+    }
 
     public String toString(boolean includeRelation) {
         if (includeRelation) {
@@ -276,6 +281,20 @@ public class Column extends AbstractDatabaseObject {
         return this;
     }
 
+    public static Column fromName(String columnName) {
+        columnName = columnName.trim();
+        Boolean descending = null;
+        if (columnName.matches("(?i).*\\s+DESC")) {
+            columnName = columnName.replaceFirst("(?i)\\s+DESC$", "");
+            descending = true;
+        } else if (columnName.matches("(?i).*\\s+ASC")) {
+            columnName = columnName.replaceFirst("(?i)\\s+ASC$", "");
+            descending = false;
+        }
+        return new Column(columnName)
+                .setDescending(descending);
+    }
+
     public static Column[] arrayFromNames(String columnNames) {
         if (columnNames == null) {
             return null;
@@ -283,8 +302,8 @@ public class Column extends AbstractDatabaseObject {
 
         List<String> columnNameList = StringUtils.splitAndTrim(columnNames, ",");
         Column[] returnArray = new Column[columnNameList.size()];
-        for (int i=0; i<columnNameList.size(); i++) {
-            returnArray[i] = new Column(columnNameList.get(i));
+        for (int i = 0; i < columnNameList.size(); i++) {
+            returnArray[i] = fromName(columnNameList.get(i));
         }
         return returnArray;
     }

--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.4.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.4.xsd
@@ -298,6 +298,7 @@
                 </xsd:appinfo>
             </xsd:annotation>
         </xsd:attribute>
+        <xsd:attribute name="descending" type="booleanExp"/>
         <xsd:anyAttribute namespace="##other" processContents="lax"/>
     </xsd:attributeGroup>
 

--- a/liquibase-core/src/test/groovy/liquibase/change/ColumnConfigTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/ColumnConfigTest.groovy
@@ -428,6 +428,8 @@ public class ColumnConfigTest extends Specification {
             testValue = "838"
         } else if (field in ["valueNumeric", "defaultValueNumeric"]) {
             testValue = "347.22"
+        } else if (field in ["descending"]) {
+            testValue = true
         }
         node.addChild(null, field, testValue)
         try {

--- a/liquibase-core/src/test/java/liquibase/serializer/core/xml/XMLChangeLogSerializerTest.java
+++ b/liquibase-core/src/test/java/liquibase/serializer/core/xml/XMLChangeLogSerializerTest.java
@@ -272,6 +272,7 @@ public class XMLChangeLogSerializerTest {
 
         AddColumnConfig column2 = new AddColumnConfig();
         column2.setName("COL2");
+        column2.setDescending(true);
         refactoring.addColumn(column2);
 
         Element element = new XMLChangeLogSerializer(DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument()).createNode(refactoring);
@@ -284,6 +285,7 @@ public class XMLChangeLogSerializerTest {
         assertEquals("COL1", ((Element) element.getChildNodes().item(0)).getAttribute("name"));
         assertEquals("column", ((Element) element.getChildNodes().item(1)).getTagName());
         assertEquals("COL2", ((Element) element.getChildNodes().item(1)).getAttribute("name"));
+        assertEquals("true", ((Element) element.getChildNodes().item(1)).getAttribute("descending"));
     }
 
     @Test


### PR DESCRIPTION
Adds support for descending key columns on indexes, unique constraints and primary keys

For example:
```
<createIndex tableName="my_table" indexName="my_index">
    <column name="col1"/>
    <column name="col2" descending="true"/>
</createIndex>

<addPrimaryKey tableName="my_table" columnNames="col1, col2 DESC"/>

<addUniqueConstraint tableName="my_table" columnNames="col1, col2 DESC"/>
```

~~Snapshots aren't addressed, but~~ This should resolve all the following issues:

Liquibase JIRA:
[CORE-419](https://liquibase.jira.com/browse/CORE-419) Allowing ASC and DESC in index definitions
[CORE-1232](https://liquibase.jira.com/browse/CORE-1232) Ordered index creation

Liquibase Forum:
http://forum.liquibase.org/topic/create-index-and-order

Stack Overflow:
http://stackoverflow.com/questions/11955313/how-to-create-ordered-index-with-liquibase

