### PR TITLE
Put back echo for $LIQUIBASE_HOME

### DIFF
--- a/liquibase-rpm/src/main/resources/liquibase
+++ b/liquibase-rpm/src/main/resources/liquibase
@@ -1,7 +1,7 @@
 #! /bin/sh
 
 if [ ! -n "${LIQUIBASE_HOME+x}" ]; then
-  # echo "Liquibase Home is not set."
+  echo "Liquibase Home is not set."
 
   ## resolve links - $0 may be a symlink
   PRG="$0"


### PR DESCRIPTION

Since removal of the echo, the liquibase command does not work properly at all : it is even not possible to get liquibase version

liquibase --version
/usr/bin/liquibase: 5: /usr/bin/liquibase: Syntax error: "else" unexpected

This affects the debian version.