### PR TITLE
CORE-2345 Add XMLType

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/XMLType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/XMLType.java
@@ -1,0 +1,81 @@
+package liquibase.datatype.core;
+
+import liquibase.database.Database;
+import liquibase.database.core.*;
+import liquibase.datatype.DataTypeInfo;
+import liquibase.datatype.DatabaseDataType;
+import liquibase.datatype.LiquibaseDataType;
+import liquibase.exception.DatabaseException;
+import liquibase.util.StringUtils;
+
+@DataTypeInfo(name = "xml", aliases = { "xmltype", "java.sql.Types.SQLXML" }, minParameters = 0, maxParameters = 1, priority = LiquibaseDataType.PRIORITY_DEFAULT)
+public class XMLType extends LiquibaseDataType {
+    @Override
+    protected String otherToSql(Object value, Database database) {
+        if (value == null) {
+            return null;
+        }
+        String val = value.toString();
+        if (database instanceof MSSQLDatabase && !StringUtils.isAscii(val)) {
+            return "N'" + database.escapeStringForDatabase(val) + "'";
+        } else if (database instanceof PostgresDatabase) {
+            try {
+                if (database.getDatabaseMajorVersion() <= 7 // 8.2 or earlier
+                        || (database.getDatabaseMajorVersion() == 8 && database.getDatabaseMinorVersion() <= 2)) {
+
+                    return "'" + database.escapeStringForDatabase(val) + "'";
+                }
+            } catch (DatabaseException ignore) { } // assuming it is a newer version
+
+            return "xml '" + database.escapeStringForDatabase(val) + "'";
+        } else if (database instanceof OracleDatabase) {
+            return "XMLType('" + database.escapeStringForDatabase(val) + "')";
+        }
+        return "'" + database.escapeStringForDatabase(val) + "'";
+    }
+
+    @Override
+    public DatabaseDataType toDatabaseDataType(Database database) {
+        if (database instanceof MSSQLDatabase) {
+            try {
+                if (database.getDatabaseMajorVersion() <= 8) { // 2000 or earlier
+                    return new DatabaseDataType(database.escapeDataTypeName("ntext"));
+                }
+            } catch (DatabaseException ignore) { } // assuming it is a newer version
+
+            Object[] parameters = getParameters();
+            if (parameters.length > 1) {
+              parameters = new Object[] { parameters[0] };
+            }
+            return new DatabaseDataType(database.escapeDataTypeName("xml"), parameters);
+        } else if (database instanceof PostgresDatabase) {
+            try {
+                if (database.getDatabaseMajorVersion() <= 7 // 8.2 or earlier
+                        || (database.getDatabaseMajorVersion() == 8 && database.getDatabaseMinorVersion() <= 2)) {
+
+                    return new DatabaseDataType("TEXT");
+                }
+            } catch (DatabaseException ignore) { } // assuming it is a newer version
+
+            return new DatabaseDataType("XML");
+        } else if (database instanceof DB2Database) {
+            return new DatabaseDataType("XML");
+        } else if (database instanceof OracleDatabase) {
+            return new DatabaseDataType("XMLTYPE");
+        } else if (database instanceof FirebirdDatabase) {
+            return new DatabaseDataType("BLOB SUB_TYPE TEXT");
+        } else if (database instanceof SybaseASADatabase) {
+            return new DatabaseDataType("LONG VARCHAR");
+        } else if (database instanceof MySQLDatabase) {
+            return new DatabaseDataType("LONGTEXT");
+        } else if (database instanceof H2Database
+                || database instanceof HsqlDatabase
+                || database instanceof InformixDatabase) {
+
+            return new DatabaseDataType("CLOB");
+        } else if (database instanceof SQLiteDatabase || database instanceof SybaseDatabase) {
+            return new DatabaseDataType("TEXT");
+        }
+        return super.toDatabaseDataType(database);
+    }
+}

