### PR TITLE
CORE-2443 - Liquibase 3.4.0 ignores third party loggers in certain situations

### DIFF
--- a/liquibase-core/src/main/java/liquibase/logging/LogFactory.java
+++ b/liquibase-core/src/main/java/liquibase/logging/LogFactory.java
@@ -1,7 +1,6 @@
 package liquibase.logging;
 
 import liquibase.exception.ServiceNotFoundException;
-import liquibase.logging.core.DefaultLogger;
 import liquibase.servicelocator.ServiceLocator;
 
 import java.util.HashMap;
@@ -44,7 +43,7 @@ public class LogFactory {
             try {
                 value = (Logger) ServiceLocator.getInstance().newInstance(Logger.class);
             } catch (Exception e) {
-                value = new DefaultLogger();
+                throw new ServiceNotFoundException(e);
             }
             value.setName(name);
             if (defaultLoggingLevel != null) {


### PR DESCRIPTION
This PR reverts the small change to the LogFactory that uses the `DefaultLogger` when the `ServiceLocator` throws and exception. This should fix [CORE-2443](https://liquibase.jira.com/browse/CORE-2443).
I am open to other solutions to the problem but as I am getting messages about my logger no longer working and I rather get this patched quickly.