### PR TITLE
CORE-3063 integration tests that cannot connect should be Ignored not Passed

### DIFF
--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
@@ -52,6 +52,7 @@ import java.util.*;
 
 import static junit.framework.Assert.*;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assume.assumeNotNull;
 
 /**
  * Base class for all database integration tests.  There is an AbstractIntegrationTest subclass for each supported database.
@@ -188,9 +189,7 @@ public abstract class AbstractIntegrationTest {
 
     @Test
     public void testRunChangeLog() throws Exception {
-        if (database == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
 
         runCompleteChangeLog();
     }
@@ -222,9 +221,7 @@ public abstract class AbstractIntegrationTest {
 
     @Test
     public void runUpdateOnOldChangelogTableFormat() throws Exception {
-        if (database == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
         Liquibase liquibase = createLiquibase(completeChangeLog);
         clearDatabase(liquibase);
 
@@ -247,9 +244,7 @@ public abstract class AbstractIntegrationTest {
 
     @Test
     public void testOutputChangeLog() throws Exception {
-        if (database == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
 
         StringWriter output = new StringWriter();
         Liquibase liquibase = createLiquibase(completeChangeLog);
@@ -312,9 +307,7 @@ public abstract class AbstractIntegrationTest {
 
     @Test
     public void testUpdateTwice() throws Exception {
-        if (database == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
 
         Liquibase liquibase = createLiquibase(completeChangeLog);
         clearDatabase(liquibase);
@@ -326,9 +319,7 @@ public abstract class AbstractIntegrationTest {
 
     @Test
     public void testUpdateClearUpdate() throws Exception {
-        if (database == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
 
         Liquibase liquibase = createLiquibase(completeChangeLog);
         clearDatabase(liquibase);
@@ -343,9 +334,7 @@ public abstract class AbstractIntegrationTest {
 
     @Test
     public void testRollbackableChangeLog() throws Exception {
-        if (database == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
 
         Liquibase liquibase = createLiquibase(rollbackChangeLog);
         clearDatabase(liquibase);
@@ -365,9 +354,7 @@ public abstract class AbstractIntegrationTest {
 
     @Test
     public void testRollbackableChangeLogScriptOnExistingDatabase() throws Exception {
-        if (database == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
 
         Liquibase liquibase = createLiquibase(rollbackChangeLog);
         clearDatabase(liquibase);
@@ -385,9 +372,7 @@ public abstract class AbstractIntegrationTest {
 
     @Test
     public void testRollbackableChangeLogScriptOnFutureDatabase() throws Exception {
-        if (database == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
 
         StringWriter writer = new StringWriter();
 
@@ -402,9 +387,7 @@ public abstract class AbstractIntegrationTest {
 
     @Test
     public void testTag() throws Exception {
-        if (database == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
 
         Liquibase liquibase = createLiquibase(completeChangeLog);
         clearDatabase(liquibase);
@@ -417,9 +400,7 @@ public abstract class AbstractIntegrationTest {
 
     @Test
     public void testDiff() throws Exception {
-        if (database == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
 
         runCompleteChangeLog();
 
@@ -438,9 +419,7 @@ public abstract class AbstractIntegrationTest {
 
     @Test
     public void testRerunDiffChangeLog() throws Exception {
-        if (database == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
 
         for (int run=0; run < 2; run++) { //run once outputting data as insert, once as csv
             boolean outputCsv = run == 1;
@@ -528,9 +507,7 @@ public abstract class AbstractIntegrationTest {
 
     @Test
     public void testRerunDiffChangeLogAltSchema() throws Exception {
-        if (database == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
         if (!database.supportsSchemas()) {
             return;
         }
@@ -601,9 +578,7 @@ public abstract class AbstractIntegrationTest {
 
     @Test
     public void testClearChecksums() throws Exception {
-        if (database == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
 
         Liquibase liquibase = createLiquibase(completeChangeLog);
         clearDatabase(liquibase);
@@ -619,9 +594,7 @@ public abstract class AbstractIntegrationTest {
 
     @Test
     public void testTagEmptyDatabase() throws Exception {
-        if (database == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
 
         Liquibase liquibase = createLiquibase(completeChangeLog);
         clearDatabase(liquibase);
@@ -639,9 +612,7 @@ public abstract class AbstractIntegrationTest {
 
     @Test
     public void testUnrunChangeSetsEmptyDatabase() throws Exception {
-        if (database == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
 
         Liquibase liquibase = createLiquibase(completeChangeLog);
         clearDatabase(liquibase);
@@ -655,9 +626,7 @@ public abstract class AbstractIntegrationTest {
 
     @Test
     public void testAbsolutePathChangeLog() throws Exception {
-        if (database == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
 
 
         Set<String> urls = new JUnitResourceAccessor().list(null, includedChangeLog, true, false, true);
@@ -682,9 +651,7 @@ public abstract class AbstractIntegrationTest {
 
 //    @Test
 //    public void testRerunChangeLogOnDifferentSchema() throws Exception {
-//        if (database == null) {
-//            return;
-//        }
+//        assumeNotNull(this.getDatabase());
 //
 //        if (!database.supportsSchemas()) {
 //            return;
@@ -735,9 +702,7 @@ public abstract class AbstractIntegrationTest {
 
     @Test
     public void testRollbackToChange() throws Exception {
-        if (database == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
 
         Liquibase liquibase = createLiquibase(rollbackChangeLog);
         liquibase.dropAll(getSchemasToDrop());
@@ -759,9 +724,7 @@ public abstract class AbstractIntegrationTest {
 
     @Test
     public void testDbDoc() throws Exception {
-        if (database == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
 
         Liquibase liquibase = createLiquibase(completeChangeLog);
         liquibase.dropAll(getSchemasToDrop());
@@ -782,9 +745,7 @@ public abstract class AbstractIntegrationTest {
 
     @Test
     public void testEncodingUpdating2SQL() throws Exception {
-        if (database == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
 
         Liquibase liquibase = createLiquibase(encodingChangeLog);
 
@@ -803,9 +764,7 @@ public abstract class AbstractIntegrationTest {
 
 //    @Test
 //    public void testEncondingUpdatingDatabase() throws Exception {
-//        if (database == null) {
-//            return;
-//        }
+//        assumeNotNull(this.getDatabase());
 //        
 //        // First import some data from utf8 encoded csv
 //        // and create a snapshot
@@ -855,9 +814,7 @@ public abstract class AbstractIntegrationTest {
      */
    @Test
    public void testDiffExternalForeignKeys() throws Exception {
-       if (database == null) {
-           return;
-       }
+       assumeNotNull(this.getDatabase());
        Liquibase liquibase = createLiquibase(externalfkInitChangeLog);
        liquibase.update(contexts);
 
@@ -867,9 +824,7 @@ public abstract class AbstractIntegrationTest {
 
     @Test
     public void invalidIncludeDoesntBreakLiquibase() throws Exception{
-        if (database == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
         Liquibase liquibase = createLiquibase(invalidReferenceChangeLog);
         try {
             liquibase.update(new Contexts());
@@ -884,9 +839,7 @@ public abstract class AbstractIntegrationTest {
 
     @Test
     public void contextsWithHyphensWorkInFormattedSql() throws Exception {
-        if (database == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
         Liquibase liquibase = createLiquibase("changelogs/common/sqlstyle/formatted.changelog.sql");
         liquibase.update("hyphen-context-using-sql,camelCaseContextUsingSql");
 
@@ -899,9 +852,7 @@ public abstract class AbstractIntegrationTest {
 
     @Test
     public void verifyObjectQuotingStrategy() throws Exception {
-        if (database == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
         if (!Arrays.asList("oracle,h2,hsqldb,postgresql,mysql").contains(database.getShortName())) {
             return;
         }
@@ -914,9 +865,7 @@ public abstract class AbstractIntegrationTest {
 
     @Test
     public void testOutputChangeLogIgnoringSchema() throws Exception {
-        if (getDatabase() == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
 
         String schemaName = getDatabase().getDefaultSchemaName();
         if (schemaName == null) {
@@ -947,9 +896,7 @@ public abstract class AbstractIntegrationTest {
 
     @Test
     public void generateChangeLog_noChanges() throws Exception{
-        if (database == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
 
         runCompleteChangeLog();
 
@@ -962,9 +909,7 @@ public abstract class AbstractIntegrationTest {
 
 //   @Test
 //   public void testXMLInclude() throws Exception{
-//       if (database == null) {
-//            return;
-//       }
+//       assumeNotNull(this.getDatabase());
 //       //Test external entity with a standard class loaded resource
 //       Liquibase liquibase = createLiquibase(externalEntityChangeLog);
 //       liquibase.update(contexts);

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/mssql/AbstractMssqlIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/mssql/AbstractMssqlIntegrationTest.java
@@ -7,6 +7,8 @@ import liquibase.exception.MigrationFailedException;
 import liquibase.exception.ValidationFailedException;
 import org.junit.Test;
 
+import static org.junit.Assume.assumeNotNull;
+
 /**
  *
  * @author lujop
@@ -24,9 +26,7 @@ public abstract class AbstractMssqlIntegrationTest extends AbstractIntegrationTe
 
     @Test
     public void smartDataLoad() throws Exception {
-        if (this.getDatabase() == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
         Liquibase liquibase = createLiquibase("changelogs/common/smartDataLoad.changelog.xml");
         clearDatabase(liquibase);
         try {

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/mssql/MssqlIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/mssql/MssqlIntegrationTest.java
@@ -4,29 +4,22 @@ import liquibase.CatalogAndSchema;
 import liquibase.Liquibase;
 import liquibase.database.core.MSSQLDatabase;
 import liquibase.datatype.DataTypeFactory;
-import liquibase.datatype.DatabaseDataType;
-import liquibase.diff.DiffResult;
-import liquibase.diff.compare.CompareControl;
-import liquibase.diff.output.DiffOutputControl;
-import liquibase.diff.output.changelog.DiffToChangeLog;
 import liquibase.snapshot.DatabaseSnapshot;
-import liquibase.snapshot.EmptyDatabaseSnapshot;
 import liquibase.snapshot.SnapshotControl;
 import liquibase.snapshot.SnapshotGeneratorFactory;
 import liquibase.statement.DatabaseFunction;
 import liquibase.structure.core.Column;
-import liquibase.structure.core.DataType;
 import liquibase.structure.core.Table;
 import org.junit.Test;
 
 import java.util.Calendar;
 import java.util.Date;
-import java.util.Set;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assume.assumeNotNull;
 
 public class MssqlIntegrationTest extends AbstractMssqlIntegrationTest {
 
@@ -41,9 +34,7 @@ public class MssqlIntegrationTest extends AbstractMssqlIntegrationTest {
 
     @Test
     public void defaultValuesTests() throws Exception {
-        if (this.getDatabase() == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
 
         Liquibase liquibase = createLiquibase("changelogs/mssql/issues/default.values.xml");
         liquibase.update((String) null);
@@ -81,9 +72,7 @@ public class MssqlIntegrationTest extends AbstractMssqlIntegrationTest {
 
     @Test
     public void dataTypesTest() throws Exception {
-        if (this.getDatabase() == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
 
         Liquibase liquibase = createLiquibase("changelogs/mssql/issues/data.types.xml");
         liquibase.update((String) null);
@@ -119,9 +108,7 @@ public class MssqlIntegrationTest extends AbstractMssqlIntegrationTest {
 
     @Test
     public void dataTypeParamsTest() throws Exception {
-        if (this.getDatabase() == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
 
         Liquibase liquibase = createLiquibase("changelogs/mssql/issues/data.type.params.xml");
         liquibase.update((String) null);

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/oracle/OracleIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/oracle/OracleIntegrationTest.java
@@ -7,6 +7,7 @@ import liquibase.exception.ValidationFailedException;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeNotNull;
 
 import java.sql.Statement;
 import java.sql.ResultSet;
@@ -34,9 +35,7 @@ public class OracleIntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void indexCreatedOnCorrectSchema() throws Exception {
-         if (this.getDatabase() == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
 
         Liquibase liquibase = createLiquibase(this.indexOnSchemaChangeLog);
         clearDatabase(liquibase);
@@ -73,9 +72,7 @@ public class OracleIntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void viewCreatedOnCorrectSchema() throws Exception {
-         if (this.getDatabase() == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
 
         Liquibase liquibase = createLiquibase(this.viewOnSchemaChangeLog);
         clearDatabase(liquibase);
@@ -108,9 +105,7 @@ public class OracleIntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void smartDataLoad() throws Exception {
-        if (this.getDatabase() == null) {
-            return;
-        }
+        assumeNotNull(this.getDatabase());
 
         Liquibase liquibase = createLiquibase("changelogs/common/smartDataLoad.changelog.xml");
         clearDatabase(liquibase);

--- a/liquibase-integration-tests/src/test/java/liquibase/test/DatabaseTestContext.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/test/DatabaseTestContext.java
@@ -9,6 +9,7 @@ import liquibase.database.jvm.JdbcConnection;
 import liquibase.dbtest.AbstractIntegrationTest;
 import liquibase.resource.ResourceAccessor;
 import liquibase.exception.DatabaseException;
+import org.junit.internal.AssumptionViolatedException;
 
 import java.util.*;
 import java.sql.SQLException;
@@ -152,8 +153,8 @@ public class DatabaseTestContext {
         try {
             driver = (Driver) Class.forName(DatabaseFactory.getInstance().findDefaultDriver(url), true, jdbcDriverLoader).newInstance();
         } catch (Exception e) {
-            System.out.println("Could not connect to " + url + ": Will not test against.  " + e.getMessage());
-            return null; //could not connect
+            throw new AssumptionViolatedException(
+                "Could not connect to " + url + ": Will not test against.  " + e.getMessage());
         }
 
         Properties info = new Properties();
@@ -168,8 +169,8 @@ public class DatabaseTestContext {
         try {
             connection = driver.connect(url, info);
         } catch (SQLException e) {
-            System.out.println("Could not connect to " + url + ": Will not test against.  " + e.getMessage());
-            return null; //could not connect
+            throw new AssumptionViolatedException(
+                "Could not connect to " + url + ": Will not test against.  " + e.getMessage());
         }
         if (connection == null) {
             throw new DatabaseException("Connection could not be created to " + url + " with driver " + driver.getClass().getName() + ".  Possibly the wrong driver for the given database URL");


### PR DESCRIPTION
This is a minor change that causes any Integration Tests which are skipped because there is not a reachable database of that type to be marked as Ignored by JUnit instead of marked as Passed.

I think this is clearer and more correct.

This arose from https://liquibase.jira.com/browse/CORE-3063