### PR TITLE
Java-side date generation

### DIFF
--- a/liquibase-cdi/pom.xml
+++ b/liquibase-cdi/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-parent</artifactId>
-        <version>3.7.0-SNAPSHOT</version>
+        <version>3.7.0-localdates-SNAPSHOT</version>
 	</parent>
 	<artifactId>liquibase-cdi</artifactId>
 	<name>Liquibase CDI</name>

--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.liquibase</groupId>
 		<artifactId>liquibase-parent</artifactId>
-		<version>3.7.0-SNAPSHOT</version>
+		<version>3.7.0-localdates-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>liquibase-core</artifactId>

--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeLogParameters.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeLogParameters.java
@@ -41,7 +41,7 @@ public class ChangeLogParameters {
 
         if (database != null) {
             this.set("database.autoIncrementClause", database.getAutoIncrementClause(null, null));
-            this.set("database.currentDateTimeFunction", database.getCurrentDateTimeFunction());
+            this.set("database.currentDateTimePlaceholder", database.getCurrentDateTimePlaceholder());
             this.set("database.databaseChangeLogLockTableName", database.getDatabaseChangeLogLockTableName());
             this.set("database.databaseChangeLogTableName", database.getDatabaseChangeLogTableName());
             try {

--- a/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -126,6 +126,8 @@ public abstract class AbstractJdbcDatabase implements Database {
     private boolean outputDefaultCatalog = true;
 
     private boolean defaultCatalogSet;
+    private boolean supportingPrimaryKeys = true;
+    private boolean supportingTransactions = true;
 
     private Map<String, Object> attributes = new HashMap<>();
 
@@ -1541,6 +1543,26 @@ public abstract class AbstractJdbcDatabase implements Database {
     @Override
     public void setOutputDefaultCatalog(final boolean outputDefaultCatalog) {
         this.outputDefaultCatalog = outputDefaultCatalog;
+    }
+
+    @Override
+    public boolean isSupportingPrimaryKeys() {
+        return supportingPrimaryKeys;
+    }
+
+    @Override
+    public void setSupportingPrimaryKeys(boolean supportingPrimaryKeys) {
+        this.supportingPrimaryKeys = supportingPrimaryKeys;
+    }
+
+    @Override
+    public boolean isSupportingTransactions() {
+        return supportingTransactions;
+    }
+
+    @Override
+    public void setSupportingTransactions(boolean supportingTransactions) {
+        this.supportingTransactions = supportingTransactions;
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/database/Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/Database.java
@@ -423,6 +423,14 @@ public interface Database extends PrioritizedService {
 
     void setOutputDefaultCatalog(boolean outputDefaultCatalog);
 
+    boolean isSupportingTransactions();
+
+    void setSupportingTransactions(boolean supportingTransactions);
+
+    boolean isSupportingPrimaryKeys();
+
+    void setSupportingPrimaryKeys(boolean supportingPrimaryKeys);
+
     boolean supportsPrimaryKeyNames();
 
     /**

--- a/liquibase-core/src/main/java/liquibase/database/Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/Database.java
@@ -10,6 +10,7 @@ import liquibase.servicelocator.PrioritizedService;
 import liquibase.sql.visitor.SqlVisitor;
 import liquibase.statement.DatabaseFunction;
 import liquibase.statement.SqlStatement;
+import liquibase.statement.core.CurrentDateTimeFunction;
 import liquibase.structure.DatabaseObject;
 
 import java.io.IOException;
@@ -124,9 +125,13 @@ public interface Database extends PrioritizedService {
     /**
      * Returns database-specific function for generating the current date/time.
      */
-    String getCurrentDateTimeFunction();
+    String getCurrentDateTimePlaceholder();
 
-    void setCurrentDateTimeFunction(String function);
+    void setCurrentDateTimePlaceholder(String function);
+
+    CurrentDateTimeFunction getCurrentDateTimeFunction();
+
+    void setCurrentDateTimeFunction(CurrentDateTimeFunction currentDateTimeFunction);
 
     String getLineComment();
 

--- a/liquibase-core/src/main/java/liquibase/database/core/AbstractDb2Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/AbstractDb2Database.java
@@ -21,15 +21,10 @@ import liquibase.structure.core.Schema;
 import liquibase.util.JdbcUtils;
 import liquibase.util.StringUtil;
 
-import java.sql.ResultSet;
-import java.sql.Statement;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-
 public abstract class AbstractDb2Database extends AbstractJdbcDatabase {
 
     public AbstractDb2Database() {
-        super.setCurrentDateTimeFunction("CURRENT TIMESTAMP");
+        super.setCurrentDateTimePlaceholder("CURRENT TIMESTAMP");
         super.sequenceNextValueFunction = "NEXT VALUE FOR %s";
         super.sequenceCurrentValueFunction = "PREVIOUS VALUE FOR %s";
         super.unquotedObjectsAreUppercased=true;

--- a/liquibase-core/src/main/java/liquibase/database/core/Db2zDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/Db2zDatabase.java
@@ -10,7 +10,7 @@ import liquibase.util.StringUtil;
 public class Db2zDatabase extends AbstractDb2Database {
 
     public Db2zDatabase() {
-        super.setCurrentDateTimeFunction("CURRENT TIMESTAMP");
+        super.setCurrentDateTimePlaceholder("CURRENT TIMESTAMP");
         super.sequenceNextValueFunction = "NEXT VALUE FOR %s";
         super.sequenceCurrentValueFunction = "PREVIOUS VALUE FOR %s";
         super.unquotedObjectsAreUppercased=true;

--- a/liquibase-core/src/main/java/liquibase/database/core/DerbyDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/DerbyDatabase.java
@@ -8,9 +8,7 @@ import liquibase.database.OfflineConnection;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.executor.ExecutorService;
-import liquibase.logging.LogService;
 import liquibase.logging.LogType;
-import liquibase.logging.Logger;
 import liquibase.statement.core.RawSqlStatement;
 import liquibase.structure.DatabaseObject;
 
@@ -27,7 +25,7 @@ public class DerbyDatabase extends AbstractJdbcDatabase {
     protected int driverVersionMinor;
 
     public DerbyDatabase() {
-        super.setCurrentDateTimeFunction("CURRENT_TIMESTAMP");
+        super.setCurrentDateTimePlaceholder("CURRENT_TIMESTAMP");
         super.sequenceNextValueFunction = "NEXT VALUE FOR %s";
         super.sequenceCurrentValueFunction = "(SELECT currentvalue FROM sys.syssequences WHERE sequencename = upper('%s'))";
         determineDriverVersion();

--- a/liquibase-core/src/main/java/liquibase/database/core/FirebirdDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/FirebirdDatabase.java
@@ -15,7 +15,7 @@ import java.util.Locale;
 public class FirebirdDatabase extends AbstractJdbcDatabase {
 
     public FirebirdDatabase() {
-        super.setCurrentDateTimeFunction("CURRENT_TIMESTAMP");
+        super.setCurrentDateTimePlaceholder("CURRENT_TIMESTAMP");
         super.sequenceNextValueFunction="NEXT VALUE FOR %s";
     }
 

--- a/liquibase-core/src/main/java/liquibase/database/core/H2Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/H2Database.java
@@ -9,8 +9,6 @@ import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.DateParseException;
 import liquibase.exception.UnexpectedLiquibaseException;
-import liquibase.logging.LogFactory;
-import liquibase.logging.LogService;
 import liquibase.logging.LogType;
 import liquibase.statement.DatabaseFunction;
 import liquibase.util.ISODateFormat;
@@ -81,7 +79,7 @@ public class H2Database extends AbstractJdbcDatabase {
 
     public H2Database() {
         super.unquotedObjectsAreUppercased=true;
-        super.setCurrentDateTimeFunction("NOW()");
+        super.setCurrentDateTimePlaceholder("NOW()");
         // for current date
         this.dateFunctions.add(new DatabaseFunction("CURRENT_DATE"));
         this.dateFunctions.add(new DatabaseFunction("CURDATE"));

--- a/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/HsqlDatabase.java
@@ -316,7 +316,7 @@ public class HsqlDatabase extends AbstractJdbcDatabase {
 
     public HsqlDatabase() {
         super.unquotedObjectsAreUppercased = true;
-        super.setCurrentDateTimeFunction("NOW");
+        super.setCurrentDateTimePlaceholder("NOW");
         super.sequenceNextValueFunction = "NEXT VALUE FOR %s";
         super.defaultAutoIncrementStartWith = BigInteger.ZERO;
         super.sequenceCurrentValueFunction = "CURRVAL('%s')";

--- a/liquibase-core/src/main/java/liquibase/database/core/InformixDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/InformixDatabase.java
@@ -8,7 +8,6 @@ import liquibase.database.OfflineConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.executor.ExecutorService;
-import liquibase.logging.LogService;
 import liquibase.logging.LogType;
 import liquibase.statement.core.GetViewDefinitionStatement;
 import liquibase.statement.core.RawSqlStatement;
@@ -34,7 +33,7 @@ public class InformixDatabase extends AbstractJdbcDatabase {
     		Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
 	public InformixDatabase() {
-        super.setCurrentDateTimeFunction("CURRENT " + DATETIME_FIELD_QUALIFIER);
+        super.setCurrentDateTimePlaceholder("CURRENT " + DATETIME_FIELD_QUALIFIER);
         super.sequenceNextValueFunction = "%s.NEXTVAL";
         systemTablesAndViews.add("systables");
 		systemTablesAndViews.add("syscolumns");

--- a/liquibase-core/src/main/java/liquibase/database/core/Ingres9Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/Ingres9Database.java
@@ -24,7 +24,7 @@ public class Ingres9Database extends AbstractJdbcDatabase {
     private static Pattern CREATE_VIEW_AS_PATTERN = Pattern.compile("^CREATE\\s+.*?VIEW\\s+.*?AS\\s+", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
     public Ingres9Database() {
-        setCurrentDateTimeFunction("date('now')");
+        setCurrentDateTimePlaceholder("date('now')");
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
@@ -9,7 +9,6 @@ import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.executor.ExecutorService;
-import liquibase.logging.LogService;
 import liquibase.logging.LogType;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.GetViewDefinitionStatement;
@@ -61,7 +60,7 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
     // "Magic numbers" are ok here because we populate a lot of self-explaining metadata.
     @SuppressWarnings("squid:S109")
     public MSSQLDatabase() {
-        super.setCurrentDateTimeFunction("GETDATE()");
+        super.setCurrentDateTimePlaceholder("GETDATE()");
 
         super.sequenceNextValueFunction = "NEXT VALUE FOR %s";
 

--- a/liquibase-core/src/main/java/liquibase/database/core/MockDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MockDatabase.java
@@ -749,6 +749,26 @@ public class MockDatabase implements Database, InternalDatabase {
     }
 
     @Override
+    public boolean isSupportingTransactions() {
+        return true;
+    }
+
+    @Override
+    public void setSupportingTransactions(boolean supportingTransactions) {
+
+    }
+
+    @Override
+    public boolean isSupportingPrimaryKeys() {
+        return true;
+    }
+
+    @Override
+    public void setSupportingPrimaryKeys(boolean supportingPrimaryKeys) {
+
+    }
+
+    @Override
     public boolean isDefaultSchema(final String catalog, final String schema) {
         return false;
     }

--- a/liquibase-core/src/main/java/liquibase/database/core/MockDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MockDatabase.java
@@ -15,6 +15,7 @@ import liquibase.lockservice.DatabaseChangeLogLock;
 import liquibase.sql.visitor.SqlVisitor;
 import liquibase.statement.DatabaseFunction;
 import liquibase.statement.SqlStatement;
+import liquibase.statement.core.CurrentDateTimeFunction;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.Schema;
 
@@ -255,12 +256,22 @@ public class MockDatabase implements Database, InternalDatabase {
     }
 
     @Override
-    public String getCurrentDateTimeFunction() {
+    public String getCurrentDateTimePlaceholder() {
         return "DATETIME()";
     }
 
     @Override
-    public void setCurrentDateTimeFunction(final String function) {
+    public void setCurrentDateTimePlaceholder(final String function) {
+    }
+
+    @Override
+    public CurrentDateTimeFunction getCurrentDateTimeFunction() {
+        return null;
+    }
+
+    @Override
+    public void setCurrentDateTimeFunction(CurrentDateTimeFunction currentDateTimeFunction) {
+
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/database/core/MySQLDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MySQLDatabase.java
@@ -9,7 +9,6 @@ import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.executor.ExecutorService;
-import liquibase.logging.LogService;
 import liquibase.logging.LogType;
 import liquibase.statement.core.RawSqlStatement;
 import liquibase.structure.DatabaseObject;
@@ -35,7 +34,7 @@ public class MySQLDatabase extends AbstractJdbcDatabase {
     private Boolean hasJdbcConstraintDeferrableBug;
 
     public MySQLDatabase() {
-        super.setCurrentDateTimeFunction("NOW()");
+        super.setCurrentDateTimePlaceholder("NOW()");
         setHasJdbcConstraintDeferrableBug(null);
     }
 

--- a/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
@@ -21,7 +21,6 @@ import liquibase.exception.DatabaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.exception.ValidationErrors;
 import liquibase.executor.ExecutorService;
-import liquibase.logging.LogService;
 import liquibase.logging.LogType;
 import liquibase.statement.DatabaseFunction;
 import liquibase.statement.SequenceCurrentValueFunction;
@@ -64,7 +63,7 @@ public class OracleDatabase extends AbstractJdbcDatabase {
     public OracleDatabase() {
         super.unquotedObjectsAreUppercased=true;
         //noinspection HardCodedStringLiteral
-        super.setCurrentDateTimeFunction("SYSTIMESTAMP");
+        super.setCurrentDateTimePlaceholder("SYSTIMESTAMP");
         // Setting list of Oracle's native functions
         //noinspection HardCodedStringLiteral
         dateFunctions.add(new DatabaseFunction("SYSDATE"));

--- a/liquibase-core/src/main/java/liquibase/database/core/PostgresDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/PostgresDatabase.java
@@ -10,7 +10,6 @@ import liquibase.database.jvm.JdbcConnection;
 import liquibase.logging.Logger;
 import liquibase.structure.DatabaseObject;
 import liquibase.exception.DatabaseException;
-import liquibase.logging.LogService;
 import liquibase.logging.LogType;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.RawCallStatement;
@@ -39,7 +38,7 @@ public class PostgresDatabase extends AbstractJdbcDatabase {
     private Set<String> reservedWords = new HashSet<>();
 
     public PostgresDatabase() {
-        super.setCurrentDateTimeFunction("NOW()");
+        super.setCurrentDateTimePlaceholder("NOW()");
         // "Reserved" or "reserved (can be function or type)" in PostgreSQL
         // from https://www.postgresql.org/docs/9.6/static/sql-keywords-appendix.html
         reservedWords.addAll(Arrays.asList("ALL", "ANALYSE", "ANALYZE", "AND", "ANY", "ARRAY", "AS", "ASC",

--- a/liquibase-core/src/main/java/liquibase/database/core/SQLiteDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/SQLiteDatabase.java
@@ -34,7 +34,7 @@ public class SQLiteDatabase extends AbstractJdbcDatabase {
     }
 
     public SQLiteDatabase() {
-        super.setCurrentDateTimeFunction("CURRENT_TIMESTAMP");
+        super.setCurrentDateTimePlaceholder("CURRENT_TIMESTAMP");
     }
 
     public static List<SqlStatement> getAlterTableStatements(

--- a/liquibase-core/src/main/java/liquibase/database/core/SybaseASADatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/SybaseASADatabase.java
@@ -130,7 +130,7 @@ public class SybaseASADatabase extends AbstractJdbcDatabase {
      */
     public SybaseASADatabase() {
         super();
-        super.setCurrentDateTimeFunction("now()");
+        super.setCurrentDateTimePlaceholder("now()");
         super.unmodifiableDataTypes.addAll(Arrays.asList("integer", "bigint"));
 
     }

--- a/liquibase-core/src/main/java/liquibase/database/core/SybaseDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/SybaseDatabase.java
@@ -10,12 +10,8 @@ import liquibase.structure.DatabaseObject;
 import liquibase.exception.DatabaseException;
 import liquibase.executor.Executor;
 import liquibase.executor.ExecutorService;
-import liquibase.logging.LogService;
 import liquibase.logging.LogType;
-import liquibase.statement.SqlStatement;
 import liquibase.statement.core.GetViewDefinitionStatement;
-import liquibase.statement.core.RawSqlStatement;
-import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.Table;
 import liquibase.structure.core.View;
 
@@ -32,7 +28,7 @@ public class SybaseDatabase extends AbstractJdbcDatabase {
     protected Set<String> systemTablesAndViews = new HashSet<>();
 
     public SybaseDatabase() {
-        super.setCurrentDateTimeFunction("GETDATE()");
+        super.setCurrentDateTimePlaceholder("GETDATE()");
         systemTablesAndViews.add("syscolumns");
         systemTablesAndViews.add("syscomments");
         systemTablesAndViews.add("sysdepends");

--- a/liquibase-core/src/main/java/liquibase/database/core/UnsupportedDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/UnsupportedDatabase.java
@@ -14,8 +14,8 @@ public class UnsupportedDatabase extends AbstractJdbcDatabase {
     @Override
     public void setConnection(DatabaseConnection conn) {
         super.setConnection(conn);
-        if (currentDateTimeFunction == null) {
-            currentDateTimeFunction = findCurrentDateTimeFunction();
+        if (currentDateTimePlaceholder == null) {
+            currentDateTimePlaceholder = findCurrentDateTimeFunction();
         }
     }
 
@@ -58,8 +58,8 @@ public class UnsupportedDatabase extends AbstractJdbcDatabase {
     }
 
     @Override
-    public String getCurrentDateTimeFunction() {
-        return currentDateTimeFunction;
+    public String getCurrentDateTimePlaceholder() {
+        return currentDateTimePlaceholder;
     }
 
     private String findCurrentDateTimeFunction() {

--- a/liquibase-core/src/main/java/liquibase/datatype/LiquibaseDataType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/LiquibaseDataType.java
@@ -240,7 +240,7 @@ public abstract class LiquibaseDataType implements PrioritizedService {
     protected boolean isCurrentDateTimeFunction(String string, Database database) {
         return string.toLowerCase(Locale.US).startsWith("current_timestamp")
                 || string.toLowerCase(Locale.US).startsWith(DatabaseFunction.CURRENT_DATE_TIME_PLACE_HOLDER)
-                || database.getCurrentDateTimeFunction().toLowerCase(Locale.US).equals(string.toLowerCase(Locale.US));
+                || database.getCurrentDateTimePlaceholder().toLowerCase(Locale.US).equals(string.toLowerCase(Locale.US));
     }
 
     public void finishInitialization(String originalDefinition) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/DateType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/DateType.java
@@ -35,7 +35,7 @@ public class DateType extends LiquibaseDataType {
         } else if (value instanceof DatabaseFunction) {
             return database.generateDatabaseFunctionValue((DatabaseFunction) value);
         } else if ("CURRENT_TIMESTAMP()".equals(value.toString())) {
-              return database.getCurrentDateTimeFunction();
+              return database.getCurrentDateTimePlaceholder();
         } else if (value instanceof java.sql.Timestamp) {
             return database.getDateLiteral(((java.sql.Timestamp) value));
         } else if (value instanceof java.sql.Date) {

--- a/liquibase-core/src/main/java/liquibase/integration/ant/BaseLiquibaseTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/BaseLiquibaseTask.java
@@ -350,7 +350,7 @@ public abstract class BaseLiquibaseTask extends Task {
      */
     @Deprecated
     public void setCurrentDateTimeFunction(String currentDateTimeFunction) {
-        log("The currentDateTimeFunction attribute is deprecated. Use a nested <database> element or set the databaseRef attribute instead.", Project.MSG_WARN);
+        log("The currentDateTimePlaceholder attribute is deprecated. Use a nested <database> element or set the databaseRef attribute instead.", Project.MSG_WARN);
         getDatabaseType().setCurrentDateTimeFunction(currentDateTimeFunction);
     }
 

--- a/liquibase-core/src/main/java/liquibase/integration/ant/type/DatabaseType.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/type/DatabaseType.java
@@ -105,7 +105,7 @@ public class DatabaseType extends DataType {
             }
             String dbmsCurrentDateTimeFunction = getCurrentDateTimeFunction();
             if(dbmsCurrentDateTimeFunction != null) {
-                database.setCurrentDateTimeFunction(dbmsCurrentDateTimeFunction);
+                database.setCurrentDateTimePlaceholder(dbmsCurrentDateTimeFunction);
             }
 
             database.setOutputDefaultSchema(isOutputDefaultSchema());

--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -107,6 +107,8 @@ public class Main {
     protected String excludeObjects;
     protected Boolean includeCatalog;
     protected String includeObjects;
+    protected Boolean noPrimaryKeys;
+    protected Boolean noTransactions;
     protected Boolean includeSchema;
     protected Boolean includeTablespace;
     protected String outputSchemasAs;
@@ -560,6 +562,7 @@ public class Main {
                             && !cmdParm.startsWith("--" + OPTIONS.REFERENCE_SCHEMAS)
                             && !cmdParm.startsWith("--" + OPTIONS.REFERENCE_URL)
                             && !cmdParm.startsWith("--" + OPTIONS.EXCLUDE_OBJECTS)
+                            && !cmdParm.startsWith("--" + OPTIONS.NO_PRIMARY_KEYS)
                             && !cmdParm.startsWith("--" + OPTIONS.INCLUDE_OBJECTS)
                             && !cmdParm.startsWith("--" + OPTIONS.DIFF_TYPES)) {
                         messages.add(String.format(coreBundle.getString("unexpected.command.parameter"), cmdParm));
@@ -838,6 +841,12 @@ public class Main {
         if (this.includeSchema == null) {
             this.includeSchema = false;
         }
+        if (this.noPrimaryKeys == null) {
+            this.noPrimaryKeys = false;
+        }
+        if (this.noTransactions == null) {
+            this.noTransactions = false;
+        }
         if (this.includeCatalog == null) {
             this.includeCatalog = false;
         }
@@ -960,6 +969,9 @@ public class Main {
                 this.liquibaseCatalogName, this.liquibaseSchemaName, this.databaseChangeLogTableName,
                 this.databaseChangeLogLockTableName);
         database.setLiquibaseTablespaceName(this.databaseChangeLogTablespaceName);
+        database.setSupportingPrimaryKeys(this.noPrimaryKeys == null || !this.noPrimaryKeys);
+        database.setSupportingTransactions(this.noTransactions == null || !this.noTransactions);
+
         try {
 
             if ((excludeObjects != null) && (includeObjects != null)) {
@@ -1400,6 +1412,10 @@ public class Main {
                 dataOutputDirectory = value;
             } else if (OPTIONS.CURRENT_DATE_TIME_FUNCTION.equalsIgnoreCase(attributeName)) {
                 currentDateTimeFunction = value;
+            } else if (OPTIONS.NO_PRIMARY_KEYS.equalsIgnoreCase(attributeName)) {
+            	noPrimaryKeys = Boolean.parseBoolean(value);
+			} else if (OPTIONS.NO_TRANSACTIONS.equalsIgnoreCase(attributeName)) {
+                noTransactions = Boolean.parseBoolean(value);
             }
         }
 
@@ -1505,6 +1521,8 @@ public class Main {
         private static final String DATA_OUTPUT_DIRECTORY = "dataOutputDirectory";
         private static final String DIFF_TYPES = "diffTypes";
         private static final String EXCLUDE_OBJECTS = "excludeObjects";
+        private static final String NO_PRIMARY_KEYS = "noPrimaryKeys";
+        private static final String NO_TRANSACTIONS = "noTransactions";
         private static final String INCLUDE_CATALOG = "includeCatalog";
         private static final String INCLUDE_OBJECTS = "includeObjects";
         private static final String INCLUDE_SCHEMA = "includeSchema";

--- a/liquibase-core/src/main/java/liquibase/lockservice/LockServiceFactory.java
+++ b/liquibase-core/src/main/java/liquibase/lockservice/LockServiceFactory.java
@@ -54,6 +54,10 @@ public class LockServiceFactory {
 	}
 
 	public LockService getLockService(Database database) {
+    	if (!database.isSupportingTransactions()) {
+    		return new OfflineLockService();
+		}
+
 		if (!openLockServices.containsKey(database)) {
 			SortedSet<LockService> foundServices = new TreeSet<>(new Comparator<LockService>() {
                 @Override

--- a/liquibase-core/src/main/java/liquibase/resource/InputStreamSupplier.java
+++ b/liquibase-core/src/main/java/liquibase/resource/InputStreamSupplier.java
@@ -1,0 +1,19 @@
+package liquibase.resource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.function.Supplier;
+
+import liquibase.exception.LiquibaseException;
+
+@FunctionalInterface
+public interface InputStreamSupplier extends Supplier<InputStream> {
+	InputStream safeGet() throws IOException;
+	default InputStream get() {
+		try {
+			return safeGet();
+		} catch (IOException e) {
+			throw new RuntimeException(e); // TODO
+		}
+	}
+}

--- a/liquibase-core/src/main/java/liquibase/sdk/resource/MockResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/sdk/resource/MockResourceAccessor.java
@@ -4,6 +4,7 @@ import liquibase.configuration.GlobalConfiguration;
 import liquibase.configuration.LiquibaseConfiguration;
 import liquibase.resource.AbstractResourceAccessor;
 import liquibase.resource.InputStreamList;
+import liquibase.resource.InputStreamSupplier;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -26,9 +27,9 @@ public class MockResourceAccessor extends AbstractResourceAccessor {
 
     @Override
     public InputStreamList openStreams(String relativeTo, String streamPath) throws IOException {
-        InputStream stream = null;
+        InputStreamSupplier stream = null;
         if (contentByFileName.containsKey(streamPath)) {
-            stream = new ByteArrayInputStream(contentByFileName.get(streamPath).getBytes(LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).getOutputEncoding()));
+            stream = () -> new ByteArrayInputStream(contentByFileName.get(streamPath).getBytes(LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).getOutputEncoding()));
         }
         if (stream == null) {
             return null;

--- a/liquibase-core/src/main/java/liquibase/sdk/supplier/resource/ResourceSupplier.java
+++ b/liquibase-core/src/main/java/liquibase/sdk/supplier/resource/ResourceSupplier.java
@@ -8,6 +8,7 @@ import liquibase.configuration.LiquibaseConfiguration;
 import liquibase.database.core.HsqlDatabase;
 import liquibase.resource.AbstractResourceAccessor;
 import liquibase.resource.InputStreamList;
+import liquibase.resource.InputStreamSupplier;
 import liquibase.resource.ResourceAccessor;
 
 import java.io.ByteArrayInputStream;
@@ -33,18 +34,18 @@ public class ResourceSupplier {
 
         @Override
         public InputStreamList openStreams(String relativeTo, String streamPath) throws IOException {
-            InputStream stream = null;
+            InputStreamSupplier stream = null;
             String encoding = LiquibaseConfiguration.getInstance().getConfiguration(
                     GlobalConfiguration.class).getOutputEncoding();
             if (streamPath.toLowerCase().endsWith("csv")) {
-                stream = new ByteArrayInputStream(USERS_CSV.getBytes(encoding));
+                stream = () -> new ByteArrayInputStream(USERS_CSV.getBytes(encoding));
             } else if (streamPath.toLowerCase().endsWith("my-logic.sql")) {
-                stream = new ByteArrayInputStream(((String) Scope.getCurrentScope().getSingleton(ChangeFactory.class).getChangeMetaData(
+                stream = () -> new ByteArrayInputStream(((String) Scope.getCurrentScope().getSingleton(ChangeFactory.class).getChangeMetaData(
                         new CreateProcedureChange()).getParameters().get("procedureBody").getExampleValue(
                         new HsqlDatabase())).getBytes(encoding)
                 );
             } else if (streamPath.toLowerCase().endsWith("sql")) {
-                stream = new ByteArrayInputStream(EXAMPLE_SQL_COMMAND.getBytes(encoding));
+                stream = () -> new ByteArrayInputStream(EXAMPLE_SQL_COMMAND.getBytes(encoding));
             } else {
                 throw new RuntimeException("Unknown resource type: "+ streamPath);
             }

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AbstractSqlGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AbstractSqlGenerator.java
@@ -57,7 +57,7 @@ public abstract class AbstractSqlGenerator<T extends SqlStatement> implements Sq
     public boolean looksLikeFunctionCall(String value, Database database) {
         // TODO: SYSIBM looks DB2-specific, we should move that out of AbstractSqlGenerator into a DB2-specific class.
         return value.startsWith("\"SYSIBM\"") || value.startsWith("to_date(") ||
-            value.equalsIgnoreCase(database.getCurrentDateTimeFunction());
+            value.equalsIgnoreCase(database.getCurrentDateTimePlaceholder());
     }
 
 }

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateDatabaseChangeLogLockTableGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateDatabaseChangeLogLockTableGenerator.java
@@ -22,9 +22,15 @@ public class CreateDatabaseChangeLogLockTableGenerator extends AbstractSqlGenera
     public Sql[] generateSql(CreateDatabaseChangeLogLockTableStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
         String charTypeName = getCharTypeName(database);
         String dateTimeTypeString = getDateTimeTypeString(database);
-        CreateTableStatement createTableStatement = new CreateTableStatement(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogLockTableName())
-                .setTablespace(database.getLiquibaseTablespaceName())
-                .addPrimaryKeyColumn("ID", DataTypeFactory.getInstance().fromDescription("int", database), null, null, null, new NotNullConstraint())
+        CreateTableStatement baseStatement = new CreateTableStatement(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogLockTableName())
+                .setTablespace(database.getLiquibaseTablespaceName());
+        if (database.isSupportingPrimaryKeys()) {
+            baseStatement = baseStatement.addPrimaryKeyColumn("ID", DataTypeFactory.getInstance().fromDescription("int", database), null, null, null, new NotNullConstraint());
+        } else {
+            baseStatement = baseStatement.addColumn("ID", DataTypeFactory.getInstance().fromDescription("int", database), null, null, new NotNullConstraint());
+        }
+
+        CreateTableStatement createTableStatement = baseStatement
                 .addColumn("LOCKED", DataTypeFactory.getInstance().fromDescription("boolean", database), null, null, new NotNullConstraint())
                 .addColumn("LOCKGRANTED", DataTypeFactory.getInstance().fromDescription(dateTimeTypeString, database))
                 .addColumn("LOCKEDBY", DataTypeFactory.getInstance().fromDescription(charTypeName + "(255)", database));

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateDatabaseChangeLogTableGeneratorSybase.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateDatabaseChangeLogTableGeneratorSybase.java
@@ -43,8 +43,10 @@ public class CreateDatabaseChangeLogTableGeneratorSybase extends AbstractSqlGene
                         "LIQUIBASE VARCHAR(20) NULL, " +
                         "CONTEXTS VARCHAR(255) NULL, " +
                         "LABELS VARCHAR(255) NULL, " +
-                        "DEPLOYMENT_ID VARCHAR(10) NULL, " +
-                        "PRIMARY KEY(ID, AUTHOR, FILENAME))",
+                        "DEPLOYMENT_ID VARCHAR(10) NULL" +
+                        ((database.isSupportingPrimaryKeys()) ?
+                        ", PRIMARY KEY(ID, AUTHOR, FILENAME))" :
+                        ")"),
                         getAffectedTable(database))
         };
     }

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/MarkChangeSetRanGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/MarkChangeSetRanGenerator.java
@@ -39,14 +39,14 @@ public class MarkChangeSetRanGenerator extends AbstractSqlGenerator<MarkChangeSe
 
     @Override
     public Sql[] generateSql(MarkChangeSetRanStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
-        String dateValue = database.getCurrentDateTimeFunction();
+        String dateValue = database.getCurrentDateTimePlaceholder();
 
         ChangeSet changeSet = statement.getChangeSet();
 
         SqlStatement runStatement;
         try {
             if (statement.getExecType().equals(ChangeSet.ExecType.FAILED) || statement.getExecType().equals(ChangeSet.ExecType.SKIPPED)) {
-                return new Sql[0]; //don't mark
+                return new Sql[0]; //don'tt pull mark
             }
 
             String tag = null;

--- a/liquibase-core/src/main/java/liquibase/statement/core/CurrentDateTimeFunction.java
+++ b/liquibase-core/src/main/java/liquibase/statement/core/CurrentDateTimeFunction.java
@@ -1,0 +1,6 @@
+package liquibase.statement.core;
+
+@FunctionalInterface
+public interface CurrentDateTimeFunction {
+	String getTime();
+}

--- a/liquibase-core/src/main/java/liquibase/statement/core/NamedDateTimeFormatter.java
+++ b/liquibase-core/src/main/java/liquibase/statement/core/NamedDateTimeFormatter.java
@@ -41,7 +41,7 @@ public enum NamedDateTimeFormatter implements CurrentDateTimeFunction {
 				.filter(ndtf -> Objects.equals(ndtf.getName(), nameOrPattern))
 				.findFirst()
 				.map(CurrentDateTimeFunction.class::cast)
-				.orElse(() -> DateTimeFormatter.ofPattern(nameOrPattern).format(ZonedDateTime.now()));
+				.orElse(nameOrPattern != null ? () -> DateTimeFormatter.ofPattern(nameOrPattern).format(ZonedDateTime.now()) : null);
 	}
 
 	public String getName() {

--- a/liquibase-core/src/main/java/liquibase/statement/core/NamedDateTimeFormatter.java
+++ b/liquibase-core/src/main/java/liquibase/statement/core/NamedDateTimeFormatter.java
@@ -1,0 +1,61 @@
+package liquibase.statement.core;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+public enum NamedDateTimeFormatter implements CurrentDateTimeFunction {
+
+	BASIC_ISO_DATE("BASIC_ISO_DATE", DateTimeFormatter.BASIC_ISO_DATE)
+	, ISO_LOCAL_DATE("ISO_LOCAL_DATE", DateTimeFormatter.ISO_LOCAL_DATE)
+	, ISO_OFFSET_DATE("ISO_OFFSET_DATE", DateTimeFormatter.ISO_OFFSET_DATE)
+	, ISO_DATE("ISO_DATE", DateTimeFormatter.ISO_DATE)
+	, ISO_LOCAL_TIME("ISO_LOCAL_DATE", DateTimeFormatter.ISO_LOCAL_TIME)
+	, ISO_OFFSET_TIME("ISO_OFFSET_TIME", DateTimeFormatter.ISO_OFFSET_TIME)
+	, ISO_TIME("ISO_TIME", DateTimeFormatter.ISO_TIME)
+	, ISO_LOCAL_DATE_TIME("ISO_LOCAL_DATE_TIME", DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+	, ISO_OFFSET_DATE_TIME("ISO_OFFSET_DATE_TIME", DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+	, ISO_ZONED_DATE_TIME("ISO_ZONED_DATE_TIME", DateTimeFormatter.ISO_ZONED_DATE_TIME)
+	, ISO_DATE_TIME("ISO_DATE_TIME", DateTimeFormatter.ISO_DATE_TIME)
+	, ISO_ORDINAL_DATE("ISO_ORDINAL_DATE", DateTimeFormatter.ISO_ORDINAL_DATE)
+	, ISO_WEEK_DATE("ISO_WEEK_DATE", DateTimeFormatter.ISO_WEEK_DATE)
+	, ISO_INSTANT("ISO_INSTANT", DateTimeFormatter.ISO_INSTANT)
+	, RFC_1123_DATE_TIME("RFC_1123_DATE_TIME", DateTimeFormatter.RFC_1123_DATE_TIME)
+	, OFLOCALIZEDTIME("ofLocalizedTime", DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT))
+	, OFLOCALIZEDDATE("ofLocalizedDate", DateTimeFormatter.ofLocalizedDate(FormatStyle.FULL))
+	, OFLOCALIZEDDATETIME("ofLocalizedDateTime", DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM));
+
+
+	private final String name;
+	private final DateTimeFormatter formatter;
+
+	NamedDateTimeFormatter(String name, DateTimeFormatter formatter) {
+		this.name = name;
+		this.formatter = formatter;
+	}
+
+	public static CurrentDateTimeFunction byNameOrPattern(String nameOrPattern) {
+		return Stream.of(NamedDateTimeFormatter.values())
+				.filter(ndtf -> Objects.equals(ndtf.getName(), nameOrPattern))
+				.findFirst()
+				.map(CurrentDateTimeFunction.class::cast)
+				.orElse(() -> DateTimeFormatter.ofPattern(nameOrPattern).format(ZonedDateTime.now()));
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public DateTimeFormatter getFormatter() {
+		return formatter;
+	}
+
+	@Override
+	public String getTime() {
+		return "'" + formatter.format(ZonedDateTime.now()) + "'";
+	}
+
+
+}

--- a/liquibase-core/src/test/java/liquibase/LiquibaseTest.java
+++ b/liquibase-core/src/test/java/liquibase/LiquibaseTest.java
@@ -158,8 +158,8 @@ public class LiquibaseTest {
 //
 //        new Liquibase("com/example/test.xml", mockResourceAccessor, database)
 //            .getDatabase()
-//            .setCurrentDateTimeFunction(testFunction);
-//        verify(database).setCurrentDateTimeFunction(testFunction);
+//            .setCurrentDateTimePlaceholder(testFunction);
+//        verify(database).setCurrentDateTimePlaceholder(testFunction);
 //    }
 
     @Test

--- a/liquibase-core/src/test/java/liquibase/database/core/H2DatabaseTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/core/H2DatabaseTest.java
@@ -2,8 +2,7 @@ package liquibase.database.core;
 
 import liquibase.database.AbstractJdbcDatabaseTest;
 import liquibase.database.Database;
-import liquibase.database.DatabaseConnection;
-import liquibase.exception.DatabaseException;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -30,7 +29,7 @@ public class H2DatabaseTest extends AbstractJdbcDatabaseTest {
     @Override
     @Test
     public void getCurrentDateTimeFunction() {
-        Assert.assertEquals("NOW()", getDatabase().getCurrentDateTimeFunction());
+        Assert.assertEquals("NOW()", getDatabase().getCurrentDateTimePlaceholder());
     }
 
     @Test

--- a/liquibase-core/src/test/java/liquibase/database/core/MSSQLDatabaseTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/core/MSSQLDatabaseTest.java
@@ -30,7 +30,7 @@ public class MSSQLDatabaseTest extends AbstractJdbcDatabaseTest {
     @Override
     @Test
     public void getCurrentDateTimeFunction() {
-        assertEquals("GETDATE()", getDatabase().getCurrentDateTimeFunction());
+        assertEquals("GETDATE()", getDatabase().getCurrentDateTimePlaceholder());
     }
 
     @Test

--- a/liquibase-core/src/test/java/liquibase/database/core/MariaDBDatabaseTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/core/MariaDBDatabaseTest.java
@@ -30,7 +30,7 @@ public class MariaDBDatabaseTest extends AbstractJdbcDatabaseTest {
     @Override
     @Test
     public void getCurrentDateTimeFunction() {
-        Assert.assertEquals("NOW()", getDatabase().getCurrentDateTimeFunction());
+        Assert.assertEquals("NOW()", getDatabase().getCurrentDateTimePlaceholder());
     }
 
     @Test

--- a/liquibase-core/src/test/java/liquibase/database/core/MySQLDatabaseTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/core/MySQLDatabaseTest.java
@@ -32,7 +32,7 @@ public class MySQLDatabaseTest extends AbstractJdbcDatabaseTest {
     @Override
     @Test
     public void getCurrentDateTimeFunction() {
-        Assert.assertEquals("NOW()", getDatabase().getCurrentDateTimeFunction());
+        Assert.assertEquals("NOW()", getDatabase().getCurrentDateTimePlaceholder());
     }
 
     public void testGetDefaultDriver() {

--- a/liquibase-core/src/test/java/liquibase/database/core/OracleDatabaseTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/core/OracleDatabaseTest.java
@@ -25,9 +25,6 @@ import java.util.ResourceBundle;
 import static java.util.ResourceBundle.getBundle;
 import static org.junit.Assert.*;
 
-import org.hamcrest.CoreMatchers;
-import org.junit.Test;
-
 /**
  * Tests for {@link liquibase.database.core.OracleDatabase}.
  */
@@ -80,7 +77,7 @@ public class OracleDatabaseTest extends AbstractJdbcDatabaseTest {
     @Test
     public void getCurrentDateTimeFunction() {
         Assert.assertEquals("Oracle Database's 'give me the current timestamp' function is correctly reported.",
-                "SYSTIMESTAMP", getDatabase().getCurrentDateTimeFunction());
+                "SYSTIMESTAMP", getDatabase().getCurrentDateTimePlaceholder());
     }
 
     @Test

--- a/liquibase-core/src/test/java/liquibase/database/core/PostgresDatabaseTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/core/PostgresDatabaseTest.java
@@ -33,7 +33,7 @@ public class PostgresDatabaseTest extends AbstractJdbcDatabaseTest {
     @Override
     @Test
     public void getCurrentDateTimeFunction() {
-        Assert.assertEquals("NOW()", getDatabase().getCurrentDateTimeFunction());
+        Assert.assertEquals("NOW()", getDatabase().getCurrentDateTimePlaceholder());
     }
 
     @Test

--- a/liquibase-debian/pom.xml
+++ b/liquibase-debian/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-parent</artifactId>
-        <version>3.7.0-SNAPSHOT</version>
+        <version>3.7.0-localdates-SNAPSHOT</version>
     </parent>
 
     <artifactId>liquibase-debian</artifactId>

--- a/liquibase-integration-tests/pom.xml
+++ b/liquibase-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>liquibase-parent</artifactId>
         <groupId>org.liquibase</groupId>
-        <version>3.7.0-SNAPSHOT</version>
+        <version>3.7.0-localdates-SNAPSHOT</version>
     </parent>
 
 

--- a/liquibase-integration-tests/src/test/java/liquibase/statementexecute/AbstractExecuteTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/statementexecute/AbstractExecuteTest.java
@@ -13,7 +13,6 @@ import liquibase.exception.DatabaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.executor.ExecutorService;
 import liquibase.lockservice.LockServiceFactory;
-import liquibase.logging.LogService;
 import liquibase.logging.LogType;
 import liquibase.database.core.MockDatabase;
 import liquibase.snapshot.SnapshotGeneratorFactory;
@@ -143,7 +142,7 @@ public abstract class AbstractExecuteTest {
 
         convertedSql = convertedSql.replaceAll("FALSE", DataTypeFactory.getInstance().fromDescription("boolean", database).objectToSql(false, database));
         convertedSql = convertedSql.replaceAll("TRUE", DataTypeFactory.getInstance().fromDescription("boolean", database).objectToSql(true, database));
-        convertedSql = convertedSql.replaceAll("NOW\\(\\)", database.getCurrentDateTimeFunction());
+        convertedSql = convertedSql.replaceAll("NOW\\(\\)", database.getCurrentDateTimePlaceholder());
 
         return convertedSql;
     }

--- a/liquibase-integration-tests/src/test/resources/changelogs/yaml/common.tests.changelog.yaml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/yaml/common.tests.changelog.yaml
@@ -31,7 +31,7 @@ databaseChangeLog:
       - changeLogPropertyDefined:
           property: database.autoIncrementClause
       - changeLogPropertyDefined:
-          property: database.currentDateTimeFunction
+          property: database.currentDateTimePlaceholder
       - changeLogPropertyDefined:
           property: database.databaseChangeLogLockTableName
       - changeLogPropertyDefined:

--- a/liquibase-maven-plugin/pom.xml
+++ b/liquibase-maven-plugin/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>liquibase-parent</artifactId>
         <groupId>org.liquibase</groupId>
-        <version>3.7.0-SNAPSHOT</version>
+        <version>3.7.0-localdates-SNAPSHOT</version>
     </parent>
 
 	<dependencies>

--- a/liquibase-rpm/pom.xml
+++ b/liquibase-rpm/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.liquibase</groupId>
 		<artifactId>liquibase-parent</artifactId>
-		<version>3.7.0-SNAPSHOT</version>
+		<version>3.7.0-localdates-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>liquibase-rpm</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.liquibase</groupId>
     <artifactId>liquibase-parent</artifactId>
-    <version>3.7.0-SNAPSHOT</version>
+    <version>3.7.0-localdates-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Liquibase Parent Configuration</name>

--- a/pom.xml
+++ b/pom.xml
@@ -532,6 +532,7 @@
             </modules>
         </profile>
 
+<!--
         <profile>
             <id>rpm</id>
             <activation>
@@ -543,7 +544,7 @@
                 <module>liquibase-rpm</module>
             </modules>
         </profile>
-
+-->
         <profile>
             <id>doclint-java8-disable</id>
             <activation>


### PR DESCRIPTION
This contains a new feature allowing one to override the existing currentDateTimeFunction (now renamed currentDateTimePlaceholder) that uses a SQL function call, with a Java-generated static date strings. Some SQL datastores (Azure Datawarehouse) do not support functions on INSERT. This makes using Liquibase with these datastores impossible for trivial reasons. 

See NamedDateTimeFormatter. This is an enum of named common instances for date time formats that might be used. When one cannot be found, it falls back on DateTimeFormatter.parse() for the input argument. When using a named formatter, it encapsulates the resulting date string with single quotes (may need to be configurable). There's an accompanying command line option to specify the formatter.

We started building this functionality off the 3.6.x branch, as it looked more stable. This PR is against master, for 3.7.0-SNAPSHOT. master as it is, does not currently seem to be able to load changeset xml files, be it from the classpath or the local filesystem. There are two issues present:

* The classloader configured for CommandLineResourceAccessor by Main.configureClassLoader() seems incorrect. I may be missing configuration and/or other settings/changes needed. FileSystemResourceAccessors' rootPaths is always empty regardless of my testing without changing the classloader.
* InputStreams for our chngeset xml files are getting closed prematurely (prior to read) because their parent zip file(s) get closed in the try-with-resources block. I worked around this by changing InputStreamList to take Supplier<InputStream> instead, but really you should use Java 8 Stream<InputStream> and Stream.onClose().

I've "fixed" these bugs in this branch by making ad-hoc changes that ignore the intent of the current developers. I'm looking forward to finding the real fixes to these issues, one endorsed by liquibase development. Unfortunately, I am limited in my knowledge and understanding of the conventions at play and may have missed some of this intent in the process.

