### PR TITLE
fix the escaping of object name on the MS SQL

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
@@ -272,7 +272,7 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
             return objectName;
         }
 
-        return quoteObject(objectName, objectType);
+        return super.escapeObjectName(objectName, objectType);
     }
 
     @Override


### PR DESCRIPTION
There is a bug that AbstractJdbcDatabase.quotingStrategy is ignored when 
```java
class MSSQLDatabase  {
public String escapeObjectName(String objectName, Class<? extends DatabaseObject> objectType)
```
calls directly 
```
quoteObject(objectName, objectType)
```
I think it should call 
```java
super.escapeObjectName(objectName, objectType)
```
then quotingStrategy can be used to influence quoting of objects in MS SQL scripts. It works for me on branch 3.5.x. I did not tested on master, but it seems to be same there too