### PR TITLE
CORE-2965 allow any additional attributes for the change elements in …

### DIFF
--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.6.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.6.xsd
@@ -266,6 +266,11 @@
 		<xsd:attribute name="runOrder" type="xsd:string"/>
 	</xsd:attributeGroup>
 
+    <!-- Attributes for changes -->
+    <xsd:attributeGroup name="changeAttributes">
+        <xsd:anyAttribute namespace="##any" processContents="lax"/>
+    </xsd:attributeGroup>
+
 	<!-- Attributes for constraints -->
 	<xsd:attributeGroup name="constraintsAttributes">
 		<xsd:attribute name="nullable" type="booleanExp" />
@@ -433,6 +438,7 @@
 			<xsd:choice maxOccurs="unbounded">
 				<xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded" />
 			</xsd:choice>
+            <xsd:attributeGroup ref="changeAttributes" />
             <xsd:attributeGroup ref="tableNameAttribute" />
 			<xsd:attribute name="columnNames" type="xsd:string"
 				use="required" />
@@ -447,6 +453,7 @@
 
 	<xsd:element name="dropPrimaryKey">
 		<xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
             <xsd:attributeGroup ref="tableNameAttribute" />
 			<xsd:attribute name="constraintName" type="xsd:string" />
 		</xsd:complexType>
@@ -454,6 +461,7 @@
 
 	<xsd:element name="addUniqueConstraint">
 		<xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
             <xsd:attributeGroup ref="tableNameAttribute" />
 			<xsd:attribute name="columnNames" type="xsd:string"
 				use="required" />
@@ -471,6 +479,7 @@
 
 	<xsd:element name="dropUniqueConstraint">
 		<xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
             <xsd:attributeGroup ref="tableNameAttribute" />
 			<xsd:attribute name="constraintName" type="xsd:string" />
 			<xsd:attribute name="uniqueColumns" type="xsd:string" />
@@ -479,6 +488,7 @@
 
 	<xsd:element name="modifyDataType">
 		<xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
             <xsd:attributeGroup ref="tableNameAttribute" />
 			<xsd:attribute name="columnName" type="xsd:string" use="required" />
 			<xsd:attribute name="newDataType" type="xsd:string" use="required" />
@@ -487,6 +497,7 @@
 
 	<xsd:element name="addLookupTable">
 		<xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
             <xsd:attribute name="existingTableCatalogName" type="xsd:string" />
 			<xsd:attribute name="existingTableSchemaName" type="xsd:string" />
 			<xsd:attribute name="existingTableName" type="xsd:string"
@@ -506,6 +517,7 @@
 
 	<xsd:element name="addAutoIncrement">
 		<xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
             <xsd:attributeGroup ref="tableNameAttribute" />
 			<xsd:attribute name="columnName" type="xsd:string" use="required" />
 			<xsd:attribute name="columnDataType" type="xsd:string" />
@@ -516,6 +528,7 @@
 
 	<xsd:element name="addDefaultValue">
 		<xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
             <xsd:attributeGroup ref="tableNameAttribute" />
 			<xsd:attribute name="columnName" type="xsd:string" use="required" />
 			<xsd:attribute name="columnDataType" type="xsd:string" />
@@ -530,6 +543,7 @@
 
 	<xsd:element name="dropDefaultValue">
 		<xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
             <xsd:attributeGroup ref="tableNameAttribute" />
 			<xsd:attribute name="columnName" type="xsd:string" use="required" />
 			<xsd:attribute name="columnDataType" type="xsd:string" />
@@ -553,6 +567,7 @@
 					</xsd:complexType>
 				</xsd:element>
 			</xsd:sequence>
+            <xsd:attributeGroup ref="changeAttributes" />
             <xsd:attributeGroup ref="tableNameAttribute" />
 			<xsd:attribute name="file" type="xsd:string" />
 			<xsd:attribute name="relativeToChangelogFile" type="booleanExp" />
@@ -635,12 +650,14 @@
 
 	<xsd:element name="addNotNullConstraint">
 		<xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
 			<xsd:attributeGroup ref="addNotNullConstraintAttrib" />
 		</xsd:complexType>
 	</xsd:element>
 
 	<xsd:element name="addForeignKeyConstraint">
 		<xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
 			<xsd:attributeGroup ref="addForeignKeyConstraintAttrib" />
 		</xsd:complexType>
 	</xsd:element>
@@ -827,6 +844,7 @@
 
 	<xsd:element name="dropForeignKeyConstraint">
 		<xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
 			<xsd:attributeGroup ref="dropForeignKeyConstraintAttrib" />
 		</xsd:complexType>
 	</xsd:element>
