### PR TITLE
CORE-155 Add ability for a change set to inherit context expressions from parent containers (WIP)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/ContextExpression.java
+++ b/liquibase-core/src/main/java/liquibase/ContextExpression.java
@@ -162,4 +162,19 @@ public class ContextExpression {
     public boolean isEmpty() {
         return this.contexts == null || this.contexts.size() == 0;
     }
+
+    public static boolean matchesAll(Collection<ContextExpression> expressions, Contexts contexts) {
+        if (expressions == null || expressions.isEmpty()) {
+            return true;
+        }
+        if (contexts == null || contexts.isEmpty()) {
+            return true;
+        }
+        for (ContextExpression expression : expressions) {
+            if (!expression.matches(contexts)) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeLogInclude.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeLogInclude.java
@@ -4,17 +4,20 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import liquibase.ContextExpression;
 import liquibase.serializer.AbstractLiquibaseSerializable;
 
 public class ChangeLogInclude extends AbstractLiquibaseSerializable implements ChangeLogChild {
     private String file;
     private Boolean relativeToChangelogFile;
+    private ContextExpression context;
 
     @Override
     public Set<String> getSerializableFields() {
         return new LinkedHashSet<String>(Arrays.asList(
                 "file",
-                "relativeToChangelogFile"));
+                "relativeToChangelogFile",
+                "context"));
     }
 
     @Override
@@ -41,5 +44,13 @@ public class ChangeLogInclude extends AbstractLiquibaseSerializable implements C
 
     public void setRelativeToChangelogFile(Boolean relativeToChangelogFile) {
         this.relativeToChangelogFile = relativeToChangelogFile;
+    }
+
+    public ContextExpression getContext() {
+        return context;
+    }
+
+    public void setContext(ContextExpression context) {
+        this.context = context;
     }
 }

--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeLogIncludeAll.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeLogIncludeAll.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import liquibase.ContextExpression;
 import liquibase.serializer.AbstractLiquibaseSerializable;
 
 public class ChangeLogIncludeAll extends AbstractLiquibaseSerializable implements ChangeLogChild {
@@ -11,6 +12,7 @@ public class ChangeLogIncludeAll extends AbstractLiquibaseSerializable implement
     private Boolean errorIfMissingOrEmpty;
     private Boolean relativeToChangelogFile;
     private String resourceFilter;
+    private ContextExpression context;
 
     @Override
     public Set<String> getSerializableFields() {
@@ -18,7 +20,8 @@ public class ChangeLogIncludeAll extends AbstractLiquibaseSerializable implement
                 "path",
                 "errorIfMissingOrEmpty",
                 "relativeToChangelogFile",
-                "resourceFilter"));
+                "resourceFilter",
+                "context"));
     }
 
     @Override
@@ -61,5 +64,13 @@ public class ChangeLogIncludeAll extends AbstractLiquibaseSerializable implement
 
     public void setResourceFilter(String resourceFilter) {
         this.resourceFilter = resourceFilter;
+    }
+
+    public ContextExpression getContext() {
+        return context;
+    }
+
+    public void setContext(ContextExpression context) {
+        this.context = context;
     }
 }

--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
@@ -717,6 +717,23 @@ public class ChangeSet implements Conditional, ChangeLogChild {
         return dbmsSet;
     }
 
+    public Collection<ContextExpression> getInheritableContexts() {
+        Collection<ContextExpression> expressions = new ArrayList<ContextExpression>();
+        DatabaseChangeLog changeLog = getChangeLog();
+        while (changeLog != null) {
+            ContextExpression expression = changeLog.getContexts();
+            if (expression != null && !expression.isEmpty()) {
+                expressions.add(expression);
+            }
+            ContextExpression includeExpression = changeLog.getIncludeContexts();
+            if (includeExpression != null && !includeExpression.isEmpty()) {
+                expressions.add(includeExpression);
+            }
+            changeLog = changeLog.getParentChangeLog();
+        }
+        return Collections.unmodifiableCollection(expressions);
+    }
+
     public DatabaseChangeLog getChangeLog() {
         return changeLog;
     }

