### PR TITLE
Core 3063 resourceaccessor fixes

### DIFF
--- a/liquibase-core/src/main/java/liquibase/resource/CompositeResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/CompositeResourceAccessor.java
@@ -24,7 +24,7 @@ public class CompositeResourceAccessor extends AbstractResourceAccessor {
     public InputStreamList openStreams(String relativeTo, String streamPath) throws IOException {
         InputStreamList returnList = new InputStreamList();
         for (ResourceAccessor accessor : resourceAccessors) {
-            returnList.addAll(accessor.openStreams(null, streamPath));
+            returnList.addAll(accessor.openStreams(relativeTo, streamPath));
         }
         return returnList;
     }

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
@@ -882,11 +882,10 @@ public abstract class AbstractIntegrationTest {
     public void testAbsolutePathChangeLog() throws Exception {
         assumeNotNull(this.getDatabase());
 
+        String fileUrlToChangeLog = getClass().getResource("/" + includedChangeLog).toString();
+        assertTrue(fileUrlToChangeLog.startsWith("file:/"));
 
-        Set<String> urls = new JUnitResourceAccessor().list(null, includedChangeLog, true, false, true);
-        String absolutePathOfChangeLog = urls.iterator().next();
-
-        absolutePathOfChangeLog = absolutePathOfChangeLog.replaceFirst("file:\\/", "");
+        String absolutePathOfChangeLog = fileUrlToChangeLog.replaceFirst("file:\\/", "");
         if (System.getProperty("os.name").startsWith("Windows ")) {
             absolutePathOfChangeLog = absolutePathOfChangeLog.replace('/', '\\');
         } else {


### PR DESCRIPTION
This fixes a few bugs that were causing `MySQLIntegrationTest` to fail, I think caused by recent work to `ResourceAccessor`.

See my comments on https://liquibase.jira.com/browse/CORE-3063 -- what is the current plan for the integration tests?

There is still one failing test: [testAbsolutePathChangeLog](https://github.com/liquibase/liquibase/blob/658e17bb5b415cf975e63277ddc84bc8e6ed6cb2/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java#L882) which checks that Liquibase will accept an absolute file path to a changelog. After recent changes to `ResourceAccessor`, this now fails as `new FileSystemResourceAccessor().openStream(x)` will not resolve an absolute filename `x`.