### PR TITLE
Core 3159 log binding classcast

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/commandline/CommandLineOutputAppender.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/CommandLineOutputAppender.java
@@ -95,7 +95,8 @@ public class CommandLineOutputAppender extends ConsoleAppender {
     /**
      * Set up Logback logging to the STDOUT/STDERR console streams.
      */
-    protected static void setupLogging(final Logger root, final LogLevel defaultLogLevel) {
+    protected static void setupLogging(final org.slf4j.Logger rootLogger, final LogLevel defaultLogLevel) {
+        Logger root = (ch.qos.logback.classic.Logger) rootLogger;
         // NOTE: Mismatched levels default to debug.
         root.setLevel(Level.toLevel(defaultLogLevel.name()));
     

--- a/liquibase-core/src/main/java/liquibase/integration/commandline/CommandLineOutputAppender.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/CommandLineOutputAppender.java
@@ -1,14 +1,24 @@
 package liquibase.integration.commandline;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.ConsoleAppender;
+import ch.qos.logback.core.filter.AbstractMatcherFilter;
 import ch.qos.logback.core.filter.Filter;
 import ch.qos.logback.core.joran.spi.ConsoleTarget;
 import ch.qos.logback.core.spi.FilterReply;
+import liquibase.logging.LogLevel;
 import liquibase.logging.LogType;
+
+import java.util.Iterator;
+
 import org.slf4j.ILoggerFactory;
+import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 
 /**
@@ -80,5 +90,44 @@ public class CommandLineOutputAppender extends ConsoleAppender {
          * Outputs all log messages to stdout
          */
         FULL_LOG,
+    }
+
+    /**
+     * Set up Logback logging to the STDOUT/STDERR console streams.
+     */
+    protected static void setupLogging(final Logger root, final LogLevel defaultLogLevel) {
+        // NOTE: Mismatched levels default to debug.
+        root.setLevel(Level.toLevel(defaultLogLevel.name()));
+    
+        ConsoleLogFilter consoleLogFilter = new ConsoleLogFilter();
+
+        Iterator<Appender<ILoggingEvent>> appenderIterator = root.iteratorForAppenders();
+        while (appenderIterator.hasNext()) {
+            Appender<ILoggingEvent> next = appenderIterator.next();
+            if (next instanceof ConsoleAppender) {
+                ((ConsoleAppender) next).addFilter(consoleLogFilter);
+            }
+        }
+    
+        for (String target : new String[] { "System.out", "System.err" }) {
+            CommandLineOutputAppender appender = new CommandLineOutputAppender(LoggerFactory.getILoggerFactory(), target);
+            root.addAppender(appender);
+            appender.start();
+        }
+    }
+
+    private static class ConsoleLogFilter extends AbstractMatcherFilter {
+
+        // NOTE: This is never set so the reply is always DENY.
+        private boolean outputLogs;
+
+        @Override
+        public FilterReply decide(Object event) {
+            if (outputLogs) {
+                return FilterReply.ACCEPT;
+            } else {
+                return FilterReply.DENY;
+            }
+        }
     }
 }

--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -224,14 +224,11 @@ public class Main {
 
         org.slf4j.Logger rootLogger = LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
 
-        switch (rootLogger.getClass().getName()) {
-            case "ch.qos.logback.classic.Logger":
-                CommandLineOutputAppender.setupLogging((ch.qos.logback.classic.Logger) rootLogger, defaultLogLevel);
-                break;
-
-            default:
-                System.err.println(
-                        "Logging cannot be configured; a supported org.slf4j.Logger implementation is not on the classpath.");
+        if ("ch.qos.logback.classic.Logger".equals(rootLogger.getClass().getName())) {
+            CommandLineOutputAppender.setupLogging(rootLogger, defaultLogLevel);
+        } else {
+            System.err.println(
+                    "Liquibase command line logging cannot be configured; a supported org.slf4j.Logger implementation is not on the classpath.");
         }
     }
 


### PR DESCRIPTION
1. Changed Main to check the root logger name before attempting to cast to the Logback implementation.
2. Moved all the Logback implementation specific classes into the CommandLineOutputAppender.

 I don't think using the logging framework for program output is the best choice but at this point not easily changed. For now, this should at least allow the Main to be used by the gradle-liquibase plugin.

I looked at making a CommandLineLog4jOutputAppender but log4j2 is not really set up for extension. I think if someone was going to attempt this programmatically, they'd want to use the exsiting log4j2 classes and just configure the layout and filters. The log4j-slf4j-impl bridge also complicates matters because you can't publically get to the real log4j2 Logger as was done with Logback.