### PR TITLE
Using JAVA_HOME instead of simply calling java

### DIFF
--- a/liquibase-core/src/main/resources/dist/liquibase
+++ b/liquibase-core/src/main/resources/dist/liquibase
@@ -51,9 +51,32 @@ else
   done
 fi
 
+# Make sure prerequisite environment variables are set
+if [ -z "$JAVA_HOME" ] && [ -z "$JRE_HOME" ]; then
+  JAVA_PATH=`which java 2>/dev/null`
+  if [ "x$JAVA_PATH" != "x" ]; then
+    JAVA_PATH=`dirname "$JAVA_PATH" 2>/dev/null`
+    JRE_HOME=`dirname "$JAVA_PATH" 2>/dev/null`
+  fi
+  if [ "x$JRE_HOME" = "x" ]; then
+    if [ -x /usr/bin/java ]; then
+      JRE_HOME=/usr
+    fi
+  fi
+  if [ -z "$JAVA_HOME" ] && [ -z "$JRE_HOME" ]; then
+    echo "Neither the JAVA_HOME nor the JRE_HOME environment variable is defined"
+    echo "At least one of these environment variable is needed to run this program"
+    exit 1
+  fi
+fi
+
+if [ -z "$JRE_HOME" ]; then
+  JRE_HOME="$JAVA_HOME"
+fi
+
 # add any JVM options here
 JAVA_OPTS="${JAVA_OPTS-}"
 
-java -cp "$CP" $JAVA_OPTS liquibase.integration.commandline.Main ${1+"$@"}
+"$JRE_HOME"/bin/java -cp "$CP" $JAVA_OPTS liquibase.integration.commandline.Main ${1+"$@"}
 
 


### PR DESCRIPTION
Using JAVA_HOME instead of simply calling java, and determining JAVA_HOME value if not defined

┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-62) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 4.0 beta 2
