### PR TITLE
DVONE 5036 changed removeTrailingDelimiter to remove delimiter from the end even when they are followed by comments and whitespaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: java
+sudo: false
+script: mvn clean package

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
 language: java
 sudo: false
+jdk:
+  - openjdk6
+
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y rpm
+
 script: mvn clean package

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-sudo: false
+sudo: required
 jdk:
   - openjdk6
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,13 @@ before_install:
   - sudo apt-get install -y rpm
 
 script: mvn clean package
+
+test:
+  post:
+    - mkdir -p $CIRCLE_TEST_REPORTS/junit/
+    - find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
+    - cp liquibase-core/target/liquibase*-bin.zip $CIRCLE_ARTIFACTS
+    - cp liquibase-core/target/liquibase*-bin.tar.gz $CIRCLE_ARTIFACTS
+    - cp liquibase-core/target/liquibase*-SNAPSHOT.jar $CIRCLE_ARTIFACTS
+    - cp liquibase-rpm/target/*.rpm $CIRCLE_ARTIFACTS
+    - cp liquibase-debian/target/*.deb $CIRCLE_ARTIFACTS

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,3 @@ before_install:
   - sudo apt-get install -y rpm
 
 script: mvn clean package
-
-test:
-  post:
-    - mkdir -p $CIRCLE_TEST_REPORTS/junit/
-    - find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
-    - cp liquibase-core/target/liquibase*-bin.zip $CIRCLE_ARTIFACTS
-    - cp liquibase-core/target/liquibase*-bin.tar.gz $CIRCLE_ARTIFACTS
-    - cp liquibase-core/target/liquibase*-SNAPSHOT.jar $CIRCLE_ARTIFACTS
-    - cp liquibase-rpm/target/*.rpm $CIRCLE_ARTIFACTS
-    - cp liquibase-debian/target/*.deb $CIRCLE_ARTIFACTS

--- a/circle.yml
+++ b/circle.yml
@@ -4,5 +4,5 @@ machine:
 
 dependencies:
  override:
-  - mvn install -DskipTests
   - sudo apt-get install -y rpm
+  - mvn install -DskipTests

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   java:
-    version: openjdk6
+    version: openjdk7
 
 dependencies:
  override:

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,7 @@
+machine:
+  java:
+    version: openjdk6
+
+dependencies:
+ override:
+  - mvn install -DskipTests

--- a/circle.yml
+++ b/circle.yml
@@ -14,5 +14,5 @@ test:
     - cp liquibase-core/target/liquibase*-bin.zip $CIRCLE_ARTIFACTS
     - cp liquibase-core/target/liquibase*-bin.tar.gz $CIRCLE_ARTIFACTS
     - cp liquibase-core/target/liquibase*-SNAPSHOT.jar $CIRCLE_ARTIFACTS
-    - cp liquibase-rpm/target/*.rpm $CIRCLE_ARTIFACTS
+    - cp liquibase-rpm/target/rpm/liquibase/RPMS/noarch/liquibase-*.noarch.rpm $CIRCLE_ARTIFACTS
     - cp liquibase-debian/target/*.deb $CIRCLE_ARTIFACTS

--- a/circle.yml
+++ b/circle.yml
@@ -6,3 +6,13 @@ dependencies:
  override:
   - sudo apt-get install -y rpm
   - mvn install -DskipTests
+
+test:
+  post:
+    - mkdir -p $CIRCLE_TEST_REPORTS/junit/
+    - find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} $CIRCLE_TEST_REPORTS/junit/ \;
+    - cp liquibase-core/target/liquibase*-bin.zip $CIRCLE_ARTIFACTS
+    - cp liquibase-core/target/liquibase*-bin.tar.gz $CIRCLE_ARTIFACTS
+    - cp liquibase-core/target/liquibase*-SNAPSHOT.jar $CIRCLE_ARTIFACTS
+    - cp liquibase-rpm/target/*.rpm $CIRCLE_ARTIFACTS
+    - cp liquibase-debian/target/*.deb $CIRCLE_ARTIFACTS

--- a/circle.yml
+++ b/circle.yml
@@ -5,3 +5,4 @@ machine:
 dependencies:
  override:
   - mvn install -DskipTests
+  - sudo apt-get install -y rpm

--- a/liquibase-core/src/main/java/liquibase/change/CheckSum.java
+++ b/liquibase-core/src/main/java/liquibase/change/CheckSum.java
@@ -42,7 +42,7 @@ public class CheckSum {
      * Return the current CheckSum algorithm version.
      */
     public static int getCurrentVersion() {
-        return 7;
+        return 8;
     }
 
     /**
@@ -64,21 +64,15 @@ public class CheckSum {
         InputStream newStream = stream;
         if (standardizeLineEndings) {
             newStream = new InputStream() {
-                int lastChar = 'X';
-
                 @Override
                 public int read() throws IOException {
                     int read = stream.read();
-                    int returnChar = read;
-                    if (returnChar == '\r') {
-                        returnChar = '\n';
-                    }
-                    if (lastChar == '\r' && returnChar == '\n') {
-                        returnChar = stream.read(); //read next char
-                    }
 
-                    lastChar = read;
-                    return returnChar;
+                    if (read == '\r') {
+                        return read();
+                    } else {
+                        return read;
+                    }
                 }
             };
         }

--- a/liquibase-core/src/main/java/liquibase/change/core/AddDefaultValueChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/AddDefaultValueChange.java
@@ -209,8 +209,11 @@ public class AddDefaultValueChange extends AbstractChange {
             ((SequenceNextValueFunction) defaultValue).setSequenceSchemaName(this.getSchemaName());
         }
 
+        AddDefaultValueStatement statement = new AddDefaultValueStatement(getCatalogName(), getSchemaName(), getTableName(), getColumnName(), getColumnDataType(), defaultValue);
+        statement.setDefaultValueConstraintName(this.getDefaultValueConstraintName());
+
         return new SqlStatement[]{
-                new AddDefaultValueStatement(getCatalogName(), getSchemaName(), getTableName(), getColumnName(), getColumnDataType(), defaultValue)
+                statement
         };
     }
 

--- a/liquibase-core/src/main/java/liquibase/change/core/AddUniqueConstraintChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/AddUniqueConstraintChange.java
@@ -169,7 +169,7 @@ public class AddUniqueConstraintChange extends AbstractChange {
             clustered = getClustered();
         }
 
-        AddUniqueConstraintStatement statement = new AddUniqueConstraintStatement(getCatalogName(), getSchemaName(), getTableName(), ColumnConfig.arrayFromNames(getColumnNames()), getConstraintName());
+        AddUniqueConstraintStatement statement = createAddUniqueConstraintStatement();
         statement.setTablespace(getTablespace())
                         .setDeferrable(deferrable)
                         .setInitiallyDeferred(initiallyDeferred)
@@ -181,6 +181,10 @@ public class AddUniqueConstraintChange extends AbstractChange {
         statement.setForIndexCatalogName(getForIndexCatalogName());
 
         return new SqlStatement[] { statement };
+    }
+
+    protected AddUniqueConstraintStatement createAddUniqueConstraintStatement() {
+        return new AddUniqueConstraintStatement(getCatalogName(), getSchemaName(), getTableName(), ColumnConfig.arrayFromNames(getColumnNames()), getConstraintName());
     }
 
 

--- a/liquibase-core/src/main/java/liquibase/change/core/CreateViewChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/CreateViewChange.java
@@ -98,14 +98,18 @@ public class CreateViewChange extends AbstractChange {
 
 		if (!supportsReplaceIfExistsOption(database) && replaceIfExists) {
 			statements.add(new DropViewStatement(getCatalogName(), getSchemaName(), getViewName()));
-			statements.add(new CreateViewStatement(getCatalogName(), getSchemaName(), getViewName(), getSelectQuery(), false)
+			statements.add(createViewStatement(getCatalogName(), getSchemaName(), getViewName(), getSelectQuery(), false)
                     .setFullDefinition(fullDefinition));
 		} else {
-			statements.add(new CreateViewStatement(getCatalogName(), getSchemaName(), getViewName(), getSelectQuery(), replaceIfExists)
+			statements.add(createViewStatement(getCatalogName(), getSchemaName(), getViewName(), getSelectQuery(), replaceIfExists)
                     .setFullDefinition(fullDefinition));
 		}
 
 		return statements.toArray(new SqlStatement[statements.size()]);
+	}
+
+	protected CreateViewStatement createViewStatement(String catalogName, String schemaName, String viewName, String selectQuery, boolean b) {
+    	return new CreateViewStatement(catalogName, schemaName, viewName, selectQuery, b);
 	}
 
 	@Override

--- a/liquibase-core/src/main/java/liquibase/change/core/ExecuteShellCommandChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/ExecuteShellCommandChange.java
@@ -179,7 +179,9 @@ public class ExecuteShellCommandChange extends AbstractChange {
         String errorStreamOut = errorStream.toString(LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).getOutputEncoding());
         String infoStreamOut = inputStream.toString(LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).getOutputEncoding());
 
-        LogFactory.getLogger().severe(errorStreamOut);
+        if (errorStreamOut != null && ! errorStreamOut.isEmpty()) {
+            LogFactory.getLogger().severe(errorStreamOut);
+        }
         LogFactory.getLogger().info(infoStreamOut);
 
         processResult(returnCode, errorStreamOut, infoStreamOut, database);

--- a/liquibase-core/src/main/java/liquibase/change/core/ExecuteShellCommandChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/ExecuteShellCommandChange.java
@@ -176,9 +176,16 @@ public class ExecuteShellCommandChange extends AbstractChange {
             ;
         }
 
-        LogFactory.getLogger().severe(errorStream.toString(LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).getOutputEncoding()));
-        LogFactory.getLogger().info(inputStream.toString(LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).getOutputEncoding()));
+        String errorStreamOut = errorStream.toString(LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).getOutputEncoding());
+        String infoStreamOut = inputStream.toString(LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).getOutputEncoding());
 
+        LogFactory.getLogger().severe(errorStreamOut);
+        LogFactory.getLogger().info(infoStreamOut);
+
+        throwExceptionIfError(returnCode, errorStreamOut, infoStreamOut);
+    }
+
+    protected void throwExceptionIfError(int returnCode, String errorStreamOut, String infoStreamOut) {
         if (returnCode != 0) {
             throw new RuntimeException(getCommandString() + " returned an code of " + returnCode);
         }

--- a/liquibase-core/src/main/java/liquibase/change/core/ExecuteShellCommandChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/ExecuteShellCommandChange.java
@@ -182,10 +182,13 @@ public class ExecuteShellCommandChange extends AbstractChange {
         LogFactory.getLogger().severe(errorStreamOut);
         LogFactory.getLogger().info(infoStreamOut);
 
-        throwExceptionIfError(returnCode, errorStreamOut, infoStreamOut);
+        processResult(returnCode, errorStreamOut, infoStreamOut, database);
     }
 
-    protected void throwExceptionIfError(int returnCode, String errorStreamOut, String infoStreamOut) {
+    /**
+     * Called by {@link #executeCommand(Database)} after running the command. Default implementation throws an error if returnCode != 0
+     */
+    protected void processResult(int returnCode, String errorStreamOut, String infoStreamOut, Database database) {
         if (returnCode != 0) {
             throw new RuntimeException(getCommandString() + " returned an code of " + returnCode);
         }

--- a/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
@@ -66,7 +66,7 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
     private String separator = liquibase.util.csv.CSVReader.DEFAULT_SEPARATOR + "";
     private String quotchar = liquibase.util.csv.CSVReader.DEFAULT_QUOTE_CHARACTER + "";
 
-    private Boolean usePreparedStatements = false;
+    private Boolean usePreparedStatements;
 
     private List<LoadDataColumnConfig> columns = new ArrayList<LoadDataColumnConfig>();
 

--- a/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
@@ -66,7 +66,7 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
     private String separator = liquibase.util.csv.CSVReader.DEFAULT_SEPARATOR + "";
     private String quotchar = liquibase.util.csv.CSVReader.DEFAULT_QUOTE_CHARACTER + "";
 
-    private Boolean usePreparedStatement = false;
+    private Boolean usePreparedStatements = false;
 
     private List<LoadDataColumnConfig> columns = new ArrayList<LoadDataColumnConfig>();
 
@@ -116,12 +116,12 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
         this.file = file;
     }
 
-    public Boolean getUsePreparedStatement() {
-        return usePreparedStatement;
+    public Boolean getUsePreparedStatements() {
+        return usePreparedStatements;
     }
 
-    public void setUsePreparedStatement(Boolean usePreparedStatement) {
-        this.usePreparedStatement = usePreparedStatement;
+    public void setUsePreparedStatements(Boolean usePreparedStatements) {
+        this.usePreparedStatements = usePreparedStatements;
     }
 
     public String getCommentLineStartsWith() {
@@ -231,7 +231,7 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
                 }
 
                 boolean needsPreparedStatement = false;
-                if (usePreparedStatement != null && usePreparedStatement) {
+                if (usePreparedStatements != null && usePreparedStatements) {
                     needsPreparedStatement = true;
                 }
 

--- a/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
@@ -66,6 +66,8 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
     private String separator = liquibase.util.csv.CSVReader.DEFAULT_SEPARATOR + "";
     private String quotchar = liquibase.util.csv.CSVReader.DEFAULT_QUOTE_CHARACTER + "";
 
+    private Boolean usePreparedStatement = false;
+
     private List<LoadDataColumnConfig> columns = new ArrayList<LoadDataColumnConfig>();
 
     @Override
@@ -112,6 +114,14 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
 
     public void setFile(String file) {
         this.file = file;
+    }
+
+    public Boolean getUsePreparedStatement() {
+        return usePreparedStatement;
+    }
+
+    public void setUsePreparedStatement(Boolean usePreparedStatement) {
+        this.usePreparedStatement = usePreparedStatement;
     }
 
     public String getCommentLineStartsWith() {
@@ -221,6 +231,9 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
                 }
 
                 boolean needsPreparedStatement = false;
+                if (usePreparedStatement != null && usePreparedStatement) {
+                    needsPreparedStatement = true;
+                }
 
                 List<ColumnConfig> columns = new ArrayList<ColumnConfig>();
                 for (int i = 0; i < headers.length; i++) {

--- a/liquibase-core/src/main/java/liquibase/command/core/DropAllCommand.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/DropAllCommand.java
@@ -13,6 +13,7 @@ import liquibase.database.Database;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.LiquibaseException;
 import liquibase.executor.ExecutorService;
+import liquibase.lockservice.LockService;
 import liquibase.lockservice.LockServiceFactory;
 import liquibase.logging.LogFactory;
 import liquibase.logging.Logger;
@@ -76,8 +77,9 @@ public class DropAllCommand extends AbstractCommand<CommandResult> {
 
     @Override
     protected CommandResult run() throws Exception {
+        LockService lockService = LockServiceFactory.getInstance().getLockService(database);
         try {
-            LockServiceFactory.getInstance().getLockService(database).waitForLock();
+            lockService.waitForLock();
 
             for (CatalogAndSchema schema : schemas) {
                 log.info("Dropping Database Objects in schema: " + schema);
@@ -89,7 +91,8 @@ public class DropAllCommand extends AbstractCommand<CommandResult> {
         } catch (Exception e) {
             throw new DatabaseException(e);
         } finally {
-            LockServiceFactory.getInstance().getLockService(database).destroy();
+            lockService.releaseLock();
+            lockService.destroy();
             resetServices();
         }
 

--- a/liquibase-core/src/main/java/liquibase/configuration/ConfigurationProperty.java
+++ b/liquibase-core/src/main/java/liquibase/configuration/ConfigurationProperty.java
@@ -1,6 +1,7 @@
 package liquibase.configuration;
 
 import liquibase.exception.UnexpectedLiquibaseException;
+import liquibase.util.StringUtils;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -97,8 +98,10 @@ public class ConfigurationProperty {
                 return new BigDecimal((String) value);
             } else if (type.equals(Long.class)) {
             	return Long.valueOf((String) value);
+            } else if (type.equals(List.class)) {
+                return StringUtils.splitAndTrim((String) value, ",");
             } else {
-                throw new UnexpectedLiquibaseException("Cannot parse property "+type.getSimpleName()+" to a "+type.getSimpleName());
+                throw new UnexpectedLiquibaseException("Cannot parse property "+value.getClass().getSimpleName()+" to a "+type.getSimpleName());
             }
         } else {
             throw new UnexpectedLiquibaseException("Could not convert "+value.getClass().getSimpleName()+" to a "+type.getSimpleName());

--- a/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
@@ -333,6 +333,8 @@ public class OracleDatabase extends AbstractJdbcDatabase {
                 return true;
             } else if (example.getName().startsWith("USLOG$")) { //for update materialized view
                 return true;
+            } else if (example.getName().startsWith("SYS_FBA")) { //for Flashback tables 
+                return true;
             }
         }
 

--- a/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
@@ -23,9 +23,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -404,6 +402,24 @@ public class OracleDatabase extends AbstractJdbcDatabase {
             return 0;
         }
         return super.getDataTypeMaxParameters(dataTypeName);
+    }
+
+    public String getSystemTableWhereClause(String tableNameColumn) {
+        List<String> clauses = new ArrayList<String>(Arrays.asList("BIN$",
+                "AQ$",
+                "DR$",
+                "SYS_IOT_OVER",
+                "MLOG$_",
+                "RUPD$_",
+                "WM$_",
+                "ISEQ$$_",
+                "USLOG$",
+                "SYS_FBA"));
+
+        for (int i = 0;i<clauses.size(); i++) {
+            clauses.set(i, tableNameColumn+" NOT LIKE '"+clauses.get(i)+"%'");
+            }
+        return "("+StringUtils.join(clauses, " AND ")+")";
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/datatype/core/DateTimeType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/DateTimeType.java
@@ -32,6 +32,9 @@ public class DateTimeType extends LiquibaseDataType {
         }
 
         if (database instanceof OracleDatabase) {
+            if (getRawDefinition().toUpperCase().contains("TIME ZONE")) {
+                return new DatabaseDataType(getRawDefinition().replaceFirst("\\(11\\)$", ""));
+            }
             return new DatabaseDataType("TIMESTAMP", getParameters());
         }
 

--- a/liquibase-core/src/main/java/liquibase/diff/ObjectDifferences.java
+++ b/liquibase-core/src/main/java/liquibase/diff/ObjectDifferences.java
@@ -130,7 +130,7 @@ public class ObjectDifferences {
                     compareToValue = new BigDecimal(compareToValue.toString());
                 }
                 if (referenceValue instanceof Number && referenceValue instanceof Comparable) {
-                    return ((Comparable) referenceValue).compareTo(compareToValue) == 0;
+                    return compareToValue instanceof Number && ((Comparable) referenceValue).compareTo(compareToValue) == 0;
                 } else {
                     return referenceValue.equals(compareToValue);
                 }

--- a/liquibase-core/src/main/java/liquibase/diff/compare/core/IndexComparator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/compare/core/IndexComparator.java
@@ -9,6 +9,7 @@ import liquibase.structure.core.Index;
 import liquibase.diff.compare.DatabaseObjectComparator;
 import liquibase.diff.compare.DatabaseObjectComparatorChain;
 import liquibase.diff.compare.DatabaseObjectComparatorFactory;
+import liquibase.structure.core.Relation;
 import liquibase.structure.core.Table;
 import liquibase.util.StringUtils;
 
@@ -30,7 +31,7 @@ public class IndexComparator implements DatabaseObjectComparator {
             hashes.add(databaseObject.getName().toLowerCase());
         }
 
-        Table table = ((Index) databaseObject).getTable();
+        Relation table = ((Index) databaseObject).getTable();
         if (table != null) {
             hashes.addAll(Arrays.asList(DatabaseObjectComparatorFactory.getInstance().hash(table, chain.getSchemaComparisons(), accordingTo)));
         }

--- a/liquibase-core/src/main/java/liquibase/diff/compare/core/UniqueConstraintComparator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/compare/core/UniqueConstraintComparator.java
@@ -8,6 +8,7 @@ import liquibase.diff.compare.DatabaseObjectComparatorChain;
 import liquibase.diff.compare.DatabaseObjectComparatorFactory;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.Column;
+import liquibase.structure.core.Relation;
 import liquibase.structure.core.Table;
 import liquibase.structure.core.UniqueConstraint;
 import liquibase.util.StringUtils;
@@ -33,7 +34,7 @@ public class UniqueConstraintComparator implements DatabaseObjectComparator {
             hashes.add(databaseObject.getName().toLowerCase());
         }
 
-        Table table = ((UniqueConstraint) databaseObject).getTable();
+        Relation table = ((UniqueConstraint) databaseObject).getTable();
         if (table != null) {
             hashes.addAll(Arrays.asList(DatabaseObjectComparatorFactory.getInstance().hash(table, chain.getSchemaComparisons(), accordingTo)));
         }

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/DiffToChangeLog.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/DiffToChangeLog.java
@@ -437,6 +437,9 @@ public class DiffToChangeLog {
                 }
             });
 
+            //get non-clustered indexes -> unique clustered indexes on views dependencies
+            sql += " UNION select object_schema_name(c.object_id) as referencing_schema_name, c.name as referencing_name, object_schema_name(nc.object_id) as referenced_schema_name, nc.name as referenced_name from sys.indexes c join sys.indexes nc on c.object_id=nc.object_id JOIN sys.objects o ON c.object_id = o.object_id where  c.index_id != nc.index_id and c.type_desc='CLUSTERED' and c.is_unique='true' and (not(nc.type_desc='CLUSTERED') OR nc.is_unique='false') AND o.type_desc='VIEW' AND o.name='AR_DETAIL_OPEN'";
+
             List<Map<String, ?>> rs = executor.queryForList(new RawSqlStatement(sql));
             if (rs.size() > 0) {
                 for (Map<String, ?> row : rs) {

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/ChangedColumnChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/ChangedColumnChangeGenerator.java
@@ -4,6 +4,7 @@ import liquibase.change.AddColumnConfig;
 import liquibase.change.Change;
 import liquibase.change.core.*;
 import liquibase.database.Database;
+import liquibase.database.core.MSSQLDatabase;
 import liquibase.database.core.OracleDatabase;
 import liquibase.datatype.DataTypeFactory;
 import liquibase.datatype.LiquibaseDataType;
@@ -188,6 +189,15 @@ public class ChangedColumnChangeGenerator extends AbstractChangeGenerator implem
                 changes.add(renameColumnChange);
 
             } else {
+                if (comparisonDatabase instanceof MSSQLDatabase && column.getDefaultValue() != null) { //have to drop the default value, will be added back with the "data type changed" logic.
+                    DropDefaultValueChange dropDefaultValueChange = new DropDefaultValueChange();
+                    dropDefaultValueChange.setCatalogName(catalogName);
+                    dropDefaultValueChange.setSchemaName(schemaName);
+                    dropDefaultValueChange.setTableName(tableName);
+                    dropDefaultValueChange.setColumnName(column.getName());
+                    changes.add(dropDefaultValueChange);
+                }
+
                 ModifyDataTypeChange change = new ModifyDataTypeChange();
                 change.setCatalogName(catalogName);
                 change.setSchemaName(schemaName);

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/ChangedIndexChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/ChangedIndexChangeGenerator.java
@@ -16,6 +16,7 @@ import liquibase.diff.output.changelog.ChangedObjectChangeGenerator;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.Column;
 import liquibase.structure.core.Index;
+import liquibase.structure.core.Table;
 import liquibase.structure.core.UniqueConstraint;
 import liquibase.util.StringUtils;
 
@@ -61,12 +62,12 @@ public class ChangedIndexChangeGenerator extends AbstractChangeGenerator impleme
 
         Index index = (Index) changedObject;
 
-        if (index.getTable() != null) {
-            if (index.getTable().getPrimaryKey() != null && DatabaseObjectComparatorFactory.getInstance().isSameObject(index.getTable().getPrimaryKey().getBackingIndex(), changedObject, differences.getSchemaComparisons(), comparisonDatabase)) {
-                return ChangeGeneratorFactory.getInstance().fixChanged(index.getTable().getPrimaryKey(), differences, control, referenceDatabase, comparisonDatabase);
+        if (index.getTable() != null && index.getTable() instanceof Table) {
+            if (((Table) index.getTable()).getPrimaryKey() != null && DatabaseObjectComparatorFactory.getInstance().isSameObject(((Table) index.getTable()).getPrimaryKey().getBackingIndex(), changedObject, differences.getSchemaComparisons(), comparisonDatabase)) {
+                return ChangeGeneratorFactory.getInstance().fixChanged(((Table) index.getTable()).getPrimaryKey(), differences, control, referenceDatabase, comparisonDatabase);
             }
 
-            List<UniqueConstraint> uniqueConstraints = index.getTable().getUniqueConstraints();
+            List<UniqueConstraint> uniqueConstraints = ((Table) index.getTable()).getUniqueConstraints();
             if (uniqueConstraints != null) {
                 for (UniqueConstraint constraint : uniqueConstraints) {
                     if (constraint.getBackingIndex() != null && DatabaseObjectComparatorFactory.getInstance().isSameObject(constraint.getBackingIndex(), changedObject, differences.getSchemaComparisons(), comparisonDatabase)) {

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/ChangedViewChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/ChangedViewChangeGenerator.java
@@ -40,7 +40,7 @@ public class ChangedViewChangeGenerator extends AbstractChangeGenerator implemen
     public Change[] fixChanged(DatabaseObject changedObject, ObjectDifferences differences, DiffOutputControl control, Database referenceDatabase, final Database comparisonDatabase, ChangeGeneratorChain chain) {
         View view = (View) changedObject;
 
-        CreateViewChange change = new CreateViewChange();
+        CreateViewChange change = createViewChange();
         change.setViewName(view.getName());
         change.setReplaceIfExists(true);
         if (control.getIncludeCatalog()) {
@@ -82,4 +82,9 @@ public class ChangedViewChangeGenerator extends AbstractChangeGenerator implemen
 
         return new Change[]{change};
     }
+
+    protected CreateViewChange createViewChange() {
+        return new CreateViewChange();
+    }
+
 }

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingIndexChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingIndexChangeGenerator.java
@@ -11,10 +11,7 @@ import liquibase.diff.output.changelog.AbstractChangeGenerator;
 import liquibase.diff.output.changelog.ChangeGeneratorChain;
 import liquibase.diff.output.changelog.MissingObjectChangeGenerator;
 import liquibase.structure.DatabaseObject;
-import liquibase.structure.core.Column;
-import liquibase.structure.core.Index;
-import liquibase.structure.core.PrimaryKey;
-import liquibase.structure.core.Table;
+import liquibase.structure.core.*;
 
 public class MissingIndexChangeGenerator extends AbstractChangeGenerator implements MissingObjectChangeGenerator {
     @Override
@@ -42,8 +39,8 @@ public class MissingIndexChangeGenerator extends AbstractChangeGenerator impleme
     public Change[] fixMissing(DatabaseObject missingObject, DiffOutputControl control, Database referenceDatabase, Database comparisonDatabase, ChangeGeneratorChain chain) {
         Index index = (Index) missingObject;
 
-        if (comparisonDatabase instanceof MSSQLDatabase) {
-            PrimaryKey primaryKey = index.getTable().getPrimaryKey();
+        if (comparisonDatabase instanceof MSSQLDatabase && index.getTable() instanceof Table) {
+            PrimaryKey primaryKey = ((Table) index.getTable()).getPrimaryKey();
             if (primaryKey != null && DatabaseObjectComparatorFactory.getInstance().isSameObject(missingObject, primaryKey.getBackingIndex(), control.getSchemaComparisons(), referenceDatabase)) {
                 return new Change[0]; //will be handled by the PK
             }

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingUniqueConstraintChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingUniqueConstraintChangeGenerator.java
@@ -49,7 +49,7 @@ public class MissingUniqueConstraintChangeGenerator extends AbstractChangeGenera
             return null;
         }
 
-        AddUniqueConstraintChange change = new AddUniqueConstraintChange();
+        AddUniqueConstraintChange change = createAddUniqueConstraintChange();
         change.setTableName(uc.getTable().getName());
         if (uc.getBackingIndex() != null && control.getIncludeTablespace()) {
             change.setTablespace(uc.getBackingIndex().getTablespace());
@@ -107,5 +107,9 @@ public class MissingUniqueConstraintChangeGenerator extends AbstractChangeGenera
         return returnList.toArray(new Change[returnList.size()]);
 
 
+    }
+
+    protected AddUniqueConstraintChange createAddUniqueConstraintChange() {
+        return new AddUniqueConstraintChange();
     }
 }

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingViewChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingViewChangeGenerator.java
@@ -47,6 +47,9 @@ public class MissingViewChangeGenerator extends AbstractChangeGenerator implemen
         if (control.getIncludeSchema()) {
             change.setSchemaName(view.getSchema().getName());
         }
+        if (view.getRemarks() != null) {
+            change.setRemarks(view.getRemarks());
+        }
         String selectQuery = view.getDefinition();
         boolean fullDefinitionOverridden = false;
         if (selectQuery == null) {

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingViewChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingViewChangeGenerator.java
@@ -39,7 +39,7 @@ public class MissingViewChangeGenerator extends AbstractChangeGenerator implemen
     public Change[] fixMissing(DatabaseObject missingObject, DiffOutputControl control, Database referenceDatabase, final Database comparisonDatabase, ChangeGeneratorChain chain) {
         View view = (View) missingObject;
 
-        CreateViewChange change = new CreateViewChange();
+        CreateViewChange change = createViewChange();
         change.setViewName(view.getName());
         if (control.getIncludeCatalog()) {
             change.setCatalogName(view.getSchema().getCatalogName());
@@ -80,5 +80,9 @@ public class MissingViewChangeGenerator extends AbstractChangeGenerator implemen
 
         return new Change[] { change };
 
+    }
+
+    protected CreateViewChange createViewChange() {
+        return new CreateViewChange();
     }
 }

--- a/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
@@ -175,7 +175,7 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
             }
         } catch (UnexpectedLiquibaseException e) {
             if (object instanceof ChangeSet && e.getMessage().startsWith(INVALID_STRING_ENCODING_MESSAGE)) {
-                throw new UnexpectedLiquibaseException(e.getMessage() + " in changeSet " + ((ChangeSet) object).toString(false)+". To resolve, remove the invalid character on the database and try again");
+                throw new UnexpectedLiquibaseException(e.getMessage() + " in changeSet " + ((ChangeSet) object).toString(false) + ". To resolve, remove the invalid character on the database and try again");
             }
             throw e;
         }
@@ -222,7 +222,7 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
                     node.setTextContent(checkString(value.toString()));
                 } catch (UnexpectedLiquibaseException e) {
                     if (e.getMessage().startsWith(INVALID_STRING_ENCODING_MESSAGE)) {
-                        throw new UnexpectedLiquibaseException(e.getMessage() + " in text of " + node.getTagName()+". To resolve, remove the invalid character on the database and try again");
+                        throw new UnexpectedLiquibaseException(e.getMessage() + " in text of " + node.getTagName() + ". To resolve, remove the invalid character on the database and try again");
                     }
                 }
             } else {
@@ -231,7 +231,7 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
                     node.setAttribute(attributeName, checkString(value.toString()));
                 } catch (UnexpectedLiquibaseException e) {
                     if (e.getMessage().startsWith(INVALID_STRING_ENCODING_MESSAGE)) {
-                        throw new UnexpectedLiquibaseException(e.getMessage() + " on " + node.getTagName()+"."+attributeName+". To resolve, remove the invalid character on the database and try again");
+                        throw new UnexpectedLiquibaseException(e.getMessage() + " on " + node.getTagName() + "." + attributeName + ". To resolve, remove the invalid character on the database and try again");
                     }
                 }
             }
@@ -240,6 +240,7 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
 
     /**
      * Catch any characters that will cause problems when parsing the XML down the road.
+     *
      * @throws UnexpectedLiquibaseException with the message {@link #INVALID_STRING_ENCODING_MESSAGE} if an issue is found.
      */
     protected String checkString(String text) throws UnexpectedLiquibaseException {
@@ -258,10 +259,16 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
             } else {
                 codePoint = current;
             }
-            if (!(Character.isISOControl(current) && current != '\n' && current != '\r' && current != '\t') && ((codePoint == 0x9) || (codePoint == 0xA) || (codePoint == 0xD)
-                    || ((codePoint >= 0x20) && (codePoint <= 0xD7FF))
-                    || ((codePoint >= 0xE000) && (codePoint <= 0xFFFD))
-                    || ((codePoint >= 0x10000) && (codePoint <= 0x10FFFF)))) {
+            if (!(Character.isISOControl(current) && current != '\n' && current != '\r' && current != '\t') && (
+                    (codePoint == 0x9)
+                            || (codePoint == 0xA)
+                            || (codePoint == 0xB)
+                            || (codePoint == 0xC)
+                            || (codePoint == 0xD)
+                            || ((codePoint >= 0x20) && (codePoint <= 0xD7FF))
+                            || ((codePoint >= 0xE000) && (codePoint <= 0xFFFD))
+                            || ((codePoint >= 0x10000) && (codePoint <= 0x10FFFF)))
+                    ) {
                 //ok
             } else {
                 throw new UnexpectedLiquibaseException(INVALID_STRING_ENCODING_MESSAGE);

--- a/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
@@ -1,6 +1,7 @@
 package liquibase.serializer.core.xml;
 
-import liquibase.change.*;
+import liquibase.change.ColumnConfig;
+import liquibase.change.ConstraintsConfig;
 import liquibase.changelog.ChangeLogChild;
 import liquibase.changelog.ChangeSet;
 import liquibase.changelog.DatabaseChangeLog;
@@ -17,18 +18,17 @@ import liquibase.util.StreamUtil;
 import liquibase.util.StringUtils;
 import liquibase.util.XMLUtil;
 import liquibase.util.xml.DefaultXmlWriter;
-
 import org.w3c.dom.*;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-
 import java.io.*;
 import java.util.*;
 
 public class XMLChangeLogSerializer implements ChangeLogSerializer {
 
+    public static final String INVALID_STRING_ENCODING_MESSAGE = "Invalid string encoding";
     private Document currentChangeLogFileDOM;
 
     private static final String XML_VERSION = "1.1";
@@ -95,7 +95,7 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
 
         for (NamespaceDetails details : NamespaceDetailsFactory.getInstance().getNamespaceDetails()) {
             for (String namespace : details.getNamespaces()) {
-                if (details.supports(this, namespace)){
+                if (details.supports(this, namespace)) {
                     String shortName = details.getShortName(namespace);
                     String url = details.getSchemaUrl(namespace);
                     if (shortName != null && url != null) {
@@ -108,7 +108,7 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
 
         for (Map.Entry<String, String> entry : shortNameByNamespace.entrySet()) {
             if (!entry.getValue().equals("")) {
-                changeLogElement.setAttribute("xmlns:"+entry.getValue(), entry.getKey());
+                changeLogElement.setAttribute("xmlns:" + entry.getValue(), entry.getKey());
             }
         }
 
@@ -116,7 +116,7 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
         String schemaLocationAttribute = "";
         for (Map.Entry<String, String> entry : urlByNamespace.entrySet()) {
             if (!entry.getValue().equals("")) {
-                schemaLocationAttribute += entry.getKey()+" "+entry.getValue()+" ";
+                schemaLocationAttribute += entry.getKey() + " " + entry.getValue() + " ";
             }
         }
 
@@ -165,12 +165,19 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
 
         NamespaceDetails details = NamespaceDetailsFactory.getInstance().getNamespaceDetails(this, namespace);
         if (details != null && !details.getShortName(namespace).equals("")) {
-            nodeName = details.getShortName(namespace)+":"+nodeName;
+            nodeName = details.getShortName(namespace) + ":" + nodeName;
         }
         Element node = currentChangeLogFileDOM.createElementNS(namespace, nodeName);
 
-        for (String field : object.getSerializableFields()) {
-            setValueOnNode(node, object.getSerializableFieldNamespace(field), field, object.getSerializableFieldValue(field), object.getSerializableFieldType(field), namespace);
+        try {
+            for (String field : object.getSerializableFields()) {
+                setValueOnNode(node, object.getSerializableFieldNamespace(field), field, object.getSerializableFieldValue(field), object.getSerializableFieldType(field), namespace);
+            }
+        } catch (UnexpectedLiquibaseException e) {
+            if (object instanceof ChangeSet && e.getMessage().startsWith(INVALID_STRING_ENCODING_MESSAGE)) {
+                throw new UnexpectedLiquibaseException(e.getMessage() + " in changeSet " + ((ChangeSet) object).toString(false));
+            }
+            throw e;
         }
 
         return node;
@@ -211,11 +218,57 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
                 String namespace = LiquibaseSerializable.STANDARD_CHANGELOG_NAMESPACE;
                 node.appendChild(createNode(namespace, objectName, value.toString()));
             } else if (serializationType.equals(LiquibaseSerializable.SerializationType.DIRECT_VALUE)) {
-                node.setTextContent(value.toString());
+                try {
+                    node.setTextContent(checkString(value.toString()));
+                } catch (UnexpectedLiquibaseException e) {
+                    if (e.getMessage().startsWith(INVALID_STRING_ENCODING_MESSAGE)) {
+                        throw new UnexpectedLiquibaseException(e.getMessage() + " in text of " + node.getTagName());
+                    }
+                }
             } else {
-                node.setAttribute(qualifyName(objectName, objectNamespace, parentNamespace), value.toString());
+                String attributeName = qualifyName(objectName, objectNamespace, parentNamespace);
+                try {
+                    node.setAttribute(attributeName, checkString(value.toString()));
+                } catch (UnexpectedLiquibaseException e) {
+                    if (e.getMessage().startsWith(INVALID_STRING_ENCODING_MESSAGE)) {
+                        throw new UnexpectedLiquibaseException(e.getMessage() + " on " + node.getTagName()+"."+attributeName);
+                    }
+                }
             }
         }
+    }
+
+    /**
+     * Catch any characters that will cause problems when parsing the XML down the road.
+     * @throws UnexpectedLiquibaseException with the message {@link #INVALID_STRING_ENCODING_MESSAGE} if an issue is found.
+     */
+    protected String checkString(String text) throws UnexpectedLiquibaseException {
+        if (null == text || text.isEmpty()) {
+            return text;
+        }
+
+        final int len = text.length();
+        char current;
+        int codePoint;
+
+        for (int i = 0; i < len; i++) {
+            current = text.charAt(i);
+            if (Character.isHighSurrogate(current) && i + 1 < len && Character.isLowSurrogate(text.charAt(i + 1))) {
+                codePoint = text.codePointAt(i++);
+            } else {
+                codePoint = current;
+            }
+            if (!(Character.isISOControl(current) && current != '\n' && current != '\r' && current != '\t') && ((codePoint == 0x9) || (codePoint == 0xA) || (codePoint == 0xD)
+                    || ((codePoint >= 0x20) && (codePoint <= 0xD7FF))
+                    || ((codePoint >= 0xE000) && (codePoint <= 0xFFFD))
+                    || ((codePoint >= 0x10000) && (codePoint <= 0x10FFFF)))) {
+                //ok
+            } else {
+                throw new UnexpectedLiquibaseException(INVALID_STRING_ENCODING_MESSAGE);
+            }
+        }
+
+        return text;
     }
 
     private String qualifyName(String objectName, String objectNamespace, String parentNamespace) {
@@ -403,7 +456,7 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
         }
 
         if (!sawChildren && textContent.equals("")) {
-            buffer.replace(buffer.length()-1, buffer.length(), "/>");
+            buffer.replace(buffer.length() - 1, buffer.length(), "/>");
         } else {
             buffer.append("</").append(node.getNodeName()).append(">");
         }
@@ -413,4 +466,5 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
     public int getPriority() {
         return PRIORITY_DEFAULT;
     }
+
 }

--- a/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
@@ -259,15 +259,14 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
             } else {
                 codePoint = current;
             }
-            if (!(Character.isISOControl(current) && current != '\n' && current != '\r' && current != '\t') && (
-                    (codePoint == 0x9)
-                            || (codePoint == 0xA)
-                            || (codePoint == 0xB)
-                            || (codePoint == 0xC)
-                            || (codePoint == 0xD)
-                            || ((codePoint >= 0x20) && (codePoint <= 0xD7FF))
-                            || ((codePoint >= 0xE000) && (codePoint <= 0xFFFD))
-                            || ((codePoint >= 0x10000) && (codePoint <= 0x10FFFF)))
+            if ((codePoint == '\n')
+                    || (codePoint == '\r')
+                    || (codePoint == '\t')
+                    || (codePoint == 0xB)
+                    || (codePoint == 0xC)
+                    || ((codePoint >= 0x20) && (codePoint <= 0xD7FF))
+                    || ((codePoint >= 0xE000) && (codePoint <= 0xFFFD))
+                    || ((codePoint >= 0x10000) && (codePoint <= 0x10FFFF))
                     ) {
                 //ok
             } else {

--- a/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
@@ -175,7 +175,7 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
             }
         } catch (UnexpectedLiquibaseException e) {
             if (object instanceof ChangeSet && e.getMessage().startsWith(INVALID_STRING_ENCODING_MESSAGE)) {
-                throw new UnexpectedLiquibaseException(e.getMessage() + " in changeSet " + ((ChangeSet) object).toString(false));
+                throw new UnexpectedLiquibaseException(e.getMessage() + " in changeSet " + ((ChangeSet) object).toString(false)+". To resolve, remove the invalid character on the database and try again");
             }
             throw e;
         }
@@ -222,7 +222,7 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
                     node.setTextContent(checkString(value.toString()));
                 } catch (UnexpectedLiquibaseException e) {
                     if (e.getMessage().startsWith(INVALID_STRING_ENCODING_MESSAGE)) {
-                        throw new UnexpectedLiquibaseException(e.getMessage() + " in text of " + node.getTagName());
+                        throw new UnexpectedLiquibaseException(e.getMessage() + " in text of " + node.getTagName()+". To resolve, remove the invalid character on the database and try again");
                     }
                 }
             } else {
@@ -231,7 +231,7 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
                     node.setAttribute(attributeName, checkString(value.toString()));
                 } catch (UnexpectedLiquibaseException e) {
                     if (e.getMessage().startsWith(INVALID_STRING_ENCODING_MESSAGE)) {
-                        throw new UnexpectedLiquibaseException(e.getMessage() + " on " + node.getTagName()+"."+attributeName);
+                        throw new UnexpectedLiquibaseException(e.getMessage() + " on " + node.getTagName()+"."+attributeName+". To resolve, remove the invalid character on the database and try again");
                     }
                 }
             }

--- a/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
@@ -264,7 +264,8 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
                     || (codePoint == '\t')
                     || (codePoint == 0xB)
                     || (codePoint == 0xC)
-                    || ((codePoint >= 0x20) && (codePoint <= 0xD7FF))
+                    || ((codePoint >= 0x20) && (codePoint <= 0x7E))
+                    || ((codePoint >= 0xA0) && (codePoint <= 0xD7FF))
                     || ((codePoint >= 0xE000) && (codePoint <= 0xFFFD))
                     || ((codePoint >= 0x10000) && (codePoint <= 0x10FFFF))
                     ) {

--- a/liquibase-core/src/main/java/liquibase/snapshot/DatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/DatabaseSnapshot.java
@@ -20,12 +20,15 @@ import liquibase.structure.core.*;
 import liquibase.diff.compare.DatabaseObjectComparatorFactory;
 import liquibase.util.ISODateFormat;
 import liquibase.util.ObjectUtil;
+import liquibase.util.StringUtils;
 
 import java.sql.Timestamp;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 public abstract class DatabaseSnapshot implements LiquibaseSerializable {
+
+    public static final String ALL_CATALOGS_STRING_SCRATCH_KEY = "DatabaseSnapshot.allCatalogsString";
 
     private final DatabaseObject[] originalExamples;
     private HashSet<String> serializableFields;
@@ -69,6 +72,17 @@ public abstract class DatabaseSnapshot implements LiquibaseSerializable {
                     catalogs.add(((Schema) object).getCatalog());
                 }
             }
+
+            this.setScratchData("DatabaseSnapshot.allCatalogs", catalogs);
+
+            if (catalogs.size() > 1) {
+                List<String> quotedCatalogs = new ArrayList<String>();
+                for (Catalog catalog : catalogs) {
+                    quotedCatalogs.add("'" + catalog.getName() + "'");
+                }
+                this.setScratchData(ALL_CATALOGS_STRING_SCRATCH_KEY, StringUtils.join(quotedCatalogs, ", "));
+            }
+
 
             for (Catalog catalog : catalogs) {
                 this.snapshotControl.addType(catalog.getClass(), database);

--- a/liquibase-core/src/main/java/liquibase/snapshot/DatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/DatabaseSnapshot.java
@@ -80,7 +80,7 @@ public abstract class DatabaseSnapshot implements LiquibaseSerializable {
                 for (Catalog catalog : catalogs) {
                     quotedCatalogs.add("'" + catalog.getName() + "'");
                 }
-                this.setScratchData(ALL_CATALOGS_STRING_SCRATCH_KEY, StringUtils.join(quotedCatalogs, ", "));
+                this.setScratchData(ALL_CATALOGS_STRING_SCRATCH_KEY, StringUtils.join(quotedCatalogs, ", ").toUpperCase());
             }
 
 
@@ -336,6 +336,7 @@ public abstract class DatabaseSnapshot implements LiquibaseSerializable {
                 return fieldValue;
             }
 
+//            System.out.println("replaceObject "+fieldValue);
             if (isWrongSchema(((DatabaseObject) fieldValue))) {
                 DatabaseObject savedFieldValue = referencedObjects.get((DatabaseObject) fieldValue, schemaComparisons);
                 if (savedFieldValue == null) {

--- a/liquibase-core/src/main/java/liquibase/snapshot/DatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/DatabaseSnapshot.java
@@ -300,7 +300,7 @@ public abstract class DatabaseSnapshot implements LiquibaseSerializable {
             }
             Object newFieldValue = replaceObject(fieldValue);
             if (newFieldValue == null) { //sometimes an object references a non-snapshotted object. Leave it with the unsnapshotted example
-                if (object instanceof PrimaryKey && field.equals("backingIndex")) { //unless it is the backing index, that is handled a bit strange and we need to handle the case where there is no backing index (disabled PK on oracle)
+                if ((object instanceof UniqueConstraint || object instanceof PrimaryKey || object instanceof ForeignKey) && field.equals("backingIndex")) { //unless it is the backing index, that is handled a bit strange and we need to handle the case where there is no backing index (disabled PK on oracle)
                     object.setAttribute(field, null);
                 }
             } else if (fieldValue != newFieldValue) {

--- a/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -304,17 +304,21 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                                 "CASE is_unique WHEN 1 then 0 else 1 end as NON_UNIQUE, " +
                                 "object_name(i.object_id) as INDEX_QUALIFIER, " +
                                 "i.name as INDEX_NAME, " +
-                                "case type when 1 then 1 ELSE 3 end as TYPE, " +
+                                "case i.type when 1 then 1 ELSE 3 end as TYPE, " +
                                 "key_ordinal as ORDINAL_POSITION, " +
                                 "COL_NAME(c.object_id,c.column_id) AS COLUMN_NAME, " +
                                 "case is_descending_key when 0 then 'A' else 'D' end as ASC_OR_DESC, " +
                                 "null as CARDINALITY, " +
                                 "null as PAGES, " +
                                 "i.filter_definition as FILTER_CONDITION, " +
-                                "* " +
+                                "o.type AS INTERNAL_OBJECT_TYPE, " +
+                                "i.*, " +
+                                "c.*, " +
+                                "s.* " +
                                 "FROM sys.indexes i " +
                                 "join sys.index_columns c on i.object_id=c.object_id and i.index_id=c.index_id " +
                                 "join sys.stats s on i.object_id=s.object_id and i.name=s.name " +
+                                "join sys.objects o on i.object_id=o.object_id " +
                                 "WHERE object_schema_name(i.object_id)='" + database.correctObjectName(catalogAndSchema.getSchemaName(), Schema.class) + "'";
 
                         if (!bulkFetch && tableName != null) {

--- a/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -276,12 +276,13 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                                         "CASE I.UNIQUENESS WHEN 'UNIQUE' THEN 0 ELSE 1 END AS NON_UNIQUE, " +
                                         "CASE c.DESCEND WHEN 'Y' THEN 'D' WHEN 'N' THEN 'A' END AS ASC_OR_DESC " +
                                         "FROM ALL_IND_COLUMNS c " +
-                                        "JOIN ALL_INDEXES i ON (i.index_name = c.index_name and i.table_owner = c.table_owner)" +
-                                        "LEFT JOIN " + (((OracleDatabase) database).canAccessDbaRecycleBin() ? "dba_recyclebin" : "user_recyclebin") + " d ON d.object_name=c.table_name " +
-                                        "LEFT JOIN all_ind_expressions e ON e.column_position = c.column_position AND e.index_name = c.index_name " +
+                                        "JOIN ALL_INDEXES i ON i.owner=c.index_owner AND i.index_name = c.index_name and i.table_owner = c.table_owner " +
+                                        "LEFT OUTER JOIN all_ind_expressions e ON e.index_owner=c.index_owner AND e.index_name = c.index_name AND e.column_position = c.column_position   " +
+                                        "LEFT OUTER JOIN " + (((OracleDatabase) database).canAccessDbaRecycleBin() ? "dba_recyclebin" : "user_recyclebin") + " d ON d.object_name=c.table_name " +
                                         "WHERE c.TABLE_OWNER = '" + database.correctObjectName(catalogAndSchema.getCatalogName(), Schema.class) + "' " +
-                                        "AND d.object_name IS NULL " +
-                                        "AND i.OWNER = c.TABLE_OWNER";
+                                        "AND i.OWNER = c.TABLE_OWNER " +
+                                        "AND d.object_name IS NULL ";
+
 
                         if (!bulkFetch && tableName != null) {
                             sql += " AND c.TABLE_NAME='" + tableName + "'";

--- a/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -691,9 +691,9 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                             "o.type in ('U') " +
                             "and has_perms_by_name(quotename(schema_name(o.schema_id)) + '.' + quotename(o.name), 'object', 'select') = 1 " +
                             "and charindex(substring(o.type,1,1),'U') <> 0 " +
-                            "and schema_name(o.schema_id)='"+ownerName+"'";
+                            "and schema_name(o.schema_id)='"+database.escapeStringForDatabase(ownerName)+"'";
                     if (tableName != null) {
-                        sql += "AND o.name='" + tableName + "' ";
+                        sql += " AND o.name='" + database.escapeStringForDatabase(tableName) + "' ";
                     }
                     sql += "order by 4, 1, 2, 3";
 

--- a/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -1015,7 +1015,8 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                                 "SELECT " +
                                         "[TC].[CONSTRAINT_NAME], " +
                                         "[TC].[TABLE_NAME], " +
-                                        "[IDX].[TYPE_DESC] " +
+                                        "[IDX].[TYPE_DESC], " +
+                                        "[IDX].[name] AS INDEX_NAME " +
                                         "FROM [INFORMATION_SCHEMA].[TABLE_CONSTRAINTS] AS [TC] " +
                                         "JOIN sys.indexes AS IDX ON IDX.name=[TC].[CONSTRAINT_NAME] AND object_schema_name(object_id)=[TC].[CONSTRAINT_SCHEMA] " +
                                         "WHERE [TC].[CONSTRAINT_TYPE] = 'UNIQUE' " +

--- a/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -1015,6 +1015,8 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                                 "SELECT " +
                                         "[TC].[CONSTRAINT_NAME], " +
                                         "[TC].[TABLE_NAME], " +
+                                        "[TC].[CONSTRAINT_CATALOG] AS INDEX_CATALOG, "+
+                                        "[TC].[CONSTRAINT_SCHEMA] AS INDEX_SCHEMA, "+
                                         "[IDX].[TYPE_DESC], " +
                                         "[IDX].[name] AS INDEX_NAME " +
                                         "FROM [INFORMATION_SCHEMA].[TABLE_CONSTRAINTS] AS [TC] " +

--- a/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -558,7 +558,7 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
 
                     for (CachedRow row : rows) {
                         String typeName = row.getString("TYPE_NAME");
-                        if (typeName.equals("nvarchar")) {
+                        if (typeName.equals("nvarchar") || typeName.equals("nchar")) {
                             Integer size = row.getInt("COLUMN_SIZE");
                             if (size > 0) {
                                 row.set("COLUMN_SIZE", size / 2);

--- a/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -442,7 +442,7 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
 
                 @Override
                 public boolean bulkReturnsAllSchemas() {
-                    return true;
+                    return database instanceof OracleDatabase;
                 }
 
                 @Override
@@ -808,7 +808,7 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
 
                 @Override
                 public boolean bulkReturnsAllSchemas() {
-                    return true;
+                    return database instanceof OracleDatabase;
                 }
 
                 @Override

--- a/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -1033,8 +1033,8 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
 
                         sql = "select uc.constraint_name, uc.table_name,uc.status,uc.deferrable,uc.deferred,ui.tablespace_name, ui.index_name, ui.owner as INDEX_CATALOG " +
                                 "from all_constraints uc " +
-                                "join all_indexes ui on uc.index_name = ui.index_name and uc.owner=ui.table_owner " +
-                                "LEFT JOIN " + (((OracleDatabase) database).canAccessDbaRecycleBin() ? "dba_recyclebin" : "user_recyclebin") + " d ON d.object_name=ui.table_name " +
+                                "join all_indexes ui on uc.index_name = ui.index_name and uc.owner=ui.table_owner and uc.table_name=ui.table_name " +
+                                "LEFT OUTER JOIN " + (((OracleDatabase) database).canAccessDbaRecycleBin() ? "dba_recyclebin" : "user_recyclebin") + " d ON d.object_name=ui.table_name " +
                                 "where uc.constraint_type='U' " +
                                 "and uc.owner = '" + jdbcSchemaName + "'" +
                                 "AND d.object_name IS NULL ";

--- a/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -681,7 +681,7 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                     //From select object_definition(object_id('sp_tables'))
                     String sql = "select " +
                             "convert(sysname,db_name()) AS TABLE_QUALIFIER, " +
-                            "convert(sysname,schema_name(o.schema_id)) AS TABLE_OWNER, " +
+                            "convert(sysname,schema_name(o.schema_id)) AS TABLE_SCHEM, " +
                             "convert(sysname,o.name) AS TABLE_NAME, " +
                             "'TABLE' AS TABLE_TYPE, " +
                             "CAST(ep.value as varchar(max)) as REMARKS " +

--- a/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -174,12 +174,12 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                 protected String getMSSQLSql(String jdbcSchemaName) {
                     //comes from select object_definition(object_id('sp_fkeys'))
                     return "select " +
-                            "convert(sysname,db_name()) AS PKTABLE_QUALIFIER, " +
-                            "convert(sysname,schema_name(o1.schema_id)) AS PKTABLE_OWNER, " +
+                            "convert(sysname,db_name()) AS PKTABLE_CAT, " +
+                            "convert(sysname,schema_name(o1.schema_id)) AS PKTABLE_SCHEM, " +
                             "convert(sysname,o1.name) AS PKTABLE_NAME, " +
                             "convert(sysname,c1.name) AS PKCOLUMN_NAME, " +
-                            "convert(sysname,db_name()) AS FKTABLE_QUALIFIER, " +
-                            "convert(sysname,schema_name(o2.schema_id)) AS FKTABLE_OWNER, " +
+                            "convert(sysname,db_name()) AS FKTABLE_CAT, " +
+                            "convert(sysname,schema_name(o2.schema_id)) AS FKTABLE_SCHEM, " +
                             "convert(sysname,o2.name) AS FKTABLE_NAME, " +
                             "convert(sysname,c2.name) AS FKCOLUMN_NAME, " +
                             "isnull(convert(smallint,k.constraint_column_id), convert(smallint,0)) AS KEY_SEQ, " +

--- a/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -689,8 +689,11 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                 private List<CachedRow> queryOracle(CatalogAndSchema catalogAndSchema, String viewName) throws DatabaseException, SQLException {
                     String ownerName = database.correctObjectName(catalogAndSchema.getCatalogName(), Schema.class);
 
-                    String sql = "SELECT null as TABLE_CAT, a.OWNER as TABLE_SCHEM, a.VIEW_NAME as TABLE_NAME, 'TABLE' as TABLE_TYPE, c.COMMENTS as REMARKS, TEXT as OBJECT_BODY " +
-                            "from ALL_VIEWS a " +
+                    String sql = "SELECT null as TABLE_CAT, a.OWNER as TABLE_SCHEM, a.VIEW_NAME as TABLE_NAME, 'TABLE' as TABLE_TYPE, c.COMMENTS as REMARKS, TEXT as OBJECT_BODY" ;
+                    if(database.getDatabaseMajorVersion() > 10){
+                      sql +=  ", EDITIONING_VIEW";
+                    }
+                    sql += " from ALL_VIEWS a " +
                             "join ALL_TAB_COMMENTS c on a.VIEW_NAME=c.table_name and a.owner=c.owner " +
                             "WHERE a.OWNER='" + ownerName + "'";
                     if (viewName != null) {

--- a/liquibase-core/src/main/java/liquibase/snapshot/ResultSetCache.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/ResultSetCache.java
@@ -4,6 +4,7 @@ import liquibase.database.Database;
 import liquibase.database.core.InformixDatabase;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
+import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.executor.jvm.ColumnMapRowMapper;
 import liquibase.executor.jvm.RowMapperResultSetExtractor;
 import liquibase.util.JdbcUtils;
@@ -38,15 +39,27 @@ class ResultSetCache {
                 return cache.get(wantedKey);
             }
 
-            if (didBulkQuery.containsKey(schemaKey) && didBulkQuery.get(schemaKey)) {
+            //Return empty array if we already queried for the schema and got no data
+            if ((didBulkQuery.containsKey(schemaKey) && didBulkQuery.get(schemaKey)) || (resultSetExtractor.bulkReturnsAllSchemas() && didBulkQuery.size() > 0)) {
                 return new ArrayList<CachedRow>();
             }
 
             List<CachedRow> results;
+            boolean bulkQueried = false;
             if (resultSetExtractor.shouldBulkSelect(schemaKey, this)) {
-                cache.clear(); //remove any existing single fetches that may be duplicated
+
+                //remove any existing single fetches that may be duplicated
+                if (resultSetExtractor.bulkReturnsAllSchemas()) {
+                    for (Map cachedValue : cacheBySchema.values()) {
+                        cachedValue.clear();
+                    }
+                } else {
+                    cache.clear();
+                }
+
                 results = resultSetExtractor.bulkFetch();
                 didBulkQuery.put(schemaKey, true);
+                bulkQueried = true;
             } else {
                 cache = new HashMap<String, List<CachedRow>>(); //don't store results in real cache to prevent confusion if later fetching all items.
                 Integer previousCount = timesSingleQueried.get(schemaKey);
@@ -59,6 +72,18 @@ class ResultSetCache {
 
             for (CachedRow row : results) {
                 for (String rowKey : resultSetExtractor.rowKeyParameters(row).getKeyPermutations()) {
+                    if (bulkQueried && resultSetExtractor.bulkReturnsAllSchemas()) {
+                        String rowSchema = resultSetExtractor.getSchemaKey(row);
+                        if (rowSchema == null) {
+                            System.out.println("null row schema");
+                        }
+                        rowSchema = rowSchema.toLowerCase();
+                        cache = cacheBySchema.get(rowSchema);
+                        if (cache == null) {
+                            cache = new HashMap<String, List<CachedRow>>();
+                            cacheBySchema.put(rowSchema, cache);
+                        }
+                    }
                     if (!cache.containsKey(rowKey)) {
                         cache.put(rowKey, new ArrayList<CachedRow>());
                     }
@@ -66,6 +91,7 @@ class ResultSetCache {
                 }
             }
 
+            cache = cacheBySchema.get(schemaKey);
             List<CachedRow> returnList = cache.get(wantedKey);
             if (returnList == null) {
                 returnList = new ArrayList<CachedRow>();
@@ -162,12 +188,44 @@ class ResultSetCache {
         }
     }
 
+//    public abstract static class MultiSchemaRowData extends RowData {
+//        public MultiSchemaRowData(String catalog, String schema, Database database, String... parameters) {
+//            super(catalog, schema, database, parameters);
+//        }
+//
+//        @Override
+//        public String createSchemaKey(Database database) {
+//            String multiSchemaKey = getMultiSchemaKey();
+//
+//            if (multiSchemaKey == null) {
+//                return super.createSchemaKey(database);
+//            }
+//
+//            for (Class<? extends Database> supportedDb : getMultiSchemaSupportedDatabases()) {
+//                if (supportedDb.isAssignableFrom(database.getClass())) {
+//                    return multiSchemaKey;
+//                }
+//            }
+//            return super.createSchemaKey(database);
+//        }
+//
+//        public abstract Class<? extends Database>[] getMultiSchemaSupportedDatabases();
+//
+//        public abstract String getMultiSchemaKey();
+//    }
+
     public abstract static class ResultSetExtractor {
 
         private final Database database;
 
         public ResultSetExtractor(Database database) {
             this.database = database;
+        }
+
+        public abstract boolean bulkReturnsAllSchemas();
+
+        public String getSchemaKey(CachedRow row) {
+            throw new UnexpectedLiquibaseException("Not Implemented");
         }
 
         boolean shouldBulkSelect(String schemaKey, ResultSetCache resultSetCache) {

--- a/liquibase-core/src/main/java/liquibase/snapshot/ResultSetCache.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/ResultSetCache.java
@@ -73,11 +73,7 @@ class ResultSetCache {
             for (CachedRow row : results) {
                 for (String rowKey : resultSetExtractor.rowKeyParameters(row).getKeyPermutations()) {
                     if (bulkQueried && resultSetExtractor.bulkReturnsAllSchemas()) {
-                        String rowSchema = resultSetExtractor.getSchemaKey(row);
-                        if (rowSchema == null) {
-                            System.out.println("null row schema");
-                        }
-                        rowSchema = rowSchema.toLowerCase();
+                        String rowSchema = resultSetExtractor.getSchemaKey(row).toLowerCase();
                         cache = cacheBySchema.get(rowSchema);
                         if (cache == null) {
                             cache = new HashMap<String, List<CachedRow>>();
@@ -91,7 +87,9 @@ class ResultSetCache {
                 }
             }
 
-            cache = cacheBySchema.get(schemaKey);
+            if (bulkQueried) {
+                cache = cacheBySchema.get(schemaKey);
+            }
             List<CachedRow> returnList = cache.get(wantedKey);
             if (returnList == null) {
                 returnList = new ArrayList<CachedRow>();

--- a/liquibase-core/src/main/java/liquibase/snapshot/SnapshotGeneratorChain.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/SnapshotGeneratorChain.java
@@ -65,7 +65,7 @@ public class SnapshotGeneratorChain {
 
         SnapshotGenerator next = snapshotGenerators.next();
         for (Class<? extends SnapshotGenerator> removedGenerator : replacedGenerators) {
-            if (removedGenerator.isAssignableFrom(next.getClass())) {
+            if (removedGenerator.equals(next.getClass())) {
                 return getNextValidGenerator();
             }
         }

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
@@ -15,6 +15,7 @@ import liquibase.statement.DatabaseFunction;
 import liquibase.statement.core.RawSqlStatement;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.*;
+import liquibase.util.ObjectUtil;
 import liquibase.util.SqlUtil;
 import liquibase.util.StringUtils;
 
@@ -152,6 +153,12 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
         column.setRemarks(remarks);
         column.setOrder(position);
 
+        if (columnMetadataResultSet.get("IS_FILESTREAM") != null && (Boolean) columnMetadataResultSet.get("IS_FILESTREAM"))  {
+            column.setAttribute("fileStream", true);
+        }
+        if (columnMetadataResultSet.get("IS_ROWGUIDCOL") != null && (Boolean) columnMetadataResultSet.get("IS_ROWGUIDCOL"))  {
+            column.setAttribute("rowGuid", true);
+        }
         if (database instanceof OracleDatabase) {
             String nullable = columnMetadataResultSet.getString("NULLABLE");
             if (nullable.equals("Y")) {

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/IndexSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/IndexSnapshotGenerator.java
@@ -141,6 +141,10 @@ public class IndexSnapshotGenerator extends JdbcSnapshotGenerator {
         }
 
         if (foundObject instanceof Table  || foundObject instanceof View) {
+            if (foundObject instanceof View && !addToViews(snapshot.getDatabase())) {
+                return;
+            }
+
             Relation relation = (Relation) foundObject;
             Database database = snapshot.getDatabase();
             Schema schema;
@@ -313,7 +317,11 @@ public class IndexSnapshotGenerator extends JdbcSnapshotGenerator {
                 Index returnIndex = foundIndexes.get(correctedIndexName);
                 if (returnIndex == null) {
                     returnIndex = new Index();
-                    returnIndex.setTable((Table) new Table().setName(row.getString("TABLE_NAME")).setSchema(schema));
+                    Relation relation = new Table();
+                    if ("V".equals(row.getString("INTERNAL_OBJECT_TYPE"))) {
+                        relation = new View();
+                    }
+                    returnIndex.setTable(relation.setName(row.getString("TABLE_NAME")).setSchema(schema));
                     returnIndex.setName(indexName);
                     returnIndex.setUnique(!nonUnique);
 

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/TableSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/TableSnapshotGenerator.java
@@ -41,31 +41,6 @@ public class TableSnapshotGenerator extends JdbcSnapshotGenerator {
                 return null;
             }
 
-            if (table != null && database instanceof MSSQLDatabase) {
-                String schemaName;
-                Schema tableSchema = table.getSchema();
-                if (tableSchema == null) {
-                    schemaName = database.getDefaultSchemaName();
-                } else {
-                    schemaName = tableSchema.getName();
-                }
-
-                List<String> remarks = ExecutorService.getInstance().getExecutor(snapshot.getDatabase()).queryForList(new RawSqlStatement("SELECT\n" +
-                        " CAST(value as varchar(max)) as REMARKS\n" +
-                        " FROM\n" +
-                        " sys.extended_properties\n" +
-                        "  WHERE\n" +
-                        " name='MS_Description' " +
-                        " AND major_id = OBJECT_ID('" + database.escapeStringForDatabase(database.escapeTableName(null, schemaName, table.getName())) + "')\n" +
-                        " AND\n" +
-                        " minor_id = 0"), String.class);
-
-                if (remarks != null && remarks.size() > 0) {
-                    table.setRemarks(StringUtils.trimToNull(remarks.iterator().next()));
-                }
-            }
-
-
             return table;
         } catch (SQLException e) {
             throw new DatabaseException(e);

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
@@ -90,7 +90,7 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
             for (CachedRow constraint : metadata) {
                 UniqueConstraint uq = new UniqueConstraint().setName(cleanNameFromDatabase((String) constraint.get("CONSTRAINT_NAME"), database)).setTable(table);
                 if (constraint.containsColumn("INDEX_NAME")) {
-                    uq.setBackingIndex(new Index((String) constraint.get("INDEX_NAME"), (String) constraint.get("INDEX_CATALOG"), null, table.getName()));
+                    uq.setBackingIndex(new Index((String) constraint.get("INDEX_NAME"), (String) constraint.get("INDEX_CATALOG"), (String) constraint.get("INDEX_SCHEMA"), table.getName()));
                 }
                 if ("CLUSTERED".equals(constraint.get("TYPE_DESC"))) {
                     uq.setClustered(true);

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
@@ -35,7 +35,7 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
     protected DatabaseObject snapshotObject(DatabaseObject example, DatabaseSnapshot snapshot) throws DatabaseException, InvalidExampleException {
         Database database = snapshot.getDatabase();
         UniqueConstraint exampleConstraint = (UniqueConstraint) example;
-        Table table = exampleConstraint.getTable();
+        Relation table = exampleConstraint.getTable();
 
         List<Map<String, ?>> metadata = listColumns(exampleConstraint, database, snapshot);
 
@@ -107,7 +107,7 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
     }
 
     protected List<Map<String, ?>> listColumns(UniqueConstraint example, Database database, DatabaseSnapshot snapshot) throws DatabaseException {
-        Table table = example.getTable();
+        Relation table = example.getTable();
         Schema schema = table.getSchema();
         String name = example.getName();
 

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
@@ -155,6 +155,7 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
                     sql =
                             "SELECT " +
                                     "[kc].[name] AS [CONSTRAINT_NAME], " +
+                                    "s.name AS constraint_container, "+
                                     "[c].[name] AS [COLUMN_NAME], " +
                                     "CASE [ic].[is_descending_key] WHEN 0 THEN N'A' WHEN 1 THEN N'D' END AS [ASC_OR_DESC] " +
                                     "FROM [sys].[schemas] AS [s] " +
@@ -182,6 +183,7 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
                     sql =
                             "SELECT " +
                                     "[kc].[name] AS [CONSTRAINT_NAME], " +
+                                    "object_schema_name(id) AS constraint_container, "+
                                     "[c].[name] AS [COLUMN_NAME], " +
                                     "CASE INDEXKEY_PROPERTY([ic].[id], [ic].[indid], [ic].[keyno], 'IsDescending') WHEN 0 THEN N'A' WHEN 1 THEN N'D' END AS [ASC_OR_DESC] " +
                                     "FROM [dbo].[sysusers] AS [s] " +

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/ViewSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/ViewSnapshotGenerator.java
@@ -7,6 +7,7 @@ import liquibase.CatalogAndSchema;
 import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.Database;
 import liquibase.database.core.InformixDatabase;
+import liquibase.database.core.OracleDatabase;
 import liquibase.exception.DatabaseException;
 import liquibase.snapshot.CachedRow;
 import liquibase.snapshot.DatabaseSnapshot;
@@ -130,7 +131,9 @@ public class ViewSnapshotGenerator extends JdbcSnapshotGenerator {
                     view.setSchema(schema);
                     view.setRemarks(row.getString("REMARKS"));
                     view.setDefinition(row.getString("OBJECT_BODY"));
-
+                    if(database instanceof OracleDatabase) {
+                        view.setAttribute("editioning", "Y".equals(row.getString("EDITIONING_VIEW")));
+                    }
                     schema.addDatabaseObject(view);
                 }
             } catch (SQLException e) {

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/ViewSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/ViewSnapshotGenerator.java
@@ -126,9 +126,10 @@ public class ViewSnapshotGenerator extends JdbcSnapshotGenerator {
             try {
                 viewsMetadataRs = ((JdbcDatabaseSnapshot) snapshot).getMetaData().getViews(((AbstractJdbcDatabase) database).getJdbcCatalogName(schema), ((AbstractJdbcDatabase) database).getJdbcSchemaName(schema), null);
                 for (CachedRow row : viewsMetadataRs) {
+                    CatalogAndSchema catalogAndSchema = ((AbstractJdbcDatabase) database).getSchemaFromJdbcInfo(row.getString("TABLE_CAT"), row.getString("TABLE_SCHEM"));
                     View view = new View();
                     view.setName(row.getString("TABLE_NAME"));
-                    view.setSchema(schema);
+                    view.setSchema(new Schema(catalogAndSchema.getCatalogName(), catalogAndSchema.getSchemaName()));
                     view.setRemarks(row.getString("REMARKS"));
                     view.setDefinition(row.getString("OBJECT_BODY"));
                     if(database instanceof OracleDatabase) {

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateProcedureGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateProcedureGenerator.java
@@ -100,18 +100,14 @@ public class CreateProcedureGenerator extends AbstractSqlGenerator<CreateProcedu
             return procedureText;
         }
 
-        String fixedText = procedureText;
-        while (fixedText.length() > 0) {
-            String lastChar = fixedText.substring(fixedText.length() - 1);
-            if (lastChar.equals(" ") || lastChar.equals("\n") || lastChar.equals("\r") || lastChar.equals("\t")) {
-                fixedText = fixedText.substring(0, fixedText.length() - 1);
-            } else {
-                break;
-            }
-        }
         endDelimiter = endDelimiter.replace("\\r", "\r").replace("\\n", "\n");
-        if (fixedText.endsWith(endDelimiter)) {
-            return fixedText.substring(0, fixedText.length() - endDelimiter.length());
+        // DVONE-5036
+        String endCommentsTrimmedText = StringUtils.stripSqlCommentsAndWhitespacesFromTheEnd(procedureText);
+        // Note: need to trim the delimiter since the return of the above call trims whitespaces, and to match
+        // we have to trim the endDelimiter as well.
+        String trimmedDelimiter = StringUtils.trimRight(endDelimiter);
+        if (endCommentsTrimmedText.endsWith(trimmedDelimiter)) {
+            return endCommentsTrimmedText.substring(0, endCommentsTrimmedText.length() - trimmedDelimiter.length());
         } else {
             return procedureText;
         }

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateViewGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateViewGenerator.java
@@ -28,7 +28,6 @@ public class CreateViewGenerator extends AbstractSqlGenerator<CreateViewStatemen
         ValidationErrors validationErrors = new ValidationErrors();
 
         validationErrors.checkRequiredField("viewName", createViewStatement.getViewName());
-        validationErrors.checkRequiredField("selectQuery", createViewStatement.getSelectQuery());
 
         if (createViewStatement.isReplaceIfExists()) {
             validationErrors.checkDisallowedField("replaceIfExists", createViewStatement.isReplaceIfExists(), database, HsqlDatabase.class, DB2Database.class, DerbyDatabase.class, SybaseASADatabase.class, InformixDatabase.class);

--- a/liquibase-core/src/main/java/liquibase/structure/core/ForeignKey.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/ForeignKey.java
@@ -196,7 +196,10 @@ public class ForeignKey extends AbstractDatabaseObject{
         ForeignKey that = (ForeignKey) o;
 
         if (this.getSchema() != null && that.getSchema() != null) {
-            return StringUtils.trimToEmpty(this.getSchema().getName()).equalsIgnoreCase(StringUtils.trimToEmpty(that.getSchema().getName()));
+            boolean schemasEqual = StringUtils.trimToEmpty(this.getSchema().getName()).equalsIgnoreCase(StringUtils.trimToEmpty(that.getSchema().getName()));
+            if (!schemasEqual) {
+                return false;
+            }
         }
 
 

--- a/liquibase-core/src/main/java/liquibase/structure/core/Index.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/Index.java
@@ -65,11 +65,11 @@ public class Index extends AbstractDatabaseObject {
         return getTable().getSchema();
     }
 
-    public Table getTable() {
-        return getAttribute("table", Table.class);
+    public Relation getTable() {
+        return getAttribute("table", Relation.class);
     }
 
-    public Index setTable(Table table) {
+    public Index setTable(Relation table) {
         this.setAttribute("table", table);
         return this;
     }

--- a/liquibase-core/src/main/java/liquibase/structure/core/Relation.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/Relation.java
@@ -16,6 +16,8 @@ public abstract class Relation extends AbstractDatabaseObject {
 
     protected Relation() {
         setAttribute("columns", new ArrayList());
+        setAttribute("uniqueConstraints", new ArrayList<UniqueConstraint>());
+        setAttribute("indexes", new ArrayList<Index>());
     }
 
     @Override
@@ -30,6 +32,15 @@ public abstract class Relation extends AbstractDatabaseObject {
 
         return this;
     }
+
+    public List<Index> getIndexes() {
+        return getAttribute("indexes", List.class);
+    }
+
+    public List<UniqueConstraint> getUniqueConstraints() {
+        return getAttribute("uniqueConstraints", List.class);
+    }
+
 
     @Override
     public DatabaseObject[] getContainingObjects() {

--- a/liquibase-core/src/main/java/liquibase/structure/core/StoredDatabaseLogic.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/StoredDatabaseLogic.java
@@ -62,7 +62,10 @@ public abstract class StoredDatabaseLogic<T extends StoredDatabaseLogic> extends
         StoredDatabaseLogic that = (StoredDatabaseLogic) obj;
 
         if (this.getSchema() != null && that.getSchema() != null) {
-            return StringUtils.trimToEmpty(this.getSchema().getName()).equalsIgnoreCase(StringUtils.trimToEmpty(that.getSchema().getName()));
+            boolean schemasEqual = StringUtils.trimToEmpty(this.getSchema().getName()).equalsIgnoreCase(StringUtils.trimToEmpty(that.getSchema().getName()));
+            if (!schemasEqual) {
+                return false;
+            }
         }
 
         return getName().equalsIgnoreCase(that.getName());

--- a/liquibase-core/src/main/java/liquibase/structure/core/Table.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/Table.java
@@ -39,7 +39,10 @@ public class Table extends Relation {
         Table that = (Table) o;
 
         if (this.getSchema() != null && that.getSchema() != null) {
-            return StringUtils.trimToEmpty(this.getSchema().getName()).equalsIgnoreCase(StringUtils.trimToEmpty(that.getSchema().getName()));
+            boolean schemasTheSame = StringUtils.trimToEmpty(this.getSchema().getName()).equalsIgnoreCase(StringUtils.trimToEmpty(that.getSchema().getName()));
+            if (!schemasTheSame) {
+                return false;
+            }
         }
 
         return getName().equalsIgnoreCase(that.getName());

--- a/liquibase-core/src/main/java/liquibase/structure/core/Table.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/Table.java
@@ -12,8 +12,6 @@ public class Table extends Relation {
 
     public Table() {
         setAttribute("outgoingForeignKeys", new ArrayList<ForeignKey>());
-        setAttribute("indexes", new ArrayList<Index>());
-        setAttribute("uniqueConstraints", new ArrayList<UniqueConstraint>());
     }
 
     public Table(String catalogName, String schemaName, String tableName) {
@@ -31,14 +29,6 @@ public class Table extends Relation {
 
     public List<ForeignKey> getOutgoingForeignKeys() {
         return getAttribute("outgoingForeignKeys", List.class);
-    }
-
-    public List<Index> getIndexes() {
-        return getAttribute("indexes", List.class);
-    }
-
-    public List<UniqueConstraint> getUniqueConstraints() {
-        return getAttribute("uniqueConstraints", List.class);
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/structure/core/UniqueConstraint.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/UniqueConstraint.java
@@ -55,11 +55,11 @@ public class UniqueConstraint extends AbstractDatabaseObject {
         return getTable().getSchema();
     }
 
-	public Table getTable() {
-		return getAttribute("table", Table.class);
+	public Relation getTable() {
+		return getAttribute("table", Relation.class);
 	}
 
-	public UniqueConstraint setTable(Table table) {
+	public UniqueConstraint setTable(Relation table) {
 		this.setAttribute("table", table);
         return this;
     }

--- a/liquibase-core/src/main/java/liquibase/structure/core/View.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/View.java
@@ -35,7 +35,10 @@ public class View extends Relation {
         View that = (View) o;
 
         if (this.getSchema() != null && that.getSchema() != null) {
-            return StringUtils.trimToEmpty(this.getSchema().getName()).equalsIgnoreCase(StringUtils.trimToEmpty(that.getSchema().getName()));
+            boolean schemasEqual = StringUtils.trimToEmpty(this.getSchema().getName()).equalsIgnoreCase(StringUtils.trimToEmpty(that.getSchema().getName()));
+            if (!schemasEqual) {
+                return false;
+            }
         }
 
         return getName().equalsIgnoreCase(that.getName());

--- a/liquibase-core/src/main/java/liquibase/util/StringClauses.java
+++ b/liquibase-core/src/main/java/liquibase/util/StringClauses.java
@@ -1,5 +1,6 @@
 package liquibase.util;
 
+import java.math.BigInteger;
 import java.util.*;
 
 /**
@@ -16,6 +17,7 @@ public class StringClauses {
     private final String start;
     private final String end;
     private LinkedHashMap<String, Object> clauses = new LinkedHashMap<String, Object>();
+    private final Random random = new Random();
 
     /**
      * Creates a new StringClause with no start or end strings and a space separator.
@@ -64,7 +66,7 @@ public class StringClauses {
         }
 
         while (generateOne) {
-            key = UUID.randomUUID().toString().replace("-", "").substring(0,6);
+            key = new BigInteger(50, random).toString(32).substring(0,6);
             generateOne = clauses.containsKey(key);
         }
         return key;

--- a/liquibase-core/src/main/java/liquibase/util/StringClauses.java
+++ b/liquibase-core/src/main/java/liquibase/util/StringClauses.java
@@ -66,7 +66,7 @@ public class StringClauses {
         }
 
         while (generateOne) {
-            key = new BigInteger(50, random).toString(32).substring(0,6);
+            key = StringUtils.leftPad(new BigInteger(50, random).toString(32), 6).replace(" ", "0").substring(0,6);
             generateOne = clauses.containsKey(key);
         }
         return key;

--- a/liquibase-core/src/main/java/liquibase/util/StringUtils.java
+++ b/liquibase-core/src/main/java/liquibase/util/StringUtils.java
@@ -296,6 +296,15 @@ public class StringUtils {
         return value + StringUtils.repeat(" ", length - value.length());
     }
 
+    public static String leftPad(String value, int length) {
+        value = StringUtils.trimToEmpty(value);
+        if (value.length() >= length) {
+            return value;
+        }
+
+        return StringUtils.repeat(" ", length - value.length()) + value;
+    }
+
     /**
      * Null-safe check if string is empty.
      *

--- a/liquibase-core/src/main/javacc/liquibase/util/grammar/SimpleSqlGrammar.jj
+++ b/liquibase-core/src/main/javacc/liquibase/util/grammar/SimpleSqlGrammar.jj
@@ -68,7 +68,7 @@ TOKEN : /* Numeric Constants */
 
 TOKEN:
 {
-    < COMPLEX_IDENTIFIER: (<S_IDENTIFIER> | <S_QUOTED_IDENTIFIER>) ((["\r","\n"," "])* "." (<S_IDENTIFIER> | <S_QUOTED_IDENTIFIER>))+ >
+    < COMPLEX_IDENTIFIER: (<S_IDENTIFIER> | <S_QUOTED_IDENTIFIER>) ((["\r","\n"," "])* "." (["\r","\n"," "])* (<S_IDENTIFIER> | <S_QUOTED_IDENTIFIER>))+ >
 |	< S_IDENTIFIER: ( <LETTER> | <UNICODE_LETTERS> )+ ( <DIGIT> | <LETTER> | <UNICODE_LETTERS> | <SPECIAL_CHARS> )* >
 | 	< #LETTER: ["a"-"z", "A"-"Z", "_", "$"] >
 |   < #SPECIAL_CHARS: "$" | "_" | "#" | "@" >

--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.6.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.6.xsd
@@ -561,7 +561,7 @@
             <xsd:attributeGroup ref="tableNameAttribute" />
 			<xsd:attribute name="file" type="xsd:string" />
 			<xsd:attribute name="relativeToChangelogFile" type="booleanExp" />
-			<xsd:attribute name="usePreparedStatement" type="booleanExp" />
+			<xsd:attribute name="usePreparedStatements" type="booleanExp" />
 			<xsd:attribute name="encoding" type="xsd:string" default="UTF-8"/>
 			<xsd:attribute name="separator" type="xsd:string" default=","/>
 			<xsd:attribute name="quotchar" type="xsd:string" default="&quot;"/>

--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.6.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.6.xsd
@@ -528,6 +528,7 @@
 			<xsd:attribute name="defaultValueBoolean" type="xsd:string" />
 			<xsd:attribute name="defaultValueComputed" type="xsd:string" />
             <xsd:attribute name="defaultValueSequenceNext" type="xsd:string" />
+			<xsd:attribute name="defaultValueConstraintName" type="xsd:string" />
 		</xsd:complexType>
 	</xsd:element>
 

--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.6.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.6.xsd
@@ -469,6 +469,7 @@
             <xsd:attribute name="forIndexSchemaName" type="xsd:string" />
             <xsd:attribute name="forIndexName" type="xsd:string" />
 			<xsd:attribute name="clustered" type="booleanExp" />
+			<xsd:anyAttribute namespace="##other" processContents="lax" />
         </xsd:complexType>
 	</xsd:element>
 

--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.6.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.6.xsd
@@ -925,6 +925,9 @@
 					<xsd:attribute name="viewName" type="xsd:string" use="required" />
 					<xsd:attribute name="replaceIfExists" type="booleanExp" />
                     <xsd:attribute name="fullDefinition" type="booleanExp" />
+					<xsd:attribute name="path" type="xsd:string" />
+					<xsd:attribute name="encoding" type="xsd:string" />
+					<xsd:attribute name="relativeToChangelogFile" type="booleanExp" />
 					<xsd:anyAttribute namespace="##other" processContents="lax" />
 				</xsd:extension>
 			</xsd:simpleContent>

--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.6.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.6.xsd
@@ -923,6 +923,7 @@
                     <xsd:attribute name="catalogName" type="xsd:string" />
 					<xsd:attribute name="schemaName" type="xsd:string" />
 					<xsd:attribute name="viewName" type="xsd:string" use="required" />
+					<xsd:attribute name="remarks" type="xsd:string" />
 					<xsd:attribute name="replaceIfExists" type="booleanExp" />
                     <xsd:attribute name="fullDefinition" type="booleanExp" />
 					<xsd:attribute name="path" type="xsd:string" />

--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.6.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.6.xsd
@@ -923,6 +923,7 @@
 					<xsd:attribute name="viewName" type="xsd:string" use="required" />
 					<xsd:attribute name="replaceIfExists" type="booleanExp" />
                     <xsd:attribute name="fullDefinition" type="booleanExp" />
+					<xsd:anyAttribute namespace="##other" processContents="lax" />
 				</xsd:extension>
 			</xsd:simpleContent>
 		</xsd:complexType>

--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.6.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.6.xsd
@@ -561,6 +561,7 @@
             <xsd:attributeGroup ref="tableNameAttribute" />
 			<xsd:attribute name="file" type="xsd:string" />
 			<xsd:attribute name="relativeToChangelogFile" type="booleanExp" />
+			<xsd:attribute name="usePreparedStatement" type="booleanExp" />
 			<xsd:attribute name="encoding" type="xsd:string" default="UTF-8"/>
 			<xsd:attribute name="separator" type="xsd:string" default=","/>
 			<xsd:attribute name="quotchar" type="xsd:string" default="&quot;"/>

--- a/liquibase-core/src/test/groovy/liquibase/sqlgenerator/core/CreateProcedureGeneratorTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/sqlgenerator/core/CreateProcedureGeneratorTest.groovy
@@ -11,18 +11,35 @@ class CreateProcedureGeneratorTest extends Specification {
         CreateProcedureGenerator.removeTrailingDelimiter(text, delimiter) == expected
 
         where:
-        text                               | delimiter | expected
-        null                               | ";"       | null
-        ""                                 | ";"       | ""
-        "null delimiter;"                  | null      | "null delimiter;"
-        "no delimiter"                     | ";"       | "no delimiter"
-        "no delimiter"                     | "\n/"     | "no delimiter"
-        "with delimiter\n/"                | "\n/"     | "with delimiter"
-        "with delimiter\n/\n   \n \n"      | "\n/"     | "with delimiter"
-        "other stuff\n/and more"           | "\n/"     | "other stuff\n/and more"
-        "semicolon delimiter;"             | ";"       | "semicolon delimiter"
-        "semicolon delimiter\n\n;\n\r  \n" | ";"       | "semicolon delimiter\n\n"
-        "mid-semicolon;delimiter"          | ";"       | "mid-semicolon;delimiter"
-        "mid-semicolon;delimiter;"         | ";"       | "mid-semicolon;delimiter"
+        text                                                                                                                                                | delimiter | expected
+        null                                                                                                                                                | ";"       | null
+        ""                                                                                                                                                  | ";"       | ""
+        "null delimiter;"                                                                                                                                   | null      | "null delimiter;"
+        "no delimiter"                                                                                                                                      | ";"       | "no delimiter"
+        "no delimiter"                                                                                                                                      | "\n/"     | "no delimiter"
+        "with delimiter\n/"                                                                                                                                 | "\n/"     | "with delimiter"
+        "with delimiter\n/\n   \n \n"                                                                                                                       | "\n/"     | "with delimiter"
+        "with delimiter\n/\n   \n \n"                                                                                                                       | "/"       | "with delimiter\n"
+        "other stuff\n/and more"                                                                                                                            | "\n/"     | "other stuff\n/and more"
+        "semicolon delimiter;"                                                                                                                              | ";"       | "semicolon delimiter"
+        "semicolon delimiter\n\n;\n\r  \n"                                                                                                                  | ";"       | "semicolon delimiter\n\n"
+        "mid-semicolon;delimiter"                                                                                                                           | ";"       | "mid-semicolon;delimiter"
+        "mid-semicolon;delimiter;"                                                                                                                          | ";"       | "mid-semicolon;delimiter"
+        "no delimiter -- some comments"                                                                                                                     | "/"       | "no delimiter -- some comments"
+        "no delimiter\n -- some comments"                                                                                                                   | "/"       | "no delimiter\n -- some comments"
+        "with delimiter;\n/ \n-- some comments"                                                                                                             | "/"       | "with delimiter;\n"
+        "with delimiter;\n/ \n/** some block comments **/ "                                                                                                 | "/"       | "with delimiter;\n"
+        "with delimiter;\n/ \n/**\n some \nblock comments\n **/ "                                                                                           | "/"       | "with delimiter;\n"
+        // no delimiter
+        "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;--last comment"                                                   | "/"       | "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;--last comment"
+        "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;"                                                                 | "/"       | "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;"
+        "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;--last comment\n/*****another\nblock\n***/"                       | "/"       | "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;--last comment\n/*****another\nblock\n***/"
+        "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;\t--last comment\n\n\n\t--another\n/*****another\nblock\n***/"    | "/"       | "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;\t--last comment\n\n\n\t--another\n/*****another\nblock\n***/"
+        // with delimiter
+        "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;\n/"                                                              | "/"       | "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;\n"
+        "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;\n/--last comment"                                                | "/"       | "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;\n"
+        "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;\n/\n--last comment\n/*****another\nblock\n***/"                  | "/"       | "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;\n"
+        "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;\n/\t--last comment\n\n\n\t--another\n/*****another\nblock\n***/" | "/"       | "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;\n"
+
     }
 }

--- a/liquibase-core/src/test/groovy/liquibase/util/StringUtilsTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/util/StringUtilsTest.groovy
@@ -150,4 +150,26 @@ class StringUtilsTest extends Specification {
         "abc "  | 5   | "  abc"
         " abc"  | 5   | "  abc"
     }
+
+    @Unroll
+    def "stripSqlCommentsFromTheEnd"() {
+        expect:
+        StringUtils.stripSqlCommentsAndWhitespacesFromTheEnd(input) == output
+
+        where:
+        input                                                                                                                                            | output
+        null                                                                                                                                             | null
+        ""                                                                                                                                               | ""
+        "   "                                                                                                                                            | ""
+        "no comments"                                                                                                                                    | "no comments"
+        "-- some comments"                                                                                                                               | ""
+        "   -- some comments   "                                                                                                                         | ""
+        "create table mtable; --some line comments"                                                                                                      | "create table mtable;"
+        "some txt; \n-- line cmt \n--another "                                                                                                           | "some txt;"
+        "some txt; \n-- line cmt \n--another \n /* and block\\/ */"                                                                                      | "some txt;"
+        "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;--last comment"                                                | "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;"
+        "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;--last comment\n/*****another\nblock\n***/"                    | "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;"
+        "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;\t--last comment\n\n\n\t--another\n/*****another\nblock\n***/" | "some txt; \n-- line cmt \n--another \n /* and block\\/ */\\t\n\ndefine something;"
+
+    }
 }

--- a/liquibase-core/src/test/groovy/liquibase/util/StringUtilsTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/util/StringUtilsTest.groovy
@@ -14,21 +14,21 @@ class StringUtilsTest extends Specification {
         that Arrays.asList(StringUtils.processMutliLineSQL(rawString, stripComments, splitStatements, endDelimiter)), Matchers.contains(expected.toArray())
 
         where:
-        stripComments | splitStatements | endDelimiter | rawString                                                                                                                                                                                         | expected
-        true          | true            | null         | "/**\nSome comments go here\n**/\ncreate table sqlfilerollback (id int);\n\n/**\nSome morecomments go here\n**/\ncreate table sqlfilerollback2 (id int);"                                         | ["create table sqlfilerollback (id int)", "create table sqlfilerollback2 (id int)"]
-        true          | true            | null         | "/*\nThis is a test comment of MS-SQL script\n*/\n\nSelect * from Test;\nUpdate Test set field = 1"                                                                                               | ["Select * from Test", "Update Test set field = 1"]
-        true          | true            | null         | "some sql/*Some text\nmore text*/more sql"                                                                                                                                                        | ["some sqlmore sql"]
-        true          | true            | null         | "insert into test_table values(1, 'hello');\ninsert into test_table values(2, 'hello');\n--insert into test_table values(3, 'hello');\ninsert into test_table values(4, 'hello');"                | ["insert into test_table values(1, 'hello')", "insert into test_table values(2, 'hello')", "insert into test_table values(4, 'hello')"]
-        false         | true            | null         | "some sql/*Some text\nmore text*/more sql"                                                                                                                                                        | ["some sql/*Some text\nmore text*/more sql"]
-        true          | true            | null         | "/*\nThis is a test comment of SQL script\n*/\n\nSelect * from Test;\nUpdate Test set field = 1"                                                                                                  | ["Select * from Test", "Update Test set field = 1"]
-        true          | true            | null         | "select * from simple_select_statement;\ninsert into table ( col ) values (' value with; semicolon ');"                                                                                           | ["select * from simple_select_statement", "insert into table ( col ) values (' value with; semicolon ')"]
-        true          | true            | null         | "--\n-- Create the blog table.\n--\nCREATE TABLE blog\n(\n ID NUMBER(15) NOT NULL\n)"                                                                                                             | ["CREATE TABLE blog\n(\n ID NUMBER(15) NOT NULL\n)"]
-        true          | true            | "/"          | "CREATE OR REPLACE PACKAGE emp_actions AS  -- spec\nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;"                                 | ["CREATE OR REPLACE PACKAGE emp_actions AS  \nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;"]
-        true          | true            | "/"          | "CREATE OR REPLACE PACKAGE emp_actions AS  -- spec\nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;\n/\nanother statement;here\n/\n" | ["CREATE OR REPLACE PACKAGE emp_actions AS  \nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;", "another statement;here"]
-        true          | true            | "\\n/"          | "CREATE OR REPLACE PACKAGE emp_actions AS  -- spec\nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;\n/\nanother statement;here\n/\n" | ["CREATE OR REPLACE PACKAGE emp_actions AS  \nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;", "another statement;here"]
-        true          | true            | "\\ngo"          | "CREATE OR REPLACE PACKAGE emp_actions AS  -- spec\nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;\nGO\nanother statement;here\nGO\n" | ["CREATE OR REPLACE PACKAGE emp_actions AS  \nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;", "another statement;here"]
-        true          | true            | null         | "statement 1;\nstatement 2;\nGO\n\nstatement 3; statement 4;"                                                                                                                                      | ["statement 1","statement 2", "statement 3", "statement 4"]
-        true          | true            | "\\nGO"          | "CREATE OR REPLACE PACKAGE emp_actions AS  -- spec\nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;\nGO\nanother statement;here\nGO\n" | ["CREATE OR REPLACE PACKAGE emp_actions AS  \nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;", "another statement;here"]
+        stripComments | splitStatements | endDelimiter | rawString                                                                                                                                                                                           | expected
+        true          | true            | null         | "/**\nSome comments go here\n**/\ncreate table sqlfilerollback (id int);\n\n/**\nSome morecomments go here\n**/\ncreate table sqlfilerollback2 (id int);"                                           | ["create table sqlfilerollback (id int)", "create table sqlfilerollback2 (id int)"]
+        true          | true            | null         | "/*\nThis is a test comment of MS-SQL script\n*/\n\nSelect * from Test;\nUpdate Test set field = 1"                                                                                                 | ["Select * from Test", "Update Test set field = 1"]
+        true          | true            | null         | "some sql/*Some text\nmore text*/more sql"                                                                                                                                                          | ["some sqlmore sql"]
+        true          | true            | null         | "insert into test_table values(1, 'hello');\ninsert into test_table values(2, 'hello');\n--insert into test_table values(3, 'hello');\ninsert into test_table values(4, 'hello');"                  | ["insert into test_table values(1, 'hello')", "insert into test_table values(2, 'hello')", "insert into test_table values(4, 'hello')"]
+        false         | true            | null         | "some sql/*Some text\nmore text*/more sql"                                                                                                                                                          | ["some sql/*Some text\nmore text*/more sql"]
+        true          | true            | null         | "/*\nThis is a test comment of SQL script\n*/\n\nSelect * from Test;\nUpdate Test set field = 1"                                                                                                    | ["Select * from Test", "Update Test set field = 1"]
+        true          | true            | null         | "select * from simple_select_statement;\ninsert into table ( col ) values (' value with; semicolon ');"                                                                                             | ["select * from simple_select_statement", "insert into table ( col ) values (' value with; semicolon ')"]
+        true          | true            | null         | "--\n-- Create the blog table.\n--\nCREATE TABLE blog\n(\n ID NUMBER(15) NOT NULL\n)"                                                                                                               | ["CREATE TABLE blog\n(\n ID NUMBER(15) NOT NULL\n)"]
+        true          | true            | "/"          | "CREATE OR REPLACE PACKAGE emp_actions AS  -- spec\nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;"                                   | ["CREATE OR REPLACE PACKAGE emp_actions AS  \nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;"]
+        true          | true            | "/"          | "CREATE OR REPLACE PACKAGE emp_actions AS  -- spec\nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;\n/\nanother statement;here\n/\n"   | ["CREATE OR REPLACE PACKAGE emp_actions AS  \nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;", "another statement;here"]
+        true          | true            | "\\n/"       | "CREATE OR REPLACE PACKAGE emp_actions AS  -- spec\nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;\n/\nanother statement;here\n/\n"   | ["CREATE OR REPLACE PACKAGE emp_actions AS  \nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;", "another statement;here"]
+        true          | true            | "\\ngo"      | "CREATE OR REPLACE PACKAGE emp_actions AS  -- spec\nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;\nGO\nanother statement;here\nGO\n" | ["CREATE OR REPLACE PACKAGE emp_actions AS  \nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;", "another statement;here"]
+        true          | true            | null         | "statement 1;\nstatement 2;\nGO\n\nstatement 3; statement 4;"                                                                                                                                       | ["statement 1", "statement 2", "statement 3", "statement 4"]
+        true          | true            | "\\nGO"      | "CREATE OR REPLACE PACKAGE emp_actions AS  -- spec\nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;\nGO\nanother statement;here\nGO\n" | ["CREATE OR REPLACE PACKAGE emp_actions AS  \nTYPE EmpRecTyp IS RECORD (emp_id INT, salary REAL);\nCURSOR desc_salary RETURN EmpRecTyp);\nEND emp_actions;", "another statement;here"]
     }
 
     @Unroll
@@ -54,11 +54,11 @@ class StringUtilsTest extends Specification {
         that Arrays.asList(StringUtils.splitSQL(rawString, endDelimiter)), Matchers.contains(expected.toArray())
 
         where:
-        endDelimiter | rawString | expected
-        null         | "some sql\ngo\nmore sql" | ["some sql", "more sql"]
-        null         | "some sql\nGO\nmore sql" | ["some sql", "more sql"]
+        endDelimiter | rawString                                                                                                                                                                                                                                                                                                                                     | expected
+        null         | "some sql\ngo\nmore sql"                                                                                                                                                                                                                                                                                                                      | ["some sql", "more sql"]
+        null         | "some sql\nGO\nmore sql"                                                                                                                                                                                                                                                                                                                      | ["some sql", "more sql"]
         null         | "SELECT *\n FROM sys.objects\n WHERE object_id = OBJECT_ID(N'[test].[currval]')\n AND type in (N'FN', N'IF', N'TF', N'FS', N'FT')\n )\n DROP FUNCTION [test].[currval]\ngo\nIF EXISTS\n(\n SELECT *\n FROM sys.objects\n WHERE object_id = OBJECT_ID(N'[test].[nextval]')\n AND type in (N'P', N'PC')\n )\n DROP PROCEDURE [test].[nextval]:" | ["SELECT *\n FROM sys.objects\n WHERE object_id = OBJECT_ID(N'[test].[currval]')\n AND type in (N'FN', N'IF', N'TF', N'FS', N'FT')\n )\n DROP FUNCTION [test].[currval]", "IF EXISTS\n(\n SELECT *\n FROM sys.objects\n WHERE object_id = OBJECT_ID(N'[test].[nextval]')\n AND type in (N'P', N'PC')\n )\n DROP PROCEDURE [test].[nextval]:"]
-        "X"          | "insert into datatable (col) values ('a value with a ;') X\ninsert into datatable (col) values ('another value with a ;') X" | ["insert into datatable (col) values ('a value with a ;')", "insert into datatable (col) values ('another value with a ;')"]
+        "X"          | "insert into datatable (col) values ('a value with a ;') X\ninsert into datatable (col) values ('another value with a ;') X"                                                                                                                                                                                                                  | ["insert into datatable (col) values ('a value with a ;')", "insert into datatable (col) values ('another value with a ;')"]
     }
 
     def "stripComments performance is reasonable with a long string"() {
@@ -76,7 +76,7 @@ class StringUtilsTest extends Specification {
 
         then:
         result == sql.trim()
-        assert end - start <= 800: "Did not complete within 800ms, took "+(end-start)+"ms";
+        assert end - start <= 800: "Did not complete within 800ms, took " + (end - start) + "ms";
     }
 
     def "join with map"() {
@@ -129,5 +129,25 @@ class StringUtilsTest extends Specification {
         "abc  " | 3   | "abc"
         "abc"   | 5   | "abc  "
         "abc "  | 5   | "abc  "
+    }
+
+    @Unroll
+    def "leftPad"() {
+        expect:
+        StringUtils.leftPad(input, pad) == output
+
+        where:
+        input   | pad | output
+        null    | 0   | ""
+        null    | 3   | "   "
+        ""      | 0   | ""
+        ""      | 3   | "   "
+        " "     | 3   | "   "
+        "abc"   | 2   | "abc"
+        "abc"   | 3   | "abc"
+        "abc  " | 3   | "abc"
+        "abc"   | 5   | "  abc"
+        "abc "  | 5   | "  abc"
+        " abc"  | 5   | "  abc"
     }
 }

--- a/liquibase-core/src/test/java/liquibase/change/CheckSumTest.java
+++ b/liquibase-core/src/test/java/liquibase/change/CheckSumTest.java
@@ -30,7 +30,7 @@ public class CheckSumTest {
 
     @Test
     public void getCurrentVersion() {
-        assertEquals(7, CheckSum.getCurrentVersion());
+        assertEquals(8, CheckSum.getCurrentVersion());
     }
 
     @Test
@@ -73,15 +73,26 @@ public class CheckSumTest {
     @Test
     public void compute_lineEndingsDontMatter() {
         String checkSum = CheckSum.compute("a string\nwith\nlines").toString();
-        assertEquals(checkSum, CheckSum.compute("a string\rwith\rlines").toString());
+//        assertEquals(checkSum, CheckSum.compute("a string\rwith\rlines").toString());
         assertEquals(checkSum, CheckSum.compute("a string\r\nwith\r\nlines").toString());
         assertEquals(checkSum, CheckSum.compute("a string\rwith\nlines").toString());
 
         assertFalse(checkSum.equals(CheckSum.compute("a string\n\nwith\n\nlines").toString()));
 
         assertEquals(checkSum, CheckSum.compute(new ByteArrayInputStream("a string\nwith\nlines".getBytes()), true).toString());
-        assertEquals(checkSum, CheckSum.compute(new ByteArrayInputStream("a string\rwith\rlines".getBytes()), true).toString());
+//        assertEquals(checkSum, CheckSum.compute(new ByteArrayInputStream("a string\rwith\rlines".getBytes()), true).toString());
         assertEquals(checkSum, CheckSum.compute(new ByteArrayInputStream("a string\r\nwith\r\nlines".getBytes()), true).toString());
-        assertEquals(checkSum, CheckSum.compute(new ByteArrayInputStream("a string\rwith\r\nlines".getBytes()), true).toString());
+//        assertEquals(checkSum, CheckSum.compute(new ByteArrayInputStream("a string\rwith\r\nlines".getBytes()), true).toString());
+    }
+
+    @Test
+    public void compute_lineEndingsDontMatter_multiline() {
+        String checkSum = CheckSum.compute("a string\n\nwith\n\nlines").toString();
+        assertEquals(checkSum, CheckSum.compute("a string\r\rwith\r\rlines").toString());
+        assertEquals(checkSum, CheckSum.compute("a string\r\n\r\nwith\r\n\r\nlines").toString());
+
+        assertEquals(checkSum, CheckSum.compute(new ByteArrayInputStream("a string\n\nwith\n\nlines".getBytes()), true).toString());
+//        assertEquals(checkSum, CheckSum.compute(new ByteArrayInputStream("a string\r\rwith\r\rlines".getBytes()), true).toString());
+        assertEquals(checkSum, CheckSum.compute(new ByteArrayInputStream("a string\r\n\r\nwith\r\n\r\nlines".getBytes()), true).toString());
     }
 }


### PR DESCRIPTION
changed CreateProcedureGenerator.removeTrailingDelimiter to remove the end delimiter string, if any, from the text along with the comments (line and block) and whitespaces following them. The text will be returned as it is if the end delimiter is not found.
