### PR TITLE
CORE-2947 Make Load*DataChange aware of ChangeLogParameters

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
@@ -295,6 +295,14 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
 
             boolean isCommentingEnabled = StringUtil.isNotEmpty(commentLineStartsWith);
 
+            boolean isParameterSubstitutionEnabled = false;
+            if (getChangeSet() != null && getChangeSet().getChangeLogParameters() != null) {
+                Object value = getChangeSet().getChangeLogParameters().getValue("enableCsvParameterSubstitution", getChangeSet().getChangeLog());
+                if (value != null && "true".equalsIgnoreCase(value.toString())) {
+                    isParameterSubstitutionEnabled = true;
+                }
+            }
+
             List<SqlStatement> statements = new ArrayList<>();
             while ((line = reader.readNext()) != null) {
                 lineNumber++;
@@ -323,7 +331,12 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
 
                 List<ColumnConfig> columnsFromCsv = new ArrayList<>();
                 for (int i = 0; i < headers.length; i++) {
-                    Object value = line[i];
+                    Object value;
+                    if (isParameterSubstitutionEnabled) {
+                        value = getChangeSet().getChangeLogParameters().expandExpressions(line[i], getChangeSet().getChangeLog());
+                    } else {
+                        value = line[i];
+                    }
                     String columnName = headers[i].trim();
 
                     ColumnConfig valueConfig = new ColumnConfig();

--- a/liquibase-core/src/test/resources/liquibase/change/core/sample.data1-parameterSubstitution.csv
+++ b/liquibase-core/src/test/resources/liquibase/change/core/sample.data1-parameterSubstitution.csv
@@ -1,0 +1,3 @@
+name,username
+Bob ${surNameJohnson},${userNameBJ}
+John ${unset},jdoe

--- a/liquibase-core/src/test/resources/liquibase/change/core/sample.data1-parameterSubstitution.tsv
+++ b/liquibase-core/src/test/resources/liquibase/change/core/sample.data1-parameterSubstitution.tsv
@@ -1,0 +1,3 @@
+name	username
+Bob ${surNameJohnson}	${userNameBJ}
+John ${unset}	jdoe

--- a/liquibase-core/src/test/resources/liquibase/change/core/sample.quotchar-parameterSubstitution.tsv
+++ b/liquibase-core/src/test/resources/liquibase/change/core/sample.quotchar-parameterSubstitution.tsv
@@ -1,0 +1,3 @@
+name	username
+'Bob ${surNameJohnson}'	${userNameBJ}
+John ${unset}	'jdoe'


### PR DESCRIPTION
Fix for: https://liquibase.jira.com/browse/CORE-2947

Enable dynamic substitution of parameters in CSV files if ChangeLog property or JVM parameter enableCsvParameterSubstitution is set to true, if not explicitly set to true no substitution is done for backwards compatibility.

I've also added some unit tests in LoadDataChangeTest to test behaviour both with and without enableCsvParameterSubstitution set.

Not sure using a property is the best way to enable this feature, but wasn't sure how to propagate a flag from command line down to code in question otherwise.

No new test failures have been observed due to this fix.