### PR TITLE
Support loadUpdateData with informix database. (Bug fix / feature)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/InsertOrUpdateGeneratorInformix.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/InsertOrUpdateGeneratorInformix.java
@@ -1,0 +1,142 @@
+package liquibase.sqlgenerator.core;
+
+import liquibase.database.Database;
+import liquibase.database.core.InformixDatabase;
+import liquibase.datatype.DataTypeFactory;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.statement.core.InsertOrUpdateStatement;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+
+@SuppressWarnings("ALL")
+public class InsertOrUpdateGeneratorInformix extends InsertOrUpdateGenerator {
+
+  // Table Aliases for Merge references
+  private static final String SOURCE_ALIAS = "src";
+  private static final String DEST_ALIAS = "dst";
+
+  @Override
+  public boolean supports(InsertOrUpdateStatement statement, Database database) {
+    return database instanceof InformixDatabase;
+  }
+
+  @Override
+  protected String getRecordCheck(InsertOrUpdateStatement insertOrUpdateStatement, Database database, String whereClause) {
+    StringBuilder sql = new StringBuilder();
+    String[] pkFields = insertOrUpdateStatement.getPrimaryKey().split(",");
+    String tableReference = database.escapeTableName(insertOrUpdateStatement.getCatalogName(), insertOrUpdateStatement.getSchemaName(), insertOrUpdateStatement.getTableName());
+
+    sql.append("MERGE INTO ").append(tableReference).append(" AS ").append(DEST_ALIAS).append("\n");
+    sql.append("USING (\n");
+    sql.append(getSelect(insertOrUpdateStatement, database));
+    sql.append(") AS ").append(SOURCE_ALIAS).append("\n");
+    sql.append("ON ");
+
+    // Merge and match upon the Primary key fields
+    for (int i = 0; i < pkFields.length; i++) {
+      sql.append(DEST_ALIAS).append(".").append(pkFields[i]).append(" = ").append(SOURCE_ALIAS).append(".").append(pkFields[i]);
+
+      if (i < pkFields.length - 1) {
+        sql.append(" AND ");
+      }
+    }
+    sql.append("\nWHEN NOT MATCHED THEN\n");
+
+    return sql.toString();
+  }
+
+  @Override
+  protected String getInsertStatement(InsertOrUpdateStatement insertOrUpdateStatement, Database database,
+                                      SqlGeneratorChain sqlGeneratorChain) {
+    StringBuilder columns = new StringBuilder();
+    StringBuilder values = new StringBuilder();
+
+    for (String columnKey : insertOrUpdateStatement.getColumnValues().keySet()) {
+      columns.append(", ");
+      columns.append(DEST_ALIAS).append(".").append(columnKey);
+      values.append(SOURCE_ALIAS).append(".").append(columnKey).append(", ");
+    }
+    columns.delete(0, 2);
+
+    int lastComma = values.lastIndexOf(",");
+    if (lastComma > -1) {
+      values.delete(lastComma, lastComma + 2);
+    }
+
+    return "INSERT (" + columns.toString() + ") VALUES (" + values.toString() + ")\n";
+  }
+
+  @Override
+  protected String getElse(Database database) {
+    return "WHEN MATCHED THEN\n";
+  }
+
+  @Override
+  protected String getUpdateStatement(InsertOrUpdateStatement insertOrUpdateStatement, Database database,
+                                      String whereClause, SqlGeneratorChain sqlGeneratorChain) {
+    String[] pkFields = insertOrUpdateStatement.getPrimaryKey().split(",");
+    StringBuilder sql = new StringBuilder("UPDATE SET ");
+
+    HashSet<String> hashPkFields = new HashSet<String>(Arrays.asList(pkFields));
+
+    for (String columnKey : insertOrUpdateStatement.getColumnValues().keySet()) {
+      // Do not include Primary Key fields within the update
+      if (!hashPkFields.contains(columnKey)) {
+        sql.append(DEST_ALIAS).append(".").append(columnKey).append(" = ");
+        sql.append(SOURCE_ALIAS).append(".").append(columnKey);
+        sql.append(", ");
+      }
+    }
+
+    int lastComma = sql.lastIndexOf(",");
+    if (lastComma > -1) {
+      sql.delete(lastComma, lastComma + 2);
+    }
+    return sql.toString();
+  }
+
+  // Copied and modified from liquibase.sqlgenerator.core.InsertOrUpdateGeneratorMySQL
+  private String convertToString(Object newValue, Database database) {
+    String sqlString;
+    if (newValue == null || newValue.toString().equals("") || newValue.toString().equalsIgnoreCase("NULL")) {
+      sqlString = "NULL::INTEGER";
+    } else if (newValue instanceof String && !looksLikeFunctionCall(((String) newValue), database)) {
+      sqlString = "'" + database.escapeStringForDatabase(newValue.toString()) + "'";
+    } else if (newValue instanceof Date) {
+      sqlString = database.getDateLiteral(((Date) newValue));
+    } else if (newValue instanceof Boolean) {
+      if (((Boolean) newValue)) {
+        sqlString = DataTypeFactory.getInstance().getTrueBooleanValue(database);
+      } else {
+        sqlString = DataTypeFactory.getInstance().getFalseBooleanValue(database);
+      }
+    } else {
+      sqlString = newValue.toString();
+    }
+    return sqlString;
+  }
+
+  private String getSelect(InsertOrUpdateStatement insertOrUpdateStatement, Database database) {
+    StringBuilder select = new StringBuilder();
+    select.append("\tSELECT ");
+
+    for (String columnKey : insertOrUpdateStatement.getColumnValues().keySet()) {
+      select.append(convertToString(insertOrUpdateStatement.getColumnValue(columnKey), database));
+      select.append(" AS ");
+      select.append(columnKey);
+      select.append(", ");
+    }
+
+    int lastComma = select.lastIndexOf(", ");
+    if (lastComma > -1) {
+      select.delete(lastComma, lastComma + 2);
+    }
+
+    select.append("\n\tFROM sysmaster:informix.sysdual\n");
+
+    return select.toString();
+  }
+
+}

