### PR TITLE
fix for CORE-3117 : H2 now supports TIMESTAMP WITH TIME ZONE data type

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/TimestampType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/TimestampType.java
@@ -118,7 +118,7 @@ public class TimestampType extends DateTimeType {
         }
 
         if (((getAdditionalInformation() != null) && ((database instanceof PostgresDatabase) || (database instanceof
-            OracleDatabase))) || (database instanceof HsqlDatabase)){
+            OracleDatabase))) || (database instanceof HsqlDatabase) || (database instanceof H2Database)){
             String additionalInformation = this.getAdditionalInformation();
 
             if ((additionalInformation != null) && (database instanceof PostgresDatabase)) {


### PR DESCRIPTION
This is a fix for https://liquibase.jira.com/browse/CORE-3117