### PR TITLE
(Derby) If error when determine Driver Version set a bigger

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/DerbyDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/DerbyDatabase.java
@@ -188,11 +188,11 @@ public class DerbyDatabase extends AbstractJdbcDatabase {
                 }
             }
 //            log.debug("Unable to load/access Apache Derby driver class " + "to check version");
-            driverVersionMajor = -1;
+            driverVersionMajor = 99;
             driverVersionMinor = -1;
         } catch (Exception e) {
 //            log.debug("Unable to load/access Apache Derby driver class " + "org.apache.derby.tools.sysinfo to check version: " + e.getMessage());
-            driverVersionMajor = -1;
+            driverVersionMajor = 99;
             driverVersionMinor = -1;
         }
     }


### PR DESCRIPTION
When I use liquibase with maven plugin it can't get the Driver Version, so it is set to -1 and I can't use sequences or other resource available on bigger versions of database. I think would better set it to bigger version and not restrict the features. If you could find why it doesn't work on maven plugin would be a solution too.