### PR TITLE
[CORE-2008] Add support for H2 sequences with minValue and maxValue

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/H2Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/H2Database.java
@@ -34,6 +34,10 @@ public class H2Database extends AbstractJdbcDatabase {
     private static String SEP_CONCAT = ", ";
     private String connectionSchemaName = "PUBLIC";
 
+    private static final int MAJOR_VERSION_FOR_MINMAX_IN_SEQUENCES = 1;
+    private static final int MINOR_VERSION_FOR_MINMAX_IN_SEQUENCES = 3;
+    private static final int BUILD_VERSION_FOR_MINMAX_IN_SEQUENCES = 175;
+
     public H2Database() {
         super.unquotedObjectsAreUppercased=true;
         super.setCurrentDateTimeFunction("NOW()");
@@ -298,5 +302,42 @@ public class H2Database extends AbstractJdbcDatabase {
             }
         }
         super.setConnection(conn);
+    }
+
+    public boolean supportsMinMaxForSequences() {
+
+        try {
+            if (getDatabaseMajorVersion() > MAJOR_VERSION_FOR_MINMAX_IN_SEQUENCES) {
+
+                return true;
+            } else if (getDatabaseMajorVersion() == MAJOR_VERSION_FOR_MINMAX_IN_SEQUENCES
+                       && getDatabaseMinorVersion() > MINOR_VERSION_FOR_MINMAX_IN_SEQUENCES) {
+
+                return true;
+            } else if (getDatabaseMajorVersion() == MAJOR_VERSION_FOR_MINMAX_IN_SEQUENCES
+                       && getDatabaseMinorVersion() == MINOR_VERSION_FOR_MINMAX_IN_SEQUENCES
+                       && getBuildVersion() >= BUILD_VERSION_FOR_MINMAX_IN_SEQUENCES) {
+                return true;
+            }
+
+        } catch (DatabaseException e) {
+            LogFactory.getInstance().getLog().warning("Failed to determine database version, reported error: " + e.getMessage());
+        }
+        return false;
+    }
+
+    private int getBuildVersion() throws DatabaseException {
+
+        Pattern patchVersionPattern = Pattern.compile("^(?:\\d+\\.)(?:\\d+\\.)(\\d+).*$");
+        Matcher matcher = patchVersionPattern.matcher(getDatabaseProductVersion());
+
+        if (matcher.matches()) {
+            return Integer.parseInt(matcher.group(1));
+        }
+        else {
+            LogFactory.getInstance().getLog().warning("Failed to determine H2 build number from product version: " + getDatabaseProductVersion());
+            return -1;
+        }
+
     }
 }

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AlterSequenceGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AlterSequenceGenerator.java
@@ -23,8 +23,16 @@ public class AlterSequenceGenerator extends AbstractSqlGenerator<AlterSequenceSt
         ValidationErrors validationErrors = new ValidationErrors();
 
         validationErrors.checkDisallowedField("incrementBy", alterSequenceStatement.getIncrementBy(), database, HsqlDatabase.class, H2Database.class);
-        validationErrors.checkDisallowedField("maxValue", alterSequenceStatement.getMaxValue(), database, HsqlDatabase.class, H2Database.class);
-        validationErrors.checkDisallowedField("minValue", alterSequenceStatement.getMinValue(), database, H2Database.class);
+
+        if (isH2WithMinMaxSupport(database)) {
+
+            validationErrors.checkDisallowedField("maxValue", alterSequenceStatement.getMaxValue(), database, HsqlDatabase.class);
+        } else {
+
+            validationErrors.checkDisallowedField("maxValue", alterSequenceStatement.getMaxValue(), database, H2Database.class, HsqlDatabase.class);
+            validationErrors.checkDisallowedField("minValue", alterSequenceStatement.getMinValue(), database, H2Database.class);
+        }
+
         validationErrors.checkDisallowedField("ordered", alterSequenceStatement.getOrdered(), database, HsqlDatabase.class, DB2Database.class);
 
         validationErrors.checkRequiredField("sequenceName", alterSequenceStatement.getSequenceName());
