### PR TITLE
Update versions for debian and rpm

### DIFF
--- a/liquibase-debian/pom.xml
+++ b/liquibase-debian/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-parent</artifactId>
-        <version>3.6.3-SNAPSHOT</version>
+        <version>3.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>liquibase-debian</artifactId>

--- a/liquibase-rpm/pom.xml
+++ b/liquibase-rpm/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.liquibase</groupId>
 		<artifactId>liquibase-parent</artifactId>
-		<version>3.6.3-SNAPSHOT</version>
+		<version>3.6.4-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>liquibase-rpm</artifactId>


### PR DESCRIPTION
Hello,

When building 3.6.x branch locally, the debian and rpm versions need to be bumped too to 3.6.4-SNAPSHOT so Maven can resolve the parent POMs.

Best regards,
Adam