### PR TITLE
fix for CORE-3206 - OutputChange's target attribute should have a dif…

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/OutputChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/OutputChange.java
@@ -19,7 +19,7 @@ import liquibase.util.StringUtils;
 public class OutputChange extends AbstractChange {
 
     private String message;
-    private String target = "";
+    private String target = null;
 
     @Override
     public ValidationErrors validate(Database database) {


### PR DESCRIPTION
fixes Core 2998 - OutputChange's target attribute should have a different default value.
set target to null

The getTarget method of OutputChange attempts to use a default value of "STDERR" for the "target" property when no value has been given, but the "target" property is initialized to the empty string.  This causes errors for any parsers that create an OutputChange without explicitly setting the target to something. 

## Steps to reproduce:
Create a changelog file with:

<changeSet id="x" author="y">
<output>Test message</output>
</changeSet>

## Expected results:
outputs "Test message" to STDERR

## Actual results:
Throws an "unknown target: " error

## DEV Unit Test Requirements
[~accountid:557058:c8f0b24d-f02f-431c-8842-fd9c929dfbf2] to add detail

## DEV Integration Test Requirements
[~accountid:557058:c8f0b24d-f02f-431c-8842-fd9c929dfbf2] to add detail

## QA Manual Test Requirements
_Verify output change correctly writes to the console when running CLI._
_Verify output change correctly writes to console when running MVN._
ASSERT ::
The expected text is visible.
You do not need to have logging enabled to see the text.
There are no errors thrown.

## QA Automated Test Requirements
* Write a regression test following the instructions in steps to reproduce.
  * It does not matter which database you use for this test
  * This does not need to be a multi-db test



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-120) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 3.10.2
