### PR TITLE
Build info value assignment fix

### DIFF
--- a/liquibase-core/src/main/java/liquibase/util/LiquibaseUtil.java
+++ b/liquibase-core/src/main/java/liquibase/util/LiquibaseUtil.java
@@ -39,7 +39,10 @@ public class LiquibaseUtil {
                 throw new UnexpectedLiquibaseException("Cannot open a URL to the manifest of our own JAR file.");
             }
             Attributes attr = manifest.getMainAttributes();
-            buildInfoValue = attr.getValue(manifestId);
+
+            if (attr.containsKey(manifestId)) {
+                buildInfoValue = attr.getValue(manifestId);
+            }
         }
 
         if (buildInfoValue.equals("UNKNOWN")) {


### PR DESCRIPTION
I faced with NPE while used liqubase API in my own app
`java.lang.NullPointerException
	at liquibase.util.LiquibaseUtil.getBuildInfo(LiquibaseUtil.java:45)
	at liquibase.util.LiquibaseUtil.getBuildVersion(LiquibaseUtil.java:17)
	at liquibase.sqlgenerator.core.MarkChangeSetRanGenerator.generateSql(MarkChangeSetRanGenerator.java:91)
	at liquibase.sqlgenerator.core.MarkChangeSetRanGenerator.generateSql(MarkChangeSetRanGenerator.java:25)
	at liquibase.sqlgenerator.SqlGeneratorChain.generateSql(SqlGeneratorChain.java:30)
	at liquibase.sqlgenerator.SqlGeneratorFactory.generateSql(SqlGeneratorFactory.java:222)
	at liquibase.executor.AbstractExecutor.applyVisitors(AbstractExecutor.java:25)
	at liquibase.executor.jvm.JdbcExecutor.access$600(JdbcExecutor.java:40)
	at liquibase.executor.jvm.JdbcExecutor$ExecuteStatementCallback.doInStatement(JdbcExecutor.java:384)
	at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:59)
	at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:131)
	at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:111)
	at liquibase.changelog.StandardChangeLogHistoryService.setExecType(StandardChangeLogHistoryService.java:388)
	at liquibase.database.AbstractJdbcDatabase.markChangeSetExecStatus(AbstractJdbcDatabase.java:1130)
	at liquibase.changelog.visitor.UpdateVisitor.visit(UpdateVisitor.java:64)
	at liquibase.changelog.ChangeLogIterator.run(ChangeLogIterator.java:83)
	at liquibase.Liquibase.update(Liquibase.java:202)
	at liquibase.Liquibase.update(Liquibase.java:179)
	at liquibase.Liquibase.update(Liquibase.java:175)
	at
`

If your MANIFEST.MF wasn't built properly then you'll face with this NPE too.
I believe LB shouldn't throw an NPE even if doesn't contain necessary fields