@@ -840,12 +858,14 @@
 
 	<xsd:element name="dropAllForeignKeyConstraints">
 		<xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
 			<xsd:attributeGroup ref="dropAllForeignKeyConstraintsAttrib" />
 		</xsd:complexType>
 	</xsd:element>
 
 	<xsd:element name="dropNotNullConstraint">
 		<xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
             <xsd:attribute name="catalogName" type="xsd:string" />
 			<xsd:attribute name="schemaName" type="xsd:string" />
 			<xsd:attribute name="tableName" type="xsd:string" use="required" />
@@ -903,10 +923,10 @@
 				<xsd:element ref="column" minOccurs="1" maxOccurs="unbounded" />
                 <xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded" />
 			</xsd:choice>
+            <xsd:attributeGroup ref="changeAttributes" />
 			<xsd:attributeGroup ref="tableNameAttribute" />
             <xsd:attribute name="tablespace" type="xsd:string" />            
 			<xsd:attribute name="remarks" type="xsd:string" />
-            <xsd:anyAttribute namespace="##other" processContents="lax"/>
 		</xsd:complexType>
 	</xsd:element>
 
@@ -915,6 +935,7 @@
 		<xsd:complexType>
 			<xsd:simpleContent>
 				<xsd:extension base="xsd:string">
+                    <xsd:attributeGroup ref="changeAttributes" />
                     <xsd:attribute name="catalogName" type="xsd:string" />
 					<xsd:attribute name="schemaName" type="xsd:string" />
 					<xsd:attribute name="viewName" type="xsd:string" use="required" />
@@ -931,6 +952,7 @@
 			<xsd:sequence>
 				<xsd:element ref="column" maxOccurs="unbounded" />
 			</xsd:sequence>
+            <xsd:attributeGroup ref="changeAttributes" />
 			<xsd:attributeGroup ref="tableNameAttribute" />
             <xsd:attribute name="dbms" type="xsd:string" />
 		</xsd:complexType>
@@ -943,6 +965,7 @@
                 <xsd:element name="where" minOccurs="0" maxOccurs="1"/>
                 <xsd:element ref="whereParams" minOccurs="0" maxOccurs="1" />
 			</xsd:sequence>
+            <xsd:attributeGroup ref="changeAttributes" />
 			<xsd:attributeGroup ref="tableNameAttribute" />
 		</xsd:complexType>
 	</xsd:element>
@@ -981,6 +1004,7 @@
 					</xsd:complexType>
 				</xsd:element>
 			</xsd:sequence>
+            <xsd:attributeGroup ref="changeAttributes" />
 			<xsd:attributeGroup ref="tableNameAttribute" />
 		</xsd:complexType>
 	</xsd:element>
@@ -1006,6 +1030,7 @@
 			<xsd:sequence>
 				<xsd:element ref="comment" minOccurs="0" maxOccurs="1" />
 			</xsd:sequence>
+            <xsd:attributeGroup ref="changeAttributes" />
 			<xsd:attribute name="stripComments" type="booleanExp" />
 			<xsd:attribute name="splitStatements" type="booleanExp" />
 			<xsd:attribute name="endDelimiter" type="xsd:string" />
@@ -1018,6 +1043,7 @@
 			<xsd:sequence>
 				<xsd:element ref="comment" minOccurs="0" maxOccurs="1" />
 			</xsd:sequence>
+            <xsd:attributeGroup ref="changeAttributes" />
 			<xsd:attribute name="catalogName" type="xsd:string" />
             <xsd:attribute name="schemaName" type="xsd:string" />
             <xsd:attribute name="procedureName" type="xsd:string" />
@@ -1038,6 +1064,7 @@
 					</xsd:complexType>
 				</xsd:element>
 			</xsd:sequence>
+            <xsd:attributeGroup ref="changeAttributes" />
 			<xsd:attribute name="executable" type="xsd:string" use="required" />
 			<xsd:attribute name="os" type="xsd:string" />
 		</xsd:complexType>
@@ -1045,6 +1072,7 @@
 
 	<xsd:element name="sqlFile">
 		<xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
 			<xsd:attribute name="path" type="xsd:string" use="required" />
 			<xsd:attribute name="stripComments" type="booleanExp" />
 			<xsd:attribute name="splitStatements" type="booleanExp" />
@@ -1057,16 +1085,22 @@
 
 	<xsd:element name="tagDatabase">
 		<xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
 			<xsd:attribute name="tag" type="xsd:string" use="required" />
-			<xsd:anyAttribute namespace="##other"  processContents="lax"/>
 		</xsd:complexType>
 	</xsd:element>
 
 	<xsd:element name="stop">
