### PR TITLE
Allow false on Disallowed Values

### DIFF
--- a/liquibase-core/src/main/java/liquibase/exception/ValidationErrors.java
+++ b/liquibase-core/src/main/java/liquibase/exception/ValidationErrors.java
@@ -57,7 +57,7 @@ public class ValidationErrors {
             }
         }
 
-        if (isDisallowed && (value != null)) {
+        if (isDisallowed && (value != null && value instanceof Boolean && ((Boolean) value).booleanValue())) {
             addError(disallowedFieldName + " is not allowed on "+(database == null?"unknown":database.getShortName()));
         }
     }


### PR DESCRIPTION
Liquibase validate changesets before they are applied to a DBMS.
For example, following changeset for PostgreSQL is rejected because
PostgreSQL does not support ordered sequences:

```
<changeSet id="1" author="author">
   <createSequence cycle="false"
                   cacheSize="20"
                   incrementBy="50"
                   sequenceName="SOME_SEQUENCE"
                   ordered="true"
                   startValue="1"/>
</changeSet>
```

However, if someone writes the following changeset it will be
rejected by liquibase as well:

```
<changeSet id="1" author="author">
   <createSequence cycle="false"
                   cacheSize="20"
                   incrementBy="50"
                   sequenceName="SOME_SEQUENCE"
                   ordered="false"
                   startValue="1"/>
</changeSet>
```

This commit improves the validation in order to write ordered=false
explicitly.

By the way, liquibase documentation claims to support ordered for postgresql: https://www.liquibase.org/documentation/changes/create_sequence.html



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-65) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Community 4.x,Community 4.4.0,Liquibase 4.4.0
