### PR TITLE
CORE-931: addColumn should support not-null constraint with an initia…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
         if: ${{ matrix.java == 8}}
         uses: actions/cache@v2
         with:
-          key: built-code-${{ github.sha }}
+          key: built-code-${{ needs.setup.outputs.thisSha }}
           path: ./**/target
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
@@ -140,7 +140,7 @@ jobs:
       - name: Restore Built Code Cache
         uses: actions/cache@v2
         with:
-          key: built-code-${{ github.sha }}
+          key: built-code-${{ needs.setup.outputs.thisSha }}
           path: ./**/target
 
       - name: Login to Artifactory
@@ -173,7 +173,7 @@ jobs:
       - name: Built Code Cache
         uses: actions/cache@v2
         with:
-          key: built-code-${{ github.sha }}
+          key: built-code-${{ needs.setup.outputs.thisSha }}
           path: ./**/target
       - name: Install4j Cache
         uses: actions/cache@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
         if: ${{ matrix.java == 8}}
         uses: actions/cache@v2
         with:
-          key: built-code-${{ needs.setup.outputs.thisSha }}
+          key: built-code-${{ github.run_number }}-${{ github.run_attempt }}
           path: ./**/target
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v2
@@ -140,7 +140,7 @@ jobs:
       - name: Restore Built Code Cache
         uses: actions/cache@v2
         with:
-          key: built-code-${{ needs.setup.outputs.thisSha }}
+          key: built-code-${{ github.run_number }}-${{ github.run_attempt }}
           path: ./**/target
 
       - name: Login to Artifactory
@@ -173,7 +173,7 @@ jobs:
       - name: Built Code Cache
         uses: actions/cache@v2
         with:
-          key: built-code-${{ needs.setup.outputs.thisSha }}
+          key: built-code-${{ github.run_number }}-${{ github.run_attempt }}
           path: ./**/target
       - name: Install4j Cache
         uses: actions/cache@v2

--- a/liquibase-core/src/main/java/liquibase/GlobalConfiguration.java
+++ b/liquibase-core/src/main/java/liquibase/GlobalConfiguration.java
@@ -166,7 +166,7 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
 
         STRICT = builder.define("strict", Boolean.class)
                 .setDescription("Be stricter on allowed Liquibase configuration and setup?")
-                .setDefaultValue(true)
+                .setDefaultValue(false)
                 .build();
 
         DDL_LOCK_TIMEOUT = builder.define("ddlLockTimeout", Integer.class)

--- a/liquibase-core/src/main/java/liquibase/change/core/AddColumnChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/AddColumnChange.java
@@ -15,10 +15,7 @@ import liquibase.structure.core.PrimaryKey;
 import liquibase.structure.core.Table;
 import liquibase.util.StringUtil;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Adds a column to an existing table.
@@ -88,6 +85,7 @@ public class AddColumnChange extends AbstractChange implements ChangeWithColumns
         List<SqlStatement> sql = new ArrayList<>();
         List<AddColumnStatement> addColumnStatements = new ArrayList<>();
         List<UpdateStatement> addColumnUpdateStatements = new ArrayList<>();
