### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/liquibase-rpm/pom.xml
+++ b/liquibase-rpm/pom.xml
@@ -30,7 +30,7 @@
         <snakeyaml.version>1.13</snakeyaml.version>
         <postgresql.version>9.3-1101-jdbc41</postgresql.version>
         <commons-cli.version>1.2</commons-cli.version>
-        <commons-collections.version>3.2.1</commons-collections.version>
+        <commons-collections.version>3.2.2</commons-collections.version>
         <commons-lang.version>2.4</commons-lang.version>
         <hamcrest-core.version>1.3</hamcrest-core.version>
         <javax.servlet.version>3.0.0.v201112011016</javax.servlet.version>


### PR DESCRIPTION
Upgrade Apache Commons Collections to v3.2.2

Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/