### PR TITLE
Add support for Informix using IBM DB2 Universal JDBC (jcc) driver

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/InformixDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/InformixDatabase.java
@@ -21,7 +21,8 @@ import liquibase.structure.DatabaseObject;
 
 public class InformixDatabase extends AbstractJdbcDatabase {
 
-	private static final String PRODUCT_NAME = "Informix Dynamic Server";
+    private static final String PRODUCT_NAME = "Informix Dynamic Server"; // product name returned by Informix driver
+    private static final String PRODUCT_NAME_DB2JCC_PREFIX = "IDS"; // prefix of the product name (e.g. "IDS/UNIX64") returned by IBM DB2 Universal JDBC (jcc) driver.
     private static final String INTERVAL_FIELD_QUALIFIER = "HOUR TO FRACTION(5)";
     private static final String DATETIME_FIELD_QUALIFIER = "YEAR TO FRACTION(5)";
 
@@ -153,7 +154,12 @@ public class InformixDatabase extends AbstractJdbcDatabase {
 	@Override
     public boolean isCorrectDatabaseImplementation(final DatabaseConnection conn)
 			throws DatabaseException {
-		return PRODUCT_NAME.equals(conn.getDatabaseProductName());
+		Boolean correct = false;
+		String name = conn.getDatabaseProductName();
+		if (name != null && (name.equals(PRODUCT_NAME) || name.startsWith(PRODUCT_NAME_DB2JCC_PREFIX))) {
+				correct = true;
+		}
+		return correct;
 	}
 
 	@Override


### PR DESCRIPTION
When using the IBM DB2 Universal JDBC (jcc) driver to connect to an Informix database the "product name" will be something like "IDS/UNIX64" or "IDS/UNIX32". Liquibase fails to recognise these databases as Informix databases. With this fix these "IDS" product names will be recognised as Informix databases.

For further  explanation:
http://forum.liquibase.org/#Topic/49382000001534007
