### PR TITLE
CORE-2650 Use Base64-encoding to safely store BLOB data in CSV files

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.util.*;
+import java.util.regex.Pattern;
 
 import static java.util.ResourceBundle.getBundle;
 
@@ -76,6 +77,7 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
      * CSV Lines starting with that sign(s) will be treated as comments by default
      */
     public static final String DEFAULT_COMMENT_PATTERN = "#";
+    public static final Pattern BASE64_PATTERN = Pattern.compile("^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$");
     private static final Logger LOG = LogService.getLog(LoadDataChange.class);
     private static ResourceBundle coreBundle = getBundle("liquibase/i18n/liquibase-core");
     private String catalogName;
@@ -404,6 +406,10 @@ public class LoadDataChange extends AbstractChange implements ChangeWithColumns<
                             } else if (columnConfig.getType().equalsIgnoreCase(LOAD_DATA_TYPE.BLOB.toString())) {
                                 if ("NULL".equalsIgnoreCase(value.toString())) {
                                     valueConfig.setValue(null);
+                                } else if (BASE64_PATTERN.matcher(value.toString()).matches()) {
+                                    valueConfig.setType(columnConfig.getType());
+                                    valueConfig.setValue(value.toString());
+                                    needsPreparedStatement = true;
                                 } else {
                                     valueConfig.setValueBlobFile(value.toString());
                                     needsPreparedStatement = true;

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingDataExternalFileChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingDataExternalFileChangeGenerator.java
@@ -26,6 +26,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import org.springframework.util.Base64Utils;
+
 @LiquibaseService(skip = true)
 public class MissingDataExternalFileChangeGenerator extends MissingDataChangeGenerator {
 
@@ -115,6 +117,8 @@ public class MissingDataExternalFileChangeGenerator extends MissingDataChangeGen
                                     dataTypes[i] = "BOOLEAN";
                                 } else if (value instanceof Date) {
                                     dataTypes[i] = "DATE";
+                                } else if (value instanceof byte[]) {
+                                    dataTypes[i] = "BLOB";
                                 } else {
                                     dataTypes[i] = "STRING";
                                 }
@@ -124,6 +128,10 @@ public class MissingDataExternalFileChangeGenerator extends MissingDataChangeGen
                             } else {
                                 if (value instanceof Date) {
                                     line[i] = new ISODateFormat().format(((Date) value));
+                                } else if (value instanceof byte[]) {
+                                    // extract the value as a Base64 string, to safely store the
+                                    // binary data
+                                    line[i] = Base64Utils.encodeToString((byte[])value);
                                 } else {
                                     line[i] = value.toString();
                                 }

--- a/liquibase-core/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
+++ b/liquibase-core/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
@@ -25,6 +25,8 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.*;
 
+import org.springframework.util.Base64Utils;
+
 import static java.util.ResourceBundle.getBundle;
 import liquibase.change.core.LoadDataChange;
 
@@ -127,9 +129,11 @@ public abstract class ExecutablePreparedStatementBase implements ExecutablePrepa
     private void applyColumnParameter(PreparedStatement stmt, int i, ColumnConfig col) throws SQLException,
             DatabaseException {
         if (col.getValue() != null) {
-            LOG.debug(LogType.LOG, "value is string = " + col.getValue());
+            LOG.debug(LogType.LOG, "value is string/UUID/blob = " + col.getValue());
             if (col.getType() != null && col.getType().equalsIgnoreCase(LoadDataChange.LOAD_DATA_TYPE.UUID.name())) {
                 stmt.setObject(i, UUID.fromString(col.getValue()));
+            } else if (LoadDataChange.LOAD_DATA_TYPE.BLOB.name().equalsIgnoreCase(col.getType())) {
+                stmt.setBlob(i, new ByteArrayInputStream(Base64Utils.decodeFromString(col.getValue())));
             } else {
                 stmt.setString(i, col.getValue());
             }


### PR DESCRIPTION
I had a problem when using the generateChangelog, and then re-importing that file into an Oracle database. I found that this problem had already been reported in [CORE-2650](https://liquibase.jira.com/browse/CORE-2650), and I have found/implemented a (in my opinion) simple/straightforward way of processing BLOB data.

The BLOB file option seems interesting, and I have tried to leave it untouched the best I can, but I do think that in the future, it would be best so simply serialize the data into Base64 and include it in the file itself (making the "export"/snapshot a bit more portable).

_I would really appreciate some feedback on this (and some other) PRs I've sent. I'm happy to do integration work or fix my changes to comply with your coding standards, etc. The tests were already failing before my changes on branch_ `3.8.x` _(it seems there is one more test failure afterwards). In any case, I think these changes are worth sending because I find that a bug in exporting and re-importing the same data is very significant. In any case, establishing a working baseline of all tests passing would be great (and once again, I'm happy to fix my code to get any previously passing tests working again)._

The test output run on branch `3.8.x` is:

```java
[ERROR] Tests run: 397, Failures: 7, Errors: 20, Skipped: 257
[INFO]
[INFO] --- maven-failsafe-plugin:2.20:verify (integration-test) @ liquibase-integration-tests ---
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Liquibase Parent Configuration 3.8.1-SNAPSHOT:
[INFO]
[INFO] Liquibase Parent Configuration ..................... SUCCESS [  0.177 s]
[INFO] Liquibase Core ..................................... SUCCESS [01:03 min]
[INFO] Liquibase Maven Plugin ............................. SUCCESS [  5.051 s]
[INFO] Liquibase CDI ...................................... SUCCESS [  6.978 s]
[INFO] Liquibase Integration Tests ........................ FAILURE [01:41 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:57 min
[INFO] Finished at: 2019-08-27T12:54:54+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-failsafe-plugin:2.20:verify
        (integration-test) on project liquibase-integration-tests: There are test failures.
```

## QA Manual Tests
##### Setup
* Create Oracle tables with binary datatypes.
```java
CREATE TABLE RAWCOLUMN(
id NUMBER,
hex RAW(16) 
);

CREATE TABLE BLOBCOLUMN(
    id NUMBER,
    blob blob
);


* Insert data into the tables.
```



INSERT INTO RAWCOLUMN VALUES (1, ‘9CA181F1F7E94D1EADBFC270C8BC53EB’);
INSERT INTO BLOBCOLUMN VALUES (1, '08FC133785A6412CABF5A130201FBEE1');
{code:java}{code}

##### Validations
_Verify generateChangeLog is successful._

* 

  * Be Sure to Pass diffTypes=tables,columns,data and dataOutputDirectory=someDir to the generateChangeLog command.

ASSERT:

* Generated changelog has datatype RAW for column RAWCOLUMN.HEX.
* Generated changelog has datatype BLOB for column BLOBCOLUMN.BLOB.
* CSV in includes RAWCOLUMN table's data._
* CSV includes the BLOBCOLUMN table's data._

_Verify an update to a second database is successful._
ASSERT :: 

* There is no error due to invalid hex value during update



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-59) by [Unito](https://www.unito.io/learn-more)
┆Attachments: <a href="https://share.unito.io/8yf24dxmgXP2rCmltMf-j7Fv2KXYM_zmZd5T0YUUfvvj">blob.png</a> | <a href="https://share.unito.io/Z3Hk49vYfk7NlChdJc43Yfr7q9cPScqdMa5VNDGQA91v">error.png</a> | <a href="https://share.unito.io/whscl6-VFa-QVmBeui3Zd9D3qj1hlWQrhhMPyq3Qx4d1">liquibase.log</a> | <a href="https://share.unito.io/39TkLiXa-IWA4Vu5ESYLlD6R6wHYEBcAujpyONa4jKk3">log.png</a> | <a href="https://share.unito.io/8Dx46BZd023ENdwJrXHtJRjBeeIMcMZ_K54go6ULwTvT">raw.png</a> | <a href="https://share.unito.io/k61GqM6BcK76D4YCFKli29_yv8HKRt1DrsOgwXP7DQvi">tables.png</a>
┆Fix Versions: Liquibase 3.10.2
