### PR TITLE
CORE-1167 Changed validCheckSum behavior to make more sense...

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
@@ -9,6 +9,8 @@ import liquibase.change.DbmsTargetedChange;
 import liquibase.change.core.EmptyChange;
 import liquibase.change.core.RawSQLChange;
 import liquibase.changelog.visitor.ChangeExecListener;
+import liquibase.configuration.GlobalConfiguration;
+import liquibase.configuration.LiquibaseConfiguration;
 import liquibase.database.Database;
 import liquibase.database.DatabaseList;
 import liquibase.database.ObjectQuotingStrategy;
@@ -832,6 +834,7 @@ public class ChangeSet implements Conditional, ChangeLogChild {
                 return true;
             }
         }
+
         CheckSum currentMd5Sum = generateCheckSum();
         if (currentMd5Sum == null) {
             return true;
@@ -843,8 +846,15 @@ public class ChangeSet implements Conditional, ChangeLogChild {
             return true;
         }
 
+        // Old checksum behavior compares each validCheckSum to the new computed value
+        // New (default) behavior compares each to the stored value
+        boolean legacyChecksumBehavior = LiquibaseConfiguration.getInstance()
+                .getConfiguration(GlobalConfiguration.class)
+                .getLegacyChecksumCompare();
+        CheckSum actual = legacyChecksumBehavior ? currentMd5Sum : storedCheckSum;
+
         for (CheckSum validCheckSum : validCheckSums) {
-            if (currentMd5Sum.equals(validCheckSum)) {
+            if (actual.equals(validCheckSum)) {
                 return true;
             }
         }

--- a/liquibase-core/src/main/java/liquibase/configuration/GlobalConfiguration.java
+++ b/liquibase-core/src/main/java/liquibase/configuration/GlobalConfiguration.java
@@ -17,6 +17,7 @@ public class GlobalConfiguration extends AbstractConfigurationContainer {
     public static final String CHANGELOGLOCK_POLL_RATE = "changeLogLockPollRate";
     public static final String CONVERT_DATA_TYPES = "convertDataTypes";
     public static final String GENERATE_CHANGESET_CREATED_VALUES = "generateChangeSetCreatedValues";
+    public static final String LEGACY_CHECKSUM_COMPARE = "legacyCheckSumCompare";
 
     public GlobalConfiguration() {
         super("liquibase");
@@ -66,6 +67,11 @@ public class GlobalConfiguration extends AbstractConfigurationContainer {
 
         getContainer().addProperty(GENERATE_CHANGESET_CREATED_VALUES, Boolean.class)
                 .setDescription("Should Liquibase include a 'created' attribute in diff/generateChangeLog changeSets with the current datetime")
+                .setDefaultValue(false);
+        
+        getContainer().addProperty(LEGACY_CHECKSUM_COMPARE, Boolean.class)
+                .setDescription("Whether liquibase should use the legacy validCheckSums comparison "
+                        + "behavior (compare to current) or the default (compare to stored).")
                 .setDefaultValue(false);
     }
 
@@ -188,4 +194,20 @@ public class GlobalConfiguration extends AbstractConfigurationContainer {
         getContainer().setValue(OUTPUT_ENCODING, name);
         return this;
     }
+
+    /**
+     * Whether Liquibase should use the legacy validCheckSum comparison behavior (compare to current)
+     * or the default (compare to stored).
+     * 
+     * @see <a href="https://liquibase.jira.com/browse/CORE-1167">CORE-1167</a>
+     */
+    public boolean getLegacyChecksumCompare() {
+        return getContainer().getValue(LEGACY_CHECKSUM_COMPARE, Boolean.class);
+    }
+
+    public GlobalConfiguration setLegacyChecksumCompare(boolean value) {
+        getContainer().setValue(LEGACY_CHECKSUM_COMPARE, value);
+        return this;
+    }
+
 }

--- a/liquibase-core/src/test/groovy/liquibase/changelog/ChangeSetTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/changelog/ChangeSetTest.groovy
@@ -2,6 +2,8 @@ package liquibase.changelog
 
 import liquibase.change.CheckSum
 import liquibase.change.core.*
+import liquibase.configuration.GlobalConfiguration
+import liquibase.configuration.LiquibaseConfiguration
 import liquibase.parser.core.ParsedNode
 import liquibase.parser.core.ParsedNodeException
 import liquibase.precondition.core.RunningAsPrecondition
@@ -19,6 +21,14 @@ public class ChangeSetTest extends Specification {
 
     @Shared
             resourceSupplier = new ResourceSupplier()
+
+    def setup() {
+        LiquibaseConfiguration.getInstance().reset()
+    }
+
+    def cleanup() {
+        LiquibaseConfiguration.getInstance().reset()
+    }
 
     def getDescriptions() {
         when:
@@ -97,6 +107,21 @@ public class ChangeSetTest extends Specification {
 
     def isCheckSumValid_differentButValidCheckSum() {
         when:
+        CheckSum checkSum = CheckSum.parse("2:asdf");
+
+        ChangeSet changeSet = new ChangeSet("1", "2", false, false, "/test.xml", null, null, null);
+        changeSet.addValidCheckSum("2:asdf");
+
+        then:
+        assert changeSet.isCheckSumValid(checkSum)
+    }
+
+    def isCheckSumValid_differentButValidCheckSumLegacy() {
+        when:
+        LiquibaseConfiguration.getInstance()
+                .getConfiguration(GlobalConfiguration.class)
+                .setLegacyChecksumCompare(true);
+
         CheckSum checkSum = CheckSum.parse("2:asdf");
 
         ChangeSet changeSet = new ChangeSet("1", "2", false, false, "/test.xml", null, null, null);


### PR DESCRIPTION
[CORE-1167](https://liquibase.jira.com/browse/CORE-1167) Changed validCheckSum behavior to make more sense and match
the original documentation. By default, each validCheckSum now specifies
a stored checkSum value that will be considered valid. This allows a
changeSet to be altered and still pass validation.

The old behavior can still be used by setting the legacyCheckSumCompare
configuration property to true.

----

See the reasoning for this change here: https://liquibase.jira.com/browse/CORE-1167
I will try to give another example below.

Say I create a changeSet to update the value of a column

    <changeSet id="update-some-value" author="svanhoose">
        <update tableName="WIDGET">
            <column name="PRICE" valueComputed="special sql" />
        </update>
    </changeSet>

This goes into production and it works for 90% of my users on Oracle but fails for one user on Postgres. I look into the problem and find that my update SQL was bad so I fix it to be DB-agnostic.

Now I want to fix the changeSet for the next release. It already ran successfully for 90% of my customers and they should not have to do anything. I want the updated changeSet to run for the 10% of customers where it previously failed.

Essentially, "**If this changeSet already ran successfully and the old checksum matches the provided value, everything is okay. Otherwise run the changeSet or report a validation error.**"

    <changeSet id="update-some-value" author="svanhoose">
        <validCheckSum>7:2cad55a6ddef7f531bc0bdb867929d89</validCheckSum>
        <update tableName="WIDGET">
            <column name="PRICE" valueComputed="improved special sql" />
        </update>
    </changeSet>

Except that this doesn't work. The current behavior of Liquibase is such that validCheckSum is checked against the **newly computed checksum.** This behavior is logically equivalent to:

    <changeSet id="update-some-value" author="svanhoose">
        <ignoreDatabaseChecksum>true</ignoreDatabaseChecksum>
        <update tableName="WIDGET">
            <column name="PRICE" valueComputed="improved special sql" />
        </update>
    </changeSet>

I don't want to ignore the stored database checksum entirely. I only want to ignore one specific value.

----

Apologies for the long message... I'm really trying to make sure this is clear since the previous discussion of this issue in [CORE-1112](https://liquibase.jira.com/browse/CORE-1112) ended with the documentation being updated instead of the bug being fixed.

Let me know if you think I should submit this against a different branch.