### PR TITLE
Corrected documentation errors in AbstractLiquibaseMojo.java

### DIFF
--- a/liquibase-cdi/src/main/java/liquibase/integration/cdi/CDILiquibaseConfig.java
+++ b/liquibase-cdi/src/main/java/liquibase/integration/cdi/CDILiquibaseConfig.java
@@ -1,7 +1,5 @@
 package liquibase.integration.cdi;
 
-import liquibase.resource.ResourceAccessor;
-
 import java.util.Map;
 
 /**

--- a/liquibase-cdi/src/main/java/liquibase/integration/cdi/annotations/LiquibaseType.java
+++ b/liquibase-cdi/src/main/java/liquibase/integration/cdi/annotations/LiquibaseType.java
@@ -11,7 +11,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Qualifier Annontation
+ * Qualifier Annotation
  *
  *  @author Aaron Walker (http://github.com/aaronwalker)
  */

--- a/liquibase-cdi/src/test/java/liquibase/integration/cdi/CDITestProducer.java
+++ b/liquibase-cdi/src/test/java/liquibase/integration/cdi/CDITestProducer.java
@@ -4,15 +4,10 @@ import liquibase.integration.cdi.annotations.LiquibaseType;
 import liquibase.resource.ClassLoaderResourceAccessor;
 import liquibase.resource.ResourceAccessor;
 import org.hsqldb.jdbc.JDBCDataSource;
-import org.jboss.weld.resources.ClassLoaderResourceLoader;
 
 import javax.enterprise.inject.Produces;
 import javax.sql.DataSource;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
 import java.sql.SQLException;
-import java.util.Enumeration;
 
 /**
  * A Test CDI Producer used for testing CDILiquibase

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
@@ -200,7 +200,7 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
     protected boolean propertyFileWillOverride;
 
     /**
-     * Flag for forcing the checksums to be cleared from teh DatabaseChangeLog table.
+     * Flag for forcing the checksums to be cleared from the DatabaseChangeLog table.
      *
      * @parameter expression="${liquibase.clearCheckSums}" default-value="false"
      */
@@ -235,10 +235,10 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
     private Properties expressionVars;
 
     /**
-     * Set this to 'false' to skip running liquibase. Its use is NOT RECOMMENDED, but quite
+     * Set this to 'true' to skip running liquibase. Its use is NOT RECOMMENDED, but quite
      * convenient on occasion.
      *
-     * @parameter expression="${liquibase.skip}"
+     * @parameter expression="${liquibase.skip}" default-value="false"
      */
     protected boolean skip = false;
 

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
@@ -545,7 +545,7 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
     }
 
     /**
-     * Parses a properties file and sets the assocaited fields in the plugin.
+     * Parses a properties file and sets the associated fields in the plugin.
      *
      * @param propertiesInputStream The input stream which is the Liquibase properties that
      *                              needs to be parsed.

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseDropAll.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseDropAll.java
@@ -2,7 +2,6 @@ package org.liquibase.maven.plugins;
 
 import liquibase.CatalogAndSchema;
 import liquibase.Liquibase;
-import liquibase.structure.core.Schema;
 import liquibase.exception.LiquibaseException;
 
 import java.util.ArrayList;

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseMigrate.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseMigrate.java
@@ -21,7 +21,7 @@ public class LiquibaseMigrate extends AbstractLiquibaseUpdateMojo {
   @Override
   public void configureFieldsAndValues(ResourceAccessor fo)
           throws MojoExecutionException, MojoFailureException {
-    getLog().warn("This plugin goal is DEPRICATED and will be removed in a future "
+    getLog().warn("This plugin goal is DEPRECATED and will be removed in a future "
                   + "release, please use \"update\" instead of \"migrate\".");
     super.configureFieldsAndValues(fo);
   }

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseMigrateSQL.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseMigrateSQL.java
@@ -37,7 +37,7 @@ public class LiquibaseMigrateSQL extends AbstractLiquibaseUpdateMojo {
   @Override
   public void configureFieldsAndValues(ResourceAccessor fo)
           throws MojoExecutionException, MojoFailureException {
-    getLog().warn("This plugin goal is DEPRICATED and will bre removed in a future "
+    getLog().warn("This plugin goal is DEPRECATED and will bre removed in a future "
                   + "release, please use \"updateSQL\" instead of \"migrateSQL\".");
     super.configureFieldsAndValues(fo);
   }

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseRollback.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseRollback.java
@@ -13,7 +13,8 @@ import liquibase.util.ISODateFormat;
 import org.apache.maven.plugin.MojoFailureException;
 
 /**
- * Invokes Liquibase rollbacks on a database.
+ * Invokes Liquibase rollbacks the database to the specified using
+ * pointing attributes 'rollbackCount', 'rollbackTag' and/or 'rollbackDate'
  * @author Peter Murray
  * @goal rollback
  */

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseRollbackSQL.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseRollbackSQL.java
@@ -1,12 +1,9 @@
 package org.liquibase.maven.plugins;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
