### PR TITLE
CORE-1888: Add BigInt for Sybase (Can't specify a length)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/BigIntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/BigIntType.java
@@ -36,6 +36,9 @@ public class BigIntType extends LiquibaseDataType {
         if (database instanceof OracleDatabase) {
             return new DatabaseDataType("NUMBER", 38,0);
         }
+        if (database instanceof SybaseDatabase) {
+            return new DatabaseDataType("BIGINT");
+        }
         if (database instanceof MSSQLDatabase) {
             return new DatabaseDataType(database.escapeDataTypeName("bigint"));
         }


### PR DESCRIPTION
Fix error: liquibase.exception.DatabaseException: Can't specify a length, scale or storage property on type 'bigint' during table creation with type="BIGINT(19)"