### PR TITLE
CORE-2019: Rollback Fails When Containing Only a Comment Tag

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
@@ -364,8 +364,11 @@ public class ChangeSet implements Conditional, LiquibaseSerializable {
 
         boolean foundValue = false;
         for (ParsedNode childNode : rollbackNode.getChildren()) {
-            addRollbackChange(toChange(childNode, resourceAccessor));
-            foundValue =  true;
+            Change rollbackChange = toChange(childNode, resourceAccessor);
+            if (rollbackChange != null) {
+                addRollbackChange(rollbackChange);
+                foundValue =  true;
+            }
         }
 
         Object value = rollbackNode.getValue();
@@ -588,12 +591,12 @@ public class ChangeSet implements Conditional, LiquibaseSerializable {
         try {
             Executor executor = ExecutorService.getInstance().getExecutor(database);
             executor.comment("Rolling Back ChangeSet: " + toString());
-            
+
             // set auto-commit based on runInTransaction if database supports DDL in transactions
             if (database.supportsDDLInTransaction()) {
                 database.setAutoCommit(!runInTransaction);
             }
-            
+
             RanChangeSet ranChangeSet = database.getRanChangeSet(this);
             if (rollBackChanges != null && rollBackChanges.size() > 0) {
                 for (Change rollback : rollBackChanges) {
@@ -866,7 +869,7 @@ public class ChangeSet implements Conditional, LiquibaseSerializable {
     public ObjectQuotingStrategy getObjectQuotingStrategy() {
         return objectQuotingStrategy;
     }
- 
+
     @Override
     public String getSerializedObjectName() {
         return "changeSet";

--- a/liquibase-core/src/test/groovy/liquibase/changelog/ChangeSetTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/changelog/ChangeSetTest.groovy
@@ -12,6 +12,8 @@ import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import java.time.format.Parsed
+
 import static org.junit.Assert.assertTrue
 import static spock.util.matcher.HamcrestSupport.that
 
@@ -312,7 +314,7 @@ public class ChangeSetTest extends Specification {
         when:
         def changeSet = new ChangeSet(new DatabaseChangeLog("com/example/test.xml"))
         try {
-            changeSet.load(new liquibase.parser.core.ParsedNode(null, "changeSet").addChildren([preConditions: [
+            changeSet.load(new ParsedNode(null, "changeSet").addChildren([preConditions: [
                     [runningAs: [username: "my_user"]],
                     [runningAs: [username: "my_other_user"]],
             ]]), resourceSupplier.simpleResourceAccessor)
@@ -330,7 +332,7 @@ public class ChangeSetTest extends Specification {
         when:
         def changeSet = new ChangeSet(new DatabaseChangeLog("com/example/test.xml"))
         try {
-            changeSet.load(new liquibase.parser.core.ParsedNode(null, "changeSet").setValue(new liquibase.parser.core.ParsedNode(null, "preConditions").setValue([
+            changeSet.load(new ParsedNode(null, "changeSet").setValue(new ParsedNode(null, "preConditions").setValue([
                     [runningAs: [username: "my_user"]],
                     [runningAs: [username: "my_other_user"]],
             ])), resourceSupplier.simpleResourceAccessor)
@@ -348,9 +350,9 @@ public class ChangeSetTest extends Specification {
         when:
         def changeSet = new ChangeSet(new DatabaseChangeLog("com/example/test.xml"))
         try {
-            changeSet.load(new liquibase.parser.core.ParsedNode(null, "changeSet").setValue([
-                    new liquibase.parser.core.ParsedNode(null, "modifySql").addChildren([applyToRollback: "true", replace: [replace: "a", with: "b"]]),
-                    new liquibase.parser.core.ParsedNode(null, "modifySql").addChildren([dbms: "mysql, oracle", context: "live, test", applyToRollback: "false"]).setValue([
+            changeSet.load(new ParsedNode(null, "changeSet").setValue([
+                    new ParsedNode(null, "modifySql").addChildren([applyToRollback: "true", replace: [replace: "a", with: "b"]]),
+                    new ParsedNode(null, "modifySql").addChildren([dbms: "mysql, oracle", context: "live, test", applyToRollback: "false"]).setValue([
                             [replace: [replace: "x1", with: "y1"]],
                             [replace: [replace: "x2", with: "y2"]],
                     ])
@@ -382,7 +384,7 @@ public class ChangeSetTest extends Specification {
         when:
         def changeSet = new ChangeSet(new DatabaseChangeLog("com/example/test.xml"))
         try {
-            changeSet.load(new liquibase.parser.core.ParsedNode(null, "changeSet").addChild(new liquibase.parser.core.ParsedNode(null, "rollback")), resourceSupplier.simpleResourceAccessor)
+            changeSet.load(new ParsedNode(null, "changeSet").addChild(new ParsedNode(null, "rollback")), resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -391,6 +393,43 @@ public class ChangeSetTest extends Specification {
         changeSet.changes.size() == 0
         changeSet.rollBackChanges.size() == 1
         changeSet.rollBackChanges[0] instanceof EmptyChange
+    }
+
+    def "load node with rollback containing only a comment creates an EmptyChange"() {
+        when:
+        def changeSet = new ChangeSet(new DatabaseChangeLog("com/example/test.xml"))
+        try {
+            def commentNode = new ParsedNode(null, "comment").setValue("comment here")
+            def rollbackNode = new ParsedNode(null, "rollback").addChild(commentNode)
+            def changeSetNode = new ParsedNode(null, "changeSet").addChild(rollbackNode)
+            changeSet.load(changeSetNode, resourceSupplier.simpleResourceAccessor)
+        } catch (ParsedNodeException e) {
+            e.printStackTrace()
+        }
+        then:
+        changeSet.changes.size() == 0
+        changeSet.rollBackChanges.size() == 1
+        changeSet.rollBackChanges[0] instanceof EmptyChange
+    }
+
+    def "load node with rollback containing change node and a comment as value"() {
+        when:
+        def changeSet = new ChangeSet(new DatabaseChangeLog("com/example/test.xml"))
+        def createTableNode = new ParsedNode(null, "createTable").addChild(null, "tableName", "table_1")
+        def renameTableNode = new ParsedNode(null, "renameTable").addChild(null, "newTableName", "rename_to_x")
+        def commentNode = new ParsedNode(null, "comment").setValue("comment here")
+        def rollbackNode = new ParsedNode(null, "rollback").addChild(commentNode).addChild(renameTableNode)
+        def changeSetNode = new ParsedNode(null, "changeSet").addChild(createTableNode).addChild(rollbackNode)
+        try {
+            changeSet.load(changeSetNode, resourceSupplier.simpleResourceAccessor)
+        } catch (ParsedNodeException e) {
+            e.printStackTrace()
+        }
+
+        then:
+        changeSet.changes.size() == 1
+        changeSet.rollBackChanges.size() == 1
+        ((RenameTableChange) changeSet.rollBackChanges[0]).newTableName == "rename_to_x"
     }
 
     @Unroll("#featureName with changeSetPath=#changeSetPath")
@@ -440,7 +479,7 @@ public class ChangeSetTest extends Specification {
         when:
         def changeSet = new ChangeSet(new DatabaseChangeLog("com/example/test.xml"))
         try {
-            changeSet.load(new liquibase.parser.core.ParsedNode(null, "changeSet").addChild(null, param, value), resourceSupplier.simpleResourceAccessor)
+            changeSet.load(new ParsedNode(null, "changeSet").addChild(null, param, value), resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -461,7 +500,7 @@ public class ChangeSetTest extends Specification {
         when:
         def changeSet = new ChangeSet(new DatabaseChangeLog("com/example/test.xml"))
         try {
-            changeSet.load(new liquibase.parser.core.ParsedNode(null, "changeSet").addChild(null, param, value), resourceSupplier.simpleResourceAccessor)
+            changeSet.load(new ParsedNode(null, "changeSet").addChild(null, param, value), resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }


### PR DESCRIPTION
When parsing a changelog where one or more changeSets have a rollback containing a single "comment" tag, the rollback will fail.  Liquibase will attempt converting the comment into a change.  The conversion fails with a null Change object which is not checked prior to adding to the rollbackChanges collection.

Note:  I just realized by commit message does not include the summary of CORE-2019.  My apologies.