### PR TITLE
CORE-2162 MSSQL: Multiple inserts in sqlFile do not fail as expected.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/executor/jvm/JdbcExecutor.java
+++ b/liquibase-core/src/main/java/liquibase/executor/jvm/JdbcExecutor.java
@@ -304,7 +304,25 @@ public class JdbcExecutor extends AbstractExecutor {
                     stmt.setEscapeProcessing(false);
                 }
                 try {
-                    stmt.execute(statement);
+                    //if execute returns false, we can retrieve the affected rows count
+                    // (true used when resultset is returned)
+                    if (!stmt.execute(statement)) {
+                        log.debug(Integer.toString(stmt.getUpdateCount()) + " row(s) affected");
+                    }
+                } catch (Throwable e) {
+                    throw new DatabaseException(e.getMessage()+ " [Failed SQL: "+statement+"]", e);
+                }
+                try {
+                    int updateCount = 0;
+                    //cycle for retrieving row counts from all statements
+                    do {
+                        if (!stmt.getMoreResults()) {
+                            updateCount = stmt.getUpdateCount();
+                            if (updateCount != -1)
+                                log.debug(Integer.toString(updateCount) + " row(s) affected");
+                        }
+                    } while (updateCount != -1);
+
                 } catch (Throwable e) {
                     throw new DatabaseException(e.getMessage()+ " [Failed SQL: "+statement+"]", e);
                 }


### PR DESCRIPTION
Guys I know how to solve this problem
JDBC driver has a very interesting feature: when you execute command containing multiple statements, driver returns only the result of the first statement (resultset for SELECT statement and true/false for other types of statements). If you want to know the results of other statements you should use getMoreResults/getUpdateCount methods of Statement, Resultset or Connection class. And if the error occurs, these methods throws an exception. And you should use these methods in a cycle until it stops to return new results.
I've tested such a way of getting errors against SQL Server JDBC driver and it works out just fine