### PR TITLE
Fix Turkish uppercase column keys bug

### DIFF
--- a/liquibase-core/src/main/java/liquibase/executor/jvm/ColumnMapRowMapper.java
+++ b/liquibase-core/src/main/java/liquibase/executor/jvm/ColumnMapRowMapper.java
@@ -6,6 +6,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -54,7 +55,7 @@ public class ColumnMapRowMapper implements RowMapper {
      * @see java.sql.ResultSetMetaData#getColumnName
      */
     protected String getColumnKey(String columnName) {
-        return columnName.toUpperCase();
+        return columnName.toUpperCase(Locale.US);
     }
 
     /**


### PR DESCRIPTION
[`Liquibase.listUnrunChangeSets` is broken when the user's Locale is Turkish](https://github.com/liquibase/liquibase.github.com/issues/125). (See also related bugfix PR: #751)

If your locale is set to Turkish `String.toUpperCase()` surprisingly will putting dots on things for you. 

e.g. 

```clojure
;; with Locale set to Turkish
(.toUpperCase "filename") ;; -> "FİLENAME"
```

The right solution is to always use `Locale.US` for things like 

```clojure
(.toUpperCase "filename" Locale/US) ;; -> "FILENAME"
```

which are used as keys elsewhere in the codebase. 

Fixes https://github.com/liquibase/liquibase.github.com/issues/125