### PR TITLE
Fix schema name generation (again)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/InformixDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/InformixDatabase.java
@@ -39,7 +39,7 @@ public class InformixDatabase extends AbstractJdbcDatabase {
 		systemTablesAndViews.add("systabauth");
 		systemTablesAndViews.add("syscolauth");
 		systemTablesAndViews.add("sysviews");
-		systemTablesAndViews.add("syØsusers");
+		systemTablesAndViews.add("sysusers");
 		systemTablesAndViews.add("sysdepend");
 		systemTablesAndViews.add("syssynonyms");
 		systemTablesAndViews.add("syssyntable");


### PR DESCRIPTION
I have finally had a chance to revisit this problem. The original fix made it easy to generate the tables for the first time but it still did not support upgrading. I have fixed the getConnectionSchemaName method now to get the schema for the current session.

This has enabled us to upgrade our current database for Keycloak with the changes for the most recent version. 

There is still an issue whereby the Informix database cannot be in ANSI mode, due to the various combinations of upper- and lower-case conversion and case sensitivity (not helped by the JDBC driver). I think, though, that this will fix the problem for the majority of cases.