### PR TITLE
Fix CORE-3078 bug

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/DropDefaultValueGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/DropDefaultValueGenerator.java
@@ -63,6 +63,8 @@ public class DropDefaultValueGenerator extends AbstractSqlGenerator<DropDefaultV
         	sql = "ALTER TABLE " + escapedTableName + " MODIFY (" + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " " + statement.getColumnDataType() + ")";
         } else if (database instanceof AbstractDb2Database) {
             sql = "ALTER TABLE " + escapedTableName + " ALTER COLUMN " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " DROP DEFAULT";
+        } else if (database instanceof PostgresDatabase) {
+            sql = "ALTER TABLE " + escapedTableName + " ALTER COLUMN " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " DROP DEFAULT";
         } else {
             sql = "ALTER TABLE " + escapedTableName + " ALTER COLUMN  " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " SET DEFAULT NULL";
         }


### PR DESCRIPTION
## Overview
On PostgreSQL, the dropDefaultValue command only sets the default value to NULL rather than actually dropping it. 

Looking at DropDefaultValueGenerator.java, there's no mention of PostgreSQL anywhere, so it ends up using the default "SET DEFAULT NULL".

## Steps to Reproduce
1. Create a table with an int column containing a default value of 10
1. Run a changeLog with <dropDefaultValue> for that column
1. `\d` describe that table to see that it now has a default value of null

### Expected Results
`\d` describe that table to see that it has no default value.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-42) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Community 4.2.1,Liquibase 4.2.1
