### PR TITLE
CORE-3221 fix oracle date literal without millis

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
@@ -319,14 +319,14 @@ public class OracleDatabase extends AbstractJdbcDatabase {
             int seppos = normalLiteral.lastIndexOf('.');
             if (seppos != -1) {
                 normalLiteral = normalLiteral.substring(0, seppos) + "'";
-                StringBuffer val = new StringBuffer(26);
-                //noinspection HardCodedStringLiteral
-                val.append("TO_DATE(");
-                val.append(normalLiteral);
-                //noinspection HardCodedStringLiteral
-                val.append(", 'YYYY-MM-DD HH24:MI:SS')");
-                return val.toString();
             }
+            StringBuffer val = new StringBuffer(26);
+            //noinspection HardCodedStringLiteral
+            val.append("TO_DATE(");
+            val.append(normalLiteral);
+            //noinspection HardCodedStringLiteral
+            val.append(", 'YYYY-MM-DD HH24:MI:SS')");
+            return val.toString();
         }
         //noinspection HardCodedStringLiteral
         return "UNSUPPORTED:" + isoDate;

--- a/liquibase-core/src/test/java/liquibase/database/core/OracleDatabaseTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/core/OracleDatabaseTest.java
@@ -121,6 +121,12 @@ public class OracleDatabaseTest extends AbstractJdbcDatabaseTest {
     }
 
     @Test
+    public void getDateLiteral_date() {
+        // DATE in Oracle can have hours/minutes/seconds.
+        assertEquals("TO_DATE('2017-08-16 16:32:55', 'YYYY-MM-DD HH24:MI:SS')", database.getDateLiteral("2017-08-16T16:32:55"));
+    }
+
+    @Test
     public void getDateLiteral_dateOnly() {
         assertEquals("TO_DATE('2017-08-16', 'YYYY-MM-DD')", database.getDateLiteral("2017-08-16"));
     }


### PR DESCRIPTION
Original fix by Tim Gödde (https://github.com/liquibase/liquibase/pull/800); I fixed formatting and added test case.

https://liquibase.jira.com/browse/CORE-3221