### PR TITLE
CORE-3251 Adding restricted words for MSSQL Server Database

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
@@ -57,8 +57,6 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
 
     private Boolean sendsStringParametersAsUnicode;
 
-    private static final List<String> RESERVED_WORDS = createReservedWords();
-
     // "Magic numbers" are ok here because we populate a lot of self-explaining metadata.
     @SuppressWarnings("squid:S109")
     public MSSQLDatabase() {
@@ -104,9 +102,7 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
         defaultDataTypeParameters.put("money", 4);
         defaultDataTypeParameters.put("smallmoney", 0);
 
-
-        // JDBC Driver version 6.2.0 does not seem to return this keyword, which causes an integration test to fail.
-        addReservedWords(Arrays.asList("KEY"));
+        addReservedWords(createReservedWordsCollection());
     }
 
     @Override
@@ -607,15 +603,10 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
         return "]]";
     }
 
-    @Override
-    public boolean isReservedWord(String string) {
-        return RESERVED_WORDS.contains(string.toUpperCase()) || super.isReservedWord(string);
-    }
-
     /*
     Source: https://docs.microsoft.com/en-us/sql/t-sql/language-elements/reserved-keywords-transact-sql?view=sql-server-2017
      */
-    private static List<String> createReservedWords() {
+    private static List<String> createReservedWordsCollection() {
         return Arrays.asList("ADD", "ALL", "ALTER", "AND", "ANY", "AS", "ASC", "AUTHORIZATION",
                 "BACKUP", "BEGIN", "BETWEEN", "BREAK", "BROWSE", "BULK", "BY",
                 "CASCADE", "CASE", "CHECK", "CHECKPOINT", "CLOSE", "CLUSTERED", "COALESCE", "COLLATE",

--- a/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
@@ -57,6 +57,8 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
 
     private Boolean sendsStringParametersAsUnicode;
 
+    private static final List<String> RESERVED_WORDS = createReservedWords();
+
     // "Magic numbers" are ok here because we populate a lot of self-explaining metadata.
     @SuppressWarnings("squid:S109")
     public MSSQLDatabase() {
@@ -603,5 +605,50 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
     @Override
     protected String getQuotingEndReplacement() {
         return "]]";
+    }
+
+    @Override
+    public boolean isReservedWord(String string) {
+        return RESERVED_WORDS.contains(string.toUpperCase()) || super.isReservedWord(string);
+    }
+
+    /*
+    Source: https://docs.microsoft.com/en-us/sql/t-sql/language-elements/reserved-keywords-transact-sql?view=sql-server-2017
+     */
+    private static List<String> createReservedWords() {
+        return Arrays.asList("ADD", "ALL", "ALTER", "AND", "ANY", "AS", "ASC", "AUTHORIZATION",
+                "BACKUP", "BEGIN", "BETWEEN", "BREAK", "BROWSE", "BULK", "BY",
+                "CASCADE", "CASE", "CHECK", "CHECKPOINT", "CLOSE", "CLUSTERED", "COALESCE", "COLLATE",
+                "COLUMN", "COMMIT", "COMPUTE", "CONSTRAINT", "CONTAINS", "CONTAINSTABLE", "CONTINUE",
+                "CONVERT", "CREATE", "CROSS", "CURRENT", "CURRENT_DATE", "CURRENT_TIME",
+                "CURRENT_TIMESTAMP", "CURRENT_USER", "CURSOR",
+                "DATABASE", "DBCC", "DEALLOCATE", "DECLARE", "DEFAULT", "DELETE", "DENY", "DESC",
+                "DISK", "DISTINCT", "DISTRIBUTED", "DOUBLE", "DROP", "DUMP",
+                "ELSE", "END", "ERRLVL", "ESCAPE", "EXCEPT", "EXEC", "EXECUTE", "EXISTS", "EXIT", "EXTERNAL",
+                "FETCH", "FILE", "FILLFACTOR", "FOR", "FOREIGN", "FREETEXT", "FREETEXTTABLE",
+                "FROM", "FULL", "FUNCTION",
+                "GOTO", "GRANT", "GROUP",
+                "HAVING", "HOLDLOCK",
+                "IDENTITY", "IDENTITY_INSERT", "IDENTITYCOL", "IF", "IN", "INDEX",
+                "INNER", "INSERT", "INTERSECT", "INTO", "IS",
+                "JOIN",
+                "KEY", "KILL",
+                "LEFT", "LIKE", "LINENO", "LOAD",
+                "MERGE",
+                "NATIONAL", "NOCHECK", "NONCLUSTERED", "NOT", "NULL", "NULLIF",
+                "OF", "OFF", "OFFSETS", "ON", "OPEN", "OPENDATASOURCE", "OPENQUERY", "OPENROWSET",
+                "OPENXML", "OPTION", "OR", "ORDER", "OUTER", "OVER",
+                "PERCENT", "PIVOT", "PLAN", "PRECISION", "PRIMARY", "PRINT", "PROC", "PROCEDURE", "PUBLIC",
+                "RAISERROR", "READ", "READTEXT", "RECONFIGURE", "REFERENCES",
+                "REPLICATION", "RESTORE", "RESTRICT", "RETURN", "REVERT", "REVOKE",
+                "RIGHT", "ROLLBACK", "ROWCOUNT", "ROWGUIDCOL", "RULE",
+                "SAVE", "SCHEMA", "SECURITYAUDIT", "SELECT", "SEMANTICKEYPHRASETABLE",
+                "SEMANTICSIMILARITYDETAILSTABLE", "SEMANTICSIMILARITYTABLE", "SESSION_USER",
+                "SET", "SETUSER", "SHUTDOWN", "SOME", "STATISTICS", "SYSTEM_USER",
+                "TABLE", "TABLESAMPLE", "TEXTSIZE", "THEN", "TO", "TOP", "TRAN", "TRANSACTION",
+                "TRIGGER", "TRUNCATE", "TRY_CONVERT", "TSEQUAL",
+                "UNION", "UNIQUE", "UNPIVOT", "UPDATE", "UPDATETEXT", "USE", "USER",
+                "VALUES", "VARYING", "VIEW",
+                "WAITFOR", "WHEN", "WHERE", "WHILE", "WITH", "WITHIN GROUP", "WRITETEXT");
     }
 }


### PR DESCRIPTION
Source for keyword for reserved ones take from [TSQL documentation](https://docs.microsoft.com/en-us/sql/t-sql/language-elements/reserved-keywords-transact-sql?view=sql-server-2017).