### PR TITLE
Fix missing catalog on add column rollback

### DIFF
--- a/liquibase-core/src/test/groovy/liquibase/util/FilenameUtilTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/util/FilenameUtilTest.groovy
@@ -55,7 +55,9 @@ class FilenameUtilTest extends Specification {
         null           | "liquibase\\delta-changelogs/" | "liquibase/delta-changelogs"
         null           | "liquibase/delta-changelogs"   | "liquibase/delta-changelogs"
         "base/path"    | "liquibase/changelogs"         | "base/path/liquibase/changelogs"
+        "base/path"    | "/liquibase/changelogs"        | "base/path/liquibase/changelogs"
         "\\base\\path" | "liquibase/changelogs"         | "/base/path/liquibase/changelogs"
+        "\\base\\path" | "\\liquibase\\changelogs"         | "/base/path/liquibase/changelogs"
     }
 
     @Unroll


### PR DESCRIPTION
When rollback script for "add column" change is generated, catalog name is missing from generated SQL. As a result of that the rollback may not work if the affected table is not in the default catalog.

