### PR TITLE
CORE-2565 Fix oracle sequence name with schema quoting

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
@@ -10,6 +10,8 @@ import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.executor.ExecutorService;
 import liquibase.logging.LogFactory;
 import liquibase.statement.DatabaseFunction;
+import liquibase.statement.SequenceCurrentValueFunction;
+import liquibase.statement.SequenceNextValueFunction;
 import liquibase.statement.core.RawCallStatement;
 import liquibase.statement.core.RawSqlStatement;
 import liquibase.structure.DatabaseObject;
@@ -364,6 +366,14 @@ public class OracleDatabase extends AbstractJdbcDatabase {
         if (databaseFunction != null && databaseFunction.toString().equalsIgnoreCase("current_timestamp")) {
             return databaseFunction.toString();
         }
+        if(databaseFunction instanceof SequenceNextValueFunction
+                || databaseFunction instanceof SequenceCurrentValueFunction){
+            String quotedSeq = super.generateDatabaseFunctionValue(databaseFunction);
+            // replace "myschema.my_seq".nextval with "myschema"."my_seq".nextval
+            return quotedSeq.replaceFirst("\"([^\\.\"]*)\\.([^\\.\"]*)\"","\"$1\".\"$2\"");
+
+        }
+
         return super.generateDatabaseFunctionValue(databaseFunction);
     }
 }

--- a/liquibase-core/src/test/java/liquibase/sqlgenerator/core/InsertOrUpdateGeneratorOracleTest.java
+++ b/liquibase-core/src/test/java/liquibase/sqlgenerator/core/InsertOrUpdateGeneratorOracleTest.java
@@ -3,10 +3,15 @@ package liquibase.sqlgenerator.core;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
+
+import liquibase.change.ColumnConfig;
 import liquibase.database.core.OracleDatabase;
+import liquibase.database.core.PostgresDatabase;
 import liquibase.sql.Sql;
+import liquibase.statement.SequenceNextValueFunction;
 import liquibase.statement.core.InsertOrUpdateStatement;
 
+import liquibase.statement.core.InsertStatement;
 import org.junit.Test;
 
 
@@ -90,5 +95,21 @@ END;*/
         assertEquals("UPDATE mycatalog.mytable SET col2 = 'value2' WHERE pk_col1 = 'value1';",sqlLines[lineToCheck].trim());
         lineToCheck++;
         assertEquals( "Wrong number of lines", 1, sqlLines.length);
+    }
+
+    @Test
+    public void testInsertSequenceValWithSchema(){
+        OracleDatabase database = new OracleDatabase();
+        InsertGenerator generator = new InsertGenerator();
+        InsertStatement statement = new InsertStatement("mycatalog", "myschema","mytable");
+        ColumnConfig columnConfig = new ColumnConfig();
+        columnConfig.setValueSequenceNext(new SequenceNextValueFunction("myschema.my_seq"));
+        columnConfig.setName("col3");
+        statement.addColumn(columnConfig);
+
+        Sql[] sql = generator.generateSql( statement, database,  null);
+
+        String theSql = sql[0].toSql();
+        assertEquals("INSERT INTO mycatalog.mytable (col3) VALUES (\"myschema\".\"my_seq\".nextval)",theSql);
     }
 }

--- a/liquibase-core/src/test/java/liquibase/sqlgenerator/core/InsertOrUpdateGeneratorPostgresTest.java
+++ b/liquibase-core/src/test/java/liquibase/sqlgenerator/core/InsertOrUpdateGeneratorPostgresTest.java
@@ -1,0 +1,33 @@
+package liquibase.sqlgenerator.core;
+
+import static org.junit.Assert.assertEquals;
+
+import liquibase.change.ColumnConfig;
+import liquibase.database.core.PostgresDatabase;
+import liquibase.sql.Sql;
+import liquibase.statement.SequenceNextValueFunction;
+import liquibase.statement.core.InsertStatement;
+import org.junit.Test;
+
+public class InsertOrUpdateGeneratorPostgresTest {
+    private static final String CATALOG_NAME = "mycatalog";
+    private static final String SCHEMA_NAME = "myschema";
+    private static final String TABLE_NAME = "mytable";
+    private static final String SEQUENCE_NAME = "my_sequence";
+
+    @Test
+    public void testInsertSequenceValWithSchema(){
+        PostgresDatabase postgresDatabase = new PostgresDatabase();
+        InsertGenerator generator = new InsertGenerator();
+        InsertStatement statement = new InsertStatement(CATALOG_NAME, SCHEMA_NAME, TABLE_NAME);
+        ColumnConfig columnConfig = new ColumnConfig();
+        columnConfig.setValueSequenceNext(new SequenceNextValueFunction(SCHEMA_NAME+'.'+SEQUENCE_NAME));
+        columnConfig.setName("col3");
+        statement.addColumn(columnConfig);
+
+        Sql[] sql = generator.generateSql( statement, postgresDatabase,  null);
+        String theSql = sql[0].toSql();
+        assertEquals(String.format("INSERT INTO %s.%s (col3) VALUES (nextval('%s.%s'))",SCHEMA_NAME,TABLE_NAME,SCHEMA_NAME,SEQUENCE_NAME)
+                ,theSql);
+    }
+}


### PR DESCRIPTION
#### [CORE-2565](https://liquibase.jira.com/browse/CORE-2565)

  * fix `"schema.seqname".nextval` to `"schema"."seqname".nextval`

Original:
```sql
-- Oracle
INSERT INTO mycatalog.mytable (col3) VALUES ("myschema.my_seq".nextval)
-- Postgres
INSERT INTO myschema.mytable (col3) VALUES (nextval('myschema.my_seq'))
```
Fixed:
```sql
-- Oracle
INSERT INTO mycatalog.mytable (col3) VALUES ("myschema"."my_seq".nextval)
-- Postgres
INSERT INTO myschema.mytable (col3) VALUES (nextval('myschema.my_seq'))
```

Defference is `"."` between schema name and seq. name

Changeset example:
```xml
 <insert tableName="MYTABLE" schemaName="${database.defaultSchemaName}">
   <column name="col3" valueSequenceNext="${database.defaultSchemaName}.my_seq"/>
...
```
