### PR TITLE
add British pound sign to list of unicode letters

### DIFF
--- a/liquibase-core/src/main/javacc/liquibase/util/grammar/SimpleSqlGrammar.jj
+++ b/liquibase-core/src/main/javacc/liquibase/util/grammar/SimpleSqlGrammar.jj
@@ -80,6 +80,7 @@ TOKEN:
 Built list from http://stackoverflow.com/a/37668315/45756
 */
 | < #UNICODE_LETTERS: ["\u00AA",
+    "\u00A3",
     "\u00B5",
     "\u00BA",
     "\u00C0"-"\u00D6",

--- a/liquibase-core/src/main/javacc/liquibase/util/grammar/SimpleSqlGrammar.jj
+++ b/liquibase-core/src/main/javacc/liquibase/util/grammar/SimpleSqlGrammar.jj
@@ -69,7 +69,7 @@ TOKEN : /* Numeric Constants */
 TOKEN:
 {
     < COMPLEX_IDENTIFIER: (<S_IDENTIFIER> | <S_QUOTED_IDENTIFIER>) ((["\r","\n"," "])* "." (["\r","\n"," "])* (<S_IDENTIFIER> | <S_QUOTED_IDENTIFIER>))+ >
-|	< S_IDENTIFIER: ( <LETTER> | <UNICODE_LETTERS> )+ ( <DIGIT> | <LETTER> | <UNICODE_LETTERS> | <SPECIAL_CHARS> )* >
+|	< S_IDENTIFIER: ( <LETTER> | <UNICODE_LETTERS> | <UNICODE_CURRENCIES> )+ ( <DIGIT> | <LETTER> | <UNICODE_CURRENCIES> | <UNICODE_LETTERS> | <SPECIAL_CHARS> )* >
 | 	< #LETTER: ["a"-"z", "A"-"Z", "_", "$"] >
 |   < #SPECIAL_CHARS: "$" | "_" | "#" | "@" >
 |   < S_CHAR_LITERAL: "'" (~["'"]|"\\'")* "'" ("'" (~["'"]|"\\'")* "'")*>

--- a/liquibase-core/src/main/javacc/liquibase/util/grammar/SimpleSqlGrammar.jj
+++ b/liquibase-core/src/main/javacc/liquibase/util/grammar/SimpleSqlGrammar.jj
@@ -75,12 +75,31 @@ TOKEN:
 |   < S_CHAR_LITERAL: "'" (~["'"]|"\\'")* "'" ("'" (~["'"]|"\\'")* "'")*>
 |   < S_QUOTED_IDENTIFIER: "\"" (~["\n","\r","\""])+ "\"" | ("`" (~["\n","\r","`"])+ "`") | ( "[" ~["0"-"9","]"] (~["\n","\r","]"])* "]" ) >
 |    <EMPTY_QUOTE: "\"" "\"">
+/*
+built from http://unicode.org/charts/PDF/U20A0.pdf
+*/
+| < #UNICODE_CURRENCIES: ["\u0024",
+    "\u00A2"-"\u00A5",
+    "\u058F",
+    "\u060B",
+    "\u09F2"-"\u09F3",
+    "\u0AF1",
+    "\u0BF9",
+    "\u0E3F",
+    "\u17DB",
+    "\u2133",
+    "\u5143",
+    "\u5186",
+    "\u5706",
+    "\u5173",
+    "\uFDFC",
+    "\u20A0"-"\u20BF"
+    ]>
 
 /*
 Built list from http://stackoverflow.com/a/37668315/45756
 */
 | < #UNICODE_LETTERS: ["\u00AA",
-    "\u00A3",
     "\u00B5",
     "\u00BA",
     "\u00C0"-"\u00D6",

--- a/liquibase-core/src/test/groovy/liquibase/util/SqlParserTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/util/SqlParserTest.groovy
@@ -52,6 +52,7 @@ class SqlParserTest extends Specification {
     @Unroll
     def "parse with unicode"() {
         expect:
+        def p_out = SqlParser.parse(input)
         SqlParser.parse(input).toArray(true) == output
 
         where:
@@ -61,6 +62,24 @@ class SqlParserTest extends Specification {
         "x \u2013 abc"                                      | ["x", "\u2013", "abc"] //ndash synmbol
         "x 'quote with unicode punctuation \u2013 in it' y" | ["x", "'quote with unicode punctuation \u2013 in it'", "y"]
     }
+
+    @Unroll
+    def "parse with unicode currencies"() {
+        when:
+            SqlParser.parse(input)
+        then:
+            notThrown liquibase.util.grammar.TokenMgrError
+
+        where:
+        input | output
+        ", (('['||(REPLACE(REPLACE(REPLACE(REPLACE((X.adj_descr_list)::text, '\\\\',''),'\"[','['),']\"',']'),'£££',','))||']')::json)->0 --> need to cast/fix this JSON" | null
+        ", (('['||(REPLACE(REPLACE(REPLACE(REPLACE((X.adj_descr_list)::text, '\\\\',''),'\"[','['),']\"',']'),'£',','))||']')::json)->0 --> need to cast/fix this JSON" | null
+        ", (('['||(REPLACE(REPLACE(REPLACE(REPLACE((X.adj_descr_list)::text, '\\\\',''),'\"[','['),']\"',']'),'¥',','))||']')::json)->0 --> need to cast/fix this JSON" | null
+        ", (('['||(REPLACE(REPLACE(REPLACE(REPLACE((X.adj_descr_list)::text, '\\\\',''),'\"[','['),']\"',']'),'¥¥¥',','))||']')::json)->0 --> need to cast/fix this JSON" | null
+        ", (('['||(REPLACE(REPLACE(REPLACE(REPLACE((X.adj_descr_list)::text, '\\\\',''),'\"[','['),']\"',']'),'₿',','))||']')::json)->0 --> need to cast/fix this JSON" | null
+        ", (('['||(REPLACE(REPLACE(REPLACE(REPLACE((X.adj_descr_list)::text, '\\\\',''),'\"[','['),']\"',']'),'₿₿₿',','))||']')::json)->0 --> need to cast/fix this JSON" | null
+    }
+
 
     @Unroll("#featureName `#input`")
     def "parse with whitespace preserved"() {


### PR DESCRIPTION
so, for reasons not 100% known to me, we use the British pound sign £ as a place holder for a comma in postgresql hstore. This caused our migrations to fail with the following exception:

`Exception in thread "main" liquibase.util.grammar.TokenMgrError: Lexical error at line 130, column 115.  Encountered: "\u00a3" (163), after : ""`

This PR adds that character to the list of unicode letters in the parser

