### PR TITLE
3.5.x

### DIFF
--- a/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -773,6 +773,11 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                         if (tableName != null) {
                             sql += " and table_name='" + tableName + "'";
                         }
+                    } else if (database.getClass().getName().contains("MaxDB")) {
+                        sql = "select distinct tablename AS TABLE_NAME, constraintname AS CONSTRAINT_NAME from CONSTRAINTCOLUMNS WHERE CONSTRAINTTYPE = 'UNIQUE_CONST'";
+                        if (tableName != null) {
+                            sql += " and tablename='" + tableName + "'";
+                        }
                     } else if (database instanceof MSSQLDatabase) {
                         sql =
                                 "SELECT " +

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
@@ -185,6 +185,9 @@ public class SequenceSnapshotGenerator extends JdbcSnapshotGenerator {
                     "CAST(INCREMENT AS BIGINT) AS INCREMENT_BY, " +
                     "CYCLE_OPTION AS WILL_CYCLE " +
                     "FROM INFORMATION_SCHEMA.SEQUENCES WHERE SEQUENCE_SCHEMA = '" + schema.getName() + "'";
+        } else if (database.getClass().getName().contains("MaxDB")) {
+			return "SELECT SEQUENCE_NAME, MIN_VALUE, MAX_VALUE, INCREMENT_BY, CYCLE_FLAG AS WILL_CYCLE " +
+				   "FROM sequences WHERE SCHEMANAME = '" + schema.getName() + "'";
         } else {
             throw new UnexpectedLiquibaseException("Don't know how to query for sequences on " + database);
         }

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
@@ -140,6 +140,10 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
                         + "and const.table_name='" + database.correctObjectName(example.getTable().getName(), Table.class) + "' "
                         + "and const.constraint_name='" + database.correctObjectName(name, UniqueConstraint.class) + "'"
                         + "order by ordinal_position";
+            } else if (database.getClass().getName().contains("MaxDB")) {
+				sql = "select CONSTRAINTNAME as constraint_name, COLUMNNAME as column_name from CONSTRAINTCOLUMNS WHERE CONSTRAINTTYPE = 'UNIQUE_CONST' AND tablename = '"
+						+ database.correctObjectName(example.getRelation().getName(), Table.class) + "' AND constraintname = '"
+						+ database.correctObjectName(name, UniqueConstraint.class) + "'";
             } else if (database instanceof MSSQLDatabase) {
                 if (database.getDatabaseMajorVersion() >= 9) {
                     sql =

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
@@ -142,7 +142,7 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
                         + "order by ordinal_position";
             } else if (database.getClass().getName().contains("MaxDB")) {
 				sql = "select CONSTRAINTNAME as constraint_name, COLUMNNAME as column_name from CONSTRAINTCOLUMNS WHERE CONSTRAINTTYPE = 'UNIQUE_CONST' AND tablename = '"
-						+ database.correctObjectName(example.getRelation().getName(), Table.class) + "' AND constraintname = '"
+						+ database.correctObjectName(example.getTable().getName(), Table.class) + "' AND constraintname = '"
 						+ database.correctObjectName(name, UniqueConstraint.class) + "'";
             } else if (database instanceof MSSQLDatabase) {
                 if (database.getDatabaseMajorVersion() >= 9) {


### PR DESCRIPTION
MaxDB Liquibase Diff does not work for sequences as this database (liquibase-maxdb repo) is not included in the SequenceSnapshotGenerator.
(Query should be moved to the Database successor, anyways...)
This is the backport to the 3.5.x branch.