### PR TITLE
CORE-2361 preConditions, rollback, property, include, includeAll cannot be serialized

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeLogChild.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeLogChild.java
@@ -1,0 +1,6 @@
+package liquibase.changelog;
+
+import liquibase.serializer.LiquibaseSerializable;
+
+public interface ChangeLogChild extends LiquibaseSerializable {
+}

--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeLogInclude.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeLogInclude.java
@@ -1,0 +1,45 @@
+package liquibase.changelog;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import liquibase.serializer.AbstractLiquibaseSerializable;
+
+public class ChangeLogInclude extends AbstractLiquibaseSerializable implements ChangeLogChild {
+    private String file;
+    private Boolean relativeToChangelogFile;
+
+    @Override
+    public Set<String> getSerializableFields() {
+        return new LinkedHashSet<String>(Arrays.asList(
+                "file",
+                "relativeToChangelogFile"));
+    }
+
+    @Override
+    public String getSerializedObjectName() {
+        return "include";
+    }
+
+    @Override
+    public String getSerializedObjectNamespace() {
+        return STANDARD_CHANGELOG_NAMESPACE;
+    }
+
+    public String getFile() {
+        return file;
+    }
+
+    public void setFile(String file) {
+        this.file = file;
+    }
+
+    public Boolean getRelativeToChangelogFile() {
+        return relativeToChangelogFile;
+    }
+
+    public void setRelativeToChangelogFile(Boolean relativeToChangelogFile) {
+        this.relativeToChangelogFile = relativeToChangelogFile;
+    }
+}

