### PR TITLE
Update RanChangeSet to handle classpath prefix

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/RanChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/RanChangeSet.java
@@ -157,7 +157,7 @@ public class RanChangeSet {
     }
 
     public boolean isSameAs(ChangeSet changeSet) {
-        return this.getChangeLog().replace('\\', '/').replaceFirst("^classpath:", "").equalsIgnoreCase(changeSet.getFilePath().replace('\\', '/'))
+        return this.getChangeLog().replace('\\', '/').replaceFirst("^classpath:", "").equalsIgnoreCase(changeSet.getFilePath().replace('\\', '/').replaceFirst("^classpath:", ""))
                 && this.getId().equalsIgnoreCase(changeSet.getId())
                 && this.getAuthor().equalsIgnoreCase(changeSet.getAuthor());
     }

--- a/liquibase-core/src/test/java/liquibase/changelog/RanChangeSetTest.java
+++ b/liquibase-core/src/test/java/liquibase/changelog/RanChangeSetTest.java
@@ -1,0 +1,15 @@
+package liquibase.changelog;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class RanChangeSetTest {
+
+    @Test
+    public void is_same_as_when_both_changelogs_have_classpath_prefix() throws Exception {
+        RanChangeSet ranChangeSet = new RanChangeSet("classpath:/db/file.log", "1", "author", null, null, null, null, null, null, null, null);
+        ChangeSet incomingChangeSet = new ChangeSet("1", "author", false, false, "classpath:/db/file.log", null, null, null);
+        assertTrue(ranChangeSet.isSameAs(incomingChangeSet));
+    }
+}


### PR DESCRIPTION
Currently, when running Liquibase as part of Spring Boot, having changesets set to runOnChange and loading configuration from the classpath causes the changeset to be run every time once it has changed once and creates a new EXECUTED line in the DATABASECHANGELOG, rather than a RERAN line. This is caused by the RanChangeSet.isSameAs method not stripping classpath: from both entries, meaning they are always identified as not the same when they are.