### PR TITLE
[CORE-3520] Add support for ALWAYS generation type with PostgreSQL auto-increment column.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/PostgresDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/PostgresDatabase.java
@@ -238,6 +238,24 @@ public class PostgresDatabase extends AbstractJdbcDatabase {
     }
 
     @Override
+    protected String getAutoIncrementClause(final String generationType, final Boolean defaultOnNull) {
+        try {
+            if (getDatabaseMajorVersion() < 10) {
+                return "";
+            }
+        } catch (DatabaseException e) {
+            return "";
+        }
+
+        if (StringUtils.isEmpty(generationType)) {
+            return super.getAutoIncrementClause();
+        }
+
+        String autoIncrementClause = "GENERATED %s AS IDENTITY"; // %s -- [ ALWAYS | BY DEFAULT ]
+        return String.format(autoIncrementClause, generationType);
+    }
+
+    @Override
     public boolean generateAutoIncrementStartWith(BigInteger startWith) {
         try {
             if (getDatabaseMajorVersion() < 10) {


### PR DESCRIPTION
When using Liquibase to create a table with an auto-incrementing integer, the corresponding identity column in PostgreSQL is always created with the constraint `BY DEFAULT`, irrespective of the value set for the generation type.

Add support to Liquibase for the `ALWAYS` generation type when creating an auto-incrementing column in PostgreSQL. This will allow the generation type to be set to `BY DEFAULT` or `ALWAYS`. The default value if the `generationType` attribute is not specified in the column tag, remains `BY DEFAULT`.

┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-39) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 3.10.1
