### PR TITLE
CORE-3206 incompatibility with 3.5

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -815,7 +815,7 @@ public abstract class AbstractJdbcDatabase implements Database {
         } else if (object instanceof Column) {
             return isLiquibaseObject(((Column) object).getRelation());
         } else if (object instanceof Index) {
-            return isLiquibaseObject(((Index) object).getTable());
+            return isLiquibaseObject(((Index) object).getRelation());
         } else if (object instanceof PrimaryKey) {
             return isLiquibaseObject(((PrimaryKey) object).getTable());
         }

--- a/liquibase-core/src/main/java/liquibase/database/core/SQLiteDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/SQLiteDatabase.java
@@ -76,7 +76,7 @@ public class SQLiteDatabase extends AbstractJdbcDatabase {
             for (Index index : SnapshotGeneratorFactory.getInstance().createSnapshot(
                     new CatalogAndSchema(catalogName, schemaName), database,
                     new SnapshotControl(database, Index.class)).get(Index.class)) {
-                if (index.getTable().getName().equalsIgnoreCase(tableName)) {
+                if (index.getRelation().getName().equalsIgnoreCase(tableName)) {
                     if (alterTableVisitor.createThisIndex(index)) {
                         newIndices.add(index);
                     }

--- a/liquibase-core/src/main/java/liquibase/dbdoc/TableWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/TableWriter.java
@@ -38,7 +38,7 @@ public class TableWriter extends HTMLWriter {
             String remarks = column.getRemarks();
             cells.add(Arrays.asList(column.getType().toString(),
                     column.isNullable() ? "NULL" : "NOT NULL",
-                    "<A HREF=\"../columns/" + table.getSchema().getName().toLowerCase() + "." + table.getName().toLowerCase() + "." + column.getName().toLowerCase() + ".html" + "\">" + column.getName() + "</A>", (remarks != null) ? remarks : ""));
+                    "<A HREF=\"../columns/" + (table.getSchema().getName() != null ? table.getSchema().getName().toLowerCase() + "." : "") + table.getName().toLowerCase() + "." + column.getName().toLowerCase() + ".html" + "\">" + column.getName() + "</A>", (remarks != null) ? remarks : ""));
             //todo: add foreign key info to columns?
         }
 

--- a/liquibase-core/src/main/java/liquibase/dbdoc/TableWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/TableWriter.java
@@ -63,7 +63,7 @@ public class TableWriter extends HTMLWriter {
                 cells.add(Arrays.asList((primaryKey != null && primaryKey.getBackingIndex() == index ? "Primary Key " : index.isUnique() ? "Unique " : "Non-Unique ") +
                         (index.getClustered() == null ? "" : (index.getClustered() ? "Clustered" : "Non-Clustered")),
                         index.getName(),
-                        index.getColumnNames().replace(index.getTable().getName() + ".","")));
+                        index.getColumnNames().replace(index.getRelation().getName() + ".","")));
             }
         writeTable("Current Table Indexes", cells, fileWriter);
         }

--- a/liquibase-core/src/main/java/liquibase/diff/compare/core/IndexComparator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/compare/core/IndexComparator.java
@@ -34,7 +34,7 @@ public class IndexComparator implements DatabaseObjectComparator {
             hashes.add(databaseObject.getName().toLowerCase());
         }
 
-        Relation table = ((Index) databaseObject).getTable();
+        Relation table = ((Index) databaseObject).getRelation();
         if (table != null) {
             hashes.addAll(Arrays.asList(DatabaseObjectComparatorFactory.getInstance().hash(table, chain.getSchemaComparisons(), accordingTo)));
         }
