### PR TITLE
CORE-2467 Support default schema with SSO on MSSQL 2005 and later

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/commandline/CommandLineUtils.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/CommandLineUtils.java
@@ -120,7 +120,21 @@ public class CommandLineUtils {
                     }
                     ExecutorService.getInstance().getExecutor(database).execute(new RawSqlStatement("ALTER SESSION SET CURRENT_SCHEMA="+schema));
                 } else if (database instanceof MSSQLDatabase && defaultSchemaName != null) {
-                    ExecutorService.getInstance().getExecutor(database).execute(new RawSqlStatement("ALTER USER " + database.escapeObjectName(username, DatabaseObject.class) + " WITH DEFAULT_SCHEMA = " + database.escapeObjectName(defaultSchemaName, Schema.class)));
+                    boolean sql2005OrLater = true;
+                    try {
+                        sql2005OrLater = database.getDatabaseMajorVersion() >= 9;
+                    } catch (DatabaseException e) {
+                        // Assume SQL Server 2005 or later
+                    }
+                    if (sql2005OrLater) {
+                        ExecutorService.getInstance().getExecutor(database).execute(new RawSqlStatement(
+                                "IF USER_NAME() <> N'dbo'\r\n" +
+                                "BEGIN\r\n" +
+                                "	DECLARE @sql [nvarchar](MAX)\r\n" +
+                                "	SELECT @sql = N'ALTER USER ' + QUOTENAME(USER_NAME()) + N' WITH DEFAULT_SCHEMA = " + database.escapeStringForDatabase(database.escapeObjectName(username, DatabaseObject.class)) + "'\r\n" +
+                                "	EXEC sp_executesql @sql\r\n" +
+                                "END"));
+                    }
                 } else if (database instanceof PostgresDatabase && defaultSchemaName != null) {
                     ExecutorService.getInstance().getExecutor(database).execute(new RawSqlStatement("SET SEARCH_PATH TO " + defaultSchemaName));
                 } else if (database instanceof DB2Database) {


### PR DESCRIPTION
[CORE-2467](https://liquibase.jira.com/browse/CORE-2467) SSO with jtds MSSQL doesn't work after 3.3.5 for update - null user error