### PR TITLE
Handle TimeStamps with nano second precision correctly

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/H2Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/H2Database.java
@@ -120,15 +120,7 @@ public class H2Database extends AbstractJdbcDatabase {
     @Override
     public Date parseDate(String dateAsString) throws DateParseException {
         try {
-            if (dateAsString.indexOf(' ') > 0) {
-                return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSSSSSSS").parse(dateAsString);
-            } else {
-                if (dateAsString.indexOf(':') > 0) {
-                    return new SimpleDateFormat("HH:mm:ss").parse(dateAsString);
-                } else {
-                    return new SimpleDateFormat("yyyy-MM-dd").parse(dateAsString);
-                }
-            }
+            return new ISODateFormat().parse(dateAsString);
         } catch (ParseException e) {
             throw new DateParseException(dateAsString);
         }
@@ -190,17 +182,7 @@ public class H2Database extends AbstractJdbcDatabase {
 
     @Override
     public String getDateLiteral(String isoDate) {
-        String returnString = isoDate;
-        try {
-            if (isDateTime(isoDate)) {
-                ISODateFormat isoTimestampFormat = new ISODateFormat();
-                DateFormat dbTimestampFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
-                returnString = dbTimestampFormat.format(isoTimestampFormat.parse(isoDate));
-            }
-        } catch (ParseException e) {
-            throw new RuntimeException("Unexpected date format: " + isoDate, e);
-        }
-        return "'" + returnString + "'";
+        return "'" + isoDate.replace('T', ' ') + "'";
     }
 
 

--- a/liquibase-core/src/main/java/liquibase/datatype/core/DateTimeType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/DateTimeType.java
@@ -23,15 +23,15 @@ public class DateTimeType extends LiquibaseDataType {
     public DatabaseDataType toDatabaseDataType(Database database) {
         String originalDefinition = StringUtils.trimToEmpty(getRawDefinition());
         boolean allowFractional = supportsFractionalDigits(database);
-        if (database instanceof DB2Database
-                || database instanceof DerbyDatabase
+        if (database instanceof DerbyDatabase
                 || database instanceof FirebirdDatabase
                 || database instanceof H2Database
                 || database instanceof HsqlDatabase) {
             return new DatabaseDataType("TIMESTAMP");
         }
 
-        if (database instanceof OracleDatabase) {
+        if (database instanceof DB2Database
+                || database instanceof OracleDatabase) {
             return new DatabaseDataType("TIMESTAMP", getParameters());
         }
 

--- a/liquibase-core/src/main/java/liquibase/util/ISODateFormat.java
+++ b/liquibase-core/src/main/java/liquibase/util/ISODateFormat.java
@@ -8,15 +8,11 @@ import java.util.Date;
 public class ISODateFormat {
 
     private SimpleDateFormat dateTimeFormat = new SimpleDateFormat(DATE_TIME_FORMAT_STRING);
-    private SimpleDateFormat dateTimeFormatWithDecimal = new SimpleDateFormat(DATE_TIME_FORMAT_STRING_WITH_DECIMAL);
     private SimpleDateFormat dateTimeFormatWithSpace = new SimpleDateFormat(DATE_TIME_FORMAT_STRING_WITH_SPACE);
-    private SimpleDateFormat dateTimeFormatWithSpaceAndDecimal = new SimpleDateFormat(DATE_TIME_FORMAT_STRING_WITH_SPACE_AND_DECIMAL);
     private SimpleDateFormat timeFormat = new SimpleDateFormat("HH:mm:ss");
     private SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
     private static final String DATE_TIME_FORMAT_STRING = "yyyy-MM-dd'T'HH:mm:ss";
     private static final String DATE_TIME_FORMAT_STRING_WITH_SPACE = "yyyy-MM-dd HH:mm:ss";
-    private static final String DATE_TIME_FORMAT_STRING_WITH_DECIMAL = "yyyy-MM-dd'T'HH:mm:ss.SSS";
-    private static final String DATE_TIME_FORMAT_STRING_WITH_SPACE_AND_DECIMAL = "yyyy-MM-dd HH:mm:ss.SSS";
 
 
     public String format(java.sql.Date date) {
@@ -28,7 +24,20 @@ public class ISODateFormat {
     }
 
     public String format(java.sql.Timestamp date) {
-        return dateTimeFormatWithDecimal.format(date);
+        StringBuilder sb = new StringBuilder(dateTimeFormat.format(date));
+        int nanos = date.getNanos();
+        if (nanos != 0) {
+            String nanosString = String.format("%09d", nanos);
+            int lastNotNullIndex = 8;
+            for (; lastNotNullIndex > 0; lastNotNullIndex--) {
+                if (nanosString.charAt(lastNotNullIndex) != '0') {
+                    break;
+                }
+            }
+            sb.append('.');
+            sb.append(nanosString.substring(0, lastNotNullIndex + 1));
+        }
+        return sb.toString();
     }
 
     public String format(Date date) {
@@ -47,24 +56,35 @@ public class ISODateFormat {
     }
 
     public Date parse(String dateAsString) throws ParseException {
-        SimpleDateFormat dateTimeFormat = this.dateTimeFormat;
-
-        if (dateAsString.contains(".") && dateAsString.contains(" ")) {
-            dateTimeFormat = this.dateTimeFormatWithSpaceAndDecimal;
-        } else if (dateAsString.contains(".")) {
-            dateTimeFormat = this.dateTimeFormatWithDecimal;
-        } else if (dateAsString.contains(" ")) {
-            dateTimeFormat = this.dateTimeFormatWithSpace;
-        }
-
-        if (dateAsString.length() != dateFormat.toPattern().length() && dateAsString.length() != timeFormat.toPattern().length()) { //subtract 2 to not count the 's
-            return new java.sql.Timestamp(dateTimeFormat.parse(dateAsString).getTime());
-        } else {
-            if (dateAsString.indexOf(':') > 0) {
-                return new java.sql.Time(timeFormat.parse(dateAsString).getTime());
+        int length = dateAsString.length();
+        switch (length) {
+        case 8:
+            return new java.sql.Time(timeFormat.parse(dateAsString).getTime());
+        case 10:
+            return new java.sql.Date(dateFormat.parse(dateAsString).getTime());
+        case 19:
+            if (dateAsString.contains(" ")) {
+                return new java.sql.Timestamp(dateTimeFormatWithSpace.parse(dateAsString).getTime());
             } else {
-                return new java.sql.Date(dateFormat.parse(dateAsString).getTime());
+                return new java.sql.Timestamp(dateTimeFormat.parse(dateAsString).getTime());
             }
+        default:
+            if (length < 19 || dateAsString.charAt(19) != '.') {
+                throw new ParseException(String.format("Unknown date format to parse: %s.", dateAsString), 0);
+            }
+            long time = 0;
+            if (dateAsString.contains(" ")) {
+                time = dateTimeFormatWithSpace.parse(dateAsString.substring(0, 19)).getTime();
+            } else {
+                time = dateTimeFormat.parse(dateAsString.substring(0, 19)).getTime();
+            }
+            int nanos = Integer.parseInt(dateAsString.substring(20));
+            for (; length < 29; length++) {
+                nanos *= 10;
+            }
+            java.sql.Timestamp timestamp = new java.sql.Timestamp(time);
+            timestamp.setNanos(nanos);
+            return timestamp;
         }
     }
 }

--- a/liquibase-core/src/test/groovy/liquibase/change/ColumnConfigTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/ColumnConfigTest.groovy
@@ -218,7 +218,7 @@ public class ColumnConfigTest extends Specification {
 
         Date today = new Date();
         new ColumnConfig().setValueDate(today).getValueDate() == today
-        new ColumnConfig().setValueDate("1992-02-11T13:22:44.6").getValueDate().toString() == "1992-02-11 13:22:44.006"
+        new ColumnConfig().setValueDate("1992-02-11T13:22:44.006").getValueDate().toString() == "1992-02-11 13:22:44.006"
         new ColumnConfig().setValueDate("1992-02-12").getValueDate().toString() == "1992-02-12"
 
         new ColumnConfig().setValueDate("date_func").getValueComputed().toString() == "date_func"
@@ -289,7 +289,7 @@ public class ColumnConfigTest extends Specification {
 
         Date today = new Date();
         new ColumnConfig().setDefaultValueDate(today).getDefaultValueDate() == today
-        new ColumnConfig().setDefaultValueDate("1992-02-11T13:22:44.6").getDefaultValueDate().toString() == "1992-02-11 13:22:44.006"
+        new ColumnConfig().setDefaultValueDate("1992-02-11T13:22:44.006").getDefaultValueDate().toString() == "1992-02-11 13:22:44.006"
         new ColumnConfig().setDefaultValueDate("1992-02-12").getDefaultValueDate().toString() == "1992-02-12"
 
         new ColumnConfig().setDefaultValueDate("date_func").getDefaultValueComputed().toString() == "date_func"

--- a/liquibase-core/src/test/groovy/liquibase/parser/core/yaml/YamlChangeLogParser_RealFile_Test.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/parser/core/yaml/YamlChangeLogParser_RealFile_Test.groovy
@@ -541,7 +541,7 @@ public class YamlChangeLogParser_RealFile_Test extends Specification {
         ((AddColumnChange) changeLog.getChangeSet(path, "nvoxland", "different object types for column").changes[1]).columns[3].defaultValueComputed.toString() == "average_size()"
 
         ((AddColumnChange) changeLog.getChangeSet(path, "nvoxland", "different object types for column").changes[1]).columns[4].name == "new_col_datetime"
-        new ISODateFormat().format(new java.sql.Timestamp(((AddColumnChange) changeLog.getChangeSet(path, "nvoxland", "different object types for column").changes[1]).columns[4].defaultValueDate.time)).matches(/2014-12-\d+T\d+:15:33.000/) //timezones shift actual value around
+        new ISODateFormat().format(new java.sql.Timestamp(((AddColumnChange) changeLog.getChangeSet(path, "nvoxland", "different object types for column").changes[1]).columns[4].defaultValueDate.time)).matches(/2014-12-\d+T\d+:15:33/) //timezones shift actual value around
 
         ((AddColumnChange) changeLog.getChangeSet(path, "nvoxland", "different object types for column").changes[1]).columns[5].name == "new_col_seq"
         ((AddColumnChange) changeLog.getChangeSet(path, "nvoxland", "different object types for column").changes[1]).columns[5].defaultValueSequenceNext.toString() == "seq_test"

--- a/liquibase-core/src/test/java/liquibase/util/ISODateFormatTest.java
+++ b/liquibase-core/src/test/java/liquibase/util/ISODateFormatTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 import java.util.Date;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class ISODateFormatTest {
     @Test
@@ -21,4 +21,17 @@ public class ISODateFormatTest {
         assertEquals("2011-04-21T10:13:40.044", dateFormat.format(date));
     }
 
+    @Test
+    public void isoDateFormatWithLeadingNoFractions() throws Exception {
+        ISODateFormat dateFormat = new ISODateFormat();
+        Date date = dateFormat.parse("2011-04-21T10:13:40");
+        assertEquals("2011-04-21T10:13:40", dateFormat.format(date));
+    }
+
+    @Test
+    public void isoDateFormatWithLeadingNanoFractions() throws Exception {
+        ISODateFormat dateFormat = new ISODateFormat();
+        Date date = dateFormat.parse("2011-04-21T10:13:40.01234567");
+        assertEquals("2011-04-21T10:13:40.01234567", dateFormat.format(date));
+    }
 }


### PR DESCRIPTION
This fixes a problem exporting and importing TimeStamps with sub second precision to and from CSV files. There are 2 problems in the code:
* The sub second part of a TimeStamp is a fraction, so 1992-02-11T13:22:44.**6** is
  1992-02-11T13:22:44.**600** and not 1992-02-11T13:22:44.**006**
* The sub second part of a TimeStamp can have up to 9 digits. See the added test in 
  ISODateFormatTest.java