### PR TITLE
Core 3159 log binding classcast

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,12 @@
 Liquibase Core Changelog
 ===========================================
 
+Changes in version 3.6.1 (2018.04.11)
+
+- [CORE-3200] - Wrong SQL generator is selected
+- [CORE-3201] - Command line missing required dependencies in 3.6.0 tarball
+- [CORE-3198] - Configuration option to prefer internal XSD usage
+
 Changes in version 3.6.0 (2018.04.5)
 
 - [CORE-1609] - Command Prompt: Can't connect to database with a special character in pwd

--- a/liquibase-cdi/pom.xml
+++ b/liquibase-cdi/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-parent</artifactId>
-        <version>3.6.1</version>
+        <version>3.6.2-SNAPSHOT</version>
 	</parent>
 	<artifactId>liquibase-cdi</artifactId>
 	<name>Liquibase CDI</name>

--- a/liquibase-cdi/pom.xml
+++ b/liquibase-cdi/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-parent</artifactId>
-        <version>3.6.1-SNAPSHOT</version>
+        <version>3.6.1</version>
 	</parent>
 	<artifactId>liquibase-cdi</artifactId>
 	<name>Liquibase CDI</name>

--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.liquibase</groupId>
 		<artifactId>liquibase-parent</artifactId>
-		<version>3.6.1</version>
+		<version>3.6.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>liquibase-core</artifactId>

--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.liquibase</groupId>
 		<artifactId>liquibase-parent</artifactId>
-		<version>3.6.1-SNAPSHOT</version>
+		<version>3.6.1</version>
 	</parent>
 
 	<artifactId>liquibase-core</artifactId>

--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -17,7 +17,7 @@
 		<maven.compiler.source>1.7</maven.compiler.source>
 		<maven.compiler.target>1.7</maven.compiler.target>
 		<bundle.namespace>liquibase.*</bundle.namespace>
-        <project.version>3.6.0</project.version>
+        <project.version>3.6.1</project.version>
 	</properties>
 
 	<dependencies>

