### PR TITLE
fix() This fixes the includeAll directive when the liquibase changelo…

### DIFF
--- a/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
@@ -72,11 +72,12 @@ public class ClassLoaderResourceAccessor extends AbstractResourceAccessor {
             URL fileUrl = fileUrls.nextElement();
 
             if (fileUrl.toExternalForm().startsWith("jar:file:")
-                    || fileUrl.toExternalForm().startsWith("wsjar:file:")
-                    || fileUrl.toExternalForm().startsWith("zip:")) {
+                || fileUrl.toExternalForm().startsWith("wsjar:file:")
+                || fileUrl.toExternalForm().startsWith("zip:")) {
 
                 String[] zipAndFile = fileUrl.getFile().split("!");
                 String zipFilePath = zipAndFile[0];
+                path = zipAndFile[1];
                 if (zipFilePath.matches("file:\\/[A-Za-z]:\\/.*")) {
                     zipFilePath = zipFilePath.replaceFirst("file:\\/", "");
                 } else {
@@ -84,11 +85,15 @@ public class ClassLoaderResourceAccessor extends AbstractResourceAccessor {
                 }
                 zipFilePath = URLDecoder.decode(zipFilePath, LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).getOutputEncoding());
 
+
                 if (path.startsWith("classpath:")) {
                     path = path.replaceFirst("classpath:", "");
                 }
                 if (path.startsWith("classpath*:")) {
                     path = path.replaceFirst("classpath\\*:", "");
+                }
+                if (path.startsWith("/")) {
+                    path = path.replaceFirst("/", "");
                 }
 
                 // TODO:When we update to Java 7+, we can can create a FileSystem from the JAR (zip)
@@ -109,10 +114,10 @@ public class ClassLoaderResourceAccessor extends AbstractResourceAccessor {
 
                             if (!recursive) {
                                 String pathAsDir = path.endsWith("/")
-                                        ? path
-                                        : path + "/";
+                                    ? path
+                                    : path + "/";
                                 if (!entry.getName().startsWith(pathAsDir)
-                                 || entry.getName().substring(pathAsDir.length()).contains("/")) {
+                                    || entry.getName().substring(pathAsDir.length()).contains("/")) {
                                     continue;
                                 }
                             }

--- a/liquibase-core/src/test/groovy/liquibase/resource/ClassLoaderResourceAccessorTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/resource/ClassLoaderResourceAccessorTest.groovy
@@ -3,6 +3,9 @@ package liquibase.resource
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import java.util.jar.JarOutputStream
+import java.util.zip.ZipEntry
+
 class ClassLoaderResourceAccessorTest extends Specification {
 
     def "rootUrls populated"() {
@@ -61,4 +64,43 @@ class ClassLoaderResourceAccessorTest extends Specification {
         listedResources.contains("org/apache/log4j/Logger.class") == true
         listedResources.contains("org/apache/log4j/spi/Filter.class") == false
     }
+
+    def "can list all the files inside JAR file " () {
+        given:
+        File jarFile = new File(System.getProperty("java.io.tmpdir") + File.separator + "myapp.jar")
+        FileOutputStream fout = new FileOutputStream(jarFile);
+        JarOutputStream jarOut = new JarOutputStream(fout);
+        jarOut.putNextEntry(new ZipEntry("updates/"));
+        addFileToJar(jarOut, "updates/first.xml")
+        addFileToJar(jarOut, "updates/second.xml")
+        addFileToJar(jarOut, "updates/third.xml")
+        addFileToJar(jarOut, "updates/fourth.xml")
+        jarOut.close();
+        fout.close();
+
+        def accessor = new ClassLoaderResourceAccessor(new URLClassLoader([
+                new File(System.getProperty("java.io.tmpdir")).toURL()].toArray() as URL[]
+        ))
+
+        when:
+        String path = "jar:file:" + jarFile.getAbsolutePath() + "!/updates/"
+
+        Set<String> files = accessor.list(null, path, true, false, true)
+
+        then:
+        files.size() == 5
+        files.contains("updates/")
+        files.contains("updates/first.xml")
+        files.contains("updates/second.xml")
+        files.contains("updates/third.xml")
+        files.contains("updates/fourth.xml")
+    }
+
+    private void addFileToJar(JarOutputStream jarOut, String filePath) {
+        jarOut.putNextEntry(new ZipEntry(filePath));
+        jarOut.write("<xml>xml</xml>".bytes);
+        jarOut.closeEntry();
+    }
+
+
 }


### PR DESCRIPTION
When using the directive includeAll in changelog.xml, if the classpath is within a JAR file, the class ClassLoaderResourceAccessor will try to find the path passed as input, in the format of jar:file:/file_path!/folder/with/changelogs in the list of paths inside the jar, not finding it eventually. 
It needs to compare only the classpath with the list of paths inside the jar. The input needs to be stripped to folder/with/changelogs and try to find it inside the jar
