### PR TITLE
[CORE-1468] Comparison database types for missing table

### DIFF
--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingTableChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingTableChangeGenerator.java
@@ -67,11 +67,11 @@ public class MissingTableChangeGenerator implements MissingObjectChangeGenerator
         for (Column column : missingTable.getColumns()) {
             ColumnConfig columnConfig = new ColumnConfig();
             columnConfig.setName(column.getName());
-            LiquibaseDataType ldt = DataTypeFactory.getInstance().from(column.getType(), comparisonDatabase);
-            DatabaseDataType ddt = ldt.toDatabaseDataType(referenceDatabase);
+            LiquibaseDataType ldt = DataTypeFactory.getInstance().from(column.getType(), referenceDatabase);
+            DatabaseDataType ddt = ldt.toDatabaseDataType(comparisonDatabase);
             String typeString = ddt.toString();
-            if (referenceDatabase instanceof MSSQLDatabase) {
-                typeString = referenceDatabase.unescapeDataTypeString(typeString);
+            if (comparisonDatabase instanceof MSSQLDatabase) {
+                typeString = comparisonDatabase.unescapeDataTypeString(typeString);
             }
             columnConfig.setType(typeString);
 


### PR DESCRIPTION
JIRA: https://liquibase.jira.com/browse/CORE-1468 "Number / Numeric handling must differ between different database systems"

When generating the changelog, use the comparison database instead of the reference database to find the column types.

E.g. if your comparison database is PostgreSQL, and your reference database is Hibernate (liquibase-hibernate extension) then this will use PostgreSQL data types in the changelog, that you can properly apply to your comparison database.

Otherwise you would have to do an additional step of translating Hibernate data types (if they exist) into PostgreSQL data types, before the changelog were to become applicable to the comparison database.

**EDIT:** More specific example: Postgres has a `UUID` data type. If your field is a `java.util.UUID`, using liquibase-hibernate for the reference database, you will sadly end up with a `char(36)` in the changelog, since the method `UUIDType.toDatabaseDataType()`, called from `MissingTableChangeGenerator.fixMissing()`, will be looking at the Hibernate reference database, instead of the Postgres comparison database.