@@ -55,8 +55,8 @@ public class IndexComparator implements DatabaseObjectComparator {
         int thisIndexSize = thisIndex.getColumns().size();
         int otherIndexSize = otherIndex.getColumns().size();
 
-        if ((thisIndex.getTable() != null) && (otherIndex.getTable() != null)) {
-            if (!DatabaseObjectComparatorFactory.getInstance().isSameObject(thisIndex.getTable(), otherIndex.getTable(), chain.getSchemaComparisons(), accordingTo)) {
+        if ((thisIndex.getRelation() != null) && (otherIndex.getRelation() != null)) {
+            if (!DatabaseObjectComparatorFactory.getInstance().isSameObject(thisIndex.getRelation(), otherIndex.getRelation(), chain.getSchemaComparisons(), accordingTo)) {
                 return false;
             }
             if ((databaseObject1.getSchema() != null) && (databaseObject2.getSchema() != null) &&

--- a/liquibase-core/src/main/java/liquibase/diff/compare/core/UniqueConstraintComparator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/compare/core/UniqueConstraintComparator.java
@@ -34,7 +34,7 @@ public class UniqueConstraintComparator implements DatabaseObjectComparator {
             hashes.add(databaseObject.getName().toLowerCase());
         }
 
-        Relation table = ((UniqueConstraint) databaseObject).getTable();
+        Relation table = ((UniqueConstraint) databaseObject).getRelation();
         if (table != null) {
             hashes.addAll(Arrays.asList(DatabaseObjectComparatorFactory.getInstance().hash(table, chain.getSchemaComparisons(), accordingTo)));
         }
@@ -55,8 +55,8 @@ public class UniqueConstraintComparator implements DatabaseObjectComparator {
         int thisConstraintSize = thisConstraint.getColumns().size();
         int otherConstraintSize = otherConstraint.getColumns().size();
 
-        if ((thisConstraint.getTable() != null) && (otherConstraint.getTable() != null)) {
-            if (!DatabaseObjectComparatorFactory.getInstance().isSameObject(thisConstraint.getTable(), otherConstraint.getTable(), chain.getSchemaComparisons(), accordingTo)) {
+        if ((thisConstraint.getRelation() != null) && (otherConstraint.getRelation() != null)) {
+            if (!DatabaseObjectComparatorFactory.getInstance().isSameObject(thisConstraint.getRelation(), otherConstraint.getRelation(), chain.getSchemaComparisons(), accordingTo)) {
                 return false;
             }
             if ((databaseObject1.getSchema() != null) && (databaseObject2.getSchema() != null) &&
@@ -78,7 +78,7 @@ public class UniqueConstraintComparator implements DatabaseObjectComparator {
                 }
 
                 for (int i = 0; i < otherConstraintSize; i++) {
-                    if (!DatabaseObjectComparatorFactory.getInstance().isSameObject(thisConstraint.getColumns().get(i).setRelation(thisConstraint.getTable()), otherConstraint.getColumns().get(i).setRelation(otherConstraint.getTable()), chain.getSchemaComparisons(), accordingTo)) {
+                    if (!DatabaseObjectComparatorFactory.getInstance().isSameObject(thisConstraint.getColumns().get(i).setRelation(thisConstraint.getRelation()), otherConstraint.getColumns().get(i).setRelation(otherConstraint.getRelation()), chain.getSchemaComparisons(), accordingTo)) {
                         return false;
                     }
                 }

--- a/liquibase-core/src/main/java/liquibase/diff/output/StandardObjectChangeFilter.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/StandardObjectChangeFilter.java
@@ -115,7 +115,7 @@ public class StandardObjectChangeFilter implements ObjectChangeFilter {
                     return matches(((Column) object).getRelation());
                 }
                 if (object instanceof Index) {
-                    return matches(((Index) object).getTable());
+                    return matches(((Index) object).getRelation());
                 }
                 if (object instanceof ForeignKey) {
                     return matches(((ForeignKey) object).getForeignKeyTable());
@@ -124,7 +124,7 @@ public class StandardObjectChangeFilter implements ObjectChangeFilter {
                     return matches(((PrimaryKey) object).getTable());
                 }
                 if (object instanceof UniqueConstraint) {
-                    return matches(((UniqueConstraint) object).getTable());
+                    return matches(((UniqueConstraint) object).getRelation());
                 }
                 if (object instanceof Data) {
                     return matches(((Data) object).getTable());

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/ChangedIndexChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/ChangedIndexChangeGenerator.java
@@ -63,14 +63,14 @@ public class ChangedIndexChangeGenerator extends AbstractChangeGenerator impleme
 
         Index index = (Index) changedObject;
 
-        if (index.getTable() != null  && index.getTable() instanceof Table) {
-            if ((((Table) index.getTable()).getPrimaryKey() != null) && DatabaseObjectComparatorFactory.getInstance()
-                .isSameObject(((Table) index.getTable()).getPrimaryKey().getBackingIndex(), changedObject, differences
+        if (index.getRelation() != null  && index.getRelation() instanceof Table) {
+            if ((((Table) index.getRelation()).getPrimaryKey() != null) && DatabaseObjectComparatorFactory.getInstance()
+                .isSameObject(((Table) index.getRelation()).getPrimaryKey().getBackingIndex(), changedObject, differences
                     .getSchemaComparisons(), comparisonDatabase)) {
-                return ChangeGeneratorFactory.getInstance().fixChanged(((Table) index.getTable()).getPrimaryKey(), differences, control, referenceDatabase, comparisonDatabase);
+                return ChangeGeneratorFactory.getInstance().fixChanged(((Table) index.getRelation()).getPrimaryKey(), differences, control, referenceDatabase, comparisonDatabase);
             }
 
-            List<UniqueConstraint> uniqueConstraints = ((Table) index.getTable()).getUniqueConstraints();
+            List<UniqueConstraint> uniqueConstraints = ((Table) index.getRelation()).getUniqueConstraints();
             if (uniqueConstraints != null) {
                 for (UniqueConstraint constraint : uniqueConstraints) {
                     if ((constraint.getBackingIndex() != null) && DatabaseObjectComparatorFactory.getInstance()
@@ -84,11 +84,11 @@ public class ChangedIndexChangeGenerator extends AbstractChangeGenerator impleme
         }
 
         DropIndexChange dropIndexChange = createDropIndexChange();
-        dropIndexChange.setTableName(index.getTable().getName());
+        dropIndexChange.setTableName(index.getRelation().getName());
         dropIndexChange.setIndexName(index.getName());
 
         CreateIndexChange addIndexChange = createCreateIndexChange();
-        addIndexChange.setTableName(index.getTable().getName());
+        addIndexChange.setTableName(index.getRelation().getName());
         List<AddColumnConfig> columns = new ArrayList<>();
         for (Column col : index.getColumns()) {
             columns.add(new AddColumnConfig(col));
@@ -119,15 +119,15 @@ public class ChangedIndexChangeGenerator extends AbstractChangeGenerator impleme
                 }
             };
 
-            control.setAlreadyHandledChanged(new Index().setTable(index.getTable()).setColumns(referenceColumns));
+            control.setAlreadyHandledChanged(new Index().setRelation(index.getRelation()).setColumns(referenceColumns));
             if (!StringUtils.join(referenceColumns, ",", formatter).equalsIgnoreCase(StringUtils.join(comparedColumns, ",", formatter))) {
-                control.setAlreadyHandledChanged(new Index().setTable(index.getTable()).setColumns(comparedColumns));
+                control.setAlreadyHandledChanged(new Index().setRelation(index.getRelation()).setColumns(comparedColumns));
             }
 
             if ((index.isUnique() != null) && index.isUnique()) {
-                control.setAlreadyHandledChanged(new UniqueConstraint().setTable(index.getTable()).setColumns(referenceColumns));
+                control.setAlreadyHandledChanged(new UniqueConstraint().setRelation(index.getRelation()).setColumns(referenceColumns));
                 if (!StringUtils.join(referenceColumns, ",", formatter).equalsIgnoreCase(StringUtils.join(comparedColumns, ",", formatter))) {
-                    control.setAlreadyHandledChanged(new UniqueConstraint().setTable(index.getTable()).setColumns(comparedColumns));
+                    control.setAlreadyHandledChanged(new UniqueConstraint().setRelation(index.getRelation()).setColumns(comparedColumns));
                 }
             }
         }

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/ChangedPrimaryKeyChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/ChangedPrimaryKeyChangeGenerator.java
@@ -111,14 +111,14 @@ public class ChangedPrimaryKeyChangeGenerator extends AbstractChangeGenerator im
 
         StringUtils.ToStringFormatter formatter = new StringUtils.ToStringFormatter();
 
-        control.setAlreadyHandledChanged(new Index().setTable(pk.getTable()).setColumns(referenceColumns));
+        control.setAlreadyHandledChanged(new Index().setRelation(pk.getTable()).setColumns(referenceColumns));
         if (!StringUtils.join(referenceColumns, ",", formatter).equalsIgnoreCase(StringUtils.join(comparedColumns, ",", formatter))) {
-            control.setAlreadyHandledChanged(new Index().setTable(pk.getTable()).setColumns(comparedColumns));
+            control.setAlreadyHandledChanged(new Index().setRelation(pk.getTable()).setColumns(comparedColumns));
         }
 
-        control.setAlreadyHandledChanged(new UniqueConstraint().setTable(pk.getTable()).setColumns(referenceColumns));
+        control.setAlreadyHandledChanged(new UniqueConstraint().setRelation(pk.getTable()).setColumns(referenceColumns));
         if (!StringUtils.join(referenceColumns, ",", formatter).equalsIgnoreCase(StringUtils.join(comparedColumns, "," , formatter))) {
-            control.setAlreadyHandledChanged(new UniqueConstraint().setTable(pk.getTable()).setColumns(comparedColumns));
+            control.setAlreadyHandledChanged(new UniqueConstraint().setRelation(pk.getTable()).setColumns(comparedColumns));
         }
 
         return returnList.toArray(new Change[returnList.size()]);

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/ChangedUniqueConstraintChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/ChangedUniqueConstraintChangeGenerator.java
@@ -46,12 +46,12 @@ public class ChangedUniqueConstraintChangeGenerator extends AbstractChangeGenera
         UniqueConstraint uniqueConstraint = (UniqueConstraint) changedObject;
 
         DropUniqueConstraintChange dropUniqueConstraintChange = createDropUniqueConstraintChange();
-        dropUniqueConstraintChange.setTableName(uniqueConstraint.getTable().getName());
+        dropUniqueConstraintChange.setTableName(uniqueConstraint.getRelation().getName());
         dropUniqueConstraintChange.setConstraintName(uniqueConstraint.getName());
 
         AddUniqueConstraintChange addUniqueConstraintChange = createAddUniqueConstraintChange();
         addUniqueConstraintChange.setConstraintName(uniqueConstraint.getName());
-        addUniqueConstraintChange.setTableName(uniqueConstraint.getTable().getName());
+        addUniqueConstraintChange.setTableName(uniqueConstraint.getRelation().getName());
         addUniqueConstraintChange.setColumnNames(uniqueConstraint.getColumnNames());
 
         returnList.add(dropUniqueConstraintChange);

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingIndexChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingIndexChangeGenerator.java
@@ -39,8 +39,8 @@ public class MissingIndexChangeGenerator extends AbstractChangeGenerator impleme
     public Change[] fixMissing(DatabaseObject missingObject, DiffOutputControl control, Database referenceDatabase, Database comparisonDatabase, ChangeGeneratorChain chain) {
         Index index = (Index) missingObject;
 
-        if (comparisonDatabase instanceof MSSQLDatabase && index.getTable() instanceof Table) {
-            PrimaryKey primaryKey = ((Table) index.getTable()).getPrimaryKey();
+        if (comparisonDatabase instanceof MSSQLDatabase && index.getRelation() instanceof Table) {
+            PrimaryKey primaryKey = ((Table) index.getRelation()).getPrimaryKey();
             if ((primaryKey != null) && DatabaseObjectComparatorFactory.getInstance().isSameObject(missingObject,
                 primaryKey.getBackingIndex(), control.getSchemaComparisons(), referenceDatabase)) {
                 return new Change[0]; //will be handled by the PK
@@ -48,15 +48,15 @@ public class MissingIndexChangeGenerator extends AbstractChangeGenerator impleme
         }
 
         CreateIndexChange change = createCreateIndexChange();
-        change.setTableName(index.getTable().getName());
+        change.setTableName(index.getRelation().getName());
         if (control.getIncludeTablespace()) {
             change.setTablespace(index.getTablespace());
         }
         if (control.getIncludeCatalog()) {
-            change.setCatalogName(index.getTable().getSchema().getCatalogName());
+            change.setCatalogName(index.getRelation().getSchema().getCatalogName());
         }
         if (control.getIncludeSchema()) {
-            change.setSchemaName(index.getTable().getSchema().getName());
+            change.setSchemaName(index.getRelation().getSchema().getName());
         }
         change.setIndexName(index.getName());
         change.setUnique(((index.isUnique() != null) && index.isUnique()) ? Boolean.TRUE : null);

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingPrimaryKeyChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingPrimaryKeyChangeGenerator.java
@@ -81,7 +81,7 @@ public class MissingPrimaryKeyChangeGenerator extends AbstractChangeGenerator im
                 try {
                     if (!control.getIncludeCatalog() && !control.getIncludeSchema()) {
                         CatalogAndSchema schema = comparisonDatabase.getDefaultSchema().customize(comparisonDatabase);
-                        backingIndex.getTable().setSchema(schema.getCatalogName(), schema.getSchemaName()); //set table schema so it is found in the correct schema
+                        backingIndex.getRelation().setSchema(schema.getCatalogName(), schema.getSchemaName()); //set table schema so it is found in the correct schema
                     }
                     if (referenceDatabase.equals(comparisonDatabase) || !SnapshotGeneratorFactory.getInstance().has(backingIndex, comparisonDatabase)) {
                         Change[] fixes = ChangeGeneratorFactory.getInstance().fixMissing(backingIndex, control, referenceDatabase, comparisonDatabase);

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingUniqueConstraintChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingUniqueConstraintChangeGenerator.java
@@ -45,20 +45,20 @@ public class MissingUniqueConstraintChangeGenerator extends AbstractChangeGenera
 
         UniqueConstraint uc = (UniqueConstraint) missingObject;
 
-        if (uc.getTable() == null) {
+        if (uc.getRelation() == null) {
             return null;
         }
 
         AddUniqueConstraintChange change = createAddUniqueConstraintChange();
-        change.setTableName(uc.getTable().getName());
+        change.setTableName(uc.getRelation().getName());
         if ((uc.getBackingIndex() != null) && control.getIncludeTablespace()) {
             change.setTablespace(uc.getBackingIndex().getTablespace());
         }
         if (control.getIncludeCatalog()) {
-            change.setCatalogName(uc.getTable().getSchema().getCatalogName());
+            change.setCatalogName(uc.getRelation().getSchema().getCatalogName());
         }
         if (control.getIncludeSchema()) {
-            change.setSchemaName(uc.getTable().getSchema().getName());
+            change.setSchemaName(uc.getRelation().getSchema().getName());
         }
         change.setConstraintName(uc.getName());
         change.setColumnNames(uc.getColumnNames());

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/UnexpectedIndexChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/UnexpectedIndexChangeGenerator.java
@@ -41,12 +41,12 @@ public class UnexpectedIndexChangeGenerator extends AbstractChangeGenerator impl
 //        }
 
         DropIndexChange change = new DropIndexChange();
-        change.setTableName(index.getTable().getName());
+        change.setTableName(index.getRelation().getName());
         if (control.getIncludeCatalog()) {
-            change.setCatalogName(index.getTable().getSchema().getCatalogName());
+            change.setCatalogName(index.getRelation().getSchema().getCatalogName());
         }
         if (control.getIncludeSchema()) {
-            change.setSchemaName(index.getTable().getSchema().getName());
+            change.setSchemaName(index.getRelation().getSchema().getName());
         }
         change.setIndexName(index.getName());
         change.setAssociatedWith(index.getAssociatedWithAsString());

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/UnexpectedUniqueConstraintChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/UnexpectedUniqueConstraintChangeGenerator.java
@@ -37,17 +37,17 @@ public class UnexpectedUniqueConstraintChangeGenerator extends AbstractChangeGen
     @Override
     public Change[] fixUnexpected(DatabaseObject unexpectedObject, DiffOutputControl control, Database referenceDatabase, Database comparisonDatabase, ChangeGeneratorChain chain) {
         UniqueConstraint uc = (UniqueConstraint) unexpectedObject;
-        if (uc.getTable() == null) {
+        if (uc.getRelation() == null) {
             return null;
         }
 
         DropUniqueConstraintChange change = new DropUniqueConstraintChange();
-        change.setTableName(uc.getTable().getName());
+        change.setTableName(uc.getRelation().getName());
         if (control.getIncludeCatalog()) {
-            change.setCatalogName(uc.getTable().getSchema().getCatalogName());
+            change.setCatalogName(uc.getRelation().getSchema().getCatalogName());
         }
         if (control.getIncludeSchema()) {
-            change.setSchemaName(uc.getTable().getSchema().getName());
+            change.setSchemaName(uc.getRelation().getSchema().getName());
         }
         change.setConstraintName(uc.getName());
 

--- a/liquibase-core/src/main/java/liquibase/precondition/core/IndexExistsPrecondition.java
+++ b/liquibase-core/src/main/java/liquibase/precondition/core/IndexExistsPrecondition.java
@@ -90,7 +90,7 @@ public class IndexExistsPrecondition extends AbstractPrecondition {
             Index example = new Index();
             String tableName = StringUtils.trimToNull(getTableName());
             if (tableName != null) {
-                example.setTable((Table) new Table()
+                example.setRelation((Table) new Table()
                         .setName(database.correctObjectName(getTableName(), Table.class))
                         .setSchema(schema));
             }

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/ForeignKeySnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/ForeignKeySnapshotGenerator.java
@@ -209,7 +209,7 @@ public class ForeignKeySnapshotGenerator extends JdbcSnapshotGenerator {
                 }
                 setValidateOptionIfAvailable(database, foreignKey, row);
                 if (database.createsIndexesForForeignKeys()) {
-                    Index exampleIndex = new Index().setTable(foreignKey.getForeignKeyTable());
+                    Index exampleIndex = new Index().setRelation(foreignKey.getForeignKeyTable());
                     exampleIndex.getColumns().addAll(foreignKey.getForeignKeyColumns());
                     exampleIndex.addAssociatedWith(Index.MARK_FOREIGN_KEY);
                     foreignKey.setBackingIndex(exampleIndex);

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/IndexSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/IndexSnapshotGenerator.java
@@ -65,7 +65,7 @@ public class IndexSnapshotGenerator extends JdbcSnapshotGenerator {
                     if (index == null) {
                         index = new Index();
                         index.setName(indexName);
-                        index.setTable(relation);
+                        index.setRelation(relation);
 
                         short type = row.getShort("TYPE");
                         if (type == DatabaseMetaData.tableIndexClustered) {
@@ -85,7 +85,7 @@ public class IndexSnapshotGenerator extends JdbcSnapshotGenerator {
                     }
                     Boolean descending = "D".equals(ascOrDesc) ? Boolean.TRUE : ("A".equals(ascOrDesc) ? Boolean
                         .FALSE : null);
-                    index.addColumn(new Column(row.getString("COLUMN_NAME")).setComputed(false).setDescending(descending).setRelation(index.getTable()));
+                    index.addColumn(new Column(row.getString("COLUMN_NAME")).setComputed(false).setDescending(descending).setRelation(index.getRelation()));
                 }
 
                 //add clustered indexes first, than all others in case there is a clustered and non-clustered version of the same index. Prefer the clustered version
@@ -115,12 +115,12 @@ public class IndexSnapshotGenerator extends JdbcSnapshotGenerator {
         }
         if ((foundObject instanceof UniqueConstraint) && (((UniqueConstraint) foundObject).getBackingIndex() == null)
             && !(snapshot.getDatabase() instanceof DB2Database) && !(snapshot.getDatabase() instanceof DerbyDatabase)) {
-            Index exampleIndex = new Index().setTable(((UniqueConstraint) foundObject).getTable());
+            Index exampleIndex = new Index().setRelation(((UniqueConstraint) foundObject).getRelation());
             exampleIndex.getColumns().addAll(((UniqueConstraint) foundObject).getColumns());
             ((UniqueConstraint) foundObject).setBackingIndex(exampleIndex);
         }
         if ((foundObject instanceof ForeignKey) && (((ForeignKey) foundObject).getBackingIndex() == null)) {
-            Index exampleIndex = new Index().setTable(((ForeignKey) foundObject).getForeignKeyTable());
+            Index exampleIndex = new Index().setRelation(((ForeignKey) foundObject).getForeignKeyTable());
             exampleIndex.getColumns().addAll(((ForeignKey) foundObject).getForeignKeyColumns());
             ((ForeignKey) foundObject).setBackingIndex(exampleIndex);
         }
@@ -129,7 +129,7 @@ public class IndexSnapshotGenerator extends JdbcSnapshotGenerator {
     @Override
     protected DatabaseObject snapshotObject(DatabaseObject example, DatabaseSnapshot snapshot) throws DatabaseException, InvalidExampleException {
         Database database = snapshot.getDatabase();
-        Relation exampleIndex = ((Index) example).getTable();
+        Relation exampleIndex = ((Index) example).getRelation();
 
         String tableName = null;
         Schema schema = null;
@@ -234,7 +234,7 @@ public class IndexSnapshotGenerator extends JdbcSnapshotGenerator {
                     if ("V".equals(row.getString("INTERNAL_OBJECT_TYPE"))) {
                         relation = new View();
                     }
-                    returnIndex.setTable(relation.setName(row.getString("TABLE_NAME")).setSchema(schema));
+                    returnIndex.setRelation(relation.setName(row.getString("TABLE_NAME")).setSchema(schema));
                     returnIndex.setName(indexName);
                     returnIndex.setUnique(!nonUnique);
 
@@ -302,10 +302,10 @@ public class IndexSnapshotGenerator extends JdbcSnapshotGenerator {
                             Boolean descending = "D".equals(ascOrDesc) ? Boolean.TRUE : ("A".equals(ascOrDesc) ?
                                 Boolean.FALSE : null);
                             returnIndex.getColumns().set(position - 1, new Column(columnName)
-                                    .setDescending(descending).setRelation(returnIndex.getTable()));
+                                    .setDescending(descending).setRelation(returnIndex.getRelation()));
                         } else {
                             returnIndex.getColumns().set(position - 1, new Column()
-                                    .setRelation(returnIndex.getTable()).setName(definition, true));
+                                    .setRelation(returnIndex.getRelation()).setName(definition, true));
                         }
                     }
                 }
@@ -321,7 +321,7 @@ public class IndexSnapshotGenerator extends JdbcSnapshotGenerator {
             //prefer clustered version of the index
             List<Index> nonClusteredIndexes = new ArrayList<>();
             for (Index index : foundIndexes.values()) {
-                if (DatabaseObjectComparatorFactory.getInstance().isSameObject(index.getTable(), exampleIndex, snapshot.getSchemaComparisons(), database)) {
+                if (DatabaseObjectComparatorFactory.getInstance().isSameObject(index.getRelation(), exampleIndex, snapshot.getSchemaComparisons(), database)) {
                     boolean actuallyMatches = false;
                     if (database.isCaseSensitive()) {
                         if (index.getColumnNames().equals(((Index) example).getColumnNames())) {

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/PrimaryKeySnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/PrimaryKeySnapshotGenerator.java
@@ -76,7 +76,7 @@ public class PrimaryKeySnapshotGenerator extends JdbcSnapshotGenerator {
             }
 
             if (returnKey != null) {
-                Index exampleIndex = new Index().setTable(returnKey.getTable());
+                Index exampleIndex = new Index().setRelation(returnKey.getTable());
                 exampleIndex.setColumns(returnKey.getColumns());
                 returnKey.setBackingIndex(exampleIndex);
             }

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
@@ -35,7 +35,7 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
     protected DatabaseObject snapshotObject(DatabaseObject example, DatabaseSnapshot snapshot) throws DatabaseException, InvalidExampleException {
         Database database = snapshot.getDatabase();
         UniqueConstraint exampleConstraint = (UniqueConstraint) example;
-        Relation table = exampleConstraint.getTable();
+        Relation table = exampleConstraint.getRelation();
 
         List<Map<String, ?>> metadata = listColumns(exampleConstraint, database, snapshot);
 
@@ -43,7 +43,7 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
             return null;
         }
         UniqueConstraint constraint = new UniqueConstraint();
-        constraint.setTable(table);
+        constraint.setRelation(table);
         constraint.setName(example.getName());
         constraint.setBackingIndex(exampleConstraint.getBackingIndex());
         constraint.setInitiallyDeferred(((UniqueConstraint) example).isInitiallyDeferred());
@@ -108,7 +108,7 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
 
             for (CachedRow constraint : metadata) {
                 UniqueConstraint uq = new UniqueConstraint()
-                        .setName(cleanNameFromDatabase((String) constraint.get("CONSTRAINT_NAME"), database)).setTable(table);
+                        .setName(cleanNameFromDatabase((String) constraint.get("CONSTRAINT_NAME"), database)).setRelation(table);
                 if (constraint.containsColumn("INDEX_NAME")) {
                     uq.setBackingIndex(new Index((String) constraint.get("INDEX_NAME"), (String) constraint.get("INDEX_CATALOG"), (String) constraint.get("INDEX_SCHEMA"), table.getName()));
                 }
@@ -127,7 +127,7 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
     }
 
     protected List<Map<String, ?>> listColumns(UniqueConstraint example, Database database, DatabaseSnapshot snapshot) throws DatabaseException {
-        Relation table = example.getTable();
+        Relation table = example.getRelation();
         Schema schema = table.getSchema();
         String name = example.getName();
 
@@ -156,7 +156,7 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
                         + "and const.table_name=col.table_name "
                         + "and const.constraint_name=col.constraint_name "
                         + "where const.constraint_schema='" + database.correctObjectName(schema.getCatalogName(), Catalog.class) + "' "
-                        + "and const.table_name='" + database.correctObjectName(example.getTable().getName(), Table.class) + "' "
+                        + "and const.table_name='" + database.correctObjectName(example.getRelation().getName(), Table.class) + "' "
                         + "and const.constraint_name='" + database.correctObjectName(name, UniqueConstraint.class) + "'"
                         + "order by ordinal_position";
             } else if (database instanceof PostgresDatabase) {
@@ -168,7 +168,7 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
                         + "and const.constraint_name=col.constraint_name "
                         + "where const.constraint_catalog='" + database.correctObjectName(schema.getCatalogName(), Catalog.class) + "' "
                         + "and const.constraint_schema='" + database.correctObjectName(schema.getSchema().getName(), Schema.class) + "' "
-                        + "and const.table_name='" + database.correctObjectName(example.getTable().getName(), Table.class) + "' "
+                        + "and const.table_name='" + database.correctObjectName(example.getRelation().getName(), Table.class) + "' "
                         + "and const.constraint_name='" + database.correctObjectName(name, UniqueConstraint.class) + "'"
                         + "order by ordinal_position";
             } else if (database instanceof MSSQLDatabase) {
@@ -194,7 +194,7 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
                                 "AND [c].[column_id] = [ic].[column_id] " +
                                     "WHERE [s].[name] = N'" + database.escapeStringForDatabase(database.correctObjectName(schema.getName(), Schema.class)) + "' ";
                     if (!bulkQuery) {
-                        sql += "AND [t].[name] = N'" + database.escapeStringForDatabase(database.correctObjectName(example.getTable().getName(), Table.class)) + "' " +
+                        sql += "AND [t].[name] = N'" + database.escapeStringForDatabase(database.correctObjectName(example.getRelation().getName(), Table.class)) + "' " +
                                 "AND [kc].[name] = N'" + database.escapeStringForDatabase(database.correctObjectName(name, UniqueConstraint.class)) + "' ";
                     }
                     sql += "ORDER BY " +
@@ -273,7 +273,7 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
                         "where sysconstraint.ref_object_id = syscolumn.object_id " +
                         "and sysconstraint.table_object_id = systable.object_id " +
                         "and sysconstraint.constraint_name = '" + database.correctObjectName(name, UniqueConstraint.class) + "' " +
-                        "and systable.table_name = '" + database.correctObjectName(example.getTable().getName(), Table.class) + "'";
+                        "and systable.table_name = '" + database.correctObjectName(example.getRelation().getName(), Table.class) + "'";
             } else if (database instanceof InformixDatabase) {
                 sql = getUniqueConstraintsSqlInformix((InformixDatabase)database, schema, name);
             } else {

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddUniqueConstraintGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddUniqueConstraintGenerator.java
@@ -115,7 +115,7 @@ public class AddUniqueConstraintGenerator extends AbstractSqlGenerator<AddUnique
     protected UniqueConstraint getAffectedUniqueConstraint(AddUniqueConstraintStatement statement) {
         UniqueConstraint uniqueConstraint = new UniqueConstraint()
                 .setName(statement.getConstraintName())
-                .setTable((Table) new Table().setName(statement.getTableName()).setSchema(statement.getCatalogName(), statement.getSchemaName()));
+                .setRelation((Table) new Table().setName(statement.getTableName()).setSchema(statement.getCatalogName(), statement.getSchemaName()));
         int i = 0;
         for (Column column : Column.listFromNames(statement.getColumnNames())) {
             uniqueConstraint.addColumn(i++, column);

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateIndexGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateIndexGenerator.java
@@ -152,6 +152,6 @@ public class CreateIndexGenerator extends AbstractSqlGenerator<CreateIndexStatem
     }
 
     protected Index getAffectedIndex(CreateIndexStatement statement) {
-        return new Index().setName(statement.getIndexName()).setTable((Table) new Table().setName(statement.getTableName()).setSchema(statement.getTableCatalogName(), statement.getTableSchemaName()));
+        return new Index().setName(statement.getIndexName()).setRelation((Table) new Table().setName(statement.getTableName()).setSchema(statement.getTableCatalogName(), statement.getTableSchemaName()));
     }
 }

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/DropIndexGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/DropIndexGenerator.java
@@ -62,6 +62,6 @@ public class DropIndexGenerator extends AbstractSqlGenerator<DropIndexStatement>
         if (statement.getTableName() != null) {
             table = (Table) new Table().setName(statement.getTableName()).setSchema(statement.getTableCatalogName(), statement.getTableSchemaName());
         }
-        return new Index().setName(statement.getIndexName()).setTable(table);
+        return new Index().setName(statement.getIndexName()).setRelation(table);
     }
 }

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/DropUniqueConstraintGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/DropUniqueConstraintGenerator.java
@@ -53,7 +53,7 @@ public class DropUniqueConstraintGenerator extends AbstractSqlGenerator<DropUniq
     }
 
     protected UniqueConstraint getAffectedUniqueConstraint(DropUniqueConstraintStatement statement) {
-        UniqueConstraint constraint = new UniqueConstraint().setName(statement.getConstraintName()).setTable((Table) new Table().setName(statement.getTableName()).setSchema(statement.getCatalogName(), statement.getSchemaName()));
+        UniqueConstraint constraint = new UniqueConstraint().setName(statement.getConstraintName()).setRelation((Table) new Table().setName(statement.getTableName()).setSchema(statement.getCatalogName(), statement.getSchemaName()));
         if (statement.getUniqueColumns() != null) {
             int i = 0;
             for (ColumnConfig column : statement.getUniqueColumns()) {

--- a/liquibase-core/src/main/java/liquibase/structure/core/Index.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/Index.java
@@ -63,12 +63,17 @@ public class Index extends AbstractDatabaseObject {
         return getRelation().getSchema();
     }
     
+ // Turn off temporarily until all errors are fixed
 //    /**
 //     * @deprecated Use {@link #getRelation()}
 //     */
 //    @Deprecated
 //	public Table getTable() {
-//		return getAttribute("table", Table.class);
+//		Relation relation = getRelation();
+//	if (relation instanceof Table)
+//	return (Table) relation;
+//else
+//	return null;
 //	}
 //
 //    /**
@@ -76,8 +81,7 @@ public class Index extends AbstractDatabaseObject {
 //     */
 //    @Deprecated
 //	public Index setTable(Table table) {
-//		this.setAttribute("table", table);
-//        return this;
+//		return setRelation(table);
 //    }
     
     public Relation getRelation() {

--- a/liquibase-core/src/main/java/liquibase/structure/core/Index.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/Index.java
@@ -29,7 +29,7 @@ public class Index extends AbstractDatabaseObject {
         this();
         setName(indexName);
         if (tableName != null) {
-            setTable(new Table(catalogName, schemaName, tableName));
+            setRelation(new Table(catalogName, schemaName, tableName));
             if ((columns != null) && (columns.length > 0)) {
                 setColumns(Arrays.asList(columns));
             }
@@ -39,7 +39,7 @@ public class Index extends AbstractDatabaseObject {
     @Override
     public DatabaseObject[] getContainingObjects() {
         return new DatabaseObject[] {
-                getTable()
+        		getRelation()
         };
     }
 
@@ -56,19 +56,36 @@ public class Index extends AbstractDatabaseObject {
 
     @Override
     public Schema getSchema() {
-        if (getTable() == null) {
+        if (getRelation() == null) {
             return null;
         }
         
-        return getTable().getSchema();
+        return getRelation().getSchema();
     }
-
-    public Relation getTable() {
-        return getAttribute("table", Relation.class);
+    
+//    /**
+//     * @deprecated Use {@link #getRelation()}
+//     */
+//    @Deprecated
+//	public Table getTable() {
+//		return getAttribute("table", Table.class);
+//	}
+//
+//    /**
+//     * @deprecated Use {@link #setRelation(Relation)}
+//     */
+//    @Deprecated
+//	public Index setTable(Table table) {
+//		this.setAttribute("table", table);
+//        return this;
+//    }
+    
+    public Relation getRelation() {
+    	return getAttribute("table", Relation.class);
     }
-
-    public Index setTable(Relation table) {
-        this.setAttribute("table", table);
+    
+    public Index setRelation(Relation relation) {
+    	this.setAttribute("table", relation);
         return this;
     }
 
@@ -86,7 +103,7 @@ public class Index extends AbstractDatabaseObject {
     }
 
     public Index addColumn(Column column) {
-        column.setRelation(getTable());
+        column.setRelation(getRelation());
         getColumns().add(column);
 
         return this;
@@ -95,7 +112,7 @@ public class Index extends AbstractDatabaseObject {
     public Index setColumns(List<Column> columns) {
         if (getAttribute("table", Object.class) instanceof Table) {
             for (Column column :columns) {
-                column.setRelation(getTable());
+                column.setRelation(getRelation());
             }
         }
         setAttribute("columns", columns);
@@ -162,10 +179,10 @@ public class Index extends AbstractDatabaseObject {
         Index o = (Index) other;
         int returnValue = 0;
 
-        if ((this.getTable() != null) && (o.getTable() != null)) {
-            returnValue = this.getTable().compareTo(o.getTable());
-            if ((returnValue == 0) && (this.getTable().getSchema() != null) && (o.getTable().getSchema() != null)) {
-                returnValue = StringUtils.trimToEmpty(this.getTable().getSchema().getName()).compareToIgnoreCase(StringUtils.trimToEmpty(o.getTable().getSchema().getName()));
+        if ((this.getRelation() != null) && (o.getRelation() != null)) {
+            returnValue = this.getRelation().compareTo(o.getRelation());
+            if ((returnValue == 0) && (this.getRelation().getSchema() != null) && (o.getRelation().getSchema() != null)) {
+                returnValue = StringUtils.trimToEmpty(this.getRelation().getSchema().getName()).compareToIgnoreCase(StringUtils.trimToEmpty(o.getRelation().getSchema().getName()));
             }
         }
 
@@ -213,10 +230,10 @@ public class Index extends AbstractDatabaseObject {
         if ((this.isUnique() != null) && this.isUnique()) {
             stringBuffer.append(" UNIQUE ");
         }
-        if ((getTable() != null) && (getColumns() != null)) {
-            String tableName = getTable().getName();
-            if ((getTable().getSchema() != null) && (getTable().getSchema().getName() != null)) {
-                tableName = getTable().getSchema().getName()+"."+tableName;
+        if ((getRelation() != null) && (getColumns() != null)) {
+            String tableName = getRelation().getName();
+            if ((getRelation().getSchema() != null) && (getRelation().getSchema().getName() != null)) {
+                tableName = getRelation().getSchema().getName()+"."+tableName;
             }
             stringBuffer.append(" ON ").append(tableName);
             if ((getColumns() != null) && !getColumns().isEmpty()) {

--- a/liquibase-core/src/main/java/liquibase/structure/core/Index.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/Index.java
@@ -63,26 +63,25 @@ public class Index extends AbstractDatabaseObject {
         return getRelation().getSchema();
     }
     
- // Turn off temporarily until all errors are fixed
-//    /**
-//     * @deprecated Use {@link #getRelation()}
-//     */
-//    @Deprecated
-//	public Table getTable() {
-//		Relation relation = getRelation();
-//	if (relation instanceof Table)
-//	return (Table) relation;
-//else
-//	return null;
-//	}
-//
-//    /**
-//     * @deprecated Use {@link #setRelation(Relation)}
-//     */
-//    @Deprecated
-//	public Index setTable(Table table) {
-//		return setRelation(table);
-//    }
+    /**
+     * @deprecated Use {@link #getRelation()}
+     */
+    @Deprecated
+	public Table getTable() {
+		Relation relation = getRelation();
+		if (relation instanceof Table)
+		return (Table) relation;
+	else
+		return null;
+	}
+
+    /**
+     * @deprecated Use {@link #setRelation(Relation)}
+     */
+    @Deprecated
+	public Index setTable(Table table) {
+		return setRelation(table);
+    }
     
     public Relation getRelation() {
     	return getAttribute("table", Relation.class);

--- a/liquibase-core/src/main/java/liquibase/structure/core/UniqueConstraint.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/UniqueConstraint.java
@@ -56,26 +56,25 @@ public class UniqueConstraint extends AbstractDatabaseObject {
         return getRelation().getSchema();
     }
     
-    // Turn off temporarily until all errors are fixed
-//    /**
-//     * @deprecated Use {@link #getRelation()}
-//     */
-//    @Deprecated
-//	public Table getTable() {
-//		Relation relation = getRelation();
-//		if (relation instanceof Table)
-//			return (Table) relation;
-//		else
-//			return null;
-//	}
-//
-//    /**
-//     * @deprecated Use {@link #setRelation(Relation)}
-//     */
-//    @Deprecated
-//	public UniqueConstraint setTable(Table table) {
-//		return setRelation(table);
-//    }
+    /**
+     * @deprecated Use {@link #getRelation()}
+     */
+    @Deprecated
+	public Table getTable() {
+		Relation relation = getRelation();
+		if (relation instanceof Table)
+			return (Table) relation;
+		else
+			return null;
+	}
+
+    /**
+     * @deprecated Use {@link #setRelation(Relation)}
+     */
+    @Deprecated
+	public UniqueConstraint setTable(Table table) {
+		return setRelation(table);
+    }
     
     public Relation getRelation() {
     	return getAttribute("table", Relation.class);

--- a/liquibase-core/src/main/java/liquibase/structure/core/UniqueConstraint.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/UniqueConstraint.java
@@ -56,25 +56,26 @@ public class UniqueConstraint extends AbstractDatabaseObject {
         return getRelation().getSchema();
     }
     
-    /**
-     * @deprecated Use {@link #getRelation()}
-     */
-    @Deprecated
-	public Table getTable() {
-		Relation relation = getRelation();
-		if (relation instanceof Table)
-			return (Table) relation;
-		else
-			return null;
-	}
-
-    /**
-     * @deprecated Use {@link #setRelation(Relation)}
-     */
-    @Deprecated
-	public UniqueConstraint setTable(Table table) {
-		return setRelation(table);
-    }
+    // Turn off temporarily until all errors are fixed
+//    /**
+//     * @deprecated Use {@link #getRelation()}
+//     */
+//    @Deprecated
+//	public Table getTable() {
+//		Relation relation = getRelation();
+//		if (relation instanceof Table)
+//			return (Table) relation;
+//		else
+//			return null;
+//	}
+//
+//    /**
+//     * @deprecated Use {@link #setRelation(Relation)}
+//     */
+//    @Deprecated
+//	public UniqueConstraint setTable(Table table) {
+//		return setRelation(table);
+//    }
     
     public Relation getRelation() {
     	return getAttribute("table", Relation.class);

--- a/liquibase-core/src/main/java/liquibase/structure/core/UniqueConstraint.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/UniqueConstraint.java
@@ -25,7 +25,7 @@ public class UniqueConstraint extends AbstractDatabaseObject {
         this();
         setName(name);
         if ((tableName != null) && (columns != null)) {
-            setTable(new Table(tableCatalog, tableSchema, tableName));
+        	setRelation(new Table(tableCatalog, tableSchema, tableName));
             setColumns(new ArrayList<>(Arrays.asList(columns)));
         }
     }
@@ -49,19 +49,39 @@ public class UniqueConstraint extends AbstractDatabaseObject {
 
     @Override
     public Schema getSchema() {
-        if (getTable() == null) {
+        if (getRelation() == null) {
             return null;
         }
 
-        return getTable().getSchema();
+        return getRelation().getSchema();
     }
-
-	public Relation getTable() {
-		return getAttribute("table", Relation.class);
+    
+    /**
+     * @deprecated Use {@link #getRelation()}
+     */
+    @Deprecated
+	public Table getTable() {
+		Relation relation = getRelation();
+		if (relation instanceof Table)
+			return (Table) relation;
+		else
+			return null;
 	}
 
-	public UniqueConstraint setTable(Relation table) {
-		this.setAttribute("table", table);
+    /**
+     * @deprecated Use {@link #setRelation(Relation)}
+     */
+    @Deprecated
+	public UniqueConstraint setTable(Table table) {
+		return setRelation(table);
+    }
+    
+    public Relation getRelation() {
+    	return getAttribute("table", Relation.class);
+    }
+    
+    public UniqueConstraint setRelation(Relation relation) {
+    	this.setAttribute("table", relation);
         return this;
     }
 
@@ -73,7 +93,7 @@ public class UniqueConstraint extends AbstractDatabaseObject {
         setAttribute("columns", columns);
         if (getAttribute("table", Object.class) instanceof Table) {
             for (Column column : getColumns()) {
-                column.setRelation(getTable());
+                column.setRelation(getRelation());
             }
         }
 
@@ -183,13 +203,13 @@ public class UniqueConstraint extends AbstractDatabaseObject {
 		// Need check for nulls here due to NullPointerException using
 		// Postgres
 		if (result) {
-			if (null == this.getTable()) {
-				result = null == that.getTable();
-			} else if (null == that.getTable()) {
+			if (null == this.getRelation()) {
+				result = null == that.getRelation();
+			} else if (null == that.getRelation()) {
 				result = false;
 			} else {
-				result = this.getTable().getName().equals(
-						that.getTable().getName());
+				result = this.getRelation().getName().equals(
+						that.getRelation().getName());
 			}
 		}
 
@@ -203,8 +223,8 @@ public class UniqueConstraint extends AbstractDatabaseObject {
 		// Need check for nulls here due to NullPointerException using Postgres
 		String thisTableName;
 		String thatTableName;
-        thisTableName = (null == this.getTable()) ? "" : this.getTable().getName();
-        thatTableName = (null == o.getTable()) ? "" : o.getTable().getName();
+        thisTableName = (null == this.getRelation()) ? "" : this.getRelation().getName();
+        thatTableName = (null == o.getRelation()) ? "" : o.getRelation().getName();
 		int returnValue = thisTableName.compareTo(thatTableName);
 		if (returnValue == 0) {
 			returnValue = this.getName().compareTo(o.getName());
@@ -223,8 +243,8 @@ public class UniqueConstraint extends AbstractDatabaseObject {
     @Override
 	public int hashCode() {
 		int result = 0;
-		if (this.getTable() != null) {
-			result = this.getTable().hashCode();
+		if (this.getRelation() != null) {
+			result = this.getRelation().hashCode();
 		}
 		if (this.getName() != null) {
             result = (31 * result) + this.getName().toUpperCase().hashCode();
@@ -237,10 +257,10 @@ public class UniqueConstraint extends AbstractDatabaseObject {
 
 	@Override
 	public String toString() {
-        if (getTable() == null) {
+        if (getRelation() == null) {
             return getName();
         } else {
-            return getName() + " on " + getTable().getName() + "("
+            return getName() + " on " + getRelation().getName() + "("
                     + getColumnNames() + ")";
         }
     }

--- a/liquibase-core/src/test/groovy/liquibase/change/core/CreateIndexChangeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/core/CreateIndexChangeTest.groovy
@@ -30,7 +30,7 @@ public class CreateIndexChangeTest extends StandardChangeTest {
 
         def change = new CreateIndexChange()
         change.indexName = index.name
-        change.tableName = index.table.name
+        change.tableName = index.relation.name
         change.columns = [new AddColumnConfig().setName("test_col")]
 
         then:
@@ -63,7 +63,7 @@ public class CreateIndexChangeTest extends StandardChangeTest {
 
         def change = new CreateIndexChange()
         change.indexName = index.name
-        change.tableName = index.table.name
+        change.tableName = index.relation.name
         change.columns = [new AddColumnConfig().setName(null)]
 
         then:

--- a/liquibase-core/src/test/groovy/liquibase/change/core/DropAllForeignKeyConstraintsChangeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/core/DropAllForeignKeyConstraintsChangeTest.groovy
@@ -107,8 +107,8 @@ class DropAllForeignKeyConstraintsChangeTest extends Specification {
 
         where:
         shortDbName  | expectedValue
-        "db2"        | ["ALTER TABLE schema_base.base_table DROP CONSTRAINT fk_base_ref1",
-                        "ALTER TABLE schema_base.base_table DROP CONSTRAINT fk_base_ref2"]
+        "db2"        | ["ALTER TABLE \"schema_base\".base_table DROP CONSTRAINT fk_base_ref1",
+                        "ALTER TABLE \"schema_base\".base_table DROP CONSTRAINT fk_base_ref2"]
         "derby"      | ["ALTER TABLE schema_base.base_table DROP CONSTRAINT fk_base_ref1",
                         "ALTER TABLE schema_base.base_table DROP CONSTRAINT fk_base_ref2"]
         "firebird"   | ["ALTER TABLE base_table DROP CONSTRAINT fk_base_ref1",

--- a/liquibase-core/src/test/groovy/liquibase/change/core/DropAllForeignKeyConstraintsChangeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/core/DropAllForeignKeyConstraintsChangeTest.groovy
@@ -129,8 +129,8 @@ class DropAllForeignKeyConstraintsChangeTest extends Specification {
                         "ALTER TABLE schema_base.base_table DROP CONSTRAINT fk_base_ref2"]
         "asany"      | ["ALTER TABLE schema_base.base_table DROP FOREIGN KEY fk_base_ref1",
                         "ALTER TABLE schema_base.base_table DROP FOREIGN KEY fk_base_ref2"]
-        "sybase"     | ["ALTER TABLE [schema_base].[base_table] DROP CONSTRAINT [fk_base_ref1]",
-                        "ALTER TABLE [schema_base].[base_table] DROP CONSTRAINT [fk_base_ref2]"]
+        "sybase"     | ["ALTER TABLE schema_base.base_table DROP CONSTRAINT fk_base_ref1",
+                        "ALTER TABLE schema_base.base_table DROP CONSTRAINT fk_base_ref2"]
 
 
     }

--- a/liquibase-core/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
@@ -49,14 +49,7 @@ public class LoadDataChangeTest extends StandardChangeTest {
 
         SqlStatement[] sqlStatement = refactoring.generateStatements(mssqlDb);
         then:
-        sqlStatement.length == 1
-        assert sqlStatement[0] instanceof InsertSetStatement
-
-        when:
-        SqlStatement[] sqlStatements = ((InsertSetStatement)sqlStatement[0]).getStatementsArray();
-
-        then:
-        sqlStatements.length == 0
+        sqlStatement.length == 0
     }
 
     def "loadDataEmpty not using InsertSetStatement"() throws Exception {

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addAutoIncrement/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addAutoIncrement/sybase.sql
@@ -2,4 +2,4 @@
 -- Change Parameter: columnDataType=int
 -- Change Parameter: columnName=id
 -- Change Parameter: tableName=person
-ALTER TABLE [person] MODIFY [id] INT IDENTITY;
+ALTER TABLE person MODIFY id INT IDENTITY;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addColumn/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addColumn/sybase.sql
@@ -4,4 +4,4 @@
 --     type="int"
 -- ], ]
 -- Change Parameter: tableName=person
-ALTER TABLE [person] ADD [id] INT NULL;
+ALTER TABLE person ADD id INT NULL;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addDefaultValue/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addDefaultValue/sybase.sql
@@ -2,4 +2,4 @@
 -- Change Parameter: columnName=fileName
 -- Change Parameter: defaultValue=Something Else
 -- Change Parameter: tableName=file
-ALTER TABLE [file] REPLACE [fileName] DEFAULT 'Something Else';
+ALTER TABLE file REPLACE fileName DEFAULT 'Something Else';

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addForeignKeyConstraint/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addForeignKeyConstraint/sybase.sql
@@ -4,4 +4,4 @@
 -- Change Parameter: constraintName=fk_address_person
 -- Change Parameter: referencedColumnNames=id
 -- Change Parameter: referencedTableName=person
-ALTER TABLE [address] ADD CONSTRAINT [fk_address_person] FOREIGN KEY ([person_id]) REFERENCES [person] ([id]);
+ALTER TABLE address ADD CONSTRAINT fk_address_person FOREIGN KEY (person_id) REFERENCES person (id);

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addLookupTable/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addLookupTable/sybase.sql
@@ -3,7 +3,7 @@
 -- Change Parameter: existingTableName=address
 -- Change Parameter: newColumnName=abbreviation
 -- Change Parameter: newTableName=state
-CREATE TABLE [state] AS SELECT DISTINCT [state] AS [abbreviation] FROM [address] WHERE [state] IS NOT NULL;
-ALTER TABLE [state] MODIFY [abbreviation] NOT NULL;
-ALTER TABLE [state] ADD PRIMARY KEY ([abbreviation]);
-ALTER TABLE [address] ADD CONSTRAINT [FK_ADDRESS_STATE] FOREIGN KEY ([state]) REFERENCES [state] ([abbreviation]);
+CREATE TABLE state AS SELECT DISTINCT state AS abbreviation FROM address WHERE state IS NOT NULL;
+ALTER TABLE state MODIFY abbreviation NOT NULL;
+ALTER TABLE state ADD PRIMARY KEY (abbreviation);
+ALTER TABLE address ADD CONSTRAINT FK_ADDRESS_STATE FOREIGN KEY (state) REFERENCES state (abbreviation);

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addNotNullConstraint/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addNotNullConstraint/sybase.sql
@@ -1,4 +1,4 @@
 -- Database: sybase
 -- Change Parameter: columnName=id
 -- Change Parameter: tableName=person
-ALTER TABLE [person] MODIFY [id] NOT NULL;
+ALTER TABLE person MODIFY id NOT NULL;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addPrimaryKey/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addPrimaryKey/sybase.sql
@@ -1,4 +1,4 @@
 -- Database: sybase
 -- Change Parameter: columnNames=id, name
 -- Change Parameter: tableName=person
-ALTER TABLE [person] ADD PRIMARY KEY ([id], [name]);
+ALTER TABLE person ADD PRIMARY KEY (id, name);

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addUniqueConstraint/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addUniqueConstraint/sybase.sql
@@ -1,4 +1,4 @@
 -- Database: sybase
 -- Change Parameter: columnNames=id, name
 -- Change Parameter: tableName=person
-ALTER TABLE [person] ADD UNIQUE ([id], [name]);
+ALTER TABLE person ADD UNIQUE (id, name);

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/createIndex/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/createIndex/sybase.sql
@@ -4,4 +4,4 @@
 --     type="int"
 -- ], ]
 -- Change Parameter: tableName=person
-CREATE INDEX ON [person]([id]);
+CREATE INDEX ON person(id);

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/createTable/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/createTable/sybase.sql
@@ -4,4 +4,4 @@
 --     type="int"
 -- ], ]
 -- Change Parameter: tableName=person
-CREATE TABLE [person] ([id] INT NULL);
+CREATE TABLE person (id INT NULL);

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/createView/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/createView/sybase.sql
@@ -1,4 +1,4 @@
 -- Database: sybase
 -- Change Parameter: selectQuery=select id, name from person where id > 10
 -- Change Parameter: viewName=v_person
-CREATE VIEW [v_person] AS select id, name from person where id > 10;
+CREATE VIEW v_person AS select id, name from person where id > 10;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/delete/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/delete/sybase.sql
@@ -1,3 +1,3 @@
 -- Database: sybase
 -- Change Parameter: tableName=person
-DELETE FROM [person];
+DELETE FROM person;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropColumn/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropColumn/sybase.sql
@@ -1,4 +1,4 @@
 -- Database: sybase
 -- Change Parameter: columnName=id
 -- Change Parameter: tableName=person
-ALTER TABLE [person] DROP [id];
+ALTER TABLE person DROP id;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropDefaultValue/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropDefaultValue/sybase.sql
@@ -1,4 +1,4 @@
 -- Database: sybase
 -- Change Parameter: columnName=id
 -- Change Parameter: tableName=person
-ALTER TABLE [person] REPLACE [id] DEFAULT NULL;
+ALTER TABLE person REPLACE id DEFAULT NULL;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropForeignKeyConstraint/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropForeignKeyConstraint/sybase.sql
@@ -1,4 +1,4 @@
 -- Database: sybase
 -- Change Parameter: baseTableName=person
 -- Change Parameter: constraintName=fk_address_person
-ALTER TABLE [person] DROP CONSTRAINT [fk_address_person];
+ALTER TABLE person DROP CONSTRAINT fk_address_person;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropNotNullConstraint/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropNotNullConstraint/sybase.sql
@@ -1,4 +1,4 @@
 -- Database: sybase
 -- Change Parameter: columnName=id
 -- Change Parameter: tableName=person
-ALTER TABLE [person] MODIFY [id] NULL;
+ALTER TABLE person MODIFY id NULL;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropPrimaryKey/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropPrimaryKey/sybase.sql
@@ -1,4 +1,4 @@
 -- Database: sybase
 -- Change Parameter: constraintName=const_name
 -- Change Parameter: tableName=person
-ALTER TABLE [person] DROP CONSTRAINT [const_name];
+ALTER TABLE person DROP CONSTRAINT const_name;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropProcedure/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropProcedure/sybase.sql
@@ -1,3 +1,3 @@
 -- Database: sybase
 -- Change Parameter: procedureName=new_customer
-DROP PROCEDURE [new_customer];
+DROP PROCEDURE new_customer;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropTable/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropTable/sybase.sql
@@ -1,3 +1,3 @@
 -- Database: sybase
 -- Change Parameter: tableName=person
-DROP TABLE [person];
+DROP TABLE person;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropUniqueConstraint/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropUniqueConstraint/sybase.sql
@@ -1,4 +1,4 @@
 -- Database: sybase
 -- Change Parameter: constraintName=const_name
 -- Change Parameter: tableName=person
-ALTER TABLE [person] DROP CONSTRAINT [const_name];
+ALTER TABLE person DROP CONSTRAINT const_name;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropView/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropView/sybase.sql
@@ -1,3 +1,3 @@
 -- Database: sybase
 -- Change Parameter: viewName=v_person
-DROP VIEW [v_person];
+DROP VIEW v_person;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/insert/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/insert/sybase.sql
@@ -4,4 +4,4 @@
 --     type="int"
 -- ], ]
 -- Change Parameter: tableName=person
-INSERT INTO [person] ([id]) VALUES (NULL);
+INSERT INTO person (id) VALUES (NULL);

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/loadData/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/loadData/sybase.sql
@@ -5,5 +5,5 @@
 -- ], ]
 -- Change Parameter: file=com/example/users.csv
 -- Change Parameter: tableName=person
-INSERT INTO [person] ([username], [ fullname]) VALUES ('nvoxland', ' Nathan Voxland');
-INSERT INTO [person] ([username], [ fullname]) VALUES ('bob', ' Bob Bobson');
+INSERT INTO person (username,  fullname) VALUES ('nvoxland', ' Nathan Voxland');
+INSERT INTO [person] (username,  fullname) VALUES ('bob', ' Bob Bobson');

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/mergeColumns/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/mergeColumns/sybase.sql
@@ -4,7 +4,7 @@
 -- Change Parameter: finalColumnName=full_name
 -- Change Parameter: finalColumnType=varchar(255)
 -- Change Parameter: tableName=person
-ALTER TABLE [person] ADD [full_name] VARCHAR(255) NULL;
-UPDATE [person] SET [full_name] = [first_name] + 'null' + [last_name];
-ALTER TABLE [person] DROP [first_name];
-ALTER TABLE [person] DROP [last_name];
+ALTER TABLE person ADD full_name VARCHAR(255) NULL;
+UPDATE person SET full_name = first_name + 'null' + last_name;
+ALTER TABLE person DROP first_name;
+ALTER TABLE person DROP last_name;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/modifyDataType/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/modifyDataType/sybase.sql
@@ -2,4 +2,4 @@
 -- Change Parameter: columnName=id
 -- Change Parameter: newDataType=int
 -- Change Parameter: tableName=person
-ALTER TABLE [person] MODIFY [id] INT;
+ALTER TABLE person MODIFY id INT;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/renameView/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/renameView/sybase.sql
@@ -1,4 +1,4 @@
 -- Database: sybase
 -- Change Parameter: newViewName=v_person
 -- Change Parameter: oldViewName=v_person
-RENAME [v_person] TO [v_person];
+RENAME v_person TO v_person;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/update/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/update/sybase.sql
@@ -4,4 +4,4 @@
 --     type="int"
 -- ], ]
 -- Change Parameter: tableName=person
-UPDATE [person] SET [id] = NULL;
+UPDATE person SET id = NULL;

--- a/liquibase-debian/pom.xml
+++ b/liquibase-debian/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-parent</artifactId>
-        <version>3.6.0-SNAPSHOT</version>
+        <version>3.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>liquibase-debian</artifactId>

--- a/liquibase-integration-tests/src/test/java/liquibase/statementexecute/AddUniqueConstraintExecutorTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/statementexecute/AddUniqueConstraintExecutorTest.java
@@ -155,6 +155,7 @@ public class AddUniqueConstraintExecutorTest extends AbstractExecuteTest {
         assertCorrect("alter table [adduqtest] add constraint [uq_test] unique ([coltomakeuq])", FirebirdDatabase.class);
 
         assertCorrect("alter table [liquibaseb].[adduqtest] add constraint [uq_test] unique ([coltomakeuq])", HsqlDatabase.class);
+        assertCorrect("alter table \"liquibasec\".[adduqtest] add constraint [uq_test] unique ([coltomakeuq])", DB2Database.class, Db2zDatabase.class);
         assertCorrectOnRest("alter table [liquibasec].[adduqtest] add constraint [uq_test] unique ([coltomakeuq])");
 
     }

--- a/liquibase-integration-tests/src/test/java/liquibase/statementexecute/AddUniqueConstraintExecutorTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/statementexecute/AddUniqueConstraintExecutorTest.java
@@ -187,7 +187,7 @@ public class AddUniqueConstraintExecutorTest extends AbstractExecuteTest {
         assertCorrect("alter table adduqtest add constraint uq_test unique (coltomakeuq) DEFERRABLE INITIALLY " +
                 "DEFERRED DISABLE", OracleDatabase.class);
         assertCorrect("ALTER TABLE \"adduqtest\" ADD CONSTRAINT uq_test unique (\"coltomakeuq\") DEFERRABLE INITIALLY" +
-                " DEFERRED DISABLE", PostgresDatabase.class);
+                " DEFERRED", PostgresDatabase.class);
         assertCorrect("alter table adduqtest add constraint uq_test unique (coltomakeuq)", DerbyDatabase.class);
         assertCorrect("alter table [adduqtest] add constraint [uq_test] unique ([coltomakeuq])");
     }

--- a/liquibase-integration-tests/src/test/resources/changelogs/h2/complete/dbms.exclude.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/h2/complete/dbms.exclude.changelog.xml
@@ -9,7 +9,7 @@
     <dbms type="h2"/>
   </preConditions>
 
-  <changeSet id="1" author="dbiggs" dbms="!oracle">
+  <changeSet id="1" author="dbiggs" dbms="h2">
     <createTable tableName="testDbmsExclude">
       <column name="sampleField" type="varchar(50)"/>
     </createTable>

--- a/liquibase-rpm/pom.xml
+++ b/liquibase-rpm/pom.xml
@@ -6,11 +6,10 @@
 	<parent>
 		<groupId>org.liquibase</groupId>
 		<artifactId>liquibase-parent</artifactId>
-		<version>3.6.0-SNAPSHOT</version>
+		<version>3.6.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>liquibase-rpm</artifactId>
-    <version>3.6.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
     <url>http://www.liquibase.org/</url>
 


### PR DESCRIPTION
https://liquibase.jira.com/browse/CORE-3206
Note: this is a PR for 3.6.x since that seems to be the most recent codebase. The relevant commits (all but the POM changes) should be easy to apply to master as well.

- Modified get/setTable methods in UniqueConstraint and Index to once again concern only Table-objects so the code would be backwards compatible with code written or compiled against 3.5.x versions of liquibase.
- Added a get/setRelation method that concerned Relation-objects but uses the same attributename as get/setTable because this seems to be part of the public API (at least, the get/setAttribute methods are public and I couldn't be sure who would be depending upon the exact attributename being used).
- Deprecated get/setTable, made sure it called the respective Relation method.
- Rewrote all internal code to work with get/setRelation

- Fixed the version numbers in the POMs for the submodules so maven would want to build this project.
- Fixed a bunch of unrelated tests that failed due to earlier changes in the code base, either merge errors that restored old code or changes in the code base that hadn't updated the related tests.