### PR TITLE
CORE-1863 Fix Postgres BLOB type mappings

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/BlobType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/BlobType.java
@@ -76,8 +76,8 @@ public class BlobType extends LiquibaseDataType {
             }
         }
         if (database instanceof PostgresDatabase) {
-            if (originalDefinition.toLowerCase().startsWith("binary")) {
-                return new DatabaseDataType("BINARY", getParameters());
+            if (originalDefinition.toLowerCase().startsWith("blob") || originalDefinition.equals("java.sql.Types.BLOB")) {
+                return new DatabaseDataType("OID");
             }
 
             return new DatabaseDataType("BYTEA");


### PR DESCRIPTION
Postgres does not actually support the BINARY type.
Instead, use OID for streamable javax.sql.Blobs, and
BYTEA for everything else.