### PR TITLE
CORE-2466 Rollback referencing a change set in another file cannot be parsed

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
@@ -366,7 +366,11 @@ public class ChangeSet implements Conditional, ChangeLogChild {
             String changeSetAuthor = rollbackNode.getChildValue(null, "changeSetAuthor", String.class);
             String changeSetPath = rollbackNode.getChildValue(null, "changeSetPath", getFilePath());
 
-            ChangeSet changeSet = this.getChangeLog().getChangeSet(changeSetPath, changeSetAuthor, changeSetId);
+            DatabaseChangeLog changeLog = DatabaseChangeLog.getRootChangeLog();
+            if (changeLog == null) {
+                changeLog = getChangeLog();
+            }
+            ChangeSet changeSet = changeLog.getChangeSet(changeSetPath, changeSetAuthor, changeSetId);
             if (changeSet == null) {
                 throw new ParsedNodeException("Change set "+new ChangeSet(changeSetId, changeSetAuthor, false, false, changeSetPath, null, null, null).toString(false)+" does not exist");
             }

--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
@@ -375,7 +375,7 @@ public class ChangeSet implements Conditional, ChangeLogChild {
                 throw new ParsedNodeException("Change set "+new ChangeSet(changeSetId, changeSetAuthor, false, false, changeSetPath, null, null, null).toString(false)+" does not exist");
             }
             for (Change change : changeSet.getChanges()) {
-                addRollbackChange(change);
+                rollback.getChanges().add(change);
             }
             return;
         }

--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
@@ -366,10 +366,7 @@ public class ChangeSet implements Conditional, ChangeLogChild {
             String changeSetAuthor = rollbackNode.getChildValue(null, "changeSetAuthor", String.class);
             String changeSetPath = rollbackNode.getChildValue(null, "changeSetPath", getFilePath());
 
-            DatabaseChangeLog changeLog = DatabaseChangeLog.getRootChangeLog();
-            if (changeLog == null) {
-                changeLog = getChangeLog();
-            }
+            DatabaseChangeLog changeLog = getChangeLog().getRootChangeLog();
             ChangeSet changeSet = changeLog.getChangeSet(changeSetPath, changeSetAuthor, changeSetId);
             if (changeSet == null) {
                 throw new ParsedNodeException("Change set "+new ChangeSet(changeSetId, changeSetAuthor, false, false, changeSetPath, null, null, null).toString(false)+" does not exist");

--- a/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -45,10 +45,6 @@ import java.util.TreeSet;
 public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditional {
     private static final ThreadLocal<DatabaseChangeLog> ROOT_CHANGE_LOG = new ThreadLocal<DatabaseChangeLog>();
 
-    public static DatabaseChangeLog getRootChangeLog() {
-        return ROOT_CHANGE_LOG.get();
-    }
-
     private PreconditionContainer preconditionContainer = new PreconditionContainer();
     private String physicalFilePath;
     private String logicalFilePath;
@@ -60,7 +56,13 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
     private RuntimeEnvironment runtimeEnvironment;
     private boolean ignoreClasspathPrefix = false;
 
+    private DatabaseChangeLog rootChangeLog = ROOT_CHANGE_LOG.get();
+
     public DatabaseChangeLog() {
+    }
+
+    public DatabaseChangeLog getRootChangeLog() {
+        return rootChangeLog != null ? rootChangeLog : this;
     }
 
     public DatabaseChangeLog(String physicalFilePath) {


### PR DESCRIPTION
[CORE-2466](https://liquibase.jira.com/browse/CORE-2466) Rollback referencing a change set in another file cannot be parsed

Makes it possible to resolve the root change log from within a nested change log. Then the root change log can be used to resolve a change set referenced in a rollback node.

Maintains the original change set reference for rollback changes that are included by reference, so that paths relative to the referenced change log file can be resolved correctly.