### PR TITLE
Reduced fetch size. 

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -55,6 +55,7 @@ import java.util.regex.Pattern;
 public abstract class AbstractJdbcDatabase implements Database {
 
     private static final Pattern startsWithNumberPattern = Pattern.compile("^[0-9].*");
+    private final static int FETCH_SIZE = 1000;
 
     private DatabaseConnection connection;
     protected String defaultCatalogName;
@@ -353,6 +354,11 @@ public abstract class AbstractJdbcDatabase implements Database {
         if (!supportsSchemas()) {
             defaultCatalogSet = schemaName != null;
         }
+    }
+
+    @Override
+    public Integer getFetchSize() {
+        return FETCH_SIZE;
     }
 
     /**

--- a/liquibase-core/src/main/java/liquibase/database/Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/Database.java
@@ -78,6 +78,8 @@ public interface Database extends PrioritizedService {
 
     Integer getDefaultPort();
 
+    Integer getFetchSize();
+
     String getLiquibaseCatalogName();
 
     void setLiquibaseCatalogName(String catalogName);

--- a/liquibase-core/src/main/java/liquibase/sdk/database/MockDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/sdk/database/MockDatabase.java
@@ -36,6 +36,8 @@ import liquibase.structure.core.Schema;
 
 public class MockDatabase implements Database, InternalDatabase {
 
+    private final static int FETCH_SIZE = 1000;
+	
     private boolean outputDefaultSchema;
     private boolean outputDefaultCatalog;
     private boolean supportsCatalogs = true;
@@ -646,6 +648,11 @@ public class MockDatabase implements Database, InternalDatabase {
 
     public String correctObjectName(final String name, final Class<? extends DatabaseObject> objectType, final boolean quoteCorrectedName) {
         return correctObjectName(name, objectType);
+    }
+
+    @Override
+    public Integer getFetchSize() {
+        return FETCH_SIZE;
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/snapshot/ResultSetCache.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/ResultSetCache.java
@@ -15,7 +15,6 @@ import java.sql.Statement;
 import java.util.*;
 
 class ResultSetCache {
-    private final static int FETCH_SIZE = 1000;
     private Map<String, Integer> timesSingleQueried = new HashMap<String, Integer>();
     private Map<String, Boolean> didBulkQuery = new HashMap<String, Boolean>();
 
@@ -189,7 +188,7 @@ class ResultSetCache {
                 JdbcConnection connection = (JdbcConnection) database.getConnection();
                 statement = connection.createStatement();
                 resultSet = statement.executeQuery(sql);
-                resultSet.setFetchSize(FETCH_SIZE);
+                resultSet.setFetchSize(database.getFetchSize());
                 return extract(resultSet, informixTrimHint);
             } finally {
                 JdbcUtils.close(resultSet, statement);
@@ -225,7 +224,7 @@ class ResultSetCache {
         }
 
         protected List<CachedRow> extract(ResultSet resultSet, final boolean informixIndexTrimHint) throws SQLException {
-            resultSet.setFetchSize(FETCH_SIZE);
+            resultSet.setFetchSize(database.getFetchSize());
             List<Map> result;
             List<CachedRow> returnList = new ArrayList<CachedRow>();
             try {


### PR DESCRIPTION
Original fetch size causing SQLWarning exception with Oracle TimesTen jdbc driver.

There is no comment in oracle docu regarding setFetchSize but i have found note in squirrel forum: http://sourceforge.net/p/squirrel-sql/mailman/message/9012007/

Exception from timesten jdbc driver:
org.liquibase:liquibase-maven-plugin:3.4.2:update failed: liquibase.exception.DatabaseException: com.timesten.jdbc.JdbcOdbcSQLWarning: [TimesTen][TimesTen 11.2.2.7.0 CLIENT]Option value changed