### PR TITLE
CORE-3050 Do not build string to check StringBuilder is empty

### DIFF
--- a/liquibase-core/src/main/java/liquibase/util/StringUtils.java
+++ b/liquibase-core/src/main/java/liquibase/util/StringUtils.java
@@ -56,7 +56,7 @@ public class StringUtils {
                 previousDelimiter = true;
             } else {
                 if (!previousDelimiter || StringUtils.trimToNull((String) piece) != null) { //don't include whitespace after a delimiter
-                    if (!currentString.toString().equals("") || StringUtils.trimToNull((String) piece) != null) { //don't include whitespace before the statement
+                    if (currentString.length() > 0 || StringUtils.trimToNull((String) piece) != null) { //don't include whitespace before the statement
                         currentString.append(piece);
                     }
                 }


### PR DESCRIPTION
See https://liquibase.jira.com/browse/CORE-3050.

Fix performance regression introduced by commit https://github.com/liquibase/liquibase/commit/59b5496832e829ba8943fb1da064ad1179a0ec4d.

This commit fixed a bug, but introduced a huge performance regression on big SQL scripts.