### PR TITLE
prints the error code on Exception

### DIFF
--- a/liquibase-core/src/main/java/liquibase/executor/jvm/JdbcExecutor.java
+++ b/liquibase-core/src/main/java/liquibase/executor/jvm/JdbcExecutor.java
@@ -302,7 +302,7 @@ public class JdbcExecutor extends AbstractExecutor {
                     }
                 }
             } catch (Exception e) {
-                throw new DatabaseException(e.getMessage() + " [Failed SQL: " + sql.toSql() + "]", e);
+                throw new DatabaseException(e.getMessage() + " [Failed SQL: " + getErrorCode(e) + sql.toSql() + "]", e);
             }
         }
     }
@@ -321,7 +321,12 @@ public class JdbcExecutor extends AbstractExecutor {
         }
     }
 
-
+    String getErrorCode(Throwable e) {
+        if (e instanceof SQLException) {
+            return "(" + ((SQLException)e).getErrorCode() + ") ";
+        }
+        return "";
+    }
 
     private class ExecuteStatementCallback implements StatementCallback {
 
@@ -353,7 +358,7 @@ public class JdbcExecutor extends AbstractExecutor {
                         log.debug(Integer.toString(stmt.getUpdateCount()) + " row(s) affected");
                     }
                 } catch (Throwable e) {
-                    throw new DatabaseException(e.getMessage()+ " [Failed SQL: "+statement+"]", e);
+                    throw new DatabaseException(e.getMessage()+ " [Failed SQL: " + getErrorCode(e) + statement+"]", e);
                 }
                 try {
                     int updateCount = 0;
@@ -367,7 +372,7 @@ public class JdbcExecutor extends AbstractExecutor {
                     } while (updateCount != -1);
 
                 } catch (Exception e) {
-                    throw new DatabaseException(e.getMessage()+ " [Failed SQL: "+statement+"]", e);
+                    throw new DatabaseException(e.getMessage()+ " [Failed SQL: "+ getErrorCode(e) + statement+"]", e);
                 }
             }
             return null;

--- a/liquibase-core/src/test/java/liquibase/executor/jvm/JdbcExecutorTest.java
+++ b/liquibase-core/src/test/java/liquibase/executor/jvm/JdbcExecutorTest.java
@@ -6,6 +6,9 @@ import liquibase.database.core.OracleDatabase;
 import liquibase.executor.ExecutorService;
 import org.junit.Test;
 
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -44,4 +47,12 @@ public class JdbcExecutorTest {
         assertTrue(ExecutorService.getInstance().getExecutor(oracle1) != ExecutorService.getInstance().getExecutor(oracle2));
         assertTrue(ExecutorService.getInstance().getExecutor(oracle1) != ExecutorService.getInstance().getExecutor(mysql));
     }
+
+    @Test
+    public void testGetErrorCode() {
+        assertEquals("", new JdbcExecutor().getErrorCode(new RuntimeException()));
+        assertEquals("(123) ", new JdbcExecutor().getErrorCode(new SQLException("reason", "sqlState", 123)));
+        assertEquals("(0) ", new JdbcExecutor().getErrorCode(new SQLException()));
+    }
+
 }


### PR DESCRIPTION
SQLException includes an integer errorCode that can be very useful in debugging when something goes wrong.

In general, the more information available when a mistake happens the better.

The particular case that made me create this patch was calling a stored procedure where the message was just `Unhandled user-defined exception condition` (in mysql). But seeing the error code `1051` that can be looked up to mean "Unknown table" let us quickly identify the problem. 