### PR TITLE
Updated to properly handle symbolic links and paths with spaces.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/resource/AbstractResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/AbstractResourceAccessor.java
@@ -87,17 +87,28 @@ public abstract class AbstractResourceAccessor implements ResourceAccessor {
         for (File file : files) {
             if (file.isDirectory()) {
                 if (includeDirectories) {
-                    returnSet.add(convertToPath(file.getAbsolutePath()));
+                    returnSet.add(convertToPath(extractPath(file)));
                 }
                 if (recursive) {
                     getContents(file, recursive, includeFiles, includeDirectories, basePath, returnSet);
                 }
             } else {
                 if (includeFiles) {
-                    returnSet.add(convertToPath(file.getAbsolutePath()));
+                    returnSet.add(convertToPath(extractPath(file)));
                 }
             }
         }
+    }
+
+    private String extractPath(File file) {
+        String absolutePath;
+        try {
+            // this will properly handle symbolic links
+            absolutePath = file.getCanonicalPath();
+        } catch (IOException e) {
+            absolutePath = file.getAbsolutePath();
+        }
+        return absolutePath;
     }
 
     protected String convertToPath(String string) {
@@ -105,6 +116,7 @@ public abstract class AbstractResourceAccessor implements ResourceAccessor {
 
         String stringAsUrl = string;
         if (!stringAsUrl.matches("[a-zA-Z0-9]{2,}:.*")) {
+            stringAsUrl = stringAsUrl.replace(" ", "%20");
             if (stringAsUrl.startsWith("/")) {
                 stringAsUrl = "file:"+stringAsUrl;
             } else {

--- a/liquibase-core/src/test/groovy/liquibase/resource/AbstractResourceAccessorTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/resource/AbstractResourceAccessorTest.groovy
@@ -54,8 +54,11 @@ class AbstractResourceAccessorTest extends Specification {
     @Unroll("#featureName: #path -> #expected")
     def "convertToPath with linux rootUrls"() {
         when:
-        def accessor = createResourceAccessor(["file:/path/to/target/test-classes/",
-                                               "file:/path/to/target/classes/"], false);
+        def accessor = createResourceAccessor([
+                "file:/path/to/target/test-classes/",
+                "file:/path/to/target/classes/",
+                "file:/path/to%20spaces/"
+        ], false);
 
         then:
         accessor.convertToPath(path) == expected
@@ -68,6 +71,7 @@ class AbstractResourceAccessorTest extends Specification {
         "file:/path/to/target/classes/other/file.ext"  | "other/file.ext"
         "file:/path/to/target/outside/short.file"      | "file:/path/to/target/outside/short.file"
         "/path/to/target/classes/other/file.ext"       | "other/file.ext"
+        "/path/to spaces/another.short.file"           | "another.short.file"
         "\\path\\to\\target\\classes\\other\\file.ext" | "other/file.ext"
     }
 


### PR DESCRIPTION
Because spaces are converted to '%20' in uri's, paths that should have matched as relative paths were failing, and instead being loaded as absolute paths.

This change also makes the default path pull from a canonical path, which makes sure that things are resolved correctly when running from a directory with symlinks, and that "thefolder/../thefile" resolves to the same thing as "thefile".



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-48) by [Unito](https://www.unito.io/learn-more)
