### PR TITLE
CORE-3229 Oracle 11g doesn't support TIMESTAMP WITHOUT TIME ZONE datatype

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/TimestampType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/TimestampType.java
@@ -1,5 +1,7 @@
 package liquibase.datatype.core;
 
+import java.util.Locale;
+
 import liquibase.configuration.GlobalConfiguration;
 import liquibase.configuration.LiquibaseConfiguration;
 import liquibase.database.Database;
@@ -47,9 +49,15 @@ public class TimestampType extends DateTimeType {
             DatabaseDataType type = new DatabaseDataType("TIMESTAMP");
             String additionalInformation = this.getAdditionalInformation();
 
-            if (additionalInformation != null && database instanceof PostgresDatabase) {
-                if (additionalInformation.toUpperCase().contains("TIMEZONE")) {
-                    additionalInformation = additionalInformation.toUpperCase().replace("TIMEZONE", "TIME ZONE");
+            if (additionalInformation != null) {
+                String additionInformation = additionalInformation.toUpperCase(Locale.US);
+                if ((database instanceof PostgresDatabase) && additionInformation.contains("TIMEZONE")) {
+                    additionalInformation = additionInformation.replace("TIMEZONE", "TIME ZONE");
+                }
+                // CORE-3229 Oracle 11g doesn't support WITHOUT clause in TIMESTAMP data type
+                if ((database instanceof OracleDatabase) && additionInformation.startsWith("WITHOUT")) {
+                    // https://docs.oracle.com/cd/B19306_01/server.102/b14225/ch4datetime.htm#sthref389
+                    additionalInformation = null;
                 }
             }
 

--- a/liquibase-core/src/test/java/liquibase/database/core/OracleDatabaseTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/core/OracleDatabaseTest.java
@@ -2,8 +2,13 @@ package liquibase.database.core;
 
 import liquibase.database.AbstractJdbcDatabaseTest;
 import liquibase.database.Database;
+import liquibase.datatype.DatabaseDataType;
+import liquibase.datatype.core.TimestampType;
+
 import org.junit.Assert;
 import static org.junit.Assert.*;
+
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 /**
@@ -45,6 +50,14 @@ public class OracleDatabaseTest extends AbstractJdbcDatabaseTest {
     @Test
     public void getCurrentDateTimeFunction() {
         Assert.assertEquals("SYSTIMESTAMP", getDatabase().getCurrentDateTimeFunction());
+    }
+
+    @Test
+    public void verifyTimestampDataTypeWhenWithoutClauseIsPresent() {
+        TimestampType ts = new TimestampType();
+        ts.setAdditionalInformation("WITHOUT TIME ZONE");
+        DatabaseDataType oracleDataType = ts.toDatabaseDataType(getDatabase());
+        assertThat(oracleDataType.getType(), CoreMatchers.is("TIMESTAMP"));
     }
 
     public void testGetDefaultDriver() {


### PR DESCRIPTION
Oracle 11g doesn't support WITHOUT clause in TIMESTAMP data type (https://docs.oracle.com/cd/B19306_01/server.102/b14225/ch4datetime.htm#sthref389).
For this reason replace TIMESTAMP WITHOUT TIME ZONE with TIMESTAMP.