### PR TITLE
Traverse parent changelogs for rollbacks CORE-2844

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
@@ -377,12 +377,16 @@ public class ChangeSet implements Conditional, ChangeLogChild {
             String changeSetAuthor = rollbackNode.getChildValue(null, "changeSetAuthor", String.class);
             String changeSetPath = rollbackNode.getChildValue(null, "changeSetPath", getFilePath());
 
-            ChangeSet changeSet = this.getChangeLog().getChangeSet(changeSetPath, changeSetAuthor, changeSetId);
-            if (changeSet == null) { //check from root
-                changeSet = getChangeLog().getRootChangeLog().getChangeSet(changeSetPath, changeSetAuthor, changeSetId);
-                if (changeSet == null) {
-                    throw new ParsedNodeException("Change set " + new ChangeSet(changeSetId, changeSetAuthor, false, false, changeSetPath, null, null, null).toString(false) + " does not exist");
+            DatabaseChangeLog changeLog = this.getChangeLog();
+            ChangeSet changeSet = changeLog.getChangeSet(changeSetPath, changeSetAuthor, changeSetId);
+            while (changeSet == null && changeLog != null) {
+                changeLog = changeLog.getParentChangeLog();
+                if (changeLog != null) {
+                    changeSet = changeLog.getChangeSet(changeSetPath, changeSetAuthor, changeSetId);
                 }
+            }
+            if (changeSet == null) {
+                throw new ParsedNodeException("Change set " + new ChangeSet(changeSetId, changeSetAuthor, false, false, changeSetPath, null, null, null).toString(false) + " does not exist");
             }
             for (Change change : changeSet.getChanges()) {
                 rollback.getChanges().add(change);


### PR DESCRIPTION
This change fixes an issue where the ChangeSet doesn't correctly locate a changeLogFile for rollbacks if there are multiple levels of changeLog inclusion. Given the set of files below, the current code does not find the changes in changeSet1 for rolling back, because it goes directly to the root ChangeLog. Since v1/migrations.xml hasn't finished loading, the root changeLog doesn't know about any of its changes yet.

This change instead walks the tree of parent changeLogs looking for the reference, using the first one found.

### migrations.xml

```xml
<?xml version="1.0" encoding="UTF-8"?>
<databaseChangeLog
    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
  <include file="v1/migrations.xml" relativeToChangelogFile="true" />
</databaseChangeLog>
```

### v1/migrations.xml

```xml
<?xml version="1.0" encoding="UTF-8"?>
<databaseChangeLog
    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
  <include file="v1/changeSet1.xml" relativeToChangelogFile="true" />
  <include file="v1/changeSet2.xml" relativeToChangelogFile="true" />
</databaseChangeLog>
```

### v1/changeSet1.xml

```xml
<?xml version="1.0" encoding="UTF-8"?>
<databaseChangeLog
    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
 <changeSet id="1" author="dima">
    <createTable tableName="test-table">
      <column name="test" type="number"></column>
    </createTable>
  </changeSet>
</databaseChangeLog>
```

### v1/changeSet2.xml

```xml
<?xml version="1.0" encoding="UTF-8"?>
<databaseChangeLog
    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
   <changeSet id="2" author="dima">
    <dropTable tableName="test"/>
    <rollback changeSetAuthor="dima" changeSetId="1" changeSetPath="v1/changeSet2.xml"/>
  </changeSet>
</databaseChangeLog>
```

