### PR TITLE
Avoid error message under Kubuntu

### DIFF
--- a/liquibase-core/src/main/resources/dist/liquibase
+++ b/liquibase-core/src/main/resources/dist/liquibase
@@ -36,7 +36,7 @@ if [ -f /usr/bin/cygpath ]; then
     CP="$CP;$i"
   done
 else
-  if [[ $(uname) = MINGW* ]]; then
+  if [ $(uname) = MINGW* ]; then
     CP_SEPARATOR=";"
   else
     CP_SEPARATOR=":"


### PR DESCRIPTION
I got the message "./liquibase//liquibase: 39: ./liquibase//liquibase: [[: not found" under Kubuntu