### PR TITLE
Added support multiple parallel database connections

### DIFF
--- a/liquibase-core/src/main/java/liquibase/RuntimeEnvironment.java
+++ b/liquibase-core/src/main/java/liquibase/RuntimeEnvironment.java
@@ -2,8 +2,11 @@ package liquibase;
 
 import liquibase.database.Database;
 
+import java.util.HashMap;
+
 public class RuntimeEnvironment {
-    private Database targetDatabase;
+    public static final String MAIN_DB_KEY = "";
+    private HashMap<String, Database> targetDatabases = new HashMap<String, Database>();
     private Contexts contexts;
     private final LabelExpression labels;
 
@@ -15,12 +18,24 @@ public class RuntimeEnvironment {
     }
 
     public RuntimeEnvironment(Database targetDatabase, Contexts contexts, LabelExpression labelExpression) {
-        this.targetDatabase = targetDatabase;
+        this.targetDatabases.put(MAIN_DB_KEY, targetDatabase);
+        this.contexts = contexts;
+        this.labels = labelExpression;
+    }
+
+    public RuntimeEnvironment(HashMap<String, Database> targetDatabases, Contexts contexts, LabelExpression labelExpression) {
+        this.targetDatabases = targetDatabases;
         this.contexts = contexts;
         this.labels = labelExpression;
     }
 
     public Database getTargetDatabase() {
+        Database targetDatabase = targetDatabases.get(MAIN_DB_KEY);
+        return targetDatabase;
+    }
+
+    public Database getTargetDatabase(String dbConnection) {
+        Database targetDatabase = targetDatabases.get(dbConnection != null ? dbConnection : MAIN_DB_KEY);
         return targetDatabase;
     }
 

--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeLogIterator.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeLogIterator.java
@@ -76,11 +76,11 @@ public class ChangeLogIterator {
 
                 log.setChangeSet(changeSet);
                 if (shouldVisit && !alreadySaw(changeSet)) {
-                    visitor.visit(changeSet, databaseChangeLog, env.getTargetDatabase(), reasonsAccepted);
+                    visitor.visit(changeSet, databaseChangeLog, env.getTargetDatabase(changeSet.getDbConnection()), reasonsAccepted);
                     markSeen(changeSet);
                 } else {
                     if (visitor instanceof SkippedChangeSetVisitor) {
-                        ((SkippedChangeSetVisitor) visitor).skipped(changeSet, databaseChangeLog, env.getTargetDatabase(), reasonsDenied);
+                        ((SkippedChangeSetVisitor) visitor).skipped(changeSet, databaseChangeLog, env.getTargetDatabase(changeSet.getDbConnection()), reasonsDenied);
                     }
                 }
                 log.setChangeSet(null);

--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
@@ -101,6 +101,11 @@ public class ChangeSet implements Conditional, ChangeLogChild {
      */
     private String filePath = "UNKNOWN CHANGE LOG";
 
+    /**
+     * Name of the database connection for apply changes.
+     */
+    private String dbConnection;
+
     private Logger log;
 
     /**
@@ -607,11 +612,13 @@ public class ChangeSet implements Conditional, ChangeLogChild {
                 throw new MigrationFailedException(this, e);
             }
             if (getFailOnError() != null && !getFailOnError()) {
+                log.info("Database connection: " + (StringUtils.isEmpty(dbConnection) ? "(MAIN)" : dbConnection));
                 log.info("Change set " + toString(false) + " failed, but failOnError was false.  Error: " + e.getMessage());
                 log.debug("Failure Stacktrace", e);
                 execType = ExecType.FAILED;
             } else {
                 // just log the message, dont log the stacktrace by appending exception. Its logged anyway to stdout
+                log.severe("Database connection: " + (StringUtils.isEmpty(dbConnection) ? "(MAIN)" : dbConnection));
                 log.severe("Change Set " + toString(false) + " failed.  Error: " + e.getMessage());
                 if (e instanceof MigrationFailedException) {
                     throw ((MigrationFailedException) e);
@@ -727,6 +734,14 @@ public class ChangeSet implements Conditional, ChangeLogChild {
 
     public String getAuthor() {
         return author;
+    }
+
+    public String getDbConnection() {
+        return dbConnection;
+    }
+
+    public void setDbConnection(String dbConnection) {
+        this.dbConnection = dbConnection;
     }
 
     public ContextExpression getContexts() {

--- a/liquibase-core/src/main/java/liquibase/changelog/visitor/UpdateVisitor.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/visitor/UpdateVisitor.java
@@ -48,7 +48,7 @@ public class UpdateVisitor implements ChangeSetVisitor {
         ExecType execType = null;
         ObjectQuotingStrategy previousStr = this.database.getObjectQuotingStrategy();
         try {
-            execType = changeSet.execute(databaseChangeLog, execListener, this.database);
+            execType = changeSet.execute(databaseChangeLog, execListener, database);
         } catch (MigrationFailedException e) {
             fireRunFailed(changeSet, databaseChangeLog, database, e);
             throw e;
@@ -62,6 +62,7 @@ public class UpdateVisitor implements ChangeSetVisitor {
         this.database.markChangeSetExecStatus(changeSet, execType);
 
         this.database.commit();
+        database.commit();
     }
 
     protected void fireRunFailed(ChangeSet changeSet, DatabaseChangeLog databaseChangeLog, Database database, MigrationFailedException e) {

--- a/liquibase-core/src/main/java/liquibase/database/DatabaseFactory.java
+++ b/liquibase-core/src/main/java/liquibase/database/DatabaseFactory.java
@@ -244,6 +244,7 @@ public class DatabaseFactory {
 
             return new JdbcConnection(connection);
         } catch (Exception e) {
+            log.severe("Connection error to " + username + "@" + url);
             throw new DatabaseException(e);
         }
     }

--- a/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
@@ -122,6 +122,7 @@ public class HsqlDatabase extends AbstractJdbcDatabase {
 
     @Override
     protected String getConnectionSchemaName() {
+        // TODO: 01.03.2018 Override method AbstractJdbcDatabase.getConnectionSchemaNameCallStatement(). Schema is not "PUBLIC" if used "SET SCHEMA" or "ALTER USER ... SET INITIAL SCHEMA" HyperSQL-commands.
         return "PUBLIC";
     }
 

--- a/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.5.xsd
+++ b/liquibase-core/src/main/resources/liquibase/parser/core/xml/dbchangelog-3.5.xsd
@@ -196,6 +196,7 @@
 							<xsd:attribute name="file" type="xsd:string" use="required" />
 							<xsd:attribute name="relativeToChangelogFile" type="booleanExp" />
 							<xsd:attribute name="context" type="xsd:string" />
+							<xsd:attribute name="db" type="xsd:string" />
 							<xsd:anyAttribute namespace="##other"  processContents="lax"/>
 						</xsd:complexType>
 					</xsd:element>

--- a/liquibase-core/src/test/java/liquibase/changelog/ChangeLogIteratorTest.java
+++ b/liquibase-core/src/test/java/liquibase/changelog/ChangeLogIteratorTest.java
@@ -37,7 +37,7 @@ public class ChangeLogIteratorTest {
         TestChangeSetVisitor testChangeLogVisitor = new TestChangeSetVisitor();
 
         ChangeLogIterator iterator = new ChangeLogIterator(changeLog);
-        iterator.run(testChangeLogVisitor, new RuntimeEnvironment(null, null, null));
+        iterator.run(testChangeLogVisitor, new RuntimeEnvironment((Database) null, null, null));
         assertEquals(6, testChangeLogVisitor.visitedChangeSets.size());
     }
 
@@ -46,7 +46,7 @@ public class ChangeLogIteratorTest {
         TestChangeSetVisitor testChangeLogVisitor = new TestChangeSetVisitor();
 
         ChangeLogIterator iterator = new ChangeLogIterator(changeLog, new ContextChangeSetFilter(new Contexts("test1")));
-        iterator.run(testChangeLogVisitor, new RuntimeEnvironment(null, null, null));
+        iterator.run(testChangeLogVisitor, new RuntimeEnvironment((Database) null, null, null));
         assertEquals(4, testChangeLogVisitor.visitedChangeSets.size());
     }
 
@@ -55,7 +55,7 @@ public class ChangeLogIteratorTest {
         TestChangeSetVisitor testChangeLogVisitor = new TestChangeSetVisitor();
 
         ChangeLogIterator iterator = new ChangeLogIterator(changeLog, new ContextChangeSetFilter(new Contexts("test1")), new DbmsChangeSetFilter(new MySQLDatabase()));
-        iterator.run(testChangeLogVisitor, new RuntimeEnvironment(null, null, null));
+        iterator.run(testChangeLogVisitor, new RuntimeEnvironment((Database) null, null, null));
         assertEquals(3, testChangeLogVisitor.visitedChangeSets.size());
         assertEquals("1", testChangeLogVisitor.visitedChangeSets.get(0).getId());
         assertEquals("4", testChangeLogVisitor.visitedChangeSets.get(1).getId());
@@ -68,7 +68,7 @@ public class ChangeLogIteratorTest {
         TestChangeSetVisitor testChangeLogVisitor = new ReverseChangeSetVisitor();
 
         ChangeLogIterator iterator = new ChangeLogIterator(changeLog, new ContextChangeSetFilter(new Contexts("test1")), new DbmsChangeSetFilter(new MySQLDatabase()));
-        iterator.run(testChangeLogVisitor, new RuntimeEnvironment(null, null, null));
+        iterator.run(testChangeLogVisitor, new RuntimeEnvironment((Database) null, null, null));
         assertEquals(3, testChangeLogVisitor.visitedChangeSets.size());
         assertEquals("5", testChangeLogVisitor.visitedChangeSets.get(0).getId());
         assertEquals("4", testChangeLogVisitor.visitedChangeSets.get(1).getId());

--- a/liquibase-core/src/test/java/liquibase/database/multipledb/MultipleDatabaseTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/multipledb/MultipleDatabaseTest.java
@@ -1,0 +1,401 @@
+package liquibase.database.multipledb;
+
+import liquibase.exception.CommandLineParsingException;
+import liquibase.exception.LiquibaseException;
+import liquibase.integration.commandline.Main;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.sql.*;
+import java.util.Arrays;
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.junit.Assert.assertEquals;
+
+public class MultipleDatabaseTest {
+
+    private static Logger log = Logger.getLogger(MultipleDatabaseTest.class.getName());
+
+    private static final String USERNAME_MAIN = "sampl_main";
+    private static final String USERNAME_ADMIN = "sampl_admin";
+    private static final String USERNAME_LIQUIBASE = "sampl_liquibase";
+    //private static final String DB_URL = "jdbc:hsqldb:mem";
+    //private static final String DB_URL = "jdbc:hsqldb:mem;database=target";
+    private static final String DB_URL = "jdbc:hsqldb:mem:unittest";
+    private static final String DB_URL_MAIN = DB_URL;
+    private static final String DB_URL_ADMIN = DB_URL;
+    private static final String DB_URL_LIQUIBASE = DB_URL;
+
+    private static String fullPathToThisTest = "";
+
+    private Connection connSysAdmin;
+
+    @BeforeClass
+    public static void init() {
+        log.info("user.dir=" + System.getProperty("user.dir"));
+        String pathToThisTest = MultipleDatabaseTest.class.getPackage().getName().replace('.', '/');
+        fullPathToThisTest = new File(System.getProperty("user.dir"), "/src/test/java/" + pathToThisTest).getAbsolutePath();
+        log.info("fullPathToThisTest=" + fullPathToThisTest);
+    }
+
+    @Before
+    public void setupHSQLDB() {
+        log.finest("begin...");
+        connSysAdmin = getConnection(DB_URL, "SA", "");
+        executeSql(connSysAdmin, "DROP SCHEMA IF EXISTS " + USERNAME_MAIN + " CASCADE");
+        executeSql(connSysAdmin, "DROP SCHEMA IF EXISTS " + USERNAME_ADMIN + " CASCADE");
+        executeSql(connSysAdmin, "DROP SCHEMA IF EXISTS " + USERNAME_LIQUIBASE + " CASCADE");
+        executeSql(connSysAdmin, "DROP USER \"" + USERNAME_MAIN + "\"", java.sql.SQLInvalidAuthorizationSpecException.class);
+        executeSql(connSysAdmin, "DROP USER \"" + USERNAME_ADMIN + "\"", java.sql.SQLInvalidAuthorizationSpecException.class);
+        executeSql(connSysAdmin, "DROP USER \"" + USERNAME_LIQUIBASE + "\"", java.sql.SQLInvalidAuthorizationSpecException.class);
+        executeSql(connSysAdmin, "CREATE USER \"" + USERNAME_MAIN + "\" PASSWORD 'qwe'");
+        executeSql(connSysAdmin, "CREATE USER \"" + USERNAME_ADMIN + "\" PASSWORD 'qwe'");
+        executeSql(connSysAdmin, "CREATE SCHEMA " + USERNAME_MAIN + " AUTHORIZATION \"" + USERNAME_MAIN + "\"");
+        executeSql(connSysAdmin, "CREATE SCHEMA " + USERNAME_ADMIN + " AUTHORIZATION \"" + USERNAME_ADMIN + "\"");
+        executeSql(connSysAdmin, "ALTER USER \"" + USERNAME_MAIN + "\" SET INITIAL SCHEMA " + USERNAME_MAIN);
+        executeSql(connSysAdmin, "ALTER USER \"" + USERNAME_ADMIN + "\" SET INITIAL SCHEMA " + USERNAME_ADMIN);
+
+        assertTable(connSysAdmin, "INFORMATION_SCHEMA.SYSTEM_USERS", 3);
+        log.finest("end.");
+    }
+
+    @After
+    public void teardown() {
+        log.finest("begin...");
+        try {
+            connSysAdmin.close();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        log.finest("end.");
+    }
+
+    @Test
+    public void testNativeHSQLDB_admin() {
+        log.finest("begin...");
+        Connection conn = getConnection(DB_URL, USERNAME_ADMIN, "qwe");
+        String sql;
+        sql = "CREATE TABLE sampl_admin.users (\n" +
+                "    ID INT PRIMARY KEY,\n" +
+                "    LOGIN VARCHAR(32) NOT NULL,\n" +
+                "    PSWDCRYD VARCHAR(128) NOT NULL,\n" +
+                "    PERSON_ID INT NOT NULL\n" +
+                ")";
+        executeSql(conn, sql);
+
+        assertTable(conn, "sampl_admin.users", 0);
+        assertTable(conn, "users", 0);
+
+        assertExecuteSql(conn, "INSERT INTO users (ID, LOGIN, PSWDCRYD, PERSON_ID) VALUES (1, 'nvoxland', 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 1);\n");
+
+        assertTable(conn, "sampl_admin.users", 1);
+        assertTable(conn, "users", 1);
+
+        try { conn.close(); } catch (SQLException e) { e.printStackTrace(); }
+        assertTable(connSysAdmin, "sampl_admin.users", 1);
+        log.finest("end.");
+    }
+
+    @Test
+    public void testNativeHSQLDB_liquibase() {
+        log.finest("begin...");
+
+        // ADMIN!!!
+        executeSql(connSysAdmin, "CREATE USER \"" + USERNAME_LIQUIBASE + "\" PASSWORD 'qwe' ADMIN");
+        executeSql(connSysAdmin, "CREATE SCHEMA " + USERNAME_LIQUIBASE + " AUTHORIZATION \"" + USERNAME_LIQUIBASE + "\"");
+        executeSql(connSysAdmin, "ALTER USER \"" + USERNAME_LIQUIBASE + "\" SET INITIAL SCHEMA " + USERNAME_LIQUIBASE);
+
+        Connection conn = getConnection(DB_URL, USERNAME_LIQUIBASE, "qwe");
+        String sql;
+        sql = "CREATE TABLE sampl_admin.users (\n" +
+                "    ID INT PRIMARY KEY,\n" +
+                "    LOGIN VARCHAR(32) NOT NULL,\n" +
+                "    PSWDCRYD VARCHAR(128) NOT NULL,\n" +
+                "    PERSON_ID INT NOT NULL\n" +
+                ")";
+        executeSql(conn, sql);
+
+        assertTable(conn, "sampl_admin.users", 0);
+        assertNoTable(conn, "users");
+
+        sql = "CREATE TABLE DATABASECHANGELOG (\n" +
+                "    ID INT PRIMARY KEY,\n" +
+                ")";
+        executeSql(conn, sql);
+        assertTable(conn, USERNAME_LIQUIBASE + ".DATABASECHANGELOG", 0);
+        executeSql(conn, "DROP TABLE DATABASECHANGELOG");
+        assertNoTable(conn, USERNAME_LIQUIBASE + ".DATABASECHANGELOG");
+
+        try { conn.close(); } catch (SQLException e) { e.printStackTrace(); }
+        assertTable(connSysAdmin, "sampl_admin.users", 0);
+        log.finest("end.");
+    }
+
+    @Test
+    public void testRunAsLiquibaseUser() {
+        runLiquibaseTest(true, "versionX/changelog-cumulative.xml");
+    }
+
+    @Test
+    public void testRunByMultipleDbConnections() {
+        runLiquibaseTest(false, "versionX/changelog-multipledb-cumulative.xml");
+    }
+
+    @Test
+    public void testRunAllByMultipleDbConnections() {
+        runLiquibaseTest(false, "changelog-multipledb-cumulative.xml");
+    }
+
+    private void runLiquibaseTest(boolean runAsLiquibaseUserOnly, String changeLogFilePath) {
+        log.finest("begin...");
+
+        if (runAsLiquibaseUserOnly) {
+            // ADMIN!!!
+            executeSql(connSysAdmin, "CREATE USER \"" + USERNAME_LIQUIBASE + "\" PASSWORD 'qwe' ADMIN");
+        } else {
+            // No ADMIN!!!
+            executeSql(connSysAdmin, "CREATE USER \"" + USERNAME_LIQUIBASE + "\" PASSWORD 'qwe'");
+        }
+        executeSql(connSysAdmin, "CREATE SCHEMA " + USERNAME_LIQUIBASE + " AUTHORIZATION \"" + USERNAME_LIQUIBASE + "\"");
+        executeSql(connSysAdmin, "ALTER USER \"" + USERNAME_LIQUIBASE + "\" SET INITIAL SCHEMA " + USERNAME_LIQUIBASE);
+
+        String args[] = new String[] {
+                "--url=" + DB_URL_LIQUIBASE,
+                "--username=" + USERNAME_LIQUIBASE,
+                "--password=qwe",
+                "--changeLogFile=" + new File(fullPathToThisTest, changeLogFilePath).getAbsolutePath(),
+                "--liquibaseSchemaName=" + USERNAME_LIQUIBASE, // Need for HyperSQL: default - "PUBLIC", TODO: 01.03.2018 Release method HsqlDatabase.getConnectionSchemaNameCallStatement()
+                "--logLevel=INFO",
+                "update"
+        };
+        if (!runAsLiquibaseUserOnly) {
+            String addArgs[] = new String[] {
+                    "-Dsampl_main.url=" + DB_URL_MAIN,
+                    "-Dsampl_main.username=" + USERNAME_MAIN,
+                    "-Dsampl_main.password=qwe",
+                    //"-Dsampl_admin.url=" + DB_URL_ADMIN, // Same URL does not requered to specify
+                    "-Dsampl_admin.username=" + USERNAME_ADMIN,
+                    "-Dsampl_admin.password=qwe"
+            };
+            int argsLength = args.length;
+            int addArgsLength = addArgs.length;
+            args = Arrays.copyOf(args, argsLength + addArgsLength);
+            System.arraycopy(addArgs, 0, args, argsLength, addArgsLength);
+        }
+        log.fine("liquibase args=" + Arrays.toString(args));
+
+        try {
+            Main.run(args);
+        } catch (CommandLineParsingException e) {
+            throw new RuntimeException(e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } catch (LiquibaseException e) {
+            throw new RuntimeException(e);
+        }
+
+        assertTable(connSysAdmin, USERNAME_MAIN +".persons", 3);
+        assertTable(connSysAdmin, USERNAME_ADMIN + ".users", 2);
+        assertTable(connSysAdmin, USERNAME_LIQUIBASE + ".DATABASECHANGELOG", 3);
+
+        Connection conn = getConnection(DB_URL, USERNAME_MAIN, "qwe");
+        try {
+            assertTable(conn, USERNAME_MAIN +".persons", 3);
+            assertTable(conn, USERNAME_MAIN +".v_persons", 3);
+            assertTable(conn, USERNAME_ADMIN + ".users", 2);
+            assertNoTable(conn, USERNAME_ADMIN + ".v_users");
+            assertNoTable(conn, USERNAME_LIQUIBASE + ".DATABASECHANGELOG");
+
+            // This does not work for Oracle!!! (if run as Liquibase user only)
+            assertExecuteSql(conn, "DELETE FROM sampl_main.persons WHERE ID = 2");
+
+            assertNotExecuteSql(conn, "DELETE FROM sampl_admin.users WHERE ID = 2");
+        } finally {
+            try { conn.close(); } catch (SQLException e) { e.printStackTrace(); }
+        }
+
+        conn = getConnection(DB_URL, USERNAME_ADMIN, "qwe");
+        try {
+            assertTable(conn, USERNAME_MAIN +".persons", 2);
+            assertTable(conn, USERNAME_MAIN +".v_persons", 2);
+            assertTable(conn, USERNAME_ADMIN + ".users", 2);
+            assertTable(conn, USERNAME_ADMIN + ".v_users", 1);
+            assertNoTable(conn, USERNAME_LIQUIBASE + ".DATABASECHANGELOG");
+
+            // This does not work for Oracle!!! (if run as Liquibase user only)
+            assertExecuteSql(conn, "DELETE FROM sampl_admin.users WHERE ID = 2");
+
+            assertNotExecuteSql(conn, "DELETE FROM sampl_main.persons WHERE ID = 3");
+        } finally {
+            try { conn.close(); } catch (SQLException e) { e.printStackTrace(); }
+        }
+
+        log.finest("end.");
+    }
+
+    private Connection getConnection(String dbUrl, String userName, String password) {
+        Connection conn;
+        Properties connectionProps = new Properties();
+        if (userName != null) connectionProps.put("user", userName);
+        if (password != null) connectionProps.put("password", password);
+
+        try {
+            conn = DriverManager.getConnection(dbUrl, connectionProps);
+        } catch (SQLException ex) {
+            throw new RuntimeException(ex);
+        }
+        return conn;
+    }
+
+    private int executeSql(Connection conn, String sql) {
+        return executeSql(conn, sql, null);
+    }
+
+    private <T extends Exception> int executeSql(Connection conn, String sql, Class<T> ignoredExceptionClass) {
+        CallableStatement stmt = null;
+        try {
+            stmt = conn.prepareCall(sql);
+            int result = stmt.executeUpdate();
+            return result;
+        } catch (SQLException ex) {
+            if (ignoredExceptionClass == null || !ignoredExceptionClass.isAssignableFrom(ex.getClass())) {
+                throw new RuntimeException(ex);
+            }
+        } finally {
+            if (stmt != null) { try {stmt.close();} catch (SQLException e) {e.printStackTrace();}}
+        }
+        return 0;
+    }
+
+    private void assertExecuteSql(Connection conn, String sql) {
+        CallableStatement stmt = null;
+        try {
+            stmt = conn.prepareCall(sql);
+            int result = stmt.executeUpdate();
+        } catch (SQLException ex) {
+            if (isTableNotFoundException("s", ex)) {
+                throw new AssertionError("Insufficient rights to execute " + sql);
+            }
+            throw new RuntimeException(ex);
+        } finally {
+            if (stmt != null) { try {stmt.close();} catch (SQLException e) {e.printStackTrace();}}
+        }
+    }
+
+    private void assertNotExecuteSql(Connection conn, String sql) {
+        CallableStatement stmt = null;
+        try {
+            stmt = conn.prepareCall(sql);
+            int result = stmt.executeUpdate();
+            throw new AssertionError("There should be no rights to execute " + sql);
+        } catch (SQLException ex) {
+            if (!isTableNotFoundException("s", ex)) {
+                throw new RuntimeException(ex);
+            }
+        } finally {
+            if (stmt != null) { try {stmt.close();} catch (SQLException e) {e.printStackTrace();}}
+        }
+    }
+
+    private void assertTable(Connection conn, String tableName, int rowCount) {
+        Statement stmt = null;
+        ResultSet rs = null;
+
+        try {
+            String sql;
+            sql = "select CURRENT_TIMESTAMP, t.* from " + tableName + " t";
+            stmt = conn.createStatement();
+            rs = stmt.executeQuery(sql);
+            int i = 0;
+            ResultSetMetaData rsMetaData = rs.getMetaData();
+            int columnCount = rsMetaData.getColumnCount();
+            if (rs.next()) {
+                if (log.isLoggable(Level.FINE)) {
+                    StringBuilder sb = new StringBuilder(1000);
+                    for (int j = 1; j <= columnCount; j++) {
+                        if (j > 1) {
+                            sb.append(", ");
+                        }
+                        int columnType = rsMetaData.getColumnType(j);
+                        sb.append(rsMetaData.getColumnName(j));
+                        if (!(columnType > 0 && columnType < 1000)) {
+                            sb.append('(');
+                            sb.append(columnType);
+                            sb.append(')');
+                        }
+                    }
+                    // default java.util.logging.ConsoleHandler.level = INFO
+                    log.info(tableName);
+                    log.info(sb.toString());
+                }
+                do {
+                    if (log.isLoggable(Level.FINE)) {
+                        StringBuilder sb = new StringBuilder(1000);
+                        for (int j = 1; j <= columnCount; j++) {
+                            if (j > 1) {
+                                sb.append(", ");
+                            }
+                            int columnType = rsMetaData.getColumnType(j);
+                            if (columnType > 0 && columnType < 1000) {
+                                sb.append(rs.getString(j));
+                            } else {
+                                sb.append('*');
+                            }
+                        }
+                        log.info(i + ": " + sb);
+                    }
+                    i++;
+                } while (rs.next());
+                if (log.isLoggable(Level.FINE)) log.info(tableName + ": rows=" + i);
+            } else {
+                if (log.isLoggable(Level.FINE)) log.info(tableName + " is empty");
+            }
+            if (rowCount >= 0) {
+                assertEquals(i, rowCount);
+            }
+        } catch (SQLException ex) {
+            if (isTableNotFoundException(tableName, ex)) {
+                throw new AssertionError("Table " + tableName + " not found.");
+            }
+            throw new RuntimeException(ex);
+        } finally {
+            if (rs != null) { try {rs.close();} catch (SQLException e) {e.printStackTrace();}}
+            if (stmt != null) { try {stmt.close();} catch (SQLException e) {e.printStackTrace();}}
+        }
+    }
+
+    private void assertNoTable(Connection conn, String tableName) {
+        Statement stmt = null;
+        ResultSet rs = null;
+        try {
+            stmt = conn.createStatement();
+            rs = stmt.executeQuery("select * from " + tableName);
+            throw new AssertionError("Table " + tableName + " exists!");
+        } catch (SQLException ex) {
+            if (!isTableNotFoundException(tableName, ex)) {
+                throw new RuntimeException(ex);
+            }
+        } finally {
+            if (rs != null) { try {rs.close();} catch (SQLException e) {e.printStackTrace();}}
+            if (stmt != null) { try {stmt.close();} catch (SQLException e) {e.printStackTrace();}}
+        }
+    }
+
+    private boolean isTableNotFoundException(String tableName, SQLException ex) {
+        if (ex instanceof SQLSyntaxErrorException) {
+            String message = ex.getMessage();
+            if (message != null && message.startsWith("user lacks privilege or object not found: ")) {
+                int dotIndex = tableName.lastIndexOf('.');
+                return message.endsWith(tableName.substring(dotIndex + 1).toUpperCase());
+            }
+        }
+        return false;
+    }
+
+}

--- a/liquibase-core/src/test/java/liquibase/database/multipledb/changelog-multipledb-cumulative.xml
+++ b/liquibase-core/src/test/java/liquibase/database/multipledb/changelog-multipledb-cumulative.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <include file="versionX/changelog-multipledb-cumulative.xml" relativeToChangelogFile="true"/>
+
+</databaseChangeLog>

--- a/liquibase-core/src/test/java/liquibase/database/multipledb/versionX/YYYY-MM-DD-01-[sampl_main]-create-persons.sql
+++ b/liquibase-core/src/test/java/liquibase/database/multipledb/versionX/YYYY-MM-DD-01-[sampl_main]-create-persons.sql
@@ -1,0 +1,13 @@
+--liquibase formatted sql
+--changeset bob:1
+CREATE TABLE sampl_main.persons (
+    ID INT PRIMARY KEY,
+    FIRST_NAME VARCHAR(128) NOT NULL,
+    LAST_NAME VARCHAR(128) NOT NULL
+);
+
+GRANT SELECT, INSERT, UPDATE ON sampl_main.persons TO "sampl_admin";
+
+INSERT INTO sampl_main.persons (ID, FIRST_NAME, LAST_NAME) VALUES (1, 'Nathan', 'Voxland');
+INSERT INTO sampl_main.persons (ID, FIRST_NAME, LAST_NAME) VALUES (2, 'Bob', 'Bobson');
+INSERT INTO sampl_main.persons (ID, FIRST_NAME, LAST_NAME) VALUES (3, 'Andrei', 'Nasonov');

--- a/liquibase-core/src/test/java/liquibase/database/multipledb/versionX/YYYY-MM-DD-02-[sampl_admin]-create-users.sql
+++ b/liquibase-core/src/test/java/liquibase/database/multipledb/versionX/YYYY-MM-DD-02-[sampl_admin]-create-users.sql
@@ -1,0 +1,19 @@
+--liquibase formatted sql
+--changeset bob:2
+CREATE TABLE sampl_admin.users (
+    ID INT PRIMARY KEY,
+    LOGIN VARCHAR(32) NOT NULL,
+    PSWDCRYD VARCHAR(128) NOT NULL,
+    PERSON_ID INT NOT NULL
+);
+
+GRANT SELECT ON sampl_admin.users TO "sampl_main";
+
+CREATE VIEW sampl_admin.v_users AS
+select u.id, u.login, concat(p.first_name, concat(' ', p.last_name)) full_name
+from sampl_admin.users u
+join sampl_main.persons p on p.id = u.person_id
+;
+
+INSERT INTO sampl_admin.users (ID, LOGIN, PSWDCRYD, PERSON_ID) VALUES (1, 'nvoxland', 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 1);
+INSERT INTO sampl_admin.users (ID, LOGIN, PSWDCRYD, PERSON_ID) VALUES (2, 'bob', 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 2);

--- a/liquibase-core/src/test/java/liquibase/database/multipledb/versionX/YYYY-MM-DD-03-[sampl_main]-create-persons-view.sql
+++ b/liquibase-core/src/test/java/liquibase/database/multipledb/versionX/YYYY-MM-DD-03-[sampl_main]-create-persons-view.sql
@@ -1,0 +1,9 @@
+--liquibase formatted sql
+--changeset bob:3
+CREATE VIEW sampl_main.v_persons AS
+select p.id, p.first_name, p.last_name, concat(p.first_name, concat(' ', p.last_name)) full_name, u.login
+from sampl_main.persons p
+left join sampl_admin.users u on u.person_id = p.id
+;
+
+GRANT SELECT ON sampl_main.v_persons TO "sampl_admin";

--- a/liquibase-core/src/test/java/liquibase/database/multipledb/versionX/changelog-cumulative.xml
+++ b/liquibase-core/src/test/java/liquibase/database/multipledb/versionX/changelog-cumulative.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <include file="YYYY-MM-DD-01-[sampl_main]-create-persons.sql" relativeToChangelogFile="true"/>
+    <include file="YYYY-MM-DD-02-[sampl_admin]-create-users.sql" relativeToChangelogFile="true"/>
+    <include file="YYYY-MM-DD-03-[sampl_main]-create-persons-view.sql" relativeToChangelogFile="true"/>
+
+</databaseChangeLog>

--- a/liquibase-core/src/test/java/liquibase/database/multipledb/versionX/changelog-multipledb-cumulative.xml
+++ b/liquibase-core/src/test/java/liquibase/database/multipledb/versionX/changelog-multipledb-cumulative.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <include db="sampl_main" file="YYYY-MM-DD-01-[sampl_main]-create-persons.sql" relativeToChangelogFile="true"/>
+    <include db="sampl_admin" file="YYYY-MM-DD-02-[sampl_admin]-create-users.sql" relativeToChangelogFile="true"/>
+    <include db="sampl_main" file="YYYY-MM-DD-03-[sampl_main]-create-persons-view.sql" relativeToChangelogFile="true"/>
+
+</databaseChangeLog>


### PR DESCRIPTION
We have a big project with several schemes in Oracle. 
Our scripts usually change 2-3 schemes, and these changes often depend on each other. 
Therefore, it is convenient for us to have several connections with different schemes 
at the same time and execute scripts on different connections.

I made some adjustments including in dbchangelog-3.5.xsd.

This should be used as follows (see also MultipleDatabaseTest).

1. In changelog-cumulative.xml add tag `<include>` with attribute "db":

`<include db="sampl_main" file="YYYY-MM-DD-01-[sampl_main]-create-persons.sql" relativeToChangelogFile="true"/>`

1. In arguments of liquibase add 2 or 3 environment variables:
-Dsampl_main.url=jdbc:hsqldb:mem:unittest
-Dsampl_main.username=sampl_main
-Dsampl_main.password=qwe

Variable "...url" is not required if this URL same URL of argument --url.

This solution is checked only on sql-scripts on HyperSQL (in the test) and Oracle.
Apparently, this solution will work with connections simultaneously to only one type of DBMS:
or Oracle, or PostgreSQL, or another - not together.

