### PR TITLE
2nd round of JDK7 compatibility fixes

### DIFF
--- a/liquibase-integration-tests/setup/postgresql/create_dbs_for_integration_tests.sql
+++ b/liquibase-integration-tests/setup/postgresql/create_dbs_for_integration_tests.sql
@@ -8,7 +8,8 @@
 
 DROP DATABASE IF EXISTS liquibase;
 DROP TABLESPACE IF EXISTS liquibase2;
-DROP SCHEMA IF EXISTS lbschem2;
+DROP SCHEMA IF EXISTS lbschem2 CASCADE;
+DROP SCHEMA IF EXISTS lbcat2 CASCADE;
 DROP USER IF EXISTS lbuser;
 
 CREATE USER lbuser WITH
@@ -29,18 +30,16 @@ WITH
           ENCODING = 'UTF8'
           CONNECTION LIMIT = -1;
 
-COMMENT ON DATABASE liquibase
-IS 'LB catalog/database for integration tests';
+COMMENT ON DATABASE liquibase IS 'LB catalog/database for integration tests';
 
 GRANT ALL ON DATABASE liquibase TO lbuser;
 
 \c liquibase
 
-CREATE SCHEMA lbschem2
-AUTHORIZATION lbuser;
+/************************************************************************************************* Schema: LBSCHEM2 */
+CREATE SCHEMA lbschem2 AUTHORIZATION lbuser;
 
-COMMENT ON SCHEMA lbschem2
-IS 'Testing schema for integration tests';
+COMMENT ON SCHEMA lbschem2 IS 'Testing schema for integration tests';
 
 GRANT ALL ON SCHEMA lbschem2 TO lbuser;
 
@@ -56,21 +55,21 @@ GRANT EXECUTE ON FUNCTIONS TO lbuser;
 ALTER DEFAULT PRIVILEGES IN SCHEMA lbschem2
 GRANT USAGE ON TYPES TO lbuser;
 
+/******************************************************************************************** Tablespace: liquibase2 */
+
 CREATE TABLESPACE liquibase2 LOCATION :path_for_tablespace;
 
-ALTER TABLESPACE liquibase2
-OWNER TO lbuser;
+ALTER TABLESPACE liquibase2 OWNER TO lbuser;
 
-COMMENT ON TABLESPACE liquibase2
-IS 'A testing tablespace for integration tests';
+COMMENT ON TABLESPACE liquibase2 IS 'A testing tablespace for integration tests';
 
 GRANT CREATE ON TABLESPACE liquibase2 TO lbuser;
 
-CREATE SCHEMA lbcat2
-AUTHORIZATION lbuser;
+/**************************************************************************************************** Schema: LBCAT2 */
 
-COMMENT ON SCHEMA lbcat2
-IS 'Testing schema for integration tests';
+CREATE SCHEMA lbcat2 AUTHORIZATION lbuser;
+
+COMMENT ON SCHEMA lbcat2 IS 'Testing schema for integration tests';
 
 GRANT ALL ON SCHEMA lbcat2 TO lbuser;
 

--- a/liquibase-integration-tests/setup/postgresql/create_dbs_for_integration_tests.sql
+++ b/liquibase-integration-tests/setup/postgresql/create_dbs_for_integration_tests.sql
@@ -8,6 +8,7 @@
 
 DROP DATABASE IF EXISTS liquibase;
 DROP TABLESPACE IF EXISTS liquibase2;
+DROP SCHEMA IF EXISTS lbschem2;
 DROP USER IF EXISTS lbuser;
 
 CREATE USER lbuser WITH
@@ -15,18 +16,18 @@ CREATE USER lbuser WITH
   NOSUPERUSER
   NOCREATEDB
   NOCREATEROLE
-  INHERIT
+INHERIT
   NOREPLICATION
   CONNECTION LIMIT -1
-  PASSWORD 'lbuser';
+PASSWORD 'lbuser';
 
 COMMENT ON ROLE lbuser IS 'Integration test user for Liquibase';
 
 CREATE DATABASE liquibase
 WITH
-OWNER = default
-ENCODING = 'UTF8'
-CONNECTION LIMIT = -1;
+    OWNER = default
+          ENCODING = 'UTF8'
+          CONNECTION LIMIT = -1;
 
 COMMENT ON DATABASE liquibase
 IS 'LB catalog/database for integration tests';
@@ -36,7 +37,7 @@ GRANT ALL ON DATABASE liquibase TO lbuser;
 \c liquibase
 
 CREATE SCHEMA lbschem2
-  AUTHORIZATION lbuser;
+AUTHORIZATION lbuser;
 
 COMMENT ON SCHEMA lbschem2
 IS 'Testing schema for integration tests';
@@ -66,7 +67,7 @@ IS 'A testing tablespace for integration tests';
 GRANT CREATE ON TABLESPACE liquibase2 TO lbuser;
 
 CREATE SCHEMA lbcat2
-  AUTHORIZATION lbuser;
+AUTHORIZATION lbuser;
 
 COMMENT ON SCHEMA lbcat2
 IS 'Testing schema for integration tests';

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <hsqldb.version>2.3.5</hsqldb.version>
         <mysql-connector-java.version>5.1.42</mysql-connector-java.version>
         <jaybird.version>3.0.1</jaybird.version>
