### PR TITLE
deb: don't symlink binary to absolute path

### DIFF
--- a/liquibase-debian/pom.xml
+++ b/liquibase-debian/pom.xml
@@ -150,7 +150,7 @@
                                 <data>
                                     <type>link</type>
                                     <linkName>/usr/bin/liquibase</linkName>
-                                    <linkTarget>/usr/lib/liquibase-${project.version}/liquibase</linkTarget>  
+                                    <linkTarget>../lib/liquibase-${project.version}/liquibase</linkTarget>  
                                     <symlink>true</symlink>
                                 </data>
 			    


### PR DESCRIPTION
The Debian Policy states that symbolic links to paths one or more levels beneath the root shall be relative: https://www.debian.org/doc/debian-policy/ch-files.html#s10.5

Because the Liquibase package creates an absolute symlink from `/usr/bin/liquibase` to `/usr/lib/liquibase-X.Y.Z/liquibase`, it is broken on installations outside of `/` (for instance, using Heroku's [APT buildpack](https://github.com/heroku/heroku-buildpack-apt)).