### PR TITLE
Sets class name in CustomWrapper classes must be normalized.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/custom/CustomChangeWrapper.java
+++ b/liquibase-core/src/main/java/liquibase/change/custom/CustomChangeWrapper.java
@@ -72,6 +72,10 @@ public class CustomChangeWrapper extends AbstractChange {
         this.classLoader = classLoader;
     }
 
+    public CustomChangeWrapper setClassName(String className) throws CustomChangeException {
+        return setClass(className);
+    }
+
     /**
      * Specify the name of the class to use as the CustomChange. This method instantiates the class using {@link #getClassLoader()} or fallback methods
      * and assigns it to {@link #getCustomChange()}.

--- a/liquibase-core/src/main/java/liquibase/precondition/CustomPreconditionWrapper.java
+++ b/liquibase-core/src/main/java/liquibase/precondition/CustomPreconditionWrapper.java
@@ -30,6 +30,10 @@ public class CustomPreconditionWrapper extends AbstractPrecondition {
         this.className = className;
     }
 
+    public void setClass(String className) {
+        this.className = className;
+    }
+
     public ClassLoader getClassLoader() {
         return classLoader;
     }


### PR DESCRIPTION
To set the class name in the custom wrapper, you must call 'setClass' or 'setClassName' depending on the custom wrapper class. This pull request normalized this so both custom wrapper can be called with 'setClass' or 'setClassName'.