### PR TITLE
CORE-3141: ForeignKeySnapshotGenerator broken with recent SQL Server …

### DIFF
--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/ForeignKeySnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/ForeignKeySnapshotGenerator.java
@@ -310,7 +310,7 @@ public class ForeignKeySnapshotGenerator extends JdbcSnapshotGenerator {
                 return false;
             }
 
-            if (driverMajorVersion >= 6 && driverMinorVersion >= 3) {
+            if (driverMajorVersion > 6 || (driverMajorVersion == 6 && driverMinorVersion >= 3)) {
                 return false;
             }
 


### PR DESCRIPTION
…driver

Changed MS JDBC driver version comparison in ForeignKeySnapshotGenerator
to handle versions >= 7.0.