### PR TITLE
Patch copy rows for edge case with no copy columns

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CopyRowsGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CopyRowsGenerator.java
@@ -31,6 +31,11 @@ public class CopyRowsGenerator extends AbstractSqlGenerator<CopyRowsStatement> {
     @Override
     public Sql[] generateSql(CopyRowsStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
         StringBuffer sql = new StringBuffer();
+        
+        if (statement.getCopyColumns().size() == 0) {
+            return new Sql[]{};
+        }
+        
         if (database instanceof SQLiteDatabase) {
             sql.append("INSERT INTO `").append(statement.getTargetTable()).append("` (");
 


### PR DESCRIPTION
If the copy rows function is called with no copy columns, you'll end up with an invalid SQL statement.

This occurs when you try to add a single column to a table in an SQLITE database. This occurs because to alter table with an SQLite database you create a temporary table and copy over the rows.

Note: In the future, you might want to update the alter table implementation for SQLite since SQLIte now supports the "ALTER TABLE Query"

This patch fixes the `liquibase: [SQLITE_ERROR] SQL error or missing database (near ")": syntax error)` bug