### PR TITLE
CORE-3006 Oracle CSV-Import: "String index out of range: -1"

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
@@ -258,8 +258,10 @@ public class OracleDatabase extends AbstractJdbcDatabase {
             val.append(", 'YYYY-MM-DD HH24:MI:SS.FF')");
             return val.toString();
         } else if (isDateTime(isoDate)) {
-            normalLiteral = normalLiteral.substring(0, normalLiteral.lastIndexOf('.')) + "'";
-
+            int idx = normalLiteral.lastIndexOf('.');
+            if( idx != -1 ) {
+              normalLiteral = normalLiteral.substring(0, idx) + "'";
+            }
             StringBuffer val = new StringBuffer(26);
             val.append("to_date(");
             val.append(normalLiteral);


### PR DESCRIPTION
Prevention of error "String index out of range: -1" for timestamps with 0 nanoseconds, e.g. "2011-01-01T00:00:00.0"

With Liquibase 3.6.0-SNP the CSV import aborts with an error. This error was caused by commit 1f20d13ecb6c0aa66a0e66d9db0cfe38fb2d28c0

Unexpected error running Liquibase: String index out of range: -1

2017-02-01 14:25:06,465 FATAL String index out of range: -1
liquibase.exception.MigrationFailedException: Migration failed for change set latest/data.xml::fill-c_messg::latest:
     Reason: java.lang.StringIndexOutOfBoundsException: String index out of range: -1
	at liquibase.changelog.ChangeSet.execute(ChangeSet.java:626)
	at liquibase.changelog.visitor.UpdateVisitor.visit(UpdateVisitor.java:51)
	at liquibase.changelog.ChangeLogIterator.run(ChangeLogIterator.java:79)
	at liquibase.Liquibase.update(Liquibase.java:218)
	at liquibase.Liquibase.update(Liquibase.java:196)
	at liquibase.integration.commandline.Main.doMigration(Main.java:1135)
	at liquibase.integration.commandline.Main.run(Main.java:190)
	at liquibase.integration.commandline.Main.main(Main.java:105)
	at de.hpa.bpe.env.tools.BpeDatabaseUpdater.runLiquibaseCommand(BpeDatabaseUpdater.java:266)
	at de.hpa.bpe.env.tools.BpeDatabaseUpdater.run(BpeDatabaseUpdater.java:254)
	at de.hpa.bpe.env.tools.BpeDatabaseUpdater.main(BpeDatabaseUpdater.java:99)
Caused by: java.lang.StringIndexOutOfBoundsException: String index out of range: -1
	at java.lang.String.substring(String.java:1967)
	at liquibase.database.core.OracleDatabase.getDateLiteral(OracleDatabase.java:262)
	at liquibase.database.AbstractJdbcDatabase.getDateTimeLiteral(AbstractJdbcDatabase.java:443)
	at liquibase.database.AbstractJdbcDatabase.getDateLiteral(AbstractJdbcDatabase.java:463)
	at liquibase.sqlgenerator.core.InsertGenerator.generateValues(InsertGenerator.java:76)
	at liquibase.sqlgenerator.core.InsertGenerator.generateSql(InsertGenerator.java:42)
	at liquibase.sqlgenerator.core.InsertGenerator.generateSql(InsertGenerator.java:16)
	at liquibase.sqlgenerator.SqlGeneratorChain.generateSql(SqlGeneratorChain.java:30)
	at liquibase.sqlgenerator.SqlGeneratorFactory.generateSql(SqlGeneratorFactory.java:225)
	at liquibase.executor.AbstractExecutor.applyVisitors(AbstractExecutor.java:25)
	at liquibase.executor.jvm.JdbcExecutor.access$500(JdbcExecutor.java:36)
	at liquibase.executor.jvm.JdbcExecutor$ExecuteStatementCallback.doInStatement(JdbcExecutor.java:295)
	at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:55)
	at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:113)
	at liquibase.database.AbstractJdbcDatabase.execute(AbstractJdbcDatabase.java:1277)
	at liquibase.database.AbstractJdbcDatabase.executeStatements(AbstractJdbcDatabase.java:1259)
	at liquibase.changelog.ChangeSet.execute(ChangeSet.java:589)
	... 10 more