### PR TITLE
Use computeIfAbsent to avoid concurrency issues

### DIFF
--- a/liquibase-core/src/main/java/liquibase/executor/ExecutorService.java
+++ b/liquibase-core/src/main/java/liquibase/executor/ExecutorService.java
@@ -22,16 +22,15 @@ public class ExecutorService {
     }
 
     public Executor getExecutor(Database database) {
-        if (!executors.containsKey(database)) {
+        return executors.computeIfAbsent(database, db -> {
             try {
                 Executor executor = Scope.getCurrentScope().getServiceLocator().findInstances(Executor.class).get(0);
-                executor.setDatabase(database);
-                executors.put(database, executor);
+                executor.setDatabase(db);
+                return executor;
             } catch (Exception e) {
                 throw new UnexpectedLiquibaseException(e);
             }
-        }
-        return executors.get(database);
+        });
     }
 
     public void setExecutor(Database database, Executor executor) {


### PR DESCRIPTION
computeIfAbsent avoids concurrency issues when multiple upgrades run simultaneously