### PR TITLE
Uses SafeConstructor to enhance security

### DIFF
--- a/liquibase-core/src/main/java/liquibase/parser/core/yaml/YamlChangeLogParser.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/yaml/YamlChangeLogParser.java
@@ -11,6 +11,7 @@ import liquibase.parser.core.ParsedNode;
 import liquibase.resource.ResourceAccessor;
 import liquibase.util.StreamUtil;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -20,7 +21,7 @@ public class YamlChangeLogParser extends YamlParser implements ChangeLogParser {
 
     @Override
     public DatabaseChangeLog parse(String physicalChangeLogLocation, ChangeLogParameters changeLogParameters, ResourceAccessor resourceAccessor) throws ChangeLogParseException {
-        Yaml yaml = new Yaml();
+        Yaml yaml = new Yaml(new SafeConstructor());
 
         try {
             InputStream changeLogStream = StreamUtil.singleInputStream(physicalChangeLogLocation, resourceAccessor);
@@ -87,10 +88,9 @@ public class YamlChangeLogParser extends YamlParser implements ChangeLogParser {
     private Map parseYamlStream(String physicalChangeLogLocation, Yaml yaml, InputStream changeLogStream) throws ChangeLogParseException {
         Map parsedYaml;
         try {
-            parsedYaml = yaml.loadAs(changeLogStream, Map.class);
+            parsedYaml = (Map) yaml.load(changeLogStream);
         } catch (Exception e) {
             throw new ChangeLogParseException("Syntax error in file " + physicalChangeLogLocation + ": " + e.getMessage(), e);
-            
         }
         return parsedYaml;
     }

--- a/liquibase-core/src/main/java/liquibase/parser/core/yaml/YamlSnapshotParser.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/yaml/YamlSnapshotParser.java
@@ -12,6 +12,7 @@ import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.RestoredDatabaseSnapshot;
 import liquibase.util.StreamUtil;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -21,7 +22,7 @@ public class YamlSnapshotParser extends YamlParser implements SnapshotParser {
 
     @Override
     public DatabaseSnapshot parse(String path, ResourceAccessor resourceAccessor) throws LiquibaseParseException {
-        Yaml yaml = new Yaml();
+        Yaml yaml = new Yaml(new SafeConstructor());
 
         try (
             InputStream stream = StreamUtil.singleInputStream(path, resourceAccessor);
@@ -67,7 +68,7 @@ public class YamlSnapshotParser extends YamlParser implements SnapshotParser {
                 stream, LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).getOutputEncoding()
             );
         ) {
-            parsedYaml = yaml.loadAs(inputStreamReader, Map.class);
+            parsedYaml = (Map) yaml.load(inputStreamReader);
         } catch (Exception e) {
             throw new LiquibaseParseException("Syntax error in " + getSupportedFileExtensions()[0] + ": " + e.getMessage(), e);
         }


### PR DESCRIPTION
YAML files can contain custom object definitions, containing method
definitions, which can be executed. This can provide a means of remote
code execution.

By passing a SafeConstructor into SnakeYAML, we limit the objects it
will construct and deny this potential exploit.

Unfortunately this makes yaml.loadAs(stream, Map.class) not work because
Map is not recognised as a valid tag. Instead we can 'load' and cast to
Map. If a ClassCastException is thrown it will be caught by the catch-all
block already in place.