### PR TITLE
CORE-3006: Improve handling of invalid date literals

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
@@ -258,16 +258,17 @@ public class OracleDatabase extends AbstractJdbcDatabase {
             val.append(", 'YYYY-MM-DD HH24:MI:SS.FF')");
             return val.toString();
         } else if (isDateTime(isoDate)) {
-            normalLiteral = normalLiteral.substring(0, normalLiteral.lastIndexOf('.')) + "'";
-
-            StringBuffer val = new StringBuffer(26);
-            val.append("to_date(");
-            val.append(normalLiteral);
-            val.append(", 'YYYY-MM-DD HH24:MI:SS')");
-            return val.toString();
-        } else {
-            return "UNSUPPORTED:" + isoDate;
+            int seppos = normalLiteral.lastIndexOf('.');
+            if (seppos != -1) {
+                normalLiteral = normalLiteral.substring(0, seppos) + "'";
+                StringBuffer val = new StringBuffer(26);
+                val.append("to_date(");
+                val.append(normalLiteral);
+                val.append(", 'YYYY-MM-DD HH24:MI:SS')");
+                return val.toString();
+            }
         }
+        return "UNSUPPORTED:" + isoDate;
     }
 
     @Override

--- a/liquibase-core/src/test/java/liquibase/database/core/OracleDatabaseTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/core/OracleDatabaseTest.java
@@ -47,6 +47,7 @@ public class OracleDatabaseTest extends AbstractJdbcDatabaseTest {
         Assert.assertEquals("SYSTIMESTAMP", getDatabase().getCurrentDateTimeFunction());
     }
 
+    @Test
     public void testGetDefaultDriver() {
         Database database = new OracleDatabase();
 
@@ -55,5 +56,36 @@ public class OracleDatabaseTest extends AbstractJdbcDatabaseTest {
         assertNull(database.getDefaultDriver("jdbc:db2://localhost;databaseName=liquibase"));
     }
 
+    @Test
+    public void getDateLiteral_dateOnly() {
+    	assertEquals("to_date('2017-08-16', 'YYYY-MM-DD')", database.getDateLiteral("2017-08-16"));
+    }
+
+    @Test
+    public void getDateLiteral_timeOnly() {
+    	assertEquals("to_date('16-32-55', 'HH24:MI:SS')", database.getDateLiteral("16-32-55"));
+    }
+
+    @Test
+    public void getDateLiteral_timestamp() {
+    	assertEquals("to_timestamp('2017-08-16 16:32:55.125', 'YYYY-MM-DD HH24:MI:SS.FF')", database.getDateLiteral("2017-08-16T16:32:55.125"));
+    }
+
+    @Test
+    public void getDateLiteral_datetime() {
+    	assertEquals("to_date('2017-08-16 16:32:55', 'YYYY-MM-DD HH24:MI:SS')", database.getDateLiteral("2017-08-16T16:32:55.3"));
+    }
+
+    @Test
+    public void getDateLiteral_datetime_invalid() {
+    	assertEquals("UNSUPPORTED:2017-08-16T16:32:55_3", database.getDateLiteral("2017-08-16T16:32:55_3"));
+    }
+    
+    @Test
+    public void getDateLiteral_unsupported() {
+    	assertEquals("UNSUPPORTED:123", database.getDateLiteral("123"));
+    }
+    
+    
 }
 


### PR DESCRIPTION
In case of invalid date literals OracleDatabase.getDateLiteral() throws
an StringIndexOutOfBoundsException. This isn't helpful as the user can't
see the problematic input. With this change a "UNSUPPORTED:xxx" message
is created.