### PR TITLE
Handle java.sql.Time when setting prepared statement parameter values

### DIFF
--- a/liquibase-core/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
+++ b/liquibase-core/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
@@ -21,6 +21,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.*;
 
@@ -168,6 +169,8 @@ public abstract class ExecutablePreparedStatementBase implements ExecutablePrepa
             LOG.debug(LogType.LOG, "value is date = " + col.getValueDate());
             if (col.getValueDate() instanceof Timestamp) {
                 stmt.setTimestamp(i, (Timestamp) col.getValueDate());
+            } else if (col.getValueDate() instanceof Time) {
+                stmt.setTime(i, (Time) col.getValueDate());
             } else {
                 stmt.setDate(i, new java.sql.Date(col.getValueDate().getTime()));
             }


### PR DESCRIPTION
When loading data from a CSV file using `<loadData>`, `ISODateFormat` constructs a `java.sql.Time` value when the column format is `HH:mm:ss`.

`PreparedStatement.setTime()` needs to be called for those values for the PostgreSQL JDBC driver to properly understand the parameter.

This is a regression we noticed when upgrading to liquibase 3.6 from 3.5. Liquibase 3.5 did not use prepared statements in that case.