### PR TITLE
Various dbDoc enhancements, Fixed Debian start script

### DIFF
--- a/liquibase-core/src/main/java/liquibase/dbdoc/HTMLListWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/HTMLListWriter.java
@@ -38,7 +38,7 @@ public class HTMLListWriter {
                 fileWriter.append("<A HREF=\"");
                 fileWriter.append(directory);
                 fileWriter.append("/");
-                fileWriter.append(DBDocUtil.toFileName(object.toString().toLowerCase()));
+                fileWriter.append(DBDocUtil.toFileName(object.toString().endsWith(".xml") ? object.toString() : object.toString().toLowerCase()));
                 fileWriter.append(getTargetExtension());
                 fileWriter.append("\" target=\"objectFrame\">");
                 fileWriter.append(StringUtils.escapeHtml(object.toString()));

--- a/liquibase-core/src/main/java/liquibase/dbdoc/TableWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/TableWriter.java
@@ -36,6 +36,7 @@ public class TableWriter extends HTMLWriter {
         for (Column column : table.getColumns()) {
             String remarks = column.getRemarks();
             cells.add(Arrays.asList(column.getType().toString(),
+                    column.isNullable() ? "NULL" : "NOT NULL",
                     "<A HREF=\"../columns/" + table.getName().toLowerCase() + "." + column.getName().toLowerCase() + ".html" + "\">" + column.getName() + "</A>",
                     remarks != null ? remarks : ""));
             //todo: add foreign key info to columns?

--- a/liquibase-core/src/main/java/liquibase/dbdoc/TableWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/TableWriter.java
@@ -25,9 +25,9 @@ public class TableWriter extends HTMLWriter {
 
     @Override
     protected void writeCustomHTML(FileWriter fileWriter, Object object, List<Change> changes, Database database) throws IOException {
-    	final Table table = (Table) object;
-    	writeTableRemarks(fileWriter, table, database);
-		writeColumns(fileWriter, table, database);
+        final Table table = (Table) object;
+        writeTableRemarks(fileWriter, table, database);
+        writeColumns(fileWriter, table, database);
     }
 
     private void writeColumns(FileWriter fileWriter, Table table, Database database) throws IOException {

--- a/liquibase-core/src/main/java/liquibase/dbdoc/TableWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/TableWriter.java
@@ -2,7 +2,6 @@ package liquibase.dbdoc;
 
 import liquibase.change.Change;
 import liquibase.database.Database;
-import liquibase.datatype.DataTypeFactory;
 import liquibase.structure.core.Column;
 import liquibase.structure.core.Table;
 

--- a/liquibase-core/src/main/java/liquibase/dbdoc/TableWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/TableWriter.java
@@ -3,6 +3,8 @@ package liquibase.dbdoc;
 import liquibase.change.Change;
 import liquibase.database.Database;
 import liquibase.structure.core.Column;
+import liquibase.structure.core.Index;
+import liquibase.structure.core.PrimaryKey;
 import liquibase.structure.core.Table;
 
 import java.io.File;
@@ -28,6 +30,7 @@ public class TableWriter extends HTMLWriter {
         final Table table = (Table) object;
         writeTableRemarks(fileWriter, table, database);
         writeColumns(fileWriter, table, database);
+        writeTableIndexes(fileWriter, table, database);
     }
 
     private void writeColumns(FileWriter fileWriter, Table table, Database database) throws IOException {
@@ -52,6 +55,20 @@ public class TableWriter extends HTMLWriter {
         	final List<List<String>> cells = new ArrayList<List<String>>();
         	cells.add(Arrays.asList(tableRemarks));
         	writeTable("Table Description", cells, fileWriter);
+        }
+    }
+    
+    private void writeTableIndexes(FileWriter fileWriter, Table table, Database database) throws IOException {
+        final List<List<String>> cells = new ArrayList<List<String>>();
+        final PrimaryKey primaryKey = table.getPrimaryKey();
+        if (!table.getIndexes().isEmpty()) {
+            for (Index index : table.getIndexes()) {
+                cells.add(Arrays.asList((primaryKey != null && primaryKey.getBackingIndex() == index ? "Primary Key " : index.isUnique() ? "Unique " : "Non-Unique ") +
+                        (index.getClustered() == null ? "" : (index.getClustered() ? "Clustered" : "Non-Clustered")),
+                        index.getName(),
+                        index.getColumnNames().replace(index.getTable().getName() + ".","")));
+            }
+        writeTable("Current Table Indexes", cells, fileWriter);
         }
     }
 }

--- a/liquibase-core/src/main/java/liquibase/dbdoc/TableWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/TableWriter.java
@@ -81,7 +81,8 @@ public class TableWriter extends HTMLWriter {
             for (ForeignKey outgoingForeignKey : table.getOutgoingForeignKeys()) {
                 cells.add(Arrays.asList(outgoingForeignKey.getName(),
                         outgoingForeignKey.getForeignKeyColumns().toString().replace(table.getName() + ".", "").replaceAll("[\\[\\]]", ""),
-                        outgoingForeignKey.getPrimaryKeyColumns().toString().replaceAll("[\\[\\]]", "")));
+                        outgoingForeignKey.getPrimaryKeyTable().toString(),
+                        outgoingForeignKey.getPrimaryKeyColumns().toString().replace(outgoingForeignKey.getPrimaryKeyTable().toString() + ".", "").replaceAll("[\\[\\]]", "")));
             }
             writeTable("Current Table Foreign Keys", cells, fileWriter);
         }

--- a/liquibase-core/src/main/java/liquibase/dbdoc/TableWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/TableWriter.java
@@ -3,6 +3,7 @@ package liquibase.dbdoc;
 import liquibase.change.Change;
 import liquibase.database.Database;
 import liquibase.structure.core.Column;
+import liquibase.structure.core.ForeignKey;
 import liquibase.structure.core.Index;
 import liquibase.structure.core.PrimaryKey;
 import liquibase.structure.core.Table;
@@ -31,6 +32,7 @@ public class TableWriter extends HTMLWriter {
         writeTableRemarks(fileWriter, table, database);
         writeColumns(fileWriter, table, database);
         writeTableIndexes(fileWriter, table, database);
+        writeTableForeignKeys(fileWriter, table, database);
     }
 
     private void writeColumns(FileWriter fileWriter, Table table, Database database) throws IOException {
@@ -69,6 +71,19 @@ public class TableWriter extends HTMLWriter {
                         index.getColumnNames().replace(index.getTable().getName() + ".","")));
             }
         writeTable("Current Table Indexes", cells, fileWriter);
+        }
+    }
+    
+    private void writeTableForeignKeys(FileWriter fileWriter, Table table, Database database) throws IOException {
+        final List<List<String>> cells = new ArrayList<List<String>>();
+        if(!table.getOutgoingForeignKeys().isEmpty())
+        {
+            for (ForeignKey outgoingForeignKey : table.getOutgoingForeignKeys()) {
+                cells.add(Arrays.asList(outgoingForeignKey.getName(),
+                        outgoingForeignKey.getForeignKeyColumns().toString().replace(table.getName() + ".", "").replaceAll("[\\[\\]]", ""),
+                        outgoingForeignKey.getPrimaryKeyColumns().toString().replaceAll("[\\[\\]]", "")));
+            }
+            writeTable("Current Table Foreign Keys", cells, fileWriter);
         }
     }
 }

--- a/liquibase-debian/src/main/resources/liquibase
+++ b/liquibase-debian/src/main/resources/liquibase
@@ -1,7 +1,7 @@
 #! /bin/sh
 
 if [ -n "${LIQUIBASE_HOME+x}" ]; then
-# echo "Liquibase Home: $LIQUIBASE_HOME"
+  echo "Liquibase Home: $LIQUIBASE_HOME"
 else
   echo "Liquibase Home is not set."
 


### PR DESCRIPTION
Hi,

my teammates were not quite satisfied with the current status of generated dbDoc.
So I made following additions to these:
- Display current nullable status of each column in Column list in table view [d975a7e]
- Display current table indexes in table view, containing some details [81f63eb]
 - Primary Key or Unique/Non-Unique, Clustered/Non-Clustered
 - Index name
 - Columns in index
- Display current foreign keys in table view containing following details [5b58e4d]
 - Foreign Key Name
 - Affected Column(s)
 - Referenced Table
 - Referenced Column(s) [4e8d100]
- Change logs containing uppercase characters could produce dead links in "Change Logs" list on non-Windows Systems [404c0c5]

Also I found an syntax error in the Debian start script (/usr/bin/liquibase) [9e31fbe]

Thanks for your effort.


Best regards,

Juan