### PR TITLE
Postgres does not support parameters for type int

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/IntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/IntType.java
@@ -33,6 +33,8 @@ public class IntType extends LiquibaseDataType {
         if (database instanceof PostgresDatabase) {
             if (autoIncrement) {
                 return new DatabaseDataType("SERIAL");
+            } else {
+                return new DatabaseDataType("INTEGER");
             }
         }
         if (database instanceof MSSQLDatabase) {


### PR DESCRIPTION
See https://www.postgresql.org/docs/current/static/datatype-numeric.html