### PR TITLE
Trigger an exception on a RAISERROR

### DIFF
--- a/liquibase-core/src/main/java/liquibase/executor/jvm/JdbcExecutor.java
+++ b/liquibase-core/src/main/java/liquibase/executor/jvm/JdbcExecutor.java
@@ -305,6 +305,9 @@ public class JdbcExecutor extends AbstractExecutor {
                 }
                 try {
                     stmt.execute(statement);
+
+                    // Loop through to force an exception if there is a RAISERROR.
+                    while(!((!stmt.getMoreResults()) && (stmt.getUpdateCount() == -1))) {}
                 } catch (Throwable e) {
                     throw new DatabaseException(e.getMessage()+ " [Failed SQL: "+statement+"]", e);
                 }


### PR DESCRIPTION
Iterate through result sets and update counts returned from statement execute to trigger exception to be thrown if there is a RAISERROR.