### PR TITLE
Integration tests: configurable JDBC sources and misc. fixes for Oracle Database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ derby.log
 
 atlassian-ide-plugin.xml
 _issues
+/liquibase-integration-tests/liquibase

--- a/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -760,7 +760,7 @@ public abstract class AbstractJdbcDatabase implements Database {
 // ------- DATABASE OBJECT DROPPING METHODS ---- //
 
     /**
-     * Drops all objects in a specific schema/catalog.
+     * Drops all objects owned by the connected user.
      */
     @Override
     public void dropDatabaseObjects(final CatalogAndSchema schemaToDrop) throws LiquibaseException {
@@ -791,18 +791,7 @@ public abstract class AbstractJdbcDatabase implements Database {
             }
 
 	        final long changeSetStarted = System.currentTimeMillis();
-            CompareControl.SchemaComparison[] scs = new CompareControl.SchemaComparison[] {
-                new CompareControl.SchemaComparison(
-                    schemaToDrop, schemaToDrop
-                )
-            };
-
-	        CompareControl cc = new CompareControl(scs, snapshot.getSnapshotControl().getTypesToInclude());
-	        DiffResult diffResult = DiffGeneratorFactory.getInstance().compare(
-                    new EmptyDatabaseSnapshot(this),
-                    snapshot,
-	                cc
-            );
+	        DiffResult diffResult = DiffGeneratorFactory.getInstance().compare(new EmptyDatabaseSnapshot(this), snapshot, new CompareControl(snapshot.getSnapshotControl().getTypesToInclude()));
             List<ChangeSet> changeSets = new DiffToChangeLog(diffResult, new DiffOutputControl(true, true, false, null).addIncludedSchema(schemaToDrop)).generateChangeSets();
 	        LogFactory.getLogger().debug(String.format("ChangeSet to Remove Database Objects generated in %d ms.", System.currentTimeMillis() - changeSetStarted));
 

--- a/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
@@ -241,27 +241,25 @@ public class OracleDatabase extends AbstractJdbcDatabase {
 
         if (isDateOnly(isoDate)) {
             StringBuffer val = new StringBuffer();
-            val.append("to_date(");
+            val.append("TO_DATE(");
             val.append(normalLiteral);
             val.append(", 'YYYY-MM-DD')");
             return val.toString();
         } else if (isTimeOnly(isoDate)) {
             StringBuffer val = new StringBuffer();
-            val.append("to_date(");
+            val.append("TO_DATE(");
             val.append(normalLiteral);
             val.append(", 'HH24:MI:SS')");
             return val.toString();
         } else if (isTimestamp(isoDate)) {
             StringBuffer val = new StringBuffer(26);
-            val.append("to_timestamp(");
+            val.append("TO_TIMESTAMP(");
             val.append(normalLiteral);
             val.append(", 'YYYY-MM-DD HH24:MI:SS.FF')");
             return val.toString();
         } else if (isDateTime(isoDate)) {
-            normalLiteral = normalLiteral.substring(0, normalLiteral.lastIndexOf('.')) + "'";
-
             StringBuffer val = new StringBuffer(26);
-            val.append("to_date(");
+            val.append("TO_DATE(");
             val.append(normalLiteral);
             val.append(", 'YYYY-MM-DD HH24:MI:SS')");
             return val.toString();

--- a/liquibase-core/src/test/groovy/liquibase/parser/core/xml/XMLChangeLogSAXParser_RealFile_Test.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/parser/core/xml/XMLChangeLogSAXParser_RealFile_Test.groovy
@@ -186,7 +186,9 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
     def "changelog with preconditions can be parsed: preconditionsChangeLog.xml"() throws Exception {
         when:
         def path = "liquibase/parser/core/xml/preconditionsChangeLog.xml"
-        def changeLog = new XMLChangeLogSAXParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor());
+        def params = new ChangeLogParameters()
+        params.set("loginUser", "testUser")
+        def changeLog = new XMLChangeLogSAXParser().parse(path, params, new JUnitResourceAccessor());
 
         then:
         changeLog.getLogicalFilePath() == path
@@ -505,7 +507,9 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
     def "tests for particular features and edge conditions part 3 testCasesChangeLog.xml"() throws Exception {
         when:
         def path = "liquibase/parser/core/xml/testCasesChangeLog.xml"
-        DatabaseChangeLog changeLog = new XMLChangeLogSAXParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor());
+        def params = new ChangeLogParameters()
+        params.set("loginUser", "sa")
+        DatabaseChangeLog changeLog = new XMLChangeLogSAXParser().parse(path, params, new JUnitResourceAccessor());
 
 
         then: "complex preconditions are parsed"

--- a/liquibase-core/src/test/resources/liquibase/parser/core/xml/preconditionsChangeLog.xml
+++ b/liquibase-core/src/test/resources/liquibase/parser/core/xml/preconditionsChangeLog.xml
@@ -6,7 +6,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.2.xsd">
 
     <preConditions>
-        <runningAs username="testUser"/>
+        <runningAs username="${loginUser}"/>
         <or>
             <dbms type="mssql"/>
             <dbms type="mysql"/>

--- a/liquibase-core/src/test/resources/liquibase/parser/core/xml/testCasesChangeLog.xml
+++ b/liquibase-core/src/test/resources/liquibase/parser/core/xml/testCasesChangeLog.xml
@@ -53,7 +53,7 @@
                         <dbms type="oracle"/>
                         <dbms type="mysql"/>
                     </not>
-                    <runningAs username="sa"/>
+                    <runningAs username="${loginUser}"/>
                 </and>
                 <not>
                     <sqlCheck expectedResult="3">select count(*) from test</sqlCheck>

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/oracle/OracleIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/oracle/OracleIntegrationTest.java
@@ -1,9 +1,12 @@
 package liquibase.dbtest.oracle;
 
+import liquibase.database.Database;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.dbtest.AbstractIntegrationTest;
 import liquibase.Liquibase;
 import liquibase.exception.ValidationFailedException;
+import liquibase.test.DatabaseTest;
+import liquibase.test.DatabaseTestURL;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -17,93 +20,19 @@ import java.util.Date;
  */
 public class OracleIntegrationTest extends AbstractIntegrationTest {
 
-    private String indexOnSchemaChangeLog;
-    private String viewOnSchemaChangeLog;
-
     public OracleIntegrationTest() throws Exception {
-        super("oracle", "jdbc:oracle:thin:@" + getDatabaseServerHostname("Oracle") + ":1521:XE");
-        this.indexOnSchemaChangeLog = "changelogs/oracle/complete/indexOnSchema.xml";
-        this.viewOnSchemaChangeLog = "changelogs/oracle/complete/viewOnSchema.xml";
+        super("oracle", "jdbc:oracle:thin:@LIQUIBASE_INTEGRATION_TEST");
+        System.setProperty("oracle.net.tns_admin",System.getenv("TNS_ADMIN"));
+
+        DatabaseTestURL oracleTestURL = getDatabaseTestURL("Oracle");
+        this.setUsername(oracleTestURL.getUsername());
+        this.setPassword(oracleTestURL.getUsername());
     }
 
     @Override
     @Test
     public void testRunChangeLog() throws Exception {
         super.testRunChangeLog();    //To change body of overridden methods use File | Settings | File Templates.
-    }
-
-    @Test
-    public void indexCreatedOnCorrectSchema() throws Exception {
-         if (this.getDatabase() == null) {
-            return;
-        }
-
-        Liquibase liquibase = createLiquibase(this.indexOnSchemaChangeLog);
-        clearDatabase(liquibase);
-
-        try {
-            liquibase.update(this.contexts);
-        } catch (ValidationFailedException e) {
-            e.printDescriptiveError(System.out);
-            throw e;
-        }
-
-        Statement queryIndex = ((JdbcConnection) this.getDatabase().getConnection()).getUnderlyingConnection().createStatement();
-
-        ResultSet indexOwner = queryIndex.executeQuery("SELECT owner FROM ALL_INDEXES WHERE index_name = 'IDX_BOOK_ID'");
-
-        assertTrue(indexOwner.next());
-
-        String owner = indexOwner.getString("owner");
-
-        assertEquals("LIQUIBASEB",owner);
-
-        // check that the automatically rollback now works too
-        try {
-            liquibase.rollback( new Date(0),this.contexts);
-        } catch (ValidationFailedException e) {
-            e.printDescriptiveError(System.out);
-            throw e;
-        }
-
-
-
-
-    }
-
-    @Test
-    public void viewCreatedOnCorrectSchema() throws Exception {
-         if (this.getDatabase() == null) {
-            return;
-        }
-
-        Liquibase liquibase = createLiquibase(this.viewOnSchemaChangeLog);
-        clearDatabase(liquibase);
-
-        try {
-            liquibase.update(this.contexts);
-        } catch (ValidationFailedException e) {
-            e.printDescriptiveError(System.out);
-            throw e;
-        }
-
-        Statement queryIndex = ((JdbcConnection) this.getDatabase().getConnection()).getUnderlyingConnection().createStatement();
-
-        ResultSet indexOwner = queryIndex.executeQuery("SELECT owner FROM ALL_VIEWS WHERE view_name = 'V_BOOK2'");
-
-        assertTrue(indexOwner.next());
-
-        String owner = indexOwner.getString("owner");
-
-        assertEquals("LIQUIBASEB",owner);
-
-        // check that the automatically rollback now works too
-        try {
-            liquibase.rollback( new Date(0),this.contexts);
-        } catch (ValidationFailedException e) {
-            e.printDescriptiveError(System.out);
-            throw e;
-        }
     }
 
     @Test

--- a/liquibase-integration-tests/src/test/java/liquibase/test/DatabaseTestContext.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/test/DatabaseTestContext.java
@@ -49,13 +49,14 @@ public class DatabaseTestContext {
     private static final String TEST_DATABASES_PROPERTY = "test.databases";
     private ResourceAccessor resourceAccessor;
 
-    private DatabaseConnection openConnection(final String url) throws Exception {
+    private DatabaseConnection openConnection(final String url,
+        final String username, final String password) throws Exception {
         if (connectionsAttempted.containsKey(url)) {
             JdbcConnection connection = (JdbcConnection) connectionsByUrl.get(url);
             if (connection == null) {
                 return null;
             } else if (connection.getUnderlyingConnection().isClosed()){
-                connectionsByUrl.put(url, openDatabaseConnection(url));
+                connectionsByUrl.put(url, openDatabaseConnection(url, username, password));
             }
             return connectionsByUrl.get(url);
         }
@@ -77,7 +78,7 @@ public class DatabaseTestContext {
             }
         }
 
-        DatabaseConnection connection = openDatabaseConnection(url);
+        DatabaseConnection connection = openDatabaseConnection(url, username,password);
         if (connection == null) {
             return null;
         }
@@ -142,10 +143,8 @@ public class DatabaseTestContext {
         return databaseConnection;
     }
 
-    public DatabaseConnection openDatabaseConnection(String url) throws Exception {
-        String username = getUsername(url);
-        String password = getPassword(url);
-
+    public DatabaseConnection openDatabaseConnection(String url,
+        String username, String password) throws Exception {
 
         JUnitJDBCDriverClassLoader jdbcDriverLoader = JUnitJDBCDriverClassLoader.getInstance();
         final Driver driver;
@@ -178,19 +177,6 @@ public class DatabaseTestContext {
         return new JdbcConnection(connection);
     }
 
-    private String getUsername(String url) {
-        if (url.startsWith("jdbc:hsqldb")) {
-            return "sa";
-        }
-        return "lbuser";
-    }
-
-    private String getPassword(String url) {
-        if (url.startsWith("jdbc:hsqldb")) {
-            return "";
-        }
-        return "lbuser";
-    }
 
     public static DatabaseTestContext getInstance() {
         return instance;
@@ -246,7 +232,8 @@ public class DatabaseTestContext {
 //                if (url.indexOf("jtds") >= 0) {
 //                    continue;
 //                }
-                DatabaseConnection connection = openConnection(adaptTestURLWithConfiguredHost(url));
+                DatabaseConnection connection = openConnection(adaptTestURLWithConfiguredHost(url), url.getUsername(), url.getPassword());
+
                 if (connection != null) {
                     availableConnections.add(connection);
                 }
@@ -268,8 +255,8 @@ public class DatabaseTestContext {
         return url.getUrl().replaceAll("localhost", AbstractIntegrationTest.getDatabaseServerHostname(url.getDatabaseManager()));
     }
 
-    public DatabaseConnection getConnection(String url) throws Exception {
-        return openConnection(url);
+    public DatabaseConnection getConnection(String url, String username, String password) throws Exception {
+        return openConnection(url, username, password);
     }
 
     public String getTestUrl(Database database) throws Exception {

--- a/liquibase-integration-tests/src/test/java/liquibase/test/DatabaseTestURL.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/test/DatabaseTestURL.java
@@ -5,16 +5,36 @@
 
 package liquibase.test;
 
+import liquibase.dbtest.AbstractIntegrationTest;
+
 /**
  *
  * @author lujop
  */
 public class DatabaseTestURL {
     private String url;
+    private String username;
+    private String password;
+
     private String databaseManager;
 
-    public DatabaseTestURL(String databaseManager,String url) {
+    public DatabaseTestURL(String databaseManager, String defaultUrl) {
+        // Use a specific URL / username / password if given in the test configuration properties.
+        DatabaseTestURL configuredUrl = AbstractIntegrationTest.getDatabaseTestURL(databaseManager);
+        if (configuredUrl == null) {
+            this.url = defaultUrl;
+        } else {
+            this.url = configuredUrl.getUrl();
+            this.username = configuredUrl.getUsername();
+            this.password = configuredUrl.getPassword();
+        }
+        this.databaseManager = databaseManager;
+    }
+
+    public DatabaseTestURL(String databaseManager, String url, String username, String password) {
         this.url = url;
+        this.username = username;
+        this.password = password;
         this.databaseManager = databaseManager;
     }
 
@@ -26,4 +46,19 @@ public class DatabaseTestURL {
         return url;
     }
 
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
 }

--- a/liquibase-integration-tests/src/test/resources/changelogs/asany/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/asany/complete/root.changelog.xml
@@ -6,7 +6,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
     <preConditions>
             <dbms type="asany"/>
-            <runningAs username="lbuser"/>
+            <runningAs username="${loginUser}"/>
     </preConditions>
 
     <changeSet id="1" author="nvoxland">

--- a/liquibase-integration-tests/src/test/resources/changelogs/cache/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/cache/complete/root.changelog.xml
@@ -6,7 +6,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
     <preConditions>
         <dbms type="cache"/>
-        <runningAs username="lbuser"/>
+        <runningAs username="${loginUser}"/>
     </preConditions>
 
     <changeSet id="1" author="nvoxland">

--- a/liquibase-integration-tests/src/test/resources/changelogs/common/includerelative/pathinclude1.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/common/includerelative/pathinclude1.changelog.xml
@@ -6,10 +6,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
     <preConditions>
-        <or>
-            <runningAs username="lbuser" />
-            <runningAs username="sa" />
-        </or>
+        <runningAs username="${loginUser}" />
     </preConditions>
 
     <changeSet id="1" author="nvoxland">

--- a/liquibase-integration-tests/src/test/resources/changelogs/common/pathincluded/pathinclude1.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/common/pathincluded/pathinclude1.changelog.xml
@@ -6,10 +6,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
     <preConditions>
-        <or>
-            <runningAs username="lbuser" />
-            <runningAs username="sa" />
-        </or>
+        <runningAs username="${loginUser}" />
     </preConditions>
 
     <changeSet id="1" author="nvoxland">

--- a/liquibase-integration-tests/src/test/resources/changelogs/db2/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/db2/complete/root.changelog.xml
@@ -6,7 +6,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
     <preConditions>
             <dbms type="db2"/>
-            <runningAs username="lbuser"/>
+            <runningAs username="${loginUser}"/>
     </preConditions>
 
     <changeSet id="1" author="nvoxland">

--- a/liquibase-integration-tests/src/test/resources/changelogs/derby/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/derby/complete/root.changelog.xml
@@ -6,7 +6,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
     <preConditions>
             <dbms type="derby"/>
-            <runningAs username="lbuser"/>
+            <runningAs username="${loginUser}"/>
     </preConditions>
 
     <changeSet id="1" author="nvoxland">

--- a/liquibase-integration-tests/src/test/resources/changelogs/firebird/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/firebird/complete/root.changelog.xml
@@ -6,7 +6,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
     <preConditions>
             <dbms type="firebird"/>
-            <runningAs username="lbuser"/>
+            <runningAs username="${loginUser}"/>
     </preConditions>
 
     <changeSet id="1" author="nvoxland">

--- a/liquibase-integration-tests/src/test/resources/changelogs/h2/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/h2/complete/root.changelog.xml
@@ -7,14 +7,14 @@
 
     <preConditions onSqlOutput="IGNORE" >
             <dbms type="h2"/>
-            <runningAs username="lbuser"/>
+            <runningAs username="${loginUser}"/>
             <changeLogPropertyDefined property="database.databaseProductName" value="H2"/>
     </preConditions>
 
     <changeSet id="1" author="nvoxland">
         <preConditions onSqlOutput="TEST">
                 <dbms type="h2"/>
-                <runningAs username="lbuser"/>
+                <runningAs username="${loginUser}"/>
         </preConditions>
         <comment>
             You can add comments to changeSets.

--- a/liquibase-integration-tests/src/test/resources/changelogs/hsqldb/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/hsqldb/complete/root.changelog.xml
@@ -6,7 +6,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
     <preConditions>
             <dbms type="hsqldb"/>
-            <runningAs username="sa"/>
+            <runningAs username="${loginUser}"/>
     </preConditions>
 
     <changeSet id="1" author="nvoxland">

--- a/liquibase-integration-tests/src/test/resources/changelogs/informix/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/informix/complete/root.changelog.xml
@@ -7,7 +7,7 @@
 
     <preConditions>
         <dbms type="informix"/>
-        <runningAs username="lbuser"/>
+        <runningAs username="${loginUser}"/>
     </preConditions>
 
     <changeSet id="1" author="nvoxland">

--- a/liquibase-integration-tests/src/test/resources/changelogs/json/includerelative/pathinclude1.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/json/includerelative/pathinclude1.changelog.xml
@@ -6,10 +6,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
     <preConditions>
-        <or>
-            <runningAs username="lbuser" />
-            <runningAs username="sa" />
-        </or>
+        <runningAs username="${loginUser}" />
     </preConditions>
 
     <changeSet id="1" author="nvoxland">

--- a/liquibase-integration-tests/src/test/resources/changelogs/maxdb/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/maxdb/complete/root.changelog.xml
@@ -6,7 +6,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
     <preConditions>
             <dbms type="maxdb"/>
-            <runningAs username="lbuser"/>
+            <runningAs username="${loginUser}"/>
     </preConditions>
 
     <changeSet id="1" author="nvoxland">

--- a/liquibase-integration-tests/src/test/resources/changelogs/mssql/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/mssql/complete/root.changelog.xml
@@ -6,7 +6,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
     <preConditions>
             <dbms type="mssql"/>
-            <runningAs username="lbuser"/>
+            <runningAs username="${loginUser}"/>
     </preConditions>
 
     <changeSet id="1" author="nvoxland">

--- a/liquibase-integration-tests/src/test/resources/changelogs/mysql/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/mysql/complete/root.changelog.xml
@@ -7,7 +7,7 @@
     <preConditions>
         <dbms type="mysql"/>
         <sqlCheck expectedResult="1">select 1</sqlCheck>
-        <runningAs username="lbuser"/>
+        <runningAs username="${loginUser}"/>
     </preConditions>
 
     <changeSet id="1" author="nvoxland">

--- a/liquibase-integration-tests/src/test/resources/changelogs/oracle/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/oracle/complete/root.changelog.xml
@@ -6,7 +6,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
     <preConditions>
             <dbms type="oracle"/>
-            <runningAs username="lbuser"/>
+            <runningAs username="${loginUser}"/>
     </preConditions>
 
     <changeSet id="1" author="nvoxland">

--- a/liquibase-integration-tests/src/test/resources/changelogs/pgsql/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/pgsql/complete/root.changelog.xml
@@ -7,7 +7,7 @@
 
     <preConditions>
             <dbms type="postgresql"/>
-            <runningAs username="lbuser"/>
+            <runningAs username="${loginUser}"/>
     </preConditions>
 
     <changeSet id="1" author="nvoxland">

--- a/liquibase-integration-tests/src/test/resources/changelogs/sybase/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/sybase/complete/root.changelog.xml
@@ -6,7 +6,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
     <preConditions>
             <dbms type="sybase"/>
-            <runningAs username="lbuser"/>
+            <runningAs username="${loginUser}"/>
     </preConditions>
 
     <changeSet id="1" author="nvoxland">

--- a/liquibase-integration-tests/src/test/resources/changelogs/yaml/includerelative/pathinclude1.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/yaml/includerelative/pathinclude1.changelog.xml
@@ -6,10 +6,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
     <preConditions>
-        <or>
-            <runningAs username="lbuser" />
-            <runningAs username="sa" />
-        </or>
+        <runningAs username="${loginUser}" />
     </preConditions>
 
     <changeSet id="1" author="nvoxland">

--- a/liquibase-integration-tests/src/test/resources/liquibase/liquibase.integrationtest.properties
+++ b/liquibase-integration-tests/src/test/resources/liquibase/liquibase.integrationtest.properties
@@ -1,3 +1,12 @@
 #settings to run integration tests with.
 #Override by setting same properties in liquibase.integrationtest.local.properties
 integration.test.hostname:10.10.100.100
+
+# It is possible to specify different JDBC URLs, usernames and passwords
+# for each database type during tests. For databases other than Oracle Database,
+# copy the following block and replace "Oracle" with the name of a supported DBMS,
+# e.g. DB2, Informix, MSSQL, MySQL, Postgres etc.
+# integration.test.Oracle.url=jdbc:oracle:thin:@LIQUIBASE_INTEGRATION_TEST
+# integration.test.Oracle.username=liquibase
+# integration.test.Oracle.password=liquibase
+


### PR DESCRIPTION
This PR contains the changes I needed to make on my system to allow the integration tests to work with my Oracle database.

(1) You can now configure the JDBC URL, username and password separatly for each database.
(2) The functions for testing if a string is an ISO8601-ish date/time/timestamp expression only relied on the length, which caused a bug if a timestamp had less than three fractional digits. 
(3) Modified testing change sets so that the <runningAs> tests do not contain hardcoded usernames anymore. 