### PR TITLE
Fix a NullPointerException in DiffToChangeLog.sortMissingObjects

### DIFF
--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/DiffToChangeLog.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/DiffToChangeLog.java
@@ -211,7 +211,7 @@ public class DiffToChangeLog {
 
     private List<DatabaseObject> sortMissingObjects(Collection<DatabaseObject> missingObjects, Database database) {
 
-        if (missingObjects.size() > 0 && supportsSortingObjects(database) && database.getConnection() != null && !(database.getConnection() instanceof OfflineConnection)) {
+        if (diffOutputControl.getSchemaComparisons() != null && missingObjects.size() > 0 && supportsSortingObjects(database) && database.getConnection() != null && !(database.getConnection() instanceof OfflineConnection)) {
             List<String> schemas = new ArrayList<String>();
             for (CompareControl.SchemaComparison comparison : this.diffOutputControl.getSchemaComparisons()) {
                 String schemaName = comparison.getReferenceSchema().getSchemaName();


### PR DESCRIPTION
Fix a NullPointerException in DiffToChangeLog.sortMissingObjects when schemaComparisons.

The following code, which can only be reached, if a DB2 database is used, will throw a NullPointerException, when getSchemaComparisons() returns null.
```java
                for (CompareControl.SchemaComparison comparison : this.diffOutputControl.getSchemaComparisons()) {
```

So all the following method will not work, when using a DB2 database:
```java
liquibase.database.AbstractJdbcDatabase.dropDatabaseObjects(CatalogAndSchema)
liquibase.dbtest.AbstractIntegrationTest.generateChangeLog_noChanges()
liquibase.integration.ant.DiffDatabaseToChangeLogTask.getDiffOutputControl()
liquibase.integration.ant.GenerateChangeLogTask.getDiffOutputControl()
org.liquibase.maven.plugins.LiquibaseDatabaseDiff.performLiquibaseTask(Liquibase)
org.liquibase.maven.plugins.LiquibaseGenerateChangeLogMojo.performLiquibaseTask(Liquibase)
liquibase.dbtest.AbstractIntegrationTest.testRerunDiffChangeLog()
```

This easily testable. Try to reverse engineer a DB2 database with the maven plugin.