### PR TITLE
Fixed: Absolute filename as valueLobFile would never be found by ClasspathResourceAccessor

### DIFF
--- a/liquibase-core/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
+++ b/liquibase-core/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
@@ -284,7 +284,7 @@ public abstract class ExecutablePreparedStatementBase implements ExecutablePrepa
 		
 		// workaround for FilenameUtils.normalize() returning null for relative paths like ../conf/liquibase.xml
 		String tempFile = FilenameUtils.concat(FilenameUtils.getFullPath(relativeBaseFileName), fileName);
-		if (tempFile != null && new File(tempFile).exists() == true) {
+		if (tempFile != null) {
 			fileName = tempFile;
 		} else {
 			fileName = FilenameUtils.getFullPath(relativeBaseFileName) + fileName;


### PR DESCRIPTION
There were checks that were based on java.io.File class which always failed when the resource was on the classpath.