### PR TITLE
Added support for Oracle datatype.  If you could refer to

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/IntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/IntType.java
@@ -32,9 +32,10 @@ public class IntType extends LiquibaseDataType {
         if ((database instanceof InformixDatabase) && isAutoIncrement()) {
             return new DatabaseDataType("SERIAL");
         }
-
-        if ((database instanceof AbstractDb2Database) || (database instanceof DerbyDatabase) || (database instanceof
-            OracleDatabase)) {
+		if (database instanceof OracleDatabase) {
+            return new DatabaseDataType("NUMBER", new Object[]{10});
+        }
+        if ((database instanceof AbstractDb2Database) || (database instanceof DerbyDatabase)) {
             return new DatabaseDataType("INTEGER");
         }
         if (database instanceof PostgresDatabase) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/IntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/IntType.java
@@ -32,7 +32,7 @@ public class IntType extends LiquibaseDataType {
         if ((database instanceof InformixDatabase) && isAutoIncrement()) {
             return new DatabaseDataType("SERIAL");
         }
-		if (database instanceof OracleDatabase) {
+        if (database instanceof OracleDatabase) {
             return new DatabaseDataType("NUMBER", new Object[]{10});
         }
         if ((database instanceof AbstractDb2Database) || (database instanceof DerbyDatabase)) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/MediumIntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/MediumIntType.java
@@ -33,9 +33,9 @@ public class MediumIntType extends LiquibaseDataType {
             type.addAdditionalInformation(getAdditionalInformation());
             return type;
         }
-		if (database instanceof OracleDatabase) {
-			return new DatabaseDataType("NUMBER", new Object[]{7});
-		}
+        if (database instanceof OracleDatabase) {
+            return new DatabaseDataType("NUMBER", new Object[]{7});
+        }
         if ((database instanceof AbstractDb2Database) || (database instanceof DerbyDatabase) || (database instanceof
             FirebirdDatabase)) {
             return new DatabaseDataType("MEDIUMINT"); //always mediumint regardless of parameters passed

--- a/liquibase-core/src/main/java/liquibase/datatype/core/MediumIntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/MediumIntType.java
@@ -33,9 +33,12 @@ public class MediumIntType extends LiquibaseDataType {
             type.addAdditionalInformation(getAdditionalInformation());
             return type;
         }
+		if (database instanceof OracleDatabase) {
+			return new DatabaseDataType("NUMBER", new Object[]{7});
+		}
         if ((database instanceof AbstractDb2Database) || (database instanceof DerbyDatabase) || (database instanceof
             FirebirdDatabase)) {
-            return new DatabaseDataType("MEDIUMINT"); //always smallint regardless of parameters passed
+            return new DatabaseDataType("MEDIUMINT"); //always mediumint regardless of parameters passed
         }
         return super.toDatabaseDataType(database);
     }


### PR DESCRIPTION
https://docs.oracle.com/cd/E12151_01/doc.150/e12155/oracle_mysql_compared.htm#i1027526 on section 2.3.3.1, mediumint would be suggested as NUMBER(7,0) and mediumint does not exists in Oracle.  INT gets tricky, as liquibase translate it as INTEGER.  Oracle treats INTEGER as NUMBER(38,0) which is like a BIGINT or the maximum size support.  Following the same documentation, it's probably best to be used as NUMBER(10,0).
#3292