### PR TITLE
Bugfix. Fixed Spring Boot fat jar resource path for unit-testing.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/util/SpringBootFatJar.java
+++ b/liquibase-core/src/main/java/liquibase/util/SpringBootFatJar.java
@@ -5,7 +5,10 @@ public class SpringBootFatJar {
         String[] components = path.split("!");
         if (components.length == 3) {
             return String.format("%s%s", components[1].substring(1), components[2]);
-        } else {
+        } else if (components.length == 2) {
+            return components[1].substring(1);
+        }
+        else {
             return path;
         }
     }

--- a/liquibase-core/src/test/java/liquibase/util/SpringBootFatJarTest.java
+++ b/liquibase-core/src/test/java/liquibase/util/SpringBootFatJarTest.java
@@ -6,14 +6,20 @@ import static org.junit.Assert.*;
 public class SpringBootFatJarTest {
 
     @Test
-    public void testGetPathForResourceWithFatJarPath() {
+    public void testGetPathForResourceWithTwoBangs() {
         String result = SpringBootFatJar.getPathForResource("some/path!/that/has!/two/bangs");
         assertEquals(result, "that/has/two/bangs");
     }
 
     @Test
-    public void testGetPathForResourceWithSimplePath() {
+    public void testGetPathForResourceWithOneBang() {
         String result = SpringBootFatJar.getPathForResource("some/path!/that/has/one/bang");
-        assertEquals(result, "some/path!/that/has/one/bang");
+        assertEquals(result, "that/has/one/bang");
+    }
+
+    @Test
+    public void testGetPathForResourceWithSimplePath() {
+        String result = SpringBootFatJar.getPathForResource("some/path/that/has/no/bangs");
+        assertEquals(result, "some/path/that/has/no/bangs");
     }
 }


### PR DESCRIPTION
CORE-3192, CORE-2863 related

Fix from https://github.com/liquibase/liquibase/pull/698 doesn't work when running unit-tests with maven. In this case dependency jars have urls like [jar:file:/path_to_module/target/module.jar!/db/changelog/] with only one exclamation point.

Here is the testcase for reproduction: https://github.com/keddok/liquibase-issue
