### PR TITLE
CORE-3010 MySQL Add Default Value failed

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddDefaultValueGeneratorMySQL.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddDefaultValueGeneratorMySQL.java
@@ -3,9 +3,11 @@ package liquibase.sqlgenerator.core;
 import liquibase.database.Database;
 import liquibase.structure.core.Schema;
 import liquibase.datatype.DataTypeFactory;
+import liquibase.exception.ValidationErrors;
 import liquibase.database.core.MySQLDatabase;
 import liquibase.structure.core.Column;
 import liquibase.structure.core.Table;
+import liquibase.util.StringUtils;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
@@ -22,11 +24,22 @@ public class AddDefaultValueGeneratorMySQL extends AddDefaultValueGenerator {
         return database instanceof MySQLDatabase;
     }
 
+    @Override 
+    public ValidationErrors validate(AddDefaultValueStatement addDefaultValueStatement, Database database, SqlGeneratorChain sqlGeneratorChain) { 
+      ValidationErrors validationErrors; 
+       
+      validationErrors = super.validate(addDefaultValueStatement, database, sqlGeneratorChain); 
+       
+        validationErrors.checkRequiredField("columnDataType", StringUtils.trimToNull(addDefaultValueStatement.getColumnDataType())); 
+ 
+        return validationErrors; 
+    } 
+    
     @Override
     public Sql[] generateSql(AddDefaultValueStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
         Object defaultValue = statement.getDefaultValue();
         return new Sql[]{
-                new UnparsedSql("ALTER TABLE " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + " ALTER " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " SET DEFAULT " + DataTypeFactory.getInstance().fromObject(defaultValue, database).objectToSql(defaultValue, database),
+                new UnparsedSql("ALTER TABLE " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + " CHANGE COLUMN " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " " + DataTypeFactory.getInstance().fromDescription(statement.getColumnDataType(), database).toDatabaseDataType(database) + " DEFAULT " + DataTypeFactory.getInstance().fromObject(defaultValue, database).objectToSql(defaultValue, database),
                        getAffectedColumn(statement))
         };
     }


### PR DESCRIPTION
Following Table:
CREATE TABLE table1 (
ID int(11) NOT NULL AUTO_INCREMENT,
CREATED timestamp NULL,
PRIMARY KEY (ID));

Now I want to give CREATED a default value:

ALTER TABLE table1 ALTER CREATED SET DEFAULT NOW()
brings me:
Error Code: 1064. You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'NOW()' at line 1

But

ALTER TABLE table1 CHANGE COLUMN CREATED CREATED TIMESTAMP DEFAULT NOW()

works correctly

