### PR TITLE
Fix a bug caused by 4b451e2508f

### DIFF
--- a/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
@@ -98,11 +98,11 @@ public class ClassLoaderResourceAccessor extends AbstractResourceAccessor {
                 if (sanitizePath.startsWith("classpath*:")) {
                     sanitizePath = sanitizePath.replaceFirst("classpath\\*:", "");
                 }
-                // if path is like 'jar:<url>!/{entry}', use the last part as resource path
-                if (path.contains("!/")) {
-                    String[] components = path.split("!/");
+                // if sanitizePath is like 'jar:<url>!/{entry}', use the last part as resource path
+                if (sanitizePath.contains("!/")) {
+                    String[] components = sanitizePath.split("!/");
                     if (components.length > 1) {
-                        path = components[components.length - 1];
+                        sanitizePath = components[components.length - 1];
                     }
                 }
 


### PR DESCRIPTION
4b451e2508f1ea4a18dbf2607b285dd1f0746dbd cause 
`liquibase.resource.ClassLoaderResourceAccessorTest#can recursively enumerate files inside JARs using JAR file URL` failed