### PR TITLE
Fix TIMESTAP WITHOUT TIME ZONE issue for H2 database

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/TimestampType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/TimestampType.java
@@ -138,6 +138,11 @@ public class TimestampType extends DateTimeType {
                     // https://docs.oracle.com/cd/B19306_01/server.102/b14225/ch4datetime.htm#sthref389
                     additionalInformation = null;
                 }
+
+                if ((database instanceof H2Database) && additionInformation.startsWith("WITHOUT")) {
+                    // http://www.h2database.com/html/datatypes.html
+                    additionalInformation = null;
+                }
             }
 
             type.addAdditionalInformation(additionalInformation);


### PR DESCRIPTION
H2 also doesn't support TIMESTAMP WITHOUT TIME ZONE syntax