### PR TITLE
Fixes for broken UT & IT tests and for YAML changing timestamp values

### DIFF
--- a/liquibase-core/src/test/groovy/liquibase/change/core/DropAllForeignKeyConstraintsChangeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/core/DropAllForeignKeyConstraintsChangeTest.groovy
@@ -129,8 +129,8 @@ class DropAllForeignKeyConstraintsChangeTest extends Specification {
                         "ALTER TABLE schema_base.base_table DROP CONSTRAINT fk_base_ref2"]
         "asany"      | ["ALTER TABLE schema_base.base_table DROP FOREIGN KEY fk_base_ref1",
                         "ALTER TABLE schema_base.base_table DROP FOREIGN KEY fk_base_ref2"]
-        "sybase"     | ["ALTER TABLE [schema_base].[base_table] DROP CONSTRAINT [fk_base_ref1]",
-                        "ALTER TABLE [schema_base].[base_table] DROP CONSTRAINT [fk_base_ref2]"]
+        "sybase"     | ["ALTER TABLE schema_base.base_table DROP CONSTRAINT fk_base_ref1",
+                        "ALTER TABLE schema_base.base_table DROP CONSTRAINT fk_base_ref2"]
 
 
     }

--- a/liquibase-core/src/test/groovy/liquibase/change/core/DropAllForeignKeyConstraintsChangeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/core/DropAllForeignKeyConstraintsChangeTest.groovy
@@ -106,14 +106,14 @@ class DropAllForeignKeyConstraintsChangeTest extends Specification {
         DatabaseFactory.reset()
 
         where:
-        shortDbName  | expectedValue
-        "db2"        | ["ALTER TABLE schema_base.base_table DROP CONSTRAINT fk_base_ref1",
+        shortDbName | expectedValue
+        "db2"       | ["ALTER TABLE \"schema_base\".base_table DROP CONSTRAINT fk_base_ref1",
+                       "ALTER TABLE \"schema_base\".base_table DROP CONSTRAINT fk_base_ref2"]
+        "derby"     | ["ALTER TABLE schema_base.base_table DROP CONSTRAINT fk_base_ref1",
                         "ALTER TABLE schema_base.base_table DROP CONSTRAINT fk_base_ref2"]
-        "derby"      | ["ALTER TABLE schema_base.base_table DROP CONSTRAINT fk_base_ref1",
-                        "ALTER TABLE schema_base.base_table DROP CONSTRAINT fk_base_ref2"]
-        "firebird"   | ["ALTER TABLE base_table DROP CONSTRAINT fk_base_ref1",
+        "firebird"  | ["ALTER TABLE base_table DROP CONSTRAINT fk_base_ref1",
                         "ALTER TABLE base_table DROP CONSTRAINT fk_base_ref2"]
-        "h2"         | ["ALTER TABLE schema_base.base_table DROP CONSTRAINT fk_base_ref1",
+        "h2"        | ["ALTER TABLE schema_base.base_table DROP CONSTRAINT fk_base_ref1",
                         "ALTER TABLE schema_base.base_table DROP CONSTRAINT fk_base_ref2"]
         "hsqldb"     | ["ALTER TABLE schema_base.base_table DROP CONSTRAINT fk_base_ref1",
                         "ALTER TABLE schema_base.base_table DROP CONSTRAINT fk_base_ref2"]

--- a/liquibase-core/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
@@ -1,10 +1,9 @@
 package liquibase.change.core
+
 import liquibase.change.ChangeStatus
 import liquibase.change.StandardChangeTest
 import liquibase.changelog.ChangeSet
-import liquibase.database.DatabaseConnection
 import liquibase.database.DatabaseFactory
-import liquibase.database.OfflineConnection
 import liquibase.database.core.MSSQLDatabase
 import liquibase.parser.core.ParsedNodeException
 import liquibase.resource.ClassLoaderResourceAccessor
@@ -49,14 +48,7 @@ public class LoadDataChangeTest extends StandardChangeTest {
 
         SqlStatement[] sqlStatement = refactoring.generateStatements(mssqlDb);
         then:
-        sqlStatement.length == 1
-        assert sqlStatement[0] instanceof InsertSetStatement
-
-        when:
-        SqlStatement[] sqlStatements = ((InsertSetStatement)sqlStatement[0]).getStatementsArray();
-
-        then:
-        sqlStatements.length == 0
+        sqlStatement.length == 0
     }
 
     def "loadDataEmpty not using InsertSetStatement"() throws Exception {

--- a/liquibase-core/src/test/java/liquibase/serializer/core/json/JsonChangeLogSerializerTest.java
+++ b/liquibase-core/src/test/java/liquibase/serializer/core/json/JsonChangeLogSerializerTest.java
@@ -9,22 +9,15 @@ import liquibase.precondition.core.PreconditionContainer.FailOption;
 import liquibase.precondition.core.PreconditionContainer.OnSqlOutputOption;
 import liquibase.statement.DatabaseFunction;
 import liquibase.statement.SequenceNextValueFunction;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Date;
+import java.util.Calendar;
 
 import static org.junit.Assert.assertEquals;
 
 public class JsonChangeLogSerializerTest {
 
     private String origTimeZone =  System.getProperty("user.timezone");
-
-    @Before
-    public void setTimeZoneToUTC() {
-        System.setProperty("user.timezone", "UTC");
-    }
 
     @Test
     public void serialize_changeSet() {
@@ -34,7 +27,14 @@ public class JsonChangeLogSerializerTest {
         addColumnChange.addColumn((AddColumnConfig) new AddColumnConfig().setName("col1").setDefaultValueNumeric(3));
         addColumnChange.addColumn((AddColumnConfig) new AddColumnConfig().setName("col2").setDefaultValueComputed(new DatabaseFunction("NOW()")));
         addColumnChange.addColumn((AddColumnConfig) new AddColumnConfig().setName("col3").setDefaultValueBoolean(true));
-        addColumnChange.addColumn((AddColumnConfig) new AddColumnConfig().setName("col2").setDefaultValueDate(new Date(0)));
+
+        // Get the Date object for 1970-01-01T00:00:00 in the current time zone.
+        Calendar cal = Calendar.getInstance();
+        cal.setTimeInMillis(0);
+        cal.set(1970, 0, 1, 0, 0, 0);
+
+        addColumnChange.addColumn((AddColumnConfig) new AddColumnConfig().setName("col2").setDefaultValueDate(
+                cal.getTime()));
         addColumnChange.addColumn((AddColumnConfig) new AddColumnConfig().setName("col2").setDefaultValueSequenceNext(new SequenceNextValueFunction("seq_me")));
         ChangeSet changeSet = new ChangeSet("1", "nvoxland", false, false, "path/to/file.json", null, null, null);
         changeSet.setPreconditions(newSamplePreconditions());
@@ -117,10 +117,5 @@ public class JsonChangeLogSerializerTest {
         nestedPrecondition.setOnSqlOutput(OnSqlOutputOption.TEST);
         precondition.addNestedPrecondition(nestedPrecondition);
         return precondition;
-    }
-
-    @After
-    public void setTimeZoneBackToDefault() {
-        System.setProperty("user.timezone", origTimeZone);
     }
 }

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addAutoIncrement/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addAutoIncrement/sybase.sql
@@ -2,4 +2,4 @@
 -- Change Parameter: columnDataType=int
 -- Change Parameter: columnName=id
 -- Change Parameter: tableName=person
-ALTER TABLE [person] MODIFY [id] INT IDENTITY;
+ALTER TABLE person MODIFY id INT IDENTITY;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addColumn/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addColumn/sybase.sql
@@ -4,4 +4,4 @@
 --     type="int"
 -- ], ]
 -- Change Parameter: tableName=person
-ALTER TABLE [person] ADD [id] INT NULL;
+ALTER TABLE person ADD id INT NULL;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addDefaultValue/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addDefaultValue/sybase.sql
@@ -2,4 +2,4 @@
 -- Change Parameter: columnName=fileName
 -- Change Parameter: defaultValue=Something Else
 -- Change Parameter: tableName=file
-ALTER TABLE [file] REPLACE [fileName] DEFAULT 'Something Else';
+ALTER TABLE file REPLACE fileName DEFAULT 'Something Else';

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addForeignKeyConstraint/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addForeignKeyConstraint/sybase.sql
@@ -4,4 +4,4 @@
 -- Change Parameter: constraintName=fk_address_person
 -- Change Parameter: referencedColumnNames=id
 -- Change Parameter: referencedTableName=person
-ALTER TABLE [address] ADD CONSTRAINT [fk_address_person] FOREIGN KEY ([person_id]) REFERENCES [person] ([id]);
+ALTER TABLE address ADD CONSTRAINT fk_address_person FOREIGN KEY (person_id) REFERENCES person (id);

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addLookupTable/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addLookupTable/sybase.sql
@@ -3,7 +3,7 @@
 -- Change Parameter: existingTableName=address
 -- Change Parameter: newColumnName=abbreviation
 -- Change Parameter: newTableName=state
-CREATE TABLE [state] AS SELECT DISTINCT [state] AS [abbreviation] FROM [address] WHERE [state] IS NOT NULL;
-ALTER TABLE [state] MODIFY [abbreviation] NOT NULL;
-ALTER TABLE [state] ADD PRIMARY KEY ([abbreviation]);
-ALTER TABLE [address] ADD CONSTRAINT [FK_ADDRESS_STATE] FOREIGN KEY ([state]) REFERENCES [state] ([abbreviation]);
+CREATE TABLE state AS SELECT DISTINCT state AS abbreviation FROM address WHERE state IS NOT NULL;
+ALTER TABLE state MODIFY abbreviation NOT NULL;
+ALTER TABLE state ADD PRIMARY KEY (abbreviation);
+ALTER TABLE address ADD CONSTRAINT FK_ADDRESS_STATE FOREIGN KEY (state) REFERENCES state (abbreviation);

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addNotNullConstraint/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addNotNullConstraint/sybase.sql
@@ -1,4 +1,4 @@
 -- Database: sybase
 -- Change Parameter: columnName=id
 -- Change Parameter: tableName=person
-ALTER TABLE [person] MODIFY [id] NOT NULL;
+ALTER TABLE person MODIFY id NOT NULL;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addPrimaryKey/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addPrimaryKey/sybase.sql
@@ -1,4 +1,4 @@
 -- Database: sybase
 -- Change Parameter: columnNames=id, name
 -- Change Parameter: tableName=person
-ALTER TABLE [person] ADD PRIMARY KEY ([id], [name]);
+ALTER TABLE person ADD PRIMARY KEY (id, name);

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addUniqueConstraint/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addUniqueConstraint/sybase.sql
@@ -1,4 +1,4 @@
 -- Database: sybase
 -- Change Parameter: columnNames=id, name
 -- Change Parameter: tableName=person
-ALTER TABLE [person] ADD UNIQUE ([id], [name]);
+ALTER TABLE person ADD UNIQUE (id, name);

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/createIndex/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/createIndex/sybase.sql
@@ -4,4 +4,4 @@
 --     type="int"
 -- ], ]
 -- Change Parameter: tableName=person
-CREATE INDEX ON [person]([id]);
+CREATE INDEX ON person(id);

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/createTable/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/createTable/sybase.sql
@@ -4,4 +4,4 @@
 --     type="int"
 -- ], ]
 -- Change Parameter: tableName=person
-CREATE TABLE [person] ([id] INT NULL);
+CREATE TABLE person (id INT NULL);

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/createView/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/createView/sybase.sql
@@ -1,4 +1,4 @@
 -- Database: sybase
 -- Change Parameter: selectQuery=select id, name from person where id > 10
 -- Change Parameter: viewName=v_person
-CREATE VIEW [v_person] AS select id, name from person where id > 10;
+CREATE VIEW v_person AS select id, name from person where id > 10;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/delete/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/delete/sybase.sql
@@ -1,3 +1,3 @@
 -- Database: sybase
 -- Change Parameter: tableName=person
-DELETE FROM [person];
+DELETE FROM person;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropColumn/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropColumn/sybase.sql
@@ -1,4 +1,4 @@
 -- Database: sybase
 -- Change Parameter: columnName=id
 -- Change Parameter: tableName=person
-ALTER TABLE [person] DROP [id];
+ALTER TABLE person DROP id;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropDefaultValue/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropDefaultValue/sybase.sql
@@ -1,4 +1,4 @@
 -- Database: sybase
 -- Change Parameter: columnName=id
 -- Change Parameter: tableName=person
-ALTER TABLE [person] REPLACE [id] DEFAULT NULL;
+ALTER TABLE person REPLACE id DEFAULT NULL;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropForeignKeyConstraint/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropForeignKeyConstraint/sybase.sql
@@ -1,4 +1,4 @@
 -- Database: sybase
 -- Change Parameter: baseTableName=person
 -- Change Parameter: constraintName=fk_address_person
-ALTER TABLE [person] DROP CONSTRAINT [fk_address_person];
+ALTER TABLE person DROP CONSTRAINT fk_address_person;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropNotNullConstraint/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropNotNullConstraint/sybase.sql
@@ -1,4 +1,4 @@
 -- Database: sybase
 -- Change Parameter: columnName=id
 -- Change Parameter: tableName=person
-ALTER TABLE [person] MODIFY [id] NULL;
+ALTER TABLE person MODIFY id NULL;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropPrimaryKey/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropPrimaryKey/sybase.sql
@@ -1,4 +1,4 @@
 -- Database: sybase
 -- Change Parameter: constraintName=const_name
 -- Change Parameter: tableName=person
-ALTER TABLE [person] DROP CONSTRAINT [const_name];
+ALTER TABLE person DROP CONSTRAINT const_name;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropProcedure/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropProcedure/sybase.sql
@@ -1,3 +1,3 @@
 -- Database: sybase
 -- Change Parameter: procedureName=new_customer
-DROP PROCEDURE [new_customer];
+DROP PROCEDURE new_customer;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropTable/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropTable/sybase.sql
@@ -1,3 +1,3 @@
 -- Database: sybase
 -- Change Parameter: tableName=person
-DROP TABLE [person];
+DROP TABLE person;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropUniqueConstraint/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropUniqueConstraint/sybase.sql
@@ -1,4 +1,4 @@
 -- Database: sybase
 -- Change Parameter: constraintName=const_name
 -- Change Parameter: tableName=person
-ALTER TABLE [person] DROP CONSTRAINT [const_name];
+ALTER TABLE person DROP CONSTRAINT const_name;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropView/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropView/sybase.sql
@@ -1,3 +1,3 @@
 -- Database: sybase
 -- Change Parameter: viewName=v_person
-DROP VIEW [v_person];
+DROP VIEW v_person;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/insert/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/insert/sybase.sql
@@ -4,4 +4,4 @@
 --     type="int"
 -- ], ]
 -- Change Parameter: tableName=person
