### PR TITLE
Fixed an UnmarshalException when doing a diff with Envers on Java 9+

### DIFF
--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
@@ -25,7 +25,10 @@ import java.lang.reflect.Field;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.text.MessageFormat;
 import java.util.*;
+
+import javax.xml.bind.annotation.XmlSchema;
 
 /**
  * A base class for providing Liquibase {@link liquibase.Liquibase} functionality.
@@ -362,7 +365,7 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
                     }
                 }
             }
-
+            setupBindInfoPackage();
             performLiquibaseTask(liquibase);
         }
         catch (LiquibaseException e) {
@@ -377,6 +380,31 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
 
     protected Liquibase getLiquibase() {
         return liquibase;
+    }
+
+    protected void setupBindInfoPackage() {
+        String nsuri = "http://www.hibernate.org/xsd/orm/hbm";
+        String packageInfoClassName = "org.hibernate.boot.jaxb.hbm.spi.package-info";
+        try {
+            final Class<?> packageInfoClass = Class.forName(packageInfoClassName);
+            final XmlSchema xmlSchema = packageInfoClass.getAnnotation(XmlSchema.class);
+            if (xmlSchema == null) {
+                this.getLog().warn(MessageFormat
+                        .format("Class [{0}] is missing the [{1}] annotation. Processing bindings will probably fail.",
+                                packageInfoClassName, XmlSchema.class.getName()));
+            } else {
+                final String namespace = xmlSchema.namespace();
+                if (nsuri.equals(namespace)) {
+                    this.getLog().warn(MessageFormat
+                            .format("Namespace of the [{0}] annotation does not match [{1}]. Processing bindings will probably fail.",
+                                    XmlSchema.class.getName(), nsuri));
+                }
+            }
+        } catch (ClassNotFoundException cnfex) {
+            this.getLog().warn(MessageFormat
+                    .format("Class [{0}] could not be found. Processing bindings will probably fail.",
+                            packageInfoClassName), cnfex);
+        }
     }
 
     protected abstract void performLiquibaseTask(Liquibase liquibase)


### PR DESCRIPTION
Doing a diff with the liquibase maven plugin fails when both Envers and Java 9+ are involved, with the exact error that is described here : https://hibernate.atlassian.net/browse/HHH-12893

This is simply a fix that reproduces [what's been done here](https://github.com/highsource/maven-jaxb2-plugin/commit/7ecb8d8704cce8ff1db8d1309d005c1be1544533) but with the right packageInfoClassName as [described in a comment in the hibernate issue mentioned before](https://hibernate.atlassian.net/browse/HHH-12893?focusedCommentId=103539&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-103539)

Let me know if I you want me to reproduce it on master