### PR TITLE
CORE-3180: Skip change sets that don't match on DBMS during change log parsing

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
@@ -227,13 +227,7 @@ public class ChangeSet implements Conditional, ChangeLogChild {
     }
 
     protected void setDbms(String dbmsList) {
-        if (StringUtils.trimToNull(dbmsList) != null) {
-            String[] strings = dbmsList.toLowerCase().split(",");
-            dbmsSet = new HashSet<String>();
-            for (String string : strings) {
-                dbmsSet.add(string.trim().toLowerCase());
-            }
-        }
+        this.dbmsSet = DatabaseList.toDbmsSet(dbmsList);
     }
 
     public String getFilePath() {

--- a/liquibase-core/src/main/java/liquibase/database/DatabaseList.java
+++ b/liquibase-core/src/main/java/liquibase/database/DatabaseList.java
@@ -70,4 +70,15 @@ public class DatabaseList {
         }
         return definitionMatches(definition, shortName, returnValueIfEmptyList);
     }
+
+    public static Set<String> toDbmsSet(String dbmsList) {
+        Set<String> dbmsSet = null;
+        if (StringUtils.trimToNull(dbmsList) != null) {
+            dbmsSet = new HashSet<String>();
+            for (String string : dbmsList.toLowerCase().split(",")) {
+                dbmsSet.add(string.trim());
+            }
+        }
+        return dbmsSet;
+    }
 }

--- a/liquibase-core/src/test/groovy/liquibase/parser/core/xml/XMLChangeLogSAXParser_RealFile_Test.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/parser/core/xml/XMLChangeLogSAXParser_RealFile_Test.groovy
@@ -21,6 +21,8 @@ import liquibase.changelog.ChangeSet
 import liquibase.changelog.DatabaseChangeLog
 import liquibase.configuration.LiquibaseConfiguration
 import liquibase.database.ObjectQuotingStrategy
+import liquibase.database.core.H2Database
+import liquibase.database.core.MSSQLDatabase
 import liquibase.sdk.database.MockDatabase
 import liquibase.exception.ChangeLogParseException
 import liquibase.precondition.CustomPreconditionWrapper
@@ -692,5 +694,25 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
 
         cleanup:
         ChangeFactory.getInstance().unregister("createTableExample")
+    }
+
+    def "change sets with matching dbms are parsed"() {
+        when:
+        def path = "liquibase/parser/core/xml/rollbackWithDbmsChangeLog.xml"
+        def database = new MSSQLDatabase()
+        def changeLog = new XMLChangeLogSAXParser().parse(path, new ChangeLogParameters(database), new JUnitResourceAccessor())
+
+        then:
+        changeLog.getChangeSets().size() == 4
+    }
+
+    def "change sets with non-matching dbms are skipped"() {
+        when:
+        def path = "liquibase/parser/core/xml/rollbackWithDbmsChangeLog.xml"
+        def database = new H2Database()
+        def changeLog = new XMLChangeLogSAXParser().parse(path, new ChangeLogParameters(database), new JUnitResourceAccessor())
+
+        then:
+        changeLog.getChangeSets().size() == 2
     }
 }

--- a/liquibase-core/src/test/resources/liquibase/parser/core/xml/rollbackWithDbmsChangeLog.xml
+++ b/liquibase-core/src/test/resources/liquibase/parser/core/xml/rollbackWithDbmsChangeLog.xml
@@ -1,0 +1,28 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet id="1" author="mches" dbms="mssql">
+        <createTable tableName="a">
+            <column name="b" type="int"/>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2" author="mches" dbms="mssql">
+        <dropTable tableName="a"/>
+        <rollback changeSetId="1" changeSetAuthor="mches"/>
+    </changeSet>
+
+    <changeSet id="3" author="mches">
+        <createTable tableName="c">
+            <column name="d" type="bigint"/>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="4" author="mches">
+        <dropTable tableName="c"/>
+        <rollback changeSetId="3" changeSetAuthor="mches"/>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
A DBMS-specific change set referencing a DBMS-specific rollback can't be parsed on a different DBMS

e.g. MSSQL change-set referencing MSSQL rollback can't be parsed on H2.

```
<databaseChangeLog
        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">

    <changeSet id="1" author="mches" dbms="mssql">
        <createTable tableName="a">
            <column name="b" type="int"/>
        </createTable>
    </changeSet>

    <changeSet id="2" author="mches" dbms="mssql">
        <dropTable tableName="a"/>
        <rollback changeSetId="1" changeSetAuthor="mches"/>
    </changeSet>

</databaseChangeLog>
```
Having Liquibase skip the non-matching change sets avoids the exception parsing the rollback node, with no side unwanted effects that I can observe.

Closes: [CORE-3180](https://liquibase.jira.com/browse/CORE-3180)