-INSERT INTO [person] ([id]) VALUES (NULL);
+INSERT INTO person (id) VALUES (NULL);

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/loadData/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/loadData/sybase.sql
@@ -5,5 +5,5 @@
 -- ], ]
 -- Change Parameter: file=com/example/users.csv
 -- Change Parameter: tableName=person
-INSERT INTO [person] ([username], [ fullname]) VALUES ('nvoxland', ' Nathan Voxland');
-INSERT INTO [person] ([username], [ fullname]) VALUES ('bob', ' Bob Bobson');
+INSERT INTO person (username,  fullname) VALUES ('nvoxland', ' Nathan Voxland');
+INSERT INTO person (username,  fullname) VALUES ('bob', ' Bob Bobson');

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/loadUpdateData/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/loadUpdateData/sybase.sql
@@ -6,5 +6,5 @@
 -- Change Parameter: file=com/example/users.csv
 -- Change Parameter: primaryKey=pk_id
 -- Change Parameter: tableName=person
-INSERT INTO [person] ([username], [ fullname]) VALUES ('nvoxland', ' Nathan Voxland');
-INSERT INTO [person] ([username], [ fullname]) VALUES ('bob', ' Bob Bobson');
+INSERT INTO person (username,  fullname) VALUES ('nvoxland', ' Nathan Voxland');
+INSERT INTO person (username,  fullname) VALUES ('bob', ' Bob Bobson');

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/mergeColumns/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/mergeColumns/sybase.sql
@@ -4,7 +4,7 @@
 -- Change Parameter: finalColumnName=full_name
 -- Change Parameter: finalColumnType=varchar(255)
 -- Change Parameter: tableName=person
