### PR TITLE
BUG FIX: PostgreSQL does not support DISABLE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: java
+sudo: required
+jdk:
+  - openjdk6
+
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y rpm
+
+script: mvn clean package

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddUniqueConstraintGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddUniqueConstraintGenerator.java
@@ -1,11 +1,12 @@
 package liquibase.sqlgenerator.core;
 
+import java.lang.reflect.Array;
+
 import liquibase.database.Database;
 import liquibase.database.core.*;
 import liquibase.exception.ValidationErrors;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
-import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.statement.core.AddUniqueConstraintStatement;
 import liquibase.structure.core.Column;
@@ -16,14 +17,18 @@ import liquibase.util.StringUtils;
 
 public class AddUniqueConstraintGenerator extends AbstractSqlGenerator<AddUniqueConstraintStatement> {
 
+    // This change ensures we don't have auto-vivification of generic
+    // arrays (which is generally a bad thing) due to varargs.
+    @SuppressWarnings("unchecked")
+    private static final Class<? extends Database>[] EMPTY_DATABASE_CLAZZ_ARRAY = (Class<? extends Database>[]) Array.newInstance(Class.class, 0);
+
     @Override
     public boolean supports(AddUniqueConstraintStatement statement, Database database) {
         return !(database instanceof SQLiteDatabase)
-        		&& !(database instanceof MSSQLDatabase)
-        		&& !(database instanceof SybaseDatabase)
-        		&& !(database instanceof SybaseASADatabase)
-        		&& !(database instanceof InformixDatabase)
-        ;
+            && !(database instanceof MSSQLDatabase)
+            && !(database instanceof SybaseDatabase)
+            && !(database instanceof SybaseASADatabase)
+            && !(database instanceof InformixDatabase);
     }
 
     @Override
@@ -33,43 +38,49 @@ public class AddUniqueConstraintGenerator extends AbstractSqlGenerator<AddUnique
         validationErrors.checkRequiredField("tableName", addUniqueConstraintStatement.getTableName());
 
         if (!(database instanceof OracleDatabase)) {
-            validationErrors.checkDisallowedField("forIndexName", addUniqueConstraintStatement.getForIndexName(), database);
+            validationErrors.checkDisallowedField("forIndexName", addUniqueConstraintStatement.getForIndexName(), database, EMPTY_DATABASE_CLAZZ_ARRAY);
         }
 
-//        if (!(database instanceof MSSQLDatabase) && addUniqueConstraintStatement.isClustered()) {
-//            validationErrors.checkDisallowedField("clustered", addUniqueConstraintStatement.isClustered(), database);
-//        }
+        // if (!(database instanceof MSSQLDatabase) &&
+        // addUniqueConstraintStatement.isClustered()) {
+        // validationErrors.checkDisallowedField("clustered",
+        // addUniqueConstraintStatement.isClustered(), database);
+        // }
         return validationErrors;
     }
 
     @Override
     public Sql[] generateSql(AddUniqueConstraintStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
 
-		String sql = null;
-		if (statement.getConstraintName() == null) {
-			sql = String.format("ALTER TABLE %s ADD UNIQUE (%s)"
-					, database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName())
-					, database.escapeColumnNameList(statement.getColumnNames())
-			);
-		} else {
-			sql = String.format("ALTER TABLE %s ADD CONSTRAINT %s UNIQUE (%s)"
-					, database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName())
-					, database.escapeConstraintName(statement.getConstraintName())
-					, database.escapeColumnNameList(statement.getColumnNames())
-			);
-		}
-		if(database instanceof OracleDatabase || database instanceof PostgresDatabase) {
+        String sql = null;
+        if (statement.getConstraintName() == null) {
+            sql = String.format("ALTER TABLE %s ADD UNIQUE (%s)"
+                , database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName())
+                , database.escapeColumnNameList(statement.getColumnNames())
+                );
+        } else {
+            sql = String.format("ALTER TABLE %s ADD CONSTRAINT %s UNIQUE (%s)"
+                , database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName())
+                , database.escapeConstraintName(statement.getConstraintName())
+                , database.escapeColumnNameList(statement.getColumnNames())
+                );
+        }
+
+        final boolean isOracle = database instanceof OracleDatabase;
+        final boolean isPostgres = database instanceof PostgresDatabase;
+
+        if (isOracle || isPostgres) {
             if (statement.isDeferrable()) {
                 sql += " DEFERRABLE";
             }
 
             if (statement.isInitiallyDeferred()) {
-                sql +=" INITIALLY DEFERRED";
+                sql += " INITIALLY DEFERRED";
             }
         }
 
         // Currently, only OracleDatabase supports the DISABLE command.