--- a/liquibase-core/src/test/java/liquibase/sqlgenerator/core/InsertOrUpdateGeneratorInformixTest.java
+++ b/liquibase-core/src/test/java/liquibase/sqlgenerator/core/InsertOrUpdateGeneratorInformixTest.java
@@ -1,0 +1,113 @@
+package liquibase.sqlgenerator.core;
+
+import liquibase.database.core.InformixDatabase;
+import liquibase.statement.core.InsertOrUpdateStatement;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public class InsertOrUpdateGeneratorInformixTest {
+
+  private InsertOrUpdateGeneratorInformix generator;
+  private InsertOrUpdateStatement statement;
+  private InformixDatabase database;
+
+  @Before
+  public void setUp() throws Exception {
+    generator = new InsertOrUpdateGeneratorInformix();
+    database = new InformixDatabase();
+
+    // Setup the test statement to use throughout the tests
+    statement = new InsertOrUpdateStatement("mycatalog", "myschema", "mytable", "pk_col1,pk_col2");
+    statement.addColumnValue("pk_col1", 1);
+    statement.addColumnValue("pk_col2", 2);
+    statement.addColumnValue("col2", "value2");
+    statement.addColumnValue("col3", null);
+  }
+
+  @Test
+  public void getRecordCheck() throws Exception {
+    String recordCheck = (String)invokePrivateMethod(generator,"getRecordCheck", new Object[] { statement, database, null });
+    assertNotNull(recordCheck);
+
+    Integer lineNumber = 0;
+    String[] lines = recordCheck.split("\n");
+
+    assertEquals("MERGE INTO mycatalog:myschema.mytable AS dst", lines[lineNumber]);
+    lineNumber++;
+    assertEquals("USING (", lines[lineNumber]);
+    lineNumber++;
+    assertEquals("\tSELECT 1 AS pk_col1, 2 AS pk_col2, 'value2' AS col2, NULL::INTEGER AS col3", lines[lineNumber]);
+    lineNumber++;
+    assertEquals("\tFROM sysmaster:informix.sysdual", lines[lineNumber]);
+    lineNumber++;
+    assertEquals(") AS src", lines[lineNumber]);
+    lineNumber++;
+    assertEquals("ON dst.pk_col1 = src.pk_col1 AND dst.pk_col2 = src.pk_col2", lines[lineNumber]);
+    lineNumber++;
+    assertEquals("WHEN NOT MATCHED THEN", lines[lineNumber]);
+  }
+
+  @Test
+  public void getInsert() throws Exception {
+    String insertStatement = (String)invokePrivateMethod(generator,"getInsertStatement", new Object[] { statement, database, null });
+    assertNotNull(insertStatement);
+
+    Integer lineNumber = 0;
+    String[] lines = insertStatement.split("\n");
+
+    assertEquals("INSERT (dst.pk_col1, dst.pk_col2, dst.col2, dst.col3) VALUES (src.pk_col1, src.pk_col2, src.col2, src.col3)", lines[lineNumber]);
+  }
+
+  @Test
+  public void getElse() throws Exception {
+    String elseStatement = (String)invokePrivateMethod(generator,"getElse", new Object[] { database });
+    assertNotNull(elseStatement);
+
+    Integer lineNumber = 0;
+    String[] lines = elseStatement.split("\n");
+
+    assertEquals("WHEN MATCHED THEN", lines[lineNumber]);
+  }
+
+  @Test
+  public void getUpdateStatement() throws Exception {
+    String updateStatement = (String)invokePrivateMethod(generator,"getUpdateStatement", new Object[] { statement, database, null, null });
+    assertNotNull(updateStatement);
+
+    Integer lineNumber = 0;
+    String[] lines = updateStatement.split("\n");
+
+    assertEquals("UPDATE SET dst.col2 = src.col2, dst.col3 = src.col3", lines[lineNumber]);
+  }
+
+
+  private static Object invokePrivateMethod(Object o, String methodName, Object[] params) {
+    // Check we have valid arguments...
+    assertNotNull(o);
+    assertNotNull(methodName);
+
+    // Go and find the private method...
+    final Method methods[] = o.getClass().getDeclaredMethods();
+    for (int i = 0; i < methods.length; ++i) {
+      if (methodName.equals(methods[i].getName())) {
+        try {
+          methods[i].setAccessible(true);
+          return methods[i].invoke(o, params);
+        } catch (IllegalAccessException ex) {
+          fail("IllegalAccessException accessing " + methodName);
+        } catch (InvocationTargetException ite) {
+          fail("InvocationTargetException accessing " + methodName);
+        }
+      }
+    }
+    fail("Method '" + methodName + "' not found");
+    return null;
+  }
+}


### PR DESCRIPTION
Found that loadUpdateData wasn't operating correctly against an Informix database.  

Added Informix implementation of 'InsertOrUpdateGenerator'. The implementation utilizes Informix's version of the MERGE statement feature.