### PR TITLE
Implement Initial Sequence Support for MariaDB

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/MariaDBDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MariaDBDatabase.java
@@ -1,5 +1,7 @@
 package liquibase.database.core;
 
+import java.util.Arrays;
+
 import liquibase.database.DatabaseConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.logging.LogService;
@@ -12,6 +14,15 @@ import liquibase.util.StringUtil;
  */
 public class MariaDBDatabase extends MySQLDatabase {
     private static final String PRODUCT_NAME = "MariaDB";
+
+    public MariaDBDatabase() {
+        super.sequenceNextValueFunction = "NEXT VALUE FOR %s";
+        // According to https://mariadb.com/kb/en/library/data-types/, retrieved on 2019-02-12
+        super.unmodifiableDataTypes.addAll(Arrays.asList(
+           "boolean", "tinyint", "smallint", "mediumint", "int", "integer", "bigint", "dec", "numeric",
+           "fixed", "float", "bit"
+        ));
+    }
 
     @Override
     public String getShortName() {
@@ -79,5 +90,15 @@ public class MariaDBDatabase extends MySQLDatabase {
         // have supported microseconds.
         // https://mariadb.com/kb/en/library/microseconds-in-mariadb/
         return "5.3.0";
+    }
+
+    @Override
+    public boolean supportsSequences() {
+        try {
+            return getDatabaseMajorVersion() >= 10 && getDatabaseMinorVersion() >= 3;
+        } catch (DatabaseException e) {
+            LogService.getLog(getClass()).debug(LogType.LOG, "Cannot retrieve database version", e);
+            return false;
+        }
     }
 }

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateSequenceGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateSequenceGenerator.java
@@ -51,7 +51,7 @@ public class CreateSequenceGenerator extends AbstractSqlGenerator<CreateSequence
         if (database instanceof HsqlDatabase || database instanceof Db2zDatabase) {
             buffer.append(" AS BIGINT ");
         }
-        if (statement.getStartValue() != null) {
+        if (!(database instanceof MariaDBDatabase) && statement.getStartValue() != null) {
             buffer.append(" START WITH ").append(statement.getStartValue());
         }
         if (statement.getIncrementBy() != null) {
@@ -62,6 +62,9 @@ public class CreateSequenceGenerator extends AbstractSqlGenerator<CreateSequence
         }
         if (statement.getMaxValue() != null) {
             buffer.append(" MAXVALUE ").append(statement.getMaxValue());
+        }
+        if (database instanceof MariaDBDatabase && statement.getStartValue() != null) {
+            buffer.append(" START WITH ").append(statement.getStartValue());
         }
 
         if (statement.getCacheSize() != null) {
@@ -76,7 +79,7 @@ public class CreateSequenceGenerator extends AbstractSqlGenerator<CreateSequence
             }
         }
 
-        if (statement.getOrdered() != null) {
+        if (!(database instanceof MariaDBDatabase) && statement.getOrdered() != null) {
             if (!(database instanceof SybaseASADatabase)) {
                 if (statement.getOrdered()) {
                     buffer.append(" ORDER");
@@ -87,7 +90,7 @@ public class CreateSequenceGenerator extends AbstractSqlGenerator<CreateSequence
                 }
             }
         }
-        if (statement.getCycle() != null) {
+        if (!(database instanceof MariaDBDatabase) && statement.getCycle() != null) {
             if (statement.getCycle()) {
                 buffer.append(" CYCLE");
             }


### PR DESCRIPTION
Starting with [version 10.3](https://mariadb.com/kb/en/library/changes-improvements-in-mariadb-103/) MariaDB supports sequences. This PR introduce support through liquibase creating Sequences and default value for MariaDB. For example, following changelogs are supported through this PR:

```xml
<?xml version="1.0" encoding="utf-8" ?>
<databaseChangeLog
        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">

    <changeSet id="1" author="bob">
        <comment>A sample change log</comment>
        <createSequence cycle="true"
                        incrementBy="2"
                        maxValue="1000"
                        minValue="5"
                        ordered="true"
                        sequenceName="seq_id"
                        startValue="5"/>
    </changeSet>


    <changeSet id="2" author="bob">
        <createTable tableName="person"
                     tablespace="A String">
            <column name="address" type="varchar(255)"/>
            <column name="id" type="int" />
        </createTable>
    </changeSet>

    <changeSet id="3" author="bob">
        <addDefaultValue
                         columnName="id"
                         defaultValueSequenceNext="seq_id"
                         tableName="person"/>
    </changeSet>

</databaseChangeLog>
```
