### PR TITLE
Fix build on OpenJDK 8

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/ChangeFactory.java
+++ b/liquibase-core/src/main/java/liquibase/change/ChangeFactory.java
@@ -1,7 +1,5 @@
 package liquibase.change;
 
-import javafx.scene.layout.Priority;
-import liquibase.Scope;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.logging.LogService;
 import liquibase.logging.Logger;


### PR DESCRIPTION
Class `javafx.scene.layout.Priority` is not presented in OpenJDK 8