### PR TITLE
feat: Maven Liquibase Plugin generateChangeLog mysql sql comment supp…

### DIFF
--- a/liquibase-core/src/main/java/liquibase/serializer/core/formattedsql/FormattedSqlChangeLogSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/formattedsql/FormattedSqlChangeLogSerializer.java
@@ -42,7 +42,7 @@ public class FormattedSqlChangeLogSerializer  implements ChangeLogSerializer {
             String author = (changeSet.getAuthor()).replaceAll("\\s+", "_");
             author = author.replace("_(generated)","");
 
-            builder.append("--changeset ").append(author).append(":").append(changeSet.getId()).append("\n");
+            builder.append("-- changeset ").append(author).append(":").append(changeSet.getId()).append("\n");
             for (Change change : changeSet.getChanges()) {
                 Sql[] sqls = SqlGeneratorFactory.getInstance().generateSql(change.generateStatements(database), database);
                 if (sqls != null) {
@@ -81,7 +81,7 @@ public class FormattedSqlChangeLogSerializer  implements ChangeLogSerializer {
     @Override
     public <T extends ChangeLogChild> void write(List<T> children, OutputStream out) throws IOException {
         StringBuilder builder = new StringBuilder();
-        builder.append("--liquibase formatted sql\n\n");
+        builder.append("-- liquibase formatted sql\n\n");
 
         for (T child : children) {
             builder.append(serialize(child, true));


### PR DESCRIPTION
…orted

In a Liquibase SQL change set, you must start with the comment "--liquibase formatted sql". Unfortunately, this is not a well-formed comment in MySQL. The comment must be "-- liquibase formatted sql".

In MySQL, the --  (double-dash) comment style requires the second dash to be followed by at least one whitespace or control character (such as a space, tab, newline, and so on). This syntax differs slightly from standard SQL comment syntax, as discussed in https://dev.mysql.com/doc/refman/8.0/en/ansi-diff-comments.html Section 1.8.2.4, “'--' as the Start of a Comment”.

## QA Manual Test Requirements
##### Setup 
* Configure a MySQL database with several tables.

##### Validations
_Verify generateChangeLog produces a formatted SQL changelog._
ASSERT :: 

* The changelog starts with the comment {CODE}-- liquibase formatted sql{CODE}
  * There is a space between the dash-dash and liquibase
* Each change set starts with the comment {CODE}-- changeset ID:AUTHOR{CODE}
  * There is a space between the dash-dash and changeset

_Verify update using the formatted SQL change log is successful._
ASSERT ::

* Update to a MySQL database completes without an error

_Verify successful update adding the space between dash~~dash and liquibase AND dash~~dash and change set._
ASSERT ::

* Update to Postgres database is successful
* Update to Oracle database is successful
* Update to MSSQL database is successful



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-118) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 3.10.3
