### PR TITLE
Fix for incorrect serialization of Timestamps

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/ColumnConfig.java
+++ b/liquibase-core/src/main/java/liquibase/change/ColumnConfig.java
@@ -4,6 +4,7 @@ import liquibase.parser.core.ParsedNode;
 import liquibase.parser.core.ParsedNodeException;
 import liquibase.resource.ResourceAccessor;
 import liquibase.serializer.AbstractLiquibaseSerializable;
+import liquibase.serializer.ReflectionSerializer;
 import liquibase.statement.DatabaseFunction;
 import liquibase.statement.SequenceCurrentValueFunction;
 import liquibase.statement.SequenceNextValueFunction;
@@ -911,5 +912,15 @@ public class ColumnConfig extends AbstractLiquibaseSerializable {
             returnArray[i] = fromName(nameArray.get(i));
         }
         return returnArray;
+    }
+
+    @Override
+    public Object getSerializableFieldValue(String field) {
+        Object o = ReflectionSerializer.getInstance().getValue(this, field);
+        if (field.equals("valueDate")) {
+            return new ISODateFormat().format((Date)o);
+        } else {
+            return o;
+        }
     }
 }


### PR DESCRIPTION
When generating changeLogs I stumbled over a serialization bug. The fractional seconds (millieseconds) in java.sql.Timestamp are not serialized/deserialized correctly; This is due to not using the default DateTimeFormats. This should fix the problem.

Here is a test that outlines the problem with current implementation:

`
import org.junit.Assert;
import org.junit.Test;

import java.text.ParseException;
import java.text.SimpleDateFormat;
import java.util.Date;

public class SimpleTimestampTest {

    private static final String DATE_TIME_FORMAT_STRING_WITH_SPACE_AND_DECIMAL = "yyyy-MM-dd HH:mm:ss.SS";
    private SimpleDateFormat dateTimeFormat = new SimpleDateFormat(DATE_TIME_FORMAT_STRING_WITH_SPACE_AND_DECIMAL);

    @Test
    public void testFormat() throws ParseException {
        String dateAsString = "2017-01-06 11:10:48.75";

        Date date = dateTimeFormat.parse(dateAsString);

        System.out.println(new java.sql.Timestamp(dateTimeFormat.parse(dateAsString).getTime()));
        System.out.println(java.sql.Timestamp.valueOf(dateAsString));

        Assert.assertEquals(java.sql.Timestamp.valueOf(dateAsString), new java.sql.Timestamp(dateTimeFormat.parse(dateAsString).getTime()));
    }
}
`
