### PR TITLE
Fix [[ not found error -> [[ is bash-builtin

### DIFF
--- a/liquibase-core/src/main/resources/dist/liquibase
+++ b/liquibase-core/src/main/resources/dist/liquibase
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/usr/bin/env bash
 
 if [ ! -n "${LIQUIBASE_HOME+x}" ]; then
   # echo "LIQUIBASE_HOME is not set."


### PR DESCRIPTION
Suggested fix: use /usr/bin/env bash instead of /bin/sh

using /bin/sh yields error output:

```
liquibase: 39: liquibase: [[: not found
```