### PR TITLE
Fixed FindForeignKeyConstraintsGeneratorDerby

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/FindForeignKeyConstraintsGeneratorDerby.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/FindForeignKeyConstraintsGeneratorDerby.java
@@ -52,7 +52,9 @@ public class FindForeignKeyConstraintsGeneratorDerby extends AbstractSqlGenerato
 		sb.append("JOIN sys.syskeys k ON co2.constraintid = k.constraintid ");
 		sb.append("JOIN sys.sysconglomerates cg2 ON k.conglomerateid = cg2.conglomerateid ");
 		sb.append("WHERE co.type = 'F' ");
-		sb.append("AND sc.schemaname = '").append(schema.getCatalogName()).append("' ");
+		if (schema.getCatalogName() != null) {
+		  sb.append("AND sc.schemaname = '").append(schema.getCatalogName()).append("' ");
+		}
 		sb.append("AND t.tablename = '").append(statement.getBaseTableName()).append("'");
 		return new Sql[] {
 				new UnparsedSql(sb.toString())


### PR DESCRIPTION
I ran a changeset with dropAllForeignKeyConstraints against a derby database and soon realized that the foreign keys weren't actually dropped. The reason is the following line in the FindForeignKeyConstraintsStatementGeneratorDerby:

sb.append("AND sc.schemaname = '").append(schema.getCatalogName()).append("' ");

If the default catalog name is used, AND sc.schemaname = '' gets appended to the SQL string, which is wrong. If no catalog name is provided, the same faulty SQL is generated:

SELECT co.constraintname AS CONSTRAINT_NAME, t.tablename AS TABLE_NAME, t2.tablename AS REFERENCED_TABLE_NAME FROM sys.sysconstraints co JOIN sys.sysschemas sc ON co.schemaid = sc.schemaid JOIN sys.systables t ON co.tableid = t.tableid JOIN sys.sysforeignkeys f ON co.constraintid = f.constraintid JOIN sys.sysconglomerates cg ON f.conglomerateid = cg.conglomerateid JOIN sys.sysconstraints co2 ON f.keyconstraintid = co2.constraintid JOIN sys.systables t2 ON co2.tableid = t2.tableid JOIN sys.syskeys k ON co2.constraintid = k.constraintid JOIN sys.sysconglomerates cg2 ON k.conglomerateid = cg2.conglomerateid WHERE co.type = 'F' AND sc.schemaname = '' AND t.tablename = 'my_table_name'

Only appending    AND sc.schemaname = ''    if a catalog name is present does the trick.