### PR TITLE
Turkish upper/lower case conversion bug fix for database types

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/DataTypeFactory.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/DataTypeFactory.java
@@ -86,7 +86,7 @@ public class DataTypeFactory {
             };
 
             for (String name : names) {
-                name = name.toLowerCase();
+                name = name.toLowerCase(Locale.US);
                 if (registry.get(name) == null) {
                     registry.put(name, new ArrayList<Class<? extends LiquibaseDataType>>());
                 }
@@ -104,7 +104,7 @@ public class DataTypeFactory {
      * @param name
      */
     public void unregister(String name) {
-        registry.remove(name.toLowerCase());
+        registry.remove(name.toLowerCase(Locale.US));
     }
 
     /**
@@ -138,8 +138,8 @@ public class DataTypeFactory {
         // If the remaining string ends with " identity", then remove the " identity" and remember than we want
         // to set the autoIncrement property later.
         boolean autoIncrement = false;
-        if (dataTypeName.endsWith(" identity")) {
-            dataTypeName = dataTypeName.replaceFirst(" identity$", "");
+        if (dataTypeName.toLowerCase(Locale.US).endsWith(" identity")) {
+            dataTypeName = dataTypeName.toLowerCase(Locale.US).replaceFirst(" identity$", "");
             autoIncrement = true;
         }
 
@@ -167,8 +167,8 @@ public class DataTypeFactory {
 
         // record additional information that is still attached to the data type name
         String additionalInfo = null;
-        if (dataTypeName.toLowerCase().startsWith("bit varying")
-            || dataTypeName.toLowerCase().startsWith("character varying")) {
+        if (dataTypeName.toLowerCase(Locale.US).startsWith("bit varying")
+            || dataTypeName.toLowerCase(Locale.US).startsWith("character varying")) {
             // not going to do anything. Special case for postgres in our tests,
             // need to better support handling these types of differences
         } else {
@@ -182,12 +182,12 @@ public class DataTypeFactory {
         }
 
         // try to find matching classes for the data type name in our registry
-        Collection<Class<? extends LiquibaseDataType>> classes = registry.get(dataTypeName.toLowerCase());
+        Collection<Class<? extends LiquibaseDataType>> classes = registry.get(dataTypeName.toLowerCase(Locale.US));
 
         LiquibaseDataType liquibaseDataType = null;
         if (classes == null) {
             // Map (date/time) INTERVAL types to the UnknownType
-            if (dataTypeName.toUpperCase().startsWith("INTERVAL")) {
+            if (dataTypeName.toUpperCase(Locale.US).startsWith("INTERVAL")) {
                 liquibaseDataType = new UnknownType(dataTypeDefinition);
             } else {
                 liquibaseDataType = new UnknownType(dataTypeName);

--- a/liquibase-core/src/main/java/liquibase/datatype/DatabaseDataType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/DatabaseDataType.java
@@ -2,6 +2,8 @@ package liquibase.datatype;
 
 import liquibase.util.StringUtils;
 
+import java.util.Locale;
+
 /**
  * This class represents a native data type used by a specific RDBMS. This is in contrast of
  * {@link LiquibaseDataType}, which represents data types used in changeSets (which will later be translated into
@@ -45,8 +47,8 @@ public class DatabaseDataType {
      * @return Whether the type is serial
      */
     public boolean isAutoIncrement() {
-        return "serial".equalsIgnoreCase(type) || "bigserial".equalsIgnoreCase(type) || "smallserial"
-            .equalsIgnoreCase(type);
+        return "serial".equals(type.toLowerCase(Locale.US)) || "bigserial".equals(type.toLowerCase(Locale.US)) || "smallserial"
+            .equals(type.toLowerCase(Locale.US));
     }
 
     public String toSql() {

--- a/liquibase-core/src/main/java/liquibase/datatype/LiquibaseDataType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/LiquibaseDataType.java
@@ -11,6 +11,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Object representing a data type, instead of a plain string. It will be returned by
@@ -153,7 +154,7 @@ public abstract class LiquibaseDataType implements PrioritizedService {
             return new DatabaseDataType(name, parameters);
         }
 
-        DatabaseDataType type = new DatabaseDataType(name.toUpperCase(), getParameters());
+        DatabaseDataType type = new DatabaseDataType(name.toUpperCase(Locale.US), getParameters());
         type.addAdditionalInformation(additionalInformation);
 
         return type;
@@ -163,7 +164,7 @@ public abstract class LiquibaseDataType implements PrioritizedService {
      * Returns the value object in a format to include in SQL. Quote if necessary.
      */
     public String objectToSql(Object value, Database database) {
-        if ((value == null) || "null".equalsIgnoreCase(value.toString())) {
+        if ((value == null) || "null".equals(value.toString().toLowerCase(Locale.US))) {
             return null;
         } else if (value instanceof DatabaseFunction) {
             return functionToSql((DatabaseFunction) value, database);
@@ -237,9 +238,9 @@ public abstract class LiquibaseDataType implements PrioritizedService {
      * @return see above
      */
     protected boolean isCurrentDateTimeFunction(String string, Database database) {
-        return string.toLowerCase().startsWith("current_timestamp")
-                || string.toLowerCase().startsWith(DatabaseFunction.CURRENT_DATE_TIME_PLACE_HOLDER)
-                || database.getCurrentDateTimeFunction().equalsIgnoreCase(string);
+        return string.toLowerCase(Locale.US).startsWith("current_timestamp")
+                || string.toLowerCase(Locale.US).startsWith(DatabaseFunction.CURRENT_DATE_TIME_PLACE_HOLDER)
+                || database.getCurrentDateTimeFunction().toLowerCase(Locale.US).equals(string.toLowerCase(Locale.US));
     }
 
     public void finishInitialization(String originalDefinition) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/BigIntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/BigIntType.java
@@ -8,6 +8,8 @@ import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.LiquibaseDataType;
 import liquibase.statement.DatabaseFunction;
 
+import java.util.Locale;
+
 /**
  * Represents a signed integer number using 64 bits of storage.
  */
@@ -66,14 +68,14 @@ public class BigIntType extends LiquibaseDataType {
     public void finishInitialization(String originalDefinition) {
         super.finishInitialization(originalDefinition);
 
-        if (originalDefinition.toLowerCase().contains("serial")) {
+        if (originalDefinition.toLowerCase(Locale.US).contains("serial")) {
             autoIncrement = true;
         }
     }
 
     @Override
     public String objectToSql(Object value, Database database) {
-        if ((value == null) || "null".equalsIgnoreCase(value.toString())) {
+        if ((value == null) || "null".equals(value.toString().toLowerCase(Locale.US))) {
             return null;
         }
         if (value instanceof DatabaseFunction) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/BlobType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/BlobType.java
@@ -10,6 +10,7 @@ import liquibase.util.StringUtils;
 
 import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.Locale;
 
 @DataTypeInfo(name = "blob", aliases = {"longblob", "longvarbinary", "java.sql.Types.BLOB", "java.sql.Types.LONGBLOB", "java.sql.Types.LONGVARBINARY", "java.sql.Types.VARBINARY", "java.sql.Types.BINARY", "varbinary", "binary", "image", "tinyblob", "mediumblob"}, minParameters = 0, maxParameters = 1, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class BlobType extends LiquibaseDataType {
@@ -19,11 +20,11 @@ public class BlobType extends LiquibaseDataType {
         String originalDefinition = StringUtils.trimToEmpty(getRawDefinition());
 
         if ((database instanceof H2Database) || (database instanceof HsqlDatabase)) {
-            if (originalDefinition.toLowerCase().startsWith("varbinary") || originalDefinition.startsWith("java.sql.Types.VARBINARY")) {
+            if (originalDefinition.toLowerCase(Locale.US).startsWith("varbinary") || originalDefinition.startsWith("java.sql.Types.VARBINARY")) {
                 return new DatabaseDataType("VARBINARY", getParameters());
-            } else if (originalDefinition.toLowerCase().startsWith("longvarbinary") || originalDefinition.startsWith("java.sql.Types.LONGVARBINARY")) {
+            } else if (originalDefinition.toLowerCase(Locale.US).startsWith("longvarbinary") || originalDefinition.startsWith("java.sql.Types.LONGVARBINARY")) {
                 return new DatabaseDataType("LONGVARBINARY", getParameters());
-            } else if (originalDefinition.toLowerCase().startsWith("binary")) {
+            } else if (originalDefinition.toLowerCase(Locale.US).startsWith("binary")) {
                 return new DatabaseDataType("BINARY", getParameters());
             } else {
                 return new DatabaseDataType("BLOB");
@@ -32,13 +33,13 @@ public class BlobType extends LiquibaseDataType {
 
         if (database instanceof MSSQLDatabase) {
             Object[] parameters = getParameters();
-            if ("varbinary".equalsIgnoreCase(originalDefinition)
+            if ("varbinary".equals(originalDefinition.toLowerCase(Locale.US))
                     || "[varbinary]".equals(originalDefinition)
                     || originalDefinition.matches("(?i)varbinary\\s*\\(.+")
                     || originalDefinition.matches("\\[varbinary\\]\\s*\\(.+")) {
 
                 return new DatabaseDataType(database.escapeDataTypeName("varbinary"), maybeMaxParam(parameters, database));
-            } else if ("binary".equalsIgnoreCase(originalDefinition)
+            } else if ("binary".equals(originalDefinition.toLowerCase(Locale.US))
                     || "[binary]".equals(originalDefinition)
                     || originalDefinition.matches("(?i)binary\\s*\\(.+")
                     || originalDefinition.matches("\\[binary\\]\\s*\\(.+")) {
@@ -50,7 +51,7 @@ public class BlobType extends LiquibaseDataType {
                 }
                 return new DatabaseDataType(database.escapeDataTypeName("binary"), parameters);
             }
-            if ("image".equalsIgnoreCase(originalDefinition)
+            if ("image".equals(originalDefinition.toLowerCase(Locale.US))
                     || "[image]".equals(originalDefinition)
                     || originalDefinition.matches("(?i)image\\s*\\(.+")
                     || originalDefinition.matches("\\[image\\]\\s*\\(.+")) {
@@ -65,16 +66,16 @@ public class BlobType extends LiquibaseDataType {
         }
 
         if (database instanceof MySQLDatabase) {
-            if (originalDefinition.toLowerCase().startsWith("blob") || "java.sql.Types.BLOB".equals(originalDefinition)) {
+            if (originalDefinition.toLowerCase(Locale.US).startsWith("blob") || "java.sql.Types.BLOB".equals(originalDefinition)) {
                 return new DatabaseDataType("BLOB");
-            } else if (originalDefinition.toLowerCase().startsWith("varbinary") || "java.sql.Types.VARBINARY".equals
+            } else if (originalDefinition.toLowerCase(Locale.US).startsWith("varbinary") || "java.sql.Types.VARBINARY".equals
                 (originalDefinition)) {
                 return new DatabaseDataType("VARBINARY", getParameters());
-            } else if (originalDefinition.toLowerCase().startsWith("tinyblob")) {
+            } else if (originalDefinition.toLowerCase(Locale.US).startsWith("tinyblob")) {
                 return new DatabaseDataType("TINYBLOB");
-            } else if (originalDefinition.toLowerCase().startsWith("mediumblob")) {
+            } else if (originalDefinition.toLowerCase(Locale.US).startsWith("mediumblob")) {
                 return new DatabaseDataType("MEDIUMBLOB");
-            } else if (originalDefinition.toLowerCase().startsWith("binary")) {
+            } else if (originalDefinition.toLowerCase(Locale.US).startsWith("binary")) {
                 return new DatabaseDataType("BINARY", getParameters());
             } else {
                 return new DatabaseDataType("LONGBLOB");
@@ -82,7 +83,7 @@ public class BlobType extends LiquibaseDataType {
         }
 
         if (database instanceof PostgresDatabase) {
-            if (originalDefinition.toLowerCase().startsWith("blob") || "java.sql.Types.BLOB".equals(originalDefinition)) {
+            if (originalDefinition.toLowerCase(Locale.US).startsWith("blob") || "java.sql.Types.BLOB".equals(originalDefinition)) {
                 // There are two ways of handling byte arrays ("BLOBs") in pgsql. For consistency with Hibernate ORM
                 // (see upstream bug https://liquibase.jira.com/browse/CORE-1863) we choose the oid variant.
                 // For a more thorough discussion of the two alternatives, see:
@@ -102,11 +103,11 @@ public class BlobType extends LiquibaseDataType {
         }
 
         if (database instanceof OracleDatabase) {
-            if (originalDefinition.toLowerCase().startsWith("bfile")) {
+            if (originalDefinition.toLowerCase(Locale.US).startsWith("bfile")) {
                 return new DatabaseDataType("BFILE");
             }
 
-            if (originalDefinition.toLowerCase().startsWith("raw") || originalDefinition.toLowerCase().startsWith("binary") || originalDefinition.toLowerCase().startsWith("varbinary")) {
+            if (originalDefinition.toLowerCase(Locale.US).startsWith("raw") || originalDefinition.toLowerCase(Locale.US).startsWith("binary") || originalDefinition.toLowerCase(Locale.US).startsWith("varbinary")) {
                 return new DatabaseDataType("RAW", getParameters());
             }
 

--- a/liquibase-core/src/main/java/liquibase/datatype/core/BooleanType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/BooleanType.java
@@ -10,6 +10,8 @@ import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.statement.DatabaseFunction;
 import liquibase.util.StringUtils;
 
+import java.util.Locale;
+
 @DataTypeInfo(name = "boolean", aliases = {"java.sql.Types.BOOLEAN", "java.lang.Boolean", "bit", "bool"}, minParameters = 0, maxParameters = 0, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class BooleanType extends LiquibaseDataType {
 
@@ -21,7 +23,7 @@ public class BooleanType extends LiquibaseDataType {
         } else if (database instanceof MSSQLDatabase) {
             return new DatabaseDataType(database.escapeDataTypeName("bit"));
         } else if (database instanceof MySQLDatabase) {
-            if (originalDefinition.toLowerCase().startsWith("bit")) {
+            if (originalDefinition.toLowerCase(Locale.US).startsWith("bit")) {
                 return new DatabaseDataType("BIT", getParameters());
             }
             return new DatabaseDataType("BIT", 1);
@@ -38,7 +40,7 @@ public class BooleanType extends LiquibaseDataType {
         } else if (database instanceof HsqlDatabase) {
             return new DatabaseDataType("BOOLEAN");
         } else if (database instanceof PostgresDatabase) {
-            if (originalDefinition.toLowerCase().startsWith("bit")) {
+            if (originalDefinition.toLowerCase(Locale.US).startsWith("bit")) {
                 return new DatabaseDataType("BIT", getParameters());
             }
     }
@@ -48,17 +50,16 @@ public class BooleanType extends LiquibaseDataType {
 
     @Override
     public String objectToSql(Object value, Database database) {
-        if ((value == null) || "null".equalsIgnoreCase(value.toString())) {
+        if ((value == null) || "null".equals(value.toString().toLowerCase(Locale.US))) {
             return null;
         }
 
         String returnValue;
         if (value instanceof String) {
-            if ("true".equalsIgnoreCase((String) value) || "1".equals(value) || "b'1'".equalsIgnoreCase((String)
-                value) || "t".equals(value) || ((String) value).equalsIgnoreCase(this.getTrueBooleanValue(database))) {
+            if ("true".equals(((String) value).toLowerCase(Locale.US)) || "1".equals(value) || "b'1'".equals(((String) value).toLowerCase(Locale.US)) || "t".equals(((String) value).toLowerCase(Locale.US)) || ((String) value).toLowerCase(Locale.US).equals(this.getTrueBooleanValue(database).toLowerCase(Locale.US))) {
                 returnValue = this.getTrueBooleanValue(database);
-            } else if ("false".equalsIgnoreCase((String) value) || "0".equals(value) || "b'0'".equalsIgnoreCase(
-                (String) value) || "f".equals(value) || ((String) value).equalsIgnoreCase(this.getFalseBooleanValue(database))) {
+            } else if ("false".equals(((String) value).toLowerCase(Locale.US)) || "0".equals(value) || "b'0'".equals(
+                    ((String) value).toLowerCase(Locale.US)) || "f".equals(((String) value).toLowerCase(Locale.US)) || ((String) value).toLowerCase(Locale.US).equals(this.getFalseBooleanValue(database).toLowerCase(Locale.US))) {
                 returnValue = this.getFalseBooleanValue(database);
             } else {
                 throw new UnexpectedLiquibaseException("Unknown boolean value: " + value);

--- a/liquibase-core/src/main/java/liquibase/datatype/core/CharType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/CharType.java
@@ -12,6 +12,7 @@ import liquibase.util.StringUtils;
 
 import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.Locale;
 
 @DataTypeInfo(name="char", aliases = {"java.sql.Types.CHAR", "bpchar"}, minParameters = 0, maxParameters = 1, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class CharType extends LiquibaseDataType {
@@ -51,7 +52,7 @@ public class CharType extends LiquibaseDataType {
 
     @Override
     public String objectToSql(Object value, Database database) {
-        if ((value == null) || "null".equalsIgnoreCase(value.toString())) {
+        if ((value == null) || "null".equals(value.toString().toLowerCase(Locale.US))) {
             return null;
         }
 

--- a/liquibase-core/src/main/java/liquibase/datatype/core/ClobType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/ClobType.java
@@ -11,12 +11,14 @@ import liquibase.datatype.LiquibaseDataType;
 import liquibase.statement.DatabaseFunction;
 import liquibase.util.StringUtils;
 
+import java.util.Locale;
+
 @DataTypeInfo(name = "clob", aliases = {"longvarchar", "text", "longtext", "java.sql.Types.LONGVARCHAR", "java.sql.Types.CLOB", "nclob", "longnvarchar", "ntext", "java.sql.Types.LONGNVARCHAR", "java.sql.Types.NCLOB", "tinytext", "mediumtext"}, minParameters = 0, maxParameters = 0, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class ClobType extends LiquibaseDataType {
 
     @Override
     public String objectToSql(Object value, Database database) {
-        if ((value == null) || "null".equalsIgnoreCase(value.toString())) {
+        if ((value == null) || "null".equals(value.toString().toLowerCase(Locale.US))) {
             return null;
         }
 
@@ -43,8 +45,8 @@ public class ClobType extends LiquibaseDataType {
         String originalDefinition = StringUtils.trimToEmpty(getRawDefinition());
         if (database instanceof MSSQLDatabase) {
             if ((!LiquibaseConfiguration.getInstance().getProperty(GlobalConfiguration.class, GlobalConfiguration
-                .CONVERT_DATA_TYPES).getValue(Boolean.class) && originalDefinition.toLowerCase().startsWith("text"))
-                || originalDefinition.toLowerCase().startsWith("[text]")) {
+                .CONVERT_DATA_TYPES).getValue(Boolean.class) && originalDefinition.toUpperCase(Locale.US).startsWith("text"))
+                || originalDefinition.toUpperCase(Locale.US).startsWith("[text]")) {
                 DatabaseDataType type = new DatabaseDataType(database.escapeDataTypeName("varchar"));
                 // If there is additional specification after ntext (e.g.  COLLATE), import that.
                 String originalExtraInfo = originalDefinition.replaceFirst("^\\[?text\\]?\\s*", "");
@@ -69,8 +71,8 @@ public class ClobType extends LiquibaseDataType {
                         + (StringUtils.isEmpty(originalExtraInfo) ? "" : " " + originalExtraInfo));
                 return type;
             }
-            if (originalDefinition.toLowerCase().startsWith("ntext")
-                    || originalDefinition.toLowerCase().startsWith("[ntext]")) {
+            if (originalDefinition.toLowerCase(Locale.US).startsWith("ntext")
+                    || originalDefinition.toLowerCase(Locale.US).startsWith("[ntext]")) {
                 // The SQL Server datatype "ntext" is deprecated and should be replaced with NVARCHAR(MAX).
                 // See: https://docs.microsoft.com/en-us/sql/t-sql/data-types/ntext-text-and-image-transact-sql
                 DatabaseDataType type = new DatabaseDataType(database.escapeDataTypeName("nvarchar"));
@@ -80,19 +82,19 @@ public class ClobType extends LiquibaseDataType {
                     + (StringUtils.isEmpty(originalExtraInfo) ? "" : " " + originalExtraInfo));
                 return type;
             }
-            if ("nclob".equalsIgnoreCase(originalDefinition)) {
+            if ("nclob".equals(originalDefinition.toLowerCase(Locale.US))) {
                 return new DatabaseDataType(database.escapeDataTypeName("nvarchar"), "MAX");
             }
 
             return new DatabaseDataType(database.escapeDataTypeName("varchar"), "MAX");
         } else if (database instanceof MySQLDatabase) {
-            if (originalDefinition.toLowerCase().startsWith("text")) {
+            if (originalDefinition.toLowerCase(Locale.US).startsWith("text")) {
                 return new DatabaseDataType("TEXT");
-            } else if (originalDefinition.toLowerCase().startsWith("tinytext")) {
+            } else if (originalDefinition.toLowerCase(Locale.US).startsWith("tinytext")) {
                 return new DatabaseDataType("TINYTEXT");
-            } else if (originalDefinition.toLowerCase().startsWith("mediumtext")) {
+            } else if (originalDefinition.toLowerCase(Locale.US).startsWith("mediumtext")) {
                 return new DatabaseDataType("MEDIUMTEXT");
-            } else if (originalDefinition.toLowerCase().startsWith("nclob")) {
+            } else if (originalDefinition.toLowerCase(Locale.US).startsWith("nclob")) {
                 DatabaseDataType type = new DatabaseDataType("LONGTEXT");
                 type.addAdditionalInformation("CHARACTER SET utf8");
                 return type;
@@ -100,7 +102,7 @@ public class ClobType extends LiquibaseDataType {
                 return new DatabaseDataType("LONGTEXT");
             }
         } else if ((database instanceof H2Database) || (database instanceof HsqlDatabase)) {
-            if (originalDefinition.toLowerCase().startsWith("longvarchar") || originalDefinition.startsWith("java.sql.Types.LONGVARCHAR")) {
+            if (originalDefinition.toLowerCase(Locale.US).startsWith("longvarchar") || originalDefinition.startsWith("java.sql.Types.LONGVARCHAR")) {
                 return new DatabaseDataType("LONGVARCHAR");
             } else {
                 return new DatabaseDataType("CLOB");
@@ -109,12 +111,12 @@ public class ClobType extends LiquibaseDataType {
             instanceof SybaseDatabase)) {
             return new DatabaseDataType("TEXT");
         } else if (database instanceof OracleDatabase) {
-            if ("nclob".equalsIgnoreCase(originalDefinition)) {
+            if ("nclob".equals(originalDefinition.toLowerCase(Locale.US))) {
                 return new DatabaseDataType("NCLOB");
             }
             return new DatabaseDataType("CLOB");
         } else if (database instanceof InformixDatabase) {
-            if (originalDefinition.toLowerCase().startsWith("text")) {
+            if (originalDefinition.toLowerCase(Locale.US).startsWith("text")) {
                 return new DatabaseDataType("TEXT");
             }
         }

--- a/liquibase-core/src/main/java/liquibase/datatype/core/CurrencyType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/CurrencyType.java
@@ -8,6 +8,8 @@ import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.LiquibaseDataType;
 import liquibase.util.StringUtils;
 
+import java.util.Locale;
+
 
 @DataTypeInfo(name="currency", aliases = {"money", "smallmoney"}, minParameters = 0, maxParameters = 0, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class CurrencyType  extends LiquibaseDataType {
@@ -21,8 +23,8 @@ public class CurrencyType  extends LiquibaseDataType {
     public DatabaseDataType toDatabaseDataType(Database database) {
         String originalDefinition = StringUtils.trimToEmpty(getRawDefinition());
         if (database instanceof MSSQLDatabase) {
-            if (originalDefinition.toLowerCase().startsWith("smallmoney")
-                    || originalDefinition.toLowerCase().startsWith("[smallmoney]")) {
+            if (originalDefinition.toLowerCase(Locale.US).startsWith("smallmoney")
+                    || originalDefinition.toLowerCase(Locale.US).startsWith("[smallmoney]")) {
 
                 return new DatabaseDataType(database.escapeDataTypeName("smallmoney"));
             }

--- a/liquibase-core/src/main/java/liquibase/datatype/core/DatabaseFunctionType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/DatabaseFunctionType.java
@@ -6,12 +6,14 @@ import liquibase.datatype.DataTypeInfo;
 import liquibase.datatype.LiquibaseDataType;
 import liquibase.statement.DatabaseFunction;
 
+import java.util.Locale;
+
 @DataTypeInfo(name="function", aliases = "liquibase.statement.DatabaseFunction", minParameters = 0, maxParameters = 0, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class DatabaseFunctionType extends LiquibaseDataType {
 
     @Override
     public String objectToSql(Object value, Database database) {
-        if ((value == null) || "null".equalsIgnoreCase(value.toString()))  {
+        if ((value == null) || "null".equals(value.toString().toLowerCase(Locale.US)))  {
             return null;
         }
         if (value instanceof DatabaseFunction) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/DateTimeType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/DateTimeType.java
@@ -15,6 +15,7 @@ import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -37,7 +38,7 @@ public class DateTimeType extends LiquibaseDataType {
 		}
 
         if (database instanceof OracleDatabase) {
-            if (getRawDefinition().toUpperCase().contains("TIME ZONE")) {
+            if (getRawDefinition().toUpperCase(Locale.US).contains("TIME ZONE")) {
                 // remove the last data type size that comes from column size
                 return new DatabaseDataType(getRawDefinition().replaceFirst("\\(\\d+\\)$", ""));
             }
@@ -49,9 +50,9 @@ public class DateTimeType extends LiquibaseDataType {
             Object[] parameters = getParameters();
             if (originalDefinition.matches("(?i)^\\[?smalldatetime.*")) {
                 return new DatabaseDataType(database.escapeDataTypeName("smalldatetime"));
-            } else if ("datetime2".equalsIgnoreCase(originalDefinition)
-                    || "[datetime2]".equals(originalDefinition)
-                    || originalDefinition.matches("(?i)\\[?datetime2\\]?\\s*\\(.+")
+            } else if ("datetime2".equals(originalDefinition.toLowerCase(Locale.US))
+                    || "[datetime2]".equals(originalDefinition.toLowerCase(Locale.US))
+                    || originalDefinition.toLowerCase(Locale.US).matches("(?i)\\[?datetime2\\]?\\s*\\(.+")
                     ) {
 
                 // If the scale for datetime2 is the database default anyway, omit it.
@@ -97,7 +98,7 @@ public class DateTimeType extends LiquibaseDataType {
             return new DatabaseDataType("DATETIME YEAR TO FRACTION", 5);
         }
         if (database instanceof PostgresDatabase) {
-            String rawDefinition = originalDefinition.toLowerCase();
+            String rawDefinition = originalDefinition.toLowerCase(Locale.US);
             Object[] params = getParameters();
             if (rawDefinition.contains("tz") || rawDefinition.contains("with time zone")) {
                 if (params.length == 0 ) {
@@ -149,7 +150,7 @@ public class DateTimeType extends LiquibaseDataType {
 
     @Override
     public String objectToSql(Object value, Database database) {
-        if ((value == null) || "null".equalsIgnoreCase(value.toString())) {
+        if ((value == null) || "null".equals(value.toString().toLowerCase(Locale.US))) {
             return null;
         } else if (value instanceof DatabaseFunction) {
             return database.generateDatabaseFunctionValue((DatabaseFunction) value);

--- a/liquibase-core/src/main/java/liquibase/datatype/core/DateType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/DateType.java
@@ -11,6 +11,7 @@ import liquibase.statement.DatabaseFunction;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Locale;
 
 @DataTypeInfo(name="date", aliases = {"java.sql.Types.DATE", "java.sql.Date"}, minParameters = 0, maxParameters = 0, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class DateType extends LiquibaseDataType {
@@ -29,7 +30,7 @@ public class DateType extends LiquibaseDataType {
 
     @Override
     public String objectToSql(Object value, Database database) {
-        if ((value == null) || "null".equalsIgnoreCase(value.toString())) {
+        if ((value == null) || "null".equals(value.toString().toLowerCase(Locale.US))) {
             return null;
         } else if (value instanceof DatabaseFunction) {
             return database.generateDatabaseFunctionValue((DatabaseFunction) value);

--- a/liquibase-core/src/main/java/liquibase/datatype/core/FloatType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/FloatType.java
@@ -9,6 +9,7 @@ import liquibase.datatype.LiquibaseDataType;
 import liquibase.util.StringUtils;
 
 import java.util.Arrays;
+import java.util.Locale;
 
 @DataTypeInfo(name="float", aliases = {"java.sql.Types.FLOAT", "java.lang.Float", "real", "java.sql.Types.REAL"}, minParameters = 0, maxParameters = 2, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class FloatType  extends LiquibaseDataType {
@@ -17,8 +18,8 @@ public class FloatType  extends LiquibaseDataType {
     public DatabaseDataType toDatabaseDataType(Database database) {
         String originalDefinition = StringUtils.trimToEmpty(getRawDefinition());
         if (database instanceof MSSQLDatabase) {
-            if ("real".equalsIgnoreCase(originalDefinition)
-                    || "[real]".equals(originalDefinition)
+            if ("real".equals(originalDefinition.toLowerCase(Locale.US))
+                    || "[real]".equals(originalDefinition.toLowerCase(Locale.US))
                     || "java.lang.Float".equals(originalDefinition)
                     || "java.sql.Types.REAL".equals(originalDefinition)) {
 
@@ -34,14 +35,14 @@ public class FloatType  extends LiquibaseDataType {
             return new DatabaseDataType(database.escapeDataTypeName("float"), parameters);
         }
         if ((database instanceof MySQLDatabase) || (database instanceof AbstractDb2Database) || (database instanceof H2Database)) {
-            if ("REAL".equalsIgnoreCase(originalDefinition)) {
+            if ("REAL".equals(originalDefinition.toUpperCase(Locale.US))) {
                 return new DatabaseDataType("REAL");
             }
         }
         if ((database instanceof FirebirdDatabase) || (database instanceof InformixDatabase)) {
             return new DatabaseDataType("FLOAT");
         } else if (database instanceof PostgresDatabase) {
-            if ("real".equalsIgnoreCase(originalDefinition)) {
+            if ("real".equals(originalDefinition.toLowerCase(Locale.US))) {
                 return new DatabaseDataType("REAL");
             }
         }

--- a/liquibase-core/src/main/java/liquibase/datatype/core/IntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/IntType.java
@@ -8,6 +8,8 @@ import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.LiquibaseDataType;
 import liquibase.statement.DatabaseFunction;
 
+import java.util.Locale;
+
 /**
  * Represents a signed integer number using 32 bits of storage.
  */
@@ -67,14 +69,14 @@ public class IntType extends LiquibaseDataType {
     public void finishInitialization(String originalDefinition) {
         super.finishInitialization(originalDefinition);
 
-        if (originalDefinition.toLowerCase().startsWith("serial")) {
+        if (originalDefinition.toLowerCase(Locale.US).startsWith("serial")) {
             autoIncrement = true;
         }
     }
 
     @Override
     public String objectToSql(Object value, Database database) {
-        if ((value == null) || "null".equalsIgnoreCase(value.toString())) {
+        if ((value == null) || "null".equals(value.toString().toLowerCase(Locale.US))) {
             return null;
         }
         if (value instanceof DatabaseFunction) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/MediumIntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/MediumIntType.java
@@ -8,6 +8,8 @@ import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.LiquibaseDataType;
 import liquibase.statement.DatabaseFunction;
 
+import java.util.Locale;
+
 @DataTypeInfo(name="mediumint", minParameters = 0, maxParameters = 1, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class MediumIntType extends LiquibaseDataType {
 
@@ -40,7 +42,7 @@ public class MediumIntType extends LiquibaseDataType {
 
     @Override
     public String objectToSql(Object value, Database database) {
-        if ((value == null) || "null".equalsIgnoreCase(value.toString())) {
+        if ((value == null) || "null".equals(value.toString().toLowerCase(Locale.US))) {
             return null;
         }
         if (value instanceof DatabaseFunction) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/NVarcharType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/NVarcharType.java
@@ -9,13 +9,14 @@ import liquibase.datatype.LiquibaseDataType;
 
 import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.Locale;
 
 @DataTypeInfo(name="nvarchar", aliases = {"java.sql.Types.NVARCHAR", "nvarchar2", "national"}, minParameters = 0, maxParameters = 1, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class NVarcharType extends CharType {
 
     @Override
     public DatabaseDataType toDatabaseDataType(Database database) {
-        if ((getRawDefinition() != null) && getRawDefinition().toLowerCase().contains("national character varying")) {
+        if ((getRawDefinition() != null) && getRawDefinition().toLowerCase(Locale.US).contains("national character varying")) {
             setAdditionalInformation(null); //just go to nvarchar
         }
         if ((database instanceof HsqlDatabase) || (database instanceof PostgresDatabase) || (database instanceof

--- a/liquibase-core/src/main/java/liquibase/datatype/core/SmallIntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/SmallIntType.java
@@ -8,6 +8,8 @@ import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.LiquibaseDataType;
 import liquibase.statement.DatabaseFunction;
 
+import java.util.Locale;
+
 @DataTypeInfo(name="smallint", aliases = {"java.sql.Types.SMALLINT", "int2"}, minParameters = 0, maxParameters = 1, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class SmallIntType extends LiquibaseDataType {
 
@@ -52,7 +54,7 @@ public class SmallIntType extends LiquibaseDataType {
 
     @Override
     public String objectToSql(Object value, Database database) {
-        if ((value == null) || "null".equalsIgnoreCase(value.toString())) {
+        if ((value == null) || "null".equals(value.toString().toLowerCase(Locale.US))) {
             return null;
         }
         if (value instanceof DatabaseFunction) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/TimeType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/TimeType.java
@@ -12,6 +12,7 @@ import liquibase.util.StringUtils;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Locale;
 
 @DataTypeInfo(name="time", aliases = {"java.sql.Types.TIME", "java.sql.Time", "timetz"}, minParameters = 0, maxParameters = 0, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class TimeType  extends LiquibaseDataType {
@@ -55,7 +56,7 @@ public class TimeType  extends LiquibaseDataType {
         }
 
         if (database instanceof PostgresDatabase) {
-            String rawDefinition = originalDefinition.toLowerCase();
+            String rawDefinition = originalDefinition.toLowerCase(Locale.US);
             if (rawDefinition.contains("tz") || rawDefinition.contains("with time zone")) {
                 return new DatabaseDataType("TIME WITH TIME ZONE");
             } else {
@@ -68,7 +69,7 @@ public class TimeType  extends LiquibaseDataType {
 
     @Override
     public String objectToSql(Object value, Database database) {
-        if ((value == null) || "null".equalsIgnoreCase(value.toString())) {
+        if ((value == null) || "null".equals(value.toString().toLowerCase(Locale.US))) {
             return null;
         }  else if (value instanceof DatabaseFunction) {
             return database.generateDatabaseFunctionValue((DatabaseFunction) value);

--- a/liquibase-core/src/main/java/liquibase/datatype/core/TimestampType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/TimestampType.java
@@ -14,6 +14,8 @@ import liquibase.logging.LogType;
 import liquibase.util.StringUtils;
 import liquibase.util.grammar.ParseException;
 
+import java.util.Locale;
+
 /**
  * Data type support for TIMESTAMP data types in various DBMS. All DBMS are at least expected to support the
  * year, month, day, hour, minute and second parts. Optionally, fractional seconds and time zone information can be
@@ -69,7 +71,7 @@ public class TimestampType extends DateTimeType {
             if (!LiquibaseConfiguration.getInstance()
                     .getProperty(GlobalConfiguration.class, GlobalConfiguration.CONVERT_DATA_TYPES)
                     .getValue(Boolean.class)
-                    && originalDefinition.toLowerCase().startsWith("timestamp")) {
+                    && originalDefinition.toLowerCase(Locale.US).startsWith("timestamp")) {
                 return new DatabaseDataType(database.escapeDataTypeName("timestamp"));
             }
             return new DatabaseDataType(database.escapeDataTypeName("datetime"));
@@ -122,8 +124,8 @@ public class TimestampType extends DateTimeType {
             String additionalInformation = this.getAdditionalInformation();
 
             if ((additionalInformation != null) && (database instanceof PostgresDatabase)) {
-                if (additionalInformation.toUpperCase().contains("TIMEZONE")) {
-                    additionalInformation = additionalInformation.toUpperCase().replace("TIMEZONE", "TIME ZONE");
+                if (additionalInformation.toUpperCase(Locale.US).contains("TIMEZONE")) {
+                    additionalInformation = additionalInformation.toUpperCase(Locale.US).replace("TIMEZONE", "TIME ZONE");
                 }
             }
 

--- a/liquibase-core/src/main/java/liquibase/datatype/core/TinyIntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/TinyIntType.java
@@ -8,6 +8,8 @@ import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.LiquibaseDataType;
 import liquibase.statement.DatabaseFunction;
 
+import java.util.Locale;
+
 @DataTypeInfo(name="tinyint", aliases = "java.sql.Types.TINYINT", minParameters = 0, maxParameters = 1, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class TinyIntType  extends LiquibaseDataType {
 
@@ -44,7 +46,7 @@ public class TinyIntType  extends LiquibaseDataType {
 
     @Override
     public String objectToSql(Object value, Database database) {
-        if ((value == null) || "null".equalsIgnoreCase(value.toString())) {
+        if ((value == null) || "null".equals(value.toString().toLowerCase(Locale.US))) {
             return null;
         }
         if (value instanceof DatabaseFunction) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/UnknownType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/UnknownType.java
@@ -9,6 +9,7 @@ import liquibase.datatype.LiquibaseDataType;
 import liquibase.statement.DatabaseFunction;
 
 import java.util.Arrays;
+import java.util.Locale;
 
 /**
  * Container for a data type that is not covered by any implementation in {@link liquibase.datatype.core}. Most often,
@@ -41,7 +42,7 @@ public class UnknownType extends LiquibaseDataType {
     @Override
     public DatabaseDataType toDatabaseDataType(Database database) {
         int dataTypeMaxParameters;
-        if ("enum".equalsIgnoreCase(getName()) || "set".equalsIgnoreCase(getName())) {
+        if ("enum".equals(getName().toLowerCase(Locale.US)) || "set".equals(getName().toLowerCase(Locale.US))) {
             dataTypeMaxParameters = Integer.MAX_VALUE;
         } else {
             dataTypeMaxParameters = database.getDataTypeMaxParameters(getName());
@@ -49,21 +50,21 @@ public class UnknownType extends LiquibaseDataType {
         Object[] parameters = getParameters();
 
         if (database instanceof OracleDatabase) {
-            if ("LONG".equalsIgnoreCase(getName())
-                    || "BFILE".equalsIgnoreCase(getName())
-                    || "ROWID".equalsIgnoreCase(getName())
-                    || "ANYDATA".equalsIgnoreCase(getName())
-                    || "SDO_GEOMETRY".equalsIgnoreCase(getName())
+            if ("LONG".equals(getName().toUpperCase(Locale.US))
+                    || "BFILE".equals(getName().toUpperCase(Locale.US))
+                    || "ROWID".equals(getName().toUpperCase(Locale.US))
+                    || "ANYDATA".equals(getName().toUpperCase(Locale.US))
+                    || "SDO_GEOMETRY".equals(getName().toUpperCase(Locale.US))
                     ) {
                 parameters = new Object[0];
-            } else if ("RAW".equalsIgnoreCase(getName())) {
+            } else if ("RAW".equals(getName().toUpperCase(Locale.US))) {
                 return new DatabaseDataType(getName(), parameters);
-            } else if (getName().toUpperCase().startsWith("INTERVAL ")) {
+            } else if (getName().toUpperCase(Locale.US).startsWith("INTERVAL ")) {
                 return new DatabaseDataType(getName().replaceAll("\\(\\d+\\)", ""));
             } else {
                 // probably a user defined type. Can't call getUserDefinedTypes() to know for sure, since that returns
                 // all types including system types.
-                return new DatabaseDataType(getName().toUpperCase());
+                return new DatabaseDataType(getName().toUpperCase(Locale.US));
             }
         }
 
@@ -80,7 +81,7 @@ public class UnknownType extends LiquibaseDataType {
             }
             type = new DatabaseDataType(database.escapeDataTypeName(getName()), parameters);
         } else {
-            type = new DatabaseDataType(getName().toUpperCase(), parameters);
+            type = new DatabaseDataType(getName().toUpperCase(Locale.US), parameters);
         }
         type.addAdditionalInformation(getAdditionalInformation());
 


### PR DESCRIPTION
There is a bug related with Turkish dotless i and capital I with dot causing problems with Metabase open source project using liquibase. There are some simular bug reports & fixes related with this problem such as;
[Liquibase JIRA Bug report 1](https://liquibase.jira.com/browse/CORE-2772)
[Metabase Forum](https://discourse.metabase.com/t/metabase-centos-install-error-please-help-turkish-locale/2943)

I tried to fix by making case changes according to en-US locale for database types and it should be for such SQL language-related strings, I am not aware if there are more in the project. But the case related with database types seems fixed within my Metabase build.

Information about Turkish locale differences:
[Blog article](https://haacked.com/archive/2012/07/05/turkish-i-problem-and-why-you-should-care.aspx/)