### PR TITLE
AddColumnGeneratorSQLite should only support SQLite database.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddColumnGeneratorSQLite.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddColumnGeneratorSQLite.java
@@ -8,17 +8,19 @@ import liquibase.database.core.SQLiteDatabase;
 import liquibase.exception.ValidationErrors;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
-import liquibase.statement.ColumnConstraint;
 import liquibase.statement.core.AddColumnStatement;
 import liquibase.structure.core.Index;
-
-import java.util.Set;
 
 /**
  * Workaround for adding column on existing table for SQLite.
  *
  */
 public class AddColumnGeneratorSQLite extends AddColumnGenerator {
+
+    @Override
+    public boolean supports(AddColumnStatement statement, Database database) {
+        return database instanceof SQLiteDatabase;
+    }
 
     @Override
     public ValidationErrors validate(AddColumnStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {


### PR DESCRIPTION
AddColumnGeneratorSQLite should only `support` SQLite database, so that this generator won't apply to other databases. 

Otherwise, I have to apply this hack `SqlGeneratorFactory.getInstance().unregister(AddColumnGeneratorSQLite.class);` to make Dropwizard build, see here: https://github.com/dropwizard/dropwizard/pull/2325/files

Thanks. 