### PR TITLE
Fix for file system case sensitivity in FileSystemResourceAccessor.list

### DIFF
--- a/liquibase-core/src/main/java/liquibase/resource/FileSystemResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/FileSystemResourceAccessor.java
@@ -134,7 +134,13 @@ public class FileSystemResourceAccessor extends AbstractResourceAccessor {
             for (String returnPath : returnSet) {
                 returnPath = returnPath.replace("\\", "/");
                 for (String rootPath : rootPaths) {
-                    if (returnPath.startsWith(rootPath)) {
+                    boolean matches = false;
+                    if (isCaseSensitive()) {
+                        matches = returnPath.startsWith(rootPath);
+                    } else {
+                        matches = returnPath.toLowerCase().startsWith(rootPath.toLowerCase());
+                    }
+                    if (matches) {
                         returnPath = returnPath.substring(rootPath.length());
                         break;
                     }


### PR DESCRIPTION
TL;DR: Fixes a regression in databaseChangeLog includeAll behavior on Windows after upgrading from Liquibase 3.5.0 to 3.5.3.

Note: I currently can't log in to [liquibase.jira.com](https://liquibase.jira.com) for some reason, so I'm referring to related JIRA issues here: this should fix [CORE-2851](https://liquibase.jira.com/browse/CORE-2851) (and [CORE-2898](https://liquibase.jira.com/browse/CORE-2898)).
