### PR TITLE
Ignoring changesets that are included twice

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -187,7 +187,33 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
         return changeSets;
     }
 
+    protected boolean objectsEqual(Object a, Object b) {
+      return (a == b) || (a != null && a.equals(b));
+    }
+
+    protected boolean isChangesetAlreadyIncluded(ChangeSet changeSet) {
+        boolean changeSetFound = false;
+        Iterator<ChangeSet> iterator = changeSets.iterator();
+        while (iterator.hasNext() && !changeSetFound) {
+            ChangeSet includedChangeSet = iterator.next();
+
+            if (objectsEqual(includedChangeSet.getFilePath(), changeSet.getFilePath())
+                && objectsEqual(includedChangeSet.getId(), changeSet.getId())
+                && objectsEqual(includedChangeSet.getAuthor(), changeSet.getAuthor())
+                && objectsEqual(includedChangeSet.generateCheckSum(), changeSet.generateCheckSum())
+                && objectsEqual(includedChangeSet.getLabels().getLabels(), changeSet.getLabels().getLabels())
+                && objectsEqual(includedChangeSet.getContexts().getContexts(), changeSet.getContexts().getContexts())
+                && objectsEqual(includedChangeSet.getDbmsSet(), changeSet.getDbmsSet())) {
+              changeSetFound = true;
+            }
+        }
+        return changeSetFound;
+    }
+
     public void addChangeSet(ChangeSet changeSet) {
+        if (isChangesetAlreadyIncluded(changeSet)) {
+          return;
+        }
         if (changeSet.getRunOrder() == null) {
             ListIterator<ChangeSet> it = this.changeSets.listIterator(this.changeSets.size());
             boolean added = false;

--- a/liquibase-core/src/test/java/liquibase/parser/core/xml/XMLChangeLogSAXParserTest.java
+++ b/liquibase-core/src/test/java/liquibase/parser/core/xml/XMLChangeLogSAXParserTest.java
@@ -1,0 +1,52 @@
+package liquibase.parser.core.xml;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import liquibase.changelog.ChangeLogParameters;
+import liquibase.changelog.ChangeSet;
+import liquibase.changelog.DatabaseChangeLog;
+import liquibase.exception.ChangeLogParseException;
+import liquibase.test.JUnitResourceAccessor;
+
+public class XMLChangeLogSAXParserTest {
+
+    @Test
+    public void testIgnoreDuplicateChangeSets() throws ChangeLogParseException, Exception {
+        XMLChangeLogSAXParser xmlParser = new XMLChangeLogSAXParser();
+        DatabaseChangeLog changeLog = xmlParser.parse("liquibase/parser/core/xml/ignoreDuplicatedChangeLogs/master.changelog.xml", 
+            new ChangeLogParameters(), new JUnitResourceAccessor());
+
+        List<ChangeSet> changeSets = changeLog.getChangeSets();
+        Assert.assertEquals(8, changeSets.size());
+        
+        Assert.assertEquals("liquibase/parser/core/xml/ignoreDuplicatedChangeLogs/included.changelog4.xml::1::testuser", 
+            changeSets.get(0).toString());
+        
+        Assert.assertEquals("liquibase/parser/core/xml/ignoreDuplicatedChangeLogs/included.changelog4.xml::1::testuser", 
+            changeSets.get(1).toString());
+        Assert.assertEquals(1, changeSets.get(1).getContexts().getContexts().size());
+
+        Assert.assertEquals("liquibase/parser/core/xml/ignoreDuplicatedChangeLogs/included.changelog4.xml::1::testuser", 
+            changeSets.get(2).toString());
+        Assert.assertEquals(1, changeSets.get(2).getLabels().getLabels().size());
+
+        Assert.assertEquals("liquibase/parser/core/xml/ignoreDuplicatedChangeLogs/included.changelog4.xml::1::testuser", 
+            changeSets.get(3).toString());
+        Assert.assertEquals(2, changeSets.get(3).getLabels().getLabels().size());
+
+        Assert.assertEquals("liquibase/parser/core/xml/ignoreDuplicatedChangeLogs/included.changelog4.xml::1::testuser", 
+            changeSets.get(4).toString());
+        Assert.assertEquals(1, changeSets.get(4).getDbmsSet().size());
+
+        Assert.assertEquals("liquibase/parser/core/xml/ignoreDuplicatedChangeLogs/included.changelog1.xml::1::testuser", 
+            changeSets.get(5).toString());
+        Assert.assertEquals("liquibase/parser/core/xml/ignoreDuplicatedChangeLogs/included.changelog3.xml::1::testuser", 
+            changeSets.get(6).toString());
+        Assert.assertEquals("liquibase/parser/core/xml/ignoreDuplicatedChangeLogs/included.changelog2.xml::1::testuser", 
+            changeSets.get(7).toString());
+    }
+
+}

--- a/liquibase-core/src/test/resources/liquibase/parser/core/xml/ignoreDuplicatedChangeLogs/included.changelog1.xml
+++ b/liquibase-core/src/test/resources/liquibase/parser/core/xml/ignoreDuplicatedChangeLogs/included.changelog1.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <include file="included.changelog4.xml" relativeToChangelogFile="true" />
+
+    <changeSet id="1" author="testuser">
+        <createTable tableName="included_table_1">
+            <column name="id" type="int"/>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/liquibase-core/src/test/resources/liquibase/parser/core/xml/ignoreDuplicatedChangeLogs/included.changelog2.xml
+++ b/liquibase-core/src/test/resources/liquibase/parser/core/xml/ignoreDuplicatedChangeLogs/included.changelog2.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.2.xsd">
+
+    <include file="included.changelog4.xml" relativeToChangelogFile="true" />
+    <include file="included.changelog3.xml" relativeToChangelogFile="true" />
+
+    <changeSet id="1" author="testuser">
+        <createTable tableName="included_table_2">
+            <column name="id" type="int"/>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/liquibase-core/src/test/resources/liquibase/parser/core/xml/ignoreDuplicatedChangeLogs/included.changelog3.xml
+++ b/liquibase-core/src/test/resources/liquibase/parser/core/xml/ignoreDuplicatedChangeLogs/included.changelog3.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.2.xsd">
+
+    <changeSet id="1" author="testuser">
+        <createTable tableName="included_table_3">
+            <column name="id" type="int"/>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/liquibase-core/src/test/resources/liquibase/parser/core/xml/ignoreDuplicatedChangeLogs/included.changelog4.xml
+++ b/liquibase-core/src/test/resources/liquibase/parser/core/xml/ignoreDuplicatedChangeLogs/included.changelog4.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet id="1" author="testuser">
+        <createTable tableName="included_table_4">
+            <column name="id" type="int"/>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="1" author="testuser" context="testcontext">
+      <createTable tableName="table_table_4_testcontext">
+            <column name="id" type="int"/>
+        </createTable>
+    </changeSet>
+    
+    <changeSet id="1" author="testuser" labels="testlabel">
+      <createTable tableName="table_table_4_testlabel">
+            <column name="id" type="int"/>
+        </createTable>
+    </changeSet>
+    
+    <changeSet id="1" author="testuser" labels="testlabel,testlabel2">
+      <createTable tableName="table_table_4_testlabels">
+            <column name="id" type="int"/>
+        </createTable>
+    </changeSet>
+    
+    <changeSet id="1" author="testuser" dbms="testdb">
+      <createTable tableName="table_table_4_testdb">
+            <column name="id" type="int"/>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/liquibase-core/src/test/resources/liquibase/parser/core/xml/ignoreDuplicatedChangeLogs/master.changelog.xml
+++ b/liquibase-core/src/test/resources/liquibase/parser/core/xml/ignoreDuplicatedChangeLogs/master.changelog.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.2.xsd">
+
+    <include file="included.changelog1.xml" relativeToChangelogFile="true" />
+    <include file="included.changelog2.xml" relativeToChangelogFile="true" />
+    <include file="included.changelog3.xml" relativeToChangelogFile="true" />
+</databaseChangeLog>


### PR DESCRIPTION
Two changesets are equal they have the same

- id
- filepath
- author
- md5
- dbms
- contexts
- labels
