### PR TITLE
Fixes CORE-3256 Verbose flag not getting interperated during 'status' command

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -116,6 +116,7 @@ public class Main {
     protected String logFile;
     protected Map<String, Object> changeLogParameters = new HashMap<>();
     protected String outputFile;
+    protected Boolean verbose;
 
     /**
      * Entry point. This is what gets executes when starting this program from the command line. This is actually
@@ -270,11 +271,24 @@ public class Main {
      * @return An array of exactly 2 entries
      * @throws CommandLineParsingException if the string cannot be split into exactly 2 parts
      */
+    private static String[] splitArg(String arg) throws CommandLineParsingException {
+        return splitArg(arg, true);
+    }
+
+        /**
+         * Splits a String of the form "key=value" into the respective parts if value is present.
+         *
+         * @param arg The String expression to split
+         * @param expectValue When set to true a value has to be present in the form of key=value, when false it will
+         *                    be lenient to missing values supporting boolean flags like --verbose without an explicit value.
+         * @return An array of exactly 2 entries
+         * @throws CommandLineParsingException if the string cannot be split into exactly 2 parts and a value is expected.
+         */
     // What the number 2 stands for is obvious from the context
     @SuppressWarnings("squid:S109")
-    private static String[] splitArg(String arg) throws CommandLineParsingException {
+    private static String[] splitArg(String arg, boolean expectValue) throws CommandLineParsingException {
         String[] splitArg = arg.split("=", 2);
-        if (splitArg.length < 2) {
+        if (expectValue && splitArg.length < 2) {
             throw new CommandLineParsingException(
                     String.format(coreBundle.getString("could.not.parse.expression"), arg)
             );
@@ -786,10 +800,10 @@ public class Main {
     private void parseOptionArgument(String arg) throws CommandLineParsingException {
         final String PROMPT_FOR_VALUE = "PROMPT";
 
-        String[] splitArg = splitArg(arg);
+        String[] splitArg = splitArg(arg, false);
 
         String attributeName = splitArg[0];
-        String value = splitArg[1];
+        String value = splitArg.length > 1 ? splitArg[1] : null; // boolean options don't need a value
 
         if (PROMPT_FOR_VALUE.equalsIgnoreCase(StringUtils.trimToEmpty(value))) {
             Console c = System.console();
@@ -810,8 +824,18 @@ public class Main {
         try {
             Field field = getClass().getDeclaredField(attributeName);
             if (field.getType().equals(Boolean.class)) {
-                field.set(this, Boolean.valueOf(value));
+                if ( value == null ) { // boolean options are considered true when provided without a value like --verbose
+                    field.set(this, Boolean.TRUE);
+                } else {
+                    field.set(this, Boolean.valueOf(value));
+                }
             } else {
+                if (splitArg.length < 2) {
+                    // non boolean options should throw an exception when the value is missing
+                    throw new CommandLineParsingException(
+                            String.format(coreBundle.getString("could.not.parse.expression"), arg)
+                    );
+                }
                 field.set(this, value);
             }
         } catch (IllegalAccessException | NoSuchFieldException e) {

--- a/liquibase-core/src/test/java/liquibase/integration/commandline/MainTest.java
+++ b/liquibase-core/src/test/java/liquibase/integration/commandline/MainTest.java
@@ -205,6 +205,8 @@ public class MainTest {
         Main cli = new Main();
         cli.parseOptions(args);
 
+        assertEquals("Option --promptForNonLocalDatabase was parsed correctly",
+                Boolean.FALSE, cli.promptForNonLocalDatabase);
         assertEquals("Main command 'migrate' was parsed correctly as 'update'", "update", cli.command);
     }
 
@@ -219,6 +221,22 @@ public class MainTest {
         cli.parseOptions(args);
 
         assertEquals("Option --promptForNonLocalDatabase=true was parsed correctly",
+                Boolean.TRUE, cli.promptForNonLocalDatabase);
+        assertEquals("Main command 'update' was parsed correctly", "update", cli.command);
+
+    }
+
+    @Test
+    public void trueBooleanParametersWithoutValue() throws Exception {
+        String[] args = new String[]{
+                "--promptForNonLocalDatabase",
+                "update",
+        };
+
+        Main cli = new Main();
+        cli.parseOptions(args);
+
+        assertEquals("Option --promptForNonLocalDatabase was parsed correctly",
                 Boolean.TRUE, cli.promptForNonLocalDatabase);
         assertEquals("Main command 'update' was parsed correctly", "update", cli.command);
 
@@ -276,6 +294,64 @@ public class MainTest {
 
         Main cli = new Main();
         cli.parseOptions(args);
+    }
+
+    @Test
+    public void statusVerbose() throws Exception {
+        String[] args = new String[]{
+                "status",
+                "--verbose",
+        };
+
+        Main cli = new Main();
+        cli.parseOptions(args);
+
+        assertEquals("Main command 'status' was not correctly parsed", "status", cli.command);
+        assertTrue(cli.verbose);
+    }
+
+    @Test
+    public void statusVerboseTrue() throws Exception {
+        String[] args = new String[]{
+                "status",
+                "--verbose=true",
+        };
+
+        Main cli = new Main();
+        cli.parseOptions(args);
+
+        assertEquals("Main command 'status' was not correctly parsed", "status", cli.command);
+        assertTrue("Expect verbose=true option to be parsed as true", cli.verbose);
+    }
+
+
+    @Test
+    public void statusVerboseFalse() throws Exception {
+        String[] args = new String[]{
+                "status",
+                "--verbose=false",
+        };
+
+        Main cli = new Main();
+        cli.parseOptions(args);
+
+        assertEquals("Main command 'status' was not correctly parsed", "status", cli.command);
+        assertFalse("Expect verbose=false option to be parsed as false", cli.verbose);
+    }
+
+
+    @Test
+    public void statusVerboseOtherValue() throws Exception {
+        String[] args = new String[]{
+                "status",
+                "--verbose=yo",
+        };
+
+        Main cli = new Main();
+        cli.parseOptions(args);
+
+        assertEquals("Main command 'status' was not correctly parsed", "status", cli.command);
+        assertFalse("Expect verbose option to be false on wrong boolean value", cli.verbose);
     }
 
     @Test(expected = CommandLineParsingException.class)

--- a/liquibase-core/src/test/java/liquibase/integration/commandline/MainTest.java
+++ b/liquibase-core/src/test/java/liquibase/integration/commandline/MainTest.java
@@ -226,22 +226,6 @@ public class MainTest {
 
     }
 
-    @Test
-    public void trueBooleanParametersWithoutValue() throws Exception {
-        String[] args = new String[]{
-                "--promptForNonLocalDatabase=true",
-                "update",
-        };
-
-        Main cli = new Main();
-        cli.parseOptions(args);
-
-        assertEquals("Option --promptForNonLocalDatabase was parsed correctly",
-                Boolean.TRUE, cli.promptForNonLocalDatabase);
-        assertEquals("Main command 'update' was parsed correctly", "update", cli.command);
-
-    }
-
     @Test(expected = CommandLineParsingException.class)
     public void parameterWithoutDash() throws Exception {
         String[] args = new String[]{
@@ -351,25 +335,6 @@ public class MainTest {
         assertEquals(0,errMsgs.size());
     }
 
-
-    @Test
-    public void statusVerboseOtherValue() throws Exception {
-        String[] args = new String[]{
-                "--url=URL",
-                "--changeLogFile=FILE",
-                "status",
-                "--verbose=yo",
-        };
-
-        Main cli = new Main();
-        cli.parseOptions(args);
-
-        assertEquals("Main command 'status' was not correctly parsed", "status", cli.command);
-//        assertFalse("Expect verbose option to be false on wrong boolean value", cli.verbose);
-
-        List<String> errMsgs = cli.checkSetup();
-        assertEquals(1,errMsgs.size());
-    }
 
     @Test(expected = CommandLineParsingException.class)
     public void configureNonExistantClassloaderLocation() throws Exception {

--- a/liquibase-core/src/test/java/liquibase/integration/commandline/MainTest.java
+++ b/liquibase-core/src/test/java/liquibase/integration/commandline/MainTest.java
@@ -229,7 +229,7 @@ public class MainTest {
     @Test
     public void trueBooleanParametersWithoutValue() throws Exception {
         String[] args = new String[]{
-                "--promptForNonLocalDatabase",
+                "--promptForNonLocalDatabase=true",
                 "update",
         };
 
@@ -299,6 +299,8 @@ public class MainTest {
     @Test
     public void statusVerbose() throws Exception {
         String[] args = new String[]{
+                "--url=URL",
+                "--changeLogFile=FILE",
                 "status",
                 "--verbose",
         };
@@ -307,12 +309,16 @@ public class MainTest {
         cli.parseOptions(args);
 
         assertEquals("Main command 'status' was not correctly parsed", "status", cli.command);
-        assertTrue(cli.verbose);
+
+        List<String> errMsgs = cli.checkSetup();
+        assertEquals(0,errMsgs.size()); // verbose option parsed correctly
     }
 
     @Test
-    public void statusVerboseTrue() throws Exception {
+    public void statusVerboseWithValue() throws Exception {
         String[] args = new String[]{
+                "--url=URL",
+                "--changeLogFile=FILE",
                 "status",
                 "--verbose=true",
         };
@@ -321,28 +327,36 @@ public class MainTest {
         cli.parseOptions(args);
 
         assertEquals("Main command 'status' was not correctly parsed", "status", cli.command);
-        assertTrue("Expect verbose=true option to be parsed as true", cli.verbose);
+
+        List<String> errMsgs = cli.checkSetup();
+        assertEquals(1,errMsgs.size()); // value is not expected and will raise an error message
+
     }
 
 
     @Test
-    public void statusVerboseFalse() throws Exception {
+    public void statusWithoutVerbose() throws Exception {
         String[] args = new String[]{
+                "--url=URL",
+                "--changeLogFile=FILE",
                 "status",
-                "--verbose=false",
         };
 
         Main cli = new Main();
         cli.parseOptions(args);
 
         assertEquals("Main command 'status' was not correctly parsed", "status", cli.command);
-        assertFalse("Expect verbose=false option to be parsed as false", cli.verbose);
+
+        List<String> errMsgs = cli.checkSetup();
+        assertEquals(0,errMsgs.size());
     }
 
 
     @Test
     public void statusVerboseOtherValue() throws Exception {
         String[] args = new String[]{
+                "--url=URL",
+                "--changeLogFile=FILE",
                 "status",
                 "--verbose=yo",
         };
@@ -351,7 +365,10 @@ public class MainTest {
         cli.parseOptions(args);
 
         assertEquals("Main command 'status' was not correctly parsed", "status", cli.command);
-        assertFalse("Expect verbose option to be false on wrong boolean value", cli.verbose);
+//        assertFalse("Expect verbose option to be false on wrong boolean value", cli.verbose);
+
+        List<String> errMsgs = cli.checkSetup();
+        assertEquals(1,errMsgs.size());
     }
 
     @Test(expected = CommandLineParsingException.class)


### PR DESCRIPTION

The verbose option was not recognised as such in the liquibase.integration.commandline.Main class. When recognised all options are expected to have a value but boolean options/flags do not necessarily need this. An option like `--verbose` does not need explicit `--verbose=true`, even the commandline help instructions says `--verbose` without a value is enough. Fixed the value issue here as well so `--verbose` now works as expected but also with `--verbose=true`.

In fact all Boolean flags work with and without `=true` value.