### PR TITLE
 CORE-3005 Consideration of DB2 system views

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/DB2Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/DB2Database.java
@@ -20,9 +20,23 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.HashSet;
+import java.util.Set;
 
 public class DB2Database extends AbstractJdbcDatabase {
 
+    private static final Set<String> systemTablesAndViews;
+
+    static {
+    	systemTablesAndViews = new HashSet<String>();
+      systemTablesAndViews.add("SYSCHKCST");
+      systemTablesAndViews.add("SYSCST");
+      systemTablesAndViews.add("SYSCSTCOL");
+      systemTablesAndViews.add("SYSCSTDEP");
+      systemTablesAndViews.add("SYSKEYCST");
+      systemTablesAndViews.add("SYSREFCST");
+    }
+    
     private DataServerType dataServerType;
     
     public static enum DataServerType {
@@ -293,5 +307,10 @@ public class DB2Database extends AbstractJdbcDatabase {
             return true;
         }
         return super.isSystemObject(example);
+    }
+
+   	@Override
+    public Set<String> getSystemViews() {
+        return systemTablesAndViews;
     }
 }


### PR DESCRIPTION
During the dropAll command Liquibase tries to delete DB2 system views. The following views are not deleteable and should be omited:

* SYSCHKCST
* SYSCST
* SYSCSTCOL
* SYSCSTDEP
* SYSKEYCST
* SYSREFCST
  