### PR TITLE
CORE-3243 : avoid running runOnChange changeset when md5sum is reset to

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/filter/ShouldRunChangeSetFilter.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/filter/ShouldRunChangeSetFilter.java
@@ -93,7 +93,7 @@ public class ShouldRunChangeSetFilter implements ChangeSetFilter {
     }
 
     protected boolean checksumChanged(ChangeSet changeSet, RanChangeSet ranChangeSet) {
-        return !changeSet.generateCheckSum().equals(ranChangeSet.getLastCheckSum());
+        return null!=ranChangeSet.getLastCheckSum() && !changeSet.generateCheckSum().equals(ranChangeSet.getLastCheckSum());
     }
 
 


### PR DESCRIPTION
null in order to be recalculated after an checksum calculation upgrade