### PR TITLE
Hotfix 3.5.3 rollback loadUpdateData tag using empty csv

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
@@ -359,9 +359,7 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
                 }
 
                 if (database instanceof MSSQLDatabase || database instanceof MySQLDatabase || database instanceof PostgresDatabase) {
-
                     List<InsertStatement> innerStatements = statementSet.getStatements();
-
                     if (innerStatements != null && innerStatements.size() > 0 && innerStatements.get(0) instanceof InsertOrUpdateStatement) {
                         //cannot do insert or update in a single statement
                         return statementSet.getStatementsArray();

--- a/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
@@ -211,8 +211,6 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
                 lineNumber++;
                 if (line.length == 0 || (line.length == 1 && StringUtils.trimToNull(line[0]) == null)
                         || (isCommentingEnabled && isLineCommented(line))) {
-                	System.out.println(this.getClass().getName()+":: 4 generateStatement:: line is EMPTY");
-
                     continue; //nothing on this line
                 }
 

--- a/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
@@ -211,6 +211,8 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
                 lineNumber++;
                 if (line.length == 0 || (line.length == 1 && StringUtils.trimToNull(line[0]) == null)
                         || (isCommentingEnabled && isLineCommented(line))) {
+                	System.out.println(this.getClass().getName()+":: 4 generateStatement:: line is EMPTY");
+
                     continue; //nothing on this line
                 }
 
@@ -348,13 +350,20 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
             if (anyPreparedStatements) {
                 return statements.toArray(new SqlStatement[statements.size()]);
             } else {
+            	if (statements.isEmpty()) {
+            		// avoid returning unnecessary dummy statement
+            		return new SqlStatement[0];
+            	}
+
                 InsertSetStatement statementSet = this.createStatementSet(getCatalogName(), getSchemaName(), getTableName());
                 for (SqlStatement stmt : statements) {
                     statementSet.addInsertStatement((InsertStatement) stmt);
                 }
 
                 if (database instanceof MSSQLDatabase || database instanceof MySQLDatabase || database instanceof PostgresDatabase) {
+
                     List<InsertStatement> innerStatements = statementSet.getStatements();
+
                     if (innerStatements != null && innerStatements.size() > 0 && innerStatements.get(0) instanceof InsertOrUpdateStatement) {
                         //cannot do insert or update in a single statement
                         return statementSet.getStatementsArray();

--- a/liquibase-core/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
@@ -17,7 +17,7 @@ import spock.lang.Unroll
 public class LoadDataChangeTest extends StandardChangeTest {
 
 
-    def "loadDataEmpty using InsertSetStatement"() throws Exception {
+    def "loadDataEmpty database agnostic"() throws Exception {
         when:
         LoadDataChange refactoring = new LoadDataChange();
         refactoring.setSchemaName("SCHEMA_NAME");
@@ -29,31 +29,9 @@ public class LoadDataChangeTest extends StandardChangeTest {
 
 		SqlStatement[] sqlStatement = refactoring.generateStatements(new MSSQLDatabase());
 		then:
-		sqlStatement.length == 1
-		assert sqlStatement[0] instanceof InsertSetStatement
-
-		when:
-        SqlStatement[] sqlStatements = ((InsertSetStatement)sqlStatement[0]).getStatementsArray();
-
-		then:
-        sqlStatements.length == 0
+		sqlStatement.length == 0
     }
 
-    def "loadDataEmpty not using InsertSetStatement"() throws Exception {
-        when:
-        LoadDataChange refactoring = new LoadDataChange();
-        refactoring.setSchemaName("SCHEMA_NAME");
-        refactoring.setTableName("TABLE_NAME");
-        refactoring.setFile("liquibase/change/core/empty.data.csv");
-        refactoring.setSeparator(",");
-
-        refactoring.setResourceAccessor(new JUnitResourceAccessor());
-
-        SqlStatement[] sqlStatements = refactoring.generateStatements(new MockDatabase());
-
-        then:
-        sqlStatements.length == 0
-    }
 
     @Unroll("multiple formats with the same data for #fileName")
     def "multiple formats with the same data using InsertSetStatement"() throws Exception {

--- a/liquibase-core/src/test/groovy/liquibase/change/core/LoadUpdateDataChangeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/core/LoadUpdateDataChangeTest.groovy
@@ -8,6 +8,10 @@ import liquibase.sdk.database.MockDatabase
 import liquibase.resource.ClassLoaderResourceAccessor;
 import liquibase.statement.SqlStatement
 import liquibase.statement.core.InsertOrUpdateStatement;
+import liquibase.test.JUnitResourceAccessor
+import liquibase.database.core.MSSQLDatabase
+
+
 import static org.junit.Assert.*
 
 public class LoadUpdateDataChangeTest extends StandardChangeTest {
@@ -22,6 +26,21 @@ public class LoadUpdateDataChangeTest extends StandardChangeTest {
         "Data loaded from FILE_NAME into TABLE_NAME" == refactoring.getConfirmationMessage()
     }
 
+	def "loadUpdateEmpty database agnostic"() throws Exception {
+		when:
+		LoadUpdateDataChange refactoring = new LoadUpdateDataChange();
+		refactoring.setSchemaName("SCHEMA_NAME");
+		refactoring.setTableName("TABLE_NAME");
+		refactoring.setFile("liquibase/change/core/empty.data.csv");
+		refactoring.setSeparator(",");
+
+		refactoring.setResourceAccessor(new JUnitResourceAccessor());
+
+		SqlStatement[] sqlStatement = refactoring.generateRollbackStatements(new MSSQLDatabase());
+		
+		then:
+		sqlStatement.length == 0
+	}
 
     def "loadUpdate generates InsertOrUpdateStatements"() throws Exception {
         when:


### PR DESCRIPTION
It should be possible to rollback chnageSet with loadUpdateData tag when using empty CSV file. File have correct column names (first row) but no data rows.