### PR TITLE
CORE-2385 fix handling of null basePath in FilenameUtils.concat - backport to 3.4.x

### DIFF
--- a/liquibase-core/src/main/java/liquibase/util/file/FilenameUtils.java
+++ b/liquibase-core/src/main/java/liquibase/util/file/FilenameUtils.java
@@ -405,7 +405,7 @@ public class FilenameUtils {
             return normalize(fullFilenameToAdd);
         }
         if (basePath == null) {
-            return null;
+            return fullFilenameToAdd;
         }
         int len = basePath.length();
         if (len == 0) {

--- a/liquibase-core/src/test/java/liquibase/util/file/FilenameUtilsTest.java
+++ b/liquibase-core/src/test/java/liquibase/util/file/FilenameUtilsTest.java
@@ -1,0 +1,22 @@
+package liquibase.util.file;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Petr Kozelka
+ */
+public class FilenameUtilsTest {
+
+    /**
+     * This checks that {@link FilenameUtils#concat} works fine with <code>basePath=null</code>.
+     * <p>See <a href="https://liquibase.jira.com/browse/CORE-2385">issue CORE-2385</a>.</p>
+     */
+    @Test
+    public void concatWithNullBasePath() {
+        final String something = "liquibase/delta-changelogs/";
+        Assert.assertEquals("null basePath must not kill the result of concatenation",
+                FilenameUtils.concat(null, something),
+                something);
+    }
+}


### PR DESCRIPTION
we need the same fix like #459 in the `3.4.x` branch so that we can use next minor release.

BTW I created a local release for the meantime and published it here: https://github.com/pkozelka/liquibase/releases/tag/liquibase-parent-3.4.0-pkozelka-1