### PR TITLE
CORE-3262 fix: FileSystemResourceAccessor fails with non-hierarchical…

### DIFF
--- a/liquibase-core/src/main/java/liquibase/resource/FileSystemResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/FileSystemResourceAccessor.java
@@ -3,6 +3,7 @@ package liquibase.resource;
 import liquibase.exception.UnexpectedLiquibaseException;
 
 import java.io.*;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -48,10 +49,10 @@ public class FileSystemResourceAccessor extends AbstractResourceAccessor {
     @Override
     protected void addRootPath(URL path) {
         try {
-            File pathAsFile = new File(path.toURI());
+            URI pathAsUri = path.toURI();
 
             for (File fileSystemRoot : File.listRoots()) {
-                if (pathAsFile.equals(fileSystemRoot)) { //don't include root
+                if (pathAsUri.equals(fileSystemRoot.toURI())) { //don't include root
                     return;
                 }
             }

--- a/liquibase-core/src/test/groovy/liquibase/resource/FileSystemResourceAccessorTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/resource/FileSystemResourceAccessorTest.groovy
@@ -43,4 +43,26 @@ public class FileSystemResourceAccessorTest extends Specification {
             }
         }
     }
+
+    def addRootPathTestDirectory() {
+        expect:
+        def directoryUrl = new URL("file:/home/user/liquibase/liquibase-core/target/test-classes/");
+        def fileSystemResourceAccessor = createResourceAccessor();
+        def count = fileSystemResourceAccessor.getRootPaths().size();
+
+        fileSystemResourceAccessor.addRootPath(directoryUrl);
+
+        assert (fileSystemResourceAccessor.getRootPaths().size() == count + 1) : "non-root directory not added";
+    }
+
+    def addRootPathTestMultiReleaseJar() {
+        expect:
+        def multiReleaseJarUrl = new URL("jar:file:/home/user/.m2/repository/javax/xml/bind/jaxb-api/2.3.0/jaxb-api-2.3.0.jar!/META-INF/versions/9/");
+        def fileSystemResourceAccessor = createResourceAccessor();
+        def count = fileSystemResourceAccessor.getRootPaths().size();
+
+        fileSystemResourceAccessor.addRootPath(multiReleaseJarUrl);
+
+        assert (fileSystemResourceAccessor.getRootPaths().size() == count + 1) : "multi-release jar not added";
+    }
 }


### PR DESCRIPTION
… URLs on class path

Multi-release Jars on the classpath caused a java.lang.IllegalArgumentException "URI is not hierarchical" in FileSystemResourceAccessor::addRootPath()