### PR TITLE
CORE-2024 Replace liquibase.sdk with liquibase.sdk.database for packages to scan

### DIFF
--- a/liquibase-core/src/main/java/liquibase/servicelocator/ServiceLocator.java
+++ b/liquibase-core/src/main/java/liquibase/servicelocator/ServiceLocator.java
@@ -123,7 +123,7 @@ public class ServiceLocator {
                 addPackageToScan("liquibase.structure");
                 addPackageToScan("liquibase.structurecompare");
                 addPackageToScan("liquibase.lockservice");
-                addPackageToScan("liquibase.sdk");
+                addPackageToScan("liquibase.sdk.database");
                 addPackageToScan("liquibase.ext");
             }
         }

--- a/liquibase-core/src/main/resources/META-INF/MANIFEST.MF
+++ b/liquibase-core/src/main/resources/META-INF/MANIFEST.MF
@@ -16,5 +16,5 @@ Liquibase-Package: liquibase.change,
  liquibase.structure,
  liquibase.structurecompare,
  liquibase.lockservice,
- liquibase.sdk,
+ liquibase.sdk.database,
  liquibase.ext


### PR DESCRIPTION
[CORE-2024](https://liquibase.jira.com/browse/CORE-2024) Replace liquibase.sdk with liquibase.sdk.database for packages to scan

Until the Liquibase SDK can be split off into it's own module, this is an effective workaround for class loaders that log class loading errors (e.g. in an application server environment) to avoid loading Jetty and JUnit classes that may not be on the classpath.

This also relates to [CORE-2145](https://liquibase.jira.com/browse/CORE-2145).