### PR TITLE
Update MANIFEST.MF

### DIFF
--- a/liquibase-core/src/main/resources/META-INF/MANIFEST.MF
+++ b/liquibase-core/src/main/resources/META-INF/MANIFEST.MF
@@ -1,6 +1,5 @@
 Manifest-Version: 1.0
 Main-Class: liquibase.integration.commandline.Main
-Class-Path: lib/snakeyaml-1.13.jar
 Liquibase-Package: liquibase.change,
  liquibase.changelog,
  liquibase.database,


### PR DESCRIPTION
In Websphere Liberty, on startup I get the following.
[WARNING ] SRVE9967W: The manifest class path lib/snakeyaml-1.13.jar can not be found in jar file file:/C:/Users/Mac/.m2/repository/org/liquibase/liquibase-core/3.4.2/liquibase-core-3.4.2.jar or its parent.