### PR TITLE
Add reverse engineering support for DB2 z/OS

### DIFF
--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
@@ -133,6 +133,8 @@ public class SequenceSnapshotGenerator extends JdbcSnapshotGenerator {
         if (database instanceof DB2Database) {
             if (((DB2Database) database).getDataServerType() == DataServerType.DB2I) {
                 return "SELECT SEQNAME AS SEQUENCE_NAME FROM QSYS2.SYSSEQUENCES WHERE SEQSCHEMA = '" + schema.getCatalogName() + "'";
+            } else if (((DB2Database) database).getDataServerType() == DataServerType.DB2Z){
+                return "SELECT NAME AS SEQUENCE_NAME FROM SYSIBM.SYSSEQUENCES WHERE SEQTYPE='S' AND SCHEMA = '" + schema.getCatalogName() + "'";
             } else {
                 return "SELECT SEQNAME AS SEQUENCE_NAME FROM SYSCAT.SEQUENCES WHERE SEQTYPE='S' AND SEQSCHEMA = '" + schema.getCatalogName() + "'";
             }

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
@@ -223,7 +223,14 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
                             //+ "T2.TABLE_NAME='"+ database.correctObjectName(example.getTable().getName(), Table.class) + "'\n"
                             //+ "\n"
                             + "order by T2.COLUMN_NAME\n";
-
+                } else if (((DB2Database) database).getDataServerType() == DataServerType.DB2Z){
+                    sql = "select k.colname as column_name from sysibm.syskeycoluse k, sysibm.systabconst t "
+                            + "where k.constname = t.constname "
+                            + "and k.tbcreator = t.tbcreator "
+                            + "and t.type='U' "
+                            + "and k.constname='" + database.correctObjectName(name, UniqueConstraint.class) + "' "
+                            + "and t.tbcreator = '" + database.correctObjectName(schema.getName(), Schema.class) + "' "
+                            + "order by colseq";
                 } else {
                     sql = "select k.colname as column_name from syscat.keycoluse k, syscat.tabconst t "
                             + "where k.constname = t.constname "

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/FindForeignKeyConstraintsGeneratorDB2.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/FindForeignKeyConstraintsGeneratorDB2.java
@@ -1,7 +1,9 @@
 package liquibase.sqlgenerator.core;
 
+import liquibase.CatalogAndSchema;
 import liquibase.database.Database;
 import liquibase.database.core.DB2Database;
+import liquibase.database.core.DB2Database.DataServerType;
 import liquibase.exception.ValidationErrors;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
@@ -31,14 +33,37 @@ public class FindForeignKeyConstraintsGeneratorDB2 extends AbstractSqlGenerator<
     public Sql[] generateSql(FindForeignKeyConstraintsStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
         StringBuilder sb = new StringBuilder();
 
-        sb.append("SELECT ");
-        sb.append("TABNAME as ").append(FindForeignKeyConstraintsStatement.RESULT_COLUMN_BASE_TABLE_NAME).append(", ");
-        sb.append("PK_COLNAMES as ").append(FindForeignKeyConstraintsStatement.RESULT_COLUMN_BASE_TABLE_COLUMN_NAME).append(", ");
-        sb.append("REFTABNAME as ").append(FindForeignKeyConstraintsStatement.RESULT_COLUMN_FOREIGN_TABLE_NAME).append(", ");
-        sb.append("FK_COLNAMES as ").append(FindForeignKeyConstraintsStatement.RESULT_COLUMN_FOREIGN_COLUMN_NAME).append(",");
-        sb.append("CONSTNAME as ").append(FindForeignKeyConstraintsStatement.RESULT_COLUMN_CONSTRAINT_NAME).append(" ");
-        sb.append("FROM SYSCAT.REFERENCES ");
-        sb.append("WHERE TABNAME='").append(statement.getBaseTableName()).append("'");
+        if (((DB2Database)database).getDataServerType() == DataServerType.DB2Z){
+        	CatalogAndSchema baseTableSchema = new CatalogAndSchema(statement.getBaseTableCatalogName(), statement.getBaseTableSchemaName()).customize(database);
+
+        	sb.append("SELECT PK.TBNAME  as ").append(FindForeignKeyConstraintsStatement.RESULT_COLUMN_BASE_TABLE_NAME).append(",");
+			sb.append("       PK.NAME    as ").append(FindForeignKeyConstraintsStatement.RESULT_COLUMN_BASE_TABLE_COLUMN_NAME).append(",");
+			sb.append("       FK.TBNAME  as ").append(FindForeignKeyConstraintsStatement.RESULT_COLUMN_FOREIGN_TABLE_NAME).append(",");
+			sb.append("       FK.COLNAME as ").append(FindForeignKeyConstraintsStatement.RESULT_COLUMN_FOREIGN_COLUMN_NAME).append(",");
+			sb.append("       R.RELNAME  as ").append(FindForeignKeyConstraintsStatement.RESULT_COLUMN_CONSTRAINT_NAME).append(" ");
+			sb.append("  FROM SYSIBM.SYSRELS R,");
+			sb.append("       SYSIBM.SYSFOREIGNKEYS FK,");
+			sb.append("       SYSIBM.SYSCOLUMNS PK");
+			sb.append(" WHERE R.CREATOR = '").append(baseTableSchema.getSchemaName()).append("'");
+			sb.append("   AND R.TBNAME  = '").append(statement.getBaseTableName()).append("'");
+			sb.append("   AND R.RELNAME = FK.RELNAME ");
+			sb.append("   AND R.CREATOR=FK.CREATOR ");
+			sb.append("   AND R.TBNAME=FK.TBNAME ");
+			sb.append("   AND R.REFTBCREATOR=PK.TBCREATOR ");
+			sb.append("   AND R.REFTBNAME=PK.TBNAME ");
+			sb.append("   AND FK.COLSEQ=PK.KEYSEQ ");
+			sb.append(" ORDER BY R.RELNAME, FK.COLSEQ asc ");
+        }
+		else {
+			sb.append("SELECT ");
+			sb.append("TABNAME as ").append(FindForeignKeyConstraintsStatement.RESULT_COLUMN_BASE_TABLE_NAME).append(", ");
+			sb.append("PK_COLNAMES as ").append(FindForeignKeyConstraintsStatement.RESULT_COLUMN_BASE_TABLE_COLUMN_NAME).append(", ");
+			sb.append("REFTABNAME as ").append(FindForeignKeyConstraintsStatement.RESULT_COLUMN_FOREIGN_TABLE_NAME).append(", ");
+			sb.append("FK_COLNAMES as ").append(FindForeignKeyConstraintsStatement.RESULT_COLUMN_FOREIGN_COLUMN_NAME).append(",");
+			sb.append("CONSTNAME as ").append(FindForeignKeyConstraintsStatement.RESULT_COLUMN_CONSTRAINT_NAME).append(" ");
+			sb.append("FROM SYSCAT.REFERENCES ");
+			sb.append("WHERE TABNAME='").append(statement.getBaseTableName()).append("'");
+		}
 
         return new Sql[]{
                 new UnparsedSql(sb.toString())

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/GetViewDefinitionGeneratorDB2.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/GetViewDefinitionGeneratorDB2.java
@@ -3,6 +3,7 @@ package liquibase.sqlgenerator.core;
 import liquibase.CatalogAndSchema;
 import liquibase.database.Database;
 import liquibase.database.core.DB2Database;
+import liquibase.database.core.DB2Database.DataServerType;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
 import liquibase.sqlgenerator.SqlGenerator;
@@ -24,8 +25,14 @@ public class GetViewDefinitionGeneratorDB2 extends GetViewDefinitionGenerator {
     public Sql[] generateSql(GetViewDefinitionStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
         CatalogAndSchema schema = new CatalogAndSchema(statement.getCatalogName(), statement.getSchemaName()).customize(database);
 
-        return new Sql[] {
-                    new UnparsedSql("select view_definition from SYSIBM.VIEWS where TABLE_NAME='" + statement.getViewName() + "' and TABLE_SCHEMA='" + schema.getSchemaName() + "'")
+        if (((DB2Database)database).getDataServerType() == DataServerType.DB2Z){
+            return new Sql[] {
+                new UnparsedSql("select cast(statement as varchar(32704)) as view_definition from SYSIBM.SYSVIEWS where NAME='" + statement.getViewName() + "' and CREATOR='" + schema.getSchemaName() + "'")
             };
+        } else {  
+            return new Sql[] {
+                new UnparsedSql("select view_definition from SYSIBM.VIEWS where TABLE_NAME='" + statement.getViewName() + "' and TABLE_SCHEMA='" + schema.getSchemaName() + "'")
+            };
+        }
     }
 }


### PR DESCRIPTION
In DB2 z/OS the database definition is stored in different tables than in a standard DB2 LUW. With this patch LiquiBase will use the right SQLs to determine the database layout on a DB2 z/OS.