### PR TITLE
Clean up for usage of StringUtils.join method

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -61,7 +61,6 @@ import liquibase.util.ISODateFormat;
 import liquibase.util.NowAndTodayUtil;
 import liquibase.util.StreamUtil;
 import liquibase.util.StringUtil;
-import liquibase.util.NowAndTodayUtil;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -79,9 +78,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
-
-import static liquibase.util.StringUtil.join;
-
 
 /**
  * AbstractJdbcDatabase is extended by all supported databases as a facade to the underlying database.
@@ -611,7 +607,7 @@ public abstract class AbstractJdbcDatabase implements Database {
 
     @Override
     public String getConcatSql(final String... values) {
-        return join(values, " || ");
+        return String.join(" || ", values);
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingForeignKeyChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingForeignKeyChangeGenerator.java
@@ -11,6 +11,8 @@ import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.*;
 import liquibase.util.StringUtil;
 
+import static java.util.stream.Collectors.joining;
+
 public class MissingForeignKeyChangeGenerator extends AbstractChangeGenerator implements MissingObjectChangeGenerator {
     @Override
     public int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
@@ -76,12 +78,7 @@ public class MissingForeignKeyChangeGenerator extends AbstractChangeGenerator im
             }
         }
 
-        change.setReferencedColumnNames(StringUtil.join(fk.getPrimaryKeyColumns(), ",", new StringUtil.StringUtilFormatter<Column>() {
-            @Override
-            public String toString(Column obj) {
-                return obj.getName();
-            }
-        }));
+        change.setReferencedColumnNames(fk.getPrimaryKeyColumns().stream().map(Column::getName).collect(joining(",")));
 
         change.setBaseTableName(fk.getForeignKeyTable().getName());
         if (control.getIncludeCatalog()) {
@@ -90,12 +87,7 @@ public class MissingForeignKeyChangeGenerator extends AbstractChangeGenerator im
         if (control.getIncludeSchema()) {
             change.setBaseTableSchemaName(fk.getForeignKeyTable().getSchema().getName());
         }
-        change.setBaseColumnNames(StringUtil.join(fk.getForeignKeyColumns(), ",", new StringUtil.StringUtilFormatter<Column>() {
-            @Override
-            public String toString(Column obj) {
-                return obj.getName();
-            }
-        }));
+        change.setBaseColumnNames(fk.getForeignKeyColumns().stream().map(Column::getName).collect(joining(",")));
 
         change.setDeferrable(fk.isDeferrable());
         change.setInitiallyDeferred(fk.isInitiallyDeferred());

--- a/liquibase-core/src/main/java/liquibase/resource/FileSystemResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/FileSystemResourceAccessor.java
@@ -2,7 +2,6 @@ package liquibase.resource;
 
 import liquibase.Scope;
 import liquibase.util.CollectionUtil;
-import liquibase.util.StringUtil;
 
 import java.io.*;
 import java.net.URI;
@@ -12,6 +11,7 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -270,7 +270,8 @@ public class FileSystemResourceAccessor extends AbstractResourceAccessor {
 
     @Override
     public String toString() {
-        return getClass().getName() + " (" + StringUtil.join(getRootPaths(), ", ", new StringUtil.ToStringFormatter()) + ")";
+        return getClass().getName() + getRootPaths().stream().map(Path::toString)
+                .collect(Collectors.joining(", ", " (", ")"));
     }
 
     private static class CloseChildWillCloseParentStream extends FilterInputStream {

--- a/liquibase-core/src/main/java/liquibase/serializer/core/string/StringSnapshotSerializerReadable.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/string/StringSnapshotSerializerReadable.java
@@ -17,6 +17,7 @@ import liquibase.util.StringUtil;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class StringSnapshotSerializerReadable implements SnapshotSerializer {
 
@@ -43,13 +44,8 @@ public class StringSnapshotSerializerReadable implements SnapshotSerializer {
             SnapshotControl snapshotControl = snapshot.getSnapshotControl();
             List<Class> includedTypes = sort(snapshotControl.getTypesToInclude());
 
-            buffer.append("Included types:\n" ).append(StringUtil.indent(StringUtil.join(includedTypes, "\n", new StringUtil.StringUtilFormatter<Class>() {
-                @Override
-                public String toString(Class obj) {
-                    return obj.getName();
-                }
-            }))).append("\n");
-
+            buffer.append(includedTypes.stream().map(clazz -> StringUtil.indent(clazz.getName(), INDENT_LENGTH))
+                    .collect(Collectors.joining("\n", "Included types:\n", "\n")));
 
             List<Schema> schemas = sort(snapshot.get(Schema.class), new Comparator<Schema>() {
                 @Override


### PR DESCRIPTION
Currently Java 8 has better methods for making string from collections
rather then not updated copy-pasted methods from commons-lang.

