### PR TITLE
CORE-2360 Skip is active by default

### DIFF
--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
@@ -240,7 +240,7 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
      *
      * @parameter expression="${liquibase.should.run}"
      */
-    protected boolean liquibaseShouldRun;
+    protected boolean liquibaseShouldRun = true;
 
     /**
      * Array to put a expression variable to maven plugin.


### PR DESCRIPTION
[CORE-2360](https://liquibase.jira.com/browse/CORE-2360) Skip is active by default

Liquibase should probably continue to run by default when run using Maven. The default behavior changed in 3.3.3 to not run by default.