### PR TITLE
Tag should remain after rollback [CORE-2946]

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/filter/AfterTagChangeSetFilter.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/filter/AfterTagChangeSetFilter.java
@@ -24,9 +24,6 @@ public class AfterTagChangeSetFilter implements ChangeSetFilter {
 
             if (!seenTag && tag.equalsIgnoreCase(ranChangeSet.getTag())) {
                 seenTag = true;
-                if ("tagDatabase".equals(StringUtils.trimToEmpty(ranChangeSet.getDescription()))) { //changeSet is just tagging the database. Also remove it.
-                    changeLogsAfterTag.add(changeLogToString(ranChangeSet.getId(), ranChangeSet.getAuthor(), ranChangeSet.getChangeLog()));
-                }
             }
         }
 


### PR DESCRIPTION
Fixes https://liquibase.jira.com/browse/CORE-2946, making behavior of liquibase more consistent and predictable - rollback to tag behavior does not depend on whether the tag is isolated in it's own changeset or not. This also mirrors the behavior of updateToTag, so that updating to a tag, and rolling back to that tag, both have identical results.