### PR TITLE
fixes findForeignKeyConstraints failing on Oracle using lower-case with quoting

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/FindForeignKeyConstraintsGeneratorOracle.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/FindForeignKeyConstraintsGeneratorOracle.java
@@ -49,7 +49,7 @@ public class FindForeignKeyConstraintsGeneratorOracle extends AbstractSqlGenerat
         sb.append("AND BASE.CONSTRAINT_NAME = BCOLS.CONSTRAINT_NAME ");
         sb.append("AND FRGN.OWNER = FCOLS.OWNER ");
         sb.append("AND FRGN.CONSTRAINT_NAME = FCOLS.CONSTRAINT_NAME ");
-        sb.append("AND BASE.TABLE_NAME =  '").append(statement.getBaseTableName().toUpperCase()).append("' ");
+        sb.append("AND BASE.TABLE_NAME =  '").append(statement.getBaseTableName()).append("' ");
         sb.append("AND BASE.CONSTRAINT_TYPE = 'R' ");
         sb.append("AND BASE.OWNER = '").append(baseTableSchema.getSchemaName()).append("'");
 


### PR DESCRIPTION
We use LiquiBase with QUOTE_ALL_OBJECTS and specify table, column and constraint names in lower case. With this schema, FindForeignKeyConstraintsGeneratorOracle does never list our constraints as it transformed the table names to upper case. As a consequence, dependent refacturings such as dropAllForeignKeyConstraints also malfunctions. Especially the dropAllForeignKeyConstraints failure caused me a headache as this is a simple to use receipt like drop all constraints, alter table structure, recreate constraints.

Notice, I'm not sure if I got the change right. It works for me though. I think one could also do a
    String escapedTableName = database.escapeTableName(statement.getBaseTableCatalogName(), statement.getBaseTableSchemaName(), statement.getBaseTableName());
as is done for MS SQL, for example. Also notice, FindForeignKeyConstraintsGeneratorPostgres likely has the same issue when using upper case...

