### PR TITLE
Fixes JIRA CORE-3179 MySQL types don't match when using diffChangeLog

### DIFF
--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/ChangedColumnChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/ChangedColumnChangeGenerator.java
@@ -106,7 +106,7 @@ public class ChangedColumnChangeGenerator extends AbstractChangeGenerator implem
                 }
                 change.setTableName(column.getRelation().getName());
                 change.setColumnName(column.getName());
-                change.setColumnDataType(DataTypeFactory.getInstance().from(column.getType(), comparisonDatabase).toString());
+                change.setColumnDataType(DataTypeFactory.getInstance().from(column.getType(), comparisonDatabase).toDatabaseDataType(comparisonDatabase).toString());
                 changes.add(change);
             } else {
                 AddNotNullConstraintChange change = new AddNotNullConstraintChange();
@@ -118,7 +118,7 @@ public class ChangedColumnChangeGenerator extends AbstractChangeGenerator implem
                 }
                 change.setTableName(column.getRelation().getName());
                 change.setColumnName(column.getName());
-                change.setColumnDataType(DataTypeFactory.getInstance().from(column.getType(), comparisonDatabase).toString());
+                change.setColumnDataType(DataTypeFactory.getInstance().from(column.getType(), comparisonDatabase).toDatabaseDataType(comparisonDatabase).toString());
                 change.setValidate(column.getValidate());
                 change.setConstraintName(column.getAttribute("notNullConstraintName", String.class));
                 changes.add(change);
@@ -215,7 +215,7 @@ public class ChangedColumnChangeGenerator extends AbstractChangeGenerator implem
                 change.setTableName(tableName);
                 change.setColumnName(column.getName());
                 DataType referenceType = (DataType) typeDifference.getReferenceValue();
-                change.setNewDataType(DataTypeFactory.getInstance().from(referenceType, comparisonDatabase).toString());
+                change.setNewDataType(DataTypeFactory.getInstance().from(referenceType, comparisonDatabase).toDatabaseDataType(comparisonDatabase).toString());
 
                 changes.add(change);
             }


### PR DESCRIPTION
Need to convert to database type to get around the bug where TEXT becomes CLOB. See https://liquibase.jira.com/projects/CORE/issues/CORE-3179

