### PR TITLE
Add changeLogDirectory property in the maven plugin

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/ant/AbstractChangeLogBasedTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/AbstractChangeLogBasedTask.java
@@ -10,6 +10,7 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 
 public abstract class AbstractChangeLogBasedTask extends BaseLiquibaseTask {
+    private String changeLogDirectory;
     private String changeLogFile;
     private String contexts;
     private LabelExpression labels;
@@ -29,6 +30,19 @@ public abstract class AbstractChangeLogBasedTask extends BaseLiquibaseTask {
         return new OutputStreamWriter(outputFile.getOutputStream(), getOutputEncoding());
     }
 
+    /**
+     * Gets the change log directory set from Ant.
+     * @return The change log directory resource.
+     */
+    @Override
+    public String getChangeLogDirectory() {
+        return changeLogDirectory;
+    }
+    
+    public void setChangeLogDirectory(String changeLogDirectory) {
+        this.changeLogDirectory = changeLogDirectory;
+    }
+    
     /**
      * Gets the change log file set from Ant.
      * @return The change log file resource.

--- a/liquibase-core/src/main/java/liquibase/integration/ant/BaseLiquibaseTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/BaseLiquibaseTask.java
@@ -15,7 +15,6 @@ import liquibase.resource.ClassLoaderResourceAccessor;
 import liquibase.resource.CompositeResourceAccessor;
 import liquibase.resource.FileSystemResourceAccessor;
 import liquibase.resource.ResourceAccessor;
-import liquibase.util.StringUtils;
 import liquibase.util.ui.UIFactory;
 import org.apache.tools.ant.AntClassLoader;
 import org.apache.tools.ant.BuildException;

--- a/liquibase-core/src/test/java/liquibase/integration/ant/ChangeLogDirectoryTest.java
+++ b/liquibase-core/src/test/java/liquibase/integration/ant/ChangeLogDirectoryTest.java
@@ -1,0 +1,22 @@
+package liquibase.integration.ant;
+
+import junit.framework.TestSuite;
+import org.apache.ant.antunit.junit3.AntUnitSuite;
+import org.apache.ant.antunit.junit4.AntUnitSuiteRunner;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.UnsupportedEncodingException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLDecoder;
+
+@RunWith(AntUnitSuiteRunner.class)
+public class ChangeLogDirectoryTest extends AbstractAntTaskTest {
+    public static TestSuite suite() throws URISyntaxException {
+        setProperties();
+        URL resource = ChangeLogDirectoryTest.class.getResource("/liquibase/integration/ant/ChangeLogDirectoryTest.xml");
+        File file = new File(resource.toURI());
+        return new AntUnitSuite(file, ChangeLogDirectoryTest.class);
+    }
+}

--- a/liquibase-core/src/test/resources/liquibase/integration/ant/ChangeLogDirectoryTest.xml
+++ b/liquibase-core/src/test/resources/liquibase/integration/ant/ChangeLogDirectoryTest.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="ChangeLogDirectoryTest" basedir="."
+		xmlns="antlib:org.apache.tools.ant"
+		xmlns:au="antlib:org.apache.ant.antunit"
+		xmlns:lb="antlib:liquibase.integration.ant"
+		xmlns:db="antlib:liquibase.integration.ant.test">
+	
+	<tempfile property="temp.dir" prefix="ChangeLogDirectoryTest" destDir="${java.io.tmpdir}" />
+
+	<path id="basic-classpath">
+		<pathelement path="." />
+	</path>
+
+	<property name="jdbc.driver" value="org.h2.Driver" />
+	<property name="jdbc.url" value="jdbc:h2:mem:test;DB_CLOSE_DELAY=-1" />
+	<property name="db.user" value="sa" />
+	<property name="db.password" value="" />
+
+	<property name="column.one" value="new_column_one" />
+	<property name="column.two" value="new_column_two" />
+	<propertyset id="db-propertyset">
+		<propertyref prefix="column" />
+	</propertyset>
+
+	<lb:database id="test-db" driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}" />
+
+	<lb:changelogparameters id="test-parameters">
+		<propertyset refid="db-propertyset" />
+	</lb:changelogparameters>
+
+	<target name="setUp">
+		<sql driver="${jdbc.driver}" url="${jdbc.url}" userid="${db.user}" password="${db.password}" encoding="UTF-8" src="${liquibase.test.ant.basedir}/sql/h2-setup.sql" />
+		<mkdir dir="${temp.dir}" />
+	</target>
+
+	<target name="tearDown">
+		<sql driver="${jdbc.driver}" url="${jdbc.url}" userid="${db.user}" password="${db.password}" encoding="UTF-8" src="${liquibase.test.ant.basedir}/sql/h2-teardown.sql" />
+		<delete dir="${temp.dir}" />
+	</target>
+
+	<target name="testWithoutChangeLogDirectory">
+		<db:assertTableDoesntExist driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}" table="DATABASECHANGELOG" />
+		<lb:updateDatabase
+				changelogfile="${liquibase.test.ant.basedir}/changelog/simple-changelog.xml">
+			<lb:database refid="test-db" />
+		</lb:updateDatabase>
+		<db:assertTableExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}" table="DATABASECHANGELOG" />
+	</target>
+
+	<target name="testAbsoluteChangeLogDirectory">
+		<db:assertTableDoesntExist driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}" table="DATABASECHANGELOG" />
+		<lb:updateDatabase
+				changelogdirectory="${liquibase.test.ant.basedir}/changelog"
+				changelogfile="simple-changelog.xml">
+			<lb:database refid="test-db" />
+		</lb:updateDatabase>
+		<db:assertTableExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}" table="DATABASECHANGELOG" />
+	</target>
+
+	<target name="testAbsoluteChangeLogDirectoryEndsBySlash">
+		<db:assertTableDoesntExist driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}" table="DATABASECHANGELOG" />
+		<lb:updateDatabase
+				changelogdirectory="${liquibase.test.ant.basedir}/changelog/"
+				changelogfile="simple-changelog.xml">
+			<lb:database refid="test-db" />
+		</lb:updateDatabase>
+		<db:assertTableExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}" table="DATABASECHANGELOG" />
+	</target>
+
+	<target name="testAbsoluteChangeLogDirectoryMixSlashAndBackslash">
+		<db:assertTableDoesntExist driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}" table="DATABASECHANGELOG" />
+		<lb:updateDatabase
+				changelogdirectory="${liquibase.test.ant.basedir}\changelog\"
+				changelogfile="simple-changelog.xml">
+			<lb:database refid="test-db" />
+		</lb:updateDatabase>
+		<db:assertTableExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}" table="DATABASECHANGELOG" />
+	</target>
+
+	<target name="testRelativeChangeLogDirectory">
+		<db:assertTableDoesntExist driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}" table="DATABASECHANGELOG" />
+		<lb:updateDatabase
+				changelogdirectory="src/test/resources/liquibase/integration/ant/changelog"
+				changelogfile="simple-changelog.xml">
+			<lb:database refid="test-db" />
+		</lb:updateDatabase>
+		<db:assertTableExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}" table="DATABASECHANGELOG" />
+	</target>
+
+	<target name="testRelativeChangeLogDirectoryStartsWithSlash">
+        <au:expectfailure expectedmessage="/src/test/resources/liquibase/integration/ant/changelog must be a directory">
+			<lb:updateDatabase
+					changelogdirectory="/src/test/resources/liquibase/integration/ant/changelog"
+					changelogfile="simple-changelog.xml">
+				<lb:database refid="test-db" />
+			</lb:updateDatabase>
+		</au:expectfailure>
+	</target>
+
+	<target name="testRelativeChangeLogDirectoryEndsBySlash">
+		<db:assertTableDoesntExist driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}" table="DATABASECHANGELOG" />
+		<lb:updateDatabase
+				changelogdirectory="src/test/resources/liquibase/integration/ant/changelog/"
+				changelogfile="simple-changelog.xml">
+			<lb:database refid="test-db" />
+		</lb:updateDatabase>
+		<db:assertTableExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}" table="DATABASECHANGELOG" />
+	</target>
+
+	<target name="testRelativeBackslashedChangeLogDirectory">
+		<db:assertTableDoesntExist driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}" table="DATABASECHANGELOG" />
+		<lb:updateDatabase
+				changelogdirectory="src\test\resources\liquibase\integration\ant\changelog"
+				changelogfile="simple-changelog.xml">
+			<lb:database refid="test-db" />
+		</lb:updateDatabase>
+		<db:assertTableExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}" table="DATABASECHANGELOG" />
+	</target>
+
+	<target name="testRelativeBackslashedChangeLogDirectoryStartsWithBackslash">
+        <au:expectfailure expectedmessage="/src/test/resources/liquibase/integration/ant/changelog must be a directory">
+			<lb:updateDatabase
+					changelogdirectory="\src\test\resources\liquibase\integration\ant\changelog"
+					changelogfile="simple-changelog.xml">
+				<lb:database refid="test-db" />
+			</lb:updateDatabase>
+        </au:expectfailure>
+	</target>
+
+	<target name="testRelativeBackslashedChangeLogDirectoryEndsByBackslash">
+		<db:assertTableDoesntExist driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}" table="DATABASECHANGELOG" />
+		<lb:updateDatabase
+				changelogdirectory="src\test\resources\liquibase\integration\ant\changelog\"
+				changelogfile="simple-changelog.xml">
+			<lb:database refid="test-db" />
+		</lb:updateDatabase>
+		<db:assertTableExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}" table="DATABASECHANGELOG" />
+	</target>
+</project>

--- a/liquibase-core/src/test/resources/liquibase/integration/ant/ChangeLogSyncTaskTest.xml
+++ b/liquibase-core/src/test/resources/liquibase/integration/ant/ChangeLogSyncTaskTest.xml
@@ -84,4 +84,51 @@
             </lb:changeLogSync>
         </au:expectfailure>
     </target>
+
+	
+	<!-- ADDED FOR THE NEW changeLogDirectory PROPERTY -->
+    
+    <target name="testChangeLogSyncChangeLegacyLogDirectory">
+        <db:assertTableDoesntExist driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                                   table="DATABASECHANGELOG"/>
+        <lb:changeLogSync driver="${jdbc.driver}" url="${jdbc.url}" username="${db.user}" password="${db.password}"
+        		changelogdirectory="${liquibase.test.ant.basedir}/changelog" changelogfile="simple-changelog.xml"/>
+        <db:assertTableExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                              table="DATABASECHANGELOG"/>
+    </target>
+
+	<target name="testChangeLogSyncChangeLogDirectory">
+        <db:assertTableDoesntExist driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                                   table="DATABASECHANGELOG"/>
+        <lb:changeLogSync changelogdirectory="${liquibase.test.ant.basedir}/changelog" changelogfile="simple-changelog.xml">
+            <lb:database driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"/>
+        </lb:changeLogSync>
+        <db:assertTableExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                              table="DATABASECHANGELOG"/>
+    </target>
+
+	<target name="testChangeLogSyncChangeLogDirectoryDoesNotExist">
+        <au:expectfailure expectedmessage="${liquibase.test.ant.basedir}/bad_changelog must be a directory">
+	        <lb:changeLogSync changelogdirectory="${liquibase.test.ant.basedir}/bad_changelog" changelogfile="simple-changelog.xml">
+	            <lb:database driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"/>
+	        </lb:changeLogSync>
+        </au:expectfailure>
+    </target>
+
+    <target name="testChangeLogSyncChangeLogDirectoryToOutputFile">
+        <lb:changeLogSync changelogdirectory="${liquibase.test.ant.basedir}/changelog" changelogfile="simple-changelog.xml"
+                          outputfile="${temp.dir}/sync.sql">
+            <lb:database driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"/>
+        </lb:changeLogSync>
+        <au:assertFileExists file="${temp.dir}/sync.sql"/>
+    </target>
+
+    <target name="testChangeLogSyncDatabaseRefChangeLogDirectory">
+        <db:assertTableDoesntExist driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                                   table="DATABASECHANGELOG"/>
+        <lb:changeLogSync databaseref="test-db" changelogdirectory="${liquibase.test.ant.basedir}/changelog" changelogfile="simple-changelog.xml"/>
+        <db:assertTableExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                              table="DATABASECHANGELOG"/>
+    </target>
+
 </project>

--- a/liquibase-core/src/test/resources/liquibase/integration/ant/DatabaseRollbackFutureTaskTest.xml
+++ b/liquibase-core/src/test/resources/liquibase/integration/ant/DatabaseRollbackFutureTaskTest.xml
@@ -30,13 +30,14 @@
         <mkdir dir="${temp.dir}"/>
         <lb:tagDatabase databaseref="test-db" tag="${tag}"/>
         <lb:updateDatabase databaseref="test-db"
-                           changelogfile="${liquibase.test.ant.basedir}/changelog/changelog-with-rollback.xml"/>
+        	               changelogdirectory="${liquibase.test.ant.basedir}/changelog"
+                           changelogfile="changelog-with-rollback.xml"/>
     </target>
 
     <target name="tearDown">
         <sql driver="${jdbc.driver}" url="${jdbc.url}" userid="${db.user}" password="${db.password}" encoding="UTF-8"
              src="${liquibase.test.ant.basedir}/sql/h2-teardown.sql"/>
-        <delete dir="${temp.dir}"/>
+        <!--delete dir="${temp.dir}"/-->
     </target>
 
     <target name="testDatabaseRollbackFutureLegacy">
@@ -81,5 +82,35 @@
             <lb:rollbackFutureDatabase outputfile="${temp.dir}/rollback-future.sql"
                                        changelogfile="${liquibase.test.ant.basedir}/changelog/changelog-with-rollback.xml"/>
         </au:expectfailure>
+    </target>
+	
+	
+	<!-- ADDED FOR THE NEW changeLogDirectory PROPERTY -->
+    
+    <target name="testDatabaseRollbackFutureLegacyChangeLogDirectory">
+        <lb:rollbackFutureDatabase driver="${jdbc.driver}" url="${jdbc.url}" username="${db.user}"
+                                   password="${db.password}" outputfile="${temp.dir}/rollback-future.sql"
+                                   changelogdirectory="${liquibase.test.ant.basedir}/changelog"
+                                   changelogfile="changelog-with-rollback.xml"/>
+        <au:assertFileExists file="${temp.dir}/rollback-future.sql"/>
+    </target>
+
+    <target name="testDatabaseRollbackFutureChangeLogDirectory">
+        <lb:rollbackFutureDatabase outputfile="${temp.dir}/rollback-future.sql"
+                                   changelogdirectory="${liquibase.test.ant.basedir}/changelog"
+        	                       changelogfile="changelog-with-rollback.xml">
+            <lb:database driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"/>
+        </lb:rollbackFutureDatabase>
+        <au:assertFileExists file="${temp.dir}/rollback-future.sql"/>
+    </target>
+
+    <target name="testDatabaseRollbackFutureChangeLogDirectoryDoesNotExist">
+        <au:expectfailure expectedmessage="${liquibase.test.ant.basedir}/bad_changelog must be a directory">
+	        <lb:rollbackFutureDatabase outputfile="${temp.dir}/rollback-future.sql"
+	                                   changelogdirectory="${liquibase.test.ant.basedir}/bad_changelog"
+	        	                       changelogfile="changelog-with-rollback.xml">
+	            <lb:database driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"/>
+	        </lb:rollbackFutureDatabase>
+		</au:expectfailure>
     </target>
 </project>

--- a/liquibase-core/src/test/resources/liquibase/integration/ant/DatabaseRollbackFutureTaskTest.xml
+++ b/liquibase-core/src/test/resources/liquibase/integration/ant/DatabaseRollbackFutureTaskTest.xml
@@ -37,7 +37,7 @@
     <target name="tearDown">
         <sql driver="${jdbc.driver}" url="${jdbc.url}" userid="${db.user}" password="${db.password}" encoding="UTF-8"
              src="${liquibase.test.ant.basedir}/sql/h2-teardown.sql"/>
-        <!--delete dir="${temp.dir}"/-->
+        <delete dir="${temp.dir}"/>
     </target>
 
     <target name="testDatabaseRollbackFutureLegacy">

--- a/liquibase-core/src/test/resources/liquibase/integration/ant/DatabaseRollbackTaskTest.xml
+++ b/liquibase-core/src/test/resources/liquibase/integration/ant/DatabaseRollbackTaskTest.xml
@@ -145,4 +145,50 @@
             </lb:rollbackDatabase>
         </au:expectfailure>
     </target>
+	
+	
+	<!-- ADDED FOR THE NEW changeLogDirectory PROPERTY -->
+    
+    <target name="testRollbackDatabaseByCountLegacyChangeLogDirectory">
+    	<!-- Here we check that the rollback has no effect. -->
+    	<!-- By using the changeLogDirectory property, we change all the changelog ids -->
+    	<!-- from ${liquibase.test.ant.basedir}/changelog/changelog-with-rollback.xml::1::testuser -->
+    	<!--   to changelog-with-rollback.xml::1::testuser -->
+    	<!-- So it's not the same we inserted into databasechangelog during the setUp preStep -->
+        <db:assertRowCountEquals driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                                 table="users" count="1"/>
+        <lb:rollbackDatabase driver="${jdbc.driver}" url="${jdbc.url}" username="${db.user}" password="${db.password}"
+                             rollbackCount="1"
+                             changelogdirectory="${liquibase.test.ant.basedir}/changelog"
+                             changelogfile="changelog-with-rollback.xml"/>
+        <db:assertRowCountEquals driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                                 table="users" count="1"/>
+    </target>
+
+    <target name="testRollbackDatabaseByCountChangeLogDirectory">
+    	<!-- Here we check that the rollback has no effect. -->
+    	<!-- By using the changeLogDirectory property, we change all the changelog ids -->
+    	<!-- from ${liquibase.test.ant.basedir}/changelog/changelog-with-rollback.xml::1::testuser -->
+    	<!--   to changelog-with-rollback.xml::1::testuser -->
+    	<!-- So it's not the same we inserted into databasechangelog during the setUp preStep -->
+        <db:assertRowCountEquals driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                                 table="users" count="1"/>
+        <lb:rollbackDatabase rollbackCount="1"
+                             changelogdirectory="${liquibase.test.ant.basedir}/changelog"
+                             changelogfile="changelog-with-rollback.xml">
+            <lb:database driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"/>
+        </lb:rollbackDatabase>
+        <db:assertRowCountEquals driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                                 table="users" count="1"/>
+    </target>
+
+    <target name="testRollbackDatabaseByCountChangeLogDirectoryDoesNotExist">
+        <au:expectfailure expectedmessage="${liquibase.test.ant.basedir}/bad_changelog must be a directory">
+	        <lb:rollbackDatabase rollbackCount="1"
+                                 changelogdirectory="${liquibase.test.ant.basedir}/bad_changelog"
+                                 changelogfile="changelog-with-rollback.xml">
+	            <lb:database driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"/>
+	        </lb:rollbackDatabase>
+        </au:expectfailure>
+    </target>
 </project>

--- a/liquibase-core/src/test/resources/liquibase/integration/ant/DatabaseUpdateTaskTest.xml
+++ b/liquibase-core/src/test/resources/liquibase/integration/ant/DatabaseUpdateTaskTest.xml
@@ -149,4 +149,36 @@
             </lb:updateDatabase>
         </au:expectfailure>
     </target>
+
+	
+	<!-- ADDED FOR THE NEW changeLogDirectory PROPERTY -->
+	
+    <target name="testUpdateDatabaseChangeLogDirectoryLegacy">
+        <db:assertTableDoesntExist driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                                   table="DATABASECHANGELOG"/>
+        <lb:updateDatabase driver="${jdbc.driver}" url="${jdbc.url}" username="${db.user}" password="${db.password}"
+        	               changelogdirectory="${liquibase.test.ant.basedir}/changelog"
+        	               changelogfile="simple-changelog.xml"
+                           classpathref="basic-classpath"/>
+        <db:assertTableExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                              table="DATABASECHANGELOG"/>
+    </target>
+
+	<target name="testUpdateDatabaseChangeLogDirectory">
+        <db:assertTableDoesntExist driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                                   table="DATABASECHANGELOG"/>
+        <lb:updateDatabase changelogdirectory="${liquibase.test.ant.basedir}/changelog" changelogfile="simple-changelog.xml">
+            <lb:database driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"/>
+        </lb:updateDatabase>
+        <db:assertTableExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                              table="DATABASECHANGELOG"/>
+    </target>
+
+	<target name="testUpdateDatabaseChangeLogDirectoryDoesNotExist">
+        <au:expectfailure expectedmessage="${liquibase.test.ant.basedir}/bad_changelog must be a directory">
+	        <lb:updateDatabase changelogdirectory="${liquibase.test.ant.basedir}/bad_changelog" changelogfile="simple-changelog.xml">
+	            <lb:database driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"/>
+	        </lb:updateDatabase>
+        </au:expectfailure>
+    </target>
 </project>

--- a/liquibase-core/src/test/resources/liquibase/integration/ant/GenerateChangeLogTaskTest.xml
+++ b/liquibase-core/src/test/resources/liquibase/integration/ant/GenerateChangeLogTaskTest.xml
@@ -23,7 +23,7 @@
     <target name="tearDown">
         <sql driver="${jdbc.driver}" url="${jdbc.url}" userid="${db.user}" password="${db.password}" encoding="UTF-8"
              src="${liquibase.test.ant.basedir}/sql/h2-teardown.sql"/>
-        <delete dir="${temp.dir}"/>
+        <!--delete dir="${temp.dir}"/-->
     </target>
 
     <target name="testGenerateChangeLogLegacy">

--- a/liquibase-core/src/test/resources/liquibase/integration/ant/GenerateChangeLogTaskTest.xml
+++ b/liquibase-core/src/test/resources/liquibase/integration/ant/GenerateChangeLogTaskTest.xml
@@ -23,7 +23,7 @@
     <target name="tearDown">
         <sql driver="${jdbc.driver}" url="${jdbc.url}" userid="${db.user}" password="${db.password}" encoding="UTF-8"
              src="${liquibase.test.ant.basedir}/sql/h2-teardown.sql"/>
-        <!--delete dir="${temp.dir}"/-->
+        <delete dir="${temp.dir}"/>
     </target>
 
     <target name="testGenerateChangeLogLegacy">

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseChangeLogMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseChangeLogMojo.java
@@ -9,6 +9,9 @@ import liquibase.resource.CompositeResourceAccessor;
 import liquibase.resource.FileSystemResourceAccessor;
 import liquibase.resource.ResourceAccessor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 
@@ -69,16 +72,24 @@ public abstract class AbstractLiquibaseChangeLogMojo extends AbstractLiquibaseMo
   @Override
   protected void printSettings(String indent) {
     super.printSettings(indent);
+    getLog().info(indent + "changeLogDirectory: " + changeLogDirectory);
     getLog().info(indent + "changeLogFile: " + changeLogFile);
     getLog().info(indent + "context(s): " + contexts);
-      getLog().info(indent + "label(s): " + labels);
+    getLog().info(indent + "label(s): " + labels);
   }
 
   @Override
   protected ResourceAccessor getFileOpener(ClassLoader cl) {
-    ResourceAccessor mFO = new MavenResourceAccessor(cl);
-    ResourceAccessor fsFO = new FileSystemResourceAccessor(project.getBasedir().getAbsolutePath());
-    return new CompositeResourceAccessor(mFO, fsFO);
+    List<ResourceAccessor> resourceAccessors = new ArrayList<ResourceAccessor>();
+    resourceAccessors.add(new MavenResourceAccessor(cl));
+    resourceAccessors.add(new FileSystemResourceAccessor(project.getBasedir().getAbsolutePath()));
+
+    String theChangeLogDirectory = changeLogDirectory;
+    if (theChangeLogDirectory != null) {
+      theChangeLogDirectory = theChangeLogDirectory.trim().replace('\\', '/');  //convert to standard / if using absolute path on windows
+      resourceAccessors.add(new FileSystemResourceAccessor(theChangeLogDirectory));
+    }
+    return new CompositeResourceAccessor(resourceAccessors);
   }
 
   @Override

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseChangeLogMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseChangeLogMojo.java
@@ -20,6 +20,13 @@ import org.apache.maven.plugin.MojoFailureException;
 public abstract class AbstractLiquibaseChangeLogMojo extends AbstractLiquibaseMojo {
 
   /**
+   * Specifies the change log directory into which liquibase can find the change log file.
+   * 
+   * @parameter expression="${liquibase.changeLogDirectory}"
+   */
+  protected String changeLogDirectory;
+
+  /**
    * Specifies the change log file to use for Liquibase.
    * @parameter expression="${liquibase.changeLogFile}"
    */

--- a/liquibase-maven-plugin/src/test/java/org/liquibase/maven/plugins/LiquibaseUpdateMojoTest.java
+++ b/liquibase-maven-plugin/src/test/java/org/liquibase/maven/plugins/LiquibaseUpdateMojoTest.java
@@ -10,8 +10,10 @@ import org.codehaus.plexus.configuration.PlexusConfiguration;
 public class LiquibaseUpdateMojoTest extends AbstractLiquibaseMojoTest {
 
   private static final String CONFIG_FILE = "update/plugin_config.xml";
+  private static final String DIRECTORY_CONFIG_FILE = "update/plugin_config_directory.xml";
 
   private static final Map<String, Object> DEFAULT_PROPERTIES;
+  private static final Map<String, Object> DIRECTORY_PROPERTIES;
 
   static {
     DEFAULT_PROPERTIES = new HashMap<String, Object>();
@@ -24,21 +26,50 @@ public class LiquibaseUpdateMojoTest extends AbstractLiquibaseMojoTest {
     DEFAULT_PROPERTIES.put("outputDefaultSchema", false);
     DEFAULT_PROPERTIES.put("outputDefaultCatalog", false);
     DEFAULT_PROPERTIES.put("outputFileEncoding", "UTF-8");
+    
+    DIRECTORY_PROPERTIES = new HashMap<String, Object>();
+    DIRECTORY_PROPERTIES.put("changeLogDirectory", "org/liquibase/");
+    DIRECTORY_PROPERTIES.put("changeLogFile", "changelog.xml");
+    DIRECTORY_PROPERTIES.put("driver", "com.mysql.jdbc.Driver");
+    DIRECTORY_PROPERTIES.put("url", "jdbc:mysql://localhost/eformat");
+    DIRECTORY_PROPERTIES.put("username", "root");
+    DIRECTORY_PROPERTIES.put("password", null);
+    DIRECTORY_PROPERTIES.put("verbose", true);
+    DIRECTORY_PROPERTIES.put("outputDefaultSchema", false);
+    DIRECTORY_PROPERTIES.put("outputDefaultCatalog", false);
+    DIRECTORY_PROPERTIES.put("outputFileEncoding", "UTF-8");
   }
 
   public void testNoPropertiesFile() throws Exception {
-    LiquibaseUpdate mojo = createUpdateMojo();
+    testCommonNoPropertiesFile(CONFIG_FILE, DEFAULT_PROPERTIES);
+  }
+
+  public void testDirectoryNoPropertiesFile() throws Exception {
+    testCommonNoPropertiesFile(DIRECTORY_CONFIG_FILE, DIRECTORY_PROPERTIES);
+  }
+  
+  private void testCommonNoPropertiesFile(String configFileName, Map<String, Object> properties) throws Exception {
+    LiquibaseUpdate mojo = createUpdateMojo(configFileName);
     // Clear out any settings for the property file that may be set
     setVariableValueToObject(mojo, "propertyFile", null);
     setVariableValueToObject(mojo, "propertyFileWillOverride", false);
     
     loadPropertiesFileIfPresent(mojo);
-
+    
     Map values = getVariablesAndValuesFromObject(mojo);
-    checkValues(DEFAULT_PROPERTIES, values);
+    checkValues(properties, values);
   }
-
+  
+  
   public void testOverideAllWithPropertiesFile() throws Exception {
+    testCommonOverideAllWithPropertiesFile(CONFIG_FILE);
+  }
+  
+  public void testDirectoryOverideAllWithPropertiesFile() throws Exception {
+    testCommonOverideAllWithPropertiesFile(DIRECTORY_CONFIG_FILE);
+  }
+  
+  private void testCommonOverideAllWithPropertiesFile(String configFileName) throws Exception {
     // Create the properties file for this test
     Properties props = new Properties();
     props.setProperty("driver", "properties_driver_value");
@@ -48,7 +79,7 @@ public class LiquibaseUpdateMojoTest extends AbstractLiquibaseMojoTest {
     props.setProperty("changeLogFile", "properties_changeLogFile_value");
     createPropertiesFile("update/test.properties", props);
 
-    LiquibaseUpdate mojo = createUpdateMojo();
+    LiquibaseUpdate mojo = createUpdateMojo(configFileName);
     setVariableValueToObject(mojo, "propertyFile", "update/test.properties");
     setVariableValueToObject(mojo, "propertyFileWillOverride", true);
     loadPropertiesFileIfPresent(mojo);
@@ -56,17 +87,26 @@ public class LiquibaseUpdateMojoTest extends AbstractLiquibaseMojoTest {
     Map values = super.getVariablesAndValuesFromObject(mojo);
     checkValues(props, values);
   }
-
+  
   public void testOverrideAllButDriverWithPropertiesFile() throws Exception {
+    testCommonOverrideAllButDriverWithPropertiesFile(CONFIG_FILE, DEFAULT_PROPERTIES);
+  }
+  
+  public void testDirectoryOverrideAllButDriverWithPropertiesFile() throws Exception {
+    testCommonOverrideAllButDriverWithPropertiesFile(DIRECTORY_CONFIG_FILE, DIRECTORY_PROPERTIES);
+  }
+  
+  public void testCommonOverrideAllButDriverWithPropertiesFile(String configFileName, Map<String, Object> properties) throws Exception {
     // Create the properties file for this test
     Properties props = new Properties();
     props.setProperty("url", "properties_url_value");
     props.setProperty("username", "properties_user_value");
     props.setProperty("password", "properties_password_value");
+    props.setProperty("changeLogDirectory", "properties_changeLogDirectory_value");
     props.setProperty("changeLogFile", "properties_changeLogFile_value");
     createPropertiesFile("update/test.properties", props);
 
-    LiquibaseUpdate mojo = createUpdateMojo();
+    LiquibaseUpdate mojo = createUpdateMojo(configFileName);
     setVariableValueToObject(mojo, "propertyFile", "update/test.properties");
     setVariableValueToObject(mojo, "propertyFileWillOverride", true);
     loadPropertiesFileIfPresent(mojo);
@@ -77,20 +117,29 @@ public class LiquibaseUpdateMojoTest extends AbstractLiquibaseMojoTest {
     // Ensure that the properties file has not overridden the driver value as it was not
     // specified in the properties.
     assertEquals("Driver should be set to the default value",
-                 DEFAULT_PROPERTIES.get("driver"),
+        properties.get("driver"),
                  values.get("driver"));
   }
 
   public void testPropertiesFilePresentWithNoOverrideAndMissingProperty() throws Exception {
+    testCommonPropertiesFilePresentWithNoOverrideAndMissingProperty(CONFIG_FILE, DEFAULT_PROPERTIES);
+  }
+  
+  public void testDirectoryPropertiesFilePresentWithNoOverrideAndMissingProperty() throws Exception {
+    testCommonPropertiesFilePresentWithNoOverrideAndMissingProperty(DIRECTORY_CONFIG_FILE, DIRECTORY_PROPERTIES);
+  }
+  
+  public void testCommonPropertiesFilePresentWithNoOverrideAndMissingProperty(String configFileName, Map<String, Object> properties) throws Exception {
     // Create the properties file for this test
     Properties props = new Properties();
     props.setProperty("url", "properties_url_value");
     props.setProperty("username", "properties_user_value");
     props.setProperty("password", "properties_password_value");
+    props.setProperty("changeLogDirectory", "properties_changeLogDirectory_value");
     props.setProperty("changeLogFile", "properties_changeLogFile_value");
     createPropertiesFile("update/test.properties", props);
 
-    LiquibaseUpdate mojo = createUpdateMojo();
+    LiquibaseUpdate mojo = createUpdateMojo(configFileName);
     setVariableValueToObject(mojo, "propertyFile", "update/test.properties");
     setVariableValueToObject(mojo, "propertyFileWillOverride", false);
     loadPropertiesFileIfPresent(mojo);
@@ -98,7 +147,7 @@ public class LiquibaseUpdateMojoTest extends AbstractLiquibaseMojoTest {
     Map values = super.getVariablesAndValuesFromObject(mojo);
     // The password is not specified in the configuration XML so we expect the password
     // from the properties file to be injected into the mojo.
-    Map expected = new HashMap<String, Object>(DEFAULT_PROPERTIES);
+    Map expected = new HashMap<String, Object>(properties);
     expected.put("password", props.getProperty("password"));
     checkValues(expected, values);
   }
@@ -108,9 +157,9 @@ public class LiquibaseUpdateMojoTest extends AbstractLiquibaseMojoTest {
    * PRIVATE METHODS
   \*-------------------------------------------------------------------------*/
 
-  private LiquibaseUpdate createUpdateMojo() throws Exception {
+  private LiquibaseUpdate createUpdateMojo(String configFileName) throws Exception {
     LiquibaseUpdate mojo = new LiquibaseUpdate();
-    PlexusConfiguration config = loadConfiguration(CONFIG_FILE);
+    PlexusConfiguration config = loadConfiguration(configFileName);
     configureMojo(mojo, config);
     return mojo;
   }

--- a/liquibase-maven-plugin/src/test/resources/update/plugin_config_directory.xml
+++ b/liquibase-maven-plugin/src/test/resources/update/plugin_config_directory.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.liquibase</groupId>
+        <artifactId>liquibase-plugin</artifactId>
+        <configuration>
+          <verbose>true</verbose>
+          <changeLogDirectory>org/liquibase/</changeLogDirectory>
+          <changeLogFile>changelog.xml</changeLogFile>
+          <driver>com.mysql.jdbc.Driver</driver>
+          <url>jdbc:mysql://localhost/eformat</url>
+          <username>root</username>
+          <outputDefaultCatalog>false</outputDefaultCatalog>
+          <outputDefaultSchema>false</outputDefaultSchema>
+		  <outputFileEncoding>UTF-8</outputFileEncoding>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>


### PR DESCRIPTION
On our project, before using the maven plugin, we ran our liquibase scripts by using the command line directly from the "src/main/changelog" folder, so, the databasechangelog.filename was of type "36.0.0/master-changelog.xml".
But after using the maven plugin, the databasechangelog.filename content became "src/main/changelog/36.0.0/master-changelog.xml" so we lost the synchronization and the already executed scripts started up again.

I didn't find any way to ask to liquibase to remove the prefix folder "src/main/changelog" and I didn't want to move our changelogs (because of implying too much changes to our packaging chain, our production deployment processes, and so on). So, I thought it would be a good idea to be able to configure the location of the main changelog to remove the prefix folder in the databasechangelog.filename field.

So now we can configure liquibase-maven-plugin like that to specify the main changelog file folder :
```
<plugin>
	<groupId>org.liquibase</groupId>
	<artifactId>liquibase-maven-plugin</artifactId>
	<configuration>
		<changeLogDirectory>${project.basedir}/src/main/changelog</changeLogDirectory>
		<changeLogFile>update-db-changelog.xml</changeLogFile>
	</configuration>
</plugin>
```
So, in this particular case, the databasechangelog.filename field will only contain "update-db-changelog.xml" and not "${project.basedir}/src/main/changelog/update-db-changelog.xml" or "src/main/changelog/update-db-changelog.xml".

This new changeLogDirectory configuration property is not mandatory and it can be an absolute or a relative path to the main changelog file folder (based on the project.basedir in relative case).


Regards.
Logan HAUSPIE.