### PR TITLE
CORE-2442 Creating MD5 checksum fails if changeSet id contains the character "?"

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/UpdateGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/UpdateGenerator.java
@@ -13,6 +13,9 @@ import liquibase.structure.core.Relation;
 import liquibase.structure.core.Table;
 
 import java.util.Date;
+import java.util.Iterator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class UpdateGenerator extends AbstractSqlGenerator<UpdateStatement> {
 
@@ -42,20 +45,31 @@ public class UpdateGenerator extends AbstractSqlGenerator<UpdateStatement> {
         }
         if (statement.getWhereClause() != null) {
             String fixedWhereClause = "WHERE " + statement.getWhereClause().trim();
-            for (String columnName : statement.getWhereColumnNames()) {
-                if (columnName == null) {
-                    continue;
+            Matcher matcher = Pattern.compile(":name|\\?|:value").matcher(fixedWhereClause);
+            StringBuffer sb = new StringBuffer();
+            Iterator<String> columnNameIter = statement.getWhereColumnNames().iterator();
+            Iterator<Object> paramIter = statement.getWhereParameters().iterator();
+            while (matcher.find()) {
+                if (matcher.group().equals(":name")) {
+                    while (columnNameIter.hasNext()) {
+                        String columnName = columnNameIter.next();
+                        if (columnName == null) {
+                            continue;
+                        }
+                        matcher.appendReplacement(sb, Matcher.quoteReplacement(database.escapeObjectName(columnName, Column.class)));
+                        break;
+                    }
+                } else if (paramIter.hasNext()) {
+                    Object param = paramIter.next();
+                    matcher.appendReplacement(sb, Matcher.quoteReplacement(DataTypeFactory.getInstance().fromObject(param, database).objectToSql(param, database)));
                 }
-                fixedWhereClause = fixedWhereClause.replaceFirst(":name",
-                        database.escapeObjectName(columnName, Column.class));
             }
-            for (Object param : statement.getWhereParameters()) {
-                fixedWhereClause = fixedWhereClause.replaceFirst("\\?|:value", DataTypeFactory.getInstance().fromObject(param, database).objectToSql(param, database));
-            }
+            matcher.appendTail(sb);
+            fixedWhereClause = sb.toString();
             sql.append(" ").append(fixedWhereClause);
         }
 
-        return new Sql[]{
+        return new Sql[] {
                 new UnparsedSql(sql.toString(), getAffectedTable(statement))
         };
     }

--- a/liquibase-core/src/test/java/liquibase/sqlgenerator/core/UpdateGeneratorTest.java
+++ b/liquibase-core/src/test/java/liquibase/sqlgenerator/core/UpdateGeneratorTest.java
@@ -1,6 +1,40 @@
 package liquibase.sqlgenerator.core;
 
-public abstract class UpdateGeneratorTest {
+import static org.junit.Assert.assertEquals;
+import liquibase.database.Database;
+import liquibase.database.core.MSSQLDatabase;
+import liquibase.sql.Sql;
+import liquibase.statement.core.UpdateStatement;
+import liquibase.structure.core.Column;
+
+import org.junit.Test;
+
+public class UpdateGeneratorTest {
+    @Test
+    public void testGenerateSql() {
+        // given
+        Database database = new MSSQLDatabase();
+        UpdateStatement statement = new UpdateStatement(null, null, "DATABASECHANGELOG")
+                .addNewColumnValue("MD5SUM", "7:e27bf9c0c2313160ef960a15d44ced47")
+                .setWhereClause(database.escapeObjectName("ID", Column.class) + " = ? " +
+                        "AND " + database.escapeObjectName("AUTHOR", Column.class) + " = ? " +
+                        "AND " + database.escapeObjectName("FILENAME", Column.class) + " = ?")
+                .addWhereParameters("SYPA: AUTO_START tüüp INT -> TEXT, vaartus 0 00 17 * * ?", "martin", "db/changelog.xml");
+        UpdateGenerator generator = new UpdateGenerator();
+
+        // when
+        Sql[] sqls = generator.generateSql(statement, database, null);
+
+        // then
+        assertEquals(
+                "UPDATE [DATABASECHANGELOG] " +
+                "SET [MD5SUM] = '7:e27bf9c0c2313160ef960a15d44ced47' " +
+                "WHERE [ID] = N'SYPA: AUTO_START tüüp INT -> TEXT, vaartus 0 00 17 * * ?' " +
+                "AND [AUTHOR] = 'martin' " +
+                "AND [FILENAME] = 'db/changelog.xml'",
+                sqls[0].toSql());
+    }
+
 ////    @Test
 ////    public void addNewColumnValue_nullValue() throws Exception {
 ////        new DatabaseTestTemplate().testOnAllDatabases(new DatabaseTest() {


### PR DESCRIPTION
[CORE-2442](https://liquibase.jira.com/browse/CORE-2442) Make UpdateGenerator more resilent to parameter names and values that contain the pattern to match