### PR TITLE
Fix #CORE-3293 Non global change log parameters are wrongly resolved …

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeLogParameters.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeLogParameters.java
@@ -156,7 +156,7 @@ public class ChangeLogParameters {
             result = found.get(0);
         } else if (found.size() > 1) {
             for (ChangeLogParameter changeLogParameter : found) {
-                if (changeLogParameter.getChangeLog() == changeLog) {
+                if (changeLogParameter.getChangeLog().equals(changeLog)) {
                     result = changeLogParameter;
                 }
             }

--- a/liquibase-core/src/test/java/liquibase/changelog/ChangeLogParametersTest.java
+++ b/liquibase-core/src/test/java/liquibase/changelog/ChangeLogParametersTest.java
@@ -73,4 +73,26 @@ public class ChangeLogParametersTest {
 
         assertEquals("originalValue", changeLogParameters.getValue("doubleSet", null));
     }
+
+    @Test
+    /**
+     * root.xml
+     *  -a.xml
+     *  -b.xml
+     *
+     *  in a and b we define same prop with key 'aKey'. Expected when b is processed then bValue is taken no matter of Object instances
+     */
+    public void getParameterValue_SamePropertyNonGlobalIn2InnerFiles() {
+        DatabaseChangeLog inner1 = new DatabaseChangeLog();
+        inner1.setPhysicalFilePath("a");
+        DatabaseChangeLog inner2 = new DatabaseChangeLog();
+        inner2.setPhysicalFilePath("b");
+        ChangeLogParameters changeLogParameters = new ChangeLogParameters(new H2Database());
+        changeLogParameters.set("aKey", "aValue", "junit", "junitLabel", "baddb, h2", false, inner1);
+        changeLogParameters.set("aKey", "bValue", "junit", "junitLabel", "baddb, h2", false, inner2);
+        DatabaseChangeLog inner2SamePath = new DatabaseChangeLog();
+        inner2SamePath.setPhysicalFilePath("b");
+        Object aKey = changeLogParameters.getValue("aKey", inner2SamePath);
+        assertEquals("bValue", aKey);
+    }
 }


### PR DESCRIPTION
…in inner files

Fixed changelog comparison
added a test