### PR TITLE
CORE-2299 - bugfix - apply 'errorIfMissingOrEmpty' attribute for 'includeAll' to dbchangelog-3.5.xsd.

### DIFF
--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.5.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.5.xsd
@@ -184,6 +184,7 @@
 					<xsd:element name="includeAll" minOccurs="0" maxOccurs="unbounded">
 						<xsd:complexType>
 							<xsd:attribute name="path" type="xsd:string" use="required" />
+							<xsd:attribute name="errorIfMissingOrEmpty" type="booleanExp" default="false"/>
 							<xsd:attribute name="relativeToChangelogFile" type="booleanExp" />
                             <xsd:attribute name="filter" type="xsd:string" />
 							<xsd:anyAttribute namespace="##other"  processContents="lax"/>


### PR DESCRIPTION
 (Was in dbchangelog-3.4, but not dbchangelog-3.5)