### PR TITLE
Fix error with postgres throwing an exception with an offline connection and Refactor getConnectionSchemaName to prevent code errors

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -308,7 +308,8 @@ public abstract class AbstractJdbcDatabase implements Database {
 
     /**
      * Overwrite this method to get the default schema name for the connection.
-     *
+     * If you only need to change the statement that obtains the current schema then override
+     *  @see AbstractJdbcDatabase#getConnectionSchemaNameCallStatement()
      * @return
      */
     protected String getConnectionSchemaName() {
@@ -316,12 +317,24 @@ public abstract class AbstractJdbcDatabase implements Database {
             return null;
         }
         try {
-            return ExecutorService.getInstance().getExecutor(this).queryForObject(new RawCallStatement("call current_schema"), String.class);
-
+            String currentSchemaStatement = getConnectionSchemaNameCallStatement();
+            return ExecutorService.getInstance().getExecutor(this).
+            		queryForObject(new RawCallStatement(currentSchemaStatement), String.class);
         } catch (Exception e) {
             LogFactory.getLogger().info("Error getting default schema", e);
         }
         return null;
+    }
+
+    /**
+     * Used to obtain the connection schema name through a statement
+     * Override this method to change the statement.
+     * Only override this if getConnectionSchemaName is left unchanges or is using this method.
+     * @see AbstractJdbcDatabase#getConnectionSchemaName()
+     * @return
+     */
+    protected String getConnectionSchemaNameCallStatement(){
+        return "call current_schema";
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
@@ -176,18 +176,10 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
     }
 
     @Override
-    protected String getConnectionSchemaName() {
-        if (getConnection() == null || getConnection() instanceof OfflineConnection) {
-            return null;
-        }
-        try {
-            return ExecutorService.getInstance().getExecutor(this).queryForObject(new RawSqlStatement("select schema_name()"), String.class);
-        } catch (Exception e) {
-            LogFactory.getLogger().info("Error getting default schema", e);
-        }
-        return null;
+    protected String getConnectionSchemaNameCallStatement() {
+        return "select schema_name()";
     }
-    
+
     @Override
     public String getConcatSql(String... values) {
         StringBuffer returnString = new StringBuffer();

--- a/liquibase-core/src/main/java/liquibase/database/core/PostgresDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/PostgresDatabase.java
@@ -245,15 +245,8 @@ public class PostgresDatabase extends AbstractJdbcDatabase {
     }
 
     @Override
-    protected String getConnectionSchemaName() {
-        try {
-            String currentSchema = ExecutorService.getInstance().getExecutor(this)
-                    .queryForObject(new RawCallStatement("select current_schema"), String.class);
-            return currentSchema;
-
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to get current schema", e);
-        }
+    protected String getConnectionSchemaNameCallStatement() {
+        return "select current_schema";
     }
 
     private boolean catalogExists(String catalogName) throws DatabaseException {

--- a/liquibase-core/src/main/java/liquibase/database/core/SybaseDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/SybaseDatabase.java
@@ -223,18 +223,9 @@ public class SybaseDatabase extends AbstractJdbcDatabase {
     }
 
     @Override
-    protected String getConnectionSchemaName() {
-        if (getConnection() == null || getConnection() instanceof OfflineConnection) {
-            return null;
-        }
-        try {
-            return ExecutorService.getInstance().getExecutor(this).queryForObject(new RawSqlStatement("select user_name()"), String.class);
-        } catch (Exception e) {
-            LogFactory.getLogger().info("Error getting default schema", e);
-        }
-        return null;
+    protected String getConnectionSchemaNameCallStatement() {
+        return "select user_name()";
     }
-
 
     @Override
     public boolean supportsRestrictForeignKeys() {


### PR DESCRIPTION
By default getConnectionSchemaName calls an sql statement that obtains
the current schema. Not only does this force a custom database to copy
the code just so it can modify the call statement, but it is also error
prone as when the base implementation evolves the changes don't occur in
overridden classes. Such error occurred when the base
getConnectionSchemaName has changes so it would return null in the case
of an OfflineConnection but PostgresDatabse still used old code and
would fail on an offline connection.
This evolution adds the getconnectionSchemaNameCallStatement that can be
overridden by databases that only need to customise the statement, that
way the logic is shared with the abstract class.

The following databases have been refactored to use the new method:
- MSSQLDatabase
- PostgresDatabase
- SybaseDatabase