### PR TITLE
[Fix Bug] fix nullPointerException when migrating RedShift

### DIFF
--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
@@ -232,15 +232,17 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
                 column.setNullable(false);
             }
         } else {
-            int nullable = columnMetadataResultSet.getInt("NULLABLE");
-            if (nullable == DatabaseMetaData.columnNoNulls) {
-                column.setNullable(false);
-            } else if (nullable == DatabaseMetaData.columnNullable) {
-                column.setNullable(true);
-            } else if (nullable == DatabaseMetaData.columnNullableUnknown) {
-                LogService.getLog(getClass()).info(LogType.LOG, "Unknown nullable state for column "
-                    + column.toString() + ". Assuming nullable");
-                column.setNullable(true);
+            Integer nullable = columnMetadataResultSet.getInt("NULLABLE");
+            if (nullable != null) {
+                if (nullable == DatabaseMetaData.columnNoNulls) {
+                    column.setNullable(false);
+                } else if (nullable == DatabaseMetaData.columnNullable) {
+                    column.setNullable(true);
+                } else if (nullable == DatabaseMetaData.columnNullableUnknown) {
+                    LogService.getLog(getClass()).info(LogType.LOG, "Unknown nullable state for column "
+                            + column.toString() + ". Assuming nullable");
+                    column.setNullable(true);
+                }
             }
         }
 


### PR DESCRIPTION
in ColumnSnapshotGenerator, it is trying to get "NULLABLE" column metadata which is Integer type, and assign to an int variable. 
When running migration for RedShift, the column metadata "NULLABLE" is null, and when assigning null to int variable it raises NullPointerExeception because can not unbox null value