### PR TITLE
Revisit fix for "includeAll" usage with Spring Boot fat-jar

### DIFF
--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <bundle.namespace>liquibase.*</bundle.namespace>
-        <project.version>3.5.4</project.version>
+        <project.version>3.5.5</project.version>
     </properties>
 
     <dependencies>

--- a/liquibase-core/src/main/java/liquibase/util/SpringBootFatJar.java
+++ b/liquibase-core/src/main/java/liquibase/util/SpringBootFatJar.java
@@ -4,7 +4,7 @@ public class SpringBootFatJar {
     public static String getPathForResource(String path) {
         String[] components = path.split("!");
         if (components.length == 3) {
-            return String.format("%s%s", components[1].substring(1), components[2]);
+            return components[2].substring(1);
         } else {
             return path;
         }

--- a/liquibase-core/src/test/java/liquibase/util/SpringBootFatJarTest.java
+++ b/liquibase-core/src/test/java/liquibase/util/SpringBootFatJarTest.java
@@ -8,7 +8,7 @@ public class SpringBootFatJarTest {
     @Test
     public void testGetPathForResourceWithFatJarPath() {
         String result = SpringBootFatJar.getPathForResource("some/path!/that/has!/two/bangs");
-        assertEquals(result, "that/has/two/bangs");
+        assertEquals(result, "two/bangs");
     }
 
     @Test


### PR DESCRIPTION
Original workaround introduced by PR #698.
Please refer to comment https://github.com/liquibase/liquibase/pull/698/files#r175782032 for details on the issue that this patch addresses.

In addition, this change rolls forward patch version for `core` module. I guess this was missing, since artifact version being built was 3.5.5 but the buildinfo.properties declared 3.5.4.