--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeLogIncludeAll.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeLogIncludeAll.java
@@ -1,0 +1,65 @@
+package liquibase.changelog;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import liquibase.serializer.AbstractLiquibaseSerializable;
+
+public class ChangeLogIncludeAll extends AbstractLiquibaseSerializable implements ChangeLogChild {
+    private String path;
+    private Boolean errorIfMissingOrEmpty;
+    private Boolean relativeToChangelogFile;
+    private String resourceFilter;
+
+    @Override
+    public Set<String> getSerializableFields() {
+        return new LinkedHashSet<String>(Arrays.asList(
+                "path",
+                "errorIfMissingOrEmpty",
+                "relativeToChangelogFile",
+                "resourceFilter"));
+    }
+
+    @Override
+    public String getSerializedObjectName() {
+        return "includeAll";
+    }
+
+    @Override
+    public String getSerializedObjectNamespace() {
+        return STANDARD_CHANGELOG_NAMESPACE;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public Boolean getErrorIfMissingOrEmpty() {
+        return errorIfMissingOrEmpty;
+    }
+
+    public void setErrorIfMissingOrEmpty(Boolean errorIfMissingOrEmpty) {
+        this.errorIfMissingOrEmpty = errorIfMissingOrEmpty;
+    }
+
+    public Boolean getRelativeToChangelogFile() {
+        return relativeToChangelogFile;
+    }
+
+    public void setRelativeToChangelogFile(Boolean relativeToChangelogFile) {
+        this.relativeToChangelogFile = relativeToChangelogFile;
+    }
+
+    public String getResourceFilter() {
+        return resourceFilter;
+    }
+
+    public void setResourceFilter(String resourceFilter) {
+        this.resourceFilter = resourceFilter;
+    }
+}

--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeLogProperty.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeLogProperty.java
@@ -1,0 +1,95 @@
+package liquibase.changelog;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import liquibase.serializer.AbstractLiquibaseSerializable;
+
+public class ChangeLogProperty extends AbstractLiquibaseSerializable implements ChangeLogChild {
+    private String file;
+    private String name;
+    private String value;
+    private String context;
+    private String labels;
+    private String dbms;
+    private Boolean global;
+
+    @Override
+    public Set<String> getSerializableFields() {
+        return new LinkedHashSet<String>(Arrays.asList(
+                "file",
+                "name",
+                "value",
+                "context",
+                "labels",
+                "dbms",
+                "global"));
+    }
+
+    @Override
+    public String getSerializedObjectName() {
+        return "property";
+    }
+
+    @Override
+    public String getSerializedObjectNamespace() {
+        return STANDARD_CHANGELOG_NAMESPACE;
+    }
+
+    public String getFile() {
+        return file;
+    }
+
+    public void setFile(String file) {
+        this.file = file;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String getContext() {
+        return context;
+    }
+
+    public void setContext(String context) {
+        this.context = context;
+    }
+
+    public String getLabels() {
+        return labels;
+    }
+
+    public void setLabels(String labels) {
+        this.labels = labels;
+    }
+
+    public String getDbms() {
+        return dbms;
+    }
+
+    public void setDbms(String dbms) {
+        this.dbms = dbms;
+    }
+
+    public Boolean getGlobal() {
+        return global;
+    }
+
+    public void setGlobal(Boolean global) {
+        this.global = global;
+    }
+}

--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
@@ -24,7 +24,6 @@ import liquibase.precondition.ErrorPrecondition;
 import liquibase.precondition.FailedPrecondition;
 import liquibase.precondition.core.PreconditionContainer;
 import liquibase.resource.ResourceAccessor;
-import liquibase.serializer.LiquibaseSerializable;
 import liquibase.sql.visitor.SqlVisitor;
 import liquibase.sql.visitor.SqlVisitorFactory;
 import liquibase.statement.SqlStatement;
@@ -36,7 +35,7 @@ import java.util.*;
 /**
  * Encapsulates a changeSet and all its associated changes.
  */
-public class ChangeSet implements Conditional, LiquibaseSerializable {
+public class ChangeSet implements Conditional, ChangeLogChild {
 
     public enum RunStatus {
         NOT_RAN, ALREADY_RAN, RUN_AGAIN, MARK_RAN, INVALID_MD5SUM

--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
@@ -17,7 +17,6 @@ import liquibase.executor.Executor;
 import liquibase.executor.ExecutorService;
 import liquibase.logging.LogFactory;
 import liquibase.logging.Logger;
-import liquibase.parser.NamespaceDetails;
 import liquibase.parser.core.ParsedNode;
 import liquibase.parser.core.ParsedNodeException;
 import liquibase.precondition.Conditional;
@@ -912,19 +911,20 @@ public class ChangeSet implements Conditional, LiquibaseSerializable {
 
     @Override
     public Set<String> getSerializableFields() {
-        return new HashSet<String>(Arrays.asList(
+        return new LinkedHashSet<String>(Arrays.asList(
                 "id",
                 "author",
                 "runAlways",
                 "runOnChange",
                 "failOnError",
                 "context",
-                "dbms",
-                "comment",
-                "changes",
-                "rollback",
                 "labels",
-                "objectQuotingStrategy"));
+                "dbms",
+                "objectQuotingStrategy",
+                "comment",
+                "preconditions",
+                "changes",
+                "rollback"));
 
     }
 
@@ -996,6 +996,14 @@ public class ChangeSet implements Conditional, LiquibaseSerializable {
             return this.getObjectQuotingStrategy().toString();
         }
 
+        if (field.equals("preconditions")) {
+            if (this.getPreconditions() != null && this.getPreconditions().getNestedPreconditions().size() > 0) {
+                return this.getPreconditions();
+            } else {
+                return null;
+            }
+        }
+
         if (field.equals("changes")) {
             return getChanges();
         }
@@ -1013,7 +1021,7 @@ public class ChangeSet implements Conditional, LiquibaseSerializable {
 
     @Override
     public SerializationType getSerializableFieldType(String field) {
-        if (field.equals("comment") || field.equals("changes") || field.equals("rollback")) {
+        if (field.equals("comment") || field.equals("preconditions") || field.equals("changes") || field.equals("rollback")) {
             return SerializationType.NESTED_OBJECT;
 //        } else if (field.equals()) {
 //            return SerializationType.DIRECT_VALUE;

--- a/liquibase-core/src/main/java/liquibase/changelog/RollbackContainer.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/RollbackContainer.java
@@ -1,0 +1,29 @@
+package liquibase.changelog;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import liquibase.change.Change;
+import liquibase.serializer.AbstractLiquibaseSerializable;
+
+public class RollbackContainer extends AbstractLiquibaseSerializable {
+    private List<Change> changes = new ArrayList<Change>();
+
+    @Override
+    public String getSerializedObjectName() {
+        return "rollback";
+    }
+
+    @Override
+    public String getSerializedObjectNamespace() {
+        return STANDARD_CHANGELOG_NAMESPACE;
+    }
+
+    public List<Change> getChanges() {
+        return changes;
+    }
+
+    public void setChanges(List<Change> changes) {
+        this.changes = changes;
+    }
+}

--- a/liquibase-core/src/main/java/liquibase/precondition/AbstractPrecondition.java
+++ b/liquibase-core/src/main/java/liquibase/precondition/AbstractPrecondition.java
@@ -1,22 +1,6 @@
 package liquibase.precondition;
 
-import liquibase.exception.SetupException;
-import liquibase.exception.UnexpectedLiquibaseException;
-import liquibase.parser.core.ParsedNode;
-import liquibase.parser.core.ParsedNodeException;
-import liquibase.resource.ResourceAccessor;
 import liquibase.serializer.AbstractLiquibaseSerializable;
-import liquibase.util.ObjectUtil;
-import liquibase.util.StringUtils;
-
-import java.beans.IntrospectionException;
-import java.beans.Introspector;
-import java.beans.PropertyDescriptor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 
 public abstract class AbstractPrecondition extends AbstractLiquibaseSerializable implements Precondition {
 

--- a/liquibase-core/src/main/java/liquibase/precondition/PreconditionLogic.java
+++ b/liquibase-core/src/main/java/liquibase/precondition/PreconditionLogic.java
@@ -1,6 +1,5 @@
 package liquibase.precondition;
 
-import liquibase.exception.SetupException;
 import liquibase.parser.core.ParsedNode;
 import liquibase.parser.core.ParsedNodeException;
 import liquibase.resource.ResourceAccessor;

--- a/liquibase-core/src/main/java/liquibase/precondition/core/PreconditionContainer.java
+++ b/liquibase-core/src/main/java/liquibase/precondition/core/PreconditionContainer.java
@@ -257,4 +257,9 @@ public class PreconditionContainer extends AndPrecondition {
 
         super.load(parsedNode, resourceAccessor);
     }
+
+    @Override
+    public String getName() {
+        return "preConditions";
+    }
 }

--- a/liquibase-core/src/main/java/liquibase/precondition/core/PreconditionContainer.java
+++ b/liquibase-core/src/main/java/liquibase/precondition/core/PreconditionContainer.java
@@ -9,6 +9,7 @@ import liquibase.resource.ResourceAccessor;
 import liquibase.util.StringUtils;
 import liquibase.util.StreamUtil;
 import liquibase.database.Database;
+import liquibase.changelog.ChangeLogChild;
 import liquibase.changelog.DatabaseChangeLog;
 import liquibase.changelog.ChangeSet;
 import liquibase.executor.Executor;
@@ -18,7 +19,7 @@ import liquibase.logging.LogFactory;
 import java.util.ArrayList;
 import java.util.List;
 
-public class PreconditionContainer extends AndPrecondition {
+public class PreconditionContainer extends AndPrecondition implements ChangeLogChild {
 
     public enum FailOption {
         HALT("HALT"),

--- a/liquibase-core/src/main/java/liquibase/serializer/ChangeLogSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/ChangeLogSerializer.java
@@ -1,20 +1,16 @@
 package liquibase.serializer;
 
-import liquibase.change.Change;
-import liquibase.change.ColumnConfig;
-import liquibase.changelog.ChangeSet;
-import liquibase.changelog.DatabaseChangeLog;
-import liquibase.sql.visitor.SqlVisitor;
-
 import java.io.File;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.List;
+
+import liquibase.changelog.ChangeLogChild;
+import liquibase.changelog.ChangeSet;
 
 public interface ChangeLogSerializer extends LiquibaseSerializer {
 
-	void write(List<ChangeSet> changeSets, OutputStream out) throws IOException;
+    <T extends ChangeLogChild> void write(List<T> children, OutputStream out) throws IOException;
 
     void append(ChangeSet changeSet, File changeLogFile) throws IOException;
 }

--- a/liquibase-core/src/main/java/liquibase/serializer/core/formattedsql/FormattedSqlChangeLogSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/formattedsql/FormattedSqlChangeLogSerializer.java
@@ -1,19 +1,17 @@
 package liquibase.serializer.core.formattedsql;
 
 import liquibase.change.Change;
+import liquibase.changelog.ChangeLogChild;
 import liquibase.changelog.ChangeSet;
-import liquibase.changelog.DatabaseChangeLog;
 import liquibase.configuration.GlobalConfiguration;
 import liquibase.configuration.LiquibaseConfiguration;
 import liquibase.database.Database;
 import liquibase.database.DatabaseFactory;
-import liquibase.database.core.OracleDatabase;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.serializer.ChangeLogSerializer;
 import liquibase.serializer.LiquibaseSerializable;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.SqlGeneratorFactory;
-import liquibase.statement.SqlStatement;
 
 import java.io.File;
 import java.io.IOException;
@@ -81,12 +79,12 @@ public class FormattedSqlChangeLogSerializer  implements ChangeLogSerializer {
     }
 
     @Override
-    public void write(List<ChangeSet> changeSets, OutputStream out) throws IOException {
+    public <T extends ChangeLogChild> void write(List<T> children, OutputStream out) throws IOException {
         StringBuilder builder = new StringBuilder();
         builder.append("--liquibase formatted sql\n\n");
 
-        for (ChangeSet changeSet : changeSets) {
-            builder.append(serialize(changeSet, true));
+        for (T child : children) {
+            builder.append(serialize(child, true));
             builder.append("\n");
         }
 

--- a/liquibase-core/src/main/java/liquibase/serializer/core/json/JsonChangeLogSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/json/JsonChangeLogSerializer.java
@@ -1,6 +1,6 @@
 package liquibase.serializer.core.json;
 
-import liquibase.changelog.ChangeSet;
+import liquibase.changelog.ChangeLogChild;
 import liquibase.serializer.LiquibaseSerializable;
 import liquibase.serializer.core.yaml.YamlChangeLogSerializer;
 import liquibase.util.StringUtils;
@@ -19,13 +19,13 @@ import java.util.List;
 public class JsonChangeLogSerializer extends YamlChangeLogSerializer {
 
     @Override
-    public void write(List<ChangeSet> changeSets, OutputStream out) throws IOException {
+    public <T extends ChangeLogChild> void write(List<T> children, OutputStream out) throws IOException {
         BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(out));
         writer.write("{ \"databaseChangeLog\": [\n");
         int i = 0;
-        for (ChangeSet changeSet : changeSets) {
-            String serialized = serialize(changeSet, true);
-            if (++i < changeSets.size()) {
+        for (T child : children) {
+            String serialized = serialize(child, true);
+            if (++i < children.size()) {
                 serialized = serialized.replaceFirst("}\\s*$", "},\n");
             }
             writer.write(StringUtils.indent(serialized, 2));

--- a/liquibase-core/src/main/java/liquibase/serializer/core/string/StringChangeLogSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/string/StringChangeLogSerializer.java
@@ -1,5 +1,6 @@
 package liquibase.serializer.core.string;
 
+import liquibase.changelog.ChangeLogChild;
 import liquibase.changelog.ChangeSet;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.serializer.ChangeLogSerializer;
@@ -152,7 +153,7 @@ public class StringChangeLogSerializer implements ChangeLogSerializer {
     }
 
     @Override
-    public void write(List<ChangeSet> changeSets, OutputStream out) throws IOException {
+    public <T extends ChangeLogChild> void write(List<T> children, OutputStream out) throws IOException {
 
     }
 

--- a/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
@@ -1,6 +1,7 @@
 package liquibase.serializer.core.xml;
 
 import liquibase.change.*;
+import liquibase.changelog.ChangeLogChild;
 import liquibase.changelog.ChangeSet;
 import liquibase.changelog.DatabaseChangeLog;
 import liquibase.exception.UnexpectedLiquibaseException;
@@ -14,11 +15,13 @@ import liquibase.util.StreamUtil;
 import liquibase.util.StringUtils;
 import liquibase.util.XMLUtil;
 import liquibase.util.xml.DefaultXmlWriter;
+
 import org.w3c.dom.*;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+
 import java.io.*;
 import java.util.*;
 
@@ -64,7 +67,7 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
     }
 
     @Override
-    public void write(List<ChangeSet> changeSets, OutputStream out) throws IOException {
+    public <T extends ChangeLogChild> void write(List<T> children, OutputStream out) throws IOException {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         factory.setNamespaceAware(true);
         DocumentBuilder documentBuilder;
@@ -116,8 +119,8 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
         doc.appendChild(changeLogElement);
         setCurrentChangeLogFileDOM(doc);
 
-        for (ChangeSet changeSet : changeSets) {
-            doc.getDocumentElement().appendChild(createNode(changeSet));
+        for (T child : children) {
+            doc.getDocumentElement().appendChild(createNode(child));
         }
 
         new DefaultXmlWriter().write(doc, out);

--- a/liquibase-core/src/main/java/liquibase/serializer/core/yaml/YamlChangeLogSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/yaml/YamlChangeLogSerializer.java
@@ -1,10 +1,9 @@
 package liquibase.serializer.core.yaml;
 
+import liquibase.changelog.ChangeLogChild;
 import liquibase.changelog.ChangeSet;
 import liquibase.serializer.ChangeLogSerializer;
 import liquibase.serializer.LiquibaseSerializable;
-import liquibase.structure.DatabaseObject;
-import liquibase.structure.DatabaseObjectCollection;
 import liquibase.util.StringUtils;
 
 import java.io.*;
@@ -21,11 +20,11 @@ public class YamlChangeLogSerializer extends YamlSerializer implements ChangeLog
     }
 
     @Override
-    public void write(List<ChangeSet> changeSets, OutputStream out) throws IOException {
+    public <T extends ChangeLogChild> void write(List<T> children, OutputStream out) throws IOException {
         BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(out));
         writer.write("databaseChangeLog:\n");
-        for (ChangeSet changeSet : changeSets) {
-            writer.write(StringUtils.indent(serialize(changeSet, true), 2));
+        for (T child : children) {
+            writer.write(StringUtils.indent(serialize(child, true), 2));
             writer.write("\n");
         }
         writer.flush();

--- a/liquibase-core/src/test/groovy/liquibase/changelog/ChangeSetTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/changelog/ChangeSetTest.groovy
@@ -186,8 +186,8 @@ public class ChangeSetTest extends Specification {
 
         then:
         changeSet.changes.size() == 1
-        changeSet.rollBackChanges.size() == 1
-        ((RawSQLChange) changeSet.rollBackChanges[0]).sql == "rollback logic here"
+        changeSet.rollback.changes.size() == 1
+        ((RawSQLChange) changeSet.rollback.changes[0]).sql == "rollback logic here"
     }
 
     def "load node with rollback containing change node as value"() {
@@ -204,8 +204,8 @@ public class ChangeSetTest extends Specification {
 
         then:
         changeSet.changes.size() == 1
-        changeSet.rollBackChanges.size() == 1
-        ((RenameTableChange) changeSet.rollBackChanges[0]).newTableName == "rename_to_x"
+        changeSet.rollback.changes.size() == 1
+        ((RenameTableChange) changeSet.rollback.changes[0]).newTableName == "rename_to_x"
     }
 
     def "load node with rollback containing collection of change nodes as value"() {
@@ -225,9 +225,9 @@ public class ChangeSetTest extends Specification {
 
         then:
         changeSet.changes.size() == 1
-        changeSet.rollBackChanges.size() == 2
-        ((RenameTableChange) changeSet.rollBackChanges[0]).newTableName == "rename_to_x"
-        ((RenameTableChange) changeSet.rollBackChanges[1]).newTableName == "rename_to_y"
+        changeSet.rollback.changes.size() == 2
+        ((RenameTableChange) changeSet.rollback.changes[0]).newTableName == "rename_to_x"
+        ((RenameTableChange) changeSet.rollback.changes[1]).newTableName == "rename_to_y"
     }
 
     def "load node with rollback containing rollback nodes as children"() {
@@ -247,10 +247,10 @@ public class ChangeSetTest extends Specification {
 
         then:
         changeSet.changes.size() == 1
-        changeSet.rollBackChanges.size() == 3
-        ((RenameTableChange) changeSet.rollBackChanges[0]).newTableName == "rename_to_a"
-        ((RenameTableChange) changeSet.rollBackChanges[1]).newTableName == "rename_to_b"
-        ((RawSQLChange) changeSet.rollBackChanges[2]).sql == "rollback sql"
+        changeSet.rollback.changes.size() == 3
+        ((RenameTableChange) changeSet.rollback.changes[0]).newTableName == "rename_to_a"
+        ((RenameTableChange) changeSet.rollback.changes[1]).newTableName == "rename_to_b"
+        ((RawSQLChange) changeSet.rollback.changes[2]).sql == "rollback sql"
     }
 
     def "load node with rollback containing multiple sql statements in value"() {
@@ -268,9 +268,9 @@ public class ChangeSetTest extends Specification {
 
         then:
         changeSet.changes.size() == 1
-        ((RawSQLChange) changeSet.rollBackChanges[0]).sql == "rollback sql 1"
-        ((RawSQLChange) changeSet.rollBackChanges[1]).sql == "rollback sql 2"
-        changeSet.rollBackChanges.size() == 2
+        ((RawSQLChange) changeSet.rollback.changes[0]).sql == "rollback sql 1"
+        ((RawSQLChange) changeSet.rollback.changes[1]).sql == "rollback sql 2"
+        changeSet.rollback.changes.size() == 2
     }
 
     def "load node with valid checksums as children"() {
@@ -391,8 +391,8 @@ public class ChangeSetTest extends Specification {
 
         then:
         changeSet.changes.size() == 0
-        changeSet.rollBackChanges.size() == 1
-        changeSet.rollBackChanges[0] instanceof EmptyChange
+        changeSet.rollback.changes.size() == 1
+        changeSet.rollback.changes[0] instanceof EmptyChange
     }
 
     @Unroll("#featureName with changeSetPath=#changeSetPath")
@@ -409,8 +409,8 @@ public class ChangeSetTest extends Specification {
         then:
         changeLog.getChangeSet(path, "nvoxland", "3").changes.size() == 1
         ((DropTableChange) changeLog.getChangeSet(path, "nvoxland", "3").changes[0]).tableName == "tableX"
-        changeLog.getChangeSet(path, "nvoxland", "3").rollBackChanges.size() == 1
-        ((CreateTableChange) changeLog.getChangeSet(path, "nvoxland", "3").rollBackChanges[0]).tableName == "table2"
+        changeLog.getChangeSet(path, "nvoxland", "3").rollback.changes.size() == 1
+        ((CreateTableChange) changeLog.getChangeSet(path, "nvoxland", "3").rollback.changes[0]).tableName == "table2"
 
         where:
         changeSetPath << ["com/example/test.xml", null]

--- a/liquibase-core/src/test/groovy/liquibase/changelog/ChangeSetTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/changelog/ChangeSetTest.groovy
@@ -123,7 +123,7 @@ public class ChangeSetTest extends Specification {
                 testValue[param] = "true"
             } else if (param == "context") {
                 testValue[param] = "test or value"
-            } else if (param == "rollback" || param == "changes") {
+            } else if (param == "rollback" || param == "changes" || param == "preconditions") {
                 continue
             } else if (param == "objectQuotingStrategy") {
                 testValue[param] = "QUOTE_ONLY_RESERVED_WORDS"

--- a/liquibase-core/src/test/groovy/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.groovy
@@ -139,8 +139,8 @@ public class FormattedSqlChangeLogParserTest extends Specification {
         assert !changeLog.getChangeSets().get(1).isRunInTransaction()
         changeLog.getChangeSets().get(1).getContexts().toString() == "y"
         StringUtils.join(changeLog.getChangeSets().get(1).getDbmsSet(), ",") == "mysql"
-        changeLog.getChangeSets().get(1).getRollBackChanges().length == 1
-        ((RawSQLChange) changeLog.getChangeSets().get(1).getRollBackChanges()[0]).getSql() == "delete from table1;\ndrop table table1;"
+        changeLog.getChangeSets().get(1).rollback.changes.size() == 1
+        ((RawSQLChange) changeLog.getChangeSets().get(1).rollback.changes[0]).getSql() == "delete from table1;\ndrop table table1;"
 
 
         changeLog.getChangeSets().get(2).getAuthor() == "nvoxland"
@@ -150,28 +150,28 @@ public class FormattedSqlChangeLogParserTest extends Specification {
         ((RawSQLChange) changeLog.getChangeSets().get(2).getChanges().get(0)).getEndDelimiter() == null
         assert ((RawSQLChange) changeLog.getChangeSets().get(2).getChanges().get(0)).isSplitStatements()
         assert ((RawSQLChange) changeLog.getChangeSets().get(2).getChanges().get(0)).isStripComments()
-        changeLog.getChangeSets().get(2).getRollBackChanges().length == 1
-        assert changeLog.getChangeSets().get(2).getRollBackChanges()[0] instanceof RawSQLChange
-        ((RawSQLChange) changeLog.getChangeSets().get(2).getRollBackChanges()[0]).getSql() == "drop table table2;"
+        changeLog.getChangeSets().get(2).rollback.changes.size() == 1
+        assert changeLog.getChangeSets().get(2).rollback.changes[0] instanceof RawSQLChange
+        ((RawSQLChange) changeLog.getChangeSets().get(2).rollback.changes[0]).getSql() == "drop table table2;"
 
         changeLog.getChangeSets().get(3).getAuthor() == "alwyn"
         changeLog.getChangeSets().get(3).getId() == "4"
-        changeLog.getChangeSets().get(3).getRollBackChanges().length == 1
-        assert changeLog.getChangeSets().get(3).getRollBackChanges()[0] instanceof EmptyChange
+        changeLog.getChangeSets().get(3).rollback.changes.size() == 1
+        assert changeLog.getChangeSets().get(3).rollback.changes[0] instanceof EmptyChange
 
         changeLog.getChangeSets().get(4).getAuthor() == "nvoxland"
         changeLog.getChangeSets().get(4).getId() == "5"
-        changeLog.getChangeSets().get(4).getRollBackChanges().length == 1
-        assert changeLog.getChangeSets().get(4).getRollBackChanges()[0] instanceof EmptyChange
+        changeLog.getChangeSets().get(4).rollback.changes.size() == 1
+        assert changeLog.getChangeSets().get(4).rollback.changes[0] instanceof EmptyChange
 
         changeLog.getChangeSets().get(5).getAuthor() == "paikens"
         changeLog.getChangeSets().get(5).getId() == "6"
         changeLog.getChangeSets().get(5).getChanges().size() == 1
         assert changeLog.getChangeSets().get(5).getChanges().get(0) instanceof RawSQLChange
         ((RawSQLChange) changeLog.getChangeSets().get(5).getChanges().get(0)).getSql() == "create table table4 (\n  id int primary key\n);"
-        changeLog.getChangeSets().get(5).getRollBackChanges().length == 1
-        assert changeLog.getChangeSets().get(5).getRollBackChanges()[0] instanceof RawSQLChange
-        ((RawSQLChange) changeLog.getChangeSets().get(5).getRollBackChanges()[0]).getSql() == "drop table table4;"
+        changeLog.getChangeSets().get(5).rollback.changes.size() == 1
+        assert changeLog.getChangeSets().get(5).rollback.changes[0] instanceof RawSQLChange
+        ((RawSQLChange) changeLog.getChangeSets().get(5).rollback.changes[0]).getSql() == "drop table table4;"
 
 
         changeLog.getChangeSets().get(6).getAuthor() == "mysql"
@@ -179,16 +179,16 @@ public class FormattedSqlChangeLogParserTest extends Specification {
         changeLog.getChangeSets().get(6).getChanges().size() == 1
         assert changeLog.getChangeSets().get(6).getChanges().get(0) instanceof RawSQLChange
         ((RawSQLChange) changeLog.getChangeSets().get(6).getChanges().get(0)).getSql() == "create table mysql_boo (\n  id int primary key\n);"
-        changeLog.getChangeSets().get(6).getRollBackChanges().length == 1
-        assert changeLog.getChangeSets().get(6).getRollBackChanges()[0] instanceof RawSQLChange
-        ((RawSQLChange) changeLog.getChangeSets().get(6).getRollBackChanges()[0]).getSql() == "drop table mysql_boo;"
+        changeLog.getChangeSets().get(6).rollback.changes.size() == 1
+        assert changeLog.getChangeSets().get(6).rollback.changes[0] instanceof RawSQLChange
+        ((RawSQLChange) changeLog.getChangeSets().get(6).rollback.changes[0]).getSql() == "drop table mysql_boo;"
 
         changeLog.getChangeSets().get(7).getAuthor() == "multicontext"
         changeLog.getChangeSets().get(7).getId() == "1"
         changeLog.getChangeSets().get(7).getChanges().size() == 1
         assert changeLog.getChangeSets().get(7).getChanges().get(0) instanceof RawSQLChange
         ((RawSQLChange) changeLog.getChangeSets().get(7).getChanges().get(0)).getSql() == "select 1;"
-        changeLog.getChangeSets().get(7).getRollBackChanges().length == 0
+        changeLog.getChangeSets().get(7).rollback.changes.size() == 0
 //         changeLog.getChangeSets().get(7).getContexts().size() == 3
         assert changeLog.getChangeSets().get(7).getContexts().toString().contains("first")
         assert changeLog.getChangeSets().get(7).getContexts().toString().contains("second")
@@ -215,9 +215,9 @@ public class FormattedSqlChangeLogParserTest extends Specification {
         cs.getChanges().size() == 1
         assert cs.getChanges().get(0) instanceof RawSQLChange
         ((RawSQLChange) cs.getChanges().get(0)).getSql() == "create table my_table (\n  id int primary key\n);"
-        cs.getRollBackChanges().length == 1
-        assert cs.getRollBackChanges()[0] instanceof RawSQLChange
-        ((RawSQLChange) cs.getRollBackChanges()[0]).getSql() == "drop table my_table;"
+        cs.rollback.changes.size() == 1
+        assert cs.rollback.changes[0] instanceof RawSQLChange
+        ((RawSQLChange) cs.rollback.changes[0]).getSql() == "drop table my_table;"
     }
 
     def parse_authorWithSpace() throws Exception {

--- a/liquibase-core/src/test/groovy/liquibase/parser/core/xml/XMLChangeLogSAXParser_RealFile_Test.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/parser/core/xml/XMLChangeLogSAXParser_RealFile_Test.groovy
@@ -137,9 +137,9 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
         changeLog.getChangeSets().get(1).getComments() == "Testing add column"
         assert changeLog.getChangeSets().get(1).shouldAlwaysRun()
         assert changeLog.getChangeSets().get(1).shouldRunOnChange()
-        changeLog.getChangeSets().get(1).getRollBackChanges().length == 2
-        assert changeLog.getChangeSets().get(1).getRollBackChanges()[0] instanceof RawSQLChange
-        assert changeLog.getChangeSets().get(1).getRollBackChanges()[1] instanceof RawSQLChange
+        changeLog.getChangeSets().get(1).rollback.changes.size() == 2
+        assert changeLog.getChangeSets().get(1).rollback.changes[0] instanceof RawSQLChange
+        assert changeLog.getChangeSets().get(1).rollback.changes[1] instanceof RawSQLChange
 
         ChangeFactory.getInstance().getChangeMetaData(changeLog.getChangeSets().get(1).getChanges()[0]).getName() == "addColumn"
         assert changeLog.getChangeSets().get(1).getChanges()[0] instanceof AddColumnChange
@@ -340,7 +340,7 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
 		changeLog.getChangeSets()[0].getId() == "1"
         changeLog.getChangeSets()[0].comments == "Some values: overridden: 'Value passed in', not.overridden: 'value from changelog 2', database: 'database mock', contextNote: 'context prod', contextNote2: '\${contextNote2}'"
 		((RawSQLChange) changeLog.getChangeSets()[0].getChanges()[0]).getSql() == "create table my_table_name;"
-		((RawSQLChange) changeLog.getChangeSets()[0].getRollBackChanges()[0]).getSql() == "drop table my_table_name"
+		((RawSQLChange) changeLog.getChangeSets()[0].rollback.changes[0]).getSql() == "drop table my_table_name"
 
         and: "changeSet 2"
         changeLog.getChangeSets().get(1).getAuthor() == "nvoxland"
@@ -483,23 +483,23 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
         ((RawSQLChange) changeLog.getChangeSet(path, "nvoxland", "changeSet with UTF8").changes[0]).sql == "insert into testutf8insert (stringvalue) values ('string with € and £')"
 
         and: "rollback blocks are parsed correctly"
-        changeLog.getChangeSet(path, "nvoxland", "standard changeSet").rollBackChanges.size() == 0
+        changeLog.getChangeSet(path, "nvoxland", "standard changeSet").rollback.changes.size() == 0
 
-        changeLog.getChangeSet(path, "nvoxland", "one rollback block").rollBackChanges.length == 1
-        ((RawSQLChange) changeLog.getChangeSet(path, "nvoxland", "one rollback block").rollBackChanges[0]).sql == "drop table rollback_test"
+        changeLog.getChangeSet(path, "nvoxland", "one rollback block").rollback.changes.size() == 1
+        ((RawSQLChange) changeLog.getChangeSet(path, "nvoxland", "one rollback block").rollback.changes[0]).sql == "drop table rollback_test"
 
-        changeLog.getChangeSet(path, "nvoxland", "empty rollback block").rollBackChanges.size() == 1
-        assert changeLog.getChangeSet(path, "nvoxland", "empty rollback block").rollBackChanges[0] instanceof EmptyChange
+        changeLog.getChangeSet(path, "nvoxland", "empty rollback block").rollback.changes.size() == 1
+        assert changeLog.getChangeSet(path, "nvoxland", "empty rollback block").rollback.changes[0] instanceof EmptyChange
 
 
-        changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollBackChanges.length == 7
-        ((RawSQLChange) changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollBackChanges[0]).sql == "drop table multiRollback1"
-        ((RawSQLChange) changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollBackChanges[1]).sql == "drop table multiRollback2"
-        ((RawSQLChange) changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollBackChanges[2]).sql == "drop table multiRollback3"
-        ((DropTableChange) changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollBackChanges[3]).tableName == "multiRollback4"
-        ((DropTableChange) changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollBackChanges[4]).tableName == "multiRollback5"
-        ((DropTableChange) changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollBackChanges[5]).tableName == "multiRollback6"
-        ((RawSQLChange) changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollBackChanges[6]).sql == "select * from simple"
+        changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollback.changes.size() == 7
+        ((RawSQLChange) changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollback.changes[0]).sql == "drop table multiRollback1"
+        ((RawSQLChange) changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollback.changes[1]).sql == "drop table multiRollback2"
+        ((RawSQLChange) changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollback.changes[2]).sql == "drop table multiRollback3"
+        ((DropTableChange) changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollback.changes[3]).tableName == "multiRollback4"
+        ((DropTableChange) changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollback.changes[4]).tableName == "multiRollback5"
+        ((DropTableChange) changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollback.changes[5]).tableName == "multiRollback6"
+        ((RawSQLChange) changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollback.changes[6]).sql == "select * from simple"
 
     }
     def "tests for particular features and edge conditions part 3 testCasesChangeLog.xml"() throws Exception {

--- a/liquibase-core/src/test/groovy/liquibase/parser/core/yaml/YamlChangeLogParser_RealFile_Test.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/parser/core/yaml/YamlChangeLogParser_RealFile_Test.groovy
@@ -140,9 +140,9 @@ public class YamlChangeLogParser_RealFile_Test extends Specification {
         changeLog.getChangeSet(path, "nvoxland", "2").getComments() == "Testing add column"
         assert changeLog.getChangeSet(path, "nvoxland", "2").shouldAlwaysRun()
         assert changeLog.getChangeSet(path, "nvoxland", "2").shouldRunOnChange()
-        changeLog.getChangeSet(path, "nvoxland", "2").getRollBackChanges().length == 2
-        assert changeLog.getChangeSet(path, "nvoxland", "2").getRollBackChanges()[0] instanceof RawSQLChange
-        assert changeLog.getChangeSet(path, "nvoxland", "2").getRollBackChanges()[1] instanceof RawSQLChange
+        changeLog.getChangeSet(path, "nvoxland", "2").rollback.changes.size() == 2
+        assert changeLog.getChangeSet(path, "nvoxland", "2").rollback.changes[0] instanceof RawSQLChange
+        assert changeLog.getChangeSet(path, "nvoxland", "2").rollback.changes[1] instanceof RawSQLChange
 
         ChangeFactory.getInstance().getChangeMetaData(changeLog.getChangeSet(path, "nvoxland", "2").getChanges().get(0)).getName() == "addColumn"
         assert changeLog.getChangeSet(path, "nvoxland", "2").getChanges().get(0) instanceof AddColumnChange
@@ -331,7 +331,7 @@ public class YamlChangeLogParser_RealFile_Test extends Specification {
         changeLog.getChangeSets().get(0).getId() == "1"
         changeLog.getChangeSets().get(0).comments == "Some values: overridden: 'Value passed in', not.overridden: 'value from changelog 2', database: 'value from mock', contextNote: 'context prod', contextNote2: '\${contextNote2}'"
         ((RawSQLChange) changeLog.getChangeSets().get(0).getChanges().get(0)).getSql() == "create table my_table_name"
-        ((RawSQLChange) changeLog.getChangeSets().get(0).getRollBackChanges()[0]).getSql() == "drop table my_table_name"
+        ((RawSQLChange) changeLog.getChangeSets().get(0).rollback.changes[0]).getSql() == "drop table my_table_name"
 
         and: "changeSet 2"
         changeLog.getChangeSets().get(1).getAuthor() == "nvoxland"
@@ -475,22 +475,22 @@ public class YamlChangeLogParser_RealFile_Test extends Specification {
         ((RawSQLChange) changeLog.getChangeSet(path, "nvoxland", "changeSet with UTF8").changes[0]).sql == "insert into testutf8insert (stringvalue) values ('string with € and £')"
 
         and: "rollback blocks are parsed correctly"
-        changeLog.getChangeSet(path, "nvoxland", "standard changeSet").rollBackChanges.size() == 0
+        changeLog.getChangeSet(path, "nvoxland", "standard changeSet").rollback.changes.size() == 0
 
-        changeLog.getChangeSet(path, "nvoxland", "one rollback block").rollBackChanges.length == 1
-        ((RawSQLChange) changeLog.getChangeSet(path, "nvoxland", "one rollback block").rollBackChanges[0]).sql == "drop table rollback_test"
+        changeLog.getChangeSet(path, "nvoxland", "one rollback block").rollback.changes.size() == 1
+        ((RawSQLChange) changeLog.getChangeSet(path, "nvoxland", "one rollback block").rollback.changes[0]).sql == "drop table rollback_test"
 
-        changeLog.getChangeSet(path, "nvoxland", "empty rollback block").rollBackChanges.size() == 1
-        assert changeLog.getChangeSet(path, "nvoxland", "empty rollback block").rollBackChanges[0] instanceof EmptyChange
+        changeLog.getChangeSet(path, "nvoxland", "empty rollback block").rollback.changes.size() == 1
+        assert changeLog.getChangeSet(path, "nvoxland", "empty rollback block").rollback.changes[0] instanceof EmptyChange
 
 
-        changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollBackChanges.length == 6
-        ((RawSQLChange) changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollBackChanges[0]).sql == "drop table multiRollback1"
-        ((RawSQLChange) changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollBackChanges[1]).sql == "drop table multiRollback2"
-        ((RawSQLChange) changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollBackChanges[2]).sql == "drop table multiRollback3"
-        ((DropTableChange) changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollBackChanges[3]).tableName == "multiRollback4"
-        ((DropTableChange) changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollBackChanges[4]).tableName == "multiRollback5"
-        ((DropTableChange) changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollBackChanges[5]).tableName == "multiRollback6"
+        changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollback.changes.size() == 6
+        ((RawSQLChange) changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollback.changes[0]).sql == "drop table multiRollback1"
+        ((RawSQLChange) changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollback.changes[1]).sql == "drop table multiRollback2"
+        ((RawSQLChange) changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollback.changes[2]).sql == "drop table multiRollback3"
+        ((DropTableChange) changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollback.changes[3]).tableName == "multiRollback4"
+        ((DropTableChange) changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollback.changes[4]).tableName == "multiRollback5"
+        ((DropTableChange) changeLog.getChangeSet(path, "nvoxland", "multiple rollback blocks").rollback.changes[5]).tableName == "multiRollback6"
 
     }
 

--- a/liquibase-core/src/test/java/liquibase/serializer/MockChangeLogSerializer.java
+++ b/liquibase-core/src/test/java/liquibase/serializer/MockChangeLogSerializer.java
@@ -1,13 +1,9 @@
 package liquibase.serializer;
 
-import liquibase.change.Change;
-import liquibase.change.ColumnConfig;
+import liquibase.changelog.ChangeLogChild;
 import liquibase.changelog.ChangeSet;
-import liquibase.changelog.DatabaseChangeLog;
-import liquibase.sql.visitor.SqlVisitor;
 
 import java.io.File;
-import java.io.InputStream;
 import java.util.List;
 import java.io.OutputStream;
 import java.io.IOException;
@@ -26,15 +22,12 @@ public class MockChangeLogSerializer implements ChangeLogSerializer {
         return validExtensions;
     }
 
-	@Override
-    public void write(List<ChangeSet> changeSets, OutputStream out)
-			throws IOException {
-		;
-	}
+    @Override
+    public <T extends ChangeLogChild> void write(List<T> children, OutputStream out) throws IOException {
+    }
 
     @Override
     public void append(ChangeSet changeSet, File changeLogFile) throws IOException {
-
     }
 
     @Override


### PR DESCRIPTION
[CORE-2361](https://liquibase.jira.com/browse/CORE-2361) preConditions, rollback, property, include, includeAll cannot be serialized

Makes it possible to serialize the `preConditions`, `rollback` children of a `changeSet` and the `property`, `preConditions`, `include` and `includeAll` children of a `databaseChangeLog`.

Note that the changes to `ChangeLogSerializer` interface are backwards compatible to callers, but not implementors. I think that is acceptable for 3.4.x. It's not possible to keep or deprecate the former `write` method due to duplicate method signatures caused by type erasure.