-ALTER TABLE [person] ADD [full_name] VARCHAR(255) NULL;
-UPDATE [person] SET [full_name] = [first_name] + 'null' + [last_name];
-ALTER TABLE [person] DROP [first_name];
-ALTER TABLE [person] DROP [last_name];
+ALTER TABLE person ADD full_name VARCHAR(255) NULL;
+UPDATE person SET full_name = first_name + 'null' + last_name;
+ALTER TABLE person DROP first_name;
+ALTER TABLE person DROP last_name;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/modifyDataType/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/modifyDataType/sybase.sql
@@ -2,4 +2,4 @@
 -- Change Parameter: columnName=id
 -- Change Parameter: newDataType=int
 -- Change Parameter: tableName=person
-ALTER TABLE [person] MODIFY [id] INT;
+ALTER TABLE person MODIFY id INT;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/renameView/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/renameView/sybase.sql
@@ -1,4 +1,4 @@
 -- Database: sybase
 -- Change Parameter: newViewName=v_person
 -- Change Parameter: oldViewName=v_person
-RENAME [v_person] TO [v_person];
+RENAME v_person TO v_person;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/update/sybase.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/update/sybase.sql
@@ -4,4 +4,4 @@
 --     type="int"
 -- ], ]
 -- Change Parameter: tableName=person
