### PR TITLE
Adding logic to persist full hierarchy of context expressions into databasechangelog table

### DIFF
--- a/liquibase-core/src/main/java/liquibase/ContextExpression.java
+++ b/liquibase-core/src/main/java/liquibase/ContextExpression.java
@@ -3,8 +3,11 @@ package liquibase;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.util.StringUtils;
 
-import java.text.ParseException;
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -53,16 +53,26 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
     private boolean ignoreClasspathPrefix = false;
 
     private DatabaseChangeLog rootChangeLog = ROOT_CHANGE_LOG.get();
+
     private DatabaseChangeLog parentChangeLog = PARENT_CHANGE_LOG.get();
 
     private ContextExpression contexts;
+
     private ContextExpression includeContexts;
 
     public DatabaseChangeLog() {
     }
 
+    public void setRootChangeLog(DatabaseChangeLog rootChangeLog) {
+        this.rootChangeLog = rootChangeLog;
+    }
+
     public DatabaseChangeLog getRootChangeLog() {
         return rootChangeLog != null ? rootChangeLog : this;
+    }
+
+    public void setParentChangeLog(DatabaseChangeLog parentChangeLog) {
+        this.parentChangeLog = parentChangeLog;
     }
 
     public DatabaseChangeLog getParentChangeLog() {

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/MarkChangeSetRanGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/MarkChangeSetRanGenerator.java
@@ -1,5 +1,6 @@
 package liquibase.sqlgenerator.core;
 
+import liquibase.ContextExpression;
 import liquibase.change.Change;
 import liquibase.change.core.TagDatabaseChange;
 import liquibase.changelog.ChangeLogHistoryServiceFactory;
@@ -21,6 +22,12 @@ import liquibase.util.LiquibaseUtil;
 import liquibase.util.StringUtils;
 
 public class MarkChangeSetRanGenerator extends AbstractSqlGenerator<MarkChangeSetRanStatement> {
+
+    public static final String AND = " AND ";
+    public static final String OPEN_BRACKET = "(";
+    public static final String CLOSE_BRACKET = ")";
+    public static final String WHITESPACE = " ";
+    public static final String COMMA = ",";
 
     @Override
     public ValidationErrors validate(MarkChangeSetRanStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
@@ -58,8 +65,8 @@ public class MarkChangeSetRanGenerator extends AbstractSqlGenerator<MarkChangeSe
                         .addNewColumnValue("EXECTYPE", statement.getExecType().value)
                         .addNewColumnValue("DEPLOYMENT_ID", ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database).getDeploymentId())
                         .setWhereClause(database.escapeObjectName("ID", Column.class) + " = ? " +
-                                "AND " + database.escapeObjectName("AUTHOR", Column.class) + " = ? " +
-                                "AND " + database.escapeObjectName("FILENAME", Column.class) + " = ?")
+                                                "AND " + database.escapeObjectName("AUTHOR", Column.class) + " = ? " +
+                                                "AND " + database.escapeObjectName("FILENAME", Column.class) + " = ?")
                         .addWhereParameters(changeSet.getId(), changeSet.getAuthor(), changeSet.getFilePath());
 
                 if (tag != null) {
@@ -76,10 +83,10 @@ public class MarkChangeSetRanGenerator extends AbstractSqlGenerator<MarkChangeSe
                         .addColumnValue("DESCRIPTION", limitSize(changeSet.getDescription()))
                         .addColumnValue("COMMENTS", limitSize(StringUtils.trimToEmpty(changeSet.getComments())))
                         .addColumnValue("EXECTYPE", statement.getExecType().value)
-                        .addColumnValue("CONTEXTS", changeSet.getContexts() == null || changeSet.getContexts().isEmpty()? null : changeSet.getContexts().toString())
+                        .addColumnValue("CONTEXTS", changeSet.getContexts() == null || changeSet.getContexts().isEmpty() ? null : buildFullContext(changeSet))
                         .addColumnValue("LABELS", changeSet.getLabels() == null || changeSet.getLabels().isEmpty() ? null : changeSet.getLabels().toString())
                         .addColumnValue("LIQUIBASE", LiquibaseUtil.getBuildVersion().replaceAll("SNAPSHOT", "SNP"))
-                .addColumnValue("DEPLOYMENT_ID", ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database).getDeploymentId());
+                        .addColumnValue("DEPLOYMENT_ID", ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database).getDeploymentId());
 
                 if (tag != null) {
                     ((InsertStatement) runStatement).addColumnValue("TAG", tag);
@@ -90,6 +97,34 @@ public class MarkChangeSetRanGenerator extends AbstractSqlGenerator<MarkChangeSe
         }
 
         return SqlGeneratorFactory.getInstance().generateSql(runStatement, database);
