### PR TITLE
CORE-3400 added "manifoldclass:" to list of skipped URL protocols in …

### DIFF
--- a/liquibase-core/src/main/java/liquibase/servicelocator/DefaultPackageScanClassResolver.java
+++ b/liquibase-core/src/main/java/liquibase/servicelocator/DefaultPackageScanClassResolver.java
@@ -186,6 +186,13 @@ public class DefaultPackageScanClassResolver implements PackageScanClassResolver
                     continue;
                 }
 
+                // manifold classes should be skipped (no physical jar file present)
+                // see http://manifold.systems/ for details about manifold
+                if (url.toString().startsWith("manifoldclass:") || urlPath.startsWith("manifoldclass:")) {
+                    log.debug(LogType.LOG, "It's a manifold classes url, skipping");
+                    continue;
+                }
+
                 // Else it's in a JAR, grab the path to the jar
                 if (urlPath.contains(".jar/") && !urlPath.contains(".jar!/")) {
                     urlPath = urlPath.replace(".jar/", ".jar!/");


### PR DESCRIPTION
DefaultPackageScanClassResolver is present but unused in current master (due to switch to standard java ServiceLoader usage). I then created this pull request for the 3.6.x branch, currently 3.6.4-SNAPSHOT.

The 3.6.4-SNAPSHOT doesn't build cleanly (some tests fail), but the same tests fail before and after applying this change.

skipping tests for testing my change allowed creating a local snapshot, which fixes the issue I reported in CORE-3400.