### PR TITLE
3.5.x - CORE-3163 dbdocs Link text case mismatch

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/AddAutoIncrementChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/AddAutoIncrementChange.java
@@ -3,7 +3,6 @@ package liquibase.change.core;
 import liquibase.change.*;
 import liquibase.database.Database;
 import liquibase.database.core.PostgresDatabase;
-import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.snapshot.SnapshotGeneratorFactory;
 import liquibase.statement.SequenceNextValueFunction;
 import liquibase.statement.SqlStatement;
@@ -14,8 +13,6 @@ import liquibase.statement.core.SetNullableStatement;
 import liquibase.structure.core.Column;
 import liquibase.structure.core.Table;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.math.BigInteger;
 
 /**
@@ -118,16 +115,15 @@ public class AddAutoIncrementChange extends AbstractChange {
             } else {
                 schemaPrefix = this.schemaName;
             }
-            if (schemaPrefix == null) {
-                schemaPrefix = "";
-            } else {
-                schemaPrefix = schemaPrefix+".";
-            }
+
+            SequenceNextValueFunction nvf = new SequenceNextValueFunction(sequenceName);
+            nvf.setSequenceSchemaName(schemaPrefix);
 
             return new SqlStatement[]{
                     new CreateSequenceStatement(catalogName, this.schemaName, sequenceName),
                     new SetNullableStatement(catalogName, this.schemaName, getTableName(), getColumnName(), null, false),
-                    new AddDefaultValueStatement(catalogName, this.schemaName, getTableName(), getColumnName(), getColumnDataType(), new SequenceNextValueFunction(schemaPrefix + sequenceName)),
+                    new AddDefaultValueStatement(catalogName, this.schemaName, getTableName(), getColumnName(), getColumnDataType(),
+                            nvf)
             };
         }
 

--- a/liquibase-core/src/main/java/liquibase/dbdoc/ChangeLogWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/ChangeLogWriter.java
@@ -34,7 +34,7 @@ public class ChangeLogWriter {
 
 
         String changeLogOutFile = changeLog.replace(":", "_");
-        File xmlFile = new File(outputDir, changeLogOutFile + ".html");
+        File xmlFile = new File(outputDir, changeLogOutFile.toLowerCase() + ".html");
         xmlFile.getParentFile().mkdirs();
 
         BufferedWriter changeLogStream = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(xmlFile, false), LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).getOutputEncoding()));

--- a/liquibase-core/src/main/java/liquibase/dbdoc/HTMLWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/HTMLWriter.java
@@ -134,7 +134,7 @@ public abstract class HTMLWriter {
                 if (!change.getChangeSet().equals(lastChangeSet)) {
                     lastChangeSet = change.getChangeSet();
                     fileWriter.append("<TR BGCOLOR=\"#EEEEFF\" CLASS=\"TableSubHeadingColor\">\n");
-                    writeTD(fileWriter, "<a href='../changelogs/"+DBDocUtil.toFileName(change.getChangeSet().getFilePath())+".html'>"+change.getChangeSet().getFilePath()+"</a>");
+                    writeTD(fileWriter, "<a href='../changelogs/"+DBDocUtil.toFileName(change.getChangeSet().getFilePath().toLowerCase())+".html'>"+change.getChangeSet().getFilePath()+"</a>");
                     writeTD(fileWriter, change.getChangeSet().getId());
                     writeTD(fileWriter, "<a href='../authors/"+DBDocUtil.toFileName(change.getChangeSet().getAuthor().toLowerCase())+".html'>"+StringUtils.escapeHtml(change.getChangeSet().getAuthor().toLowerCase())+"</a>");
 
@@ -166,7 +166,7 @@ public abstract class HTMLWriter {
         }
 
         fileWriter.append("</TABLE>");
-        fileWriter.append("&nbsp;</P>");        
+        fileWriter.append("&nbsp;</P>");
 
     }
 }

--- a/liquibase-core/src/main/java/liquibase/dbdoc/TableWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/TableWriter.java
@@ -38,8 +38,7 @@ public class TableWriter extends HTMLWriter {
             String remarks = column.getRemarks();
             cells.add(Arrays.asList(column.getType().toString(),
                     column.isNullable() ? "NULL" : "NOT NULL",
-                    "<A HREF=\"../columns/" + table.getSchema().getName().toLowerCase() + "." + table.getName().toLowerCase() + "." + column.getName().toLowerCase() + ".html" + "\">" + column.getName() + "</A>",
-                    remarks != null ? remarks : ""));
+                    "<A HREF=\"../columns/" + table.getSchema().getName().toLowerCase() + "." + table.getName().toLowerCase() + "." + column.getName().toLowerCase() + ".html" + "\">" + column.getName() + "</A>", (remarks != null) ? remarks : ""));
             //todo: add foreign key info to columns?
         }
 

--- a/liquibase-core/src/main/java/liquibase/dbdoc/TableWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/TableWriter.java
@@ -38,7 +38,7 @@ public class TableWriter extends HTMLWriter {
             String remarks = column.getRemarks();
             cells.add(Arrays.asList(column.getType().toString(),
                     column.isNullable() ? "NULL" : "NOT NULL",
-                    "<A HREF=\"../columns/" + table.getName().toLowerCase() + "." + column.getName().toLowerCase() + ".html" + "\">" + column.getName() + "</A>",
+                    "<A HREF=\"../columns/" + table.getSchema().getName().toLowerCase() + "." + table.getName().toLowerCase() + "." + column.getName().toLowerCase() + ".html" + "\">" + column.getName() + "</A>",
                     remarks != null ? remarks : ""));
             //todo: add foreign key info to columns?
         }
@@ -46,7 +46,7 @@ public class TableWriter extends HTMLWriter {
 
         writeTable("Current Columns", cells, fileWriter);
     }
-    
+
     private void writeTableRemarks(Writer fileWriter, Table table, Database database) throws IOException {
         final String tableRemarks = table.getRemarks();
         if (tableRemarks != null && tableRemarks.length() > 0) {
@@ -55,7 +55,7 @@ public class TableWriter extends HTMLWriter {
         	writeTable("Table Description", cells, fileWriter);
         }
     }
-    
+
     private void writeTableIndexes(Writer fileWriter, Table table, Database database) throws IOException {
         final List<List<String>> cells = new ArrayList<List<String>>();
         final PrimaryKey primaryKey = table.getPrimaryKey();
@@ -69,7 +69,7 @@ public class TableWriter extends HTMLWriter {
         writeTable("Current Table Indexes", cells, fileWriter);
         }
     }
-    
+
     private void writeTableForeignKeys(Writer fileWriter, Table table, Database database) throws IOException {
         final List<List<String>> cells = new ArrayList<List<String>>();
         if(!table.getOutgoingForeignKeys().isEmpty())

--- a/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
@@ -107,12 +107,12 @@ public class ClassLoaderResourceAccessor extends AbstractResourceAccessor {
                     while (entries.hasMoreElements()) {
                         JarEntry entry = entries.nextElement();
 
-                        if (entry.getName().startsWith(resourcePath)) {
+                        if (entry.getName().startsWith(path)) {
 
                             if (!recursive) {
-                                String pathAsDir = resourcePath.endsWith("/")
-                                        ? resourcePath
-                                        : resourcePath + "/";
+                                String pathAsDir = path.endsWith("/")
+                                        ? path
+                                        : path + "/";
                                 if (!entry.getName().startsWith(pathAsDir)
                                  || entry.getName().substring(pathAsDir.length()).contains("/")) {
                                     continue;

--- a/liquibase-core/src/main/java/liquibase/resource/FileSystemResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/FileSystemResourceAccessor.java
@@ -127,7 +127,7 @@ public class FileSystemResourceAccessor extends AbstractResourceAccessor {
             });
 
             for (String rootPath : getRootPaths()) {
-                rootPaths.add(rootPath.replaceFirst("^file:/", "").replace("\\", "/"));
+                rootPaths.add(rootPath.replaceFirst("^file:", "").replace("\\", "/"));
             }
 
             Set<String> finalReturnSet = new LinkedHashSet<String>();

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddDefaultValueGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddDefaultValueGenerator.java
@@ -2,23 +2,20 @@ package liquibase.sqlgenerator.core;
 
 import liquibase.database.Database;
 import liquibase.database.core.HsqlDatabase;
+import liquibase.datatype.DataTypeFactory;
 import liquibase.datatype.LiquibaseDataType;
 import liquibase.datatype.core.BooleanType;
 import liquibase.datatype.core.CharType;
-import liquibase.datatype.core.NumberType;
-import liquibase.statement.DatabaseFunction;
-import liquibase.statement.SequenceNextValueFunction;
-import liquibase.structure.core.Schema;
-import liquibase.datatype.DataTypeFactory;
-import liquibase.structure.core.Column;
-import liquibase.structure.core.Table;
 import liquibase.exception.ValidationErrors;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.statement.DatabaseFunction;
+import liquibase.statement.SequenceNextValueFunction;
 import liquibase.statement.core.AddDefaultValueStatement;
-
-import javax.management.Query;
+import liquibase.structure.core.Column;
+import liquibase.structure.core.Schema;
+import liquibase.structure.core.Table;
 
 public class AddDefaultValueGenerator extends AbstractSqlGenerator<AddDefaultValueStatement> {
 
@@ -66,9 +63,23 @@ public class AddDefaultValueGenerator extends AbstractSqlGenerator<AddDefaultVal
     @Override
     public Sql[] generateSql(AddDefaultValueStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
         Object defaultValue = statement.getDefaultValue();
-        return new Sql[]{
-                new UnparsedSql("ALTER TABLE " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + " ALTER COLUMN  " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " SET DEFAULT " + DataTypeFactory.getInstance().fromObject(defaultValue, database).objectToSql(defaultValue, database),
-                        getAffectedColumn(statement))
+        return new Sql[] {
+                new UnparsedSql("ALTER TABLE "
+                        + database.escapeTableName(
+                                statement.getCatalogName(),
+                                statement.getSchemaName(),
+                                statement.getTableName() )
+                        + " ALTER COLUMN  "
+                        + database.escapeColumnName(
+                                statement.getCatalogName(),
+                                statement.getSchemaName(),
+                                statement.getTableName(),
+                                statement.getColumnName()
+                        ) + " SET DEFAULT "
+                        + DataTypeFactory.getInstance()
+                            .fromObject(defaultValue, database)
+                            .objectToSql(defaultValue, database),
+                    getAffectedColumn(statement) )
         };
     }
 


### PR DESCRIPTION
CORE-3163 dbdocs Link text case mismatch

Found a couple broken links in the dbdoc generated documentation.

Made 3 changes to fix the links.
* Changed the names of the changelog html files to be lowercase.
* Changed the href to changelog file in the authors page to be lowercase.
* The html files for columns included the schema name but the link in the table page did not.  Added the schema name to the href for the columns in the table page.