### PR TITLE
fix CORE-3379: escaping ? for postgresql

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/AbstractSQLChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/AbstractSQLChange.java
@@ -228,7 +228,7 @@ public abstract class AbstractSQLChange extends AbstractChange implements DbmsTa
                  statement = statement.replaceAll("\\n", "\r\n");
              }
             if (database instanceof PostgresDatabase) {
-                statement = statement.replaceAll("(^|[^\\?])\\?(?!\\?)", "$1??");
+                statement = statement.replaceAll("(^|[^\\?])\\?(?!\\?)(?=([^']*'[^']*')*[^']*$)", "$1??");
             }
 
             String escapedStatement = statement;

--- a/liquibase-core/src/main/java/liquibase/change/AbstractSQLChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/AbstractSQLChange.java
@@ -6,6 +6,7 @@ import liquibase.configuration.GlobalConfiguration;
 import liquibase.configuration.LiquibaseConfiguration;
 import liquibase.database.Database;
 import liquibase.database.core.MSSQLDatabase;
+import liquibase.database.core.PostgresDatabase;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.exception.ValidationErrors;
@@ -226,6 +227,9 @@ public abstract class AbstractSQLChange extends AbstractChange implements DbmsTa
             if (database instanceof MSSQLDatabase) {
                  statement = statement.replaceAll("\\n", "\r\n");
              }
+            if (database instanceof PostgresDatabase) {
+                statement = statement.replaceAll("(^|[^\\?])\\?(?!\\?)", "$1??");
+            }
 
             String escapedStatement = statement;
             try {


### PR DESCRIPTION
Replacing the postgres-operators '?', '?&' and '?|' with escaped operators '??', '??&' and '??|' if not already escaped.

If further databases use a '?' in sql-dialect I can add some more escaping rules.