### PR TITLE
HSQLDatabase UUID support

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/UUIDType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/UUIDType.java
@@ -15,7 +15,8 @@ public class UUIDType extends LiquibaseDataType {
     public DatabaseDataType toDatabaseDataType(Database database) {
         try {
             if (database instanceof H2Database
-                    || (database instanceof PostgresDatabase && database.getDatabaseMajorVersion() * 10 + database.getDatabaseMinorVersion() >= 83)) {
+                    || (database instanceof PostgresDatabase && database.getDatabaseMajorVersion() * 10 + database.getDatabaseMinorVersion() >= 83)
+                    || (database instanceof HsqlDatabase && database.getDatabaseMajorVersion() * 10 + database.getDatabaseMinorVersion() >= 24)) {
                 return new DatabaseDataType("UUID");
             }
         } catch (DatabaseException e) {


### PR DESCRIPTION
HSQL database has support for UUID since 2.3.4. Since the database implementation does not support `getDatabaseMicroVersion` I added the support for version 2.4.

This should resolve CORE-3094