### PR TITLE
Adds clearCheckSums property in spring integration

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/spring/MultiTenantSpringLiquibase.java
+++ b/liquibase-core/src/main/java/liquibase/integration/spring/MultiTenantSpringLiquibase.java
@@ -72,6 +72,8 @@ public class MultiTenantSpringLiquibase implements InitializingBean, ResourceLoa
 
     private boolean dropFirst;
 
+    private boolean clearCheckSums;
+
     private boolean shouldRun = true;
 
     private File rollbackFile;
@@ -154,6 +156,7 @@ public class MultiTenantSpringLiquibase implements InitializingBean, ResourceLoa
 		liquibase.setContexts(contexts);
         liquibase.setLabels(labels);
 		liquibase.setDropFirst(dropFirst);
+		liquibase.setClearCheckSums(clearCheckSums);
 		liquibase.setShouldRun(shouldRun);
 		liquibase.setRollbackFile(rollbackFile);
 		liquibase.setResourceLoader(resourceLoader);
@@ -253,6 +256,14 @@ public class MultiTenantSpringLiquibase implements InitializingBean, ResourceLoa
 
 	public void setDropFirst(boolean dropFirst) {
 		this.dropFirst = dropFirst;
+	}
+
+	public boolean isClearCheckSums() {
+		return clearCheckSums;
+	}
+
+	public void setClearCheckSums(boolean clearCheckSums) {
+		this.clearCheckSums = clearCheckSums;
 	}
 
 	public boolean isShouldRun() {

--- a/liquibase-core/src/main/java/liquibase/integration/spring/SpringLiquibase.java
+++ b/liquibase-core/src/main/java/liquibase/integration/spring/SpringLiquibase.java
@@ -84,6 +84,7 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
 	protected String databaseChangeLogLockTable;
 	protected String liquibaseTablespace;
 	protected boolean dropFirst;
+	protected boolean clearCheckSums;
 	protected boolean shouldRun = true;
 	protected File rollbackFile;
 
@@ -134,6 +135,14 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
 
 	public void setDropFirst(boolean dropFirst) {
 		this.dropFirst = dropFirst;
+	}
+
+	public boolean isClearCheckSums() {
+		return clearCheckSums;
+	}
+
+	public void setClearCheckSums(boolean clearCheckSums) {
+		this.clearCheckSums = clearCheckSums;
 	}
 
 	public void setShouldRun(boolean shouldRun) {
@@ -340,6 +349,10 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
     }
 
     protected void performUpdate(Liquibase liquibase) throws LiquibaseException {
+		if (isClearCheckSums()) {
+			liquibase.clearCheckSums();
+		}
+
 		if (isTestRollbackOnUpdate()) {
 			if (tag != null) {
 				liquibase.updateTestingRollback(tag, new Contexts(getContexts()), new LabelExpression(getLabels()));


### PR DESCRIPTION
# Motivation
If the database is restored from a dump on another system, if the spring-boot-liquibase tries to run migration it fails as the md5 check sum validation fails on startup. With liquibase-maven-plugin, clearCheckSums command line option is available but it is not possible to do the same with spring boot liquibase integration.

# Solution
Adds `clearCheckSums` property, which if set to true will call `liquibase.clearCheckSums` method before performing the update.