### PR TITLE
Print message for liquibase tag and tagExists command to system.out

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -1116,7 +1116,7 @@ public class Main {
             } else if (COMMANDS.TAG.equalsIgnoreCase(command)) {
                 liquibase.tag(getCommandArgument());
                 LogService.getLog(getClass()).info(
-                    LogType.LOG, String.format(
+                    LogType.USER_MESSAGE, String.format(
                         coreBundle.getString("successfully.tagged"), liquibase.getDatabase()
                             .getConnection().getConnectionUserName() + "@" +
                             liquibase.getDatabase().getConnection().getURL()
@@ -1128,14 +1128,14 @@ public class Main {
                 boolean exists = liquibase.tagExists(tag);
                 if (exists) {
                     LogService.getLog(getClass()).info(
-                        LogType.LOG, String.format(coreBundle.getString("tag.exists"), tag,
+                        LogType.USER_MESSAGE, String.format(coreBundle.getString("tag.exists"), tag,
                             liquibase.getDatabase().getConnection().getConnectionUserName() + "@" +
                                 liquibase.getDatabase().getConnection().getURL()
                         )
                     );
                 } else {
                     LogService.getLog(getClass()).info(
-                        LogType.LOG, String.format(coreBundle.getString("tag.does.not.exist"), tag,
+                        LogType.USER_MESSAGE, String.format(coreBundle.getString("tag.does.not.exist"), tag,
                             liquibase.getDatabase().getConnection().getConnectionUserName() + "@" +
                                 liquibase.getDatabase().getConnection().getURL()
                         )


### PR DESCRIPTION
I've found that after upgrade from Liquibase 3.5.5 to 3.6.3 - there is no message when databased _liquibase tag <someTag>_ executes and also there is no message when try to execute _liquibase tagExists <someTag>_

e.g. for liquibase 3.5.5 
`java -cp ./:/somedir/postgresql-42.2.5.jar:/somedir/liquibase-core-3.5.5.jar liquibase.integration.commandline.Main  --changeLogFile=liquibase/master.xml --url jdbc:postgresql://192.168.1.1:5432/postgres --username postgres --password password tagExists test`
The **tag** test does not exist in postgres@jdbc:postgresql://192.168.1.1:5432/postgres
Liquibase 'tagExists' Successful
for liquibase 3.6.3
`java -cp ./:/somedir/postgresql-42.2.5.jar:/somedir/liquibase-core-3.6.3.jar:/somedir/logback-core-1.2.3.jar:/somedir/slf4j-api-1.7.26.jar:/somedir/logback-classic-1.2.3.jar liquibase.integration.commandline.Main  --changeLogFile=liquibase/master.xml --url jdbc:postgresql://192.168.1.1:5432/postgres --username postgres --password password tagExists test`
Starting Liquibase at Wed, 29 May 2019 13:10:19 EEST (version 3.6.3 built at 2019-01-29 11:34:48)
Liquibase command 'tagExists' was executed successfully.