### PR TITLE
Add of new sybase IQ productname to supported names

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/SybaseASADatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/SybaseASADatabase.java
@@ -167,8 +167,9 @@ public class SybaseASADatabase extends AbstractJdbcDatabase {
 	@Override
     public boolean isCorrectDatabaseImplementation(DatabaseConnection conn) throws DatabaseException {
 		return "Adaptive Server Anywhere".equalsIgnoreCase(conn.getDatabaseProductName())
-                || "SQL Anywhere".equalsIgnoreCase(conn.getDatabaseProductName())
-        || "Adaptive Server IQ".equalsIgnoreCase(conn.getDatabaseProductName());
+        || "SQL Anywhere".equalsIgnoreCase(conn.getDatabaseProductName())
+        || "Adaptive Server IQ".equalsIgnoreCase(conn.getDatabaseProductName())
+		|| "Sybase IQ".equalsIgnoreCase(conn.getDatabaseProductName());
 	}
 
 	@Override


### PR DESCRIPTION
To resolve unknown database : Sybase IQ that cause the error below :                                               com.sybase.jdbc4.jdbc.SybSQLException: SQL Anywhere Error -265: Procedure 'current_schema' not found

I added "Sybase IQ" to the implementation product names supported.