### PR TITLE
Use postgres advisory lock as changelog lock service

### DIFF
--- a/liquibase-core/src/main/java/liquibase/configuration/GlobalConfiguration.java
+++ b/liquibase-core/src/main/java/liquibase/configuration/GlobalConfiguration.java
@@ -21,6 +21,7 @@ public class GlobalConfiguration extends AbstractConfigurationContainer {
     public static final String DIFF_COLUMN_ORDER = "diffColumnOrder";
     public static final String ALWAYS_OVERRIDE_STORED_LOGIC_SCHEMA = "alwaysOverrideStoredLogicSchema";
     public static final String GENERATED_CHANGESET_IDS_INCLUDE_DESCRIPTION = "generatedChangeSetIdsContainsDescription";
+    public static final String USE_DB_LOCK = "useDbLock";
 
     public GlobalConfiguration() {
         super("liquibase");
@@ -90,6 +91,11 @@ public class GlobalConfiguration extends AbstractConfigurationContainer {
         getContainer().addProperty(GENERATED_CHANGESET_IDS_INCLUDE_DESCRIPTION, Boolean.class)
             .setDescription("Should Liquibase include the change description in the id when generating changeSets?")
                 .setDefaultValue(false);
+
+        getContainer().addProperty(USE_DB_LOCK, Boolean.class)
+            .setDescription(
+                "Should Liquibase use db locks, like Postgres transaction-level advisory locks, when applying the changeSets")
+            .setDefaultValue(false);
     }
 
     /**
@@ -238,6 +244,15 @@ public class GlobalConfiguration extends AbstractConfigurationContainer {
 
     public GlobalConfiguration setGeneratedChangeSetIdsContainDescription(boolean containDescription) {
         getContainer().setValue(GENERATED_CHANGESET_IDS_INCLUDE_DESCRIPTION, containDescription);
+        return this;
+    }
+
+    public Boolean getUseDbLock() {
+        return getContainer().getValue(USE_DB_LOCK, Boolean.class);
+    }
+
+    public GlobalConfiguration setUseDbLock(boolean useDbLock) {
+        getContainer().setValue(USE_DB_LOCK, useDbLock);
         return this;
     }
 }

--- a/liquibase-core/src/main/java/liquibase/lockservice/PostgresAdvisoryLockService.java
+++ b/liquibase-core/src/main/java/liquibase/lockservice/PostgresAdvisoryLockService.java
@@ -1,0 +1,173 @@
+package liquibase.lockservice;
+
+import liquibase.configuration.GlobalConfiguration;
+import liquibase.configuration.LiquibaseConfiguration;
+import liquibase.database.Database;
+import liquibase.database.core.PostgresDatabase;
+import liquibase.exception.DatabaseException;
+import liquibase.exception.LockException;
+import liquibase.executor.Executor;
+import liquibase.executor.ExecutorService;
+import liquibase.servicelocator.PrioritizedService;
+import liquibase.statement.core.RawSqlStatement;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.logging.Logger;
+
+public class PostgresAdvisoryLockService implements LockService {
+
+    private static final Logger LOGGER = Logger.getLogger(PostgresAdvisoryLockService.class.getName());
+
+    private static final int LOCK_NAMESPACE_ID = "liquibase".hashCode();
+    private static final int LOCK_ID = "lockservice".hashCode();
+
+    static final RawSqlStatement TRY_ACQUIRE_LOCK_SQL =
+        new RawSqlStatement(String.format("select pg_try_advisory_lock(%d,%d)", LOCK_NAMESPACE_ID, LOCK_ID));
+
+    static final RawSqlStatement RELEASE_LOCK_SQL =
+        new RawSqlStatement(String.format("select pg_advisory_unlock(%d,%d)", LOCK_NAMESPACE_ID, LOCK_ID));
+
+    private Database database;
+    private boolean hasChangeLogLock;
+    private long changeLogLockWaitTime;
+    private long changeLogLocRecheckTime;
+
+    public PostgresAdvisoryLockService() {
+        this.changeLogLockWaitTime = LiquibaseConfiguration.getInstance()
+            .getConfiguration(GlobalConfiguration.class)
+            .getDatabaseChangeLogLockWaitTime();
+        this.changeLogLocRecheckTime = LiquibaseConfiguration.getInstance()
+            .getConfiguration(GlobalConfiguration.class)
+            .getDatabaseChangeLogLockPollRate();
+    }
+
+    boolean tryAcquireLock(Executor executor) throws LockException {
+        try {
+            final Boolean tryLock = executor.queryForObject(TRY_ACQUIRE_LOCK_SQL, Boolean.class);
+            if (tryLock) {
+                LOGGER.info("Successfully acquired change log lock");
+            }
+            return tryLock;
+        } catch (DatabaseException e) {
+            throw new LockException(e);
+        }
+    }
+
+    @Override
+    public boolean supports(final Database database) {
+        final boolean isPostgres = database instanceof PostgresDatabase;
+        if (!isPostgres) {
+            return false;
+        }
+        final Boolean useDbLock = LiquibaseConfiguration.getInstance()
+            .getConfiguration(GlobalConfiguration.class)
+            .getUseDbLock();
+        try {
+            // Only works with Postgres version >= 9.1
+            return useDbLock && isAtLeastPostgres91(database);
+        } catch (DatabaseException e) {
+            return false;
+        }
+    }
+
+    boolean isAtLeastPostgres91(final Database database) throws DatabaseException {
+        return (database.getDatabaseMajorVersion() > 9) ||
+            (database.getDatabaseMajorVersion() == 9 && database.getDatabaseMinorVersion() >= 1);
+    }
+
+    @Override
+    public void setDatabase(final Database database) {
+        this.database = database;
+    }
+
+    @Override
+    public void setChangeLogLockWaitTime(final long changeLogLockWaitTime) {
+        this.changeLogLockWaitTime = changeLogLockWaitTime;
+    }
+
+    public long getChangeLogLockWaitTime() {
+        return changeLogLockWaitTime;
+    }
+
+    @Override
+    public void setChangeLogLockRecheckTime(final long changeLogLocRecheckTime) {
+        this.changeLogLocRecheckTime = changeLogLocRecheckTime;
+    }
+
+    public long getChangeLogLocRecheckTime() {
+        return changeLogLocRecheckTime;
+    }
+
+    @Override
+    public boolean hasChangeLogLock() {
+        return hasChangeLogLock;
+    }
+
+    @Override
+    public void waitForLock() throws LockException {
+        boolean locked = false;
+        long timeToGiveUp = Instant.now().plus(Duration.ofMinutes(changeLogLockWaitTime)).toEpochMilli();
+        while (!locked && System.currentTimeMillis() < timeToGiveUp) {
+            locked = acquireLock();
+            if (!locked) {
+                LOGGER.info("Waiting for changelog lock....");
+                try {
+                    Thread.sleep(Duration.ofSeconds(changeLogLocRecheckTime).toMillis());
+                } catch (InterruptedException e) {
+                }
+            }
+        }
+
+        if (!locked) {
+            throw new LockException("Could not acquire change log lock.");
+        }
+    }
+
+    @Override
+    public boolean acquireLock() throws LockException {
+        return hasChangeLogLock = tryAcquireLock(getExecutor());
+    }
+
+    Executor getExecutor() {
+        return ExecutorService.getInstance().getExecutor(database);
+    }
+
+    @Override
+    public void releaseLock() throws LockException {
+        try {
+            getExecutor().queryForObject(RELEASE_LOCK_SQL, Boolean.class);
+        } catch (DatabaseException e) {
+            throw new LockException(e);
+        }
+    }
+
+    @Override
+    public DatabaseChangeLogLock[] listLocks() {
+        return new DatabaseChangeLogLock[0];
+    }
+
+    @Override
+    public void forceReleaseLock() {
+    }
+
+    @Override
+    public void reset() {
+    }
+
+    @Override
+    public void init() {
+    }
+
+    @Override
+    public void destroy() {
+    }
+
+    /**
+     * Prioritize this implementation over {@link StandardLockService}.
+     */
+    @Override
+    public int getPriority() {
+        return PrioritizedService.PRIORITY_DEFAULT + 1;
+    }
+}

--- a/liquibase-core/src/test/java/liquibase/lockservice/PostgresAdvisoryLockServiceTest.java
+++ b/liquibase-core/src/test/java/liquibase/lockservice/PostgresAdvisoryLockServiceTest.java
@@ -1,0 +1,194 @@
+package liquibase.lockservice;
+
+import static liquibase.lockservice.PostgresAdvisoryLockService.TRY_ACQUIRE_LOCK_SQL;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyArray;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.*;
+
+import liquibase.configuration.GlobalConfiguration;
+import liquibase.configuration.LiquibaseConfiguration;
+import liquibase.database.core.H2Database;
+import liquibase.database.core.PostgresDatabase;
+import liquibase.exception.DatabaseException;
+import liquibase.exception.LockException;
+import liquibase.executor.Executor;
+import liquibase.servicelocator.PrioritizedService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.Random;
+
+public class PostgresAdvisoryLockServiceTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private PostgresAdvisoryLockService lockService;
+
+    @Mock
+    private PostgresDatabase database;
+
+    @Mock
+    private Executor executor;
+
+    @Before
+    public void setUp() {
+        lockService = spy(new PostgresAdvisoryLockService());
+        lockService.setDatabase(database);
+    }
+
+    @Test
+    public void tryAcquireLockTrue() throws DatabaseException, LockException {
+        when(executor.queryForObject(TRY_ACQUIRE_LOCK_SQL, Boolean.class)).thenReturn(true);
+
+        final boolean acquired = lockService.tryAcquireLock(executor);
+
+        assertThat(acquired, is(true));
+    }
+
+    @Test
+    public void tryAcquireLockFalse() throws DatabaseException, LockException {
+        when(executor.queryForObject(TRY_ACQUIRE_LOCK_SQL, Boolean.class)).thenReturn(false);
+
+        final boolean acquired = lockService.tryAcquireLock(executor);
+
+        assertThat(acquired, is(false));
+    }
+
+    @Test
+    public void supportsPostgres() throws DatabaseException {
+        when(database.getDatabaseMajorVersion()).thenReturn(9);
+        when(database.getDatabaseMinorVersion()).thenReturn(1);
+        LiquibaseConfiguration.getInstance()
+            .getConfiguration(GlobalConfiguration.class)
+            .setUseDbLock(true);
+
+        assertThat(lockService.supports(database), is(true));
+    }
+
+    @Test
+    public void supportsPostgresReturnFalseIfUseDbLockIsFalse_Default() throws DatabaseException {
+        when(database.getDatabaseMajorVersion()).thenReturn(9);
+        when(database.getDatabaseMinorVersion()).thenReturn(1);
+
+        assertThat(lockService.supports(database), is(false));
+    }
+
+    @Test
+    public void supportsH2() {
+        assertThat(lockService.supports(mock(H2Database.class)), is(false));
+    }
+
+    @Test
+    public void changeLogLockWaitTimeDefault() {
+        final Long expected = LiquibaseConfiguration.getInstance()
+            .getConfiguration(GlobalConfiguration.class)
+            .getDatabaseChangeLogLockWaitTime();
+
+        final long actual = lockService.getChangeLogLockWaitTime();
+
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void setChangeLogLockWaitTime() {
+        final long expected = new Random().nextInt();
+        lockService.setChangeLogLockWaitTime(expected);
+
+        final long actual = lockService.getChangeLogLockWaitTime();
+
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void changeLogLockRecheckTimeDefault() {
+        final Long expected = LiquibaseConfiguration.getInstance()
+            .getConfiguration(GlobalConfiguration.class)
+            .getDatabaseChangeLogLockPollRate();
+
+        final long actual = lockService.getChangeLogLocRecheckTime();
+
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void setChangeLogLockRecheckTime() {
+        final long expected = new Random().nextInt();
+        lockService.setChangeLogLockRecheckTime(expected);
+
+        final long actual = lockService.getChangeLogLocRecheckTime();
+
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void hasChangeLogLockDefaultToFalse() {
+        assertThat(lockService.hasChangeLogLock(), is(false));
+    }
+
+    @Test
+    public void hasChangeLogLockTrue() throws DatabaseException, LockException {
+        when(lockService.getExecutor()).thenReturn(executor);
+        when(executor.queryForObject(TRY_ACQUIRE_LOCK_SQL, Boolean.class)).thenReturn(true);
+
+        lockService.acquireLock();
+
+        assertThat(lockService.hasChangeLogLock(), is(true));
+    }
+
+    @Test
+    public void hasChangeLogLockFalse() throws DatabaseException, LockException {
+        when(lockService.getExecutor()).thenReturn(executor);
+        when(executor.queryForObject(TRY_ACQUIRE_LOCK_SQL, Boolean.class)).thenReturn(false);
+
+        lockService.acquireLock();
+
+        assertThat(lockService.hasChangeLogLock(), is(false));
+    }
+
+    @Test
+    public void waitForLock() throws DatabaseException, LockException {
+        when(lockService.getExecutor()).thenReturn(executor);
+        when(executor.queryForObject(TRY_ACQUIRE_LOCK_SQL, Boolean.class)).thenReturn(true);
+
+        lockService.waitForLock();
+
+        assertThat(lockService.hasChangeLogLock(), is(true));
+    }
+
+    @Test
+    public void waitForLockRetry() throws DatabaseException, LockException {
+        lockService.setChangeLogLockRecheckTime(1);
+        when(lockService.getExecutor()).thenReturn(executor);
+        when(executor.queryForObject(TRY_ACQUIRE_LOCK_SQL, Boolean.class))
+            .thenReturn(false)
+            .thenReturn(false)
+            .thenReturn(true);
+
+        lockService.waitForLock();
+
+        verify(lockService, times(3)).acquireLock();
+        assertThat(lockService.hasChangeLogLock(), is(true));
+    }
+
+    @Test
+    public void listLocks() {
+        final DatabaseChangeLogLock[] locks = lockService.listLocks();
+
+        assertThat(locks, emptyArray());
+    }
+
+    @Test
+    public void getPriority() {
+        final int expected = PrioritizedService.PRIORITY_DEFAULT + 1;
+
+        final int actual = lockService.getPriority();
+
+        assertThat(actual, is(expected));
+    }
+}


### PR DESCRIPTION
This commit introduces a new lock service that specifically
targets Postgres >= 9.1 and uses transaction advisory lock
(pg_try_advisory_xact_lock). This fixes (at least for pg)
the issue of DATABASECHANGELOGLOCK getting stuck in lock
when Liquibase does not exit cleanly.

Transaction advisory locks have the nice property that don't need
to be explicitly released. In fact, they are automatically released
by pg when the transaction is completed or the connection closed.

