### PR TITLE
Core-3115: add trim in field splitting

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/DataTypeFactory.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/DataTypeFactory.java
@@ -134,7 +134,7 @@ public class DataTypeFactory {
             // not going to do anything. Special case for postgres in our tests,
             // need to better support handling these types of differences
         } else {
-            String[] splitTypeName = dataTypeName.split("\\s+", 2);
+            String[] splitTypeName = dataTypeName.trim().split("\\s+", 2);
             dataTypeName = splitTypeName[0];
             if (splitTypeName.length > 1) {
                 additionalInfo = splitTypeName[1];

--- a/liquibase-core/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
@@ -24,6 +24,7 @@ class DataTypeFactoryTest extends Specification {
         liquibaseString                                      | database              | databaseString                                       | expectedType  | expectedAutoIncrement
         "int"                                                | new MockDatabase()    | "INT"                                                | IntType       | false
         "varchar(255)"                                       | new MockDatabase()    | "VARCHAR(255)"                                       | VarcharType   | false
+        " varchar(255) "                                     | new MockDatabase()    | "VARCHAR(255)"                                       | VarcharType   | false
         "int{autoIncrement:true}"                            | new MockDatabase()    | "INT"                                                | IntType       | true
         "int{autoIncrement:false}"                           | new MockDatabase()    | "INT"                                                | IntType       | false
         "int{}"                                              | new MockDatabase()    | "INT"                                                | IntType       | false


### PR DESCRIPTION
Added trim() before splitting the type field