### PR TITLE
Fix for bug: Creation of parent directories when they don't exist, wh…

### DIFF
--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/DiffToChangeLog.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/DiffToChangeLog.java
@@ -82,6 +82,7 @@ public class DiffToChangeLog {
         this.changeSetPath = changeLogFile;
         File file = new File(changeLogFile);
         if (!file.exists()) {
+            file.getParentFile().mkdirs();
             LogService.getLog(getClass()).info(LogType.LOG, file + " does not exist, creating");
             FileOutputStream stream = new FileOutputStream(file);
             print(new PrintStream(stream, true, LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).getOutputEncoding()), changeLogSerializer);


### PR DESCRIPTION
The plugin does not create the parent directory for changelog file if it does not exist. Suppose you set the changeLogFile property with src/main/resources/db/changelog.xml and the db directory does not exist, an error will occur: FileNotFoundException: src/main/resources/db/changelog.xml (No such file or directory) -> [Help 1]

I know that will only happen during the plugin's first execution. But why not just create the directory when the file does not exist?

https://liquibase.jira.com/browse/CORE-3174