### PR TITLE
Don't hardcode version dependencies using 'Class-Path:' in MANIFEST.MF - 3.5.x

### DIFF
--- a/liquibase-core/src/main/resources/META-INF/MANIFEST.MF
+++ b/liquibase-core/src/main/resources/META-INF/MANIFEST.MF
@@ -1,6 +1,5 @@
 Manifest-Version: 1.0
 Main-Class: liquibase.integration.commandline.Main
-Class-Path: lib/snakeyaml-1.13.jar
 Liquibase-Package: liquibase.change,
  liquibase.changelog,
  liquibase.database,


### PR DESCRIPTION
Fixes an issue where validating classloaders will fail to load the
liquibase libs because the snakeyaml version specified in the
liquibase-core.jar's META-INF/MANIFEST.MF file doesn't match
the version specified in the pom files.

snakeyaml-1.13.jar vs. snakeyaml-1.17.jar

Rather than simply updating the META-INF/MANIFEST.MF file to match
the pom files, this patch removes the 'Class-Path:' entry from the
file altogether. The rational for this is that the 'Class-Path:'
mechanism is an anachronism which is fundamentally at odds with the
dynamic dependency management features of Maven. The liquibase-core
artifact can and should rely on Maven to get the dependencies right.