### PR TITLE
CORE-2735 test rollback on update added to SpringLiquibase

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/spring/SpringLiquibase.java
+++ b/liquibase-core/src/main/java/liquibase/integration/spring/SpringLiquibase.java
@@ -222,7 +222,8 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
 	protected boolean shouldRun = true;
 
 	protected File rollbackFile;
-    /**
+
+	/**
      * Ignores classpath prefix during changeset comparison.
      * This is particularly useful if Liquibase is run in different ways.
      *
@@ -256,6 +257,8 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
      * To avoid this issue, just set ignoreClasspathPrefix to true.
      */
     private boolean ignoreClasspathPrefix = true;
+
+	protected boolean testRollbackOnUpdate = false;
 
 	public SpringLiquibase() {
 		super();
@@ -367,6 +370,22 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
 	}
 
 	/**
+	 * Returns whether a rollback should be tested at update time or not.
+	 */
+	public boolean isTestRollbackOnUpdate() {
+		return testRollbackOnUpdate;
+	}
+
+	/**
+	 * If testRollbackOnUpdate is set to true a rollback will be tested at tupdate time.
+	 * For doing so when the update is performed
+	 * @param testRollbackOnUpdate
+     */
+	public void setTestRollbackOnUpdate(boolean testRollbackOnUpdate) {
+		this.testRollbackOnUpdate = testRollbackOnUpdate;
+	}
+
+	/**
 	 * Executed automatically when the bean is initialized.
 	 */
 	@Override
@@ -428,11 +447,19 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
     }
 
     protected void performUpdate(Liquibase liquibase) throws LiquibaseException {
-        if (tag != null) {
-            liquibase.update(tag, new Contexts(getContexts()), new LabelExpression(getLabels()));
-        } else {
-            liquibase.update(new Contexts(getContexts()), new LabelExpression(getLabels()));
-        }
+		if (isTestRollbackOnUpdate()) {
+			if (tag != null) {
+				liquibase.updateTestingRollback(tag, new Contexts(getContexts()), new LabelExpression(getLabels()));
+			} else {
+				liquibase.updateTestingRollback(new Contexts(getContexts()), new LabelExpression(getLabels()));
+			}
+		} else {
+			if (tag != null) {
+				liquibase.update(tag, new Contexts(getContexts()), new LabelExpression(getLabels()));
+			} else {
+				liquibase.update(new Contexts(getContexts()), new LabelExpression(getLabels()));
+			}
+		}
     }
 
 	protected Liquibase createLiquibase(Connection c) throws LiquibaseException {

--- a/liquibase-core/src/test/java/liquibase/integration/spring/SpringLiquibaseTest.java
+++ b/liquibase-core/src/test/java/liquibase/integration/spring/SpringLiquibaseTest.java
@@ -1,0 +1,84 @@
+package liquibase.integration.spring;
+
+import liquibase.Contexts;
+import liquibase.LabelExpression;
+import liquibase.Liquibase;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.Assert.*;
+import static  org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link SpringLiquibase}
+ */
+public class SpringLiquibaseTest {
+
+    public static final String TEST_CONTEXT = "test_context";
+    public static final String TEST_LABELS = "test_labels";
+    public static final String TEST_TAG = "test_tag";
+
+    private SpringLiquibase springLiquibase = new SpringLiquibase();
+
+    private Liquibase liquibase;
+
+    private ArgumentCaptor<Contexts> contextCaptor ;
+    private ArgumentCaptor<LabelExpression> labelCaptor ;
+    private ArgumentCaptor<String> stringCaptor ;
+
+    @Before
+    public void setUp(){
+        liquibase = mock(Liquibase.class);
+        springLiquibase.setContexts(TEST_CONTEXT);
+        springLiquibase.setLabels(TEST_LABELS);
+        contextCaptor = ArgumentCaptor.forClass(Contexts.class);
+        labelCaptor = ArgumentCaptor.forClass(LabelExpression.class);
+        stringCaptor = ArgumentCaptor.forClass(String.class);
+    }
+
+    @Test
+    public void testRollbackOnUpdateToFalse() throws Exception {
+        springLiquibase.setTestRollbackOnUpdate(false);
+        springLiquibase.performUpdate(liquibase);
+        verify(liquibase).update(contextCaptor.capture(),labelCaptor.capture());
+        assertSame(contextCaptor.getValue().getContexts().size(),1);
+        assertTrue(contextCaptor.getValue().getContexts().contains(TEST_CONTEXT));
+        assertSame(labelCaptor.getValue().getLabels().size(),1);
+        assertTrue(labelCaptor.getValue().getLabels().contains(TEST_LABELS));
+    }
+    @Test
+    public void testRollbackOnUpdateToFalseWithTag() throws Exception {
+        springLiquibase.setTag(TEST_TAG);
+        springLiquibase.setTestRollbackOnUpdate(false);
+        springLiquibase.performUpdate(liquibase);
+        verify(liquibase).update(stringCaptor.capture(),contextCaptor.capture(),labelCaptor.capture());
+        assertSame(contextCaptor.getValue().getContexts().size(),1);
+        assertTrue(contextCaptor.getValue().getContexts().contains(TEST_CONTEXT));
+        assertSame(labelCaptor.getValue().getLabels().size(),1);
+        assertTrue(labelCaptor.getValue().getLabels().contains(TEST_LABELS));
+        assertSame(stringCaptor.getValue(),TEST_TAG);
+    }
+    @Test
+    public void testRollbackOnUpdateToTrue() throws Exception {
+        springLiquibase.setTestRollbackOnUpdate(true);
+        springLiquibase.performUpdate(liquibase);
+        verify(liquibase).updateTestingRollback(contextCaptor.capture(),labelCaptor.capture());
+        assertSame(contextCaptor.getValue().getContexts().size(),1);
+        assertTrue(contextCaptor.getValue().getContexts().contains(TEST_CONTEXT));
+        assertSame(labelCaptor.getValue().getLabels().size(),1);
+        assertTrue(labelCaptor.getValue().getLabels().contains(TEST_LABELS));
+    }
+    @Test
+    public void testRollbackOnUpdateToTrueWithTag() throws Exception {
+        springLiquibase.setTag(TEST_TAG);
+        springLiquibase.setTestRollbackOnUpdate(true);
+        springLiquibase.performUpdate(liquibase);
+        verify(liquibase).updateTestingRollback(stringCaptor.capture(),contextCaptor.capture(),labelCaptor.capture());
+        assertSame(contextCaptor.getValue().getContexts().size(),1);
+        assertTrue(contextCaptor.getValue().getContexts().contains(TEST_CONTEXT));
+        assertSame(labelCaptor.getValue().getLabels().size(),1);
+        assertTrue(labelCaptor.getValue().getLabels().contains(TEST_LABELS));
+        assertSame(stringCaptor.getValue(),TEST_TAG);
+    }
+}


### PR DESCRIPTION
SpringLiquibase has been enhanced with an additional configuration field that allows users to test rollback during updating
