### PR TITLE
Microsoft SQL Server doesn't support ORDER in sequences

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateSequenceGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateSequenceGenerator.java
@@ -112,14 +112,15 @@ public class CreateSequenceGenerator extends AbstractSqlGenerator<CreateSequence
             }
         }
 
-        if (!(database instanceof MariaDBDatabase) && statement.getOrdered() != null) {
-            if (!(database instanceof SybaseASADatabase)) {
-                if (statement.getOrdered()) {
-                    queryStringBuilder.append(" ORDER");
-                } else {
-                   if (database instanceof OracleDatabase) {
-                       queryStringBuilder.append(" NOORDER");
-                   }
+        boolean databaseSupportsOrderedSequences = !(database instanceof MariaDBDatabase
+                        || database instanceof SybaseASADatabase
+                        || database instanceof MSSQLDatabase);
+        if (databaseSupportsOrderedSequences && statement.getOrdered() != null) {
+            if (statement.getOrdered()) {
+                queryStringBuilder.append(" ORDER");
+            } else {
+                if (database instanceof OracleDatabase) {
+                    queryStringBuilder.append(" NOORDER");
                 }
             }
         }


### PR DESCRIPTION
The CREATE SEQUENCE command of Microsoft SQL Server doesn't support the `ORDER` clause (see at https://docs.microsoft.com/en-us/sql/t-sql/statements/create-sequence-transact-sql?view=sql-server-2017).

Therefore, it should be ignored for this DB as well. I have tested this change on an SQL Server 2017 (I had an error with the CREATE SEQUENCE command before, and after applying this and installing to my local Maven repo, the problem was gone).