--- a/liquibase-core/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
@@ -32,7 +32,9 @@ public class DataTypeFactoryTest extends Specification {
         "serial8"                                            | new MockDatabase()    | "BIGINT"                                             | BigIntType    | true
         "int4"                                               | new MockDatabase()    | "INT"                                                | IntType       | false
         "serial4"                                            | new MockDatabase()    | "INT"                                                | IntType       | true
+        "xml"                                                | new MockDatabase()    | "XML"                                                | XMLType       | false
         "real"                                               | new DB2Database()     | "REAL"                                               | FloatType     | false
+        "xml"                                                | new DB2Database()     | "XML"                                                | XMLType       | false
         "bigint"                                             | new MSSQLDatabase()   | "[bigint]"                                           | BigIntType    | false
         "[bigint]"                                           | new MSSQLDatabase()   | "[bigint]"                                           | BigIntType    | false
         "binary"                                             | new MSSQLDatabase()   | "[binary](1)"                                        | BlobType      | false
@@ -128,18 +130,18 @@ public class DataTypeFactoryTest extends Specification {
         "[varchar](8000)"                                    | new MSSQLDatabase()   | "[varchar](8000)"                                    | VarcharType   | false
         "varchar(MAX)"                                       | new MSSQLDatabase()   | "[varchar](MAX)"                                     | VarcharType   | false
         "[varchar](MAX)"                                     | new MSSQLDatabase()   | "[varchar](MAX)"                                     | VarcharType   | false
-        "xml"                                                | new MSSQLDatabase()   | "[xml]"                                              | UnknownType   | false
-        "[xml]"                                              | new MSSQLDatabase()   | "[xml]"                                              | UnknownType   | false
-        "xml(CONTENT)"                                       | new MSSQLDatabase()   | "[xml](CONTENT)"                                     | UnknownType   | false
-        "[xml](CONTENT)"                                     | new MSSQLDatabase()   | "[xml](CONTENT)"                                     | UnknownType   | false
-        "xml(DOCUMENT)"                                      | new MSSQLDatabase()   | "[xml](DOCUMENT)"                                    | UnknownType   | false
-        "[xml](DOCUMENT)"                                    | new MSSQLDatabase()   | "[xml](DOCUMENT)"                                    | UnknownType   | false
-        "xml([MySchema].[MyXmlSchemaCollection])"            | new MSSQLDatabase()   | "[xml]([MySchema].[MyXmlSchemaCollection])"          | UnknownType   | false
-        "[xml]([MySchema].[MyXmlSchemaCollection])"          | new MSSQLDatabase()   | "[xml]([MySchema].[MyXmlSchemaCollection])"          | UnknownType   | false
-        "xml(CONTENT [MySchema].[MyXmlSchemaCollection])"    | new MSSQLDatabase()   | "[xml](CONTENT [MySchema].[MyXmlSchemaCollection])"  | UnknownType   | false
-        "[xml](CONTENT [MySchema].[MyXmlSchemaCollection])"  | new MSSQLDatabase()   | "[xml](CONTENT [MySchema].[MyXmlSchemaCollection])"  | UnknownType   | false
-        "xml(DOCUMENT [MySchema].[MyXmlSchemaCollection])"   | new MSSQLDatabase()   | "[xml](DOCUMENT [MySchema].[MyXmlSchemaCollection])" | UnknownType   | false
-        "[xml](DOCUMENT [MySchema].[MyXmlSchemaCollection])" | new MSSQLDatabase()   | "[xml](DOCUMENT [MySchema].[MyXmlSchemaCollection])" | UnknownType   | false
+        "xml"                                                | new MSSQLDatabase()   | "[xml]"                                              | XMLType       | false
+        "[xml]"                                              | new MSSQLDatabase()   | "[xml]"                                              | XMLType       | false
+        "xml(CONTENT)"                                       | new MSSQLDatabase()   | "[xml](CONTENT)"                                     | XMLType       | false
+        "[xml](CONTENT)"                                     | new MSSQLDatabase()   | "[xml](CONTENT)"                                     | XMLType       | false
+        "xml(DOCUMENT)"                                      | new MSSQLDatabase()   | "[xml](DOCUMENT)"                                    | XMLType       | false
+        "[xml](DOCUMENT)"                                    | new MSSQLDatabase()   | "[xml](DOCUMENT)"                                    | XMLType       | false
+        "xml([MySchema].[MyXmlSchemaCollection])"            | new MSSQLDatabase()   | "[xml]([MySchema].[MyXmlSchemaCollection])"          | XMLType       | false
+        "[xml]([MySchema].[MyXmlSchemaCollection])"          | new MSSQLDatabase()   | "[xml]([MySchema].[MyXmlSchemaCollection])"          | XMLType       | false
+        "xml(CONTENT [MySchema].[MyXmlSchemaCollection])"    | new MSSQLDatabase()   | "[xml](CONTENT [MySchema].[MyXmlSchemaCollection])"  | XMLType       | false
+        "[xml](CONTENT [MySchema].[MyXmlSchemaCollection])"  | new MSSQLDatabase()   | "[xml](CONTENT [MySchema].[MyXmlSchemaCollection])"  | XMLType       | false
+        "xml(DOCUMENT [MySchema].[MyXmlSchemaCollection])"   | new MSSQLDatabase()   | "[xml](DOCUMENT [MySchema].[MyXmlSchemaCollection])" | XMLType       | false
+        "[xml](DOCUMENT [MySchema].[MyXmlSchemaCollection])" | new MSSQLDatabase()   | "[xml](DOCUMENT [MySchema].[MyXmlSchemaCollection])" | XMLType       | false
         "MySchema.MyUDT"                                     | new MSSQLDatabase()   | "[MySchema].[MyUDT]"                                 | UnknownType   | false
         "MySchema.[MyUDT]"                                   | new MSSQLDatabase()   | "[MySchema].[MyUDT]"                                 | UnknownType   | false
         "[MySchema].MyUDT"                                   | new MSSQLDatabase()   | "[MySchema].[MyUDT]"                                 | UnknownType   | false
@@ -186,6 +188,9 @@ public class DataTypeFactoryTest extends Specification {
         "mediumtext"                                         | new MySQLDatabase()   | "MEDIUMTEXT"                                         | ClobType      | false
         "real"                                               | new MySQLDatabase()   | "REAL"                                               | FloatType     | false
         "nclob"                                              | new OracleDatabase()  | "NCLOB"                                              | ClobType      | false
+        "xml"                                                | new OracleDatabase()  | "XMLTYPE"                                            | XMLType       | false
+        "xmltype"                                            | new OracleDatabase()  | "XMLTYPE"                                            | XMLType       | false
+        "xml"                                                | new PostgresDatabase()| "XML"                                                | XMLType       | false
     }
 
     @Unroll("#featureName: #object for #database")

--- a/liquibase-core/src/test/groovy/liquibase/datatype/core/XMLTypeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/core/XMLTypeTest.groovy
@@ -1,0 +1,29 @@
+package liquibase.datatype.core
+
+import liquibase.database.core.*
+import liquibase.sdk.database.MockDatabase
+import liquibase.statement.DatabaseFunction
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class XMLTypeTest extends Specification {
+    @Unroll("#featureName: #object for #database")
+    def "objectToSql"() {
+        when:
+        def type = new XMLType()
+
+        then:
+        type.objectToSql(object, database) == expectedSql
+
+        where:
+        object                                                  | database                | expectedSql
+        null                                                    | new MockDatabase()      | null
+        "NULL"                                                  | new MockDatabase()      | null
+        "<?xml version=\"1.0\"?><root/>"                        | new MockDatabase()      | "'<?xml version=\"1.0\"?><root/>'"
+        "<?xml version='1.0'?><root/>"                          | new DB2Database()       | "'<?xml version=''1.0''?><root/>'"
+        "<?xml version='1.0'?><root/>"                          | new MSSQLDatabase()     | "'<?xml version=''1.0''?><root/>'"
+        "<?xml version='1.0'?><root>\u30CF\u30ED\u30FC</root>"  | new MSSQLDatabase()     | "N'<?xml version=''1.0''?><root>\u30CF\u30ED\u30FC</root>'"
+        "<?xml version='1.0'?><root/>"                          | new OracleDatabase()    | "XMLType('<?xml version=''1.0''?><root/>')"
+        "<?xml version='1.0'?><root/>"                          | new PostgresDatabase()  | "xml '<?xml version=''1.0''?><root/>'"
+    }
+}


### PR DESCRIPTION
[CORE-2345] (https://liquibase.jira.com/browse/CORE-2345) Add XML Type

With a number of databases supporting XML data types, it makes sense to have a dedicated Liquibase XMLType, rather than having the XML database types resolve to UnknownType, or requiring the plugin for each respective database to have their own XMLType.