### PR TITLE
Resolve bug in includeAll with Spring Boot

### DIFF
--- a/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
@@ -4,6 +4,7 @@ import liquibase.configuration.GlobalConfiguration;
 import liquibase.configuration.LiquibaseConfiguration;
 import liquibase.logging.LogFactory;
 import liquibase.util.StringUtils;
+import liquibase.util.SpringBootFatJar;
 
 import java.io.File;
 import java.io.IOException;
@@ -84,6 +85,7 @@ public class ClassLoaderResourceAccessor extends AbstractResourceAccessor {
                 }
                 zipFilePath = URLDecoder.decode(zipFilePath, LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).getOutputEncoding());
 
+                path = SpringBootFatJar.getPathForResource(path);
                 if (path.startsWith("classpath:")) {
                     path = path.replaceFirst("classpath:", "");
                 }

--- a/liquibase-core/src/main/java/liquibase/util/SpringBootFatJar.java
+++ b/liquibase-core/src/main/java/liquibase/util/SpringBootFatJar.java
@@ -1,0 +1,12 @@
+package liquibase.util;
+
+public class SpringBootFatJar {
+    public static String getPathForResource(String path) {
+        String[] components = path.split("!");
+        if (components.length == 3) {
+            return String.format("%s%s", components[1].substring(1), components[2]);
+        } else {
+            return path;
+        }
+    }
+}

--- a/liquibase-core/src/test/java/liquibase/util/SpringBootFatJarTest.java
+++ b/liquibase-core/src/test/java/liquibase/util/SpringBootFatJarTest.java
@@ -1,0 +1,19 @@
+package liquibase.util;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class SpringBootFatJarTest {
+
+    @Test
+    public void testGetPathForResourceWithFatJarPath() {
+        String result = SpringBootFatJar.getPathForResource("some/path!/that/has!/two/bangs");
+        assertEquals(result, "that/has/two/bangs");
+    }
+
+    @Test
+    public void testGetPathForResourceWithSimplePath() {
+        String result = SpringBootFatJar.getPathForResource("some/path!/that/has/one/bang");
+        assertEquals(result, "some/path!/that/has/one/bang");
+    }
+}


### PR DESCRIPTION
Why did you make this change?

The includeAll feature doesn't work with spring-boot packaged jar files.

Something chnaged in the path format that liquibase isn't able to
handle. It attempts to load the resources in the given path, but isn't
able to find the files because the path isn't pointing to the correct
place in the jar file.

I created a simple utility class to check for the signature of
the spring boot fat jar, which is that it includes 2 exclamation points,
and modified the path to correctly load the resources in the given path.

Resolves:
https://liquibase.jira.com/browse/CORE-2863
https://liquibase.jira.com/browse/CORE-2948