### PR TITLE
Add output file encoding for generate dbdoc

### DIFF
--- a/liquibase-core/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-core/src/main/java/liquibase/Liquibase.java
@@ -1318,17 +1318,21 @@ public class Liquibase {
 
         return changeSet.generateCheckSum();
     }
+    
+    private String getDefaultEncoding() {
+        return System.getProperty("file.encoding", "UTF-8");
+    };
 
     public void generateDocumentation(String outputDirectory) throws LiquibaseException {
         // call without context
-        generateDocumentation(outputDirectory, new Contexts(), new LabelExpression());
+        generateDocumentation(outputDirectory, null, new Contexts(), new LabelExpression());
     }
 
     public void generateDocumentation(String outputDirectory, String contexts) throws LiquibaseException {
-        generateDocumentation(outputDirectory, new Contexts(contexts), new LabelExpression());
+        generateDocumentation(outputDirectory, null, new Contexts(contexts), new LabelExpression());
     }
 
-    public void generateDocumentation(String outputDirectory, Contexts contexts, LabelExpression labelExpression) throws LiquibaseException {
+    public void generateDocumentation(String outputDirectory, String outputFileEncoding, Contexts contexts, LabelExpression labelExpression) throws LiquibaseException {
         log.info("Generating Database Documentation");
         changeLogParameters.setContexts(contexts);
         changeLogParameters.setLabels(labelExpression);
@@ -1347,7 +1351,10 @@ public class Liquibase {
             DBDocVisitor visitor = new DBDocVisitor(database);
             logIterator.run(visitor, new RuntimeEnvironment(database, contexts, labelExpression));
 
-            visitor.writeHTML(new File(outputDirectory), resourceAccessor);
+            if (outputFileEncoding == null) {
+                outputFileEncoding = getDefaultEncoding();
+            }
+            visitor.writeHTML(new File(outputDirectory), outputFileEncoding, resourceAccessor);
         } catch (IOException e) {
             throw new LiquibaseException(e);
         } finally {

--- a/liquibase-core/src/main/java/liquibase/changelog/visitor/DBDocVisitor.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/visitor/DBDocVisitor.java
@@ -118,14 +118,14 @@ public class DBDocVisitor implements ChangeSetVisitor {
         }
     }
 
-    public void writeHTML(File rootOutputDir, ResourceAccessor resourceAccessor) throws IOException, LiquibaseException, DatabaseHistoryException {
-        ChangeLogWriter changeLogWriter = new ChangeLogWriter(resourceAccessor, rootOutputDir);
-        HTMLWriter authorWriter = new AuthorWriter(rootOutputDir, database);
-        HTMLWriter tableWriter = new TableWriter(rootOutputDir, database);
-        HTMLWriter columnWriter = new ColumnWriter(rootOutputDir, database);
-        HTMLWriter pendingChangesWriter = new PendingChangesWriter(rootOutputDir, database);
-        HTMLWriter recentChangesWriter = new RecentChangesWriter(rootOutputDir, database);
-        HTMLWriter pendingSQLWriter = new PendingSQLWriter(rootOutputDir, database, rootChangeLog);
+    public void writeHTML(File rootOutputDir, String outputFileEncoding, ResourceAccessor resourceAccessor) throws IOException, LiquibaseException, DatabaseHistoryException {
+        ChangeLogWriter changeLogWriter = new ChangeLogWriter(resourceAccessor, rootOutputDir, outputFileEncoding);
+        HTMLWriter authorWriter = new AuthorWriter(rootOutputDir, outputFileEncoding, database);
+        HTMLWriter tableWriter = new TableWriter(rootOutputDir, outputFileEncoding, database);
+        HTMLWriter columnWriter = new ColumnWriter(rootOutputDir, outputFileEncoding, database);
+        HTMLWriter pendingChangesWriter = new PendingChangesWriter(rootOutputDir, outputFileEncoding, database);
+        HTMLWriter recentChangesWriter = new RecentChangesWriter(rootOutputDir, outputFileEncoding, database);
+        HTMLWriter pendingSQLWriter = new PendingSQLWriter(rootOutputDir, outputFileEncoding, database, rootChangeLog);
 
         copyFile("liquibase/dbdoc/stylesheet.css", rootOutputDir);
         copyFile("liquibase/dbdoc/index.html", rootOutputDir);
@@ -134,9 +134,9 @@ public class DBDocVisitor implements ChangeSetVisitor {
 
         DatabaseSnapshot snapshot = SnapshotGeneratorFactory.getInstance().createSnapshot(database.getDefaultSchema(), database, new SnapshotControl(database));
 
-        new ChangeLogListWriter(rootOutputDir).writeHTML(changeLogs);
-        new TableListWriter(rootOutputDir).writeHTML(new TreeSet<Object>(snapshot.get(Table.class)));
-        new AuthorListWriter(rootOutputDir).writeHTML(new TreeSet<Object>(changesByAuthor.keySet()));
+        new ChangeLogListWriter(rootOutputDir, outputFileEncoding).writeHTML(changeLogs);
+        new TableListWriter(rootOutputDir, outputFileEncoding).writeHTML(new TreeSet<Object>(snapshot.get(Table.class)));
+        new AuthorListWriter(rootOutputDir, outputFileEncoding).writeHTML(new TreeSet<Object>(changesByAuthor.keySet()));
 
         for (String author : changesByAuthor.keySet()) {
             authorWriter.writeHTML(author, changesByAuthor.get(author), changesToRunByAuthor.get(author), rootChangeLogName);

--- a/liquibase-core/src/main/java/liquibase/dbdoc/AuthorListWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/AuthorListWriter.java
@@ -4,8 +4,8 @@ import java.io.File;
 
 public class AuthorListWriter extends HTMLListWriter {
 
-    public AuthorListWriter(File outputDir) {
-        super("All Authors", "authors.html", "authors", outputDir);
+    public AuthorListWriter(File outputDir, String outputFileEncoding) {
+        super("All Authors", "authors.html", "authors", outputDir, outputFileEncoding);
     }
 
 }

--- a/liquibase-core/src/main/java/liquibase/dbdoc/AuthorWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/AuthorWriter.java
@@ -4,14 +4,14 @@ import liquibase.change.Change;
 import liquibase.database.Database;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
 import java.util.List;
 
 public class AuthorWriter extends HTMLWriter {
 
-    public AuthorWriter(File rootOutputDir, Database database) {
-        super(new File(rootOutputDir, "authors"), database);
+    public AuthorWriter(File rootOutputDir, String outputFileEncoding, Database database) {
+        super(new File(rootOutputDir, "authors"), outputFileEncoding, database);
     }
 
     @Override
@@ -20,6 +20,6 @@ public class AuthorWriter extends HTMLWriter {
     }
 
     @Override
-    protected void writeCustomHTML(FileWriter fileWriter, Object object, List<Change> changes, Database database) throws IOException {
+    protected void writeCustomHTML(Writer fileWriter, Object object, List<Change> changes, Database database) throws IOException {
     }
 }

--- a/liquibase-core/src/main/java/liquibase/dbdoc/ChangeLogListWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/ChangeLogListWriter.java
@@ -4,8 +4,8 @@ import java.io.File;
 
 public class ChangeLogListWriter extends HTMLListWriter {
 
-    public ChangeLogListWriter(File outputDir) {
-        super("All Change Logs", "changelogs.html", "changelogs", outputDir);
+    public ChangeLogListWriter(File outputDir, String outputFileEncoding) {
+        super("All Change Logs", "changelogs.html", "changelogs", outputDir, outputFileEncoding);
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/dbdoc/ChangeLogWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/ChangeLogWriter.java
@@ -8,10 +8,12 @@ import java.io.*;
 public class ChangeLogWriter {
     protected File outputDir;
     private ResourceAccessor resourceAccessor;
+    private String outputFileEncoding;
 
-    public ChangeLogWriter(ResourceAccessor resourceAccessor, File rootOutputDir) {
+    public ChangeLogWriter(ResourceAccessor resourceAccessor, File rootOutputDir, String outputFileEncoding) {
         this.outputDir = new File(rootOutputDir, "changelogs");
         this.resourceAccessor = resourceAccessor;
+        this.outputFileEncoding = outputFileEncoding;
     }
 
     public void writeChangeLog(String changeLog, String physicalFilePath) throws IOException {
@@ -35,9 +37,13 @@ public class ChangeLogWriter {
         File xmlFile = new File(outputDir, changeLogOutFile + ".html");
         xmlFile.getParentFile().mkdirs();
 
-        BufferedWriter changeLogStream = new BufferedWriter(new FileWriter(xmlFile, false));
+        Writer changeLogStream = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(xmlFile), outputFileEncoding));
         try {
-            changeLogStream.write("<html><body><pre>\n");
+            changeLogStream.write("<html>\n");
+            changeLogStream.append("<head>");
+            changeLogStream.append("<META http-equiv=\"Content-Type\" content=\"text/html; charset=").append(outputFileEncoding).append("\">");
+            changeLogStream.append("</head>\n");
+            changeLogStream.append("<body><pre>\n");
             changeLogStream.write(StreamUtil.getStreamContents(stylesheet).replace("<", "&lt;").replace(">", "&gt;"));
             changeLogStream.write("\n</pre></body></html>");
         } finally {

--- a/liquibase-core/src/main/java/liquibase/dbdoc/ColumnWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/ColumnWriter.java
@@ -4,15 +4,15 @@ import liquibase.change.Change;
 import liquibase.database.Database;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
 import java.util.List;
 
 public class ColumnWriter extends HTMLWriter {
 
 
-    public ColumnWriter(File rootOutputDir, Database database) {
-        super(new File(rootOutputDir, "columns"), database);
+    public ColumnWriter(File rootOutputDir, String outputFileEncoding, Database database) {
+        super(new File(rootOutputDir, "columns"), outputFileEncoding, database);
     }
 
     @Override
@@ -21,6 +21,6 @@ public class ColumnWriter extends HTMLWriter {
     }
 
     @Override
-    protected void writeCustomHTML(FileWriter fileWriter, Object object, List<Change> changes, Database database) throws IOException {
+    protected void writeCustomHTML(Writer fileWriter, Object object, List<Change> changes, Database database) throws IOException {
     }
 }

--- a/liquibase-core/src/main/java/liquibase/dbdoc/HTMLListWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/HTMLListWriter.java
@@ -1,19 +1,22 @@
 package liquibase.dbdoc;
 
-import liquibase.util.StringUtils;
-
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.util.SortedSet;
+
+import liquibase.util.StringUtils;
 
 public class HTMLListWriter {
     private File outputDir;
     private String directory;
     private String filename;
     private String title;
+    private String outputFileEncoding;
 
-    public HTMLListWriter(String title, String filename, String subdir, File outputDir) {
+    public HTMLListWriter(String title, String filename, String subdir, File outputDir, String outputFileEncoding) {
         this.title = title;
         this.outputDir = outputDir;
         this.filename = filename;
@@ -21,15 +24,20 @@ public class HTMLListWriter {
             outputDir.mkdir();
         }
         this.directory = subdir;
+        this.outputFileEncoding = outputFileEncoding;
     }
 
     public void writeHTML(SortedSet objects) throws IOException {
-        FileWriter fileWriter = new FileWriter(new File(outputDir, filename));
+        Writer fileWriter = new OutputStreamWriter(new FileOutputStream(new File(outputDir, filename)), outputFileEncoding);
 
         try {
-            fileWriter.append("<HTML>\n" + "<HEAD>\n" + "<TITLE>\n");
+            fileWriter.append("<HTML>\n" + "<HEAD>\n");
+            fileWriter.append("<META http-equiv=\"Content-Type\" content=\"text/html; charset=").append(outputFileEncoding).append("\">");
+            fileWriter.append("<TITLE>\n");
             fileWriter.append(title);
-            fileWriter.append("\n" + "</TITLE>\n" + "<LINK REL =\"stylesheet\" TYPE=\"text/css\" HREF=\"stylesheet.css\" TITLE=\"Style\">\n" + "</HEAD>\n" + "<BODY BGCOLOR=\"white\">\n" + "<FONT size=\"+1\" CLASS=\"FrameHeadingFont\">\n" + "<B>");
+            fileWriter.append("\n" + "</TITLE>\n" + "<LINK REL =\"stylesheet\" TYPE=\"text/css\" HREF=\"stylesheet.css\" TITLE=\"Style\">\n");
+            fileWriter.append("</HEAD>\n");
+            fileWriter.append("<BODY BGCOLOR=\"white\">\n" + "<FONT size=\"+1\" CLASS=\"FrameHeadingFont\">\n" + "<B>");
             fileWriter.append(title);
             fileWriter.append("</B></FONT>\n" + "<BR>\n" + "<TABLE BORDER=\"0\" WIDTH=\"100%\" SUMMARY=\"\">" + "<TR>\n" + "<TD NOWRAP><FONT CLASS=\"FrameItemFont\">");
 

--- a/liquibase-core/src/main/java/liquibase/dbdoc/HTMLWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/HTMLWriter.java
@@ -33,12 +33,12 @@ public abstract class HTMLWriter {
 
     protected abstract void writeCustomHTML(Writer fileWriter, Object object, List<Change> changes, Database database) throws IOException;
 
-    private Writer createFileWriter(Object object) throws IOException {
+    private Writer createWriter(Object object) throws IOException {
         return new OutputStreamWriter(new FileOutputStream(new File(outputDir, DBDocUtil.toFileName(object.toString().toLowerCase()) + ".html")), outputFileEncoding);
     }
 
     public void writeHTML(Object object, List<Change> ranChanges, List<Change> changesToRun, String changeLog) throws IOException, DatabaseHistoryException, DatabaseException {
-        Writer fileWriter = createFileWriter(object);
+        Writer fileWriter = createWriter(object);
 
 
         try {

--- a/liquibase-core/src/main/java/liquibase/dbdoc/PendingChangesWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/PendingChangesWriter.java
@@ -6,14 +6,14 @@ import liquibase.exception.DatabaseException;
 import liquibase.exception.DatabaseHistoryException;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
 import java.util.List;
 
 public class PendingChangesWriter extends HTMLWriter {
 
-    public PendingChangesWriter(File rootOutputDir, Database database) {
-        super(new File(rootOutputDir, "pending"), database);
+    public PendingChangesWriter(File rootOutputDir, String outputFileEncoding, Database database) {
+        super(new File(rootOutputDir, "pending"), outputFileEncoding, database);
     }
 
     @Override
@@ -22,12 +22,12 @@ public class PendingChangesWriter extends HTMLWriter {
     }
 
     @Override
-    protected void writeBody(FileWriter fileWriter, Object object, List<Change> ranChanges, List<Change> changesToRun) throws IOException, DatabaseHistoryException, DatabaseException {
+    protected void writeBody(Writer fileWriter, Object object, List<Change> ranChanges, List<Change> changesToRun) throws IOException, DatabaseHistoryException, DatabaseException {
         writeCustomHTML(fileWriter, object, ranChanges, database);
         writeChanges("Pending Changes", fileWriter, changesToRun);
     }
 
     @Override
-    protected void writeCustomHTML(FileWriter fileWriter, Object object, List<Change> changes, Database database) throws IOException {
+    protected void writeCustomHTML(Writer fileWriter, Object object, List<Change> changes, Database database) throws IOException {
     }
 }

--- a/liquibase-core/src/main/java/liquibase/dbdoc/PendingSQLWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/PendingSQLWriter.java
@@ -14,16 +14,16 @@ import liquibase.executor.ExecutorService;
 import liquibase.executor.LoggingExecutor;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
 import java.util.List;
 
 public class PendingSQLWriter extends HTMLWriter {
 
     private DatabaseChangeLog databaseChangeLog;
 
-    public PendingSQLWriter(File rootOutputDir, Database database, DatabaseChangeLog databaseChangeLog) {
-        super(new File(rootOutputDir, "pending"), database);
+    public PendingSQLWriter(File rootOutputDir, String outputFileEncoding, Database database, DatabaseChangeLog databaseChangeLog) {
+        super(new File(rootOutputDir, "pending"), outputFileEncoding, database);
         this.databaseChangeLog = databaseChangeLog;
     }
 
@@ -33,7 +33,7 @@ public class PendingSQLWriter extends HTMLWriter {
     }
 
     @Override
-    protected void writeBody(FileWriter fileWriter, Object object, List<Change> ranChanges, List<Change> changesToRun) throws IOException, DatabaseHistoryException, DatabaseException {
+    protected void writeBody(Writer fileWriter, Object object, List<Change> ranChanges, List<Change> changesToRun) throws IOException, DatabaseHistoryException, DatabaseException {
 
         Executor oldTemplate = ExecutorService.getInstance().getExecutor(database);
         LoggingExecutor loggingExecutor = new LoggingExecutor(ExecutorService.getInstance().getExecutor(database), fileWriter, database);
@@ -69,6 +69,6 @@ public class PendingSQLWriter extends HTMLWriter {
     }
 
     @Override
-    protected void writeCustomHTML(FileWriter fileWriter, Object object, List<Change> changes, Database database) throws IOException {
+    protected void writeCustomHTML(Writer fileWriter, Object object, List<Change> changes, Database database) throws IOException {
     }
 }

--- a/liquibase-core/src/main/java/liquibase/dbdoc/RecentChangesWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/RecentChangesWriter.java
@@ -6,14 +6,14 @@ import liquibase.exception.DatabaseException;
 import liquibase.exception.DatabaseHistoryException;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
 import java.util.List;
 
 public class RecentChangesWriter extends HTMLWriter {
 
-    public RecentChangesWriter(File rootOutputDir, Database database) {
-        super(new File(rootOutputDir, "recent"), database);
+    public RecentChangesWriter(File rootOutputDir, String outputFileEncoding, Database database) {
+        super(new File(rootOutputDir, "recent"), outputFileEncoding, database);
     }
 
     @Override
@@ -22,12 +22,12 @@ public class RecentChangesWriter extends HTMLWriter {
     }
 
     @Override
-    protected void writeBody(FileWriter fileWriter, Object object, List<Change> ranChanges, List<Change> changesToRun) throws IOException, DatabaseHistoryException, DatabaseException {
+    protected void writeBody(Writer fileWriter, Object object, List<Change> ranChanges, List<Change> changesToRun) throws IOException, DatabaseHistoryException, DatabaseException {
         writeCustomHTML(fileWriter, object, ranChanges, database);
         writeChanges("Most Recent Changes", fileWriter, ranChanges);
     }
 
     @Override
-    protected void writeCustomHTML(FileWriter fileWriter, Object object, List<Change> changes, Database database) throws IOException {
+    protected void writeCustomHTML(Writer fileWriter, Object object, List<Change> changes, Database database) throws IOException {
     }
 }

--- a/liquibase-core/src/main/java/liquibase/dbdoc/TableListWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/TableListWriter.java
@@ -4,8 +4,8 @@ import java.io.File;
 
 public class TableListWriter extends HTMLListWriter {
 
-    public TableListWriter(File outputDir) {
-        super("Current Tables", "currenttables.html", "tables", outputDir);
+    public TableListWriter(File outputDir, String outputFileEncoding) {
+        super("Current Tables", "currenttables.html", "tables", outputDir, outputFileEncoding);
     }
 
 

--- a/liquibase-core/src/main/java/liquibase/dbdoc/TableWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/TableWriter.java
@@ -9,16 +9,16 @@ import liquibase.structure.core.PrimaryKey;
 import liquibase.structure.core.Table;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 public class TableWriter extends HTMLWriter {
 
-    public TableWriter(File rootOutputDir, Database database) {
-        super(new File(rootOutputDir, "tables"), database);
+    public TableWriter(File rootOutputDir, String outputFileEncoding, Database database) {
+        super(new File(rootOutputDir, "tables"), outputFileEncoding, database);
     }
 
     @Override
@@ -27,7 +27,7 @@ public class TableWriter extends HTMLWriter {
     }
 
     @Override
-    protected void writeCustomHTML(FileWriter fileWriter, Object object, List<Change> changes, Database database) throws IOException {
+    protected void writeCustomHTML(Writer fileWriter, Object object, List<Change> changes, Database database) throws IOException {
         final Table table = (Table) object;
         writeTableRemarks(fileWriter, table, database);
         writeColumns(fileWriter, table, database);
@@ -35,7 +35,7 @@ public class TableWriter extends HTMLWriter {
         writeTableForeignKeys(fileWriter, table, database);
     }
 
-    private void writeColumns(FileWriter fileWriter, Table table, Database database) throws IOException {
+    private void writeColumns(Writer fileWriter, Table table, Database database) throws IOException {
         List<List<String>> cells = new ArrayList<List<String>>();
 
         for (Column column : table.getColumns()) {
@@ -51,7 +51,7 @@ public class TableWriter extends HTMLWriter {
         writeTable("Current Columns", cells, fileWriter);
     }
     
-    private void writeTableRemarks(FileWriter fileWriter, Table table, Database database) throws IOException {
+    private void writeTableRemarks(Writer fileWriter, Table table, Database database) throws IOException {
         final String tableRemarks = table.getRemarks();
         if (tableRemarks != null && tableRemarks.length() > 0) {
         	final List<List<String>> cells = new ArrayList<List<String>>();
@@ -60,7 +60,7 @@ public class TableWriter extends HTMLWriter {
         }
     }
     
-    private void writeTableIndexes(FileWriter fileWriter, Table table, Database database) throws IOException {
+    private void writeTableIndexes(Writer fileWriter, Table table, Database database) throws IOException {
         final List<List<String>> cells = new ArrayList<List<String>>();
         final PrimaryKey primaryKey = table.getPrimaryKey();
         if (!table.getIndexes().isEmpty()) {
@@ -74,7 +74,7 @@ public class TableWriter extends HTMLWriter {
         }
     }
     
-    private void writeTableForeignKeys(FileWriter fileWriter, Table table, Database database) throws IOException {
+    private void writeTableForeignKeys(Writer fileWriter, Table table, Database database) throws IOException {
         final List<List<String>> cells = new ArrayList<List<String>>();
         if(!table.getOutgoingForeignKeys().isEmpty())
         {

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseDBDocMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseDBDocMojo.java
@@ -1,5 +1,7 @@
 package org.liquibase.maven.plugins;
 
+import liquibase.Contexts;
+import liquibase.LabelExpression;
 import liquibase.Liquibase;
 import liquibase.exception.LiquibaseException;
 
@@ -22,7 +24,7 @@ public class LiquibaseDBDocMojo extends AbstractLiquibaseChangeLogMojo {
     @Override
     protected void performLiquibaseTask(Liquibase liquibase) throws LiquibaseException
     {
-        liquibase.generateDocumentation(outputDirectory);
+        liquibase.generateDocumentation(outputDirectory, outputFileEncoding, new Contexts(contexts), new LabelExpression());
     }
 
 


### PR DESCRIPTION
I have a databaseChangeLog file contains multibyte charactors. (ex: comment for database column)
When I generate dbdoc, html file is garbled.
So, I add `outputFileEncoding` for generating dbdoc html.
It effect html content and specifying the character encoding in html file.

┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-88) by [Unito](https://www.unito.io/learn-more)
