### PR TITLE
CORE-1272 - xsd validation to enforce DATABASECHANGELOG ID column constraints at compilation time (by the IDE)

### DIFF
--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.5.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.5.xsd
@@ -250,7 +250,7 @@
 
 	<!-- Attributes for changeSet -->
 	<xsd:attributeGroup name="changeSetAttributes">
-		<xsd:attribute name="id" type="xsd:string" use="required" />
+		<xsd:attribute name="id" type="idLength63" use="required" />
 		<xsd:attribute name="author" type="xsd:string" use="required" />
 		<xsd:attribute name="context" type="xsd:string" />
         <xsd:attribute name="labels" type="xsd:string" />
@@ -265,6 +265,12 @@
         <xsd:attribute name="created" type="xsd:string"/>
 		<xsd:attribute name="runOrder" type="xsd:string"/>
 	</xsd:attributeGroup>
+	
+	<xsd:simpleType name="idLength63">
+		<xsd:restriction base="xsd:string">
+			<xsd:maxLength value="63" />
+		</xsd:restriction>
+	</xsd:simpleType>
 
 	<!-- Attributes for constraints -->
 	<xsd:attributeGroup name="constraintsAttributes">


### PR DESCRIPTION
xsd validation to enforce database column constraints at compilation time (by the IDE) 
```
liquibase.exception.DatabaseException: Data truncation: Data too long for column 'ID' at row 1 [Failed SQL: INSERT INTO trunk.DATABASECHANGELOG 
```