### PR TITLE
Core 3220 logging fix

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/commandline/CommandLineOutputAppender.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/CommandLineOutputAppender.java
@@ -16,6 +16,7 @@ import liquibase.logging.LogLevel;
 import liquibase.logging.LogType;
 
 import java.util.Iterator;
+import java.util.List;
 
 import org.slf4j.ILoggerFactory;
 import org.slf4j.LoggerFactory;
@@ -57,6 +58,8 @@ public class CommandLineOutputAppender extends ConsoleAppender {
             LogType logType = LogType.valueOf(marker.getName());
             if (CommandLineOutputAppender.this.mode == Mode.STANDARD) {
                 if (logType == LogType.USER_MESSAGE && target.equals(ConsoleTarget.SystemOut)) {
+                    return FilterReply.ACCEPT;
+                } else if (logType == LogType.LOG && target.equals(ConsoleTarget.SystemOut)) {
                     return FilterReply.ACCEPT;
                 } else {
                     return FilterReply.DENY;
@@ -115,6 +118,18 @@ public class CommandLineOutputAppender extends ConsoleAppender {
             root.addAppender(appender);
             appender.start();
         }
+    }
+
+    /**
+     * Update the log level of the root logger if the user has changed it with
+     * a command line switch.
+     * @param rootLogger the instance of the root logger
+     * @param logLevel the level to use.
+     */
+    protected static void updateLogging(final org.slf4j.Logger rootLogger, final LogLevel logLevel) {
+        Logger root = (ch.qos.logback.classic.Logger) rootLogger;
+        // NOTE: Mismatched levels default to debug.
+        root.setLevel(Level.toLevel(logLevel.name()));
     }
 
     private static class ConsoleLogFilter extends AbstractMatcherFilter {

--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -205,6 +205,7 @@ public class Main {
             }
 
             main.applyDefaults();
+            main.updateLogging();
             main.configureClassLoader();
             main.doMigration();
 
@@ -252,6 +253,21 @@ public class Main {
 
         if ("ch.qos.logback.classic.Logger".equals(rootLogger.getClass().getName())) {
             CommandLineOutputAppender.setupLogging(rootLogger, defaultLogLevel);
+        } else {
+            System.err.println(
+                    "Liquibase command line logging cannot be configured; a supported org.slf4j.Logger implementation is not on the classpath.");
+        }
+    }
+
+    protected void updateLogging() {
+        org.slf4j.Logger rootLogger = LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
+        if ("ch.qos.logback.classic.Logger".equals(rootLogger.getClass().getName())) {
+            try {
+                CommandLineOutputAppender.updateLogging(rootLogger, LogLevel.valueOf(logLevel.toUpperCase()));
+            } catch (IllegalArgumentException e) {
+                System.err.println(
+                        "Liquibase command line logging cannot be updated; an unsupported logLevel was given.");
+            }
         } else {
             System.err.println(
                     "Liquibase command line logging cannot be configured; a supported org.slf4j.Logger implementation is not on the classpath.");


### PR DESCRIPTION
This fixes (at least partially) a long standing issue with logging.  It does 2 things.

1. The Main class initializes logging as soon as Liquibase starts, but it doesn't ever change the logging, which makes the `--logLevel` argument useless.  This pull request updates the log level just after processing command line arguments and applying defaults.

2. By default, almost nothing is output to stdout during a run.  I added LogType.LOG to the list of things that go to stdout, so the user at least sees the name of each change set as it runs.

This pull request (along with #917) resolves issues that break the Gradle plugin and Groovy DSL, so perhaps a 3.8.1 release is in order?

┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-52) by [Unito](https://www.unito.io/learn-more)
