### PR TITLE
CORE-3221 datetime string is valid, if no millis part is found

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
@@ -326,15 +326,15 @@ public class OracleDatabase extends AbstractJdbcDatabase {
             int seppos = normalLiteral.lastIndexOf('.');
             if (seppos != -1) {
                 normalLiteral = normalLiteral.substring(0, seppos) + "'";
-                StringBuffer val = new StringBuffer(26);
-                //noinspection HardCodedStringLiteral
-                val.append("TO_DATE(");
-                val.append(normalLiteral);
-                //noinspection HardCodedStringLiteral
-                val.append(", 'YYYY-MM-DD HH24:MI:SS')");
-                return val.toString();
-            }
-        }
+			}
+			StringBuffer val = new StringBuffer(26);
+			// noinspection HardCodedStringLiteral
+			val.append("TO_DATE(");
+			val.append(normalLiteral);
+			// noinspection HardCodedStringLiteral
+			val.append(", 'YYYY-MM-DD HH24:MI:SS')");
+			return val.toString();
+		}
         //noinspection HardCodedStringLiteral
         return "UNSUPPORTED:" + isoDate;
     }


### PR DESCRIPTION
The fix is done in the oracle specific class to reduce complications with other databases.
The generated sql part is also correct, if the oracle column datatype is a timestamp.