### PR TITLE
Added support for constraint name in addNotNullConstraint change. Cur…

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/AddNotNullConstraintChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/AddNotNullConstraintChange.java
@@ -28,6 +28,7 @@ public class AddNotNullConstraintChange extends AbstractChange {
     private String columnName;
     private String defaultNullValue;
     private String columnDataType;
+    private String constraintName;
 
     @DatabaseChangeProperty(mustEqualExisting ="column.relation.catalog", since = "3.0")
     public String getCatalogName() {
@@ -83,6 +84,15 @@ public class AddNotNullConstraintChange extends AbstractChange {
         this.columnDataType = columnDataType;
     }
 
+    @DatabaseChangeProperty(description = "Created constraint name (if database supports names for NOT NULL constraints)")
+    public String getConstraintName() {
+        return constraintName;
+    }
+
+    public void setConstraintName(String constraintName) {
+        this.constraintName = constraintName;
+    }
+
     @Override
     public SqlStatement[] generateStatements(Database database) {
 
@@ -99,7 +109,7 @@ public class AddNotNullConstraintChange extends AbstractChange {
                     .setWhereClause(database.escapeObjectName(getColumnName(), Column.class) + " IS NULL"));
         }
         
-    	statements.add(new SetNullableStatement(getCatalogName(), getSchemaName(), getTableName(), getColumnName(), getColumnDataType(), false));
+    	statements.add(new SetNullableStatement(getCatalogName(), getSchemaName(), getTableName(), getColumnName(), getColumnDataType(), false, getConstraintName()));
         if (database instanceof DB2Database) {
             statements.add(new ReorganizeTableStatement(getCatalogName(), getSchemaName(), getTableName()));
         }           

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/SetNullableGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/SetNullableGenerator.java
@@ -58,7 +58,9 @@ public class SetNullableGenerator extends AbstractSqlGenerator<SetNullableStatem
             nullableString = " NOT NULL";
         }
 
-        if (database instanceof OracleDatabase || database instanceof SybaseDatabase || database instanceof SybaseASADatabase) {
+        if (database instanceof OracleDatabase && statement.getConstraintName() != null) {
+            sql = "ALTER TABLE " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + " MODIFY " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " CONSTRAINT " + statement.getConstraintName() + nullableString;
+        } else if (database instanceof OracleDatabase || database instanceof SybaseDatabase || database instanceof SybaseASADatabase) {
             sql = "ALTER TABLE " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + " MODIFY " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + nullableString;
         } else if (database instanceof MSSQLDatabase) {
             sql = "ALTER TABLE " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + " ALTER COLUMN " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " " + DataTypeFactory.getInstance().fromDescription(statement.getColumnDataType(), database).toDatabaseDataType(database) + nullableString;

--- a/liquibase-core/src/main/java/liquibase/statement/core/SetNullableStatement.java
+++ b/liquibase-core/src/main/java/liquibase/statement/core/SetNullableStatement.java
@@ -9,6 +9,7 @@ public class SetNullableStatement extends AbstractSqlStatement {
     private String columnName;
     private String columnDataType;
     private boolean nullable;
+    private String constraintName;
 
     public SetNullableStatement(String catalogName, String schemaName, String tableName, String columnName, String columnDataType, boolean nullable) {
         this.catalogName = catalogName;
@@ -17,6 +18,11 @@ public class SetNullableStatement extends AbstractSqlStatement {
         this.columnName = columnName;
         this.columnDataType = columnDataType;
         this.nullable = nullable;
+    }
+
+    public SetNullableStatement(String catalogName, String schemaName, String tableName, String columnName, String columnDataType, boolean nullable, String constraintName) {
+        this(catalogName, schemaName, tableName, columnName, columnDataType, nullable);
+        this.constraintName = constraintName;
     }
 
     public String getCatalogName() {
@@ -41,5 +47,9 @@ public class SetNullableStatement extends AbstractSqlStatement {
 
     public boolean isNullable() {
         return nullable;
+    }
+
+    public String getConstraintName() {
+        return constraintName;
     }
 }

--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.3.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.3.xsd
@@ -597,6 +597,7 @@
 		<xsd:attribute name="columnName" type="xsd:string" use="required" />
 		<xsd:attribute name="defaultNullValue" type="xsd:string" />
 		<xsd:attribute name="columnDataType" type="xsd:string" />
+		<xsd:attribute name="constraintName" type="xsd:string" />
 	</xsd:attributeGroup>
 
 

--- a/liquibase-core/src/test/java/liquibase/sqlgenerator/core/SetNullableGeneratorTest.java
+++ b/liquibase-core/src/test/java/liquibase/sqlgenerator/core/SetNullableGeneratorTest.java
@@ -1,7 +1,43 @@
 package liquibase.sqlgenerator.core;
 
-public abstract class SetNullableGeneratorTest {
-////    @Test
+import liquibase.database.core.OracleDatabase;
+import liquibase.sql.Sql;
+import liquibase.statement.core.SetNullableStatement;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SetNullableGeneratorTest {
+
+  private final SetNullableGenerator generator = new SetNullableGenerator();
+  private final OracleDatabase oracle = new OracleDatabase();
+
+  @Test
+  public void testGenerateOracleNotNullSql() throws Exception {
+    final Sql[] sqls = generator.generateSql(
+        new SetNullableStatement(null, "schema_name", "table_name", "column_name", null, false), oracle, null);
+
+    assertEquals(1, sqls.length);
+
+    final Sql sql = sqls[0];
+
+    assertEquals("ALTER TABLE schema_name.table_name MODIFY column_name NOT NULL", sql.toSql());
+  }
+
+  @Test
+  public void testGenerateOracleNotNullSqlWithConstraintName() throws Exception {
+    final Sql[] sqls = generator.generateSql(
+        new SetNullableStatement(null, "schema_name", "table_name", "column_name", null, false, "constraint_name"),
+        oracle, null);
+
+    assertEquals(1, sqls.length);
+
+    final Sql sql = sqls[0];
+
+    assertEquals("ALTER TABLE schema_name.table_name MODIFY column_name CONSTRAINT constraint_name NOT NULL", sql.toSql());
+  }
+
+  ////    @Test
 ////    public void supports() throws Exception {
 ////        new DatabaseTestTemplate().testOnAllDatabases(new DatabaseTest() {
 ////


### PR DESCRIPTION
Hi
Unfortunately at the moment Liquibase doesn't support custom constraint names for NOT NULL constraints in Oracle, so I've added it into addNotNullConstraint change. This is very important for us, since we want to maintain same constraint names across all our database installations. 
Please take a look and let me know what you think. It would be great if you could put the change into next 3.3.x release.
The change is done based on 3.3.x branch
Tested on oracle instance, works fine

Thanks a lot!
Andrei