### PR TITLE
validation error on empty column name in CreateIndexChange (CORE-3014)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/CreateIndexChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/CreateIndexChange.java
@@ -2,6 +2,7 @@ package liquibase.change.core;
 
 import liquibase.change.*;
 import liquibase.database.Database;
+import liquibase.exception.ValidationErrors;
 import liquibase.snapshot.SnapshotGeneratorFactory;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.CreateIndexStatement;
@@ -221,5 +222,20 @@ public class CreateIndexChange extends AbstractChange implements ChangeWithColum
 
         }
         return value;
+    }
+
+    @Override
+    public ValidationErrors validate(Database database) {
+        ValidationErrors validationErrors = new ValidationErrors();
+        validationErrors.addAll(super.validate(database));
+
+        if (columns != null) {
+            for (ColumnConfig columnConfig : columns) {
+                if (columnConfig.getName() == null) {
+                    validationErrors.addError("column 'name' is required for all columns in an index");
+                }
+            }
+        }
+        return validationErrors;
     }
 }

--- a/liquibase-core/src/test/groovy/liquibase/change/core/CreateIndexChangeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/core/CreateIndexChangeTest.groovy
@@ -52,4 +52,21 @@ public class CreateIndexChangeTest extends StandardChangeTest {
         assert change.checkStatus(database).status == ChangeStatus.Status.complete
 
     }
+
+    def "validationErrorOnEmptyColumn"(){
+        when:
+        def database = new MockDatabase()
+        def snapshotFactory = new MockSnapshotGeneratorFactory()
+        SnapshotGeneratorFactory.instance = snapshotFactory
+
+        def index = new Index("idx_test", null, null, "test_table", new Column("test_col"))
+
+        def change = new CreateIndexChange()
+        change.indexName = index.name
+        change.tableName = index.table.name
+        change.columns = [new AddColumnConfig().setName(null)]
+
+        then:
+        assert change.validate(database).getErrorMessages().size() == 1
+    }
 }


### PR DESCRIPTION
Adds a validation error if you provided an empty column name in a CreateIndexChange. Fixes https://liquibase.jira.com/browse/CORE-3014. 