### PR TITLE
BugFix: mvn liquibase:generateChangeLog throws IllegalAccessException in AbstractLiquibaseMojo.java

### DIFF
--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseGenerateChangeLogMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseGenerateChangeLogMojo.java
@@ -29,21 +29,21 @@ public class LiquibaseGenerateChangeLogMojo extends
      *
      * @parameter expression="${liquibase.diffTypes}"
      */
-    private String diffTypes;
+    protected String diffTypes;
 
     /**
      * Directory where insert statement csv files will be kept.
      *
      * @parameter expression="${liquibase.dataDir}"
      */
-    private String dataDir;
+    protected String dataDir;
 
     /**
      * The author to be specified for Change Sets in the generated Change Log.
      *
      * @parameter expression="${liquibase.changeSetAuthor}"
      */
-    private String changeSetAuthor;
+    protected String changeSetAuthor;
 
     /**
      * are required. If no context is specified then ALL contexts will be executed.
@@ -56,7 +56,7 @@ public class LiquibaseGenerateChangeLogMojo extends
      *
      * @parameter expression="${liquibase.changeSetContext}"
      */
-    private String changeSetContext;
+    protected String changeSetContext;
 
     /**
      * The target change log file to output to. If this is null then the output will be to the screen.


### PR DESCRIPTION
If you run "mvn liquibase:generateChangeLog" with properties file including "diffTypes=data" the method bellow in AbstractLiquibaseMojo.java will throw IllegalAccessException because the field is private. The same for other private fields.

        private boolean isCurrentFieldValueSpecified(Field f) throws IllegalAccessException {
                Object currentValue = f.get(this);
                ...