### PR TITLE
Method invokes inefficient Number constructor

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/ChangeFactory.java
+++ b/liquibase-core/src/main/java/liquibase/change/ChangeFactory.java
@@ -75,7 +75,7 @@ public class ChangeFactory {
                     @Override
                     public int compare(Class<? extends Change> o1, Class<? extends Change> o2) {
                         try {
-                            return -1 * new Integer(getChangeMetaData(o1.newInstance()).getPriority()).compareTo(getChangeMetaData(o2.newInstance()).getPriority());
+                            return -1 * Integer.valueOf(getChangeMetaData(o1.newInstance()).getPriority()).compareTo(getChangeMetaData(o2.newInstance()).getPriority());
                         } catch (Exception e) {
                             throw new UnexpectedLiquibaseException(e);
                         }

--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeLogHistoryServiceFactory.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeLogHistoryServiceFactory.java
@@ -59,7 +59,7 @@ public class ChangeLogHistoryServiceFactory {
             SortedSet<ChangeLogHistoryService> foundServices = new TreeSet<ChangeLogHistoryService>(new Comparator<ChangeLogHistoryService>() {
                 @Override
                 public int compare(ChangeLogHistoryService o1, ChangeLogHistoryService o2) {
-                    return -1 * new Integer(o1.getPriority()).compareTo(o2.getPriority());
+                    return -1 * Integer.valueOf(o1.getPriority()).compareTo(o2.getPriority());
                 }
             });
 

--- a/liquibase-core/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
@@ -279,7 +279,7 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
                         }
                     }
                     String tmpOrderExecuted = rs.get("ORDEREXECUTED").toString();
-                    Integer orderExecuted = (tmpOrderExecuted == null ? null : new Integer(tmpOrderExecuted));
+                    Integer orderExecuted = (tmpOrderExecuted == null ? null : Integer.valueOf(tmpOrderExecuted));
                     String tag = rs.get("TAG") == null ? null : rs.get("TAG").toString();
                     String execType = rs.get("EXECTYPE") == null ? null : rs.get("EXECTYPE").toString();
                     ContextExpression contexts = new ContextExpression((String) rs.get("CONTEXTS"));

--- a/liquibase-core/src/main/java/liquibase/configuration/ConfigurationProperty.java
+++ b/liquibase-core/src/main/java/liquibase/configuration/ConfigurationProperty.java
@@ -96,7 +96,7 @@ public class ConfigurationProperty {
             } else if (type.equals(BigDecimal.class)) {
                 return new BigDecimal((String) value);
             } else if (type.equals(Long.class)) {
-            	return new Long((String) value);
+            	return Long.valueOf((String) value);
             } else {
                 throw new UnexpectedLiquibaseException("Cannot parse property "+type.getSimpleName()+" to a "+type.getSimpleName());
             }

--- a/liquibase-core/src/main/java/liquibase/datatype/DataTypeFactory.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/DataTypeFactory.java
@@ -61,7 +61,7 @@ public class DataTypeFactory {
                 @Override
                 public int compare(Class<? extends LiquibaseDataType> o1, Class<? extends LiquibaseDataType> o2) {
                     try {
-                        return -1 * new Integer(o1.newInstance().getPriority()).compareTo(o2.newInstance().getPriority());
+                        return -1 * Integer.valueOf(o1.newInstance().getPriority()).compareTo(o2.newInstance().getPriority());
                     } catch (Exception e) {
                         throw new UnexpectedLiquibaseException(e);
                     }

--- a/liquibase-core/src/main/java/liquibase/diff/DiffGeneratorFactory.java
+++ b/liquibase-core/src/main/java/liquibase/diff/DiffGeneratorFactory.java
@@ -45,7 +45,7 @@ public class DiffGeneratorFactory {
         SortedSet<DiffGenerator> foundGenerators = new TreeSet<DiffGenerator>(new Comparator<DiffGenerator>() {
             @Override
             public int compare(DiffGenerator o1, DiffGenerator o2) {
-                return -1 * new Integer(o1.getPriority()).compareTo(o2.getPriority());
+                return -1 * Integer.valueOf(o1.getPriority()).compareTo(o2.getPriority());
             }
         });
 

--- a/liquibase-core/src/main/java/liquibase/diff/compare/DatabaseObjectComparatorComparator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/compare/DatabaseObjectComparatorComparator.java
@@ -17,7 +17,7 @@ class DatabaseObjectComparatorComparator implements Comparator<DatabaseObjectCom
 
     @Override
     public int compare(DatabaseObjectComparator o1, DatabaseObjectComparator o2) {
-        int result = -1 * new Integer(o1.getPriority(objectType, database)).compareTo(o2.getPriority(objectType, database));
+        int result = -1 * Integer.valueOf(o1.getPriority(objectType, database)).compareTo(o2.getPriority(objectType, database));
         if (result == 0) {
             return o1.getClass().getName().compareTo(o2.getClass().getName());
         }

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/ChangeGeneratorComparator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/ChangeGeneratorComparator.java
@@ -17,7 +17,7 @@ public class ChangeGeneratorComparator implements Comparator<ChangeGenerator> {
 
     @Override
     public int compare(ChangeGenerator o1, ChangeGenerator o2) {
-        int result = -1 * new Integer(o1.getPriority(objectType, database)).compareTo(o2.getPriority(objectType, database));
+        int result = -1 * Integer.valueOf(o1.getPriority(objectType, database)).compareTo(o2.getPriority(objectType, database));
         if (result == 0) {
             return o1.getClass().getName().compareTo(o2.getClass().getName());
         }

--- a/liquibase-core/src/main/java/liquibase/lockservice/LockServiceFactory.java
+++ b/liquibase-core/src/main/java/liquibase/lockservice/LockServiceFactory.java
@@ -65,7 +65,7 @@ public class LockServiceFactory {
 			SortedSet<LockService> foundServices = new TreeSet<LockService>(new Comparator<LockService>() {
 				@Override
                 public int compare(LockService o1, LockService o2) {
-					return -1 * new Integer(o1.getPriority()).compareTo(o2.getPriority());
+					return -1 * Integer.valueOf(o1.getPriority()).compareTo(o2.getPriority());
 				}
 			});
 

--- a/liquibase-core/src/main/java/liquibase/snapshot/SnapshotGeneratorComparator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/SnapshotGeneratorComparator.java
@@ -17,7 +17,7 @@ class SnapshotGeneratorComparator implements Comparator<SnapshotGenerator> {
 
     @Override
     public int compare(SnapshotGenerator o1, SnapshotGenerator o2) {
-        int result = -1 * new Integer(o1.getPriority(objectType, database)).compareTo(o2.getPriority(objectType, database));
+        int result = -1 * Integer.valueOf(o1.getPriority(objectType, database)).compareTo(o2.getPriority(objectType, database));
         if (result == 0) {
             return o1.getClass().getName().compareTo(o2.getClass().getName());
         }

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/SqlGeneratorComparator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/SqlGeneratorComparator.java
@@ -5,6 +5,6 @@ import java.util.Comparator;
 class SqlGeneratorComparator implements Comparator<SqlGenerator> {
     @Override
     public int compare(SqlGenerator o1, SqlGenerator o2) {
-        return -1 * new Integer(o1.getPriority()).compareTo(o2.getPriority());
+        return -1 * Integer.valueOf(o1.getPriority()).compareTo(o2.getPriority());
     }
 }

--- a/liquibase-core/src/main/java/liquibase/util/SqlUtil.java
+++ b/liquibase-core/src/main/java/liquibase/util/SqlUtil.java
@@ -132,7 +132,7 @@ public class SqlUtil {
             if (scanner.hasNextBoolean()) {
                 return scanner.nextBoolean();
             } else {
-                return new Integer(stringVal);
+                return Integer.valueOf(stringVal);
             }
         } else if (liquibaseDataType instanceof BlobType|| typeId == Types.BLOB) {
             if (strippedSingleQuotes) {

--- a/liquibase-core/src/main/java/liquibase/util/file/FilenameUtils.java
+++ b/liquibase-core/src/main/java/liquibase/util/file/FilenameUtils.java
@@ -105,7 +105,7 @@ public class FilenameUtils {
      * The extension separator String.
      * @since Commons IO 1.4
      */
-    public static final String EXTENSION_SEPARATOR_STR = (new Character(EXTENSION_SEPARATOR)).toString();
+    public static final String EXTENSION_SEPARATOR_STR = Character.valueOf(EXTENSION_SEPARATOR).toString();
 
     /**
      * The Unix separator character.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule findbugs:DM_NUMBER_CTOR - Performance - Method invokes inefficient Number constructor; use static valueOf instead
You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=findbugs:DM_NUMBER_CTOR
Please let me know if you have any questions.
Kirill Vlasov