### PR TITLE
Put back echo for $LIQUIBASE_HOME

### DIFF
--- a/liquibase-debian/src/main/resources/liquibase
+++ b/liquibase-debian/src/main/resources/liquibase
@@ -1,7 +1,7 @@
 #! /bin/sh
 
 if [ -n "${LIQUIBASE_HOME+x}" ]; then
-# echo "Liquibase Home: $LIQUIBASE_HOME"
+  echo "Liquibase Home: $LIQUIBASE_HOME"
 else
   echo "Liquibase Home is not set."
 


### PR DESCRIPTION
Since removal of the echo, the liquibase command does not work properly at all : it is even not possible to get liquibase version

liquibase --version
/usr/bin/liquibase: 5: /usr/bin/liquibase: Syntax error: "else" unexpected 

This affects the debian version.