--- a/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -1,5 +1,6 @@
 package liquibase.changelog;
 
+import liquibase.ContextExpression;
 import liquibase.Contexts;
 import liquibase.LabelExpression;
 import liquibase.RuntimeEnvironment;
@@ -37,6 +38,7 @@ import java.util.*;
  */
 public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditional {
     private static final ThreadLocal<DatabaseChangeLog> ROOT_CHANGE_LOG = new ThreadLocal<DatabaseChangeLog>();
+    private static final ThreadLocal<DatabaseChangeLog> PARENT_CHANGE_LOG = new ThreadLocal<DatabaseChangeLog>();
 
     private PreconditionContainer preconditionContainer = new PreconditionContainer();
     private String physicalFilePath;
@@ -50,12 +52,20 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
     private boolean ignoreClasspathPrefix = false;
 
     private DatabaseChangeLog rootChangeLog = ROOT_CHANGE_LOG.get();
+    private DatabaseChangeLog parentChangeLog = PARENT_CHANGE_LOG.get();
+
+    private ContextExpression contexts;
+    private ContextExpression includeContexts;
 
     public DatabaseChangeLog() {
     }
 
     public DatabaseChangeLog getRootChangeLog() {
         return rootChangeLog != null ? rootChangeLog : this;
+    }
+
+    public DatabaseChangeLog getParentChangeLog() {
+        return parentChangeLog;
     }
 
     public DatabaseChangeLog(String physicalFilePath) {
@@ -127,6 +137,22 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
 
     public void setObjectQuotingStrategy(ObjectQuotingStrategy objectQuotingStrategy) {
         this.objectQuotingStrategy = objectQuotingStrategy;
+    }
+
+    public ContextExpression getContexts() {
+        return contexts;
+    }
+
+    public void setContexts(ContextExpression contexts) {
+        this.contexts = contexts;
+    }
+
+    public ContextExpression getIncludeContexts() {
+        return includeContexts;
+    }
+
+    public void setIncludeContexts(ContextExpression includeContexts) {
+        this.includeContexts = includeContexts;
     }
 
     @Override
@@ -246,6 +272,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
 
     public void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException, SetupException {
         setLogicalFilePath(parsedNode.getChildValue(null, "logicalFilePath", String.class));
+        setContexts(new ContextExpression(parsedNode.getChildValue(null, "context", String.class)));
         String objectQuotingStrategy = parsedNode.getChildValue(null, "objectQuotingStrategy", String.class);
         if (objectQuotingStrategy != null) {
             setObjectQuotingStrategy(ObjectQuotingStrategy.valueOf(objectQuotingStrategy));
@@ -287,8 +314,9 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                 throw new UnexpectedLiquibaseException("No 'file' attribute on 'include'");
             }
             path = path.replace('\\', '/');
+            ContextExpression includeContexts = new ContextExpression(node.getChildValue(null, "context", String.class));
             try {
-                include(path, node.getChildValue(null, "relativeToChangelogFile", false), resourceAccessor);
+                include(path, node.getChildValue(null, "relativeToChangelogFile", false), resourceAccessor, includeContexts);
             } catch (LiquibaseException e) {
                 throw new SetupException(e);
             }
@@ -316,9 +344,10 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                 }
             }
 
+            ContextExpression includeContexts = new ContextExpression(node.getChildValue(null, "context", String.class));
             includeAll(path, node.getChildValue(null, "relativeToChangelogFile", false), resourceFilter,
                     node.getChildValue(null, "errorIfMissingOrEmpty", true),
-                    getStandardChangeLogComparator(), resourceAccessor);
+                    getStandardChangeLogComparator(), resourceAccessor, includeContexts);
         } else if (nodeName.equals("preConditions")) {
             this.preconditionContainer = new PreconditionContainer();
             try {
@@ -368,7 +397,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
 
     public void includeAll(String pathName, boolean isRelativeToChangelogFile, IncludeAllFilter resourceFilter,
                            boolean errorIfMissingOrEmpty,
-                           Comparator<String> resourceComparator, ResourceAccessor resourceAccessor) throws SetupException {
+                           Comparator<String> resourceComparator, ResourceAccessor resourceAccessor, ContextExpression includeContexts) throws SetupException {
         try {
             pathName = pathName.replace('\\', '/');
 
@@ -406,14 +435,14 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
             }
 
             for (String path : resources) {
-                include(path, false, resourceAccessor);
+                include(path, false, resourceAccessor, includeContexts);
             }
         } catch (Exception e) {
             throw new SetupException(e);
         }
     }
 
-    public boolean include(String fileName, boolean isRelativePath, ResourceAccessor resourceAccessor) throws LiquibaseException {
+    public boolean include(String fileName, boolean isRelativePath, ResourceAccessor resourceAccessor, ContextExpression includeContexts) throws LiquibaseException {
 
         if (fileName.equalsIgnoreCase(".svn") || fileName.equalsIgnoreCase("cvs")) {
             return false;
@@ -435,12 +464,20 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
             if (rootChangeLog == null) {
                 ROOT_CHANGE_LOG.set(this);
             }
+            DatabaseChangeLog parentChangeLog = PARENT_CHANGE_LOG.get();
+            PARENT_CHANGE_LOG.set(this);
             try {
                 ChangeLogParser parser = ChangeLogParserFactory.getInstance().getParser(fileName, resourceAccessor);
                 changeLog = parser.parse(fileName, changeLogParameters, resourceAccessor);
+                changeLog.setIncludeContexts(includeContexts);
             } finally {
                 if (rootChangeLog == null) {
                     ROOT_CHANGE_LOG.remove();
+                }
+                if (parentChangeLog == null) {
+                    PARENT_CHANGE_LOG.remove();
+                } else {
+                    PARENT_CHANGE_LOG.set(parentChangeLog);
                 }
             }
         } catch (UnknownChangelogFormatException e) {

--- a/liquibase-core/src/main/java/liquibase/changelog/filter/ContextChangeSetFilter.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/filter/ContextChangeSetFilter.java
@@ -1,5 +1,6 @@
 package liquibase.changelog.filter;
 
+import liquibase.ContextExpression;
 import liquibase.Contexts;
 import liquibase.changelog.ChangeSet;
 import liquibase.sql.visitor.SqlVisitor;
@@ -31,11 +32,12 @@ public class ContextChangeSetFilter implements ChangeSetFilter {
             return new ChangeSetFilterResult(true, "No runtime context specified, all contexts will run", this.getClass());
         }
 
-        if (changeSet.getContexts().isEmpty()) {
+        Collection<ContextExpression> inheritableContexts = changeSet.getInheritableContexts();
+        if (changeSet.getContexts().isEmpty() && inheritableContexts.isEmpty()) {
             return new ChangeSetFilterResult(true, "Change set runs under all contexts", this.getClass());
         }
 
-        if (changeSet.getContexts().matches(contexts)) {
+        if (changeSet.getContexts().matches(contexts) && ContextExpression.matchesAll(inheritableContexts, contexts)) {
             return new ChangeSetFilterResult(true, "Context matches '"+contexts.toString()+"'", this.getClass());
         } else {
             return new ChangeSetFilterResult(false, "Context does not match '"+contexts.toString()+"'", this.getClass());

--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.5.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.5.xsd
@@ -178,6 +178,7 @@
 						<xsd:complexType>
 							<xsd:attribute name="file" type="xsd:string" use="required" />
 							<xsd:attribute name="relativeToChangelogFile" type="booleanExp" />
+							<xsd:attribute name="context" type="xsd:string" />
 							<xsd:anyAttribute namespace="##other"  processContents="lax"/>
 						</xsd:complexType>
 					</xsd:element>
@@ -188,6 +189,7 @@
 							<xsd:attribute name="relativeToChangelogFile" type="booleanExp" />
 							<xsd:attribute name="resourceComparator" type="xsd:string"/>
 							<xsd:attribute name="filter" type="xsd:string" />
+							<xsd:attribute name="context" type="xsd:string" />
 							<xsd:anyAttribute namespace="##other"  processContents="lax"/>
 						</xsd:complexType>
 					</xsd:element>
@@ -241,6 +243,7 @@
 	<!-- Attributes for changeSet -->
 	<xsd:attributeGroup name="changeLogAttributes">
 		<xsd:attribute name="logicalFilePath" type="xsd:string" />
+		<xsd:attribute name="context" type="xsd:string" />
         <xsd:attribute name="objectQuotingStrategy" type="objectQuotingStrategy" default="LEGACY" />
 	</xsd:attributeGroup>
 

--- a/liquibase-core/src/test/groovy/liquibase/changelog/DatabaseChangeLogTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/changelog/DatabaseChangeLogTest.groovy
@@ -1,5 +1,6 @@
 package liquibase.changelog
 
+import liquibase.ContextExpression;
 import liquibase.change.core.CreateTableChange
 import liquibase.change.core.RawSQLChange
 import liquibase.exception.SetupException
@@ -201,7 +202,7 @@ create view sql_view as select * from sql_table;'''
                 "com/example/not/fileX.sql"     : "file X",
         ])
         def changeLogFile = new DatabaseChangeLog("com/example/root.xml")
-        changeLogFile.includeAll("com/example/children", false, null, true, changeLogFile.getStandardChangeLogComparator(), resourceAccessor)
+        changeLogFile.includeAll("com/example/children", false, null, true, changeLogFile.getStandardChangeLogComparator(), resourceAccessor, new ContextExpression())
 
         then:
         changeLogFile.changeSets.collect { it.filePath } == ["com/example/children/file1.sql",
@@ -248,7 +249,7 @@ create view sql_view as select * from sql_table;'''
                 "com/example/not/fileX.sql": "file X",
         ])
         def changeLogFile = new DatabaseChangeLog("com/example/root.xml")
-        changeLogFile.includeAll("com/example/missing", false, null, true, changeLogFile.getStandardChangeLogComparator(), resourceAccessor)
+        changeLogFile.includeAll("com/example/missing", false, null, true, changeLogFile.getStandardChangeLogComparator(), resourceAccessor, new ContextExpression())
 
         then:
         SetupException e = thrown()
@@ -265,7 +266,7 @@ create view sql_view as select * from sql_table;'''
                 "com/example/not/fileX.sql": "file X",
         ])
         def changeLogFile = new DatabaseChangeLog("com/example/root.xml")
-        changeLogFile.includeAll("com/example/missing", false, null, false, changeLogFile.getStandardChangeLogComparator(), resourceAccessor)
+        changeLogFile.includeAll("com/example/missing", false, null, false, changeLogFile.getStandardChangeLogComparator(), resourceAccessor, new ContextExpression())
         then:
         changeLogFile.changeSets.collect {it.filePath } == []
 


### PR DESCRIPTION
Adds ability for a change set to inherit context expressions via databaseChangeLog, include or includeAll parent containers

[CORE-155](https://liquibase.jira.com/browse/CORE-155) Default-context attribute in databaseChangeLog tag

The context expressions from the parent containers are inheritable and ANDed together logically.

Example usage:

_changelog-master.xml:_
```xml
<databaseChangeLog>
    <include file="changelog-included.xml" context="d and e"/>
    <includeAll ... context="f or g"/>
</databaseChangeLog>
```
_changelog-included.xml:_
```xml
<databaseChangeLog ... context="a and (b or c)">
    <!-- logically, the context expression for this change set is 
         "(d and e) and (a and (b or c)) and (h or j or k)", 
         assuming changelog-master.xml is the root change log
    -->
    <changeSet ... context="h or j or k">...</changeSet>
    <changeSet ...>...</changeSet>
    <changeSet ...>...</changeSet>
</databaseChangeLog>
```

