### PR TITLE
CORE-3229 Oracle 11g doesn't support TIMESTAMP WITHOUT TIME ZONE datatype

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/TimestampType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/TimestampType.java
@@ -119,13 +119,22 @@ public class TimestampType extends DateTimeType {
             type = new DatabaseDataType("TIMESTAMP");
         }
 
-        if (((getAdditionalInformation() != null) && ((database instanceof PostgresDatabase) || (database instanceof
-            OracleDatabase))) || (database instanceof HsqlDatabase) || (database instanceof H2Database)){
+        if (getAdditionalInformation() != null
+                && (database instanceof PostgresDatabase
+                || database instanceof OracleDatabase)
+                || database instanceof H2Database
+                || database instanceof HsqlDatabase){
             String additionalInformation = this.getAdditionalInformation();
 
-            if ((additionalInformation != null) && (database instanceof PostgresDatabase)) {
-                if (additionalInformation.toUpperCase(Locale.US).contains("TIMEZONE")) {
-                    additionalInformation = additionalInformation.toUpperCase(Locale.US).replace("TIMEZONE", "TIME ZONE");
+            if (additionalInformation != null) {
+                String additionInformation = additionalInformation.toUpperCase(Locale.US);
+                if ((database instanceof PostgresDatabase) && additionInformation.contains("TIMEZONE")) {
+                    additionalInformation = additionInformation.replace("TIMEZONE", "TIME ZONE");
+                }
+                // CORE-3229 Oracle 11g doesn't support WITHOUT clause in TIMESTAMP data type
+                if ((database instanceof OracleDatabase) && additionInformation.startsWith("WITHOUT")) {
+                    // https://docs.oracle.com/cd/B19306_01/server.102/b14225/ch4datetime.htm#sthref389
+                    additionalInformation = null;
                 }
             }
 

--- a/liquibase-core/src/test/java/liquibase/database/core/OracleDatabaseTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/core/OracleDatabaseTest.java
@@ -4,6 +4,8 @@ import liquibase.database.AbstractJdbcDatabaseTest;
 import liquibase.database.Database;
 import liquibase.database.ObjectQuotingStrategy;
 import liquibase.database.OfflineConnection;
+import liquibase.datatype.DatabaseDataType;
+import liquibase.datatype.core.TimestampType;
 import liquibase.exception.LiquibaseException;
 import liquibase.executor.ExecutorService;
 import liquibase.resource.ResourceAccessor;
@@ -21,6 +23,9 @@ import java.util.ResourceBundle;
 
 import static java.util.ResourceBundle.getBundle;
 import static org.junit.Assert.*;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
 
 /**
  * Tests for {@link liquibase.database.core.OracleDatabase}.
@@ -78,6 +83,13 @@ public class OracleDatabaseTest extends AbstractJdbcDatabaseTest {
     }
 
     @Test
+    public void verifyTimestampDataTypeWhenWithoutClauseIsPresent() {
+        TimestampType ts = new TimestampType();
+        ts.setAdditionalInformation("WITHOUT TIME ZONE");
+        DatabaseDataType oracleDataType = ts.toDatabaseDataType(getDatabase());
+        assertThat(oracleDataType.getType(), CoreMatchers.is("TIMESTAMP"));
+    }
+
     public void testGetDefaultDriver() {
         Database database = new OracleDatabase();
 


### PR DESCRIPTION
Oracle 11g doesn't support WITHOUT clause in TIMESTAMP data type (https://docs.oracle.com/cd/B19306_01/server.102/b14225/ch4datetime.htm#sthref389).
For this reason replace TIMESTAMP WITHOUT TIME ZONE with TIMESTAMP.

Porting from branch 3.5.x