### PR TITLE
Fixing CORE-3121  Getting a java.io.FileNotFoundException using Liquibase with Spring reactive web

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/spring/SpringLiquibase.java
+++ b/liquibase-core/src/main/java/liquibase/integration/spring/SpringLiquibase.java
@@ -507,7 +507,9 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
 
                 for (String foundPackage : liquibasePackages) {
                     for (Resource res : getResources(foundPackage)) {
-                        addRootPath(res.getURL());
+                        if (res.exists()) {
+                            addRootPath(res.getURL());
+                        }
                     }
                 }
 

--- a/liquibase-core/src/main/java/liquibase/integration/spring/SpringLiquibase.java
+++ b/liquibase-core/src/main/java/liquibase/integration/spring/SpringLiquibase.java
@@ -509,6 +509,10 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
                     for (Resource res : getResources(foundPackage)) {
                         if (res.exists()) {
                             addRootPath(res.getURL());
+                        } else {
+                            LogService.getLog(getClass()).warning(LogType.LOG,
+                                "Resource does not exist: " +
+                                res.getDescription());
                         }
                     }
                 }


### PR DESCRIPTION
As per Cabot's comment in the issue, "resource loader generates FilteredReactiveWebContextResource and that implementation returns false for exists()." To fix this issue an additional call for exists() is added before trying to call getURL() for the resource. If the resource does not exist, it does not make sense to try to get its URL.