+    }
+
+    private String buildFullContext(ChangeSet changeSet) {
+        StringBuilder contextExpression = new StringBuilder();
+        boolean notFirstContext = false;
+        for (ContextExpression inheritableContext : changeSet.getInheritableContexts()) {
+            appendContext(contextExpression, inheritableContext.toString(), notFirstContext);
+            notFirstContext = true;
+        }
+        ContextExpression changeSetContext = changeSet.getContexts();
+        if (changeSetContext != null && !changeSetContext.isEmpty()) {
+            appendContext(contextExpression, changeSetContext.toString(), notFirstContext);
+        }
+        return contextExpression.toString();
+    }
+
+    private void appendContext(StringBuilder contextExpression, String contextToAppend, boolean notFirstContext) {
+        boolean complexExpression = contextToAppend.contains(COMMA) || contextToAppend.contains(WHITESPACE);
+        if (notFirstContext) {
+            contextExpression.append(AND);
+        }
+        if (complexExpression) {
+            contextExpression.append(OPEN_BRACKET);
+        }
+        contextExpression.append(contextToAppend);
+        if (complexExpression) {
+            contextExpression.append(CLOSE_BRACKET);
+        }
     }
 
     private String limitSize(String string) {

--- a/liquibase-core/src/test/java/liquibase/sqlgenerator/core/MarkChangeSetRanGeneratorTest.java
+++ b/liquibase-core/src/test/java/liquibase/sqlgenerator/core/MarkChangeSetRanGeneratorTest.java
@@ -1,6 +1,8 @@
 package liquibase.sqlgenerator.core;
 
+import liquibase.ContextExpression;
 import liquibase.changelog.ChangeSet;
+import liquibase.changelog.DatabaseChangeLog;
 import liquibase.sdk.database.MockDatabase;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.AbstractSqlGeneratorTest;
@@ -26,5 +28,23 @@ public class MarkChangeSetRanGeneratorTest extends AbstractSqlGeneratorTest<Mark
         Sql[] sqls = new MarkChangeSetRanGenerator().generateSql(new MarkChangeSetRanStatement(new ChangeSet("1", "a", false, false, "c", null, null, null), ChangeSet.ExecType.MARK_RAN), new MockDatabase(), new MockSqlGeneratorChain());
         assertEquals(1, sqls.length);
         assertTrue(sqls[0].toSql(), sqls[0].toSql().contains("MARK_RAN"));
+    }
+
+    @Test
+    public void generateSqlWithComplexContext() {
+        String changeSetContextExpression = "changeSetContext1 AND changeSetContext2";
+        DatabaseChangeLog rootChangeLog = new DatabaseChangeLog();
+        rootChangeLog.setContexts(new ContextExpression("rootContext1 OR (rootContext2) AND (rootContext3)"));
+        DatabaseChangeLog childChangeLog = new DatabaseChangeLog();
+        childChangeLog.setContexts(new ContextExpression("childChangeLogContext1, childChangeLogContext2 AND childChangeLogContext3"));
+        childChangeLog.setIncludeContexts(new ContextExpression("includeContext1, includeContext2 AND includeContext3"));
+        childChangeLog.setParentChangeLog(rootChangeLog);
+        ChangeSet changeSet = new ChangeSet("1", "a", false, false, "c", changeSetContextExpression, null, childChangeLog);
+
+        Sql[] sqls = new MarkChangeSetRanGenerator().generateSql(new MarkChangeSetRanStatement(changeSet, ChangeSet.ExecType.EXECUTED), new MockDatabase(), new MockSqlGeneratorChain());
+        assertTrue(sqls[0].toSql(), sqls[0].toSql().contains("(childChangeLogContext1, childChangeLogContext2 AND childChangeLogContext3) AND " +
+                                                                     "(includeContext1, includeContext2 AND includeContext3) AND " +
+                                                                     "(rootContext1 OR (rootContext2) AND (rootContext3)) AND " +
+                                                                     "(changeSetContext1 AND changeSetContext2)"));
     }
 }


### PR DESCRIPTION
You can also take a look at: http://stackoverflow.com/questions/43032168/context-attribute-in-include-includeall-is-not-persisted-in-databasechangelog

@mches, @nvoxland, your review will be highly appreciated.

For several reasons, we decided to stick to a formatted SQL format and since it doesn't support 'tag' attribute, we want to at least be able to track every context applied to a changeSet(fine-grained use for different environments including Production).
I know that adding something similar for 'label' is also under consideration, but it is more critical for 'context', I believe, simply because the hierarchy of 'contexts' is more compler and more difficult to trace.