### PR TITLE
CORE-3171: loadUpdateData for SASQL

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/InsertOrUpdateGeneratorSybaseASA.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/InsertOrUpdateGeneratorSybaseASA.java
@@ -1,0 +1,42 @@
+package liquibase.sqlgenerator.core;
+
+import liquibase.database.Database;
+import liquibase.database.core.SybaseASADatabase;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.statement.core.InsertOrUpdateStatement;
+
+/**
+ *
+ * @author A. Pohl
+ */
+public class InsertOrUpdateGeneratorSybaseASA extends InsertOrUpdateGenerator {
+    @Override
+    public boolean supports(InsertOrUpdateStatement statement, Database database) {
+         return database instanceof SybaseASADatabase;
+    }
+
+    @Override
+    protected String getInsertStatement(InsertOrUpdateStatement insertOrUpdateStatement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+        StringBuffer sql = new StringBuffer(super.getInsertStatement(insertOrUpdateStatement, database, sqlGeneratorChain));
+        
+        int pos = sql.indexOf("VALUES (", 0);
+        sql.insert(pos, " ON EXISTING UPDATE ");
+
+        return sql.toString();
+    }
+
+    @Override
+    protected String getUpdateStatement(InsertOrUpdateStatement insertOrUpdateStatement, Database database, String whereClause, SqlGeneratorChain sqlGeneratorChain) {
+        return "";
+    }
+
+    @Override
+    protected String getRecordCheck(InsertOrUpdateStatement insertOrUpdateStatement, Database database, String whereClause) {
+        return "";
+    }
+
+    @Override
+    protected String getElse(Database database) {
+        return "";
+    }
+}


### PR DESCRIPTION
SQL Anywhere need the following syntax:

`INSERT INTO <tablename> ON EXISTING UPDATE VALUES (...)`
[Docu](http://dcx.sap.com/index.html#sqla170/de/html/81712f3a6ce21014ada883e2b235cf26.html)

