### PR TITLE
Determine the DB2 data server type correctly

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/DB2Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/DB2Database.java
@@ -11,7 +11,6 @@ import liquibase.structure.DatabaseObject;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.DateParseException;
 import liquibase.structure.core.Catalog;
-import liquibase.structure.core.Index;
 import liquibase.util.JdbcUtils;
 import liquibase.util.StringUtils;
 
@@ -22,9 +21,19 @@ import java.text.SimpleDateFormat;
 
 public class DB2Database extends AbstractJdbcDatabase {
 
-    private Boolean isZOS;
-    private Boolean isAS400;
-
+    private DataServerType dataServerType;
+    
+    public static enum DataServerType {
+        /** DB2 on Linux, Unix and Windows */
+        DB2LUW,
+        
+        /** DB2 on IBM iSeries */
+        DB2I,
+        
+        /** DB2 on IBM zSeries */
+        DB2Z
+    }
+    
     public DB2Database() {
         super.setCurrentDateTimeFunction("CURRENT TIMESTAMP");
         super.sequenceNextValueFunction = "NEXT VALUE FOR %s";
@@ -239,34 +248,35 @@ public class DB2Database extends AbstractJdbcDatabase {
         return true;
     }
 
-    public boolean isZOS() {
-        if (this.isZOS == null) {
-            if (getConnection() != null && getConnection() instanceof JdbcConnection) {
+    /**
+     * Determine the DB2 data server type. This replaces the isZOS() and
+     * isAS400() methods, which was based on DatabaseMetaData
+     * getDatabaseProductName(), which does not work correctly for some DB2
+     * types.
+     * 
+     * @see http://www.ibm.com/support/knowledgecenter/SSEPEK_10.0.0/com.ibm.db2z10.doc.java/src/tpc/imjcc_c0053013.html
+     * @return the data server type
+     */
+    public DataServerType getDataServerType() {
+        if (this.dataServerType == null) {
+            DatabaseConnection databaseConnection = getConnection();
+            if (databaseConnection != null && databaseConnection instanceof JdbcConnection) {
                 try {
-                    this.isZOS = getConnection().getDatabaseProductName().toLowerCase().contains("zos");
+                    String databaseProductVersion = databaseConnection.getDatabaseProductVersion();
+                    if (databaseProductVersion.startsWith("SQL")) {
+                        this.dataServerType = DataServerType.DB2LUW;
+                    } else if (databaseProductVersion.startsWith("QSQ")) {
+                        this.dataServerType = DataServerType.DB2I;
+                    } else if (databaseProductVersion.startsWith("DSN")) {
+                        this.dataServerType = DataServerType.DB2Z;
+                    }
                 } catch (DatabaseException e) {
-                    this.isZOS = false;
+                    this.dataServerType = DataServerType.DB2LUW;
                 }
             } else {
-                this.isZOS = false;
+                this.dataServerType = DataServerType.DB2LUW;
             }
         }
-        return this.isZOS;
+        return this.dataServerType;
     }
-
-    public boolean isAS400() {
-        if (this.isAS400 == null) {
-            if (getConnection() != null && getConnection() instanceof JdbcConnection) {
-                try {
-                    this.isAS400 = getConnection().getDatabaseProductName().startsWith("DB2 UDB for AS/400");
-                } catch (DatabaseException e) {
-                    this.isAS400 = false;
-                }
-            } else {
-                this.isAS400 = false;
-            }
-        }
-        return this.isAS400;
-    }
-
 }

--- a/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -5,6 +5,7 @@ import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.Database;
 import liquibase.database.DatabaseConnection;
 import liquibase.database.core.*;
+import liquibase.database.core.DB2Database.DataServerType;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.logging.LogFactory;
@@ -83,7 +84,7 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
 
                     if (database instanceof DB2Database) {
                         String sql;
-                        if (((DB2Database) database).isAS400()) {
+                        if (((DB2Database) database).getDataServerType() == DataServerType.DB2I) {
                             sql = getDB2ISql(jdbcSchemaName);
                         } else {
                             sql = getDB2Sql(jdbcSchemaName);
@@ -159,7 +160,7 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                         String jdbcSchemaName = ((AbstractJdbcDatabase) database).getJdbcSchemaName(catalogAndSchema);
 
                         String sql;
-                        if (database.getDatabaseProductName().startsWith("DB2 UDB for AS/400")) {
+                        if (((DB2Database) database).getDataServerType() == DataServerType.DB2I) {
                             sql = getDB2ISql(jdbcSchemaName);
                         } else {
                             sql = getDB2Sql(jdbcSchemaName);
@@ -823,7 +824,7 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                         }
                     } else if (database instanceof DB2Database) {
                         // if we are on DB2 AS400 iSeries
-                        if (((DB2Database) database).isAS400()) {
+                        if (((DB2Database) database).getDataServerType() == DataServerType.DB2I) {
                             sql = "select constraint_name as constraint_name, table_name as table_name from QSYS2.TABLE_CONSTRAINTS where table_schema='" + jdbcSchemaName + "' and constraint_type='UNIQUE'";
                             if (tableName != null) {
                                 sql += " and table_name = '" + tableName + "'";

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
@@ -3,6 +3,7 @@ package liquibase.snapshot.jvm;
 import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.Database;
 import liquibase.database.core.*;
+import liquibase.database.core.DB2Database.DataServerType;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
@@ -183,7 +184,7 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
                 } else {
                     //probably older version of java, need to select from the column to find out if it is auto-increment
                     String selectStatement;
-                    if (database.getDatabaseProductName().startsWith("DB2 UDB for AS/400")) {
+                    if (((DB2Database) database).getDataServerType() == DataServerType.DB2I) {
                         selectStatement = "select " + database.escapeColumnName(rawCatalogName, rawSchemaName, rawTableName, rawColumnName) + " from " + rawSchemaName + "." + rawTableName + " where 0=1";
                         LogFactory.getLogger().debug("rawCatalogName : <" + rawCatalogName + ">");
                         LogFactory.getLogger().debug("rawSchemaName : <" + rawSchemaName + ">");

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
@@ -3,6 +3,7 @@ package liquibase.snapshot.jvm;
 import liquibase.CatalogAndSchema;
 import liquibase.database.Database;
 import liquibase.database.core.*;
+import liquibase.database.core.DB2Database.DataServerType;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.executor.ExecutorService;
@@ -130,7 +131,7 @@ public class SequenceSnapshotGenerator extends JdbcSnapshotGenerator {
 
     protected String getSelectSequenceSql(Schema schema, Database database) {
         if (database instanceof DB2Database) {
-            if (database.getDatabaseProductName().startsWith("DB2 UDB for AS/400")) {
+            if (((DB2Database) database).getDataServerType() == DataServerType.DB2I) {
                 return "SELECT SEQNAME AS SEQUENCE_NAME FROM QSYS2.SYSSEQUENCES WHERE SEQSCHEMA = '" + schema.getCatalogName() + "'";
             } else {
                 return "SELECT SEQNAME AS SEQUENCE_NAME FROM SYSCAT.SEQUENCES WHERE SEQTYPE='S' AND SEQSCHEMA = '" + schema.getCatalogName() + "'";

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
@@ -2,6 +2,7 @@ package liquibase.snapshot.jvm;
 
 import liquibase.database.Database;
 import liquibase.database.core.*;
+import liquibase.database.core.DB2Database.DataServerType;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.executor.ExecutorService;
@@ -214,7 +215,7 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
                         "and ucc.table_name not like 'BIN$%' "+
                         "order by ucc.position";
             } else if (database instanceof DB2Database) {
-                if (database.getDatabaseProductName().startsWith("DB2 UDB for AS/400")) {
+                if (((DB2Database) database).getDataServerType() == DataServerType.DB2I) {
                     sql = "select T1.constraint_name as CONSTRAINT_NAME, T2.COLUMN_NAME as COLUMN_NAME from QSYS2.TABLE_CONSTRAINTS T1, QSYS2.SYSCSTCOL T2\n"
                             + "where T1.CONSTRAINT_TYPE='UNIQUE' and T1.CONSTRAINT_NAME=T2.CONSTRAINT_NAME\n"
                             + "and T1.CONSTRAINT_SCHEMA='" + database.correctObjectName(schema.getName(), Schema.class) + "'\n"

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/ReorganizeTableGeneratorDB2.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/ReorganizeTableGeneratorDB2.java
@@ -4,6 +4,7 @@ import liquibase.configuration.GlobalConfiguration;
 import liquibase.configuration.LiquibaseConfiguration;
 import liquibase.database.Database;
 import liquibase.database.core.DB2Database;
+import liquibase.database.core.DB2Database.DataServerType;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.ValidationErrors;
 import liquibase.sql.Sql;
@@ -25,7 +26,7 @@ public class ReorganizeTableGeneratorDB2 extends AbstractSqlGenerator<Reorganize
 
     @Override
     public boolean supports(ReorganizeTableStatement statement, Database database) {
-        return database instanceof DB2Database && !((DB2Database) database).isZOS();
+        return database instanceof DB2Database && ((DB2Database) database).getDataServerType() != DataServerType.DB2Z;
     }
 
     @Override


### PR DESCRIPTION
This patch replaces the DB2Database.isZOS() and DB2Database.isAS400() methods, which were based on DatabaseMetaData.getDatabaseProductName(), which does not work correctly for some DB2 server types.

[IBM Knowledge Center - DatabaseMetaData methods for identifying the type of data server](http://www.ibm.com/support/knowledgecenter/SSEPEK_10.0.0/com.ibm.db2z10.doc.java/src/tpc/imjcc_c0053013.html)