### PR TITLE
[CORE-3523] Consistently map Liquibase integer types to Oracle integer types

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/BigIntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/BigIntType.java
@@ -37,7 +37,7 @@ public class BigIntType extends LiquibaseDataType {
             }
         }
         if (database instanceof OracleDatabase) {
-            return new DatabaseDataType("NUMBER", 38,0);
+            return new DatabaseDataType("NUMBER", 19, 0);
         }
         if (database instanceof SybaseDatabase) {
             return new DatabaseDataType("BIGINT");

--- a/liquibase-core/src/main/java/liquibase/datatype/core/IntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/IntType.java
@@ -33,8 +33,11 @@ public class IntType extends LiquibaseDataType {
         if ((database instanceof InformixDatabase) && isAutoIncrement()) {
             return new DatabaseDataType("SERIAL");
         }
-        if ((database instanceof AbstractDb2Database) || (database instanceof DerbyDatabase) || database instanceof OracleDatabase) {
+        if ((database instanceof AbstractDb2Database) || (database instanceof DerbyDatabase)) {
             return new DatabaseDataType("INTEGER");
+        }
+        if (database instanceof OracleDatabase) {
+            return new DatabaseDataType("NUMBER", 10, 0);
         }
         if (database instanceof PostgresDatabase) {
             if (isAutoIncrement()) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/MediumIntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/MediumIntType.java
@@ -33,8 +33,11 @@ public class MediumIntType extends LiquibaseDataType {
             type.addAdditionalInformation(getAdditionalInformation());
             return type;
         }
-        if ((database instanceof AbstractDb2Database) || (database instanceof DerbyDatabase) || (database instanceof FirebirdDatabase) || database instanceof OracleDatabase) {
+        if ((database instanceof AbstractDb2Database) || (database instanceof DerbyDatabase) || (database instanceof FirebirdDatabase)) {
             return new DatabaseDataType("MEDIUMINT"); //always mediumint regardless of parameters passed
+        }
+        if (database instanceof OracleDatabase) {
+            return new DatabaseDataType("NUMBER", 7, 0);
         }
         return super.toDatabaseDataType(database);
     }

--- a/liquibase-core/src/main/java/liquibase/datatype/core/SmallIntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/SmallIntType.java
@@ -40,7 +40,7 @@ public class SmallIntType extends LiquibaseDataType {
         }
 
         if (database instanceof OracleDatabase) {
-            return new DatabaseDataType("NUMBER", 5);
+            return new DatabaseDataType("NUMBER", 5, 0);
         }
 
         if (database instanceof PostgresDatabase)

--- a/liquibase-core/src/main/java/liquibase/datatype/core/TinyIntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/TinyIntType.java
@@ -39,7 +39,7 @@ public class TinyIntType  extends LiquibaseDataType {
             return type;
         }
         if (database instanceof OracleDatabase) {
-            return new DatabaseDataType("NUMBER",3);
+            return new DatabaseDataType("NUMBER", 3, 0);
         }
         return super.toDatabaseDataType(database);
     }

--- a/liquibase-core/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
@@ -210,6 +210,12 @@ class DataTypeFactoryTest extends Specification {
         "nclob"                                        | new OracleDatabase()   | "NCLOB"                                        | ClobType      | false
         "xml"                                          | new OracleDatabase()   | "XMLTYPE"                                      | XMLType       | false
         "xmltype"                                      | new OracleDatabase()   | "XMLTYPE"                                      | XMLType       | false
+        "tinyint"                                      | new OracleDatabase()   | "NUMBER(3, 0)"                                 | TinyIntType   | false
+        "smallint"                                     | new OracleDatabase()   | "NUMBER(5, 0)"                                 | SmallIntType  | false
+        "mediumint"                                    | new OracleDatabase()   | "NUMBER(7, 0)"                                 | MediumIntType | false
+        "int"                                          | new OracleDatabase()   | "NUMBER(10, 0)"                                | IntType       | false
+        "integer"                                      | new OracleDatabase()   | "NUMBER(10, 0)"                                | IntType       | false
+        "bigint"                                       | new OracleDatabase()   | "NUMBER(19, 0)"                                | BigIntType    | false
         "xml"                                          | new PostgresDatabase() | "XML"                                          | XMLType       | false
         "BINARY(16)"                                   | new H2Database()       | "BINARY(16)"                                   | BlobType      | false
     }

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addColumn/oracle.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addColumn/oracle.sql
@@ -4,4 +4,4 @@
 --     type="int"
 -- ], ]
 -- Change Parameter: tableName=person
-ALTER TABLE person ADD id INTEGER;
+ALTER TABLE person ADD id NUMBER(10, 0);

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/createTable/oracle.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/createTable/oracle.sql
@@ -4,4 +4,4 @@
 --     type="int"
 -- ], ]
 -- Change Parameter: tableName=person
-CREATE TABLE person (id INTEGER);
+CREATE TABLE person (id NUMBER(10, 0));

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/modifyDataType/oracle.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/modifyDataType/oracle.sql
@@ -2,4 +2,4 @@
 -- Change Parameter: columnName=id
 -- Change Parameter: newDataType=int
 -- Change Parameter: tableName=person
-ALTER TABLE person MODIFY id INTEGER;
+ALTER TABLE person MODIFY id NUMBER(10, 0);

--- a/liquibase-integration-tests/src/test/java/liquibase/statementexecute/CreateDatabaseChangeLogLockTableExecuteTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/statementexecute/CreateDatabaseChangeLogLockTableExecuteTest.java
@@ -61,7 +61,7 @@ public class CreateDatabaseChangeLogLockTableExecuteTest extends AbstractExecute
                 "constraint [pk_dbchgloglock] primary key ([id]))"}, DB2Database.class);
     
         assertCorrect(new String[]{"create table databasechangeloglock (" +
-                "id integer not null, " +
+                "id number(10, 0) not null, " +
                 "locked number(1) not null, " +
                 "lockgranted timestamp, " +
                 "lockedby varchar2(255), " +


### PR DESCRIPTION
All integer types are represented in Oracle as number(precision, scale). The `INTEGER` keyword is converted to a number(*) by Oracle and the `MEDIUMINT` keyword is not supported.

Adopt a consistent mapping from Liquibase to Oracle numbers:

* tinyint => number(3,0)
* smallint => number(5,0)
* mediumint => number(7,0)
* integer => number(10,0)
* bigint => number(19,0)



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-36) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 4.1.0
