### PR TITLE
Use the method setBlob to insert blob data

### DIFF
--- a/liquibase-core/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
+++ b/liquibase-core/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
@@ -198,9 +198,9 @@ public abstract class ExecutablePreparedStatementBase implements ExecutablePrepa
             try {
                 LOBContent<InputStream> lob = toBinaryStream(col.getValueBlobFile());
                 if (lob.length <= Integer.MAX_VALUE) {
-                    stmt.setBinaryStream(i, lob.content, (int) lob.length);
+                    stmt.setBlob(i, lob.content, (int) lob.length);
                 } else {
-                    stmt.setBinaryStream(i, lob.content, lob.length);
+                    stmt.setBlob(i, lob.content, lob.length);
                 }
             } catch (IOException | LiquibaseException e) {
                 throw new DatabaseException(e.getMessage(), e); // wrap


### PR DESCRIPTION
On postgresql if you use setBinaryStream the field must be of type bytea but a blob type is oid (ref pull request #600).  Instead you must use setBlob method to be able to insert or update data with valueBlobFile

