### PR TITLE
CORE-3211: Firebird does not support RESTRICT option on Foreign Keys

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddForeignKeyConstraintGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddForeignKeyConstraintGenerator.java
@@ -62,9 +62,9 @@ public class AddForeignKeyConstraintGenerator extends AbstractSqlGenerator<AddFo
                 //don't use
 		    } else if (database instanceof InformixDatabase) {
 			    //TODO don't know if correct
-            } else if ((database instanceof FirebirdDatabase) && "RESTRICT".equalsIgnoreCase(statement.getOnUpdate())) {
-                //don't use
-            } else {
+		    } else if ((database instanceof FirebirdDatabase) && "RESTRICT".equalsIgnoreCase(statement.getOnUpdate())) {
+			    //don't use
+		    } else {
 			    sb.append(" ON UPDATE ").append(statement.getOnUpdate());
 		    }
 	    }

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddForeignKeyConstraintGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddForeignKeyConstraintGenerator.java
@@ -62,7 +62,9 @@ public class AddForeignKeyConstraintGenerator extends AbstractSqlGenerator<AddFo
                 //don't use
 		    } else if (database instanceof InformixDatabase) {
 			    //TODO don't know if correct
-		    } else {
+            } else if ((database instanceof FirebirdDatabase) && "RESTRICT".equalsIgnoreCase(statement.getOnUpdate())) {
+                //don't use
+            } else {
 			    sb.append(" ON UPDATE ").append(statement.getOnUpdate());
 		    }
 	    }
@@ -76,6 +78,8 @@ public class AddForeignKeyConstraintGenerator extends AbstractSqlGenerator<AddFo
             } else if ((database instanceof InformixDatabase) && !("CASCADE".equalsIgnoreCase(statement.getOnDelete()))) {
                 //TODO Informix can handle ON DELETE CASCADE only, but I don't know if this is really correct
                 // see "REFERENCES Clause" in manual
+            } else if ((database instanceof FirebirdDatabase) && "RESTRICT".equalsIgnoreCase(statement.getOnDelete())) {
+                //don't use
             } else {
                 sb.append(" ON DELETE ").append(statement.getOnDelete());
             }


### PR DESCRIPTION
fix to leave out the onUpdate and onDelete part of foreign keys, when running on Firebird and RESTRICT is used.