### PR TITLE
Fix regression introduced by merge 3.5 to 3.6

### DIFF
--- a/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
@@ -99,10 +99,10 @@ public class ClassLoaderResourceAccessor extends AbstractResourceAccessor {
                     sanitizePath = sanitizePath.replaceFirst("classpath\\*:", "");
                 }
                 // if path is like 'jar:<url>!/{entry}', use the last part as resource path
-                if (path.contains("!/")) {
-                    String[] components = path.split("!/");
+                if (sanitizePath.contains("!/")) {
+                    String[] components = sanitizePath.split("!/");
                     if (components.length > 1) {
-                        path = components[components.length - 1];
+                        sanitizePath = components[components.length - 1];
                     }
                 }
 


### PR DESCRIPTION
Merge commit `cbf6d25dd6368f936dcd27f56b9644f4b154ef13` intrudoced regression in `ClassLoaderResourceAccessor`
Usage of variable `path` was replaced by `sanitizePath` in the class in CORE-3213 (`4b451e2508f1ea4a18dbf2607b285dd1f0746dbd`) 
