### PR TITLE
CORE-2989: Custom change: configure change before calling getConfirmationMessage

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/custom/CustomChangeWrapper.java
+++ b/liquibase-core/src/main/java/liquibase/change/custom/CustomChangeWrapper.java
@@ -239,6 +239,14 @@ public class CustomChangeWrapper extends AbstractChange {
      */
     @Override
     public String getConfirmationMessage() {
+        try {
+            if (!configured) {
+                configureCustomChange();
+            }
+        } catch (CustomChangeException e) {
+            throw new UnexpectedLiquibaseException(e);
+        }
+
         return customChange.getConfirmationMessage();
     }
 

--- a/liquibase-core/src/main/java/liquibase/change/custom/CustomChangeWrapper.java
+++ b/liquibase-core/src/main/java/liquibase/change/custom/CustomChangeWrapper.java
@@ -171,9 +171,7 @@ public class CustomChangeWrapper extends AbstractChange {
     public SqlStatement[] generateStatements(Database database) {
         SqlStatement[] statements = null;
         try {
-            if (!configured) {
-                configureCustomChange();
-            }
+            configureCustomChange();
             if (customChange instanceof CustomSqlChange) {
                 statements = ((CustomSqlChange) customChange).generateStatements(database);
             } else if (customChange instanceof CustomTaskChange) {
@@ -202,9 +200,7 @@ public class CustomChangeWrapper extends AbstractChange {
     public SqlStatement[] generateRollbackStatements(Database database) throws RollbackImpossibleException {
         SqlStatement[] statements = null;
         try {
-            if (!configured) {
-                configureCustomChange();
-            }
+            configureCustomChange();
             if (customChange instanceof CustomSqlRollback) {
                 statements = ((CustomSqlRollback) customChange).generateRollbackStatements(database);
             } else if (customChange instanceof CustomTaskRollback) {
@@ -240,9 +236,7 @@ public class CustomChangeWrapper extends AbstractChange {
     @Override
     public String getConfirmationMessage() {
         try {
-            if (!configured) {
-                configureCustomChange();
-            }
+            configureCustomChange();
         } catch (CustomChangeException e) {
             throw new UnexpectedLiquibaseException(e);
         }
@@ -251,12 +245,18 @@ public class CustomChangeWrapper extends AbstractChange {
     }
 
     private void configureCustomChange() throws CustomChangeException {
+        if (configured) {
+            return;
+        }
+
         try {
             for (String param : params) {
                 ObjectUtil.setProperty(customChange, param, paramValues.get(param));
             }
             customChange.setFileOpener(getResourceAccessor());
             customChange.setUp();
+
+            configured = true;
         } catch (Exception e) {
             throw new CustomChangeException(e);
         }

--- a/liquibase-core/src/test/groovy/liquibase/change/custom/CustomChangeWrapperTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/custom/CustomChangeWrapperTest.groovy
@@ -245,7 +245,7 @@ public class CustomChangeWrapperTest extends Specification {
         thrown(RollbackImpossibleException.class)
     }
 
-    def getConfirmationMessage() {
+    def getConfirmationMessage_nominal() {
         when:
         CustomChangeWrapper changeWrapper = new CustomChangeWrapper();
 
@@ -254,6 +254,18 @@ public class CustomChangeWrapperTest extends Specification {
 
         then:
         changeWrapper.getConfirmationMessage() == "mock message"
+    }
+
+    def getConfirmationMessage_usingParams() {
+        when:
+        CustomChangeWrapper changeWrapper = new CustomChangeWrapper();
+        changeWrapper.setClassLoader(getClass().getClassLoader());
+        changeWrapper.setClass(ExampleCustomSqlChange.class.getName());
+        changeWrapper.setParam("tableName", "myName");
+        changeWrapper.setParam("columnName", "myCol");
+
+        then:
+        changeWrapper.getConfirmationMessage() == "Custom class updated myName.myCol";
     }
 
     def "load works correctly"() {


### PR DESCRIPTION
When running dbDoc a custom change properties are set when
CustomChangeWrapper.validate is called. 
But since PR #88, already ran
changes are no longer validated (for performance reasons). Unfortunately that causes problems if the properties are used in composing the confirmation
message (from NPEs - causing dbDoc to fail - to wrong messages - nulls
everywhere).