### PR TITLE
Informix: Return null for connection schema name

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/InformixDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/InformixDatabase.java
@@ -226,4 +226,8 @@ public class InformixDatabase extends AbstractJdbcDatabase {
     public String quoteObject(String objectName, Class<? extends DatabaseObject> objectType) {
         return objectName;
     }
+    @Override
+    protected String getConnectionSchemaName() {
+        return null;
+    }
 }


### PR DESCRIPTION
This fixes a problem with using Informix with Liquibase. The base class method causes a call to a non-existent stored procedure.