+        List<SqlStatement> addNotNullConstraintStatements = new ArrayList<>();
 
         if (getColumns().isEmpty()) {
             return new SqlStatement[] {
@@ -100,12 +98,13 @@ public class AddColumnChange extends AbstractChange implements ChangeWithColumns
             ConstraintsConfig constraintsConfig =column.getConstraints();
             if (constraintsConfig != null) {
                 if ((constraintsConfig.isNullable() != null) && !constraintsConfig.isNullable()) {
-                    NotNullConstraint notNullConstraint = new NotNullConstraint();
-                    if (constraintsConfig.getValidateNullable()!=null && !constraintsConfig.getValidateNullable()) {
-                        notNullConstraint.setValidateNullable(false);
+                    if (column.getValueObject() != null) {
+                        List<SqlStatement> sqlStatements = generateAddNotNullConstraintStatements(column, database);
+                        addNotNullConstraintStatements.addAll(sqlStatements);
+                    } else {
+                        NotNullConstraint notNullConstraint = createNotNullConstraint(constraintsConfig);
+                        constraints.add(notNullConstraint);
                     }
-                    notNullConstraint.setConstraintName(constraintsConfig.getNotNullConstraintName());
-                    constraints.add(notNullConstraint);
                 }
                 if (constraintsConfig.isUnique() != null && constraintsConfig.isUnique()) {
                     UniqueConstraint uniqueConstraint = new UniqueConstraint(constraintsConfig.getUniqueConstraintName());
@@ -192,6 +191,8 @@ public class AddColumnChange extends AbstractChange implements ChangeWithColumns
           sql.add(0, new AddColumnStatement(addColumnStatements));
       }
 
+      sql.addAll(addNotNullConstraintStatements);
+
       for (ColumnConfig column : getColumns()) {
           String columnRemarks = StringUtil.trimToNull(column.getRemarks());
           if (columnRemarks != null) {
@@ -272,4 +273,26 @@ public class AddColumnChange extends AbstractChange implements ChangeWithColumns
         return STANDARD_CHANGELOG_NAMESPACE;
     }
 
+    private NotNullConstraint createNotNullConstraint(ConstraintsConfig constraintsConfig) {
+        NotNullConstraint notNullConstraint = new NotNullConstraint();
+        if (constraintsConfig.getValidateNullable() != null && !constraintsConfig.getValidateNullable()) {
+            notNullConstraint.setValidateNullable(false);
+        }
+        notNullConstraint.setConstraintName(constraintsConfig.getNotNullConstraintName());
+        return notNullConstraint;
+    }
+
+    private List<SqlStatement> generateAddNotNullConstraintStatements(AddColumnConfig column, Database database) {
+        AddNotNullConstraintChange addNotNullConstraintChange = createAddNotNullConstraintChange(column);
+        return Arrays.asList(addNotNullConstraintChange.generateStatements(database));
+    }
+
+    private AddNotNullConstraintChange createAddNotNullConstraintChange(AddColumnConfig column) {
+        AddNotNullConstraintChange addNotNullConstraintChange = new AddNotNullConstraintChange();
+        addNotNullConstraintChange.setCatalogName(getCatalogName());
+        addNotNullConstraintChange.setTableName(getTableName());
+        addNotNullConstraintChange.setColumnName(column.getName());
+        addNotNullConstraintChange.setColumnDataType(column.getType());
+        return addNotNullConstraintChange;
+    }
 }

--- a/liquibase-core/src/main/java/liquibase/configuration/core/DefaultsFileValueProvider.java
+++ b/liquibase-core/src/main/java/liquibase/configuration/core/DefaultsFileValueProvider.java
@@ -1,5 +1,6 @@
 package liquibase.configuration.core;
 
+import liquibase.GlobalConfiguration;
 import liquibase.Scope;
 import liquibase.command.CommandDefinition;
 import liquibase.command.CommandFactory;
@@ -46,6 +47,7 @@ public class DefaultsFileValueProvider extends AbstractMapConfigurationValueProv
 
     @Override
     public void validate(CommandScope commandScope) throws IllegalArgumentException {
+        boolean strict = GlobalConfiguration.STRICT.getCurrentValue();
         SortedSet<String> invalidKeys = new TreeSet<>();
         for (Map.Entry<Object, Object> entry : this.properties.entrySet()) {
             String key = (String) entry.getKey();
@@ -57,7 +59,7 @@ public class DefaultsFileValueProvider extends AbstractMapConfigurationValueProv
             }
 
             final String genericCommandPrefix = "liquibase.command.";
-            final String targettedCommandPrefix = "liquibase.command." + StringUtil.join(commandScope.getCommand().getName(), ".") + ".";
+            final String targetedCommandPrefix = "liquibase.command." + StringUtil.join(commandScope.getCommand().getName(), ".") + ".";
             if (!key.contains(".")) {
                 if (commandScope.getCommand().getArgument(key) == null) {
                         if(!key.startsWith("liquibase")) {
@@ -67,8 +69,8 @@ public class DefaultsFileValueProvider extends AbstractMapConfigurationValueProv
                         invalidKeys.add(" - '" + originalKey + "'");
                     }
                 }
-            } else if (key.startsWith(targettedCommandPrefix)) {
-                String keyAsArg = key.replace(targettedCommandPrefix, "");
+            } else if (key.startsWith(targetedCommandPrefix)) {
+                String keyAsArg = key.replace(targetedCommandPrefix, "");
                 if (commandScope.getCommand().getArgument(keyAsArg) == null) {
                     invalidKeys.add(" - '" + originalKey + "'");
                 }
@@ -93,11 +95,12 @@ public class DefaultsFileValueProvider extends AbstractMapConfigurationValueProv
         }
 
         if (invalidKeys.size() > 0) {
-            if (this.properties.getProperty("strict", "false").equalsIgnoreCase("true")) {
-                throw new IllegalArgumentException("Strict check failed due to undefined key(s) for '" + StringUtil.join(commandScope.getCommand().getName(), " ")
-                        + "' command in " + StringUtil.lowerCaseFirst(sourceDescription) + "':\n"
-                        + StringUtil.join(invalidKeys, "\n")
-                        + "\nTo define keys that could apply to any command, prefix it with 'liquibase.command.'\nTo disable strict checking, remove 'strict' from the file.");
+            if (strict) {
+                String message = "Strict check failed due to undefined key(s) for '" + StringUtil.join(commandScope.getCommand().getName(), " ")
+                    + "' command in " + StringUtil.lowerCaseFirst(sourceDescription) + "':\n"
+                    + StringUtil.join(invalidKeys, "\n")
+                    + "\nTo define keys that could apply to any command, prefix it with 'liquibase.command.'\nTo disable strict checking, remove 'strict' from the file.";
+                throw new IllegalArgumentException(message);
             } else {
                 Scope.getCurrentScope().getLog(getClass()).warning("Potentially ignored key(s) in " + StringUtil.lowerCaseFirst(sourceDescription) + "\n" + StringUtil.join(invalidKeys, "\n"));
             }

--- a/liquibase-core/src/main/java/liquibase/lockservice/StandardLockService.java
+++ b/liquibase-core/src/main/java/liquibase/lockservice/StandardLockService.java
@@ -8,6 +8,7 @@ import liquibase.database.ObjectQuotingStrategy;
 import liquibase.database.core.DB2Database;
 import liquibase.database.core.DerbyDatabase;
 import liquibase.database.core.MSSQLDatabase;
+import liquibase.database.core.PostgresDatabase;
 import liquibase.diff.output.DiffOutputControl;
 import liquibase.diff.output.changelog.ChangeGeneratorFactory;
 import liquibase.exception.DatabaseException;
@@ -25,6 +26,7 @@ import liquibase.statement.core.*;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.Table;
 
+import java.security.SecureRandom;
 import java.sql.SQLException;
 import java.text.DateFormat;
 import java.time.LocalDateTime;
@@ -46,6 +48,7 @@ public class StandardLockService implements LockService {
     private Boolean hasDatabaseChangeLogLockTable;
     private boolean isDatabaseChangeLogLockTableInitialized;
     private ObjectQuotingStrategy quotingStrategy;
+    private final SecureRandom random = new SecureRandom();
 
 
     public StandardLockService() {
@@ -95,87 +98,88 @@ public class StandardLockService implements LockService {
         boolean createdTable = false;
         Executor executor = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc",  database);
 
-        if (!hasDatabaseChangeLogLockTable()) {
+        int maxIterations = 10;
+        for (int i = 0; i < maxIterations; i++) {
             try {
-                executor.comment("Create Database Lock Table");
-                executor.execute(new CreateDatabaseChangeLogLockTableStatement());
-                database.commit();
-                Scope.getCurrentScope().getLog(getClass()).fine(
-                        "Created database lock table with name: " +
-                                database.escapeTableName(
+                if (!hasDatabaseChangeLogLockTable(true)) {
+                    executor.comment("Create Database Lock Table");
+                    executor.execute(new CreateDatabaseChangeLogLockTableStatement());
+                    database.commit();
+                    Scope.getCurrentScope().getLog(getClass()).fine(
+                            "Created database lock table with name: " +
+                                    database.escapeTableName(
+                                            database.getLiquibaseCatalogName(),
+                                            database.getLiquibaseSchemaName(),
+                                            database.getDatabaseChangeLogLockTableName()
+                                    )
+                    );
+                    this.hasDatabaseChangeLogLockTable = true;
+                    createdTable = true;
+                    hasDatabaseChangeLogLockTable = true;
+                }
+
+                if (!isDatabaseChangeLogLockTableInitialized(createdTable, true)) {
+                    executor.comment("Initialize Database Lock Table");
+                    executor.execute(new InitializeDatabaseChangeLogLockTableStatement());
+                    database.commit();
+                }
+
+                if (executor.updatesDatabase() && (database instanceof DerbyDatabase) && ((DerbyDatabase) database)
+                        .supportsBooleanDataType() || database.getClass().isAssignableFrom(DB2Database.class) && ((DB2Database) database)
+                        .supportsBooleanDataType()) {
+                    //check if the changelog table is of an old smallint vs. boolean format
+                    String lockTable = database.escapeTableName(
+                            database.getLiquibaseCatalogName(),
+                            database.getLiquibaseSchemaName(),
+                            database.getDatabaseChangeLogLockTableName()
+                    );
+                    Object obj = executor.queryForObject(
+                            new RawSqlStatement(
+                                    "SELECT MIN(locked) AS test FROM " + lockTable + " FETCH FIRST ROW ONLY"
+                            ), Object.class
+                    );
+                    if (!(obj instanceof Boolean)) { //wrong type, need to recreate table
+                        executor.execute(
+                                new DropTableStatement(
                                         database.getLiquibaseCatalogName(),
                                         database.getLiquibaseSchemaName(),
-                                        database.getDatabaseChangeLogLockTableName()
+                                        database.getDatabaseChangeLogLockTableName(),
+                                        false
                                 )
-                );
-            } catch (DatabaseException e) {
-                if (isLockTableExistsException(e)) {
-                    //hit a race condition where the table got created by another node.
-                    Scope.getCurrentScope().getLog(getClass()).fine("Database lock table already appears to exist " +
-                            "due to exception: " + e.getMessage() + ". Continuing on");
-                }  else {
+                        );
+                        executor.execute(new CreateDatabaseChangeLogLockTableStatement());
+                        executor.execute(new InitializeDatabaseChangeLogLockTableStatement());
+                    }
+                }
+            } catch (Exception e) {
+                if (i == maxIterations - 1) {
                     throw e;
+                } else {
+                    Scope.getCurrentScope().getLog(getClass()).fine("Failed to create or initialize the lock table, trying again, iteration " + (i + 1) + " of " + maxIterations, e);
+                    // If another node already created the table, then we need to rollback this current transaction,
+                    // otherwise servers like Postgres will not allow continued use of the same connection, failing with
+                    // a message like "current transaction is aborted, commands ignored until end of transaction block"
+                    database.rollback();
+                    try {
+                        Thread.sleep(random.nextInt(1000));
+                    } catch (InterruptedException ex) {
+                        Scope.getCurrentScope().getLog(getClass()).warning("Lock table retry loop thread sleep interrupted", ex);
+                    }
                 }
             }
-            this.hasDatabaseChangeLogLockTable = true;
-            createdTable = true;
-            hasDatabaseChangeLogLockTable = true;
         }
+    }
 
-        if (!isDatabaseChangeLogLockTableInitialized(createdTable)) {
-            executor.comment("Initialize Database Lock Table");
-            executor.execute(new InitializeDatabaseChangeLogLockTableStatement());
-            database.commit();
-        }
-
-        if (executor.updatesDatabase() && (database instanceof DerbyDatabase) && ((DerbyDatabase) database)
-                .supportsBooleanDataType() || database.getClass().isAssignableFrom(DB2Database.class) && ((DB2Database) database)
-    			.supportsBooleanDataType()) {
-            //check if the changelog table is of an old smallint vs. boolean format
-            String lockTable = database.escapeTableName(
-                    database.getLiquibaseCatalogName(),
-                    database.getLiquibaseSchemaName(),
-                    database.getDatabaseChangeLogLockTableName()
-            );
-            Object obj = executor.queryForObject(
-                    new RawSqlStatement(
-                            "SELECT MIN(locked) AS test FROM " + lockTable + " FETCH FIRST ROW ONLY"
-                    ), Object.class
-            );
-            if (!(obj instanceof Boolean)) { //wrong type, need to recreate table
-                executor.execute(
-                        new DropTableStatement(
-                                database.getLiquibaseCatalogName(),
-                                database.getLiquibaseSchemaName(),
-                                database.getDatabaseChangeLogLockTableName(),
-                                false
-                        )
-                );
-                executor.execute(new CreateDatabaseChangeLogLockTableStatement());
-                executor.execute(new InitializeDatabaseChangeLogLockTableStatement());
-            }
-        }
-
+    public boolean isDatabaseChangeLogLockTableInitialized(final boolean tableJustCreated) {
+        return isDatabaseChangeLogLockTableInitialized(tableJustCreated, false);
     }
 
     /**
-     * @return true if the given exception is because the lock table already exists. Used for better logging and handling of race conditions.
+     * Determine whether the databasechangeloglock table has been initialized.
+     * @param forceRecheck if true, do not use any cached information, and recheck the actual database
      */
-    protected boolean isLockTableExistsException(final DatabaseException e) {
-        final Throwable cause = e.getCause();
-        if (cause instanceof SQLException) {
-            // now database specific error code evaluation can follow, currently for sqlserver, only
-            if (database instanceof MSSQLDatabase) {
-                // see https://docs.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors?view=sql-server-ver15
-                return ((SQLException) cause).getErrorCode() == 2714;
-            }
-        }
-        // fallback to default
-        return e.getMessage() != null && e.getMessage().toLowerCase().contains("exists");
-    }
-
-    public boolean isDatabaseChangeLogLockTableInitialized(final boolean tableJustCreated) throws DatabaseException {
-        if (!isDatabaseChangeLogLockTableInitialized) {
+    private boolean isDatabaseChangeLogLockTableInitialized(final boolean tableJustCreated, final boolean forceRecheck) {
+        if (!isDatabaseChangeLogLockTableInitialized || forceRecheck) {
             Executor executor = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database);
 
             try {
@@ -205,8 +209,12 @@ public class StandardLockService implements LockService {
         return hasChangeLogLock;
     }
 
-    public boolean hasDatabaseChangeLogLockTable() throws DatabaseException {
-        if (hasDatabaseChangeLogLockTable == null) {
+    /**
+     * Check whether the databasechangeloglock table exists in the database.
+     * @param forceRecheck if true, do not use any cached information and check the actual database
+     */
+    private boolean hasDatabaseChangeLogLockTable(boolean forceRecheck) {
+        if (forceRecheck || hasDatabaseChangeLogLockTable == null) {
             try {
                 hasDatabaseChangeLogLockTable = SnapshotGeneratorFactory.getInstance()
                         .hasDatabaseChangeLogLockTable(database);
@@ -217,6 +225,9 @@ public class StandardLockService implements LockService {
         return hasDatabaseChangeLogLockTable;
     }
 
+    public boolean hasDatabaseChangeLogLockTable() throws DatabaseException {
+        return hasDatabaseChangeLogLockTable(false);
+    }
 
     @Override
     public void waitForLock() throws LockException {

--- a/liquibase-core/src/test/groovy/liquibase/configuration/core/DefaultsFileValueProviderTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/configuration/core/DefaultsFileValueProviderTest.groovy
@@ -1,6 +1,8 @@
 package liquibase.configuration.core
 
+import liquibase.Scope
 import liquibase.command.CommandScope
+import liquibase.configuration.LiquibaseConfiguration
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -56,11 +58,19 @@ long.multiWord: Long MultiWord
     def "validate valid values"() {
         when:
         def provider = new DefaultsFileValueProvider([
-                (key) : "test value",
-                strict: String.valueOf(strict)
+                (key) : "test value"
         ] as Properties)
 
-        provider.validate(new CommandScope("update"))
+        //
+        // Set the strict setting in the Scope for this test
+        //
+        LiquibaseConfiguration configuration = Scope.getCurrentScope().getSingleton(LiquibaseConfiguration.class)
+        configuration.registerProvider(new ScopeValueProvider())
+
+        Map<String, String> scopeValues = ["liquibase.strict":strict] as Map<String, String>
+        Scope.getCurrentScope().child(scopeValues, (Scope.ScopedRunner) { ->
+            provider.validate(new CommandScope("update"))
+        })
 
         then:
         noExceptionThrown()
@@ -88,11 +98,19 @@ long.multiWord: Long MultiWord
     def "validate invalid values"() {
         when:
         def provider = new DefaultsFileValueProvider([
-                (key) : "test value",
-                strict: "true",
+                (key) : "test value"
         ] as Properties)
 
-        provider.validate(new CommandScope("update"))
+        //
+        // Set the strict setting in the Scope for this test
+        //
+        LiquibaseConfiguration configuration = Scope.getCurrentScope().getSingleton(LiquibaseConfiguration.class)
+        configuration.registerProvider(new ScopeValueProvider())
+
+        Map<String, String> scopeValues = ["liquibase.strict":"true"]
+        Scope.getCurrentScope().child(scopeValues, (Scope.ScopedRunner) { ->
+            provider.validate(new CommandScope("update"))
+        })
 
         then:
         def e = thrown(IllegalArgumentException)

--- a/liquibase-core/src/test/java/liquibase/sqlgenerator/core/AddColumnGeneratorTest.java
+++ b/liquibase-core/src/test/java/liquibase/sqlgenerator/core/AddColumnGeneratorTest.java
@@ -1,13 +1,18 @@
 package liquibase.sqlgenerator.core;
 
+import liquibase.change.AddColumnConfig;
+import liquibase.change.ConstraintsConfig;
+import liquibase.change.core.AddColumnChange;
 import liquibase.database.core.*;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.AbstractSqlGeneratorTest;
 import liquibase.sqlgenerator.MockSqlGeneratorChain;
 import liquibase.sqlgenerator.SqlGenerator;
+import liquibase.sqlgenerator.SqlGeneratorFactory;
 import liquibase.statement.AutoIncrementConstraint;
 import liquibase.statement.NotNullConstraint;
 import liquibase.statement.PrimaryKeyConstraint;
+import liquibase.statement.SqlStatement;
 import liquibase.statement.core.AddColumnStatement;
 import org.junit.Test;
 
@@ -92,5 +97,36 @@ public class AddColumnGeneratorTest extends AbstractSqlGeneratorTest<AddColumnSt
 
         assertEquals(1, sql.length);
         assertEquals("ALTER TABLE " + TABLE_NAME + " ADD `PERIOD` INT NOT NULL", sql[0].toSql());
+    }
+
+    @Test
+    public void testAddColumnWithNotNullConstraintAndValue() {
+        AddColumnChange change = new AddColumnChange();
+        change.setTableName(TABLE_NAME);
+
+        AddColumnConfig column = new AddColumnConfig();
+        column.setName("column1");
+        column.setType("int8");
+        column.setValueNumeric("0");
+        column.setConstraints(new ConstraintsConfig().setNullable(false));
+        change.addColumn(column);
+
+        AddColumnConfig column2 = new AddColumnConfig();
+        column2.setName("column2");
+        column2.setType("boolean");
+        column2.setValueBoolean("true");
+        column2.setConstraints(new ConstraintsConfig().setNullable(false));
+        change.addColumn(column2);
+
+        SqlStatement[] statements = change.generateStatements(new MySQLDatabase());
+        SqlGeneratorFactory instance = SqlGeneratorFactory.getInstance();
+        Sql[] sql = instance.generateSql(statements, new MySQLDatabase());
+
+        assertEquals(5, sql.length);
+        assertEquals("ALTER TABLE table_name ADD column1 BIGINT NULL, ADD column2 BIT(1) NULL", sql[0].toSql());
+        assertEquals("UPDATE table_name SET column1 = 0", sql[1].toSql());
+        assertEquals("UPDATE table_name SET column2 = 1", sql[2].toSql());
+        assertEquals("ALTER TABLE table_name MODIFY column1 BIGINT NOT NULL", sql[3].toSql());
+        assertEquals("ALTER TABLE table_name MODIFY column2 BIT(1) NOT NULL", sql[4].toSql());
     }
 }


### PR DESCRIPTION
Liquibase generates invalid SQL on addColumn changesets specified with a not-nullable column. The bug manifests when update is executed against a table that is **populated** with data. Bug is reproducible in 4.6.0.

## Steps to Reproduce
* See [https://liquibase.jira.com/browse/CORE-931](https://liquibase.jira.com/browse/CORE-931|smart-link) 

## Dev Notes
nvoxland this pull request should resolve JIRA ticket [https://liquibase.jira.com/browse/CORE-931](https://liquibase.jira.com/browse/CORE-931|smart-link) 

## Test Requirements (Internal Liquibase QA)
This test requires a Postgres instance; version does not matter. The test-harness will execute the test against the following versions: `9, 9.5, 10, 11, 12, 13`. The attached changelog includes a changeset that replicates the bug as well as a changeset that was the workaround to the bug prior to the fix; we want to make sure both versions of adding a not-nullable constraint both work after the fix.

**Manual Tests**

_Verify liquibase update~~sql generates valid SQL for an addColumn with a not~~nullable constraint._

`liquibase update-sql --changelog-file lb45-changelog.xml`

* Generated SQL for the changeset 2::addColumn is:
`ALTER TABLE lb45 ALTER COLUMN  "columnWithInitialValue" SET NOT NULL;`
* Generated SQL for the changeset 3::addColumnAndAddNotNullConstraint is:
`ALTER TABLE lb45 ALTER COLUMN  "columnWithConstraintInSeparateChange" SET NOT NULL;`

_Verify update is successful for adding a column with a not-nullable constraint on a populated table._

`liquibase update --changelog-file lb45-changelog.xml`

* There is no error that column "columnWithInitialValue" contains null values.
* Column is added to the table lb45.

**Automated Tests**

* No new functional automated tests required.
* A liquibase/liquibase-test-harness test is required.
  * Add an XML changelog with the following changesets included in the manual test changelog.
    * 1::createTable
    * 1::insertData
    * 2::addColumn
    * liquibase-test-harness/src/main/resources/liquibase/harness/change/changelogs/postgresql.
  * Add the JSON snapshot for test validation:
    * src/main/resources/liquibase/harness/change/expectedSnapshot/
      * You only need to validate the JSON for the changeset 2::addColumn
  * Add the generated SQL for test validation:
    * src/main/resources/liquibase/harness/change/expectedSql/
      * You only need to validate the SQL for the changeset 2::addColumn
  * Validate that a column with a not-nullable constraint can be added to a populated Postgres table.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-45) by [Unito](https://www.unito.io)