-import java.text.DateFormat;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 
 import liquibase.Contexts;
 import liquibase.LabelExpression;
@@ -18,9 +15,9 @@ import liquibase.resource.ResourceAccessor;
 import org.apache.maven.plugin.MojoExecutionException;
 
 /**
- * Generates the SQL that is required to rollback the database to the specified
- * pointing attributes 'rollbackCount', 'rollbackTag'
- * 
+ * Generates the SQL that is required to rollback the database using one or more of the specified
+ * attributes 'rollbackCount', 'rollbackTag' and/or 'rollbackDate'
+ *
  * @author Oleg Taranenko
  * @description Liquibase RollbackSQL Maven plugin
  * @goal rollbackSQL

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseTag.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseTag.java
@@ -13,6 +13,8 @@ import org.apache.maven.plugin.MojoFailureException;
 public class LiquibaseTag extends AbstractLiquibaseMojo {
 
   /**
+   * The text to write to the databasechangelog.
+   *
    * @parameter expression="${liquibase.tag}"
    * @required
    */

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/MavenUtils.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/MavenUtils.java
@@ -38,7 +38,7 @@ public class MavenUtils {
                                                    boolean verbose)
           throws MalformedURLException {
     if (verbose) {
-      log.info("Loading artfacts into URLClassLoader");
+      log.info("Loading artifacts into URLClassLoader");
     }
     Set<URI> uris = new HashSet<URI>();
     // Find project dependencies, including the transitive ones.
@@ -55,7 +55,7 @@ public class MavenUtils {
     if (includeArtifact) {
       // If the actual artifact can be resolved, then use that, otherwise use the build
       // directory as that should contain the files for this project that we will need to
-      // run against. It is possible that the build directy could be empty, but we cannot
+      // run against. It is possible that the build directly could be empty, but we cannot
       // directly include the source and resources as the resources may require filtering
       // to replace any placeholders in the resource files.
       Artifact a = project.getArtifact();
@@ -83,7 +83,7 @@ public class MavenUtils {
   /**
    * Adds the artifact file into the set of URLs so it can be used in a URLClassLoader.
    * @param urls The set to add the artifact file URL to.
-   * @param artifact The Artifiact to resolve the file for.
+   * @param artifact The Artifact to resolve the file for.
    * @throws MalformedURLException If there is a problem creating the URL for the file.
    */
   private static void addArtifact(Set<URI> urls,

--- a/liquibase-maven-plugin/src/test/java/org/liquibase/maven/plugins/LiquibaseUpdateMojoTest.java
+++ b/liquibase-maven-plugin/src/test/java/org/liquibase/maven/plugins/LiquibaseUpdateMojoTest.java
@@ -38,7 +38,7 @@ public class LiquibaseUpdateMojoTest extends AbstractLiquibaseMojoTest {
     checkValues(DEFAULT_PROPERTIES, values);
   }
 
-  public void testOverideAllWithPropertiesFile() throws Exception {
+  public void testOverrideAllWithPropertiesFile() throws Exception {
     // Create the properties file for this test
     Properties props = new Properties();
     props.setProperty("driver", "properties_driver_value");


### PR DESCRIPTION
Corrected documentation type-o on line 203 "teh" is now "the".
Corrected the skip documentation default value is false.  Lines 238 & 241