### PR TITLE
CORE-3379 escaping postgres questionmark operators to prevent unwante…

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/AbstractSQLChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/AbstractSQLChange.java
@@ -5,6 +5,7 @@ import liquibase.configuration.GlobalConfiguration;
 import liquibase.configuration.LiquibaseConfiguration;
 import liquibase.database.Database;
 import liquibase.database.core.MSSQLDatabase;
+import liquibase.database.core.PostgresDatabase;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.exception.ValidationErrors;
@@ -224,8 +225,11 @@ public abstract class AbstractSQLChange extends AbstractChange implements DbmsTa
         }
         for (String statement : StringUtils.processMutliLineSQL(processedSQL, isStripComments(), isSplitStatements(), getEndDelimiter())) {
             if (database instanceof MSSQLDatabase) {
-                 statement = statement.replaceAll("\\n", "\r\n");
-             }
+                statement = statement.replaceAll("\\n", "\r\n");
+            }
+            if (database instanceof PostgresDatabase) {
+                statement = statement.replaceAll("(^|[^\\?])\\?(?!\\?)(?=([^']*'[^']*')*[^']*$)", "$1??");
+            }
 
             String escapedStatement = statement;
             try {

--- a/liquibase-core/src/test/java/liquibase/change/AbstractSQLChangeTest.java
+++ b/liquibase-core/src/test/java/liquibase/change/AbstractSQLChangeTest.java
@@ -3,6 +3,7 @@ package liquibase.change;
 import liquibase.database.Database;
 import liquibase.database.DatabaseConnection;
 import liquibase.database.core.MSSQLDatabase;
+import liquibase.database.core.PostgresDatabase;
 import liquibase.exception.DatabaseException;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.RawSqlStatement;
@@ -250,6 +251,29 @@ public class AbstractSQLChangeTest {
         statements = change.generateStatements(database);
         assertEquals(1, statements.length);
         assertEquals("SOME SQL", ((RawSqlStatement) statements[0]).getSql());
+    }
+
+
+    @Test
+    public void escapingPostgresQuestionmarkOperators() throws DatabaseException {
+        ExampleAbstractSQLChange change = new ExampleAbstractSQLChange("? ??'Is this escaped?' col? another?? ?");
+
+        Database postgresDatabase = mock(PostgresDatabase.class);
+        DatabaseConnection connection = mock(DatabaseConnection.class);
+        when(postgresDatabase.getConnection()).thenReturn(connection);
+        when(connection.nativeSQL("?? ??'Is this escaped?' col?? another?? ??")).thenReturn("ESCAPED");
+
+        SqlStatement[] statements = change.generateStatements(postgresDatabase);
+        assertEquals(1, statements.length);
+        assertEquals("ESCAPED", ((RawSqlStatement) statements[0]).getSql());
+
+        Database database = mock(Database.class);
+        when(database.getConnection()).thenReturn(connection);
+        when(connection.nativeSQL("? ??'Is this escaped?' col? another?? ?")).thenReturn("NOT_ESCAPED");
+
+        statements = change.generateStatements(database);
+        assertEquals(1, statements.length);
+        assertEquals("NOT_ESCAPED", ((RawSqlStatement) statements[0]).getSql());
     }
 
     @DatabaseChange(name = "exampleAbstractSQLChange", description = "Used for the AbstractSQLChangeTest unit test", priority = 1)


### PR DESCRIPTION
…d parameter syntax



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-58) by [Unito](https://www.unito.io/learn-more)
