### PR TITLE
Different object quoting strategies are used for validation and execution of a ChangeSet.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -252,6 +252,8 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
 
     public void validate(Database database, Contexts contexts, LabelExpression labelExpression) throws LiquibaseException {
 
+    	database.setObjectQuotingStrategy(objectQuotingStrategy);
+    	
         ChangeLogIterator logIterator = new ChangeLogIterator(this, new DbmsChangeSetFilter(database), new ContextChangeSetFilter(contexts), new LabelChangeSetFilter(labelExpression));
 
         ValidatingVisitor validatingVisitor = new ValidatingVisitor(database.getRanChangeSetList());


### PR DESCRIPTION
By now, if the object quoting strategy is changed in ```<databaseChangeLog />``` tag, this strategy will be used for the execution of a ```<changeSet />``` but not for its validation. This pull request changes the object quoting strategy, so the same strategy is used for both.