### PR TITLE
Added validateOnly flag to make liquibase just check the database is up-to-date

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/spring/SpringLiquibase.java
+++ b/liquibase-core/src/main/java/liquibase/integration/spring/SpringLiquibase.java
@@ -257,6 +257,9 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
      */
     private boolean ignoreClasspathPrefix = true;
 
+    private boolean validateOnly = false;
+
+
 	public SpringLiquibase() {
 		super();
 	}
@@ -269,6 +272,14 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
 		this.dropFirst = dropFirst;
 	}
 
+	public boolean isValidateOnly() {
+	    return validateOnly;
+	}
+
+	public void setValidateOnly(boolean validateOnly) {
+	    this.validateOnly = validateOnly;
+	}
+	
 	public void setShouldRun(boolean shouldRun) {
 		this.shouldRun = shouldRun;
 	}
@@ -387,8 +398,16 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
 		try {
 			c = getDataSource().getConnection();
             liquibase = createLiquibase(c);
+            
+            if (validateOnly) {
+                if (liquibase.listUnrunChangeSets(new Contexts(contexts), new LabelExpression(getLabels()))
+                        .size() > 0) {
+                    throw new LiquibaseException("Unrun changes found in validate only mode");
+                }                
+            } else {
 			generateRollbackFile(liquibase);
 			performUpdate(liquibase);
+            }
 		} catch (SQLException e) {
 			throw new DatabaseException(e);
 		} finally {


### PR DESCRIPTION
The change means that when you use the spring integration you can have Liquibase check the DB is in a valid state and throw an exception if it isn't, instead of trying to modify the state.