### PR TITLE
fix for Timestamp/Date handling

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/ColumnConfig.java
+++ b/liquibase-core/src/main/java/liquibase/change/ColumnConfig.java
@@ -917,7 +917,7 @@ public class ColumnConfig extends AbstractLiquibaseSerializable {
     @Override
     public Object getSerializableFieldValue(String field) {
         Object o = ReflectionSerializer.getInstance().getValue(this, field);
-        if (field.equals("valueDate")) {
+        if (field.equals("valueDate") || field.equals("defaultValueDate")) {
             return new ISODateFormat().format((Date)o);
         } else {
             return o;

--- a/liquibase-core/src/main/java/liquibase/change/ColumnConfig.java
+++ b/liquibase-core/src/main/java/liquibase/change/ColumnConfig.java
@@ -4,6 +4,7 @@ import liquibase.parser.core.ParsedNode;
 import liquibase.parser.core.ParsedNodeException;
 import liquibase.resource.ResourceAccessor;
 import liquibase.serializer.AbstractLiquibaseSerializable;
+import liquibase.serializer.ReflectionSerializer;
 import liquibase.statement.DatabaseFunction;
 import liquibase.statement.SequenceCurrentValueFunction;
 import liquibase.statement.SequenceNextValueFunction;
@@ -911,5 +912,15 @@ public class ColumnConfig extends AbstractLiquibaseSerializable {
             returnArray[i] = fromName(nameArray.get(i));
         }
         return returnArray;
+    }
+
+    @Override
+    public Object getSerializableFieldValue(String field) {
+        Object o = ReflectionSerializer.getInstance().getValue(this, field);
+        if (field.equals("valueDate")) {
+            return new ISODateFormat().format((Date)o);
+        } else {
+            return o;
+        }
     }
 }

--- a/liquibase-core/src/main/java/liquibase/util/ISODateFormat.java
+++ b/liquibase-core/src/main/java/liquibase/util/ISODateFormat.java
@@ -50,6 +50,8 @@ public class ISODateFormat {
             return format(((java.sql.Time) date));
         } else if (date instanceof java.sql.Timestamp) {
             return format(((java.sql.Timestamp) date));
+        } else if (date instanceof java.util.Date) {
+            return format(new java.sql.Timestamp(date.getTime()));
         } else {
             throw new RuntimeException("Unknown type: "+date.getClass().getName());
         }

--- a/liquibase-core/src/test/groovy/liquibase/change/ColumnConfigTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/ColumnConfigTest.groovy
@@ -421,7 +421,7 @@ public class ColumnConfigTest extends Specification {
 
         def testValue = "value for ${field}"
         if (field in ["defaultValueDate", "valueDate"]) {
-            testValue = "2012-03-13 18:52:22.129"
+            testValue = "2012-03-13T18:52:22.12"
         } else if (field in ["defaultValueBoolean", "valueBoolean", "autoIncrement", "computed"]) {
             testValue = "true"
         } else if (field in ["startWith", "incrementBy"]) {

--- a/liquibase-core/src/test/groovy/liquibase/change/core/InsertDataChangeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/core/InsertDataChangeTest.groovy
@@ -30,10 +30,15 @@ public class InsertDataChangeTest extends StandardChangeTest {
         col4.setName("height");
         col4.setValueNumeric("1.78");
 
+        ColumnConfig col5 = new ColumnConfig();
+        col5.setName("date");
+        col5.setValueNumeric("2012-03-13 18:52:22.75");
+
         change.addColumn(col1);
         change.addColumn(col2);
         change.addColumn(col3);
         change.addColumn(col4);
+        change.addColumn(col5);
 
         then:
         "New row inserted into TABLE_NAME" == change.getConfirmationMessage()

--- a/liquibase-core/src/test/java/liquibase/serializer/core/json/JsonChangeLogSerializerTest.java
+++ b/liquibase-core/src/test/java/liquibase/serializer/core/json/JsonChangeLogSerializerTest.java
@@ -6,13 +6,23 @@ import liquibase.change.core.AddColumnChange;
 import liquibase.changelog.ChangeSet;
 import liquibase.statement.DatabaseFunction;
 import liquibase.statement.SequenceNextValueFunction;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Date;
+import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 
 public class JsonChangeLogSerializerTest {
+
+    private String origTimeZone =  System.getProperty("user.timezone");
+
+    @Before
+    public void setTimeZoneToUTC() {
+        System.setProperty("user.timezone", "UTC");
+    }
 
     @Test
     public void serialize_changeSet() {
@@ -56,7 +66,7 @@ public class JsonChangeLogSerializerTest {
                 "            },\n" +
                 "            {\n" +
                 "              \"column\": {\n" +
-                "                \"defaultValueDate\": 1970-01-01T00:00:00Z,\n" +
+                "                \"defaultValueDate\": \"1970-01-01T00:00:00\",\n" +
                 "                \"name\": \"col2\"\n" +
                 "              }\n" +
                 "            },\n" +
@@ -72,5 +82,10 @@ public class JsonChangeLogSerializerTest {
                 "    \n" +
                 "  }\n" +
                 "}\n", new JsonChangeLogSerializer().serialize(changeSet, true));
+    }
+
+    @After
+    public void setTimeZoneBackToDefault() {
+        System.setProperty("user.timezone", origTimeZone);
     }
 }

--- a/liquibase-core/src/test/java/liquibase/serializer/core/json/JsonChangeLogSerializerTest.java
+++ b/liquibase-core/src/test/java/liquibase/serializer/core/json/JsonChangeLogSerializerTest.java
@@ -11,7 +11,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Date;
-import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 

--- a/liquibase-core/src/test/java/liquibase/util/ISODateFormatTest.java
+++ b/liquibase-core/src/test/java/liquibase/util/ISODateFormatTest.java
@@ -7,30 +7,35 @@ import java.util.Date;
 import static org.junit.Assert.assertEquals;
 
 public class ISODateFormatTest {
+
+    private ISODateFormat dateFormat = new ISODateFormat();
+
     @Test
     public void isoDateFormatWithNoLeadingZeroFractions() throws Exception {
-        ISODateFormat dateFormat = new ISODateFormat();
         Date date = dateFormat.parse("2012-09-12T09:47:54.664");
         assertEquals("2012-09-12T09:47:54.664", dateFormat.format(date));
     }
 
     @Test
     public void isoDateFormatWithLeadingZeroFractions() throws Exception {
-        ISODateFormat dateFormat = new ISODateFormat();
         Date date = dateFormat.parse("2011-04-21T10:13:40.044");
         assertEquals("2011-04-21T10:13:40.044", dateFormat.format(date));
     }
 
     @Test
     public void isoDateFormatWithLeadingNoFractions() throws Exception {
-        ISODateFormat dateFormat = new ISODateFormat();
         Date date = dateFormat.parse("2011-04-21T10:13:40");
         assertEquals("2011-04-21T10:13:40", dateFormat.format(date));
     }
 
     @Test
+    public void isoDateFormatWithLeadingFractions() throws Exception {
+        Date date = dateFormat.parse("2011-04-21T10:13:40.12");
+        assertEquals("2011-04-21T10:13:40.12", dateFormat.format(date));
+    }
+
+    @Test
     public void isoDateFormatWithLeadingNanoFractions() throws Exception {
-        ISODateFormat dateFormat = new ISODateFormat();
         Date date = dateFormat.parse("2011-04-21T10:13:40.01234567");
         assertEquals("2011-04-21T10:13:40.01234567", dateFormat.format(date));
     }


### PR DESCRIPTION
I want to share my fix for the timestamp handling whenever the change log created via liquibase contains values with fractional seconds less than 3 digits; in this case the current implementation in the corresponding "insert" always add leading zeros (e.g. 2017-01-10 10:34:12.34 -> 2017-01-10 10:34:12.[**0**]34.

My solution is to override the getSerializableFieldValue in the ColumnConfig class, using liquibase's ISODateFormat. ISODateFormat now uses java.util.Date as a fallback in the format method.

As a side effect that changes the output format in the change logs which works well for me, but I am not sure about backwards compatibility. I also had to fix the timezone for the JsonChangeLogSerializerTest.e 

I would kindly ask you to review this PR and let me know whether that this can be merged. 