### PR TITLE
Fix json serialize fail on changeset precondition enums

### DIFF
--- a/liquibase-core/src/main/java/liquibase/precondition/core/PreconditionContainer.java
+++ b/liquibase-core/src/main/java/liquibase/precondition/core/PreconditionContainer.java
@@ -103,6 +103,10 @@ public class PreconditionContainer extends AndPrecondition implements ChangeLogC
         }
     }
 
+    public void setOnFail(FailOption onFail) {
+        this.onFail = onFail;
+    }
+
     public ErrorOption getOnError() {
         return onError;
     }
@@ -123,6 +127,10 @@ public class PreconditionContainer extends AndPrecondition implements ChangeLogC
             }
             throw new RuntimeException("Unknown onError attribute value '"+onError+"'.  Possible values: " + StringUtils.join(possibleOptions, ", "));
         }
+    }
+
+    public void setOnError(ErrorOption onError) {
+        this.onError = onError;
     }
 
     public OnSqlOutputOption getOnSqlOutput() {

--- a/liquibase-core/src/test/java/liquibase/serializer/core/json/JsonChangeLogSerializerTest.java
+++ b/liquibase-core/src/test/java/liquibase/serializer/core/json/JsonChangeLogSerializerTest.java
@@ -1,9 +1,12 @@
 package liquibase.serializer.core.json;
 
 import liquibase.change.AddColumnConfig;
-import liquibase.change.ColumnConfig;
 import liquibase.change.core.AddColumnChange;
 import liquibase.changelog.ChangeSet;
+import liquibase.precondition.core.PreconditionContainer;
+import liquibase.precondition.core.PreconditionContainer.ErrorOption;
+import liquibase.precondition.core.PreconditionContainer.FailOption;
+import liquibase.precondition.core.PreconditionContainer.OnSqlOutputOption;
 import liquibase.statement.DatabaseFunction;
 import liquibase.statement.SequenceNextValueFunction;
 import org.junit.Test;
@@ -16,6 +19,7 @@ public class JsonChangeLogSerializerTest {
 
     @Test
     public void serialize_changeSet() {
+        //given
         AddColumnChange addColumnChange = new AddColumnChange();
         addColumnChange.setCatalogName("cat");
         addColumnChange.addColumn((AddColumnConfig) new AddColumnConfig().setName("col1").setDefaultValueNumeric(3));
@@ -23,14 +27,33 @@ public class JsonChangeLogSerializerTest {
         addColumnChange.addColumn((AddColumnConfig) new AddColumnConfig().setName("col3").setDefaultValueBoolean(true));
         addColumnChange.addColumn((AddColumnConfig) new AddColumnConfig().setName("col2").setDefaultValueDate(new Date(0)));
         addColumnChange.addColumn((AddColumnConfig) new AddColumnConfig().setName("col2").setDefaultValueSequenceNext(new SequenceNextValueFunction("seq_me")));
-
         ChangeSet changeSet = new ChangeSet("1", "nvoxland", false, false, "path/to/file.json", null, null, null);
+        changeSet.setPreconditions(newSamplePreconditions());
         changeSet.addChange(addColumnChange);
+        //when
+        String serializedJson = new JsonChangeLogSerializer().serialize(changeSet, true);
+        //then
         assertEquals("{\n" +
                 "  \"changeSet\": {\n" +
                 "    \"id\": \"1\",\n" +
                 "    \"author\": \"nvoxland\",\n" +
                 "    \"objectQuotingStrategy\": \"LEGACY\",\n" +
+                "    \"preconditions\": {\n" +
+                "      \"preConditions\": {\n" +
+                "        \"nestedPreconditions\": [\n" +
+                "          {\n" +
+                "            \"preConditions\": {\n" +
+                "              \"onError\": \"WARN\",\n" +
+                "              \"onFail\": \"CONTINUE\",\n" +
+                "              \"onSqlOutput\": \"TEST\"\n" +
+                "            }\n" +
+                "          }]\n" +
+                "        ,\n" +
+                "        \"onError\": \"CONTINUE\",\n" +
+                "        \"onFail\": \"MARK_RAN\",\n" +
+                "        \"onSqlOutput\": \"FAIL\"\n" +
+                "      }\n" +
+                "    },\n" +
                 "    \"changes\": [\n" +
                 "      {\n" +
                 "        \"addColumn\": {\n" +
@@ -71,6 +94,19 @@ public class JsonChangeLogSerializerTest {
                 "      }]\n" +
                 "    \n" +
                 "  }\n" +
-                "}\n", new JsonChangeLogSerializer().serialize(changeSet, true));
+                "}\n", serializedJson);
+    }
+
+    private PreconditionContainer newSamplePreconditions() {
+        PreconditionContainer precondition = new PreconditionContainer();
+        precondition.setOnError(ErrorOption.CONTINUE);
+        precondition.setOnFail(FailOption.MARK_RAN);
+        precondition.setOnSqlOutput(OnSqlOutputOption.FAIL);
+        PreconditionContainer nestedPrecondition = new PreconditionContainer();
+        nestedPrecondition.setOnError(ErrorOption.WARN);
+        nestedPrecondition.setOnFail(FailOption.CONTINUE);
+        nestedPrecondition.setOnSqlOutput(OnSqlOutputOption.TEST);
+        precondition.addNestedPrecondition(nestedPrecondition);
+        return precondition;
     }
 }


### PR DESCRIPTION
This pullrequest resolve json serialize error, when changeset contains precondition flags: _onError_, _onFail_ or _onSqlOutput_. 
I'll give you an example. Changeset had _onError_ flag **HALT**. In that case, the property was serialized to:
`"onError": !!liquibase.precondition.core.PreconditionContainer$ErrorOption "HALT"`, what is compatible with yaml, but not json.

It is a minor change, none refactoring. I only extended used regexp and made fail-fast.