### PR TITLE
Fix case sensitivity issues in MSSQL (n)text (n)varchar conversion

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/ClobType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/ClobType.java
@@ -45,11 +45,11 @@ public class ClobType extends LiquibaseDataType {
         String originalDefinition = StringUtils.trimToEmpty(getRawDefinition());
         if (database instanceof MSSQLDatabase) {
             if ((!LiquibaseConfiguration.getInstance().getProperty(GlobalConfiguration.class, GlobalConfiguration
-                .CONVERT_DATA_TYPES).getValue(Boolean.class) && originalDefinition.toUpperCase(Locale.US).startsWith("text"))
-                || originalDefinition.toUpperCase(Locale.US).startsWith("[text]")) {
+                .CONVERT_DATA_TYPES).getValue(Boolean.class) && originalDefinition.toLowerCase(Locale.US).startsWith("text"))
+                || originalDefinition.toLowerCase(Locale.US).startsWith("[text]")) {
                 DatabaseDataType type = new DatabaseDataType(database.escapeDataTypeName("varchar"));
                 // If there is additional specification after ntext (e.g.  COLLATE), import that.
-                String originalExtraInfo = originalDefinition.replaceFirst("^\\[?text\\]?\\s*", "");
+                String originalExtraInfo = originalDefinition.replaceFirst("^(?i)\\[?text\\]?\\s*", "");
                 type.addAdditionalInformation("(max)"
                         + (StringUtils.isEmpty(originalExtraInfo) ? "" : " " + originalExtraInfo));
                 return type;
@@ -66,7 +66,7 @@ public class ClobType extends LiquibaseDataType {
                 // See: https://docs.microsoft.com/en-us/sql/t-sql/data-types/ntext-text-and-image-transact-sql
                 DatabaseDataType type = new DatabaseDataType(database.escapeDataTypeName("varchar"));
                 // If there is additional specification after ntext (e.g.  COLLATE), import that.
-                String originalExtraInfo = originalDefinition.replaceFirst("^\\[?text\\]?\\s*", "");
+                String originalExtraInfo = originalDefinition.replaceFirst("^(?i)\\[?text\\]?\\s*", "");
                 type.addAdditionalInformation("(max)"
                         + (StringUtils.isEmpty(originalExtraInfo) ? "" : " " + originalExtraInfo));
                 return type;
@@ -77,7 +77,7 @@ public class ClobType extends LiquibaseDataType {
                 // See: https://docs.microsoft.com/en-us/sql/t-sql/data-types/ntext-text-and-image-transact-sql
                 DatabaseDataType type = new DatabaseDataType(database.escapeDataTypeName("nvarchar"));
                 // If there is additional specification after ntext (e.g.  COLLATE), import that.
-                String originalExtraInfo = originalDefinition.replaceFirst("^\\[?ntext\\]?\\s*", "");
+                String originalExtraInfo = originalDefinition.replaceFirst("^(?i)\\[?ntext\\]?\\s*", "");
                 type.addAdditionalInformation("(max)"
                     + (StringUtils.isEmpty(originalExtraInfo) ? "" : " " + originalExtraInfo));
                 return type;

--- a/liquibase-core/src/test/java/liquibase/datatype/ClobTypeTest.java
+++ b/liquibase-core/src/test/java/liquibase/datatype/ClobTypeTest.java
@@ -1,0 +1,95 @@
+package liquibase.datatype;
+
+import liquibase.configuration.GlobalConfiguration;
+import liquibase.configuration.LiquibaseConfiguration;
+import liquibase.database.core.MSSQLDatabase;
+import liquibase.datatype.core.ClobType;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ClobTypeTest {
+    @Before
+    public void prepare() {
+        LiquibaseConfiguration.getInstance().reset();
+    }
+
+    @Test
+    public void mssqlTextToVarcharTest() {
+        LiquibaseConfiguration.getInstance()
+                .getConfiguration(GlobalConfiguration.class)
+                .getProperty(GlobalConfiguration.CONVERT_DATA_TYPES)
+                .setValue(Boolean.TRUE);
+
+        ClobType ct = new ClobType();
+        ct.finishInitialization("Text");
+        DatabaseDataType dbType = ct.toDatabaseDataType(new MSSQLDatabase());
+        assertEquals("varchar (max)", dbType.getType());
+    }
+
+    @Test
+    public void mssqlEscapedTextToVarcharTest() {
+        LiquibaseConfiguration.getInstance()
+                .getConfiguration(GlobalConfiguration.class)
+                .getProperty(GlobalConfiguration.CONVERT_DATA_TYPES)
+                .setValue(Boolean.TRUE);
+
+        ClobType ct = new ClobType();
+        ct.finishInitialization("[Text]");
+        DatabaseDataType dbType = ct.toDatabaseDataType(new MSSQLDatabase());
+        assertEquals("varchar (max)", dbType.getType());
+    }
+
+    @Test
+    public void mssqlTextToVarcharNoConvertTest() {
+        LiquibaseConfiguration.getInstance()
+                .getConfiguration(GlobalConfiguration.class)
+                .getProperty(GlobalConfiguration.CONVERT_DATA_TYPES)
+                .setValue(Boolean.FALSE);
+
+        ClobType ct = new ClobType();
+        ct.finishInitialization("Text");
+        DatabaseDataType dbType = ct.toDatabaseDataType(new MSSQLDatabase());
+        assertEquals("varchar (max)", dbType.getType());
+    }
+
+    @Test
+    public void mssqlNTextToNVarcharNoConvertTest() {
+        LiquibaseConfiguration.getInstance()
+                .getConfiguration(GlobalConfiguration.class)
+                .getProperty(GlobalConfiguration.CONVERT_DATA_TYPES)
+                .setValue(Boolean.FALSE);
+
+        ClobType ct = new ClobType();
+        ct.finishInitialization("NText");
+        DatabaseDataType dbType = ct.toDatabaseDataType(new MSSQLDatabase());
+        assertEquals("nvarchar (max)", dbType.getType());
+    }
+
+    @Test
+    public void mssqlEscapedTextToVarcharNoConvertTest() {
+        LiquibaseConfiguration.getInstance()
+                .getConfiguration(GlobalConfiguration.class)
+                .getProperty(GlobalConfiguration.CONVERT_DATA_TYPES)
+                .setValue(Boolean.FALSE);
+
+        ClobType ct = new ClobType();
+        ct.finishInitialization("[Text]");
+        DatabaseDataType dbType = ct.toDatabaseDataType(new MSSQLDatabase());
+        assertEquals("varchar (max)", dbType.getType());
+    }
+
+    @Test
+    public void mssqlEscapedNTextToNVarcharNoConvertTest() {
+        LiquibaseConfiguration.getInstance()
+                .getConfiguration(GlobalConfiguration.class)
+                .getProperty(GlobalConfiguration.CONVERT_DATA_TYPES)
+                .setValue(Boolean.FALSE);
+
+        ClobType ct = new ClobType();
+        ct.finishInitialization("[NText]");
+        DatabaseDataType dbType = ct.toDatabaseDataType(new MSSQLDatabase());
+        assertEquals("nvarchar (max)", dbType.getType());
+    }
+}


### PR DESCRIPTION
Without these fixes column definitions of text/ntext where not all characters are lowercase end up with duplicate datatypes (e.g. `COL1 varchar (max) TEXT`) or are not recognized at all.
One part of the problem was introduced in #751, but even without the toUpperCase bug from that PR there are problems in the regexes.