### PR TITLE
fix includeall on WebSphere and Weblogic

### DIFF
--- a/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
@@ -64,7 +64,7 @@ public class ClassLoaderResourceAccessor extends AbstractResourceAccessor {
 
         Set<String> returnSet = new HashSet<String>();
 
-        if (!fileUrls.hasMoreElements() && (path.startsWith("jar:") || path.startsWith("file:"))) {
+        if (!fileUrls.hasMoreElements() && (path.startsWith("jar:") || path.startsWith("file:") || path.startsWith("wsjar:file:") || path.startsWith("zip:"))) {
             fileUrls = new Vector<URL>(Arrays.asList(new URL(path))).elements();
         }
 


### PR DESCRIPTION
Wheblogic path to the includeall folder starts with zip:, not file/jar. It is taken into account several lines further but not on the main check.