### PR TITLE
Fixes Java9 compatibility in SystemUtils::getJavaVersionAsInt

### DIFF
--- a/liquibase-core/src/main/java/liquibase/util/SystemUtils.java
+++ b/liquibase-core/src/main/java/liquibase/util/SystemUtils.java
@@ -1183,7 +1183,7 @@ public class SystemUtils {
             return 0;
         }
         String str = JAVA_VERSION_TRIMMED.substring(0, 1);
-        str = str + JAVA_VERSION_TRIMMED.substring(2, 3);
+        str = str + (JAVA_VERSION_TRIMMED.length() < 3 ? "0" : JAVA_VERSION_TRIMMED.substring(2, 3));
         if (JAVA_VERSION_TRIMMED.length() >= 5) {
             str = str + JAVA_VERSION_TRIMMED.substring(4, 5);
         } else {


### PR DESCRIPTION
Re-introduces the fix made in #710 **but overseen** in #688 .