### PR TITLE
CORE-1852 checksum depends on line endings and startCommentSymbol

### DIFF
--- a/liquibase-core/src/main/java/liquibase/io/EmptyLineAndCommentSkippingInputStream.java
+++ b/liquibase-core/src/main/java/liquibase/io/EmptyLineAndCommentSkippingInputStream.java
@@ -33,20 +33,24 @@ public class EmptyLineAndCommentSkippingInputStream extends BufferedInputStream 
     @Override
     public synchronized int read() throws IOException {
         int read = super.read();
+
+        // skip comment
+        if (commentSkipEnabled && read == this.commentLineStartsWith.toCharArray()[0]) {
+            while ((read = super.read()) != '\n' && read != '\r' && read > 0) {
+                ;//keep looking
+            }
+        }
+
         if (read < 0) {
             return read;
         }
         if (read == '\r') {
             return this.read();
-        } else if (read == '\n') {
+        }
+        if (read == '\n') {
             if (lastRead == '\n') {
                 return this.read();
             }
-        } else if (commentSkipEnabled && read == this.commentLineStartsWith.toCharArray()[0]) {
-            while ((read = super.read()) != '\n' && read != '\r' && read > 0) {
-                ;//keep looking
-            }
-            read = this.read(); //read past newline
         }
 
         if (read == '\n') {

--- a/liquibase-core/src/test/groovy/liquibase/io/EmptyLineAndCommentSkippingInputStreamTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/io/EmptyLineAndCommentSkippingInputStreamTest.groovy
@@ -1,7 +1,5 @@
 package liquibase.io
 
-import liquibase.util.StreamUtil
-import org.apache.log4j.Logger
 import spock.lang.Specification
 import spock.lang.Unroll
 

--- a/liquibase-core/src/test/groovy/liquibase/io/EmptyLineAndCommentSkippingInputStreamTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/io/EmptyLineAndCommentSkippingInputStreamTest.groovy
@@ -1,6 +1,7 @@
 package liquibase.io
 
 import liquibase.util.StreamUtil
+import org.apache.log4j.Logger
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -52,8 +53,12 @@ class EmptyLineAndCommentSkippingInputStreamTest extends Specification {
         expect:
         inputStreamToString(new EmptyLineAndCommentSkippingInputStream(getClass().getResourceAsStream("/liquibase/change/core/sample.data1-withComments.csv"), COMMENT_CHAR)) ==
         inputStreamToString(new EmptyLineAndCommentSkippingInputStream(getClass().getResourceAsStream("/liquibase/change/core/sample.data1-removedComments.csv"), COMMENT_CHAR))
+    }
 
-
+    def "Line endings in csv-files with comments"() {
+        expect:
+        inputStreamToString(new EmptyLineAndCommentSkippingInputStream(new ByteArrayInputStream("a#comment\r\nb\r\n\r\nc".getBytes()), COMMENT_CHAR)) ==
+        inputStreamToString(new EmptyLineAndCommentSkippingInputStream(new ByteArrayInputStream("a#comment\nb\n\nc".getBytes()), COMMENT_CHAR))
     }
 
     private String inputStreamToString(InputStream inputStreamWithComments) {


### PR DESCRIPTION
Line endings are not processed correct in comment strings. 
Wrote test with different line endings for windows/unix while parsing csv.