### PR TITLE
CORE-3222: Added missing slf4j-api dependency to assembly tar/zip

### DIFF
--- a/liquibase-core/src/main/resources/assembly/bin.xml
+++ b/liquibase-core/src/main/resources/assembly/bin.xml
@@ -67,6 +67,7 @@
             <includes>
                 <include>ch.qos.logback:logback-classic</include>
                 <include>ch.qos.logback:logback-core</include>
+                <include>org.slf4j:slf4j-api</include>
                 <include>org.yaml:snakeyaml</include>
             </includes>
         </dependencySet>


### PR DESCRIPTION
Signed-off-by: Anders Hammar <anders@hammar.net>