### PR TITLE
Fix for includeAll which duplicates relative path with absolute in da…

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
@@ -107,22 +107,23 @@ public class ValidatingVisitor implements ChangeSetVisitor {
             
             if(shouldValidate){
                 warnings.addAll(change.warn(database));
-            
-                try {                
-                    ValidationErrors foundErrors = change.validate(database);
 
-                    if ((foundErrors != null) && foundErrors.hasErrors() && (changeSet.getOnValidationFail().equals
-                        (ChangeSet.ValidationFailOption.MARK_RAN))) {
+                try {
+                    ValidationErrors foundErrors = change.validate(database);
+                    if ((foundErrors != null)) {
+                        if (foundErrors.hasErrors() && (changeSet.getOnValidationFail().equals
+                                (ChangeSet.ValidationFailOption.MARK_RAN))) {
                             LogService.getLog(getClass()).info(
                                     LogType.LOG, "Skipping change set " + changeSet + " due to validation error(s): " +
                                             StringUtils.join(foundErrors.getErrorMessages(), ", "));
                             changeSet.setValidationFailed(true);
-                    } else {
-                        if (!foundErrors.getWarningMessages().isEmpty())
-                            LogService.getLog(getClass()).warning(
-                                    LogType.LOG, "Change set " + changeSet + ": " +
-                                            StringUtils.join(foundErrors.getWarningMessages(), ", "));
-                        validationErrors.addAll(foundErrors, changeSet);
+                        } else {
+                            if (!foundErrors.getWarningMessages().isEmpty())
+                                LogService.getLog(getClass()).warning(
+                                        LogType.LOG, "Change set " + changeSet + ": " +
+                                                StringUtils.join(foundErrors.getWarningMessages(), ", "));
+                            validationErrors.addAll(foundErrors, changeSet);
+                        }
                     }
                 } catch (Exception e) {
                     changeValidationExceptions.add(e);

--- a/liquibase-core/src/main/java/liquibase/resource/FileSystemResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/FileSystemResourceAccessor.java
@@ -126,7 +126,7 @@ public class FileSystemResourceAccessor extends AbstractResourceAccessor {
             });
 
             for (String rootPath : getRootPaths()) {
-                rootPaths.add(rootPath.replaceFirst("^file:/", "").replace("\\", "/"));
+                rootPaths.add(rootPath.replaceFirst("^file:", "").replace("\\", "/"));
             }
 
             Set<String> finalReturnSet = new LinkedHashSet<>();


### PR DESCRIPTION
…tabase on macOS

Fix for ValidatingVisitor: there was a bug (NullPointerException) when foundErrors == null