### PR TITLE
Make CSV files created by LiquiBase readable by Liquibase

### DIFF
--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingDataExternalFileChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingDataExternalFileChangeGenerator.java
@@ -21,7 +21,8 @@ import liquibase.util.csv.CSVWriter;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -83,7 +84,8 @@ public class MissingDataExternalFileChangeGenerator extends MissingDataChangeGen
                         + " is not a directory");
             }
 
-            CSVWriter outputFile = new CSVWriter(new BufferedWriter(new FileWriter(fileName)));
+            CSVWriter outputFile = new CSVWriter(
+                    new BufferedWriter(new OutputStreamWriter(new FileOutputStream(fileName), "UTF-8")));
             String[] dataTypes = new String[columnNames.size()];
             String[] line = new String[columnNames.size()];
             for (int i = 0; i < columnNames.size(); i++) {

--- a/liquibase-core/src/main/java/liquibase/util/csv/opencsv/CSVWriter.java
+++ b/liquibase-core/src/main/java/liquibase/util/csv/opencsv/CSVWriter.java
@@ -32,7 +32,7 @@ public class CSVWriter implements Closeable, Flushable {
    /**
     * The character used for escaping quotes.
     */
-   public static final char DEFAULT_ESCAPE_CHARACTER = '"';
+   public static final char DEFAULT_ESCAPE_CHARACTER = '\\';
    /**
     * The default separator to use if none is supplied to the constructor.
     */


### PR DESCRIPTION
At the moment CSV files created by LiquiBase reverse engineering some database cannot been read back by LiquiBase under some circumstances. There are 2 reasons for that:
* CSV files are always read with UTF-8 encoding, but written with the default system encoding.  
  *  See MissingDataExternalFileChangeGenerator.java:  
```java
    CSVWriter outputFile = new CSVWriter(new BufferedWriter(new FileWriter(fileName)));
    ...
    LoadDataChange change = new LoadDataChange();
    change.setFile(fileName);
    change.setEncoding("UTF-8");
```
* CSVWriter and CSVParser using different escape characters  
  *  See CSVWriter.java and CSVParser.java:  
```java
    public static final char DEFAULT_ESCAPE_CHARACTER = '"';
```
```java
    public static final char DEFAULT_ESCAPE_CHARACTER = '\\';
```
