### PR TITLE
CORE-2410 Snapshot should not include paramaters for MSSQL geometry, geography or sql_variant types

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/UnknownType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/UnknownType.java
@@ -35,42 +35,11 @@ public class UnknownType extends LiquibaseDataType {
             dataTypeMaxParameters = database.getDataTypeMaxParameters(getName());
         }
         Object[] parameters = getParameters();
-        if (database instanceof MySQLDatabase && (
-                getName().equalsIgnoreCase("TINYBLOB")
-                        || getName().equalsIgnoreCase("MEDIUMBLOB")
-                        || getName().equalsIgnoreCase("TINYTEXT")
-                        || getName().equalsIgnoreCase("MEDIUMTEXT")
-                        || getName().equalsIgnoreCase("REAL")
-        )) {
-            parameters = new Object[0];
-        }
-
-        if (database instanceof DB2Database && (getName().equalsIgnoreCase("REAL") || getName().equalsIgnoreCase("XML"))) {
-            parameters = new Object[0];
-        }
-
-        if (database instanceof MSSQLDatabase && (
-                getName().equalsIgnoreCase("REAL")
-                        || getName().equalsIgnoreCase("XML")
-                        || getName().equalsIgnoreCase("HIERARCHYID")
-                        || getName().equalsIgnoreCase("DATETIMEOFFSET")
-                        || getName().equalsIgnoreCase("IMAGE")
-                        || getName().equalsIgnoreCase("NTEXT")
-                        || getName().equalsIgnoreCase("SYSNAME")
-                        || getName().equalsIgnoreCase("SMALLMONEY")
-                        || getName().equalsIgnoreCase("GEOGRAPHY")
-                        || getName().equalsIgnoreCase("GEOMETRY")
-                        || getName().equalsIgnoreCase("SQL_VARIANT")
-        )) {
-            parameters = new Object[0];
-        }
 
         if (database instanceof OracleDatabase) {
             if (getName().equalsIgnoreCase("LONG")
-                    || getName().equalsIgnoreCase("NCLOB")
                     || getName().equalsIgnoreCase("BFILE")
                     || getName().equalsIgnoreCase("ROWID")
-                    || getName().equalsIgnoreCase("XMLTYPE")
                     || getName().equalsIgnoreCase("ANYDATA")
                     || getName().equalsIgnoreCase("SDO_GEOMETRY")
                     ) {

--- a/liquibase-core/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
@@ -70,6 +70,12 @@ public class DataTypeFactoryTest extends Specification {
         "[float]"                                            | new MSSQLDatabase()   | "[float](53)"                                        | FloatType     | false
         "float(53)"                                          | new MSSQLDatabase()   | "[float](53)"                                        | FloatType     | false
         "[float](53)"                                        | new MSSQLDatabase()   | "[float](53)"                                        | FloatType     | false
+        "geography"                                          | new MSSQLDatabase()   | "[geography]"                                        | UnknownType   | false
+        "[geography]"                                        | new MSSQLDatabase()   | "[geography]"                                        | UnknownType   | false
+        "geography(1, 2)"                                    | new MSSQLDatabase()   | "[geography]"                                        | UnknownType   | false
+        "geometry"                                           | new MSSQLDatabase()   | "[geometry]"                                         | UnknownType   | false
+        "[geometry]"                                         | new MSSQLDatabase()   | "[geometry]"                                         | UnknownType   | false
+        "geometry(3, 4)"                                     | new MSSQLDatabase()   | "[geometry]"                                         | UnknownType   | false
         "image"                                              | new MSSQLDatabase()   | "[image]"                                            | BlobType      | false
         "[image]"                                            | new MSSQLDatabase()   | "[image]"                                            | BlobType      | false
         "int"                                                | new MSSQLDatabase()   | "[int]"                                              | IntType       | false
@@ -106,6 +112,9 @@ public class DataTypeFactoryTest extends Specification {
         "[smallint]"                                         | new MSSQLDatabase()   | "[smallint]"                                         | SmallIntType  | false
         "smallmoney"                                         | new MSSQLDatabase()   | "[smallmoney]"                                       | CurrencyType  | false
         "[smallmoney]"                                       | new MSSQLDatabase()   | "[smallmoney]"                                       | CurrencyType  | false
+        "sql_variant"                                        | new MSSQLDatabase()   | "[sql_variant]"                                      | UnknownType   | false
+        "[sql_variant]"                                      | new MSSQLDatabase()   | "[sql_variant]"                                      | UnknownType   | false
+        "sql_variant(5, 6)"                                  | new MSSQLDatabase()   | "[sql_variant]"                                      | UnknownType   | false
         "text"                                               | new MSSQLDatabase()   | "[text]"                                             | ClobType      | false
         "[text]"                                             | new MSSQLDatabase()   | "[text]"                                             | ClobType      | false
         "time"                                               | new MSSQLDatabase()   | "[time](7)"                                          | TimeType      | false


### PR DESCRIPTION
Reverts 8713973 (unneeded due to [CORE-2217](https://liquibase.jira.com/browse/CORE-2217), [CORE-2345](https://liquibase.jira.com/browse/CORE-2345))  while retaining cd69419 (needed for [CORE-2410](https://liquibase.jira.com/browse/CORE-2410))

Adds a test case that shows CORE-2410 is fixed