### PR TITLE
Update AbstractLiquibaseMojo.java

### DIFF
--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
@@ -144,7 +144,7 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
      * changes on a database that is not local to the machine that the user is current
      * executing the plugin on.
      *
-     * @parameter expression="${liquibase.promptOnNonLocalDatabase}" default-value="true"
+     * @parameter expression="${liquibase.promptOnNonLocalDatabase}" default-value="false"
      */
     protected boolean promptOnNonLocalDatabase;
 


### PR DESCRIPTION
A default value of "true" creates many problems on CI and in automated deployments. Many users have difficulty figuring out why errors such as "No X11 DISPLAY variable was set, but this program performed an operation which requires it" occur.