### PR TITLE
CORE-2397 Improve robustness of SQL generation for obtaining a view definition on MSSQL

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/GetViewDefinitionGeneratorMSSQL.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/GetViewDefinitionGeneratorMSSQL.java
@@ -7,6 +7,7 @@ import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.statement.core.GetViewDefinitionStatement;
+import liquibase.structure.core.View;
 
 public class GetViewDefinitionGeneratorMSSQL extends GetViewDefinitionGenerator {
     @Override
@@ -22,7 +23,23 @@ public class GetViewDefinitionGeneratorMSSQL extends GetViewDefinitionGenerator 
     @Override
     public Sql[] generateSql(GetViewDefinitionStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
         CatalogAndSchema schema = new CatalogAndSchema(statement.getCatalogName(), statement.getSchemaName()).customize(database);
-
-        String sql = "SELECT OBJECT_DEFINITION (OBJECT_ID('"+schema.getSchemaName()+"."+statement.getViewName() +"')) AS ObjectDefinition";
-            return new Sql[]{new UnparsedSql(sql) };
-    }}
+        boolean sql2005OrLater = true;
+        try {
+            sql2005OrLater = database.getDatabaseMajorVersion() >= 9;
+        } catch (Exception ignored) {
+            // Assume 2005 or later
+        }
+        String viewNameEscaped = database.escapeObjectName(schema.getCatalogName(), schema.getSchemaName(), statement.getViewName(), View.class);
+        String sql;
+        if (sql2005OrLater) {
+            sql = "SELECT OBJECT_DEFINITION(OBJECT_ID(N'" + database.escapeStringForDatabase(viewNameEscaped) + "')) AS [ObjectDefinition]";
+        } else {
+            sql =
+                    "SELECT [c].[text] " +
+                    "FROM [dbo].[syscomments] AS [c] " +
+                    "WHERE [c].[id] = OBJECT_ID(N'" + database.escapeStringForDatabase(viewNameEscaped) + "') " +
+                    "ORDER BY [c].[colid]";
+        }
+        return new Sql[] { new UnparsedSql(sql) };
+    }
+}


### PR DESCRIPTION
[CORE-2397](https://liquibase.jira.com/browse/CORE-2397) MSSQL View Snapshot should not use sp_helptext

Improves robustness of SQL generation for obtaining a view definition on SQL Server. Supports SQL Server 2000 and later without using sp_helptext.