### PR TITLE
 0# Fixes for CORE-2604 and CORE- 2606

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/DatabaseDataType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/DatabaseDataType.java
@@ -37,7 +37,7 @@ public class DatabaseDataType {
      * @return Whether the type is serial
      */
     public boolean isAutoIncrement() {
-        return type.equalsIgnoreCase("serial") || type.equalsIgnoreCase("bigserial");
+        return type.equalsIgnoreCase("serial") || type.equalsIgnoreCase("bigserial") || type.equalsIgnoreCase("smallserial");
     }
 
     public String toSql() {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/BooleanType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/BooleanType.java
@@ -12,6 +12,7 @@ import liquibase.database.core.OracleDatabase;
 import liquibase.database.core.SQLiteDatabase;
 import liquibase.database.core.SybaseASADatabase;
 import liquibase.database.core.SybaseDatabase;
+import liquibase.database.core.PostgresDatabase;
 import liquibase.datatype.DataTypeInfo;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.LiquibaseDataType;
@@ -46,7 +47,11 @@ public class BooleanType extends LiquibaseDataType {
             }
         } else if (database instanceof HsqlDatabase) {
             return new DatabaseDataType("BOOLEAN");
-        }
+        } else if (database instanceof PostgresDatabase) {
+            if (originalDefinition.toLowerCase().startsWith("bit")) {
+                return new DatabaseDataType("BIT", getParameters());
+            }
+	}
 
         return super.toDatabaseDataType(database);
     }

--- a/liquibase-core/src/main/java/liquibase/datatype/core/SmallIntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/SmallIntType.java
@@ -30,7 +30,7 @@ public class SmallIntType extends LiquibaseDataType {
             type.addAdditionalInformation(getAdditionalInformation());
             return type;
         }
-        if (database instanceof DB2Database || database instanceof DerbyDatabase || database instanceof FirebirdDatabase || database instanceof PostgresDatabase || database instanceof InformixDatabase) {
+        if (database instanceof DB2Database || database instanceof DerbyDatabase || database instanceof FirebirdDatabase || database instanceof InformixDatabase) {
             return new DatabaseDataType("SMALLINT"); //always smallint regardless of parameters passed
         }
 
@@ -38,6 +38,13 @@ public class SmallIntType extends LiquibaseDataType {
             return new DatabaseDataType("NUMBER", 5);
         }
 
+	if (database instanceof PostgresDatabase) {
+            if (isAutoIncrement()) {
+                return new DatabaseDataType("SMALLSERIAL");
+            } else {
+		return new DatabaseDataType("SMALLINT");
+	    }
+        }
         return super.toDatabaseDataType(database);
     }
 


### PR DESCRIPTION
Fixes for following defects

1. CORE-2604:PostgreSQL datatype bit(n) column gives BOOLEAN(n) type for CreateTableChange genearated sql statement

2. CORE-2606: PostgreSQL : Table creation with datatype smallserial fails.