### PR TITLE
Fix for bug: Error while including resources with includeAll directiv…

### DIFF
--- a/liquibase-cdi/pom.xml
+++ b/liquibase-cdi/pom.xml
@@ -33,6 +33,7 @@
 		<dependency>
 			<groupId>org.jboss.weld.se</groupId>
 			<artifactId>weld-se</artifactId>
+			<version>1.1.12.Final</version>
 		</dependency>
 
 		<!-- provided scope -->

--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -144,6 +144,11 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
 
+		<!-- Google Reflections -->
+		<dependency>
+			<groupId>org.reflections</groupId>
+			<artifactId>reflections</artifactId>
+		</dependency>
     </dependencies>
 
 	<build>

--- a/liquibase-debian/pom.xml
+++ b/liquibase-debian/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-parent</artifactId>
-        <version>3.6.2-SNAPSHOT</version>
+        <version>3.6.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>liquibase-debian</artifactId>

--- a/liquibase-rpm/pom.xml
+++ b/liquibase-rpm/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.liquibase</groupId>
 		<artifactId>liquibase-parent</artifactId>
-		<version>3.6.2-SNAPSHOT</version>
+		<version>3.6.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>liquibase-rpm</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,7 @@
         <org.codehaus.groovy.version>2.4.11</org.codehaus.groovy.version>
         <org.spockframework.version>1.1-groovy-2.4</org.spockframework.version>
         <system-rules.version>1.16.0</system-rules.version>
+        <reflections.version>0.9.11</reflections.version>
 
         <!-- Code coverage settings for the combination JaCoCo (offline instrumentation) and SONAR (cloud) -->
         <jacoco.version>0.7.9</jacoco.version>
@@ -404,6 +405,13 @@
                 <groupId>org.xerial</groupId>
                 <artifactId>sqlite-jdbc</artifactId>
                 <version>${sqlite-jdbc.version}</version>
+            </dependency>
+
+            <!-- Google Reflections -->
+            <dependency>
+                <groupId>org.reflections</groupId>
+                <artifactId>reflections</artifactId>
+                <version>${reflections.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
If we try to access a resource present in the Application's Classpath, when we are using a JBoss / WildFly server, this resource is made available through the server's own file system, called VFS.

There are two basic ways we may deploy a Web Application on a JBoss / WildFly server. Or via exploded War, or via War artifact itself.

In both cases, if you try to access for example the db/changelog/20180223-12-45-changelog.xml resource in the my-app.war application, the JBoss / WildFly server will generate the following path for the resource:

1) War Exploded
vfs:/<my-local-projects-path>/my-app/target/my-app/WEB-INF/classes/db/changelog/20180223-12-45-changelog.xml

2) War Artifact
vfs:/content/my-app.war/WEB-INF/classes/db/changelog/20180223-12-45-changelog.xml

Even worse, if the resource is present in a Jar file and not inside the War application itself, the path for it will be:

1) War Exploded
vfs:/<my-local-projects-path>/my-app/target/my-app/WEB-INF/lib/my-lib.jar/db/changelog/20180223-12-45-changelog.xml

2) War Artifact
vfs:/content/my-app.war/WEB-INF/lib/my-lib.jar/db/changelog/20180223-12-45-changelog.xml

As you can imagine, liquibase until now does not have support for VFS resources inside a Jar file or directly in a War file. Basically what we need to do is to change the ClassLoaderResourceAccessor class so when it is listing the resources defined by the includeAll directive, it knows how to handle VFS resources.

I've tried to NOT use Google Reflections Lib to patch this error, but I couldn't find an easy and simple way. So if you guys are interested in a solution using Google Reflections, I can send a PR.

Here, as attachment (Lines 137:178), is the code to solve the problem using Google Reflections.

https://liquibase.jira.com/browse/CORE-3177