### PR TITLE
actually includeAll is not working within a SPRING BOOT jar

### DIFF
--- a/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
@@ -84,12 +84,16 @@ public class ClassLoaderResourceAccessor extends AbstractResourceAccessor {
                 }
                 zipFilePath = URLDecoder.decode(zipFilePath, LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).getOutputEncoding());
 
-                if (path.startsWith("classpath:")) {
+                /*if (path.startsWith("classpath:")) {
                     path = path.replaceFirst("classpath:", "");
                 }
                 if (path.startsWith("classpath*:")) {
                     path = path.replaceFirst("classpath\\*:", "");
-                }
+                }*/
+                
+                path = zipAndFile[1].replaceFirst("/", "");
+                if (zipAndFile.length==3) path = path + zipAndFile[2]; 
+                
 
                 // TODO:When we update to Java 7+, we can can create a FileSystem from the JAR (zip)
                 // file, and then use NIO's directory walking and filtering mechanisms to search through it.


### PR DESCRIPTION
Basically the resource files (and others files) are not placed at the root (“/”) of spring boot executable jar but inside the path BOOT-INF/classes. See the example I’ve used to deploy this fix: 
```
BOOT-INF
        └── lib
         └── classes
	      └── application.yml
                  └── your classes
                  └── update.xml
                  └── db
		    └──  01 changelog.xml
                            └──  02 changelog.xml
                            └──  03 changelog.xml
```
My main changelog file is named update.xml and it is places, in my sources dir, at /src/main/resources/update.xml, along side with the directory db where all my changelogs files ar stored.  

In the picture above you could se that update.xml and db are not placed at the root of the Spring boot jar, as you could expected, but respectively  at the path BOO-INF/classes/update.xm and BOOT-INF/classes/db. 

To complete my scenario here the content of my update.xml file:
```xml
<databaseChangeLog 
        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">

	<!--  include file="env-check.xml" /-->
	<includeAll path="db" relativeToChangelogFile="true"  />

</databaseChangeLog>
```

To explain in details why liquibase class  ClassLoaderResourceAccessor could not work on Spring boot jar please refer to the code of method list, from line 95: in the example above the variables when debugger stop here are:
* path: “jar:file:/home/nicola/myproject/build/libs/app.jar!/BOOT-INF/classes!/db/”
* zipAndFile: “/home/nicola/myproject/build/libs/app.jar”, “/BOOT-INF/classes”, “/db/”]

As you could see zipAndFile as 3 entries and NOT 2 as you could expect. My patch  is quite rudimentary and use last entries  of zipAndFile to compute the correct resource path inside Spring boot jar, that is “/BOOT-INF/classes” + “/db/”, with the accountancy of remove the first “/” to match with JarEntry with doesn’t use it for root elements :-(

I hope my fix could be of some help to build a more engineered solution.

Nicola
P.S.
Please refer to the last post on this closed ticket:
https://liquibase.jira.com/browse/CORE-1986?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel
