### PR TITLE
Adding hook to support liquibase hibernate extension

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/DatabaseFactory.java
+++ b/liquibase-core/src/main/java/liquibase/database/DatabaseFactory.java
@@ -200,6 +200,10 @@ public class DatabaseFactory {
                 throw new RuntimeException("Cannot find database driver: " + e.getMessage());
             }
 
+            if (driverObject instanceof LiquibaseExtDriver) {
+                ((LiquibaseExtDriver)driverObject).setResourceAccessor(resourceAccessor);
+            }
+
             Properties driverProperties;
             if (propertyProviderClass == null) {
                 driverProperties = new Properties();

--- a/liquibase-core/src/main/java/liquibase/database/LiquibaseExtDriver.java
+++ b/liquibase-core/src/main/java/liquibase/database/LiquibaseExtDriver.java
@@ -1,0 +1,7 @@
+package liquibase.database;
+
+import liquibase.resource.ResourceAccessor;
+
+public interface LiquibaseExtDriver {
+    void setResourceAccessor(ResourceAccessor accessor);
+}


### PR DESCRIPTION
Liquibase-Hibernate fails in Maven due to a classloading issue. I've added this small interface change to the main Liquibase project to allow a fix for this issue in Liquibase-Hibernate.