@@ -43,7 +51,7 @@ public class AlterSequenceGenerator extends AbstractSqlGenerator<AlterSequenceSt
         }
 
         if (statement.getMinValue() != null) {
-            if (database instanceof FirebirdDatabase || database instanceof HsqlDatabase || database instanceof H2Database) {
+            if (database instanceof FirebirdDatabase || database instanceof HsqlDatabase) {
                 buffer.append(" RESTART WITH ").append(statement.getMinValue());
             } else {
                 buffer.append(" MINVALUE ").append(statement.getMinValue());
@@ -83,5 +91,10 @@ public class AlterSequenceGenerator extends AbstractSqlGenerator<AlterSequenceSt
 
     protected Sequence getAffectedSequence(AlterSequenceStatement statement) {
         return new Sequence().setName(statement.getSequenceName()).setSchema(statement.getCatalogName(), statement.getSchemaName());
+    }
+
+    private boolean isH2WithMinMaxSupport(Database database) {
+        return H2Database.class.isAssignableFrom(database.getClass())
+                && ((H2Database) database).supportsMinMaxForSequences();
     }
 }

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateSequenceGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateSequenceGenerator.java
@@ -28,8 +28,15 @@ public class CreateSequenceGenerator extends AbstractSqlGenerator<CreateSequence
         validationErrors.checkDisallowedField("startValue", statement.getStartValue(), database, FirebirdDatabase.class);
         validationErrors.checkDisallowedField("incrementBy", statement.getIncrementBy(), database, FirebirdDatabase.class);
 
-        validationErrors.checkDisallowedField("minValue", statement.getMinValue(), database, FirebirdDatabase.class, H2Database.class, HsqlDatabase.class);
-        validationErrors.checkDisallowedField("maxValue", statement.getMaxValue(), database, FirebirdDatabase.class, H2Database.class, HsqlDatabase.class);
+        if (isH2WithMinMaxSupport(database)) {
+
+            validationErrors.checkDisallowedField("minValue", statement.getMinValue(), database, FirebirdDatabase.class, HsqlDatabase.class);
+            validationErrors.checkDisallowedField("maxValue", statement.getMaxValue(), database, FirebirdDatabase.class, HsqlDatabase.class);
+        } else {
+
+            validationErrors.checkDisallowedField("minValue", statement.getMinValue(), database, FirebirdDatabase.class, H2Database.class, HsqlDatabase.class);
+            validationErrors.checkDisallowedField("maxValue", statement.getMaxValue(), database, FirebirdDatabase.class, H2Database.class, HsqlDatabase.class);
+        }
 
         validationErrors.checkDisallowedField("ordered", statement.getOrdered(), database, DB2Database.class, HsqlDatabase.class, PostgresDatabase.class);
 
@@ -86,5 +93,10 @@ public class CreateSequenceGenerator extends AbstractSqlGenerator<CreateSequence
 
     protected Sequence getAffectedSequence(CreateSequenceStatement statement) {
         return new Sequence().setName(statement.getSequenceName()).setSchema(statement.getCatalogName(), statement.getSchemaName());
+    }
+
+    private boolean isH2WithMinMaxSupport(Database database) {
+        return H2Database.class.isAssignableFrom(database.getClass())
+                && ((H2Database) database).supportsMinMaxForSequences();
     }
 }

--- a/liquibase-core/src/test/java/liquibase/database/core/H2DatabaseTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/core/H2DatabaseTest.java
@@ -2,9 +2,15 @@ package liquibase.database.core;
 
 import liquibase.database.AbstractJdbcDatabaseTest;
 import liquibase.database.Database;
+import liquibase.database.DatabaseConnection;
+import liquibase.exception.DatabaseException;
 import org.junit.Assert;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.junit.Assert.*;
 import org.junit.Test;
+
+import java.sql.Connection;
 
 public class H2DatabaseTest extends AbstractJdbcDatabaseTest {
 
@@ -51,5 +57,100 @@ public class H2DatabaseTest extends AbstractJdbcDatabaseTest {
     public void escapeTableName_withSchema() {
         Database database = getDatabase();
         assertEquals("schemaName.tableName", database.escapeTableName("catalogName", "schemaName", "tableName"));
-    }    
+    }
+
+    @Test
+    public void versionBeforeMinMaxSequenceIntroductionShouldReturnFalse() throws DatabaseException {
+
+        // GIVEN
+        DatabaseConnection mockedConnection = mock(DatabaseConnection.class);
+        when(mockedConnection.getDatabaseMajorVersion()).thenReturn(1);
+        when(mockedConnection.getDatabaseMinorVersion()).thenReturn(3);
+        when(mockedConnection.getDatabaseProductVersion()).thenReturn("1.3.174 (2013-10-19)");
+
+        H2Database cut = (H2Database) getDatabase();
+        cut.setConnection(mockedConnection);
+
+        // WHEN
+        boolean result = cut.supportsMinMaxForSequences();
+
+        // THEN
+        assertFalse("Version 1.3.174 should not report minMaxSequence support", result);
+    }
+
+    @Test
+    public void oldVersionShouldReturnFalse() throws DatabaseException {
+
+        // GIVEN
+        DatabaseConnection mockedConnection = mock(DatabaseConnection.class);
+        when(mockedConnection.getDatabaseMajorVersion()).thenReturn(1);
+        when(mockedConnection.getDatabaseMinorVersion()).thenReturn(2);
+        when(mockedConnection.getDatabaseProductVersion()).thenReturn("1.2.001 (2010-12-31)");
+
+        H2Database cut = (H2Database) getDatabase();
+        cut.setConnection(mockedConnection);
+
+        // WHEN
+        boolean result = cut.supportsMinMaxForSequences();
+
+        // THEN
+        assertFalse("Version 1.2.001 should not report minMaxSequence support", result);
+    }
+
+    @Test
+    public void versionAfterMinMaxSequenceIntroductionShouldReturnTrue() throws DatabaseException {
+
+        // GIVEN
+        DatabaseConnection mockedConnection = mock(DatabaseConnection.class);
+        when(mockedConnection.getDatabaseMajorVersion()).thenReturn(1);
+        when(mockedConnection.getDatabaseMinorVersion()).thenReturn(3);
+        when(mockedConnection.getDatabaseProductVersion()).thenReturn("1.3.175 (2014-01-18)");
+
+        H2Database cut = (H2Database) getDatabase();
+        cut.setConnection(mockedConnection);
+
+        // WHEN
+        boolean result = cut.supportsMinMaxForSequences();
+
+        // THEN
+        assertTrue("Version 1.3.175 should not report minMaxSequence support", result);
+    }
+
+    @Test
+    public void newerMinorVersionShouldReturnTrue() throws DatabaseException {
+
+        // GIVEN
+        DatabaseConnection mockedConnection = mock(DatabaseConnection.class);
+        when(mockedConnection.getDatabaseMajorVersion()).thenReturn(1);
+        when(mockedConnection.getDatabaseMinorVersion()).thenReturn(4);
+        when(mockedConnection.getDatabaseProductVersion()).thenReturn("1.4.100 (2014-08-18)");
+
+        H2Database cut = (H2Database) getDatabase();
+        cut.setConnection(mockedConnection);
+
+        // WHEN
+        boolean result = cut.supportsMinMaxForSequences();
+
+        // THEN
+        assertTrue("Version 1.4.100 should not report minMaxSequence support", result);
+    }
+
+    @Test
+    public void newerMajorVersionShouldReturnTrue() throws DatabaseException {
+
+        // GIVEN
+        DatabaseConnection mockedConnection = mock(DatabaseConnection.class);
+        when(mockedConnection.getDatabaseMajorVersion()).thenReturn(2);
+        when(mockedConnection.getDatabaseMinorVersion()).thenReturn(1);
+        when(mockedConnection.getDatabaseProductVersion()).thenReturn("2.1.100 (2017-08-18)");
+
+        H2Database cut = (H2Database) getDatabase();
+        cut.setConnection(mockedConnection);
+
+        // WHEN
+        boolean result = cut.supportsMinMaxForSequences();
+
+        // THEN
+        assertTrue("Version 2.1..100 should not report minMaxSequence support", result);
+    }
 }

--- a/liquibase-core/src/test/java/liquibase/sqlgenerator/core/AlterSequenceGeneratorTest.java
+++ b/liquibase-core/src/test/java/liquibase/sqlgenerator/core/AlterSequenceGeneratorTest.java
@@ -1,18 +1,24 @@
 package liquibase.sqlgenerator.core;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import java.math.BigInteger;
 
 import liquibase.database.Database;
-import liquibase.database.core.DB2Database;
+import liquibase.database.DatabaseConnection;
+import liquibase.database.core.H2Database;
 import liquibase.database.core.OracleDatabase;
-import liquibase.database.core.PostgresDatabase;
+import liquibase.exception.DatabaseException;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.AbstractSqlGeneratorTest;
+import liquibase.sqlgenerator.MockSqlGeneratorChain;
 import liquibase.statement.core.AlterSequenceStatement;
 import liquibase.test.TestContext;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
 import org.junit.Test;
 
 public class AlterSequenceGeneratorTest extends AbstractSqlGeneratorTest<AlterSequenceStatement> {
@@ -20,16 +26,32 @@ public class AlterSequenceGeneratorTest extends AbstractSqlGeneratorTest<AlterSe
 	protected static final String SEQUENCE_NAME = "SEQUENCE_NAME";
     protected static final String CATALOG_NAME = "CATALOG_NAME";
     protected static final String SCHEMA_NAME = "SCHEMA_NAME";
-	
+    private DatabaseConnection mockedUnsupportedMinMaxSequenceConnection;
+    private DatabaseConnection mockedSupportedMinMaxSequenceConnection;
+
     public AlterSequenceGeneratorTest() throws Exception {
         super(new AlterSequenceGenerator());
     }
 
-	@Test
+    @Before
+    public void setUpMocks() throws DatabaseException {
+
+        mockedUnsupportedMinMaxSequenceConnection = mock(DatabaseConnection.class);
+        when(mockedUnsupportedMinMaxSequenceConnection.getDatabaseMajorVersion()).thenReturn(1);
+        when(mockedUnsupportedMinMaxSequenceConnection.getDatabaseMinorVersion()).thenReturn(3);
+        when(mockedUnsupportedMinMaxSequenceConnection.getDatabaseProductVersion()).thenReturn("1.3.174 (2013-10-19)");
+
+        mockedSupportedMinMaxSequenceConnection = mock(DatabaseConnection.class);
+        when(mockedSupportedMinMaxSequenceConnection.getDatabaseMajorVersion()).thenReturn(1);
+        when(mockedSupportedMinMaxSequenceConnection.getDatabaseMinorVersion()).thenReturn(3);
+        when(mockedSupportedMinMaxSequenceConnection.getDatabaseProductVersion()).thenReturn("1.3.175 (2014-01-18)");
+    }
+
+    @Test
     public void testAlterSequenceDatabase() throws Exception {
     	for (Database database : TestContext.getInstance().getAllDatabases()) {
     		if (database instanceof OracleDatabase) {
-    			AlterSequenceStatement statement = new AlterSequenceStatement(CATALOG_NAME, SCHEMA_NAME, SEQUENCE_NAME);
+    			AlterSequenceStatement statement =  createSampleSqlStatement();
 	    		statement.setCacheSize(BigInteger.valueOf(3000L));
 
 	    		Sql[] generatedSql = this.generatorUnderTest.generateSql(statement, database, null);
@@ -37,6 +59,54 @@ public class AlterSequenceGeneratorTest extends AbstractSqlGeneratorTest<AlterSe
     			assertEquals("ALTER SEQUENCE CATALOG_NAME.SEQUENCE_NAME CACHE 3000", generatedSql[0].toSql());
     		}
     	}
+    }
+
+	@Test
+	public void h2DatabaseSupportsSequenceMaxValue() throws Exception {
+
+		H2Database h2Database = new H2Database();
+        h2Database.setConnection(mockedSupportedMinMaxSequenceConnection);
+
+		AlterSequenceStatement alterSequenceStatement = createSampleSqlStatement();
+		alterSequenceStatement.setMaxValue(new BigInteger("1000"));
+
+		assertFalse(generatorUnderTest.validate(alterSequenceStatement, h2Database, new MockSqlGeneratorChain()).hasErrors());
+	}
+
+    @Test
+    public void h2DatabaseDoesNotSupportsSequenceMaxValue() throws Exception {
+
+        H2Database h2Database = new H2Database();
+        h2Database.setConnection(mockedUnsupportedMinMaxSequenceConnection);
+
+        AlterSequenceStatement alterSequenceStatement = createSampleSqlStatement();
+        alterSequenceStatement.setMaxValue(new BigInteger("1000"));
+
+        assertTrue(generatorUnderTest.validate(alterSequenceStatement, h2Database, new MockSqlGeneratorChain()).hasErrors());
+    }
+
+	@Test
+	public void h2DatabaseSupportsSequenceMinValue() throws Exception {
+
+		H2Database h2Database = new H2Database();
+        h2Database.setConnection(mockedSupportedMinMaxSequenceConnection);
+
+		AlterSequenceStatement alterSequenceStatement = createSampleSqlStatement();
+		alterSequenceStatement.setMinValue(new BigInteger("10"));
+
+		assertFalse(generatorUnderTest.validate(alterSequenceStatement, h2Database, new MockSqlGeneratorChain()).hasErrors());
+	}
+
+    @Test
+    public void h2DatabaseDoesNotSupportsSequenceMinValue() throws Exception {
+
+        H2Database h2Database = new H2Database();
+        h2Database.setConnection(mockedUnsupportedMinMaxSequenceConnection);
+
+        AlterSequenceStatement alterSequenceStatement = createSampleSqlStatement();
+        alterSequenceStatement.setMinValue(new BigInteger("10"));
+
+        assertTrue(generatorUnderTest.validate(alterSequenceStatement, h2Database, new MockSqlGeneratorChain()).hasErrors());
     }
 
 	@Override


### PR DESCRIPTION
- checking for H2 version, accepting minValue and maxValue fro version 1.3.175 beginning
  - added unit tests

Integrated and modified both commits from @fm8
see https://github.com/fm8/liquibase/commit/09225d8b35d881f0779d42bb07ccedfda7c4bb7a and https://github.com/fm8/liquibase/commit/a6450883a527f95cb0cc993e0e13c17b0b58d189
