### PR TITLE
Check diffchangelog params

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -331,6 +331,10 @@ public class Main {
               }
             }
           }
+        } else if ("diffChangeLog".equalsIgnoreCase(command)) {
+          if (diffTypes.toLowerCase().contains("data")) {
+            messages.add("Including diffTypes=data in the diffChangeLog command has no effect. This option should only be used with the generateChangeLog command.");
+          }
         }
       }
     }

--- a/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -254,6 +254,9 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
 
                     //seenTables.add(catalogName + ":" + schemaName + ":" + tableName);
                     //return seenTables.size() > 2;
+                    if (System.getProperty("NO_BULK_SELECT") != null) {
+                       return false;
+                    }
                     return true;
                 }
 


### PR DESCRIPTION
A small change to check for diffTypes=data in the diffChangeLog command. Users keep trying to use this, so a message indicating that it doesn't work is better than going forward and producing unexpected results. 