### PR TITLE
CORE-3220 print detailed output when using logLevel INFO or greater

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -187,6 +187,7 @@ public class Main {
             }
 
             main.applyDefaults();
+            main.changeLogLevel();
             main.configureClassLoader();
             main.doMigration();
 
@@ -246,6 +247,25 @@ public class Main {
             CommandLineOutputAppender appender = new CommandLineOutputAppender(LoggerFactory.getILoggerFactory(), target);
             root.addAppender(appender);
             appender.start();
+        }
+    }
+
+    /**
+     * Change the logging based on the parsed value of logLevel
+     */
+    protected void changeLogLevel() {
+        if ("off".equals(logLevel)) {
+            return;
+        }
+
+        Level newLevel = Level.toLevel(logLevel);
+
+        ch.qos.logback.classic.Logger root =
+            (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
+        root.setLevel(newLevel);
+
+        if (Level.INFO.isGreaterOrEqual(newLevel)) {
+            consoleLogFilter.outputLogs = true;
         }
     }
 


### PR DESCRIPTION
In the current 3.6.x code, logLevel is not used to configure the root logger and the outputLogs field of the consoleLogFilter is never changed.

This change will keep the current behaviour if --logLevel is not used.
If --logLevel is used and it is INFO or greater, the root logger is set to this level and outputLogs will be set to true as well.

This will probably be of interest to people watching https://liquibase.jira.com/browse/CORE-3220 as well.



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-117) by [Unito](https://www.unito.io/learn-more)
