### PR TITLE
Lazy initialization of "static" fields should be "synchronized"

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/ChangeFactory.java
+++ b/liquibase-core/src/main/java/liquibase/change/ChangeFactory.java
@@ -56,7 +56,7 @@ public class ChangeFactory {
     /**
      * Reset the ChangeFactory so it reloads the registry on the next call to @{link #getInstance()}. Mainly used in testing
      */
-    public static void reset() {
+    public static synchronized void reset() {
         instance = null;
     }
 

--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeLogHistoryServiceFactory.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeLogHistoryServiceFactory.java
@@ -30,7 +30,7 @@ public class ChangeLogHistoryServiceFactory {
     }
 
 
-    public static void reset() {
+    public static synchronized void reset() {
         instance = null;
     }
 
@@ -93,7 +93,7 @@ public class ChangeLogHistoryServiceFactory {
             }
     }
 
-    public void resetAll() {
+    public synchronized void resetAll() {
         for (ChangeLogHistoryService changeLogHistoryService : registry) {
             changeLogHistoryService.reset();
         }

--- a/liquibase-core/src/main/java/liquibase/configuration/LiquibaseConfiguration.java
+++ b/liquibase-core/src/main/java/liquibase/configuration/LiquibaseConfiguration.java
@@ -28,7 +28,7 @@ public class LiquibaseConfiguration {
     /**
      * Returns the singleton instance, creating it if necessary. On creation, the configuration is initialized with {@link liquibase.configuration.SystemPropertyProvider}
      */
-    public static LiquibaseConfiguration getInstance() {
+    public static synchronized LiquibaseConfiguration getInstance() {
         if (instance == null) {
             instance = new LiquibaseConfiguration();
             instance.init(new SystemPropertyProvider());

--- a/liquibase-core/src/main/java/liquibase/database/DatabaseFactory.java
+++ b/liquibase-core/src/main/java/liquibase/database/DatabaseFactory.java
@@ -43,21 +43,21 @@ public class DatabaseFactory {
 
     }
 
-    public static DatabaseFactory getInstance() {
+    public static synchronized DatabaseFactory getInstance() {
         if (instance == null) {
             instance = new DatabaseFactory();
         }
         return instance;
     }
 
-    public static void reset() {
+    public static synchronized void reset() {
         instance = new DatabaseFactory();
     }
 
     /**
      * Set singleton instance. Primarily used in testing
      */
-    public static void setInstance(DatabaseFactory databaseFactory) {
+    public static synchronized void setInstance(DatabaseFactory databaseFactory) {
         instance = databaseFactory;
     }
 

--- a/liquibase-core/src/main/java/liquibase/datatype/DataTypeFactory.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/DataTypeFactory.java
@@ -45,7 +45,7 @@ public class DataTypeFactory {
         return instance;
     }
 
-    public static void reset() {
+    public static synchronized void reset() {
         instance = new DataTypeFactory();
     }
 

--- a/liquibase-core/src/main/java/liquibase/diff/DiffGeneratorFactory.java
+++ b/liquibase-core/src/main/java/liquibase/diff/DiffGeneratorFactory.java
@@ -29,7 +29,7 @@ public class DiffGeneratorFactory {
         }
     }
 
-    public static DiffGeneratorFactory getInstance() {
+    public static synchronized DiffGeneratorFactory getInstance() {
         if (instance == null) {
             instance = new DiffGeneratorFactory();
         }

--- a/liquibase-core/src/main/java/liquibase/diff/compare/DatabaseObjectComparatorFactory.java
+++ b/liquibase-core/src/main/java/liquibase/diff/compare/DatabaseObjectComparatorFactory.java
@@ -39,14 +39,14 @@ public class DatabaseObjectComparatorFactory {
     /**
      * Return singleton DatabaseObjectComparatorFactory
      */
-    public static DatabaseObjectComparatorFactory getInstance() {
+    public static synchronized DatabaseObjectComparatorFactory getInstance() {
         if (instance == null) {
             instance = new DatabaseObjectComparatorFactory();
         }
         return instance;
     }
 
-    public static void reset() {
+    public static synchronized void reset() {
         instance = new DatabaseObjectComparatorFactory();
     }
 
@@ -92,7 +92,7 @@ public class DatabaseObjectComparatorFactory {
     }
 
 
-    public static void resetAll() {
+    public static synchronized void resetAll() {
         instance = null;
     }
 

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/ChangeGeneratorFactory.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/ChangeGeneratorFactory.java
@@ -36,14 +36,14 @@ public class ChangeGeneratorFactory {
     /**
      * Return singleton ChangeGeneratorFactory
      */
-    public static ChangeGeneratorFactory getInstance() {
+    public static synchronized ChangeGeneratorFactory getInstance() {
         if (instance == null) {
             instance = new ChangeGeneratorFactory();
         }
         return instance;
     }
 
-    public static void reset() {
+    public static synchronized void reset() {
         instance = new ChangeGeneratorFactory();
     }
 

--- a/liquibase-core/src/main/java/liquibase/lockservice/LockServiceFactory.java
+++ b/liquibase-core/src/main/java/liquibase/lockservice/LockServiceFactory.java
@@ -38,7 +38,7 @@ public class LockServiceFactory {
     }
 
 
-    public static void reset() {
+    public static synchronized void reset() {
         instance = null;
     }
 
@@ -91,7 +91,7 @@ public class LockServiceFactory {
 
 	}
 
-	public void resetAll() {
+	public synchronized void resetAll() {
 		for (LockService lockService : registry) {
 			lockService.reset();
 		}

--- a/liquibase-core/src/main/java/liquibase/logging/LogFactory.java
+++ b/liquibase-core/src/main/java/liquibase/logging/LogFactory.java
@@ -14,11 +14,11 @@ public class LogFactory {
 
     private static LogFactory instance;
 
-    public static void reset() {
+    public static synchronized void reset() {
         instance = new LogFactory();
     }
 
-    public static LogFactory getInstance() {
+    public static synchronized LogFactory getInstance() {
         if (instance == null) {
             instance = new LogFactory();
         }

--- a/liquibase-core/src/main/java/liquibase/osgi/OSGiUtil.java
+++ b/liquibase-core/src/main/java/liquibase/osgi/OSGiUtil.java
@@ -4,7 +4,7 @@ import org.osgi.framework.BundleReference;
 
 public final class OSGiUtil {
 
-    private static Boolean loadedAsBundle;
+    private static volatile Boolean loadedAsBundle;
 
     public static boolean isLiquibaseLoadedAsOSGiBundle() {
         if (loadedAsBundle == null) {

--- a/liquibase-core/src/main/java/liquibase/parser/ChangeLogParserFactory.java
+++ b/liquibase-core/src/main/java/liquibase/parser/ChangeLogParserFactory.java
@@ -16,11 +16,11 @@ public class ChangeLogParserFactory {
     private Comparator<ChangeLogParser> changelogParserComparator;
 
 
-    public static void reset() {
+    public static synchronized void reset() {
         instance = new ChangeLogParserFactory();
     }
 
-    public static ChangeLogParserFactory getInstance() {
+    public static synchronized ChangeLogParserFactory getInstance() {
         if (instance == null) {
              instance = new ChangeLogParserFactory();
         }

--- a/liquibase-core/src/main/java/liquibase/parser/NamespaceDetailsFactory.java
+++ b/liquibase-core/src/main/java/liquibase/parser/NamespaceDetailsFactory.java
@@ -13,11 +13,11 @@ public class NamespaceDetailsFactory {
 
     private List<NamespaceDetails> namespaceDetails = new ArrayList<NamespaceDetails>();
 
-    public static void reset() {
+    public static synchronized void reset() {
         instance = null;
     }
 
-    public static NamespaceDetailsFactory getInstance() {
+    public static synchronized NamespaceDetailsFactory getInstance() {
         if (instance == null) {
             instance = new NamespaceDetailsFactory();
         }

--- a/liquibase-core/src/main/java/liquibase/parser/SnapshotParserFactory.java
+++ b/liquibase-core/src/main/java/liquibase/parser/SnapshotParserFactory.java
@@ -19,11 +19,11 @@ public class SnapshotParserFactory {
     private Comparator<SnapshotParser> snapshotParserComparator;
 
 
-    public static void reset() {
+    public static synchronized void reset() {
         instance = new SnapshotParserFactory();
     }
 
-    public static SnapshotParserFactory getInstance() {
+    public static synchronized SnapshotParserFactory getInstance() {
         if (instance == null) {
              instance = new SnapshotParserFactory();
         }

--- a/liquibase-core/src/main/java/liquibase/precondition/PreconditionFactory.java
+++ b/liquibase-core/src/main/java/liquibase/precondition/PreconditionFactory.java
@@ -27,14 +27,14 @@ public class PreconditionFactory {
         }
     }
 
-    public static PreconditionFactory getInstance() {
+    public static synchronized PreconditionFactory getInstance() {
         if (instance == null) {
              instance = new PreconditionFactory();
         }
         return instance;
     }
 
-    public static void reset() {
+    public static synchronized void reset() {
         instance = new PreconditionFactory();
     }
 

--- a/liquibase-core/src/main/java/liquibase/sdk/Context.java
+++ b/liquibase-core/src/main/java/liquibase/sdk/Context.java
@@ -28,11 +28,11 @@ public class Context {
     private Context() {
     }
 
-    public static void reset() {
+    public static synchronized void reset() {
         instance = null;
     }
 
-    public static Context getInstance() {
+    public static synchronized Context getInstance() {
         if (instance == null) {
             instance = new Context();
             try {

--- a/liquibase-core/src/main/java/liquibase/sdk/supplier/database/ConnectionConfigurationFactory.java
+++ b/liquibase-core/src/main/java/liquibase/sdk/supplier/database/ConnectionConfigurationFactory.java
@@ -26,7 +26,7 @@ public class ConnectionConfigurationFactory {
 
     }
 
-    public static ConnectionConfigurationFactory getInstance() {
+    public static synchronized ConnectionConfigurationFactory getInstance() {
         if (instance == null) {
             instance = new ConnectionConfigurationFactory();
         }
@@ -41,7 +41,7 @@ public class ConnectionConfigurationFactory {
         return configurations;
     }
 
-    public static void reset() {
+    public static synchronized void reset() {
         instance = new ConnectionConfigurationFactory();
     }
 

--- a/liquibase-core/src/main/java/liquibase/serializer/ChangeLogSerializerFactory.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/ChangeLogSerializerFactory.java
@@ -11,11 +11,11 @@ public class ChangeLogSerializerFactory {
 
     private Map<String, List<ChangeLogSerializer>> serializers = new HashMap<String, List<ChangeLogSerializer>>();
 
-    public static void reset() {
+    public static synchronized void reset() {
         instance = new ChangeLogSerializerFactory();
     }
 
-    public static ChangeLogSerializerFactory getInstance() {
+    public static synchronized ChangeLogSerializerFactory getInstance() {
         if (instance == null) {
             instance = new ChangeLogSerializerFactory();
         }

--- a/liquibase-core/src/main/java/liquibase/serializer/SnapshotSerializerFactory.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/SnapshotSerializerFactory.java
@@ -11,11 +11,11 @@ public class SnapshotSerializerFactory {
 
     private Map<String, List<SnapshotSerializer>> serializers = new HashMap<String, List<SnapshotSerializer>>();
 
-    public static void reset() {
+    public static synchronized void reset() {
         instance = new SnapshotSerializerFactory();
     }
 
-    public static SnapshotSerializerFactory getInstance() {
+    public static synchronized SnapshotSerializerFactory getInstance() {
         if (instance == null) {
             instance = new SnapshotSerializerFactory();
         }

--- a/liquibase-core/src/main/java/liquibase/servicelocator/ServiceLocator.java
+++ b/liquibase-core/src/main/java/liquibase/servicelocator/ServiceLocator.java
@@ -80,7 +80,7 @@ public class ServiceLocator {
         return instance;
     }
 
-    public static void setInstance(ServiceLocator newInstance) {
+    public static synchronized void setInstance(ServiceLocator newInstance) {
         instance = newInstance;
     }
 
@@ -247,7 +247,7 @@ public class ServiceLocator {
         return classes;
     }
 
-    public static void reset() {
+    public static synchronized void reset() {
         instance = new ServiceLocator();
     }
 

--- a/liquibase-core/src/main/java/liquibase/snapshot/SnapshotGeneratorFactory.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/SnapshotGeneratorFactory.java
@@ -45,14 +45,14 @@ public class SnapshotGeneratorFactory {
     /**
      * Return singleton SnapshotGeneratorFactory
      */
-    public static SnapshotGeneratorFactory getInstance() {
+    public static synchronized SnapshotGeneratorFactory getInstance() {
         if (instance == null) {
             instance = new SnapshotGeneratorFactory();
         }
         return instance;
     }
 
-    public static void reset() {
+    public static synchronized void reset() {
         instance = new SnapshotGeneratorFactory();
     }
 
@@ -193,7 +193,7 @@ public class SnapshotGeneratorFactory {
         }
     }
 
-    public static void resetAll() {
+    public static synchronized void resetAll() {
         instance = null;
     }
 

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/SqlGeneratorFactory.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/SqlGeneratorFactory.java
@@ -49,14 +49,14 @@ public class SqlGeneratorFactory {
     /**
      * Return singleton SqlGeneratorFactory
      */
-    public static SqlGeneratorFactory getInstance() {
+    public static synchronized SqlGeneratorFactory getInstance() {
         if (instance == null) {
             instance = new SqlGeneratorFactory();
         }
         return instance;
     }
 
-    public static void reset() {
+    public static synchronized void reset() {
         instance = new SqlGeneratorFactory();
     }
 

--- a/liquibase-core/src/main/java/liquibase/structure/core/DatabaseObjectFactory.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/DatabaseObjectFactory.java
@@ -15,7 +15,7 @@ public class DatabaseObjectFactory {
     private static DatabaseObjectFactory instance;
     private Set<Class<? extends DatabaseObject>> standardTypes;
 
-    public static DatabaseObjectFactory getInstance() {
+    public static synchronized DatabaseObjectFactory getInstance() {
         if (instance == null) {
             instance = new DatabaseObjectFactory();
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2444 - Lazy initialization of "static" fields should be "synchronized"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2444

Please let me know if you have any questions.

Kirill Vlasov