### PR TITLE
fix confusing error message

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/CreateProcedureChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/CreateProcedureChange.java
@@ -184,7 +184,7 @@ public class CreateProcedureChange extends AbstractChange implements DbmsTargete
 
         if ((StringUtils.trimToNull(getProcedureText()) == null) && (StringUtils.trimToNull(getPath()) == null)) {
             validate.addError(
-                "Cannot specify either 'path' or a nested procedure text in " +
+                "Must specify either 'path' or a nested procedure text in " +
                     ChangeFactory.getInstance().getChangeMetaData(this).getName()
             );
         }


### PR DESCRIPTION
the error text "Cannot specify either 'path' or a nested procedure text in createProcedure, " should indicate the fix is to create one of them - the error is actually that both are missing.