-        if (database instanceof OracleDatabase && statement.isDisabled()) {
+        if (isOracle && statement.isDisabled()) {
             sql += " DISABLE";
         }
 
@@ -79,26 +90,26 @@ public class AddUniqueConstraintGenerator extends AbstractSqlGenerator<AddUnique
             } else if (database instanceof DB2Database
                 || database instanceof SybaseASADatabase
                 || database instanceof InformixDatabase) {
-                ; //not supported
+                ; // not supported
             } else {
                 sql += " USING INDEX TABLESPACE " + statement.getTablespace();
             }
         }
 
         if (statement.getForIndexName() != null) {
-            sql += " USING INDEX "+database.escapeObjectName(statement.getForIndexCatalogName(), statement.getForIndexSchemaName(), statement.getForIndexName(), Index.class);
+            sql += " USING INDEX " + database.escapeObjectName(statement.getForIndexCatalogName(), statement.getForIndexSchemaName(), statement.getForIndexName(), Index.class);
         }
 
         return new Sql[] {
-                new UnparsedSql(sql, getAffectedUniqueConstraint(statement))
+            new UnparsedSql(sql, getAffectedUniqueConstraint(statement))
         };
 
     }
 
     protected UniqueConstraint getAffectedUniqueConstraint(AddUniqueConstraintStatement statement) {
         UniqueConstraint uniqueConstraint = new UniqueConstraint()
-                .setName(statement.getConstraintName())
-                .setTable((Table) new Table().setName(statement.getTableName()).setSchema(statement.getCatalogName(), statement.getSchemaName()));
+            .setName(statement.getConstraintName())
+            .setTable((Table) new Table().setName(statement.getTableName()).setSchema(statement.getCatalogName(), statement.getSchemaName()));
         int i = 0;
         for (Column column : Column.listFromNames(statement.getColumnNames())) {
             uniqueConstraint.addColumn(i++, column);

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddUniqueConstraintGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddUniqueConstraintGenerator.java
@@ -66,9 +66,11 @@ public class AddUniqueConstraintGenerator extends AbstractSqlGenerator<AddUnique
             if (statement.isInitiallyDeferred()) {
                 sql +=" INITIALLY DEFERRED";
             }
-            if (statement.isDisabled()) {
-                sql +=" DISABLE";
-            }
+        }
+
+        // Currently, only OracleDatabase supports the DISABLE command.
+        if (database instanceof OracleDatabase && statement.isDisabled()) {
+            sql += " DISABLE";
         }
 
         if (StringUtils.trimToNull(statement.getTablespace()) != null && database.supportsTablespaces()) {


### PR DESCRIPTION
I attempted to create Jira account, but Atlassian stated that Jira is out of licenses (which is odd, because I have an Atlassian Cloud account already). Anyway, there is a bug in liquibase 3.5.x that causes certain automated table migrations to fail.

Basically, commit ddd903a added support for PostgreSQL DEFER. It did this by piggybacking existing Oracle code (as Oracle supports this as well). However, the way this change was made introduced "DISABLE" to PostgreSQL as well (which is not supported).

I have corrected this mistake by splitting disable into its own 'if' test.

This should also be merged into master as master has the same bug.

Here is a relevant Exception text:

Reason: liquibase.exception.DatabaseException: ERROR: syntax error at or near "DISABLE"
  Position: 94 [Failed SQL: ALTER TABLE public.some_table ADD CONSTRAINT some_table_id UNIQUE (id) DEFERRABLE INITIALLY DEFERRED DISABLE]
