### PR TITLE
CORE-2405, CORE-2406 MSSQL data type bugs

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/ClobType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/ClobType.java
@@ -43,7 +43,7 @@ public class ClobType extends LiquibaseDataType {
         String originalDefinition = StringUtils.trimToEmpty(getRawDefinition());
         if (database instanceof MSSQLDatabase) {
             if (!LiquibaseConfiguration.getInstance().getProperty(GlobalConfiguration.class, GlobalConfiguration.CONVERT_DATA_TYPES).getValue(Boolean.class) && originalDefinition.toLowerCase().startsWith("text")) {
-                return new DatabaseDataType("TEXT");
+                return new DatabaseDataType(database.escapeDataTypeName("text"));
             }
         }
 

--- a/liquibase-core/src/main/java/liquibase/datatype/core/ClobType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/ClobType.java
@@ -43,7 +43,9 @@ public class ClobType extends LiquibaseDataType {
         String originalDefinition = StringUtils.trimToEmpty(getRawDefinition());
         if (database instanceof MSSQLDatabase) {
             if (!LiquibaseConfiguration.getInstance().getProperty(GlobalConfiguration.class, GlobalConfiguration.CONVERT_DATA_TYPES).getValue(Boolean.class) && originalDefinition.toLowerCase().startsWith("text")) {
-                return new DatabaseDataType(database.escapeDataTypeName("text"));
+                DatabaseDataType type = new DatabaseDataType(database.escapeDataTypeName("text"));
+                type.addAdditionalInformation(getAdditionalInformation());
+                return type;
             }
         }
 

--- a/liquibase-core/src/main/java/liquibase/datatype/core/TimestampType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/TimestampType.java
@@ -24,10 +24,10 @@ public class TimestampType extends DateTimeType {
         }
         if (database instanceof MSSQLDatabase) {
             if (!LiquibaseConfiguration.getInstance().getProperty(GlobalConfiguration.class, GlobalConfiguration.CONVERT_DATA_TYPES).getValue(Boolean.class) && originalDefinition.toLowerCase().startsWith("timestamp")) {
-                return new DatabaseDataType(database.escapeDataTypeName("TIMESTAMP"));
+                return new DatabaseDataType(database.escapeDataTypeName("timestamp"));
             }
 
-            return new DatabaseDataType(database.escapeDataTypeName("DATETIME"));
+            return new DatabaseDataType(database.escapeDataTypeName("datetime"));
         }
         return super.toDatabaseDataType(database);
     }

--- a/liquibase-core/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
@@ -112,7 +112,7 @@ public class DataTypeFactoryTest extends Specification {
         "[time]"                                             | new MSSQLDatabase()   | "[time](7)"                                          | TimeType      | false
         "time(6)"                                            | new MSSQLDatabase()   | "[time](6)"                                          | TimeType      | false
         "[time](6)"                                          | new MSSQLDatabase()   | "[time](6)"                                          | TimeType      | false
-        "timestamp"                                          | new MSSQLDatabase()   | "[DATETIME]"                                         | TimestampType | false
+        "timestamp"                                          | new MSSQLDatabase()   | "[datetime]"                                         | TimestampType | false
         "tinyint"                                            | new MSSQLDatabase()   | "[tinyint]"                                          | TinyIntType   | false
         "[tinyint]"                                          | new MSSQLDatabase()   | "[tinyint]"                                          | TinyIntType   | false
         "uniqueidentifier"                                   | new MSSQLDatabase()   | "[uniqueidentifier]"                                 | UUIDType      | false


### PR DESCRIPTION
[CORE-2405](https://liquibase.jira.com/browse/CORE-2405) Collation not preserved, depending on configuration
[CORE-2406](https://liquibase.jira.com/browse/CORE-2406) Escaped built-in data types should be lower case

Preserves collation and ensures compatibility with case-sensitive database collations