### PR TITLE
CORE-864 ability for LoadData to emit multi row insert statements.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
@@ -11,6 +11,7 @@ import liquibase.resource.ResourceAccessor;
 import liquibase.resource.UtfBomAwareReader;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.InsertStatement;
+import liquibase.statement.core.InsertSetStatement;
 import liquibase.structure.core.Column;
 import liquibase.util.StreamUtil;
 import liquibase.util.StringUtils;
@@ -162,7 +163,7 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
                 throw new UnexpectedLiquibaseException("Data file "+getFile()+" was empty");
             }
 
-            List<SqlStatement> statements = new ArrayList<SqlStatement>();
+            InsertSetStatement statements = this.createStatementSet(getCatalogName(), getSchemaName(), getTableName());
             String[] line;
             int lineNumber = 0;
 
@@ -222,10 +223,10 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
 
                     insertStatement.addColumnValue(columnName, value);
                 }
-                statements.add(insertStatement);
+                statements.addInsertStatement(insertStatement);
             }
 
-            return statements.toArray(new SqlStatement[statements.size()]);
+            return new SqlStatement[]{statements}; // we only return a single "statement" - it's capable of emitting multiple sub-statements, should the need arrise, on generation.
         } catch (IOException e) {
             throw new RuntimeException(e);
         } catch (UnexpectedLiquibaseException ule) {
@@ -285,6 +286,10 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
 
     protected InsertStatement createStatement(String catalogName, String schemaName, String tableName){
         return new InsertStatement(catalogName, schemaName,tableName);
+    }
+
+    protected InsertSetStatement createStatementSet(String catalogName, String schemaName, String tableName){
+        return new InsertSetStatement(catalogName, schemaName,tableName);
     }
 
     protected ColumnConfig getColumnConfig(int index, String header) {

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/InsertSetGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/InsertSetGenerator.java
@@ -1,0 +1,78 @@
+package liquibase.sqlgenerator.core;
+
+import liquibase.database.Database;
+import liquibase.datatype.DataTypeFactory;
+import liquibase.exception.ValidationErrors;
+import liquibase.sql.Sql;
+import liquibase.sql.UnparsedSql;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.sqlgenerator.core.InsertGenerator;
+import liquibase.statement.DatabaseFunction;
+import liquibase.statement.core.InsertStatement;
+import liquibase.statement.core.InsertSetStatement;
+import liquibase.structure.core.Relation;
+import liquibase.structure.core.Table;
+
+import java.util.Date;
+
+public class InsertSetGenerator extends AbstractSqlGenerator<InsertSetStatement> {
+
+    @Override
+    public ValidationErrors validate(InsertSetStatement insertStatementSet, Database database, SqlGeneratorChain sqlGeneratorChain) {
+        ValidationErrors validationErrors = new ValidationErrors();
+        validationErrors.checkRequiredField("tableName", insertStatementSet.peek().getTableName());
+        validationErrors.checkRequiredField("columns", insertStatementSet.peek().getColumnValues());
+
+//      it is an error if any of the individual statements have a different table,schema, or catalog.
+
+//        if (insertStatement.getSchemaName() != null && !database.supportsSchemas()) {
+//           validationErrors.addError("Database does not support schemas");
+//       }
+
+        return validationErrors;
+    }
+
+    @Override
+    public Sql[] generateSql(InsertSetStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+       
+    	if(statement.peek() == null) {
+    		return new UnparsedSql[0];
+    	}
+        StringBuffer sql = new StringBuffer();
+        
+        generateHeader(sql,statement,database);
+        generateValues(sql,statement,database);
+
+        return new Sql[] {
+                new UnparsedSql(sql.toString(), getAffectedTable(statement))
+        };
+    }
+    
+    public void generateHeader(StringBuffer sql,InsertSetStatement statement, Database database) {
+        InsertStatement insert=statement.peek();
+        myGenerator.generateHeader(sql,insert,database);
+    }
+    
+    public void generateValues(StringBuffer sql,InsertSetStatement statements, Database database) {
+        int index = 0;
+        for( InsertStatement statement : statements.getStatements()) {
+          index++;
+          if(index>statements.getBatchThreshold()) {
+            sql.deleteCharAt(sql.lastIndexOf(","));
+            sql.append(";\n");            
+            generateHeader(sql,statements,database);
+            index=0;
+          }
+          myGenerator.generateValues(sql,statement,database);
+          sql.append(",");
+        }
+        sql.deleteCharAt(sql.lastIndexOf(","));
+        sql.append(";");
+    }
+
+    protected Relation getAffectedTable(InsertSetStatement statement) {
+        return new Table().setName(statement.getTableName()).setSchema(statement.getCatalogName(), statement.getSchemaName());
+    }
+    
+    private InsertGenerator myGenerator= new InsertGenerator();
+}

--- a/liquibase-core/src/main/java/liquibase/statement/core/InsertSetStatement.java
+++ b/liquibase-core/src/main/java/liquibase/statement/core/InsertSetStatement.java
@@ -1,0 +1,64 @@
+package liquibase.statement.core;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import liquibase.statement.AbstractSqlStatement;
+import liquibase.statement.core.InsertStatement;
+
+public class InsertSetStatement extends AbstractSqlStatement {
+    private LinkedList<InsertStatement> inserts = new LinkedList<InsertStatement>();
+    private String catalogName;
+    private String schemaName;
+    private String tableName;
+    private int batchSize;
+
+    public InsertSetStatement(String catalogName, String schemaName, String tableName) {
+        this(catalogName, schemaName, tableName, 50);
+    }
+
+    public InsertSetStatement(String catalogName, String schemaName, String tableName,int batchSize) {
+        this.catalogName = catalogName;
+        this.schemaName = schemaName;
+        this.tableName = tableName;
+        this.batchSize = batchSize;
+    }
+
+    public String getCatalogName() {
+        return catalogName;
+    }
+
+    public String getSchemaName() {
+        return schemaName;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public int getBatchThreshold() {
+        return batchSize;
+    }
+
+    public InsertSetStatement addInsertStatement(InsertStatement statement) {
+        /*
+        if(statement.getCatalogName() != this.getCatalogName() 
+        || statement.getShemaName() != this.getSchemaName()
+        || statement.getTableName() != this.getTableName()) {
+        // HANDLE ERROR CONDITION
+        }*/
+        inserts.add(statement);
+
+        return this;
+    }
+    public InsertStatement peek() {
+      return inserts.peek();
+    }
+
+    public List<InsertStatement> getStatements() {
+        return inserts;
+    }
+    public InsertStatement[] getStatementsArray() {
+        return inserts.toArray(new InsertStatement[0]);
+    }
+}

--- a/liquibase-core/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
@@ -10,6 +10,7 @@ import liquibase.snapshot.MockSnapshotGeneratorFactory
 import liquibase.snapshot.SnapshotGeneratorFactory;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.InsertStatement
+import liquibase.statement.core.InsertSetStatement;
 import spock.lang.Unroll
 import liquibase.test.JUnitResourceAccessor
 
@@ -26,9 +27,15 @@ public class LoadDataChangeTest extends StandardChangeTest {
 
         refactoring.setResourceAccessor(new JUnitResourceAccessor());
 
-        SqlStatement[] sqlStatements = refactoring.generateStatements(new MockDatabase());
-
-        then:
+		SqlStatement[] sqlStatement = refactoring.generateStatements(new MockDatabase());
+		then:
+		sqlStatement.length == 1
+		assert sqlStatement[0] instanceof InsertSetStatement
+		
+		when:	
+        SqlStatement[] sqlStatements = ((InsertSetStatement)sqlStatement[0]).getStatementsArray();
+		
+		then:
         sqlStatements.length == 0
     }
 
@@ -48,9 +55,15 @@ public class LoadDataChangeTest extends StandardChangeTest {
 
         refactoring.setResourceAccessor(new ClassLoaderResourceAccessor());
 
-        SqlStatement[] sqlStatements = refactoring.generateStatements(new MockDatabase());
-
-        then:
+		SqlStatement[] sqlStatement = refactoring.generateStatements(new MockDatabase());
+		then:
+		sqlStatement.length == 1
+		assert sqlStatement[0] instanceof InsertSetStatement
+		
+		when:	
+        SqlStatement[] sqlStatements = ((InsertSetStatement)sqlStatement[0]).getStatementsArray();
+		
+		then:
         sqlStatements.length == 2
         assert sqlStatements[0] instanceof InsertStatement
         assert sqlStatements[1] instanceof InsertStatement
@@ -91,10 +104,16 @@ public class LoadDataChangeTest extends StandardChangeTest {
         activeConfig.setHeader("active");
         activeConfig.setType("BOOLEAN");
         refactoring.addColumn(activeConfig);
-
-        SqlStatement[] sqlStatements = refactoring.generateStatements(new MockDatabase());
-
-        then:
+        
+		SqlStatement[] sqlStatement = refactoring.generateStatements(new MockDatabase());
+		then:
+		sqlStatement.length == 1
+		assert sqlStatement[0] instanceof InsertSetStatement
+		
+		when:	
+        SqlStatement[] sqlStatements = ((InsertSetStatement)sqlStatement[0]).getStatementsArray();
+		
+		then:
         sqlStatements.length == 2
         assert sqlStatements[0] instanceof InsertStatement
         assert sqlStatements[1] instanceof InsertStatement


### PR DESCRIPTION
the InsertSet is a container for a set of Insert statements, which would allow batching the updates rather than issuing RBAR (row by agonizing row) insert statments as is currently done (see CORE-864)

== code compiles and passes all unit tests in LoadDataChangeTest.groovy==

i'm proposing this PR in order to a) get some feedback, b) provide a codebase to assist resolving CORE-864.

todo:
- InsertSetGenerator.validate
- better logic for controlling the batch size; 

i suspect there are dbms specific row, packet, and sql string length limits that would be exceeded here. This is why i selected 50 as the batch size; reduces the overhead to 2% of what it was, without having a significant chance of excessively long statements.

as neither the change nor sqlgenerator folders have changed since the last merge of the 3.3.x branch, this pr should be able to be applied to all branches (3.3.x,3.4.x,4.x)

Compatibility of current batch approach:

sql server: since 2008
postgres: since 8.2
mysql: since 3.22.5

oracle: not in this format, force batch size to 1, or perform an alternate code block removing the keyword "insert" then adding a header of "insert all" and a footer of "SELECT * FROM dual;" for each batch.

