### PR TITLE
CORE-3059 Fix path handling for ClassLoaderResourceAccessor

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -457,13 +457,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
 
         String relativeBaseFileName = this.getPhysicalFilePath();
         if (isRelativePath) {
-            // workaround for FilenameUtils.normalize() returning null for relative paths like ../conf/liquibase.xml
-            String tempFile = FilenameUtils.concat(FilenameUtils.getFullPath(relativeBaseFileName), fileName);
-            if (tempFile != null && new File(tempFile).exists() == true) {
-                fileName = tempFile;
-            } else {
-                fileName = FilenameUtils.getFullPath(relativeBaseFileName) + fileName;
-            }
+            fileName = FilenameUtils.concat(FilenameUtils.getFullPath(relativeBaseFileName), fileName);
         }
         DatabaseChangeLog changeLog;
         try {


### PR DESCRIPTION
DatabaseChangeLog.include used new File(tempFile).exists() to check if
a relative path obtained from FilenameUtils.concat is valid. When
accessing a resource in a jar file, that check fails although the path
looked perfectly okay. The workaround path handling however constructs
a path by simply concatenating relativePath to basePath. Relative
paths like ../rel/ChangeLog.xml were not handled correctly.