### PR TITLE
Add ability to disable running of Liquibase via CDILiquibaseConfig

### DIFF
--- a/liquibase-cdi/src/main/java/liquibase/integration/cdi/CDILiquibase.java
+++ b/liquibase-cdi/src/main/java/liquibase/integration/cdi/CDILiquibase.java
@@ -115,6 +115,10 @@ public class CDILiquibase implements Extension {
             ));
             return;
         }
+        if (!config.getShouldRun()) {
+            log.info(LogType.LOG, String.format("Liquibase did not run on %s because CDILiquibaseConfig.shouldRun was set to false.", hostName));
+            return;
+        }
         initialized = true;
         try {
             performUpdate();

--- a/liquibase-cdi/src/main/java/liquibase/integration/cdi/CDILiquibaseConfig.java
+++ b/liquibase-cdi/src/main/java/liquibase/integration/cdi/CDILiquibaseConfig.java
@@ -15,6 +15,7 @@ public class CDILiquibaseConfig {
     private Map<String,String> parameters;
     private boolean dropFirst;
     private String defaultSchema;
+    private boolean shouldRun = true;
 
     public String getContexts() {
         return contexts;
@@ -62,5 +63,13 @@ public class CDILiquibaseConfig {
 
     public void setDefaultSchema(String defaultSchema) {
         this.defaultSchema = defaultSchema;
+    }
+
+    public boolean getShouldRun() {
+        return shouldRun;
+    }
+
+    public void setShouldRun(boolean shouldRun) {
+        this.shouldRun = shouldRun;
     }
 }

--- a/liquibase-cdi/src/test/java/liquibase/integration/cdi/CDILiquibaseTest.java
+++ b/liquibase-cdi/src/test/java/liquibase/integration/cdi/CDILiquibaseTest.java
@@ -20,26 +20,39 @@ public class CDILiquibaseTest {
     @After
     public void clearProperty() {
         System.clearProperty("liquibase.shouldRun");
+        System.clearProperty("liquibase.config.shouldRun");
         LiquibaseConfiguration.getInstance().reset();
+    }
+
+    private void validateRunningState(boolean shouldBeRunning) {
+        WeldContainer weld = new Weld().initialize();
+        CDILiquibase cdiLiquibase = weld.instance().select(CDILiquibase.class).get();
+        assertNotNull(cdiLiquibase);
+        assertEquals(shouldBeRunning, cdiLiquibase.isInitialized());
+        assertEquals(shouldBeRunning, cdiLiquibase.isUpdateSuccessful());
     }
 
     @Test
     public void shouldntRunWhenShouldRunIsFalse() {
         System.setProperty("liquibase.shouldRun", "false");
-        WeldContainer weld = new Weld().initialize();
-        CDILiquibase cdiLiquibase = weld.instance().select(CDILiquibase.class).get();
-        assertNotNull(cdiLiquibase);
-        assertFalse(cdiLiquibase.isInitialized());
-        assertFalse(cdiLiquibase.isUpdateSuccessful());
+        validateRunningState(false);
     }
 
     @Test
     public void shouldRunWhenShouldRunIsTrue() {
         System.setProperty("liquibase.shouldRun", "true");
-        WeldContainer weld = new Weld().initialize();
-        CDILiquibase cdiLiquibase = weld.instance().select(CDILiquibase.class).get();
-        assertNotNull(cdiLiquibase);
-        assertTrue(cdiLiquibase.isInitialized());
-        assertTrue(cdiLiquibase.isUpdateSuccessful());
+        validateRunningState(true);
+    }
+
+    @Test
+    public void shouldntRunWhenConfigShouldRunIsFalse() {
+        System.setProperty("liquibase.config.shouldRun", "false");
+        validateRunningState(false);
+    }
+
+    @Test
+    public void shouldRunWhenConfigShouldRunIsTrue() {
+        System.setProperty("liquibase.config.shouldRun", "true");
+        validateRunningState(true);
     }
 }

--- a/liquibase-cdi/src/test/java/liquibase/integration/cdi/CDITestProducer.java
+++ b/liquibase-cdi/src/test/java/liquibase/integration/cdi/CDITestProducer.java
@@ -21,6 +21,8 @@ public class CDITestProducer {
     public CDILiquibaseConfig createConfig() {
         CDILiquibaseConfig config = new CDILiquibaseConfig();
         config.setChangeLog("liquibase/parser/core/xml/simpleChangeLog.xml");
+        boolean configShouldRun = Boolean.valueOf(System.getProperty("liquibase.config.shouldRun", "true"));
+        config.setShouldRun(configShouldRun);
         return config;
     }
 


### PR DESCRIPTION
Currently the only way to disable Liquibase from running in a CDI environment is to set the system property "liquibase.should.run" to false.  It would be more useful for me to be able to provide this via a configuration setting that I can toggle via my producer for CDILiquibaseConfig.  This way I can set appropriate behavior in my application via config files instead of relying on system properties to be set. Passivity is maintained through all of this by still supporting the existing process and by defaulting the new process to enable by default.