### PR TITLE
Fix build, remove defaults

### DIFF
--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -11,12 +11,10 @@
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-parent</artifactId>
         <version>3.5.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <properties>
         <bundle.namespace>liquibase.*</bundle.namespace>
-        <project.version>3.5.0-SNAPSHOT</project.version>
     </properties>
 
     <dependencies>

--- a/liquibase-debian/pom.xml
+++ b/liquibase-debian/pom.xml
@@ -4,12 +4,10 @@
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-parent</artifactId>
         <version>3.5.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>liquibase-debian</artifactId>
     
-    <version>3.4.2-SNAPSHOT</version>
     <name>Liquibase Debian Packager</name>
     <description>Debian package builder for liquibase.</description>
      <organization>

--- a/liquibase-integration-tests/pom.xml
+++ b/liquibase-integration-tests/pom.xml
@@ -9,7 +9,6 @@
         <artifactId>liquibase-parent</artifactId>
         <groupId>org.liquibase</groupId>
         <version>3.5.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <dependencies>


### PR DESCRIPTION
This main point of this is to fix the build of liquibase-debian, which does not build in a clean environment where 3.4.2-SNAPSHOT isn't present. While fixing that, I reviewed the other poms for cleanups and removed some defaults that should be left to Maven to get right.