### PR TITLE
onUpdate="RESTRICT" is to be ignored on MS SQL Server like it is done for onDelete already.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddForeignKeyConstraintGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddForeignKeyConstraintGenerator.java
@@ -61,6 +61,8 @@ public class AddForeignKeyConstraintGenerator extends AbstractSqlGenerator<AddFo
 	    if (statement.getOnUpdate() != null) {
 		    if (database instanceof OracleDatabase) {
 			    //don't use
+            } else if ((database instanceof MSSQLDatabase) && statement.getOnUpdate().equalsIgnoreCase("RESTRICT")) {
+                //don't use
 		    } else if (database instanceof InformixDatabase) {
 			    //TODO don't know if correct
 		    } else {
@@ -72,7 +74,7 @@ public class AddForeignKeyConstraintGenerator extends AbstractSqlGenerator<AddFo
             if ((database instanceof OracleDatabase) && (statement.getOnDelete().equalsIgnoreCase("RESTRICT") || statement.getOnDelete().equalsIgnoreCase("NO ACTION"))) {
                 //don't use
             } else if ((database instanceof MSSQLDatabase) && statement.getOnDelete().equalsIgnoreCase("RESTRICT")) {
-                //don't use                        
+                //don't use
 		    } else if (database instanceof InformixDatabase && !(statement.getOnDelete().equalsIgnoreCase("CASCADE"))) {
 			    //TODO Informix can handle ON DELETE CASCADE only, but I don't know if this is really correct
 		    	// see "REFERENCES Clause" in manual


### PR DESCRIPTION
MS SQL Server does not understand the syntax but behaves as intended. A restrict-on-update means one must not violate the foreign key constraint which is what is enforced by the constraint anyways. The RESTRICT keyword is required for some databases, I think MySQL, which support different alternatives. Without the change <addForeignKeyConstraint onUpdate="RESTRICT"/> is doomed to fail.