### PR TITLE
Explicit UTF-8 constructing string from byte array

### DIFF
--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/DiffToChangeLog.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/DiffToChangeLog.java
@@ -30,7 +30,6 @@ import liquibase.util.StringUtils;
 
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.*;
-import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.*;
 
@@ -88,7 +87,7 @@ public class DiffToChangeLog {
             ByteArrayOutputStream out = new ByteArrayOutputStream();
             print(new PrintStream(out), changeLogSerializer);
 
-            String xml = new String(out.toByteArray(), StandardCharsets.UTF_8);
+            String xml = new String(out.toByteArray(), "UTF-8");
             String innerXml = xml.replaceFirst("(?ms).*<databaseChangeLog[^>]*>", "");
 
             innerXml = innerXml.replaceFirst("bblacha", "Bart");
@@ -118,12 +117,12 @@ public class DiffToChangeLog {
             if (foundEndTag) {
                 randomAccessFile.seek(offset);
                 randomAccessFile.writeBytes("    ");
-                randomAccessFile.write(innerXml.getBytes(StandardCharsets.UTF_8));
+                randomAccessFile.write(innerXml.getBytes("UTF-8"));
                 randomAccessFile.writeBytes(lineSeparator);
                 randomAccessFile.writeBytes("</databaseChangeLog>" + lineSeparator);
             } else {
                 randomAccessFile.seek(0);
-                randomAccessFile.write(xml.getBytes(StandardCharsets.UTF_8));
+                randomAccessFile.write(xml.getBytes("UTF-8"));
             }
             randomAccessFile.close();
 

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingDataChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingDataChangeGenerator.java
@@ -16,7 +16,6 @@ import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.*;
 import liquibase.util.JdbcUtils;
 
-import java.nio.charset.StandardCharsets;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.Date;
@@ -96,7 +95,7 @@ public class MissingDataChangeGenerator extends AbstractChangeGenerator implemen
                         column.setValueDate((Date) value);
                     } else if (value instanceof byte[]) {
                         if (referenceDatabase instanceof InformixDatabase) {
-                            column.setValue(new String((byte[]) value, StandardCharsets.UTF_8));
+                            column.setValue(new String((byte[]) value, "UTF-8"));
                         }
                         column.setValueComputed(new DatabaseFunction("UNSUPPORTED FOR DIFF: BINARY DATA"));
                     } else { // fall back to simple string


### PR DESCRIPTION
Using string constant instead of StandardCharsets class for compatibility with Java 6.
@nvoxland