### PR TITLE
Upgrade org.apache.ant:ant to 1.10.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
             <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant</artifactId>
-                <version>1.7.1</version>
+                <version>1.10.6</version>
                 <scope>provided</scope>
                 <optional>true</optional>
             </dependency>


### PR DESCRIPTION
ant versions [1.5.0,1.8.1) have a dependency on Apache Commons Compress before 1.4.1 which has a vulnerability, CVE-2012-2098

https://app.snyk.io/vuln/SNYK-JAVA-ORGAPACHEANT-30510