### PR TITLE
Sequence Support for LoadData

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
@@ -234,6 +234,9 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
                             } else if (columnConfig.getType().equalsIgnoreCase("COMPUTED")) {
                                 liquibase.statement.DatabaseFunction function = new liquibase.statement.DatabaseFunction(value.toString());
                                 valueConfig.setValueComputed(function);
+                            } else if (columnConfig.getType().equalsIgnoreCase("SEQUENCE")) {
+                                liquibase.statement.SequenceNextValueFunction function = new liquibase.statement.SequenceNextValueFunction(columnConfig.getDefaultValue());
+                                valueConfig.setValueComputed(function);
                             } else {
                                 throw new UnexpectedLiquibaseException("loadData type of "+columnConfig.getType()+" is not supported.  Please use BOOLEAN, NUMERIC, DATE, STRING, COMPUTED or SKIP");
                             }

--- a/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
@@ -238,7 +238,7 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
                                 liquibase.statement.SequenceNextValueFunction function = new liquibase.statement.SequenceNextValueFunction(columnConfig.getDefaultValue());
                                 valueConfig.setValueComputed(function);
                             } else {
-                                throw new UnexpectedLiquibaseException("loadData type of "+columnConfig.getType()+" is not supported.  Please use BOOLEAN, NUMERIC, DATE, STRING, COMPUTED or SKIP");
+                                throw new UnexpectedLiquibaseException("loadData type of "+columnConfig.getType()+" is not supported.  Please use BOOLEAN, NUMERIC, DATE, STRING, COMPUTED, SEQUENCE or SKIP");
                             }
                             value = valueConfig.getValueObject();
                         }


### PR DESCRIPTION
Today is possible load csv into tables with sequence columns this way:
```csv
id_pais|cod_bacen|descricao
SEQNAME.NEXVAL()|1234|BRASIL
SEQNAME.NEXVAL()|1234|ARGENTINA
```
```xml
<loadData tableName="pais" file="liquibase/seeds/pais.csv" separator="|" >
    <column type="computed" name="id_pais"/>
    <column type="numeric" name="cod_bacen" />
    <column type="string" name="descricao" />
</loadData>
```
but it is not multidatabase compatible.. because this I propose this change:
```csv
id_pais|cod_bacen|descricao
0|1234|BRASIL
0|1234|ARGENTINA
```
```xml
<loadData tableName="pais" file="liquibase/seeds/pais.csv" separator="|" >
    <column type="sequence" name="id_pais" defaultValue="pais_seq"/>
    <column type="numeric" name="cod_bacen" />
    <column type="string" name="descricao" />
</loadData>
```
