### PR TITLE
CORE-3138: correct AddAutoIncrement for SQLAnywhere

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddAutoIncrementGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddAutoIncrementGenerator.java
@@ -49,15 +49,24 @@ public class AddAutoIncrementGenerator extends AbstractSqlGenerator<AddAutoIncre
     		AddAutoIncrementStatement statement,
     		Database database,
     		SqlGeneratorChain sqlGeneratorChain) {
-        String sql = "ALTER TABLE "
-            + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName())
-            + " MODIFY "
-            + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName())
-            + " "
-            + DataTypeFactory.getInstance().fromDescription(statement.getColumnDataType() + "{autoIncrement:true}", database).toDatabaseDataType(database)
-            + " " 
-            + database.getAutoIncrementClause(statement.getStartWith(), statement.getIncrementBy());
-
+    	String sql;
+    	if (database instanceof SybaseASADatabase) {
+	        sql = "ALTER TABLE "
+		            + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName())
+		            + " ALTER "
+		            + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName())
+		            + " SET " 
+		            + database.getAutoIncrementClause(statement.getStartWith(), statement.getIncrementBy());
+    	} else {
+	        sql = "ALTER TABLE "
+	            + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName())
+	            + " MODIFY "
+	            + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName())
+	            + " "
+	            + DataTypeFactory.getInstance().fromDescription(statement.getColumnDataType() + "{autoIncrement:true}", database).toDatabaseDataType(database)
+	            + " " 
+	            + database.getAutoIncrementClause(statement.getStartWith(), statement.getIncrementBy());
+    	}
         return new Sql[]{
             new UnparsedSql(sql, getAffectedColumn(statement))
         };


### PR DESCRIPTION
AddAutoIncrement generate the statement:
ALTER TABLE <table> MODIFY <column> <datatype> DEFAULT AUTOINCREMENT
But if the column is used in an Index, you get the error: "Changes on a column with is in an Index is impossible".
The right syntax has to be:
ALTER TABLE <table> ALTER <column> SET DEFAULT AUTOINCREMENT

[jira CORE-3138](https://liquibase.jira.com/browse/CORE-3138)