### PR TITLE
StringUtils.isDelimiter() fix

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,10 @@
 Liquibase Core Changelog
 ===========================================
 
+Changes in version 3.5.3 (2016.10.13)
+
+- No changes
+
 Changes in version 3.5.2 (2016.09.21)
 
 -  [CORE-1863] - PostgreSQL blob is mapped to bytea instead of oid

--- a/liquibase-cdi/pom.xml
+++ b/liquibase-cdi/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-parent</artifactId>
-        <version>3.5.3-SNAPSHOT</version>
+        <version>3.5.3</version>
     </parent>
     <artifactId>liquibase-cdi</artifactId>
     <name>Liquibase CDI</name>

--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-parent</artifactId>
-        <version>3.5.3-SNAPSHOT</version>
+        <version>3.5.3</version>
     </parent>
 
     <properties>

--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <bundle.namespace>liquibase.*</bundle.namespace>
-        <project.version>3.5.2</project.version>
+        <project.version>3.5.3</project.version>
     </properties>
 
     <dependencies>

--- a/liquibase-core/src/main/java/liquibase/util/StringUtils.java
+++ b/liquibase-core/src/main/java/liquibase/util/StringUtils.java
@@ -80,7 +80,7 @@ public class StringUtils {
             if (endDelimiter.length() == 1) {
                 return piece.toLowerCase().equalsIgnoreCase(endDelimiter.toLowerCase());
             } else {
-                return piece.toLowerCase().matches(endDelimiter.toLowerCase()) || (previousPiece+piece).toLowerCase().matches("[.\n\r]*"+endDelimiter.toLowerCase());
+                return piece.toLowerCase().matches(endDelimiter.toLowerCase()) || (previousPiece+piece).toLowerCase().matches("[\\s\n\r]*"+endDelimiter.toLowerCase());
             }
         }
     }

--- a/liquibase-core/src/test/groovy/liquibase/util/StringUtilsTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/util/StringUtilsTest.groovy
@@ -29,6 +29,8 @@ class StringUtilsTest extends Specification {
         true          | true            | "\\ngo"          | "CREATE OR REPLACE PACKAGE emp_actions AS  -- spec\nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;\nGO\nanother statement;here\nGO\n" | ["CREATE OR REPLACE PACKAGE emp_actions AS  \nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;", "another statement;here"]
         true          | true            | null         | "statement 1;\nstatement 2;\nGO\n\nstatement 3; statement 4;"                                                                                                                                      | ["statement 1","statement 2", "statement 3", "statement 4"]
         true          | true            | "\\nGO"          | "CREATE OR REPLACE PACKAGE emp_actions AS  -- spec\nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;\nGO\nanother statement;here\nGO\n" | ["CREATE OR REPLACE PACKAGE emp_actions AS  \nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;", "another statement;here"]
+        true          | true            | "\\nGO"      | "statement 1 \nGO\nstatement 2" | ["statement 1", "statement 2"] 
+        
     }
 
     @Unroll

--- a/liquibase-debian/pom.xml
+++ b/liquibase-debian/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-parent</artifactId>
-        <version>3.5.3-SNAPSHOT</version>
+        <version>3.5.3</version>
     </parent>
 
     <artifactId>liquibase-debian</artifactId>

--- a/liquibase-integration-tests/pom.xml
+++ b/liquibase-integration-tests/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>liquibase-parent</artifactId>
         <groupId>org.liquibase</groupId>
-        <version>3.5.3-SNAPSHOT</version>
+        <version>3.5.3</version>
     </parent>
 
     <dependencies>

--- a/liquibase-maven-plugin/pom.xml
+++ b/liquibase-maven-plugin/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>liquibase-parent</artifactId>
         <groupId>org.liquibase</groupId>
-        <version>3.5.3-SNAPSHOT</version>
+        <version>3.5.3</version>
     </parent>
 
     <dependencies>

--- a/liquibase-rpm/pom.xml
+++ b/liquibase-rpm/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.liquibase</groupId>
     <artifactId>liquibase-rpm</artifactId>
-    <version>3.5.3-SNAPSHOT</version>
+    <version>3.5.3</version>
     <packaging>jar</packaging>
     <url>http://www.liquibase.org/</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.liquibase</groupId>
     <artifactId>liquibase-parent</artifactId>
-    <version>3.5.3-SNAPSHOT</version>
+    <version>3.5.3</version>
     <packaging>pom</packaging>
 
     <name>Liquibase Parent Configuration</name>
@@ -31,7 +31,7 @@
         <connection>scm:git:git@github.com:liquibase/liquibase.git</connection>
         <url>scm:git:git@github.com:liquibase/liquibase.git</url>
         <developerConnection>scm:git:git@github.com:liquibase/liquibase.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>liquibase-parent-3.5.3</tag>
     </scm>
 
     <developers>


### PR DESCRIPTION
Delimiter was not detected if there was an white space just before that.
In example following string "statement 1 \nGO\nstatement 2" failed when searching for \nGO delimiter within.

I've made a fix in isDelimiter() method to handle this case and also update unit test to cover it.