--- a/liquibase-core/src/main/java/liquibase/datatype/core/ClobType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/ClobType.java
@@ -45,11 +45,11 @@ public class ClobType extends LiquibaseDataType {
         String originalDefinition = StringUtils.trimToEmpty(getRawDefinition());
         if (database instanceof MSSQLDatabase) {
             if ((!LiquibaseConfiguration.getInstance().getProperty(GlobalConfiguration.class, GlobalConfiguration
-                .CONVERT_DATA_TYPES).getValue(Boolean.class) && originalDefinition.toUpperCase(Locale.US).startsWith("text"))
-                || originalDefinition.toUpperCase(Locale.US).startsWith("[text]")) {
+                .CONVERT_DATA_TYPES).getValue(Boolean.class) && originalDefinition.toLowerCase(Locale.US).startsWith("text"))
+                || originalDefinition.toLowerCase(Locale.US).startsWith("[text]")) {
                 DatabaseDataType type = new DatabaseDataType(database.escapeDataTypeName("varchar"));
                 // If there is additional specification after ntext (e.g.  COLLATE), import that.
-                String originalExtraInfo = originalDefinition.replaceFirst("^\\[?text\\]?\\s*", "");
+                String originalExtraInfo = originalDefinition.replaceFirst("^(?i)\\[?text\\]?\\s*", "");
                 type.addAdditionalInformation("(max)"
                         + (StringUtils.isEmpty(originalExtraInfo) ? "" : " " + originalExtraInfo));
                 return type;
@@ -66,7 +66,7 @@ public class ClobType extends LiquibaseDataType {
                 // See: https://docs.microsoft.com/en-us/sql/t-sql/data-types/ntext-text-and-image-transact-sql
                 DatabaseDataType type = new DatabaseDataType(database.escapeDataTypeName("varchar"));
                 // If there is additional specification after ntext (e.g.  COLLATE), import that.
-                String originalExtraInfo = originalDefinition.replaceFirst("^\\[?text\\]?\\s*", "");
+                String originalExtraInfo = originalDefinition.replaceFirst("^(?i)\\[?text\\]?\\s*", "");
                 type.addAdditionalInformation("(max)"
                         + (StringUtils.isEmpty(originalExtraInfo) ? "" : " " + originalExtraInfo));
                 return type;
@@ -77,7 +77,7 @@ public class ClobType extends LiquibaseDataType {
                 // See: https://docs.microsoft.com/en-us/sql/t-sql/data-types/ntext-text-and-image-transact-sql
                 DatabaseDataType type = new DatabaseDataType(database.escapeDataTypeName("nvarchar"));
                 // If there is additional specification after ntext (e.g.  COLLATE), import that.
-                String originalExtraInfo = originalDefinition.replaceFirst("^\\[?ntext\\]?\\s*", "");
+                String originalExtraInfo = originalDefinition.replaceFirst("^(?i)\\[?ntext\\]?\\s*", "");
                 type.addAdditionalInformation("(max)"
                     + (StringUtils.isEmpty(originalExtraInfo) ? "" : " " + originalExtraInfo));
                 return type;

--- a/liquibase-core/src/main/java/liquibase/integration/commandline/CommandLineOutputAppender.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/CommandLineOutputAppender.java
@@ -95,7 +95,8 @@ public class CommandLineOutputAppender extends ConsoleAppender {
     /**
      * Set up Logback logging to the STDOUT/STDERR console streams.
      */
-    protected static void setupLogging(final Logger root, final LogLevel defaultLogLevel) {
+    protected static void setupLogging(final org.slf4j.Logger rootLogger, final LogLevel defaultLogLevel) {
+        Logger root = (ch.qos.logback.classic.Logger) rootLogger;
         // NOTE: Mismatched levels default to debug.
         root.setLevel(Level.toLevel(defaultLogLevel.name()));
     

--- a/liquibase-core/src/main/java/liquibase/integration/commandline/CommandLineOutputAppender.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/CommandLineOutputAppender.java
@@ -1,14 +1,24 @@
 package liquibase.integration.commandline;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.ConsoleAppender;
+import ch.qos.logback.core.filter.AbstractMatcherFilter;
 import ch.qos.logback.core.filter.Filter;
 import ch.qos.logback.core.joran.spi.ConsoleTarget;
 import ch.qos.logback.core.spi.FilterReply;
+import liquibase.logging.LogLevel;
 import liquibase.logging.LogType;
+
+import java.util.Iterator;
+
 import org.slf4j.ILoggerFactory;
+import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 
 /**
@@ -80,5 +90,44 @@ public class CommandLineOutputAppender extends ConsoleAppender {
          * Outputs all log messages to stdout
          */
         FULL_LOG,
+    }
+
+    /**
+     * Set up Logback logging to the STDOUT/STDERR console streams.
+     */
+    protected static void setupLogging(final Logger root, final LogLevel defaultLogLevel) {
+        // NOTE: Mismatched levels default to debug.
+        root.setLevel(Level.toLevel(defaultLogLevel.name()));
+    
+        ConsoleLogFilter consoleLogFilter = new ConsoleLogFilter();
+
+        Iterator<Appender<ILoggingEvent>> appenderIterator = root.iteratorForAppenders();
+        while (appenderIterator.hasNext()) {
+            Appender<ILoggingEvent> next = appenderIterator.next();
+            if (next instanceof ConsoleAppender) {
+                ((ConsoleAppender) next).addFilter(consoleLogFilter);
+            }
+        }
+    
+        for (String target : new String[] { "System.out", "System.err" }) {
+            CommandLineOutputAppender appender = new CommandLineOutputAppender(LoggerFactory.getILoggerFactory(), target);
+            root.addAppender(appender);
+            appender.start();
+        }
+    }
+
+    private static class ConsoleLogFilter extends AbstractMatcherFilter {
+
+        // NOTE: This is never set so the reply is always DENY.
+        private boolean outputLogs;
+
+        @Override
+        public FilterReply decide(Object event) {
+            if (outputLogs) {
+                return FilterReply.ACCEPT;
+            } else {
+                return FilterReply.DENY;
+            }
+        }
     }
 }

--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -224,14 +224,11 @@ public class Main {
 
         org.slf4j.Logger rootLogger = LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
 
-        switch (rootLogger.getClass().getName()) {
-            case "ch.qos.logback.classic.Logger":
-                CommandLineOutputAppender.setupLogging((ch.qos.logback.classic.Logger) rootLogger, defaultLogLevel);
-                break;
-
-            default:
-                System.err.println(
-                        "Logging cannot be configured; a supported org.slf4j.Logger implementation is not on the classpath.");
+        if ("ch.qos.logback.classic.Logger".equals(rootLogger.getClass().getName())) {
+            CommandLineOutputAppender.setupLogging(rootLogger, defaultLogLevel);
+        } else {
+            System.err.println(
+                    "Liquibase command line logging cannot be configured; a supported org.slf4j.Logger implementation is not on the classpath.");
         }
     }
 

--- a/liquibase-core/src/main/java/liquibase/parser/core/xml/XMLChangeLogSAXParser.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/xml/XMLChangeLogSAXParser.java
@@ -11,20 +11,40 @@ import liquibase.util.StreamUtil;
 import liquibase.util.file.FilenameUtils;
 import org.xml.sax.*;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
 import java.io.IOException;
 import java.io.InputStream;
 
 public class XMLChangeLogSAXParser extends AbstractChangeLogParser {
     
     public static final String LIQUIBASE_SCHEMA_VERSION = "3.6";
+    private static final boolean PREFER_INTERNAL_XSD = Boolean.getBoolean("liquibase.prefer.internal.xsd");
+    private static final String XSD_FILE = "dbchangelog-" + LIQUIBASE_SCHEMA_VERSION + ".xsd";
     private SAXParserFactory saxParserFactory;
 
     public XMLChangeLogSAXParser() {
         saxParserFactory = SAXParserFactory.newInstance();
         saxParserFactory.setValidating(true);
         saxParserFactory.setNamespaceAware(true);
+        
+        if (PREFER_INTERNAL_XSD) {
+            InputStream xsdInputStream = XMLChangeLogSAXParser.class.getResourceAsStream(XSD_FILE);
+            if (xsdInputStream != null) {
+                try {
+                    SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+                    Schema schema = schemaFactory.newSchema(new StreamSource(xsdInputStream));
+                    saxParserFactory.setSchema(schema);
+                    saxParserFactory.setValidating(false);
+                } catch (SAXException e) {
+                    LogService.getLog(XMLChangeLogSAXParser.class).warning("Could not load " + XSD_FILE + ", enabling parser validator", e);
+                }
+            }
+        }
     }
 
     @Override

--- a/liquibase-core/src/main/resources/assembly/bin.xml
+++ b/liquibase-core/src/main/resources/assembly/bin.xml
@@ -65,6 +65,8 @@
         <dependencySet>
             <outputDirectory>lib</outputDirectory>
             <includes>
+                <include>ch.qos.logback:logback-classic</include>
+                <include>ch.qos.logback:logback-core</include>
                 <include>org.yaml:snakeyaml</include>
             </includes>
         </dependencySet>

--- a/liquibase-core/src/test/java/liquibase/datatype/ClobTypeTest.java
+++ b/liquibase-core/src/test/java/liquibase/datatype/ClobTypeTest.java
@@ -1,0 +1,95 @@
+package liquibase.datatype;
+
+import liquibase.configuration.GlobalConfiguration;
+import liquibase.configuration.LiquibaseConfiguration;
+import liquibase.database.core.MSSQLDatabase;
+import liquibase.datatype.core.ClobType;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ClobTypeTest {
+    @Before
+    public void prepare() {
+        LiquibaseConfiguration.getInstance().reset();
+    }
+
+    @Test
+    public void mssqlTextToVarcharTest() {
+        LiquibaseConfiguration.getInstance()
+                .getConfiguration(GlobalConfiguration.class)
+                .getProperty(GlobalConfiguration.CONVERT_DATA_TYPES)
+                .setValue(Boolean.TRUE);
+
+        ClobType ct = new ClobType();
+        ct.finishInitialization("Text");
+        DatabaseDataType dbType = ct.toDatabaseDataType(new MSSQLDatabase());
+        assertEquals("varchar (max)", dbType.getType());
+    }
+
+    @Test
+    public void mssqlEscapedTextToVarcharTest() {
+        LiquibaseConfiguration.getInstance()
+                .getConfiguration(GlobalConfiguration.class)
+                .getProperty(GlobalConfiguration.CONVERT_DATA_TYPES)
+                .setValue(Boolean.TRUE);
+
+        ClobType ct = new ClobType();
+        ct.finishInitialization("[Text]");
+        DatabaseDataType dbType = ct.toDatabaseDataType(new MSSQLDatabase());
+        assertEquals("varchar (max)", dbType.getType());
+    }
+
+    @Test
+    public void mssqlTextToVarcharNoConvertTest() {
+        LiquibaseConfiguration.getInstance()
+                .getConfiguration(GlobalConfiguration.class)
+                .getProperty(GlobalConfiguration.CONVERT_DATA_TYPES)
+                .setValue(Boolean.FALSE);
+
+        ClobType ct = new ClobType();
+        ct.finishInitialization("Text");
+        DatabaseDataType dbType = ct.toDatabaseDataType(new MSSQLDatabase());
+        assertEquals("varchar (max)", dbType.getType());
+    }
+
+    @Test
+    public void mssqlNTextToNVarcharNoConvertTest() {
+        LiquibaseConfiguration.getInstance()
+                .getConfiguration(GlobalConfiguration.class)
+                .getProperty(GlobalConfiguration.CONVERT_DATA_TYPES)
+                .setValue(Boolean.FALSE);
+
+        ClobType ct = new ClobType();
+        ct.finishInitialization("NText");
+        DatabaseDataType dbType = ct.toDatabaseDataType(new MSSQLDatabase());
+        assertEquals("nvarchar (max)", dbType.getType());
+    }
+
+    @Test
+    public void mssqlEscapedTextToVarcharNoConvertTest() {
+        LiquibaseConfiguration.getInstance()
+                .getConfiguration(GlobalConfiguration.class)
+                .getProperty(GlobalConfiguration.CONVERT_DATA_TYPES)
+                .setValue(Boolean.FALSE);
+
+        ClobType ct = new ClobType();
+        ct.finishInitialization("[Text]");
+        DatabaseDataType dbType = ct.toDatabaseDataType(new MSSQLDatabase());
+        assertEquals("varchar (max)", dbType.getType());
+    }
+
+    @Test
+    public void mssqlEscapedNTextToNVarcharNoConvertTest() {
+        LiquibaseConfiguration.getInstance()
+                .getConfiguration(GlobalConfiguration.class)
+                .getProperty(GlobalConfiguration.CONVERT_DATA_TYPES)
+                .setValue(Boolean.FALSE);
+
+        ClobType ct = new ClobType();
+        ct.finishInitialization("[NText]");
+        DatabaseDataType dbType = ct.toDatabaseDataType(new MSSQLDatabase());
+        assertEquals("nvarchar (max)", dbType.getType());
+    }
+}

--- a/liquibase-integration-tests/pom.xml
+++ b/liquibase-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>liquibase-parent</artifactId>
         <groupId>org.liquibase</groupId>
-        <version>3.6.1</version>
+        <version>3.6.2-SNAPSHOT</version>
     </parent>
 
 

--- a/liquibase-integration-tests/pom.xml
+++ b/liquibase-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>liquibase-parent</artifactId>
         <groupId>org.liquibase</groupId>
-        <version>3.6.1-SNAPSHOT</version>
+        <version>3.6.1</version>
     </parent>
 
 

--- a/liquibase-maven-plugin/pom.xml
+++ b/liquibase-maven-plugin/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>liquibase-parent</artifactId>
         <groupId>org.liquibase</groupId>
-        <version>3.6.1</version>
+        <version>3.6.2-SNAPSHOT</version>
     </parent>
 
 	<dependencies>

--- a/liquibase-maven-plugin/pom.xml
+++ b/liquibase-maven-plugin/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>liquibase-parent</artifactId>
         <groupId>org.liquibase</groupId>
-        <version>3.6.1-SNAPSHOT</version>
+        <version>3.6.1</version>
     </parent>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.liquibase</groupId>
     <artifactId>liquibase-parent</artifactId>
-    <version>3.6.1</version>
+    <version>3.6.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Liquibase Parent Configuration</name>
@@ -49,7 +49,7 @@
         <connection>scm:git:git@github.com:liquibase/liquibase.git</connection>
         <url>scm:git:git@github.com:liquibase/liquibase.git</url>
         <developerConnection>scm:git:git@github.com:liquibase/liquibase.git</developerConnection>
-        <tag>liquibase-parent-3.6.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.liquibase</groupId>
     <artifactId>liquibase-parent</artifactId>
-    <version>3.6.1-SNAPSHOT</version>
+    <version>3.6.1</version>
     <packaging>pom</packaging>
 
     <name>Liquibase Parent Configuration</name>
@@ -49,7 +49,7 @@
         <connection>scm:git:git@github.com:liquibase/liquibase.git</connection>
         <url>scm:git:git@github.com:liquibase/liquibase.git</url>
         <developerConnection>scm:git:git@github.com:liquibase/liquibase.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>liquibase-parent-3.6.1</tag>
     </scm>
 
     <issueManagement>


### PR DESCRIPTION
1. Changed Main to check the root logger name before attempting to cast to the Logback implementation.
2. Moved all the Logback implementation specific classes into the CommandLineOutputAppender.

I looked at making a CommandLineLog4jOutputAppender but log4j is really painful to configure programmatically. I don't think using the logging framework for program output is the best choice but at this point not easily changed. For now, this should at least allow the Main to be used by the gradle-liquibase plugin.