### PR TITLE
CORE-3242 fix version check for MS SQL Server 2008

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
@@ -177,7 +177,7 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
         boolean isRealSqlServerConnection = PRODUCT_NAME.equalsIgnoreCase(databaseProductName)
                 || "SQLOLEDB".equalsIgnoreCase(databaseProductName);
 
-        if (isRealSqlServerConnection && (majorVersion <= MSSQL_SERVER_VERSIONS.MSSQL2008)) {
+        if (isRealSqlServerConnection && (majorVersion < MSSQL_SERVER_VERSIONS.MSSQL2008)) {
             LogService.getLog(getClass()).warning(
                 LogType.LOG, String.format("Your SQL Server major version (%d) seems to indicate that your " +
                         "software is older than SQL Server 2008. Unfortunately, this is not supported, and this " +


### PR DESCRIPTION
Fix version comparison to allow MS SQL 2008 as intended by the log entry below.