### PR TITLE
CORE-2579 don't drop Oracle system sequences

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
@@ -270,6 +270,8 @@ public class OracleDatabase extends AbstractJdbcDatabase {
                 return true;
             } else if (example.getName().equals("JAVA$CLASS$MD5$TABLE")) { //This is a hash table that tracks the loading of Java objects into a schema.
                 return true;
+            } else if (example.getName().startsWith("ISEQ$$_")) { //System-generated sequence
+                return true;
             }
         }
 


### PR DESCRIPTION
In Oracle 12c, creating a table with an autoincrement column makes Oracle also
create a system-generated sequence for that column. Such sequences cannot be
dropped, but only purged, since undropping the table would otherwise fail.

Attempting to drop a system-generated sequence results in an ORA-32794 error,
which would make the dropAll command fail. This change makes dropAll skip all
sequences that are system objects.