### PR TITLE
CORE-2780 Clear executor before closing connection

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -1190,6 +1190,7 @@ public abstract class AbstractJdbcDatabase implements Database {
 
     @Override
     public void close() throws DatabaseException {
+        ExecutorService.getInstance().clearExecutor(this);
         DatabaseConnection connection = getConnection();
         if (connection != null) {
             if (previousAutoCommit != null) {
@@ -1203,7 +1204,6 @@ public abstract class AbstractJdbcDatabase implements Database {
             }
             connection.close();
         }
-        ExecutorService.getInstance().clearExecutor(this);
     }
 
     @Override


### PR DESCRIPTION
Removing the executor invokes hashCode on the underlying connection,
which, on tomcat 8, fails if the connection has been closed.

```
...
Caused by: java.lang.reflect.UndeclaredThrowableException
        at com.sun.proxy.$Proxy52.hashCode(Unknown Source)
        at liquibase.database.jvm.JdbcConnection.hashCode(JdbcConnection.java:436)
        at liquibase.database.AbstractJdbcDatabase.hashCode(AbstractJdbcDatabase.java:1188)
        at java.util.concurrent.ConcurrentHashMap.replaceNode(ConcurrentHashMap.java:1106)
        at java.util.concurrent.ConcurrentHashMap.remove(ConcurrentHashMap.java:1097)
        at liquibase.executor.ExecutorService.clearExecutor(ExecutorService.java:42)
        at liquibase.database.AbstractJdbcDatabase.close(AbstractJdbcDatabase.java:1206)
        at liquibase.integration.spring.SpringLiquibase.afterPropertiesSet(SpringLiquibase.java:400)
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1633)
        at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1570)
        ... 34 more
Caused by: java.sql.SQLException: PooledConnection has already been closed.
        at org.apache.tomcat.jdbc.pool.DisposableConnectionFacade.invoke(DisposableConnectionFacade.java:69)
```

See https://liquibase.jira.com/browse/CORE-2780.