### PR TITLE
Mark failed changeset executions in the databasechangelog

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/visitor/UpdateVisitor.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/visitor/UpdateVisitor.java
@@ -51,6 +51,7 @@ public class UpdateVisitor implements ChangeSetVisitor {
             execType = changeSet.execute(databaseChangeLog, execListener, this.database);
         } catch (MigrationFailedException e) {
             fireRunFailed(changeSet, databaseChangeLog, database, e);
+            this.database.markChangeSetExecStatus(changeSet, ExecType.FAILED);
             throw e;
         }
         if (!runStatus.equals(ChangeSet.RunStatus.NOT_RAN)) {

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/MarkChangeSetRanGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/MarkChangeSetRanGenerator.java
@@ -38,7 +38,7 @@ public class MarkChangeSetRanGenerator extends AbstractSqlGenerator<MarkChangeSe
 
         SqlStatement runStatement;
         try {
-            if (statement.getExecType().equals(ChangeSet.ExecType.FAILED) || statement.getExecType().equals(ChangeSet.ExecType.SKIPPED)) {
+            if (statement.getExecType().equals(ChangeSet.ExecType.SKIPPED)) {
                 return new Sql[0]; //don't mark
             }
 


### PR DESCRIPTION
This is how we've been doing it in our project for a long time now. It allows us and our customer to view the status of all changes after an update.



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-106) by [Unito](https://www.unito.io/learn-more)
