### PR TITLE
Pretty durations for changesets that take longer than 999 ms

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
@@ -592,7 +592,7 @@ public class ChangeSet implements Conditional, ChangeLogChild {
                 if (runInTransaction) {
                     database.commit();
                 }
-                log.info("ChangeSet " + toString(false) + " ran successfully in " + (new Date().getTime() - startTime + "ms"));
+                log.info("ChangeSet " + toString(false) + " ran successfully in " + DurationPrinter.prettyDuration(startTime));
                 if (execType == null) {
                     execType = ExecType.EXECUTED;
                 }

--- a/liquibase-core/src/main/java/liquibase/changelog/DurationPrinter.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/DurationPrinter.java
@@ -1,0 +1,54 @@
+package liquibase.changelog;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public final class DurationPrinter {
+
+	private static final List<TimeUnit> DISPLAY_TIME_UNITS = Arrays.asList(
+			TimeUnit.DAYS, TimeUnit.HOURS, TimeUnit.MINUTES, 
+			TimeUnit.SECONDS, TimeUnit.MILLISECONDS);
+
+	public static Map<TimeUnit, Long> computeDiff(long start, long end) {
+		long diffInMillis = end - start;
+		Map<TimeUnit, Long> result = new LinkedHashMap<TimeUnit, Long>();
+		long millisRest = diffInMillis;
+		for (TimeUnit unit : DISPLAY_TIME_UNITS) {
+			if (DISPLAY_TIME_UNITS.contains(unit)) {
+				long diff = unit.convert(millisRest, TimeUnit.MILLISECONDS);
+				long diffInMillisForUnit = unit.toMillis(diff);
+				millisRest = millisRest - diffInMillisForUnit;
+				result.put(unit, diff);
+			}
+		}
+		return result;
+	}
+
+	public static String prettyDuration(long start) {
+		return prettyDuration(start, System.currentTimeMillis());
+	}
+
+	public static String prettyDuration(long start, long end) {
+		Map<TimeUnit, Long> lookup = computeDiff(start, end);
+
+		StringBuilder sb = new StringBuilder();
+		for (TimeUnit timeUnit : DISPLAY_TIME_UNITS) {
+			Long duration = lookup.get(timeUnit);
+			if (duration != null && duration > 0) {
+				String label = timeUnit.toString().toLowerCase();
+				if (TimeUnit.MILLISECONDS.equals(timeUnit)) {
+					label = "ms";
+				} else if (duration == 1) {
+					int labelLength = label.length();
+					label = label.substring(0, labelLength - 1);
+				}
+				sb.append(String.format("%d %s", duration, label));
+			}
+		}
+		return sb.toString();
+	}
+
+}


### PR DESCRIPTION
Some of our bulk inserts take longer than 999 ms.  Didn't want to add another dependency (joda-time) so used: http://stackoverflow.com/questions/625433/how-to-convert-milliseconds-to-x-mins-x-seconds-in-java