-        <postgresql.version>42.1.1</postgresql.version>
+        <postgresql.version>42.1.1jre7</postgresql.version>
         <com.h2database.version>1.4.196</com.h2database.version>
         <sqlite-jdbc.version>3.19.3</sqlite-jdbc.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
 
         <!-- JDBC driver versions -->
         <derby.version>10.12.1.1</derby.version>
-        <mariadb-java-client.version>2.0.3</mariadb-java-client.version>
+        <mariadb-java-client.version>1.6.2</mariadb-java-client.version>
         <mssql-jdbc.version>6.2.0.jre7</mssql-jdbc.version>
         <hsqldb.version>2.3.5</hsqldb.version>
         <mysql-connector-java.version>6.0.6</mysql-connector-java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,17 +24,6 @@
         </license>
     </licenses>
 
-    <issueManagement>
-        <url>http://liquibase.jira.com/browse/CORE</url>
-    </issueManagement>
-
-    <scm>
-        <connection>scm:git:git@github.com:liquibase/liquibase.git</connection>
-        <url>scm:git:git@github.com:liquibase/liquibase.git</url>
-        <developerConnection>scm:git:git@github.com:liquibase/liquibase.git</developerConnection>
-        <tag>HEAD</tag>
-    </scm>
-
     <developers>
         <developer>
             <id>nvoxland</id>
@@ -60,6 +49,30 @@
         <module>liquibase-cdi</module>
         <module>liquibase-integration-tests</module>
     </modules>
+
+    <scm>
+        <connection>scm:git:git@github.com:liquibase/liquibase.git</connection>
+        <url>scm:git:git@github.com:liquibase/liquibase.git</url>
+        <developerConnection>scm:git:git@github.com:liquibase/liquibase.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <issueManagement>
+        <url>http://liquibase.jira.com/browse/CORE</url>
+    </issueManagement>
+
+    <distributionManagement>
+        <repository>
+            <id>sonatype-nexus-staging</id>
+            <name>Sonatype Production Repository</name>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+        </repository>
+        <snapshotRepository>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sontatype Snapshot Repository</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
 
     <properties>
         <jdk.version>1.7</jdk.version>
@@ -609,19 +622,6 @@
         </pluginManagement>
 
     </build>
-
-    <distributionManagement>
-        <repository>
-            <id>sonatype-nexus-staging</id>
-            <name>Sonatype Production Repository</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-        </repository>
-        <snapshotRepository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sontatype Snapshot Repository</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
 
     <profiles>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <hsqldb.version>2.3.5</hsqldb.version>
         <mysql-connector-java.version>5.1.42</mysql-connector-java.version>
         <jaybird.version>3.0.1</jaybird.version>
-        <postgresql.version>42.1.1jre7</postgresql.version>
+        <postgresql.version>42.1.1.jre7</postgresql.version>
         <com.h2database.version>1.4.196</com.h2database.version>
         <sqlite-jdbc.version>3.19.3</sqlite-jdbc.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <mariadb-java-client.version>1.6.2</mariadb-java-client.version>
         <mssql-jdbc.version>6.2.0.jre7</mssql-jdbc.version>
         <hsqldb.version>2.3.5</hsqldb.version>
-        <mysql-connector-java.version>6.0.6</mysql-connector-java.version>
+        <mysql-connector-java.version>5.1.42</mysql-connector-java.version>
         <jaybird.version>3.0.1</jaybird.version>
         <postgresql.version>42.1.1</postgresql.version>
         <com.h2database.version>1.4.196</com.h2database.version>

--- a/pom.xml
+++ b/pom.xml
@@ -119,8 +119,6 @@
         <derby.version>10.12.1.1</derby.version>
         <mariadb-java-client.version>2.0.3</mariadb-java-client.version>
         <mssql-jdbc.version>6.2.0.jre7</mssql-jdbc.version>
-        <hsqldb.version>2.4.0</hsqldb.version>
-        <mssql-jdbc.version>6.2.0.jre8</mssql-jdbc.version>
         <hsqldb.version>2.3.5</hsqldb.version>
         <mysql-connector-java.version>6.0.6</mysql-connector-java.version>
         <jaybird.version>3.0.1</jaybird.version>

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,8 @@
         <!-- JDBC driver versions -->
         <derby.version>10.12.1.1</derby.version>
         <mariadb-java-client.version>2.0.3</mariadb-java-client.version>
+        <mssql-jdbc.version>6.2.0.jre7</mssql-jdbc.version>
+        <hsqldb.version>2.4.0</hsqldb.version>
         <mssql-jdbc.version>6.2.0.jre8</mssql-jdbc.version>
         <hsqldb.version>2.3.5</hsqldb.version>
         <mysql-connector-java.version>6.0.6</mysql-connector-java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <derby.version>10.12.1.1</derby.version>
         <mariadb-java-client.version>2.0.3</mariadb-java-client.version>
         <mssql-jdbc.version>6.2.0.jre8</mssql-jdbc.version>
-        <hsqldb.version>2.4.0</hsqldb.version>
+        <hsqldb.version>2.3.5</hsqldb.version>
         <mysql-connector-java.version>6.0.6</mysql-connector-java.version>
         <jaybird.version>3.0.1</jaybird.version>
         <postgresql.version>42.1.1</postgresql.version>


### PR DESCRIPTION
(1) If possible, use a JDK7 driver with the same version number. If not, use the last version that is compatible with JDK7.
(2) SONAR fix: Reorder elements in pom.xmls to match the standard order for Maven
(3) Fix für the PostgreSQL IT setup script: Drop schema LBCAT2 on test db reset