### PR TITLE
AutoCloseable

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/AbstractSQLChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/AbstractSQLChange.java
@@ -17,7 +17,7 @@ import java.util.*;
  * Implements the necessary logic to choose how the SQL string should be parsed to generate the statements.
  *
  */
-public abstract class AbstractSQLChange extends AbstractChange implements DbmsTargetedChange {
+public abstract class AbstractSQLChange extends AbstractChange implements DbmsTargetedChange, Closeable {
 
     private boolean stripComments;
     private boolean splitStatements;

--- a/liquibase-core/src/main/java/liquibase/database/Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/Database.java
@@ -19,7 +19,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
-public interface Database extends PrioritizedService {
+public interface Database extends PrioritizedService, AutoCloseablecl {
 
     String databaseChangeLogTableName = "DatabaseChangeLog".toUpperCase();
     String databaseChangeLogLockTableName = "DatabaseChangeLogLock".toUpperCase();

--- a/liquibase-core/src/main/java/liquibase/database/DatabaseConnection.java
+++ b/liquibase-core/src/main/java/liquibase/database/DatabaseConnection.java
@@ -8,7 +8,7 @@ import liquibase.exception.DatabaseException;
  * connection.
  * 
  */
-public interface DatabaseConnection {
+public interface DatabaseConnection extends AutoCloseable {
 
     public void close() throws DatabaseException;
 

--- a/liquibase-core/src/main/java/liquibase/util/csv/opencsv/CSVReader.java
+++ b/liquibase-core/src/main/java/liquibase/util/csv/opencsv/CSVReader.java
@@ -17,6 +17,7 @@ package liquibase.util.csv.opencsv;
  */
 
 import java.io.BufferedReader;
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.ArrayList;
@@ -28,7 +29,7 @@ import java.util.List;
  * @author Glen Smith
  * 
  */
-public class CSVReader {
+public class CSVReader implements Closeable {
 
     private BufferedReader br;
 

--- a/liquibase-core/src/main/java/liquibase/util/csv/opencsv/CSVWriter.java
+++ b/liquibase-core/src/main/java/liquibase/util/csv/opencsv/CSVWriter.java
@@ -16,6 +16,7 @@ package liquibase.util.csv.opencsv;
  limitations under the License.
  */
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Reader;
@@ -32,7 +33,7 @@ import java.util.List;
  * @author Glen Smith
  *
  */
-public class CSVWriter {
+public class CSVWriter implements Closeable {
     
     private Writer rawWriter;
 
@@ -391,6 +392,7 @@ public class CSVWriter {
      * @throws IOException if bad things happen
      *
      */
+    @Override
     public void close() throws IOException {
         pw.flush();
         pw.close();


### PR DESCRIPTION
I believe that every single Java class/interface that shows a close() method should extend AutoCloseable so that 1) it can be instantiated in a try-with-resources block and 2) raise a compiler warning (e.g. with Eclipse) if not disposed properly of