### PR TITLE
include defaultFile arg for liquibase properties in $LIQUIBASE_HOME

### DIFF
--- a/liquibase-core/src/main/resources/dist/liquibase
+++ b/liquibase-core/src/main/resources/dist/liquibase
@@ -53,6 +53,6 @@ fi
 # add any JVM options here
 JAVA_OPTS="${JAVA_OPTS-}"
 
-java -cp "$CP" $JAVA_OPTS liquibase.integration.commandline.Main ${1+"$@"}
+java -cp "$CP" $JAVA_OPTS liquibase.integration.commandline.Main --defaultsFile="${LIQUIBASE_HOME}/liquibase.properties" ${1+"$@"}
 
 

--- a/liquibase-debian/src/main/resources/liquibase
+++ b/liquibase-debian/src/main/resources/liquibase
@@ -50,6 +50,6 @@ fi
 # add any JVM options here
 JAVA_OPTS=
 
-java -cp "$CP" $JAVA_OPTS liquibase.integration.commandline.Main ${1+"$@"}
+java -cp "$CP" $JAVA_OPTS liquibase.integration.commandline.Main --defaultsFile="${LIQUIBASE_HOME}/liquibase.properties" ${1+"$@"}
 
 

--- a/liquibase-rpm/src/main/resources/liquibase
+++ b/liquibase-rpm/src/main/resources/liquibase
@@ -48,6 +48,6 @@ fi
 # add any JVM options here
 JAVA_OPTS="${JAVA_OPTS-}"
 
-java -cp "$CP" $JAVA_OPTS liquibase.integration.commandline.Main ${1+"$@"}
+java -cp "$CP" $JAVA_OPTS liquibase.integration.commandline.Main --defaultsFile="${LIQUIBASE_HOME}/liquibase.properties" ${1+"$@"}
 
 


### PR DESCRIPTION
This is a change I use locally for managing single properties for multiple lqb schema projects to keep command line commands shorter. Might be useful to others.