### PR TITLE
avoid null pointer exception on snapshot action

### DIFF
--- a/liquibase-core/src/main/java/liquibase/serializer/core/string/StringSnapshotSerializerReadable.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/string/StringSnapshotSerializerReadable.java
@@ -137,7 +137,7 @@ public class StringSnapshotSerializerReadable implements SnapshotSerializer {
             }
 
             if (value instanceof DatabaseObject) {
-                if (parentObject != null && ((DatabaseObject) value).getSnapshotId().equals(parentObject.getSnapshotId())) {
+                if (parentObject != null && ((DatabaseObject) value).getSnapshotId() != null && ((DatabaseObject) value).getSnapshotId().equals(parentObject.getSnapshotId())) {
                     continue;
                 }
 


### PR DESCRIPTION
This bugfix resolve a problem encountered when I performed a liquibase snapshot.