### PR TITLE
Support Oracle Database's named NOT NULL constraints in createTable

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/ConstraintsConfig.java
+++ b/liquibase-core/src/main/java/liquibase/change/ConstraintsConfig.java
@@ -13,6 +13,7 @@ import liquibase.util.StringUtils;
 public class ConstraintsConfig extends AbstractLiquibaseSerializable {
 
     private Boolean nullable;
+    private String notNullConstraintName;
     private Boolean primaryKey;
     private String primaryKeyName;
     private String primaryKeyTablespace;
@@ -54,6 +55,17 @@ public class ConstraintsConfig extends AbstractLiquibaseSerializable {
         return this;
     }
 
+    /**
+     * Returns the name to use for the NOT NULL constraint. Returns null if not specified
+     */
+    public String getNotNullConstraintName() {
+        return notNullConstraintName;
+    }
+
+    public ConstraintsConfig setNotNullConstraintName(String notNullConstraintName) {
+        this.notNullConstraintName = notNullConstraintName;
+        return this;
+    }
 
     /**
      * Returns true if the column should be part of the primary key. Returns null if unspecified

--- a/liquibase-core/src/main/java/liquibase/change/core/AddNotNullConstraintChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/AddNotNullConstraintChange.java
@@ -11,6 +11,7 @@ import liquibase.statement.SqlStatement;
 import liquibase.statement.core.ReorganizeTableStatement;
 import liquibase.statement.core.SetNullableStatement;
 import liquibase.statement.core.UpdateStatement;
+import liquibase.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -200,7 +201,9 @@ public class AddNotNullConstraintChange extends AbstractChange {
 
     @Override
     public String getConfirmationMessage() {
-        return "Null constraint has been added to " + getTableName() + "." + getColumnName();
+        return "NOT NULL constraint "
+                + (StringUtils.trimToNull(getConstraintName()) != null ? String.format("\"%s\" ", getConstraintName()) : "" )
+                 + "has been added to " + getTableName() + "." + getColumnName();
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/change/core/CreateTableChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/CreateTableChange.java
@@ -85,7 +85,7 @@ public class CreateTableChange extends AbstractChange implements ChangeWithColum
 
             if (constraints != null) {
                 if (constraints.isNullable() != null && !constraints.isNullable()) {
-                    statement.addColumnConstraint(new NotNullConstraint(column.getName()));
+                    statement.addColumnConstraint(new NotNullConstraint(column.getName()).setName(constraints.getNotNullConstraintName()));
                 }
 
                 if (constraints.getReferences() != null ||

--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeLogParameters.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeLogParameters.java
@@ -68,8 +68,8 @@ public class ChangeLogParameters {
             this.set("database.supportsSchemas", database.supportsSchemas());
             this.set("database.supportsSequences", database.supportsSequences());
             this.set("database.supportsTablespaces", database.supportsTablespaces());
+            this.set("database.supportsNotNullConstraintNames", database.supportsNotNullConstraintNames());
         }
-
 
         this.expressionExpander = new ExpressionExpander(this);
         this.currentDatabase = database;

--- a/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -1563,4 +1563,9 @@ public abstract class AbstractJdbcDatabase implements Database {
     public ValidationErrors validate() {
         return new ValidationErrors();
     }
+
+    @Override
+    public boolean supportsNotNullConstraintNames() {
+        return false;
+    }
 }

--- a/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -732,7 +732,7 @@ public abstract class AbstractJdbcDatabase implements Database {
 // ------- DATABASE OBJECT DROPPING METHODS ---- //
 
     /**
-     * Drops all objects owned by the connected user.
+     * Drops all objects in a specific schema/catalog.
      */
     @Override
     public void dropDatabaseObjects(final CatalogAndSchema schemaToDrop) throws LiquibaseException {
@@ -763,7 +763,18 @@ public abstract class AbstractJdbcDatabase implements Database {
             }
 
 	        final long changeSetStarted = System.currentTimeMillis();
-	        DiffResult diffResult = DiffGeneratorFactory.getInstance().compare(new EmptyDatabaseSnapshot(this), snapshot, new CompareControl(snapshot.getSnapshotControl().getTypesToInclude()));
+            CompareControl.SchemaComparison[] scs = new CompareControl.SchemaComparison[] {
+                new CompareControl.SchemaComparison(
+                    schemaToDrop, schemaToDrop
+                )
+            };
+
+	        CompareControl cc = new CompareControl(scs, snapshot.getSnapshotControl().getTypesToInclude());
+	        DiffResult diffResult = DiffGeneratorFactory.getInstance().compare(
+                    new EmptyDatabaseSnapshot(this),
+                    snapshot,
+	                cc
+            );
             List<ChangeSet> changeSets = new DiffToChangeLog(diffResult, new DiffOutputControl(true, true, false, null).addIncludedSchema(schemaToDrop)).generateChangeSets();
 	        LogFactory.getLogger().debug(String.format("ChangeSet to Remove Database Objects generated in %d ms.", System.currentTimeMillis() - changeSetStarted));
 

--- a/liquibase-core/src/main/java/liquibase/database/Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/Database.java
@@ -333,6 +333,8 @@ public interface Database extends PrioritizedService {
 
     boolean supportsPrimaryKeyNames();
 
+    boolean supportsNotNullConstraintNames();
+
     public String getSystemSchema();
 
     public void addReservedWords(Collection<String> words);

--- a/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
@@ -496,4 +496,10 @@ public class OracleDatabase extends AbstractJdbcDatabase {
 
         return canAccessDbaRecycleBin;
     }
+
+    @Override
+    public boolean supportsNotNullConstraintNames() {
+        return true;
+    }
+
 }

--- a/liquibase-core/src/main/java/liquibase/sdk/database/MockDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/sdk/database/MockDatabase.java
@@ -783,4 +783,9 @@ public class MockDatabase implements Database, InternalDatabase {
     public ValidationErrors validate() {
         return new ValidationErrors();
     }
+
+    @Override
+    public boolean supportsNotNullConstraintNames() {
+        return false;
+    }
 }

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateTableGeneratorInformix.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateTableGeneratorInformix.java
@@ -96,7 +96,7 @@ public class CreateTableGeneratorInformix extends CreateTableGenerator {
                 }
             }
 
-            if (statement.getNotNullColumns().contains(column)) {
+            if (statement.getNotNullColumns().get(column) != null) {
                 buffer.append(" NOT NULL");
             }
 

--- a/liquibase-core/src/main/java/liquibase/statement/NotNullConstraint.java
+++ b/liquibase-core/src/main/java/liquibase/statement/NotNullConstraint.java
@@ -3,6 +3,9 @@ package liquibase.statement;
 public class NotNullConstraint implements ColumnConstraint {
     private String columnName;
 
+    /* Some RDBMS (e.g. Oracle Database) have names for NOT NULL constraints. For Liquibase to make use of this
+     * property, the Database-specific class must override supportsNotNullConstraintNames() to true.  */
+    private String name;
 
     public NotNullConstraint() {
     }
@@ -11,7 +14,6 @@ public class NotNullConstraint implements ColumnConstraint {
         setColumnName(columnName);
     }
 
-
     public String getColumnName() {
         return columnName;
     }
@@ -19,5 +21,13 @@ public class NotNullConstraint implements ColumnConstraint {
     public NotNullConstraint setColumnName(String columnName) {
         this.columnName = columnName;
         return this;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 }

--- a/liquibase-core/src/main/java/liquibase/statement/NotNullConstraint.java
+++ b/liquibase-core/src/main/java/liquibase/statement/NotNullConstraint.java
@@ -27,7 +27,8 @@ public class NotNullConstraint implements ColumnConstraint {
         return name;
     }
 
-    public void setName(String name) {
+    public NotNullConstraint setName(String name) {
         this.name = name;
+        return this;
     }
 }

--- a/liquibase-core/src/main/java/liquibase/structure/core/Table.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/Table.java
@@ -1,5 +1,6 @@
 package liquibase.structure.core;
 
+import liquibase.statement.NotNullConstraint;
 import liquibase.util.StringUtils;
 
 import java.util.ArrayList;
@@ -14,6 +15,7 @@ public class Table extends Relation {
         setAttribute("outgoingForeignKeys", new ArrayList<ForeignKey>());
         setAttribute("indexes", new ArrayList<Index>());
         setAttribute("uniqueConstraints", new ArrayList<UniqueConstraint>());
+        setAttribute("notNullConstraints", new ArrayList<UniqueConstraint>());
     }
 
     public Table(String catalogName, String schemaName, String tableName) {
@@ -39,6 +41,9 @@ public class Table extends Relation {
 
     public List<UniqueConstraint> getUniqueConstraints() {
         return getAttribute("uniqueConstraints", List.class);
+    }
+    public List<NotNullConstraint> getNotNullConstraints() {
+        return getAttribute("notNullConstraints", List.class);
     }
 
     @Override

--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.6.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.6.xsd
@@ -269,6 +269,7 @@
 	<!-- Attributes for constraints -->
 	<xsd:attributeGroup name="constraintsAttributes">
 		<xsd:attribute name="nullable" type="booleanExp" />
+		<xsd:attribute name="notNullConstraintName" type="xsd:string" />
 		<xsd:attribute name="primaryKey" type="booleanExp" />
 		<xsd:attribute name="primaryKeyName" type="xsd:string" />
         <xsd:attribute name="primaryKeyTablespace" type="xsd:string" />

--- a/liquibase-core/src/test/groovy/liquibase/change/ConstraintsConfigTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/ConstraintsConfigTest.groovy
@@ -42,6 +42,10 @@ public class ConstraintsConfigTest extends Specification {
         constraint.isNullable() == null
     }
 
+    def setNotNullConstraintName_string() {
+        expect:
+        new ConstraintsConfig().setNotNullConstraintName("xyz").getNotNullConstraintName() == "xyz"
+    }
 
     def setDeleteCascade() {
         expect:

--- a/liquibase-core/src/test/groovy/liquibase/change/core/AddNotNullConstraintChangeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/core/AddNotNullConstraintChangeTest.groovy
@@ -15,8 +15,9 @@ public class AddNotNullConstraintChangeTest extends StandardChangeTest {
         def change = new AddNotNullConstraintChange();
         change.setTableName("TABLE_NAME");
         change.setColumnName("COL_HERE");
+        change.setConstraintName("COL_NN");
 
         then:
-        change.getConfirmationMessage() == "Null constraint has been added to TABLE_NAME.COL_HERE"
+        change.getConfirmationMessage() == "NOT NULL constraint \"COL_NN\" has been added to TABLE_NAME.COL_HERE"
     }
 }

--- a/liquibase-core/src/test/groovy/liquibase/change/core/CreateTableChangeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/core/CreateTableChangeTest.groovy
@@ -11,6 +11,7 @@ import liquibase.snapshot.MockSnapshotGeneratorFactory
 import liquibase.snapshot.SnapshotGeneratorFactory
 import liquibase.statement.DatabaseFunction
 import liquibase.statement.ForeignKeyConstraint
+import liquibase.statement.NotNullConstraint
 import liquibase.statement.SequenceNextValueFunction
 import liquibase.statement.core.CreateTableStatement
 import liquibase.structure.core.Column

--- a/liquibase-integration-tests/src/test/resources/changelogs/oracle/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/oracle/complete/root.changelog.xml
@@ -3,7 +3,7 @@
 <databaseChangeLog
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
     <preConditions>
             <dbms type="oracle"/>
             <runningAs username="lbuser"/>
@@ -367,6 +367,42 @@ END testSP;
             id int not null primary key,
             bdtestcol binary_double,
             bftestcol binary_float)
+        </sql>
+    </changeSet>
+
+    <changeSet id="notNullConstraintNamingTest" author="abuschka">
+        <createTable tableName="NOTNULL_NAMING_TEST">
+            <column name="id" type="int"/>
+            <column name="testcol" type="varchar2(50 char)">
+                <constraints nullable="false" notNullConstraintName="NN_NAMING_TEST_TESTCOL_NN" />
+            </column>
+            <column name="testcol2" type="int" />
+        </createTable>
+        <addNotNullConstraint tableName="NOTNULL_NAMING_TEST" columnName="testcol2" constraintName="NN_NAMING_TEST_TESTCOL2_NN" />
+    </changeSet>
+
+    <changeSet id="notNullConstraintNamingTest_part2" author="abuschka">
+        <preConditions>
+            <and>
+                <changeSetExecuted id="notNullConstraintNamingTest" author="abuschka" />
+            </and>
+        </preConditions>
+        <sql dbms="oracle" endDelimiter="none">
+            <![CDATA[
+                DECLARE
+                  v_rows_found INTEGER;
+                BEGIN
+                  SELECT COUNT(*)
+                    INTO v_rows_found
+                    FROM user_constraints
+                   WHERE constraint_name IN ('NN_NAMING_TEST_TESTCOL_NN', 'NN_NAMING_TEST_TESTCOL2_NN');
+
+                  IF v_rows_found < 2 THEN
+                    RAISE_APPLICATION_ERROR(-20000, 'Test case notNullConstraintNamingTest should have created the constraints '
+                      || 'NN_NAMING_TEST_TESTCOL_NN and NN_NAMING_TEST_TESTCOL2_NN.');
+                  END IF;
+                END;
+            ]]>
         </sql>
     </changeSet>
 


### PR DESCRIPTION
This patch allows to specifiy the names of NOT NULL constraints in all places where column constraints can be specified. This feature is currently only supported by Oracle Database (AFAIK)