### PR TITLE
Load data is unable to find column configuration when using camel or snake case identifiers

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
@@ -590,7 +590,8 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
         // Save the columns of the database table in a lookup table
         Map<String, Column> tableColumns = new HashMap<>();
         for (Column c : snapshotOfTable.getColumns()) {
-            tableColumns.put(c.getName(), c);
+            // Normalise the LoadDataColumnConfig column names to the database
+            tableColumns.put(database.correctObjectName(c.getName(), Column.class), c);
         }
         /* The above is the JDK7 version of:
             snapshotOfTable.getColumns().forEach(c -> tableColumns.put(c.getName(), c));


### PR DESCRIPTION
If you normalize only LoadDataConlumnConfig's name; they may not match against tableColumns given a NullPointerException afterwards.