### PR TITLE
[CORE-3213] includeAll will not find child changelogs in multi-modues Spring Boot's executable JAR

### DIFF
--- a/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
@@ -14,6 +14,7 @@ import java.net.*;
 import java.util.*;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.jar.JarInputStream;
 
 /**
  * An implementation of {@link liquibase.resource.ResourceAccessor} that wraps a class loader.
@@ -60,19 +61,23 @@ public class ClassLoaderResourceAccessor extends AbstractResourceAccessor {
 
     @Override
     public Set<String> list(String relativeTo, String path, boolean includeFiles, boolean includeDirectories, boolean recursive) throws IOException {
-        path = convertToPath(relativeTo, path);
+        String sanitizePath = convertToPath(relativeTo, path);
 
-        Enumeration<URL> fileUrls = classLoader.getResources(path);
+        Enumeration<URL> fileUrls = classLoader.getResources(sanitizePath);
 
         Set<String> returnSet = new HashSet<>();
 
-        if (!fileUrls.hasMoreElements() && (path.startsWith("jar:") || path.startsWith("file:") || path.startsWith("wsjar:file:") || path.startsWith("zip:"))) {
-            fileUrls = new Vector<>(Arrays.asList(new URL(path))).elements();
+        if (!fileUrls.hasMoreElements() && (sanitizePath.startsWith("jar:") || sanitizePath.startsWith("file:") || sanitizePath.startsWith("wsjar:file:") || sanitizePath.startsWith("zip:"))) {
+            fileUrls = new Vector<>(Arrays.asList(new URL(sanitizePath))).elements();
         }
 
+        // Improve speed by removing duplicate file returned by getResources
+        Set<URL> elements = new HashSet<>();
         while (fileUrls.hasMoreElements()) {
-            URL fileUrl = fileUrls.nextElement();
+            elements.add(fileUrls.nextElement());
+        }
 
+        for (URL fileUrl : elements) {
             if (fileUrl.toExternalForm().startsWith("jar:file:")
                     || fileUrl.toExternalForm().startsWith("wsjar:file:")
                     || fileUrl.toExternalForm().startsWith("zip:")) {
@@ -86,12 +91,12 @@ public class ClassLoaderResourceAccessor extends AbstractResourceAccessor {
                 }
                 zipFilePath = URLDecoder.decode(zipFilePath, LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).getOutputEncoding());
 
-                path = SpringBootFatJar.getPathForResource(path);
-                if (path.startsWith("classpath:")) {
-                    path = path.replaceFirst("classpath:", "");
+                sanitizePath = SpringBootFatJar.getPathForResource(sanitizePath);
+                if (sanitizePath.startsWith("classpath:")) {
+                    sanitizePath = sanitizePath.replaceFirst("classpath:", "");
                 }
-                if (path.startsWith("classpath*:")) {
-                    path = path.replaceFirst("classpath\\*:", "");
+                if (sanitizePath.startsWith("classpath*:")) {
+                    sanitizePath = sanitizePath.replaceFirst("classpath\\*:", "");
                 }
 
                 // TODO:When we update to Java 7+, we can can create a FileSystem from the JAR (zip)
@@ -108,12 +113,10 @@ public class ClassLoaderResourceAccessor extends AbstractResourceAccessor {
                     while (entries.hasMoreElements()) {
                         JarEntry entry = entries.nextElement();
 
-                        if (entry.getName().startsWith(path)) {
+                        if (entry.getName().startsWith(sanitizePath)) {
 
                             if (!recursive) {
-                                String pathAsDir = path.endsWith("/")
-                                        ? path
-                                        : path + "/";
+                                String pathAsDir = sanitizePath.endsWith("/") ? sanitizePath : sanitizePath + "/";
                                 if (!entry.getName().startsWith(pathAsDir)
                                  || entry.getName().substring(pathAsDir.length()).contains("/")) {
                                     continue;
@@ -123,7 +126,28 @@ public class ClassLoaderResourceAccessor extends AbstractResourceAccessor {
                             if (entry.isDirectory() && includeDirectories) {
                                 returnSet.add(entry.getName());
                             } else if (includeFiles) {
-                                returnSet.add(entry.getName());
+                                String returnPath = SpringBootFatJar.getSimplePathForResources(entry.getName(), path);
+                                // Find changelog inside nested jar
+                                if (entry.getName().endsWith(".jar")) {
+                                    JarInputStream jarIS = null;
+                                    try {
+                                        jarIS = new JarInputStream(zipfile.getInputStream(entry));
+
+                                        JarEntry nestedEntry = jarIS.getNextJarEntry();
+                                        while (nestedEntry != null) {
+                                            if (nestedEntry.getName().startsWith(returnPath)) {
+                                                returnSet.add(nestedEntry.getName());
+                                            }
+                                            nestedEntry = jarIS.getNextJarEntry();
+                                        }
+                                    } finally {
+                                        if (jarIS != null) {
+                                            jarIS.close();
+                                        }
+                                    }
+                                } else {
+                                    returnSet.add(returnPath);
+                                }
                             }
                         }
                     }
@@ -134,18 +158,18 @@ public class ClassLoaderResourceAccessor extends AbstractResourceAccessor {
                 try {
                     File file = new File(fileUrl.toURI());
                     if (file.exists()) {
-                        getContents(file, recursive, includeFiles, includeDirectories, path, returnSet);
+                        getContents(file, recursive, includeFiles, includeDirectories, sanitizePath, returnSet);
                     }
                 } catch (URISyntaxException | IllegalArgumentException e) {
                     //not a local file
                 }
             }
 
-            Enumeration<URL> resources = classLoader.getResources(path);
+            Enumeration<URL> resources = classLoader.getResources(sanitizePath);
 
             while (resources.hasMoreElements()) {
                 String url = resources.nextElement().toExternalForm();
-                url = url.replaceFirst("^\\Q" + path + "\\E", "");
+                url = url.replaceFirst("^\\Q" + sanitizePath + "\\E", "");
                 returnSet.add(url);
             }
         }

--- a/liquibase-core/src/main/java/liquibase/util/SpringBootFatJar.java
+++ b/liquibase-core/src/main/java/liquibase/util/SpringBootFatJar.java
@@ -1,12 +1,34 @@
 package liquibase.util;
 
 public class SpringBootFatJar {
+
     public static String getPathForResource(String path) {
         String[] components = path.split("!");
         if (components.length == 3) {
+            if (components[1].endsWith(".jar")){
+                return components[1].substring(1);
+            }
             return String.format("%s%s", components[1].substring(1), components[2]);
-        } else {
-            return path;
         }
+        return path;
+    }
+
+    /**
+     * Method used to simplify an entryName
+     *
+     * Ex: with path jar:/some/jar.jar!/BOOT-INF/classes!/db/changelog and entryName /BOOT-INF/classes/db/changelog
+     * The simple entry name for Spring is db/changelog
+     * (/BOOT-INF/classes/ is not needed and break the liquibase alphabetical sort order)
+     *
+     * @param entryName the entryName to simplify
+     * @param path file path
+     * @return the simple path
+     */
+    public static String getSimplePathForResources(String entryName, String path) {
+        String[] components = path.split("!");
+        if (components.length == 3) {
+            return entryName.replaceFirst(components[1],"").substring(1);
+        }
+        return entryName;
     }
 }

