### PR TITLE
Bugfix. Directories included in resource list even if includeDirectories is false

### DIFF
--- a/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
@@ -120,9 +120,7 @@ public class ClassLoaderResourceAccessor extends AbstractResourceAccessor {
                                 }
                             }
 
-                            if (entry.isDirectory() && includeDirectories) {
-                                returnSet.add(entry.getName());
-                            } else if (includeFiles) {
+                            if ((entry.isDirectory() && includeDirectories) || (!entry.isDirectory() && includeFiles)) {
                                 returnSet.add(entry.getName());
                             }
                         }


### PR DESCRIPTION
returnSet of method ClassLoaderResourceAccessor.list contains not only files but also their directories despite includeDirectories is false. This can lead to minor performance loss.