### PR TITLE
CORE-1609 Command Prompt: Can't connect to database with a special character in pwd

### DIFF
--- a/liquibase-core/src/main/resources/dist/liquibase.bat
+++ b/liquibase-core/src/main/resources/dist/liquibase.bat
@@ -10,6 +10,9 @@ set CP=.
 for /R %LIQUIBASE_HOME% %%f in (liquibase*.jar) do set CP=!CP!;%%f
 for /R %LIQUIBASE_HOME%\lib %%f in (*.jar) do set CP=!CP!;%%f
 
+rem special characters may be lost
+setlocal DISABLEDELAYEDEXPANSION
+
 rem get command line args into a variable
 set CMD_LINE_ARGS=%1
 if ""%1""=="""" goto done


### PR DESCRIPTION
Special characters passed in via command prompt are being lost.
This is due to delayedexpansion is enabled.

Solution:
Turn off delayedexpansion when it is no longer required.

How to test: connect to the database using liquibase.bat and pass in the password as an argument.
Password must contain an exclamation mark (!).