-UPDATE [person] SET [id] = NULL;
+UPDATE person SET id = NULL;

--- a/liquibase-integration-tests/pom.xml
+++ b/liquibase-integration-tests/pom.xml
@@ -225,8 +225,8 @@
             <dependencies>
                 <dependency>
                     <groupId>com.oracle.jdbc</groupId>
-                    <artifactId>ojdbc8</artifactId>
-                    <version>12.2.0.1</version>
+                    <artifactId>ojdbc7</artifactId>
+                    <version>12.1.0.2</version>
                 </dependency>
             </dependencies>
         </profile>

--- a/liquibase-integration-tests/src/test/java/liquibase/statementexecute/AddUniqueConstraintExecutorTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/statementexecute/AddUniqueConstraintExecutorTest.java
@@ -155,6 +155,8 @@ public class AddUniqueConstraintExecutorTest extends AbstractExecuteTest {
         assertCorrect("alter table [adduqtest] add constraint [uq_test] unique ([coltomakeuq])", FirebirdDatabase.class);
 
         assertCorrect("alter table [liquibaseb].[adduqtest] add constraint [uq_test] unique ([coltomakeuq])", HsqlDatabase.class);
+        assertCorrect("alter table \"liquibasec\".adduqtest add constraint uq_test unique (coltomakeuq)", Db2zDatabase.class);
+        assertCorrect("alter table \"liquibasec\".adduqtest add constraint uq_test unique (coltomakeuq)", DB2Database.class);
         assertCorrectOnRest("alter table [liquibasec].[adduqtest] add constraint [uq_test] unique ([coltomakeuq])");
 
     }


### PR DESCRIPTION
Some unit- and integration tests have been broken due to bug fixes, and this PR fixes them. It also fixes a problem in the YAML serializer where the YAML library tempers with date and time values if the current timezone of the user executing Liquibase is not UTC.