--- a/liquibase-core/src/test/java/liquibase/util/SpringBootFatJarTest.java
+++ b/liquibase-core/src/test/java/liquibase/util/SpringBootFatJarTest.java
@@ -8,12 +8,30 @@ public class SpringBootFatJarTest {
     @Test
     public void testGetPathForResourceWithFatJarPath() {
         String result = SpringBootFatJar.getPathForResource("some/path!/that/has!/two/bangs");
-        assertEquals(result, "that/has/two/bangs");
+        assertEquals("that/has/two/bangs", result);
+    }
+
+    @Test
+    public void testGetPathForNestedJarResourceWithFatJarPath() {
+        String result = SpringBootFatJar.getPathForResource("some/path!/that/has/jar.jar!/one/bangs");
+        assertEquals("that/has/jar.jar", result);
     }
 
     @Test
     public void testGetPathForResourceWithSimplePath() {
         String result = SpringBootFatJar.getPathForResource("some/path!/that/has/one/bang");
-        assertEquals(result, "some/path!/that/has/one/bang");
+        assertEquals("some/path!/that/has/one/bang", result);
+    }
+
+    @Test
+    public void testGetSimplePathForResourceWithFatJarPath() {
+        String result = SpringBootFatJar.getSimplePathForResources("/that/has/two/bangs/entryname","some/path!/that/has!/two/bangs");
+        assertEquals("two/bangs/entryname", result);
+    }
+
+    @Test
+    public void testGetSimplePathForResourceWithSimplePath() {
+        String result = SpringBootFatJar.getSimplePathForResources("/that/has/one/bang","some/path!/that/has/one/bang");
+        assertEquals("/that/has/one/bang", result);
     }
 }


### PR DESCRIPTION
Fixes https://liquibase.jira.com/browse/CORE-3213

Fixes IncludeAll in multi-modues Spring Boot's executable JAR
Remove duplicate URL to improve speed of liquibase
Avoid reuse path variable