### PR TITLE
generateChangeLog loadData skipping empty tables and columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ release.properties
 liquibase.integrationtest.local.properties
 /liquibase
 derby.log
-/.idea
+.idea
 *.iml
 .DS_Store
 /tmp

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingDataExternalFileChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingDataExternalFileChangeGenerator.java
@@ -65,101 +65,103 @@ public class MissingDataExternalFileChangeGenerator extends MissingDataChangeGen
             stmt.setFetchSize(100);
             rs = stmt.executeQuery(sql);
 
-            List<String> columnNames = new ArrayList<>();
-            for (int i=0; i< rs.getMetaData().getColumnCount(); i++) {
-                columnNames.add(rs.getMetaData().getColumnName(i+1));
-            }
-
-            String fileName = table.getName().toLowerCase() + ".csv";
-            if (dataDir != null) {
-                fileName = dataDir + "/" + fileName;
-
-                File parentDir = new File(dataDir);
-                if (!parentDir.exists()) {
-                    parentDir.mkdirs();
+            if (rs.isBeforeFirst()) {
+                List<String> columnNames = new ArrayList<>();
+                for (int i = 0; i < rs.getMetaData().getColumnCount(); i++) {
+                    columnNames.add(rs.getMetaData().getColumnName(i + 1));
                 }
-                if (!parentDir.isDirectory()) {
-                    throw new IOException(parentDir.getAbsolutePath() +  " is not a valid directory");
+
+                String fileName = table.getName().toLowerCase() + ".csv";
+                if (dataDir != null) {
+                    fileName = dataDir + "/" + fileName;
+
+                    File parentDir = new File(dataDir);
+                    if (!parentDir.exists()) {
+                        parentDir.mkdirs();
+                    }
+                    if (!parentDir.isDirectory()) {
+                        throw new IOException(parentDir.getAbsolutePath() + " is not a valid directory");
+                    }
                 }
-            }
-    
-            String[] dataTypes = new String[0];
-            try (
+
+                String[] dataTypes = new String[0];
+                try (
                         FileOutputStream fileOutputStream = new FileOutputStream(fileName);
                         OutputStreamWriter outputStreamWriter = new OutputStreamWriter(
-                             fileOutputStream,
-                             LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class)
-                             .getOutputEncoding()
+                                fileOutputStream,
+                                LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class)
+                                        .getOutputEncoding()
                         );
                         CSVWriter outputFile = new CSVWriter(new BufferedWriter(outputStreamWriter));
-            ) {
-                
-                dataTypes = new String[columnNames.size()];
-                String[] line = new String[columnNames.size()];
-                for (int i = 0; i < columnNames.size(); i++) {
-                    line[i] = columnNames.get(i);
-                }
-                outputFile.writeNext(line);
-        
-                int rowNum = 0;
-                while (rs.next()) {
-                    line = new String[columnNames.size()];
-    
+                ) {
+
+                    dataTypes = new String[columnNames.size()];
+                    String[] line = new String[columnNames.size()];
                     for (int i = 0; i < columnNames.size(); i++) {
-                        Object value = JdbcUtils.getResultSetValue(rs, i + 1);
-                        if ((dataTypes[i] == null) && (value != null)) {
-                            if (value instanceof Number) {
-                                dataTypes[i] = "NUMERIC";
-                            } else if (value instanceof Boolean) {
-                                dataTypes[i] = "BOOLEAN";
-                            } else if (value instanceof Date) {
-                                dataTypes[i] = "DATE";
-                            } else {
-                                dataTypes[i] = "STRING";
-                            }
-                        }
-                        if (value == null) {
-                            line[i] = "NULL";
-                        } else {
-                            if (value instanceof Date) {
-                                line[i] = new ISODateFormat().format(((Date) value));
-                            } else {
-                                line[i] = value.toString();
-                            }
-                        }
+                        line[i] = columnNames.get(i);
                     }
                     outputFile.writeNext(line);
-                    rowNum++;
-                    if ((rowNum % 5000) == 0) {
-                        outputFile.flush();
+
+                    int rowNum = 0;
+                    while (rs.next()) {
+                        line = new String[columnNames.size()];
+
+                        for (int i = 0; i < columnNames.size(); i++) {
+                            Object value = JdbcUtils.getResultSetValue(rs, i + 1);
+                            if ((dataTypes[i] == null) && (value != null)) {
+                                if (value instanceof Number) {
+                                    dataTypes[i] = "NUMERIC";
+                                } else if (value instanceof Boolean) {
+                                    dataTypes[i] = "BOOLEAN";
+                                } else if (value instanceof Date) {
+                                    dataTypes[i] = "DATE";
+                                } else {
+                                    dataTypes[i] = "STRING";
+                                }
+                            }
+                            if (value == null) {
+                                line[i] = "NULL";
+                            } else {
+                                if (value instanceof Date) {
+                                    line[i] = new ISODateFormat().format(((Date) value));
+                                } else {
+                                    line[i] = value.toString();
+                                }
+                            }
+                        }
+                        outputFile.writeNext(line);
+                        rowNum++;
+                        if ((rowNum % 5000) == 0) {
+                            outputFile.flush();
+                        }
                     }
                 }
-            }
-    
-            LoadDataChange change = new LoadDataChange();
-            change.setFile(fileName);
-            change.setEncoding(LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).getOutputEncoding());
-            if (outputControl.getIncludeCatalog()) {
-                change.setCatalogName(table.getSchema().getCatalogName());
-            }
-            if (outputControl.getIncludeSchema()) {
-                change.setSchemaName(table.getSchema().getName());
-            }
-            change.setTableName(table.getName());
 
-            for (int i = 0; i < columnNames.size(); i++) {
-                String colName = columnNames.get(i);
-                LoadDataColumnConfig columnConfig = new LoadDataColumnConfig();
-                columnConfig.setHeader(colName);
-                columnConfig.setName(colName);
-                columnConfig.setType(dataTypes[i]);
+                LoadDataChange change = new LoadDataChange();
+                change.setFile(fileName);
+                change.setEncoding(LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).getOutputEncoding());
+                if (outputControl.getIncludeCatalog()) {
+                    change.setCatalogName(table.getSchema().getCatalogName());
+                }
+                if (outputControl.getIncludeSchema()) {
+                    change.setSchemaName(table.getSchema().getName());
+                }
+                change.setTableName(table.getName());
 
-                change.addColumn(columnConfig);
+                for (int i = 0; i < columnNames.size(); i++) {
+                    String colName = columnNames.get(i);
+                    LoadDataColumnConfig columnConfig = new LoadDataColumnConfig();
+                    columnConfig.setHeader(colName);
+                    columnConfig.setName(colName);
+                    columnConfig.setType(dataTypes[i] != null ? dataTypes[i] : "skip");
+
+                    change.addColumn(columnConfig);
+                }
+                return new Change[]{
+                        change
+                };
             }
-
-            return new Change[]{
-                    change
-            };
+            return new Change[]{};
         } catch (Exception e) {
             throw new UnexpectedLiquibaseException(e);
         } finally {

--- a/liquibase-debian/pom.xml
+++ b/liquibase-debian/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-parent</artifactId>
-        <version>3.6.3-SNAPSHOT</version>
+        <version>3.6.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>liquibase-debian</artifactId>

--- a/liquibase-rpm/pom.xml
+++ b/liquibase-rpm/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.liquibase</groupId>
 		<artifactId>liquibase-parent</artifactId>
-		<version>3.6.3-SNAPSHOT</version>
+		<version>3.6.4-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>liquibase-rpm</artifactId>


### PR DESCRIPTION
`generateChangeLog` was generating empty `csv` files for all tables and also inserts for columns that are empty in the whole table.

This was bad because when the table has no data, no `type` is set on the `column` on the resulting file.
Later on, when you try to load this file it triggered a unnecessary search for the column type for each load, which was taking ~20s each.