### PR TITLE
CORE-2466 Rollback referencing a change set in another file cannot be parsed

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
@@ -215,6 +215,10 @@ public class ChangeSet implements Conditional, ChangeLogChild {
         setDbms(dbmsList);
     }
 
+    void setChangeLog(DatabaseChangeLog changeLog) {
+        this.changeLog = changeLog;
+    }
+
     protected void setDbms(String dbmsList) {
         if (StringUtils.trimToNull(dbmsList) != null) {
             String[] strings = dbmsList.toLowerCase().split(",");

--- a/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -160,6 +160,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
     }
 
     public void addChangeSet(ChangeSet changeSet) {
+        changeSet.setChangeLog(this);
         this.changeSets.add(changeSet);
     }
 
@@ -399,7 +400,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
             this.getPreconditions().addNestedPrecondition(preconditions);
         }
         for (ChangeSet changeSet : changeLog.getChangeSets()) {
-            this.changeSets.add(changeSet);
+            addChangeSet(changeSet);
         }
 
         return true;


### PR DESCRIPTION
[CORE-2466](https://liquibase.jira.com/browse/CORE-2466) Set the change log of the included change sets to the referencing change log