### PR TITLE
Fix CORE-3231: NPE in LogService.pushContext for MDCs

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeLogIterator.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeLogIterator.java
@@ -42,6 +42,11 @@ public class ChangeLogIterator {
             public List<ChangeSet> getChangeSets() {
                 return changeSets;
             }
+            // Prevent NPE (CORE-3231)
+            @Override
+            public String toString() {
+                return "";
+            }
         });
 
         this.changeSetFilters = Arrays.asList(changeSetFilters);


### PR DESCRIPTION
Overwrite `toString()` method to return an empty string for the empty anonymous implementation of DatabaseChangeLog.