### PR TITLE
changing HashMap to LinkedHashMap for deterministic iterations

### DIFF
--- a/liquibase-core/src/test/java/liquibase/sqlgenerator/core/AddColumnGeneratorTest.java
+++ b/liquibase-core/src/test/java/liquibase/sqlgenerator/core/AddColumnGeneratorTest.java
@@ -11,6 +11,10 @@ import liquibase.statement.PrimaryKeyConstraint;
 import liquibase.statement.core.AddColumnStatement;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static org.junit.Assert.*;
 
 public class AddColumnGeneratorTest extends AbstractSqlGeneratorTest<AddColumnStatement> {
@@ -72,7 +76,11 @@ public class AddColumnGeneratorTest extends AbstractSqlGeneratorTest<AddColumnSt
 
         assertEquals(1, sql.length);
         assertEquals("ALTER TABLE " + TABLE_NAME + " ADD column1 INT NOT NULL, ADD column2 INT NOT NULL", sql[0].toSql());
-        assertEquals("[DEFAULT, table_name, table_name.column1, table_name.column2]", String.valueOf(sql[0].getAffectedDatabaseObjects()));
+
+        List<String> actualNames = sql[0].getAffectedDatabaseObjects().stream().map(o -> o.toString()).collect(Collectors.toList());
+        List<String> expectedNames = Arrays.asList(new String[]{"table_name.column1", "table_name.column2", "table_name", "DEFAULT"});
+        assertTrue(actualNames.containsAll(expectedNames));
+        assertTrue(expectedNames.containsAll(actualNames));
     }
 
     @Test

--- a/liquibase-core/src/test/java/liquibase/sqlgenerator/core/DropColumnGeneratorTest.java
+++ b/liquibase-core/src/test/java/liquibase/sqlgenerator/core/DropColumnGeneratorTest.java
@@ -9,6 +9,10 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertTrue;
 
 public class DropColumnGeneratorTest extends AbstractSqlGeneratorTest<DropColumnStatement> {
 
@@ -32,7 +36,11 @@ public class DropColumnGeneratorTest extends AbstractSqlGeneratorTest<DropColumn
         Sql[] sql = generatorUnderTest.generateSql(drop, new MySQLDatabase(), new MockSqlGeneratorChain());
         Assert.assertEquals(1, sql.length);
         Assert.assertEquals("ALTER TABLE TEST_TABLE DROP col1, DROP col2", sql[0].toSql());
-        Assert.assertEquals("[DEFAULT, TEST_TABLE, TEST_TABLE.col1, TEST_TABLE.col2]", String.valueOf(sql[0].getAffectedDatabaseObjects()));
+
+        List<String> actualNames = sql[0].getAffectedDatabaseObjects().stream().map(o -> o.toString()).collect(Collectors.toList());
+        List<String> expectedNames = Arrays.asList(new String[]{"TEST_TABLE.col1", "TEST_TABLE.col2", "TEST_TABLE", "DEFAULT"});
+        assertTrue(actualNames.containsAll(expectedNames));
+        assertTrue(expectedNames.containsAll(actualNames));
     }
 
 ////    @Test


### PR DESCRIPTION
Test `liquibase.sqlgenerator.core.DropColumnGeneratorTest#testDropMultipleColumnsMySQL` has this following test assertion 
```
Assert.assertEquals("[TEST_TABLE.col1, TEST_TABLE.col2, TEST_TABLE, DEFAULT]", String.valueOf(sql[0].getAffectedDatabaseObjects()))
``` 
that asserts the `toString()` value of `affectedDatabaseObjects`. 

`affectedDatabaseObjects` is a HashSet and the `toString()` function depends on the iteration order of the hash set. However, `HashSet` does not guarantee any specific order of entries. Therefore, the assertion will fail if the order is different.

This PR proposes to use a LinkedHashSet for a deterministic order (insertion order of elements) and modifies the corresponding test assertions. 

Please let me know if you want to discuss the changes more.