-		<xsd:complexType mixed="true" />
+		<xsd:complexType mixed="true">
+            <xsd:attributeGroup ref="changeAttributes" />
+		</xsd:complexType>
 	</xsd:element>
 
-    <xsd:element name="empty"/>
+    <xsd:element name="empty">
+        <xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
+        </xsd:complexType>
+    </xsd:element>
 
     <xsd:element name="output">
         <xsd:complexType mixed="true" >
@@ -1078,12 +1112,14 @@
     <!-- renameTable -->
 	<xsd:element name="renameTable">
 		<xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
 			<xsd:attributeGroup ref="renameTableAttributes" />
 		</xsd:complexType>
 	</xsd:element>
 
 	<xsd:element name="renameView">
 		<xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
 			<xsd:attributeGroup ref="renameViewAttributes" />
 		</xsd:complexType>
 	</xsd:element>
@@ -1091,12 +1127,14 @@
 	<!-- dropTable -->
 	<xsd:element name="dropTable">
 		<xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
 			<xsd:attributeGroup ref="dropTableAttributes" />
 		</xsd:complexType>
 	</xsd:element>
 
 	<xsd:element name="dropView">
 		<xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
 			<xsd:attribute name="viewName" type="xsd:string" use="required" />
             <xsd:attribute name="catalogName" type="xsd:string" />
 			<xsd:attribute name="schemaName" type="xsd:string" />
@@ -1105,6 +1143,7 @@
 
     <xsd:element name="dropProcedure">
         <xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
             <xsd:attribute name="procedureName" type="xsd:string" use="required" />
             <xsd:attribute name="catalogName" type="xsd:string" />
             <xsd:attribute name="schemaName" type="xsd:string" />
@@ -1114,6 +1153,7 @@
     <!-- renameColumn -->
 	<xsd:element name="renameColumn">
 		<xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
 			<xsd:attributeGroup ref="renameColumnAttributes" />
 		</xsd:complexType>
 	</xsd:element>
@@ -1123,12 +1163,14 @@
             <xsd:sequence>
                 <xsd:element name="column" minOccurs="0" maxOccurs="unbounded" type="columnType" />
             </xsd:sequence>
+            <xsd:attributeGroup ref="changeAttributes" />
 			<xsd:attributeGroup ref="dropColumnAttributes" />
 		</xsd:complexType>
 	</xsd:element>
 
 	<xsd:element name="mergeColumns">
 		<xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
 			<xsd:attributeGroup ref="tableNameAttribute" />
 			<xsd:attribute name="column1Name" type="xsd:string"
 				use="required" />
@@ -1144,24 +1186,28 @@
 
 	<xsd:element name="createSequence">
 		<xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
 			<xsd:attributeGroup ref="sequenceAttributes" />
 		</xsd:complexType>
 	</xsd:element>
 
 	<xsd:element name="alterSequence">
 		<xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
 			<xsd:attributeGroup ref="sequenceAttributes" />
 		</xsd:complexType>
 	</xsd:element>
 
 	<xsd:element name="dropSequence">
 		<xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
 			<xsd:attributeGroup ref="sequenceAttributes" />
 		</xsd:complexType>
 	</xsd:element>
 
 	<xsd:element name="renameSequence">
 		<xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
 			<xsd:attributeGroup ref="renameSequenceAttributes" />
 		</xsd:complexType>
 	</xsd:element>
@@ -1172,12 +1218,14 @@
 				<xsd:element ref="column" maxOccurs="unbounded" />
                 <xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded" />
             </xsd:choice>
+            <xsd:attributeGroup ref="changeAttributes" />
 			<xsd:attributeGroup ref="createIndex" />
 		</xsd:complexType>
 	</xsd:element>
 
 	<xsd:element name="dropIndex">
 		<xsd:complexType>
+            <xsd:attributeGroup ref="changeAttributes" />
 			<xsd:attributeGroup ref="tableNameAttribute" />
 			<xsd:attributeGroup ref="indexName" />
             <xsd:attribute name="associatedWith" type="xsd:string" use="optional" />            
@@ -1194,8 +1242,8 @@
 					</xsd:complexType>
 				</xsd:element>
 			</xsd:sequence>
+            <xsd:attributeGroup ref="changeAttributes" />
 			<xsd:attribute name="class" type="xsd:string" use="required" />
-			<xsd:anyAttribute processContents="lax" />
 		</xsd:complexType>
 	</xsd:element>
 


### PR DESCRIPTION
…XML changelogs

This PR changes the schema definition dbchangelog-3.6.xsd in order to support custom properties for any changes.

For a use case, see adangel/liquibase-percona#9

