### PR TITLE
Made ChangeWithColumns extend Change so that an extension would have …

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/ChangeWithColumns.java
+++ b/liquibase-core/src/main/java/liquibase/change/ChangeWithColumns.java
@@ -5,7 +5,7 @@ import java.util.List;
 /**
  * Markers a Change class as containing one or more {@link ColumnConfig} configuration.
  */
-public interface ChangeWithColumns<T extends ColumnConfig> {
+public interface ChangeWithColumns<T extends ColumnConfig> extends Change {
 
     /**
      * Add a column configuration to the Change.


### PR DESCRIPTION
…access to both sets of methods. 

An example of a usage is to create a set of helper methods that are used by both an extension of CreateTableChange and AddColumnChange.

┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-105) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 4.0 beta 2
