### PR TITLE
SpringLiquibase ResourceAccessor is now overridable

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/spring/SpringLiquibase.java
+++ b/liquibase-core/src/main/java/liquibase/integration/spring/SpringLiquibase.java
@@ -369,7 +369,7 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
     }
 
 	protected Liquibase createLiquibase(Connection c) throws LiquibaseException {
-		SpringResourceOpener resourceAccessor = createResourceOpener();
+		ResourceAccessor resourceAccessor = createResourceOpener();
 		Liquibase liquibase = new Liquibase(getChangeLog(), resourceAccessor, createDatabase(c, resourceAccessor));
         liquibase.setIgnoreClasspathPrefix(isIgnoreClasspathPrefix());
 		if (parameters != null) {
@@ -439,7 +439,7 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
 	/**
 	 * Create a new resourceOpener.
 	 */
-	protected SpringResourceOpener createResourceOpener() {
+	protected ResourceAccessor createResourceOpener() {
 		return new SpringResourceOpener(getChangeLog());
 	}
 


### PR DESCRIPTION
`SpringLiquibase` `createResourceOpener()` now returns a `ResourceAccessor`, which allows it to be overridden with any kind of `ResourceAccessor`.

The reason for this change is that I would like `SpringLiquibase` to be able use the regular `ClassLoaderResourceAccessor`. Since it appears that `SpringLiquibase` handles classpath resources differently, which makes it incompatible with other methods of running liquibase (i.e. command line or maven-plugin).

This change itself does not change the behaviour of SpringLiquibase at all, it only allows classes overriding it to use a different `ResourceAccessor`

Notes:
It should be possible to merge this change to master too, however it appears that changes have already been made, such that the `SpringResourceAccessor` no longer overrides any methods from `ClassLoaderResourceAccessor`, making their behaviour identical.



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-40) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 4.0 GA
