### PR TITLE
* fixed the mapping of TINYINT type for DB2 database

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/TinyIntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/TinyIntType.java
@@ -26,7 +26,8 @@ public class TinyIntType  extends LiquibaseDataType {
         if (database instanceof MSSQLDatabase) {
             return new DatabaseDataType(database.escapeDataTypeName("tinyint"));
         }
-        if (database instanceof DerbyDatabase || database instanceof PostgresDatabase || database instanceof FirebirdDatabase) {
+        if (database instanceof DerbyDatabase || database instanceof PostgresDatabase || database instanceof FirebirdDatabase
+                || database instanceof DB2Database) {
             return new DatabaseDataType("SMALLINT");
         }
         if (database instanceof MySQLDatabase) {


### PR DESCRIPTION
TINYINT should be mapped to SMALLINT in DB2.
See Table 1. http://www.ibm.com/developerworks/data/library/techarticle/dm-0807patel/