### PR TITLE
Prevent liquibase.exception.DatabaseException

### DIFF
--- a/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -748,9 +748,11 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
 
                     String catalog = ((AbstractJdbcDatabase) database).getJdbcCatalogName(catalogAndSchema);
                     String schema = ((AbstractJdbcDatabase) database).getJdbcSchemaName(catalogAndSchema);
+                    if (database instanceof DB2Database && ((DB2Database)database).getDataServerType() == DataServerType.DB2I) {
+                        return queryDB2I(schema, view);
+                    }
                     return extract(databaseMetaData.getTables(catalog, schema, view, new String[]{"VIEW"}));
                 }
-
 
                 @Override
                 public List<CachedRow> bulkFetchQuery() throws SQLException, DatabaseException {
@@ -762,7 +764,19 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
 
                     String catalog = ((AbstractJdbcDatabase) database).getJdbcCatalogName(catalogAndSchema);
                     String schema = ((AbstractJdbcDatabase) database).getJdbcSchemaName(catalogAndSchema);
+                    if (database instanceof DB2Database && ((DB2Database)database).getDataServerType() == DataServerType.DB2I) {
+                        return queryDB2I(schema, null);
+                    }
                     return extract(databaseMetaData.getTables(catalog, schema, null, new String[]{"VIEW"}));
+                }
+
+
+                private List<CachedRow> queryDB2I(String schema, String view) throws DatabaseException, SQLException {
+                    String sql = "SELECT TABLE_CATALOG as TABLE_CAT, TABLE_SCHEMA as TABLE_SCHEM, TABLE_NAME, VIEW_DEFINITION as OBJECT_BODY FROM SYSIBM.VIEWS WHERE TABLE_SCHEMA='" + schema + "'";
+                    if (view != null) {
+                        sql += " AND TABLE_NAME='" + view + "'";
+                    }
+                    return executeAndExtract(sql, database);
                 }
 
                 private List<CachedRow> queryOracle(CatalogAndSchema catalogAndSchema, String viewName) throws DatabaseException, SQLException {


### PR DESCRIPTION
At least on our system AS400JDBCDatabaseMetaData.getTables called to get views and view = null return a lot of of entries that are not really views.
For reference we use jtopen 9.3 against a v7r1 IBM i system.
The new code has the added bonus of returning OBJECT_BODY in the same query.

Full error message before this fix:
SEVERE 2017-06-28 15:52: liquibase: liquibase.exception.DatabaseException: Error getting jdbc:as400://xx.xx.xx.xx/schema view with liquibase.statement.core.GetViewDefinitionStatement@3cef309d
liquibase.exception.LiquibaseException: liquibase.command.CommandExecutionException: liquibase.exception.DatabaseException: Error getting jdbc:as400://xx.xx.xx.xx/schema view with liquibase.statement.core.GetViewDefinitionStatement@3cef309d
	at liquibase.integration.commandline.CommandLineUtils.doGenerateChangeLog(CommandLineUtils.java:272)
	at liquibase.integration.commandline.Main.doMigration(Main.java:1018)
	at liquibase.integration.commandline.Main.run(Main.java:191)
	at liquibase.integration.commandline.Main.main(Main.java:106)
Caused by: liquibase.command.CommandExecutionException: liquibase.exception.DatabaseException: Error getting jdbc:as400://xx.xx.xx.xx/schema view with liquibase.statement.core.GetViewDefinitionStatement@3cef309d
	at liquibase.command.AbstractCommand.execute(AbstractCommand.java:24)
	at liquibase.integration.commandline.CommandLineUtils.doGenerateChangeLog(CommandLineUtils.java:270)
	... 3 more
Caused by: liquibase.exception.DatabaseException: Error getting jdbc:as400://xx.xx.xx.xx/schema view with liquibase.statement.core.GetViewDefinitionStatement@3cef309d
	at liquibase.snapshot.jvm.ViewSnapshotGenerator.snapshotObject(ViewSnapshotGenerator.java:104)
	at liquibase.snapshot.jvm.JdbcSnapshotGenerator.snapshot(JdbcSnapshotGenerator.java:60)
	at liquibase.snapshot.SnapshotGeneratorChain.snapshot(SnapshotGeneratorChain.java:50)
	at liquibase.snapshot.jvm.JdbcSnapshotGenerator.snapshot(JdbcSnapshotGenerator.java:63)
	at liquibase.snapshot.SnapshotGeneratorChain.snapshot(SnapshotGeneratorChain.java:50)
	at liquibase.snapshot.DatabaseSnapshot.include(DatabaseSnapshot.java:257)
	at liquibase.snapshot.DatabaseSnapshot.replaceObject(DatabaseSnapshot.java:374)
	at liquibase.snapshot.DatabaseSnapshot.replaceObject(DatabaseSnapshot.java:396)
	at liquibase.snapshot.DatabaseSnapshot.includeNestedObjects(DatabaseSnapshot.java:304)
	at liquibase.snapshot.DatabaseSnapshot.include(DatabaseSnapshot.java:278)
	at liquibase.snapshot.DatabaseSnapshot.init(DatabaseSnapshot.java:82)
	at liquibase.snapshot.DatabaseSnapshot.<init>(DatabaseSnapshot.java:55)
	at liquibase.snapshot.JdbcDatabaseSnapshot.<init>(JdbcDatabaseSnapshot.java:33)
	at liquibase.snapshot.SnapshotGeneratorFactory.createSnapshot(SnapshotGeneratorFactory.java:150)
	at liquibase.snapshot.SnapshotGeneratorFactory.createSnapshot(SnapshotGeneratorFactory.java:139)
	at liquibase.command.core.DiffCommand.createReferenceSnapshot(DiffCommand.java:221)
	at liquibase.command.core.DiffCommand.createDiffResult(DiffCommand.java:143)
	at liquibase.command.core.GenerateChangeLogCommand.run(GenerateChangeLogCommand.java:46)
	at liquibase.command.AbstractCommand.execute(AbstractCommand.java:19)
	... 4 more
Caused by: liquibase.exception.DatabaseException: Expected single row from liquibase.statement.core.GetViewDefinitionStatement@50b494a6 but got 0
	at liquibase.executor.jvm.JdbcExecutor.queryForObject(JdbcExecutor.java:146)
	at liquibase.executor.jvm.JdbcExecutor.queryForObject(JdbcExecutor.java:157)
	at liquibase.executor.jvm.JdbcExecutor.queryForObject(JdbcExecutor.java:152)
	at liquibase.database.core.DB2Database.getViewDefinition(DB2Database.java:184)
	at liquibase.snapshot.jvm.ViewSnapshotGenerator.snapshotObject(ViewSnapshotGenerator.java:79)
	... 22 more
Caused by: liquibase.exception.DatabaseException: Empty result set, expected one row
	at liquibase.util.JdbcUtils.requiredSingleResult(JdbcUtils.java:141)
	at liquibase.executor.jvm.JdbcExecutor.queryForObject(JdbcExecutor.java:144)
	... 26 more
