### PR TITLE
Add liquibase.command to packages to scan

### DIFF
--- a/liquibase-core/src/main/java/liquibase/servicelocator/ServiceLocator.java
+++ b/liquibase-core/src/main/java/liquibase/servicelocator/ServiceLocator.java
@@ -132,6 +132,7 @@ public class ServiceLocator {
                 if (packagesToScan.isEmpty()) {
                     addPackageToScan("liquibase.change");
                     addPackageToScan("liquibase.changelog");
+                    addPackageToScan("liquibase.command");
                     addPackageToScan("liquibase.database");
                     addPackageToScan("liquibase.parser");
                     addPackageToScan("liquibase.precondition");


### PR DESCRIPTION
Otherwise DropAllCommand can't be located by ServiceLocator and user is required to specify VM option: -Dliquibase.scan.packages=liquibase.command,liquibase.change,liquibase.changelog,liquibase.database,liquibase.parser,liquibase.precondition,liquibase.datatype,liquibase.serializer,liquibase.sqlgenerator,liquibase.executor,liquibase.snapshot,liquibase.logging,liquibase.diff,liquibase.structure,liquibase.structurecompare,liquibase.lockservice,liquibase.sdk.database,liquibase.ext