### PR TITLE
Fix the Maven artifact name for EasyMock.

### DIFF
--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -148,7 +148,7 @@
         </dependency>
         <dependency>
         	<groupId>org.easymock</groupId>
-        	<artifactId>easyMock</artifactId>
+        	<artifactId>easymock</artifactId>
         	<scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
 
             <dependency>
             	<groupId>org.easymock</groupId>
-            	<artifactId>easyMock</artifactId>
+            	<artifactId>easymock</artifactId>
             	<version>2.5.2</version>
             	<scope>test</scope>
             </dependency>


### PR DESCRIPTION
The proper Maven artifact name for EasyMock is `easymock` not the camel-case `easyMock`. The camel-case spelling causes issues on case-sensitive filesystems (like those in use on Linux systems).