### PR TITLE
CORE-3079  Make includeObjects and excludeObjects affect which object…

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/commandline/CommandLineUtils.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/CommandLineUtils.java
@@ -258,15 +258,15 @@ public class CommandLineUtils {
 
     public static void doGenerateChangeLog(String changeLogFile, Database originalDatabase, String catalogName,
                                            String schemaName, String snapshotTypes, String author, String context,
-                                           String dataDir, DiffOutputControl diffOutputControl) throws
+                                           String dataDir, DiffOutputControl diffOutputControl, ObjectChangeFilter objectChangeFilter) throws
             IOException, ParserConfigurationException, LiquibaseException {
         doGenerateChangeLog(changeLogFile, originalDatabase, new CatalogAndSchema[]{new CatalogAndSchema(catalogName,
-                schemaName)}, snapshotTypes, author, context, dataDir, diffOutputControl);
+                schemaName)}, snapshotTypes, author, context, dataDir, diffOutputControl, objectChangeFilter);
     }
 
     public static void doGenerateChangeLog(String changeLogFile, Database originalDatabase, CatalogAndSchema[]
             schemas, String snapshotTypes, String author, String context, String dataDir, DiffOutputControl
-                                                   diffOutputControl) throws IOException, ParserConfigurationException,
+                                                   diffOutputControl, ObjectChangeFilter objectChangeFilter) throws IOException, ParserConfigurationException,
             LiquibaseException {
         CompareControl.SchemaComparison[] comparisons = new CompareControl.SchemaComparison[schemas.length];
         int i = 0;
@@ -284,7 +284,8 @@ public class CommandLineUtils {
                 .setOutputStream(System.out)
                 .setCompareControl(compareControl);
         command.setChangeLogFile(changeLogFile)
-                .setDiffOutputControl(diffOutputControl);
+                .setDiffOutputControl(diffOutputControl)
+                .setObjectChangeFilter(objectChangeFilter);
         command.setAuthor(author)
                 .setContext(context);
 

--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -959,7 +959,7 @@ public class Main {
                 CommandLineUtils.doGenerateChangeLog(currentChangeLogFile, database, finalTargetSchemas,
                         StringUtils.trimToNull(diffTypes), StringUtils.trimToNull(changeSetAuthor),
                         StringUtils.trimToNull(changeSetContext), StringUtils.trimToNull(dataOutputDirectory),
-                        diffOutputControl);
+                        diffOutputControl, objectChangeFilter);
                 return;
             } else if (COMMANDS.SNAPSHOT.equalsIgnoreCase(command)) {
                 SnapshotCommand snapshotCommand = (SnapshotCommand) CommandFactory.getInstance()

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseGenerateChangeLogMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseGenerateChangeLogMojo.java
@@ -3,6 +3,7 @@ package org.liquibase.maven.plugins;
 import liquibase.Liquibase;
 import liquibase.database.Database;
 import liquibase.diff.output.DiffOutputControl;
+import liquibase.diff.output.ObjectChangeFilter;
 import liquibase.diff.output.StandardObjectChangeFilter;
 import liquibase.exception.LiquibaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
@@ -102,15 +103,17 @@ public class LiquibaseGenerateChangeLogMojo extends
             if ((diffExcludeObjects != null) && (diffIncludeObjects != null)) {
                 throw new UnexpectedLiquibaseException("Cannot specify both excludeObjects and includeObjects");
             }
+            ObjectChangeFilter objectChangeFilter = null;
             if (diffExcludeObjects != null) {
-                diffOutputControl.setObjectChangeFilter(new StandardObjectChangeFilter(StandardObjectChangeFilter.FilterType.EXCLUDE, diffExcludeObjects));
+                objectChangeFilter = new StandardObjectChangeFilter(StandardObjectChangeFilter.FilterType.EXCLUDE, diffExcludeObjects);
             }
             if (diffIncludeObjects != null) {
-                diffOutputControl.setObjectChangeFilter(new StandardObjectChangeFilter(StandardObjectChangeFilter.FilterType.INCLUDE, diffIncludeObjects));
+                objectChangeFilter = new StandardObjectChangeFilter(StandardObjectChangeFilter.FilterType.INCLUDE, diffIncludeObjects);
             }
+            diffOutputControl.setObjectChangeFilter(objectChangeFilter);
 
             CommandLineUtils.doGenerateChangeLog(outputChangeLogFile, database, defaultCatalogName, defaultSchemaName, StringUtils.trimToNull(diffTypes),
-                    StringUtils.trimToNull(changeSetAuthor), StringUtils.trimToNull(changeSetContext), StringUtils.trimToNull(dataDir), diffOutputControl);
+                    StringUtils.trimToNull(changeSetAuthor), StringUtils.trimToNull(changeSetContext), StringUtils.trimToNull(dataDir), diffOutputControl, objectChangeFilter);
             getLog().info("Output written to Change Log file, " + outputChangeLogFile);
         }
         catch (IOException | ParserConfigurationException e) {


### PR DESCRIPTION
…s are snapshotted

In the original pull request I had forgot support for generateChangeLog. This is now added.