### PR TITLE
Escaped schema names for case when schema name can contain hyphen ( f…

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/commandline/CommandLineUtils.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/CommandLineUtils.java
@@ -145,7 +145,7 @@ public class CommandLineUtils {
                 if (schema == null) {
                     schema = defaultSchemaName;
                 }
-                ExecutorService.getInstance().getExecutor(database).execute(new RawSqlStatement("ALTER SESSION SET CURRENT_SCHEMA="+schema));
+                ExecutorService.getInstance().getExecutor(database).execute(new RawSqlStatement("ALTER SESSION SET CURRENT_SCHEMA="+database.escapeObjectName(schema, Schema.class)));
             } else if (database instanceof MSSQLDatabase && defaultSchemaName != null) {
 boolean sql2005OrLater = true;
                     try {

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateProcedureGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateProcedureGenerator.java
@@ -82,8 +82,8 @@ public class CreateProcedureGenerator extends AbstractSqlGenerator<CreateProcedu
         if ((StringUtils.trimToNull(schemaName) != null) && !LiquibaseConfiguration.getInstance().getProperty(ChangeLogParserCofiguration.class, ChangeLogParserCofiguration.USE_PROCEDURE_SCHEMA).getValue(Boolean.class)) {
             String defaultSchema = database.getDefaultSchemaName();
             if (database instanceof OracleDatabase) {
-                sql.add(0, new UnparsedSql("ALTER SESSION SET CURRENT_SCHEMA=" + schemaName));
-                sql.add(new UnparsedSql("ALTER SESSION SET CURRENT_SCHEMA=" + defaultSchema));
+                sql.add(0, new UnparsedSql("ALTER SESSION SET CURRENT_SCHEMA=" + database.escapeObjectName(schemaName, Schema.class)));
+                sql.add(new UnparsedSql("ALTER SESSION SET CURRENT_SCHEMA=" + database.escapeObjectName(defaultSchema, Schema.class)));
             } else if (database instanceof DB2Database) {
                 sql.add(0, new UnparsedSql("SET CURRENT SCHEMA "+ schemaName));
                 sql.add(new UnparsedSql("SET CURRENT SCHEMA "+ defaultSchema));


### PR DESCRIPTION
Hello.
On our legacy project we have Oracle schemas with names that contain hyphen. For these schemas liquibase fails with following message:

Unexpected error running Liquibase: ORA-00922: missing or invalid option
 [Failed SQL: ALTER SESSION SET CURRENT_SCHEMA=BUR-QA1-AGT]

That's because hyphens are not allowed for schema names. Such names should be surrounded with quotes.

With my changes "liquibase update" works fine. I hope I did everything right.