### PR TITLE
Generate diff with onDelete and onUpdate

### DIFF
--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/ChangedForeignKeyChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/ChangedForeignKeyChangeGenerator.java
@@ -57,7 +57,7 @@ public class ChangedForeignKeyChangeGenerator extends AbstractChangeGenerator im
         addFkChange.setReferencedTableName(fk.getPrimaryKeyTable().getName());
         addFkChange.setReferencedColumnNames(StringUtil.join(fk.getPrimaryKeyColumns(), ",", formatter));
         addFkChange.setOnDelete(fk.getDeleteRule());
-        addFkChange.setOnDelete(fk.getUpdateRule());
+        addFkChange.setOnUpdate(fk.getUpdateRule());
 
         if (control.getIncludeCatalog()) {
             dropFkChange.setBaseTableCatalogName(fk.getForeignKeyTable().getSchema().getCatalogName());

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/ChangedForeignKeyChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/ChangedForeignKeyChangeGenerator.java
@@ -56,6 +56,8 @@ public class ChangedForeignKeyChangeGenerator extends AbstractChangeGenerator im
         addFkChange.setBaseColumnNames(StringUtil.join(fk.getForeignKeyColumns(), ",", formatter));
         addFkChange.setReferencedTableName(fk.getPrimaryKeyTable().getName());
         addFkChange.setReferencedColumnNames(StringUtil.join(fk.getPrimaryKeyColumns(), ",", formatter));
+        addFkChange.setOnDelete(fk.getDeleteRule());
+        addFkChange.setOnDelete(fk.getUpdateRule());
 
         if (control.getIncludeCatalog()) {
             dropFkChange.setBaseTableCatalogName(fk.getForeignKeyTable().getSchema().getCatalogName());


### PR DESCRIPTION
When I am generating diff for database that has onDelete = CASCADE, liquibase sees it, but doesn't add to changelog. It just creates drop constraint and add constraint without onDelete statement.

To solve this, I've added
```
addFkChange.setOnDelete(fk.getDeleteRule());
addFkChange.setOnUpdate(fk.getUpdateRule());
```
to `ChangedForeignKeyChangeGenerator#fixChanged`