### PR TITLE
StringUtils.isDelimiter() bug fix

### DIFF
--- a/liquibase-core/src/main/java/liquibase/util/StringUtils.java
+++ b/liquibase-core/src/main/java/liquibase/util/StringUtils.java
@@ -80,7 +80,7 @@ public class StringUtils {
             if (endDelimiter.length() == 1) {
                 return piece.toLowerCase().equalsIgnoreCase(endDelimiter.toLowerCase());
             } else {
-                return piece.toLowerCase().matches(endDelimiter.toLowerCase()) || (previousPiece+piece).toLowerCase().matches("[.\n\r]*"+endDelimiter.toLowerCase());
+                return piece.toLowerCase().matches(endDelimiter.toLowerCase()) || (previousPiece+piece).toLowerCase().matches("[\\s\n\r]*"+endDelimiter.toLowerCase());
             }
         }
     }

--- a/liquibase-core/src/test/groovy/liquibase/util/StringUtilsTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/util/StringUtilsTest.groovy
@@ -29,6 +29,8 @@ class StringUtilsTest extends Specification {
         true          | true            | "\\ngo"          | "CREATE OR REPLACE PACKAGE emp_actions AS  -- spec\nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;\nGO\nanother statement;here\nGO\n" | ["CREATE OR REPLACE PACKAGE emp_actions AS  \nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;", "another statement;here"]
         true          | true            | null         | "statement 1;\nstatement 2;\nGO\n\nstatement 3; statement 4;"                                                                                                                                      | ["statement 1","statement 2", "statement 3", "statement 4"]
         true          | true            | "\\nGO"          | "CREATE OR REPLACE PACKAGE emp_actions AS  -- spec\nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;\nGO\nanother statement;here\nGO\n" | ["CREATE OR REPLACE PACKAGE emp_actions AS  \nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;", "another statement;here"]
+        true          | true            | "\\nGO"      | "statement 1 \nGO\nstatement 2" | ["statement 1", "statement 2"] 
+        
     }
 
     @Unroll


### PR DESCRIPTION
Delimiter was not detected if there was a white space just before that.
In example following string "statement 1 \nGO\nstatement 2" failed when searching for \nGO delimiter within.

I've made a fix in isDelimiter() method to handle this case and also update unit test to cover it.