### PR TITLE
Call Class.getConstructor.newInstance instead of newInstance

### DIFF
--- a/liquibase-core/src/main/java/liquibase/AbstractExtensibleObject.java
+++ b/liquibase-core/src/main/java/liquibase/AbstractExtensibleObject.java
@@ -264,7 +264,7 @@ public class AbstractExtensibleObject implements ExtensibleObject {
                 Object value = this.get(attr, Object.class);
                 if (value instanceof Collection) {
                     try {
-                        Collection valueClone = (Collection) value.getClass().newInstance();
+                        Collection valueClone = (Collection) value.getClass().getConstructor().newInstance();
                         for (Object obj : ((Collection) value)) {
                             valueClone.add(obj);
                         }
@@ -274,7 +274,7 @@ public class AbstractExtensibleObject implements ExtensibleObject {
                     }
                 } else if (value instanceof Map) {
                     try {
-                        Map valueClone = (Map) value.getClass().newInstance();
+                        Map valueClone = (Map) value.getClass().getConstructor().newInstance();
                         for (Map.Entry obj : ((Map<?, ?>) value).entrySet()) {
                             valueClone.put(obj.getKey(), obj.getValue());
                         }

--- a/liquibase-core/src/main/java/liquibase/change/AbstractChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/AbstractChange.java
@@ -637,7 +637,7 @@ public abstract class AbstractChange extends AbstractPlugin implements Change {
                             && (!collectionType.isInterface())
                             && (!Modifier.isAbstract(collectionType.getModifiers()))
                         ) {
-                            String elementName = ((LiquibaseSerializable) collectionType.newInstance())
+                            String elementName = ((LiquibaseSerializable) collectionType.getConstructor().newInstance())
                                 .getSerializedObjectName();
                             List<ParsedNode> nodes = new ArrayList<>(
                                  parsedNode.getChildren(null, param.getParameterName())
@@ -664,13 +664,13 @@ public abstract class AbstractChange extends AbstractPlugin implements Change {
                                     if ((childNodes != null) && !childNodes.isEmpty()) {
                                         for (ParsedNode childNode : childNodes) {
                                             LiquibaseSerializable childObject =
-                                                (LiquibaseSerializable)collectionType.newInstance();
+                                                (LiquibaseSerializable)collectionType.getConstructor().newInstance();
                                             childObject.load(childNode, resourceAccessor);
                                             ((Collection) param.getCurrentValue(this)).add(childObject);
                                         }
                                     } else {
                                         LiquibaseSerializable childObject =
-                                            (LiquibaseSerializable) collectionType.newInstance();
+                                            (LiquibaseSerializable) collectionType.getConstructor().newInstance();
                                         childObject.load(node, resourceAccessor);
                                         ((Collection) param.getCurrentValue(this)).add(childObject);
                                     }
@@ -686,11 +686,11 @@ public abstract class AbstractChange extends AbstractPlugin implements Change {
                             ParsedNode child = parsedNode.getChild(null, param.getParameterName());
                             if (child != null) {
                                 LiquibaseSerializable serializableChild =
-                                    (LiquibaseSerializable) param.getDataTypeClass().newInstance();
+                                    (LiquibaseSerializable) param.getDataTypeClass().getConstructor().newInstance();
                                 serializableChild.load(child, resourceAccessor);
                                 param.setValue(this, serializableChild);
                             }
-                        } catch (InstantiationException|IllegalAccessException e) {
+                        } catch (ReflectiveOperationException e) {
                             throw new UnexpectedLiquibaseException(e);
                         }
                     }
@@ -704,7 +704,7 @@ public abstract class AbstractChange extends AbstractPlugin implements Change {
                     param.setValue(this, childValue);
                 }
             }
-        } catch (InstantiationException|IllegalAccessException e) {
+        } catch (ReflectiveOperationException e) {
             throw new UnexpectedLiquibaseException(e);
         }
         customLoadLogic(parsedNode, resourceAccessor);
@@ -716,8 +716,8 @@ public abstract class AbstractChange extends AbstractPlugin implements Change {
     }
 
     protected ColumnConfig createEmptyColumnConfig(Class collectionType)
-        throws InstantiationException, IllegalAccessException {
-        return (ColumnConfig) collectionType.newInstance();
+        throws ReflectiveOperationException {
+        return (ColumnConfig) collectionType.getConstructor().newInstance();
     }
 
     protected void customLoadLogic(ParsedNode parsedNode, ResourceAccessor resourceAccessor)

--- a/liquibase-core/src/main/java/liquibase/change/ChangeFactory.java
+++ b/liquibase-core/src/main/java/liquibase/change/ChangeFactory.java
@@ -95,7 +95,7 @@ public class ChangeFactory extends AbstractPluginFactory<Change>{
             return null;
         }
         try {
-            return plugin.getClass().newInstance();
+            return plugin.getClass().getConstructor().newInstance();
         } catch (Exception e) {
             throw new UnexpectedLiquibaseException(e);
         }

--- a/liquibase-core/src/main/java/liquibase/change/ChangeParameterMetaData.java
+++ b/liquibase-core/src/main/java/liquibase/change/ChangeParameterMetaData.java
@@ -107,7 +107,7 @@ public class ChangeParameterMetaData {
                 }
                 try {
                     if (!change.generateStatementsVolatile(database)) {
-                        Change testChange = change.getClass().newInstance();
+                        Change testChange = change.getClass().getConstructor().newInstance();
                         ValidationErrors originalErrors = getStatementErrors(testChange, database);
                         this.setValue(testChange, this.getExampleValue(database));
                         ValidationErrors finalErrors = getStatementErrors(testChange, database);
@@ -151,7 +151,7 @@ public class ChangeParameterMetaData {
             for (Database database : DatabaseFactory.getInstance().getImplementedDatabases()) {
                 try {
                     if (!change.generateStatementsVolatile(database)) {
-                        Change testChange = change.getClass().newInstance();
+                        Change testChange = change.getClass().getConstructor().newInstance();
                         ValidationErrors originalErrors = getStatementErrors(testChange, database);
                         this.setValue(testChange, this.getExampleValue(database));
                         ValidationErrors finalErrors = getStatementErrors(testChange, database);

--- a/liquibase-core/src/main/java/liquibase/change/custom/CustomChangeWrapper.java
+++ b/liquibase-core/src/main/java/liquibase/change/custom/CustomChangeWrapper.java
@@ -90,12 +90,12 @@ public class CustomChangeWrapper extends AbstractChange {
         this.className = className;
             try {
                 try {
-                    customChange = (CustomChange) Class.forName(className, true, classLoader).newInstance();
+                    customChange = (CustomChange) Class.forName(className, true, classLoader).getConstructor().newInstance();
                 } catch (ClassCastException e) { //fails in Ant in particular
                     try {
-                        customChange = (CustomChange) Thread.currentThread().getContextClassLoader().loadClass(className).newInstance();
+                        customChange = (CustomChange) Thread.currentThread().getContextClassLoader().loadClass(className).getConstructor().newInstance();
                     } catch (ClassNotFoundException e1) {
-                        customChange = (CustomChange) Class.forName(className).newInstance();
+                        customChange = (CustomChange) Class.forName(className).getConstructor().newInstance();
                     }
                 }
         } catch (Exception e) {
@@ -332,7 +332,7 @@ public class CustomChangeWrapper extends AbstractChange {
 
         CustomChange customChange = null;
         try {
-            customChange = (CustomChange) Class.forName(className, false, resourceAccessor.toClassLoader()).newInstance();
+            customChange = (CustomChange) Class.forName(className, false, resourceAccessor.toClassLoader()).getConstructor().newInstance();
         } catch (Exception e) {
             throw new UnexpectedLiquibaseException(e);
         }

--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeLogHistoryServiceFactory.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeLogHistoryServiceFactory.java
@@ -78,7 +78,7 @@ public class ChangeLogHistoryServiceFactory {
                 ChangeLogHistoryService service;
                 try {
                     aClass.getConstructor();
-                    service = aClass.newInstance();
+                    service = aClass.getConstructor().newInstance();
                     service.setDatabase(database);
                 } catch (NoSuchMethodException e) {
                     // must have been manually added to the registry and so already configured.

--- a/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -345,8 +345,8 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                 IncludeAllFilter resourceFilter = null;
                 if (resourceFilterDef != null) {
                     try {
-                        resourceFilter = (IncludeAllFilter) Class.forName(resourceFilterDef).newInstance();
-                    } catch (InstantiationException|IllegalAccessException|ClassNotFoundException e) {
+                        resourceFilter = (IncludeAllFilter) Class.forName(resourceFilterDef).getConstructor().newInstance();
+                    } catch (ReflectiveOperationException e) {
                         throw new SetupException(e);
                     }
                 }
@@ -355,8 +355,8 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                 Comparator<String> resourceComparator = null;
                 if (resourceComparatorDef != null) {
                     try {
-                        resourceComparator = (Comparator<String>) Class.forName(resourceComparatorDef).newInstance();
-                    } catch (InstantiationException|IllegalAccessException|ClassNotFoundException e) {
+                        resourceComparator = (Comparator<String>) Class.forName(resourceComparatorDef).getConstructor().newInstance();
+                    } catch (ReflectiveOperationException e) {
                         //take default comparator
                         LogService.getLog(getClass()).info(LogType.LOG, "no resourceComparator defined - taking default " +
                          "implementation");

--- a/liquibase-core/src/main/java/liquibase/command/CommandFactory.java
+++ b/liquibase-core/src/main/java/liquibase/command/CommandFactory.java
@@ -57,7 +57,7 @@ public class CommandFactory  {
             throw new UnexpectedLiquibaseException("Could not find command class for "+commandName);
         }
         try {
-            LiquibaseCommand command = sortedCommands.iterator().next().getClass().newInstance();
+            LiquibaseCommand command = sortedCommands.iterator().next().getClass().getConstructor().newInstance();
 
             if (command.getPriority(commandName) <= 0) {
                 throw new UnexpectedLiquibaseException("Could not find command class for "+commandName);

--- a/liquibase-core/src/main/java/liquibase/configuration/LiquibaseConfiguration.java
+++ b/liquibase-core/src/main/java/liquibase/configuration/LiquibaseConfiguration.java
@@ -116,7 +116,7 @@ public class LiquibaseConfiguration {
 
     protected  <T extends ConfigurationContainer> T createConfiguration(Class<T> type) {
         try {
-            T configuration = type.newInstance();
+            T configuration = type.getConstructor().newInstance();
             configuration.init(configurationValueProviders);
             return configuration;
         } catch (Exception e) {

--- a/liquibase-core/src/main/java/liquibase/database/DatabaseFactory.java
+++ b/liquibase-core/src/main/java/liquibase/database/DatabaseFactory.java
@@ -114,7 +114,7 @@ public class DatabaseFactory {
 
         Database returnDatabase;
         try {
-            returnDatabase = foundDatabases.iterator().next().getClass().newInstance();
+            returnDatabase = foundDatabases.iterator().next().getClass().getConstructor().newInstance();
         } catch (Exception e) {
             throw new UnexpectedLiquibaseException(e);
         }
@@ -176,7 +176,7 @@ public class DatabaseFactory {
             DatabaseFactory databaseFactory = DatabaseFactory.getInstance();
             if (databaseClass != null) {
                 databaseFactory.clearRegistry();
-                databaseFactory.register((Database) Class.forName(databaseClass, true, resourceAccessor.toClassLoader()).newInstance());
+                databaseFactory.register((Database) Class.forName(databaseClass, true, resourceAccessor.toClassLoader()).getConstructor().newInstance());
             }
 
             try {
@@ -188,7 +188,7 @@ public class DatabaseFactory {
                     throw new RuntimeException("Driver class was not specified and could not be determined from the url (" + url + ")");
                 }
 
-                driverObject = (Driver) Class.forName(driver, true, resourceAccessor.toClassLoader()).newInstance();
+                driverObject = (Driver) Class.forName(driver, true, resourceAccessor.toClassLoader()).getConstructor().newInstance();
             } catch (Exception e) {
                 throw new RuntimeException("Cannot find database driver: " + e.getMessage());
             }
@@ -201,7 +201,7 @@ public class DatabaseFactory {
             if (propertyProviderClass == null) {
                 driverProperties = new Properties();
             } else {
-                driverProperties = (Properties) Class.forName(propertyProviderClass, true, resourceAccessor.toClassLoader()).newInstance();
+                driverProperties = (Properties) Class.forName(propertyProviderClass, true, resourceAccessor.toClassLoader()).getConstructor().newInstance();
             }
 
             if (username != null) {

--- a/liquibase-core/src/main/java/liquibase/database/core/DerbyDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/DerbyDatabase.java
@@ -142,7 +142,7 @@ public class DerbyDatabase extends AbstractJdbcDatabase {
                 // this cleans up the lock files in the embedded derby database folder
                 JdbcConnection connection = (JdbcConnection) getConnection();
                 ClassLoader classLoader = connection.getWrappedConnection().getClass().getClassLoader();
-                Driver driver = (Driver) classLoader.loadClass(driverName).newInstance();
+                Driver driver = (Driver) classLoader.loadClass(driverName).getConstructor().newInstance();
                 // this cleans up the lock files in the embedded derby database folder
                 driver.connect(url, null);
             } catch (Exception e) {

--- a/liquibase-core/src/main/java/liquibase/datatype/DataTypeFactory.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/DataTypeFactory.java
@@ -73,7 +73,7 @@ public class DataTypeFactory {
 
             Comparator<Class<? extends LiquibaseDataType>> comparator = (o1, o2) -> {
                 try {
-                    return -1 * Integer.compare(o1.newInstance().getPriority(), o2.newInstance().getPriority());
+                    return -1 * Integer.compare(o1.getConstructor().newInstance().getPriority(), o2.getConstructor().newInstance().getPriority());
                 } catch (Exception e) {
                     throw new UnexpectedLiquibaseException(e);
                 }
@@ -190,7 +190,7 @@ public class DataTypeFactory {
             Iterator<Class<? extends LiquibaseDataType>> iterator = classes.iterator();
             do {
                 try {
-                    liquibaseDataType = iterator.next().newInstance();
+                    liquibaseDataType = iterator.next().getConstructor().newInstance();
                 } catch (Exception e) {
                     throw new UnexpectedLiquibaseException(e);
                 }

--- a/liquibase-core/src/main/java/liquibase/diff/DiffGeneratorFactory.java
+++ b/liquibase-core/src/main/java/liquibase/diff/DiffGeneratorFactory.java
@@ -58,7 +58,7 @@ public class DiffGeneratorFactory {
         }
 
         try {
-            return foundGenerators.iterator().next().getClass().newInstance();
+            return foundGenerators.iterator().next().getClass().getConstructor().newInstance();
         } catch (Exception e) {
             throw new UnexpectedLiquibaseException(e);
         }

--- a/liquibase-core/src/main/java/liquibase/integration/commandline/ChangeExecListenerUtils.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/ChangeExecListenerUtils.java
@@ -54,7 +54,7 @@ public final class ChangeExecListenerUtils {
                             changeExecListener = (ChangeExecListener) cons.newInstance(properties);
                         } else {
                             logger.debug(LogType.LOG, "Create " + clazz.getSimpleName() + "()");
-                            changeExecListener = (ChangeExecListener) clazz.newInstance();
+                            changeExecListener = (ChangeExecListener) clazz.getConstructor().newInstance();
                         }
                     }
                 }

--- a/liquibase-core/src/main/java/liquibase/lockservice/LockServiceFactory.java
+++ b/liquibase-core/src/main/java/liquibase/lockservice/LockServiceFactory.java
@@ -73,7 +73,7 @@ public class LockServiceFactory {
 			}
 
 			try {
-				LockService lockService = foundServices.iterator().next().getClass().newInstance();
+				LockService lockService = foundServices.iterator().next().getClass().getConstructor().newInstance();
 				lockService.setDatabase(database);
 				openLockServices.put(database, lockService);
 			} catch (Exception e) {

--- a/liquibase-core/src/main/java/liquibase/parser/core/yaml/YamlSnapshotParser.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/yaml/YamlSnapshotParser.java
@@ -41,7 +41,7 @@ public class YamlSnapshotParser extends YamlParser implements SnapshotParser {
 
             String shortName = (String) ((Map) rootList.get("database")).get("shortName");
 
-            Database database = DatabaseFactory.getInstance().getDatabase(shortName).getClass().newInstance();
+            Database database = DatabaseFactory.getInstance().getDatabase(shortName).getClass().getConstructor().newInstance();
             database.setConnection(new OfflineConnection("offline:" + shortName, null));
 
             DatabaseSnapshot snapshot = new RestoredDatabaseSnapshot(database);

--- a/liquibase-core/src/main/java/liquibase/precondition/CustomPreconditionWrapper.java
+++ b/liquibase-core/src/main/java/liquibase/precondition/CustomPreconditionWrapper.java
@@ -69,9 +69,9 @@ public class CustomPreconditionWrapper extends AbstractPrecondition {
         try {
 //            System.out.println(classLoader.toString());
             try {
-                customPrecondition = (CustomPrecondition) Class.forName(className, true, classLoader).newInstance();
+                customPrecondition = (CustomPrecondition) Class.forName(className, true, classLoader).getConstructor().newInstance();
             } catch (ClassCastException e) { //fails in Ant in particular
-                customPrecondition = (CustomPrecondition) Class.forName(className).newInstance();
+                customPrecondition = (CustomPrecondition) Class.forName(className).getConstructor().newInstance();
             }
         } catch (Exception e) {
             throw new PreconditionFailedException("Could not open custom precondition class "+className, changeLog, this);

--- a/liquibase-core/src/main/java/liquibase/precondition/PreconditionFactory.java
+++ b/liquibase-core/src/main/java/liquibase/precondition/PreconditionFactory.java
@@ -61,7 +61,7 @@ public class PreconditionFactory {
             return null;
         }
         try {
-            return (Precondition) aClass.newInstance();
+            return (Precondition) aClass.getConstructor().newInstance();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/liquibase-core/src/main/java/liquibase/serializer/AbstractLiquibaseSerializable.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/AbstractLiquibaseSerializable.java
@@ -39,7 +39,7 @@ public abstract class AbstractLiquibaseSerializable implements LiquibaseSerializ
                                 (collectionType) && !collectionType.isInterface() && !Modifier.isAbstract
                                 (collectionType.getModifiers())) {
 
-                                String elementName = ((LiquibaseSerializable) collectionType.newInstance()).getSerializedObjectName();
+                                String elementName = ((LiquibaseSerializable) collectionType.getConstructor().newInstance()).getSerializedObjectName();
                                 List<ParsedNode> elementNodes = Collections.emptyList();
                                 if (childNode.getName().equals(elementName)) {
                                     elementNodes = Collections.singletonList(childNode);
@@ -49,7 +49,7 @@ public abstract class AbstractLiquibaseSerializable implements LiquibaseSerializ
                                 if (!elementNodes.isEmpty()) {
                                     Collection collection = ((Collection) getSerializableFieldValue(childNode.getName()));
                                     for (ParsedNode node : elementNodes) {
-                                        LiquibaseSerializable childObject = (LiquibaseSerializable) collectionType.newInstance();
+                                        LiquibaseSerializable childObject = (LiquibaseSerializable) collectionType.getConstructor().newInstance();
                                         childObject.load(node, resourceAccessor);
                                         collection.add(childObject);
                                     }
@@ -60,7 +60,7 @@ public abstract class AbstractLiquibaseSerializable implements LiquibaseSerializ
                         if (!dataTypeClass.isInterface()
                                 && !Modifier.isAbstract(dataTypeClass.getModifiers())) {
 
-                            LiquibaseSerializable childObject = (LiquibaseSerializable) dataTypeClass.newInstance();
+                            LiquibaseSerializable childObject = (LiquibaseSerializable) dataTypeClass.getConstructor().newInstance();
                             childObject.load(childNode, resourceAccessor);
                             setSerializableFieldValue(childNode.getName(), childObject);
                         }
@@ -83,7 +83,7 @@ public abstract class AbstractLiquibaseSerializable implements LiquibaseSerializ
                                     (collectionType) && !collectionType.isInterface() && !Modifier.isAbstract
                                     (collectionType.getModifiers())) {
 
-                                    String elementName = ((LiquibaseSerializable) collectionType.newInstance()).getSerializedObjectName();
+                                    String elementName = ((LiquibaseSerializable) collectionType.getConstructor().newInstance()).getSerializedObjectName();
                                     List<ParsedNode> elementNodes = Collections.emptyList();
                                     if (childNode.getName().equals(elementName)) {
                                         elementNodes = Collections.singletonList(childNode);
@@ -93,7 +93,7 @@ public abstract class AbstractLiquibaseSerializable implements LiquibaseSerializ
                                     if (!elementNodes.isEmpty()) {
                                         Collection collection = ((Collection) getSerializableFieldValue(field));
                                         for (ParsedNode node : elementNodes) {
-                                            LiquibaseSerializable childObject = (LiquibaseSerializable) collectionType.newInstance();
+                                            LiquibaseSerializable childObject = (LiquibaseSerializable) collectionType.getConstructor().newInstance();
                                             childObject.load(node, resourceAccessor);
                                             collection.add(childObject);
                                         }

--- a/liquibase-core/src/main/java/liquibase/serializer/core/yaml/YamlSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/yaml/YamlSerializer.java
@@ -186,11 +186,11 @@ public abstract class YamlSerializer implements LiquibaseSerializer {
                 if (type.equals(ChangeSet.class)) {
                     serialzableType = new ChangeSet("x", "y", false, false, null, null, null, null);
                 } else if (LiquibaseSerializable.class.isAssignableFrom(type)) {
-                    serialzableType = (LiquibaseSerializable) type.newInstance();
+                    serialzableType = (LiquibaseSerializable) type.getConstructor().newInstance();
                 } else {
                     return super.getProperties(type);
                 }
-            } catch (InstantiationException | IllegalAccessException e) {
+            } catch (ReflectiveOperationException e) {
                 throw new UnexpectedLiquibaseException(e);
             }
             for (String property : serialzableType.getSerializableFields()) {

--- a/liquibase-core/src/main/java/liquibase/snapshot/DatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/DatabaseSnapshot.java
@@ -307,7 +307,7 @@ public abstract class DatabaseSnapshot implements LiquibaseSerializable {
 
             try {
                 includeNestedObjects(object);
-            } catch (InstantiationException | IllegalAccessException e) {
+            } catch (ReflectiveOperationException e) {
                 throw new UnexpectedLiquibaseException(e);
             }
         }
@@ -319,7 +319,7 @@ public abstract class DatabaseSnapshot implements LiquibaseSerializable {
         return object;
     }
 
-    private void includeNestedObjects(DatabaseObject object) throws DatabaseException, InvalidExampleException, InstantiationException, IllegalAccessException {
+    private void includeNestedObjects(DatabaseObject object) throws DatabaseException, InvalidExampleException, ReflectiveOperationException {
         for (String field : new HashSet<>(object.getAttributes())) {
             Object fieldValue = object.getAttribute(field, Object.class);
             if ("columns".equals(field) && ((object.getClass() == PrimaryKey.class) || (object.getClass() == Index
@@ -343,7 +343,7 @@ public abstract class DatabaseSnapshot implements LiquibaseSerializable {
         }
     }
 
-    private Object replaceObject(Object fieldValue) throws DatabaseException, InvalidExampleException, IllegalAccessException, InstantiationException {
+    private Object replaceObject(Object fieldValue) throws DatabaseException, InvalidExampleException, ReflectiveOperationException {
         if (fieldValue == null) {
             return null;
         }
@@ -416,14 +416,14 @@ public abstract class DatabaseSnapshot implements LiquibaseSerializable {
                 if (List.class.isAssignableFrom(collectionClass)) {
                     collectionClass = ArrayList.class;
                 }
-                newCollection = (Collection) collectionClass.newInstance();
+                newCollection = (Collection) collectionClass.getConstructor().newInstance();
             } catch (InstantiationException e) {
                 throw e;
             }
             newCollection.addAll(newValues);
             return newCollection;
         } else if (fieldValue instanceof Map) {
-            Map newMap = (Map) fieldValue.getClass().newInstance();
+            Map newMap = (Map) fieldValue.getClass().getConstructor().newInstance();
             for (Map.Entry entry : new HashSet<>((Set<Map.Entry>) ((Map) fieldValue).entrySet())) {
                 Object key = replaceObject(entry.getKey());
                 Object value = replaceObject(entry.getValue());
@@ -596,14 +596,14 @@ public abstract class DatabaseSnapshot implements LiquibaseSerializable {
         }
     }
 
-    protected void loadObjects(Map<String, DatabaseObject> objectMap, Map<String, DatabaseObject> allObjects, ParsedNode node, ResourceAccessor resourceAccessor) throws ClassNotFoundException, InstantiationException, IllegalAccessException, ParsedNodeException {
+    protected void loadObjects(Map<String, DatabaseObject> objectMap, Map<String, DatabaseObject> allObjects, ParsedNode node, ResourceAccessor resourceAccessor) throws ReflectiveOperationException, ParsedNodeException {
         if (node == null) {
             return;
         }
         for (ParsedNode typeNode : node.getChildren()) {
             Class<? extends DatabaseObject> objectType = (Class<? extends DatabaseObject>) Class.forName(typeNode.getName());
             for (ParsedNode objectNode : typeNode.getChildren()) {
-                DatabaseObject databaseObject = objectType.newInstance();
+                DatabaseObject databaseObject = objectType.getConstructor().newInstance();
                 databaseObject.load(objectNode, resourceAccessor);
                 String key = objectType.getName() + "#" + databaseObject.getSnapshotId();
                 objectMap.put(key, databaseObject);

--- a/liquibase-core/src/main/java/liquibase/sql/visitor/SqlVisitorFactory.java
+++ b/liquibase-core/src/main/java/liquibase/sql/visitor/SqlVisitorFactory.java
@@ -22,7 +22,7 @@ public class SqlVisitorFactory {
 
         try {
             for (Class<SqlVisitor> visitorClass : visitors) {
-                SqlVisitor visitor = visitorClass.newInstance();
+                SqlVisitor visitor = visitorClass.getConstructor().newInstance();
                 tagToClassMap.put(visitor.getName(), visitorClass);
             }
         } catch (Exception e) {
@@ -43,7 +43,7 @@ public class SqlVisitorFactory {
             return null;
         }
         try {
-            return (SqlVisitor) aClass.newInstance();
+            return (SqlVisitor) aClass.getConstructor().newInstance();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/liquibase-core/src/main/java/liquibase/structure/AbstractDatabaseObject.java
+++ b/liquibase-core/src/main/java/liquibase/structure/AbstractDatabaseObject.java
@@ -134,7 +134,7 @@ public abstract class AbstractDatabaseObject implements DatabaseObject {
                 clone.setSnapshotId(((DatabaseObject) value).getSnapshotId());
                 return clone;
             } else if (value instanceof DatabaseObject) {
-                DatabaseObject clone = (DatabaseObject) value.getClass().newInstance();
+                DatabaseObject clone = (DatabaseObject) value.getClass().getConstructor().newInstance();
                 clone.setName(((DatabaseObject) value).getName());
                 clone.setSnapshotId(((DatabaseObject) value).getSnapshotId());
                 return clone;

--- a/liquibase-core/src/main/java/liquibase/util/csv/opencsv/bean/AbstractCSVToBean.java
+++ b/liquibase-core/src/main/java/liquibase/util/csv/opencsv/bean/AbstractCSVToBean.java
@@ -13,10 +13,9 @@ public abstract class AbstractCSVToBean {
      *
      * @param desc - PropertyDescriptor.
      * @return - the PropertyEditor for the given PropertyDescriptor.
-     * @throws InstantiationException - thrown when getting the PropertyEditor for the class.
-     * @throws IllegalAccessException - thrown when getting the PropertyEditor for the class.
+     * @throws ReflectiveOperationException - thrown when getting the PropertyEditor for the class.
      */
-    protected abstract PropertyEditor getPropertyEditor(PropertyDescriptor desc) throws InstantiationException, IllegalAccessException;
+    protected abstract PropertyEditor getPropertyEditor(PropertyDescriptor desc) throws ReflectiveOperationException;
 
     /**
      * Returns the trimmed value of the string only if the property the string is describing should be trimmed
@@ -41,10 +40,9 @@ public abstract class AbstractCSVToBean {
      * @param value - String value
      * @param prop  - PropertyDescriptor
      * @return The object set to value (i.e. Integer).  Will return String if no PropertyEditor is found.
-     * @throws InstantiationException - Thrown on error getting the property editor from the property descriptor.
-     * @throws IllegalAccessException - Thrown on error getting the property editor from the property descriptor.
+     * @throws ReflectiveOperationException - Thrown on error getting the property editor from the property descriptor.
      */
-    protected Object convertValue(String value, PropertyDescriptor prop) throws InstantiationException, IllegalAccessException {
+    protected Object convertValue(String value, PropertyDescriptor prop) throws ReflectiveOperationException {
         PropertyEditor editor = getPropertyEditor(prop);
         Object obj = value;
         if (null != editor) {

--- a/liquibase-core/src/main/java/liquibase/util/csv/opencsv/bean/CsvToBean.java
+++ b/liquibase-core/src/main/java/liquibase/util/csv/opencsv/bean/CsvToBean.java
@@ -101,7 +101,7 @@ public class CsvToBean<T> extends AbstractCSVToBean {
       }
    }
 
-   private void processLine(MappingStrategy<T> mapper, CsvToBeanFilter filter, String[] line, List<T> list) throws IllegalAccessException, InvocationTargetException, InstantiationException, IntrospectionException {
+   private void processLine(MappingStrategy<T> mapper, CsvToBeanFilter filter, String[] line, List<T> list) throws ReflectiveOperationException, IntrospectionException {
       if ((filter == null) || filter.allowLine(line)) {
          T obj = processLine(mapper, line);
          list.add(obj);
@@ -113,12 +113,10 @@ public class CsvToBean<T> extends AbstractCSVToBean {
     * @param mapper - MappingStrategy
     * @param line  - array of Strings from the csv file.
     * @return - object containing the values.
-    * @throws IllegalAccessException - thrown on error creating bean.
-    * @throws InvocationTargetException - thrown on error calling the setters.
-    * @throws InstantiationException - thrown on error creating bean.
+    * @throws ReflectiveOperationException - thrown on error accessing bean.
     * @throws IntrospectionException - thrown on error getting the PropertyDescriptor.
     */
-   protected T processLine(MappingStrategy<T> mapper, String[] line) throws IllegalAccessException, InvocationTargetException, InstantiationException, IntrospectionException {
+   protected T processLine(MappingStrategy<T> mapper, String[] line) throws ReflectiveOperationException, IntrospectionException {
       T bean = mapper.createBean();
       for (int col = 0; col < line.length; col++) {
          if (mapper.isAnnotationDriven()) {
@@ -130,7 +128,7 @@ public class CsvToBean<T> extends AbstractCSVToBean {
       return bean;
    }
 
-   private void processProperty(MappingStrategy<T> mapper, String[] line, T bean, int col) throws IntrospectionException, InstantiationException, IllegalAccessException, InvocationTargetException {
+   private void processProperty(MappingStrategy<T> mapper, String[] line, T bean, int col) throws IntrospectionException, ReflectiveOperationException {
       PropertyDescriptor prop = mapper.findDescriptor(col);
       if (null != prop) {
          String value = checkForTrim(line[col], prop);
@@ -174,13 +172,12 @@ public class CsvToBean<T> extends AbstractCSVToBean {
     *
     * @param desc - PropertyDescriptor.
     * @return - the PropertyEditor for the given PropertyDescriptor.
-    * @throws InstantiationException - thrown when getting the PropertyEditor for the class.
-    * @throws IllegalAccessException - thrown when getting the PropertyEditor for the class.
+    * @throws ReflectiveOperationException - thrown when getting the PropertyEditor for the class.
     */
-   protected PropertyEditor getPropertyEditor(PropertyDescriptor desc) throws InstantiationException, IllegalAccessException {
+   protected PropertyEditor getPropertyEditor(PropertyDescriptor desc) throws ReflectiveOperationException {
       Class<?> cls = desc.getPropertyEditorClass();
       if (null != cls) {
-         return (PropertyEditor) cls.newInstance();
+         return (PropertyEditor) cls.getConstructor().newInstance();
       }
       return getPropertyEditorValue(desc.getPropertyType());
    }

--- a/liquibase-core/src/main/java/liquibase/util/csv/opencsv/bean/HeaderColumnNameMappingStrategy.java
+++ b/liquibase-core/src/main/java/liquibase/util/csv/opencsv/bean/HeaderColumnNameMappingStrategy.java
@@ -224,12 +224,11 @@ public class HeaderColumnNameMappingStrategy<T> implements MappingStrategy<T> {
    /**
     * Creates an object to be mapped.
     * @return an object of type T.
-    * @throws InstantiationException - thrown on error creating object.
-    * @throws IllegalAccessException - thrown on error creating object.
+    * @throws ReflectiveOperationException - thrown on error creating object.
     */
    @Override
-   public T createBean() throws InstantiationException, IllegalAccessException {
-      return type.newInstance();
+   public T createBean() throws ReflectiveOperationException {
+      return type.getConstructor().newInstance();
    }
 
    /**

--- a/liquibase-core/src/main/java/liquibase/util/csv/opencsv/bean/MappingStrategy.java
+++ b/liquibase-core/src/main/java/liquibase/util/csv/opencsv/bean/MappingStrategy.java
@@ -53,10 +53,9 @@ public interface MappingStrategy<T> {
      * Implementation will return a bean of the type of object you are mapping.
      *
      * @return A new instance of the class being mapped.
-     * @throws InstantiationException - thrown on error creating object.
-     * @throws IllegalAccessException - thrown on error creating object.
+     * @throws ReflectiveOperationException - thrown on error creating object.
      */
-    T createBean() throws InstantiationException, IllegalAccessException;
+    T createBean() throws ReflectiveOperationException;
 
    /**
     * Implementation of this method can grab the header line before parsing begins to use to map columns

--- a/liquibase-core/src/test/groovy/liquibase/change/StandardChangeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/StandardChangeTest.groovy
@@ -20,7 +20,7 @@ public abstract class StandardChangeTest extends Specification {
 
     def "refactoring name matches expected class name"() {
         expect:
-        assert Scope.getCurrentScope().getSingleton(ChangeFactory.class).getChangeMetaData(getChangeClass().newInstance()).getName().toLowerCase() == getExpectedChangeName()
+        assert Scope.getCurrentScope().getSingleton(ChangeFactory.class).getChangeMetaData(getChangeClass().getConstructor().newInstance()).getName().toLowerCase() == getExpectedChangeName()
     }
 
     protected String getExpectedChangeName() {
@@ -68,7 +68,7 @@ public abstract class StandardChangeTest extends Specification {
 //        def serialized = change.serialize()
 //        assert serialized != null
 //
-//        def newChange = changeClass.newInstance() as Change
+//        def newChange = changeClass.getConstructor().newInstance() as Change
 //        if (!isValidForLoad(change)) {
 //            return;
 //        }

--- a/liquibase-core/src/test/groovy/liquibase/sql/visitor/StandardSqlVisitorTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/sql/visitor/StandardSqlVisitorTest.groovy
@@ -35,6 +35,6 @@ abstract class StandardSqlVisitorTest extends Specification {
     }
 
     def SqlVisitor createClass() {
-        Class.forName(getClass().getName().replaceAll('Test$', "")).newInstance()
+        Class.forName(getClass().getName().replaceAll('Test$', "")).getConstructor().newInstance()
     }
 }

--- a/liquibase-core/src/test/groovy/liquibase/util/TestUtil.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/util/TestUtil.groovy
@@ -21,7 +21,7 @@ public abstract class TestUtil {
     public static <T extends ExtensibleObject> List<T> createAllPermutations(Class<T> type, Map<String, List<Object>> defaultValues, boolean addNulls = true) throws Exception {
         List<T> returnList = new ArrayList<>();
         for (Map<String, Object> parameterValues : CollectionUtil.permutations(defaultValues, addNulls)) {
-            T obj = type.newInstance();
+            T obj = type.getConstructor().newInstance();
             for (Map.Entry<String, ?> entry : parameterValues.entrySet()) {
                 if (obj.getObjectMetaData().getAttribute(entry.getKey()) == null) {
                     throw new RuntimeException("No attribute "+entry.getKey()+" on "+type.getName())

--- a/liquibase-integration-tests/src/test/java/liquibase/lockservice/LockServiceExecuteTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/lockservice/LockServiceExecuteTest.java
@@ -201,7 +201,7 @@ public class LockServiceExecuteTest {
 //
 //                        database.commit();
 //
-////                        Database clearDatabase = database.getClass().newInstance();
+////                        Database clearDatabase = database.getClass().getConstructor().newInstance();
 ////                        clearDatabase.setConnection(database.getConnection());
 //
 //                        Executor originalTemplate = ExecutorService.getInstance().getExecutor(database);

--- a/liquibase-integration-tests/src/test/java/liquibase/test/DatabaseTestContext.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/test/DatabaseTestContext.java
@@ -199,7 +199,7 @@ public class DatabaseTestContext {
         JUnitJDBCDriverClassLoader jdbcDriverLoader = JUnitJDBCDriverClassLoader.getInstance();
         final Driver driver;
         try {
-            driver = (Driver) Class.forName(DatabaseFactory.getInstance().findDefaultDriver(url), true, jdbcDriverLoader).newInstance();
+            driver = (Driver) Class.forName(DatabaseFactory.getInstance().findDefaultDriver(url), true, jdbcDriverLoader).getConstructor().newInstance();
         } catch (Exception e) {
             System.out.println("Could not connect to " + url + ": Will not test against.  " + e.getMessage());
             return null; //could not connect

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/MavenUtils.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/MavenUtils.java
@@ -137,14 +137,14 @@ public class MavenUtils {
     try {
       dbDriver = (Driver)Class.forName(driver,
                                        true,
-                                       classLoader).newInstance();
+                                       classLoader).getConstructor().newInstance();
     }
-    catch (InstantiationException | IllegalAccessException e) {
-      throw new LiquibaseException("Failed to load JDBC driver, " + driver, e);
-    } catch (ClassNotFoundException e) {
+    catch (ClassNotFoundException e) {
       throw new LiquibaseException("Missing Class '" + e.getMessage() + "'. Database "
                                    + "driver may not be included in the project "
                                    + "dependencies or with wrong scope.");
+    } catch (ReflectiveOperationException e) {
+      throw new LiquibaseException("Failed to load JDBC driver, " + driver, e);
     }
 
     Properties info = new Properties();


### PR DESCRIPTION
First of all thanks for all the great work and providing it as open source code :)

I would like to report a problem that @Nikos410 and I have come across while testing JDK 11 with our applications:

`Class.newInstance` is deprecated as of Java 9. Usage should be replaced by calling `Class.get(Declared)Constructor.newInstance` which is backwards compatible. See [java.lang.Class.newInstance](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Class.html#newInstance()) for more information.

Not only is newInstance deprecated but using it also creates a problem testing our applications with JDK11. There even is a comment in the source code of newInstance about possible problems with the current memory model: http://hg.openjdk.java.net/jdk/jdk/file/76072a077ee1/src/java.base/share/classes/java/lang/Class.java#l543
We are experiencing such a problem and can't start using JDK 11 due to this issue. I can explain it in more detail if necessary but don't feel like it is exactly necessary to argue for the removal of a deprecated call.