### PR TITLE
[CORE-3525] Add support for java.sql.Types.TIMESTAMP_WITH_TIMEZONE.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/TimestampType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/TimestampType.java
@@ -125,7 +125,7 @@ public class TimestampType extends DateTimeType {
             || database instanceof H2Database
             || database instanceof HsqlDatabase)) {
 
-            if ((database instanceof PostgresDatabase)) {
+            if (database instanceof PostgresDatabase || database instanceof H2Database) {
                 type.addAdditionalInformation("WITH TIME ZONE");
             } else {
                 type.addAdditionalInformation("WITH TIMEZONE");
@@ -143,7 +143,7 @@ public class TimestampType extends DateTimeType {
 
             if (additionalInformation != null) {
                 String additionInformation = additionalInformation.toUpperCase(Locale.US);
-                if ((database instanceof PostgresDatabase) && additionInformation.toUpperCase(Locale.US).contains("TIMEZONE")) {
+                if ((database instanceof PostgresDatabase || database instanceof H2Database) && additionInformation.toUpperCase(Locale.US).contains("TIMEZONE")) {
                     additionalInformation = additionInformation.toUpperCase(Locale.US).replace("TIMEZONE", "TIME ZONE");
                 }
                 // CORE-3229 Oracle 11g doesn't support WITHOUT clause in TIMESTAMP data type

--- a/liquibase-core/src/main/java/liquibase/datatype/core/TimestampType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/TimestampType.java
@@ -16,14 +16,12 @@ import liquibase.logging.LogType;
 import liquibase.util.StringUtils;
 import liquibase.util.grammar.ParseException;
 
-import java.util.Locale;
-
 /**
  * Data type support for TIMESTAMP data types in various DBMS. All DBMS are at least expected to support the
  * year, month, day, hour, minute and second parts. Optionally, fractional seconds and time zone information can be
  * specified as well.
  */
-@DataTypeInfo(name = "timestamp", aliases = {"java.sql.Types.TIMESTAMP", "java.sql.Timestamp", "timestamptz"}, minParameters = 0, maxParameters = 1, priority = LiquibaseDataType.PRIORITY_DEFAULT)
+@DataTypeInfo(name = "timestamp", aliases = {"java.sql.Types.TIMESTAMP", "java.sql.Types.TIMESTAMP_WITH_TIMEZONE", "java.sql.Timestamp", "timestamptz"}, minParameters = 0, maxParameters = 1, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class TimestampType extends DateTimeType {
 
     /**
@@ -119,6 +117,21 @@ public class TimestampType extends DateTimeType {
             type =  new DatabaseDataType("TIMESTAMP", fractionalDigits);
         } else {
             type = new DatabaseDataType("TIMESTAMP");
+        }
+
+        if (originalDefinition.startsWith("java.sql.Types.TIMESTAMP_WITH_TIMEZONE")
+            && (database instanceof PostgresDatabase
+            || database instanceof OracleDatabase
+            || database instanceof H2Database
+            || database instanceof HsqlDatabase)) {
+
+            if ((database instanceof PostgresDatabase)) {
+                type.addAdditionalInformation("WITH TIME ZONE");
+            } else {
+                type.addAdditionalInformation("WITH TIMEZONE");
+            }
+
+            return type;
         }
 
         if (getAdditionalInformation() != null

--- a/liquibase-core/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
@@ -210,8 +210,50 @@ class DataTypeFactoryTest extends Specification {
         "nclob"                                        | new OracleDatabase()   | "NCLOB"                                        | ClobType      | false
         "xml"                                          | new OracleDatabase()   | "XMLTYPE"                                      | XMLType       | false
         "xmltype"                                      | new OracleDatabase()   | "XMLTYPE"                                      | XMLType       | false
+        "timestamp"                                    | new OracleDatabase()   | "TIMESTAMP"                                    | TimestampType | false
+        "timestamp(6)"                                 | new OracleDatabase()   | "TIMESTAMP(6)"                                 | TimestampType | false
+        "TIMESTAMP WITH TIMEZONE"                      | new OracleDatabase()   | "TIMESTAMP WITH TIMEZONE"                      | TimestampType | false
+        "TIMESTAMP(6) WITH TIMEZONE"                   | new OracleDatabase()   | "TIMESTAMP(6) WITH TIMEZONE"                   | TimestampType | false
+        "timestamp without timezone"                   | new OracleDatabase()   | "TIMESTAMP"                                    | TimestampType | false
+        "timestamp(6) without timezone"                | new OracleDatabase()   | "TIMESTAMP(6)"                                 | TimestampType | false
+        "timestamptz"                                  | new OracleDatabase()   | "TIMESTAMP"                                    | TimestampType | false
+        "timestamptz(6)"                               | new OracleDatabase()   | "TIMESTAMP(6)"                                 | TimestampType | false
+        "java.sql.Timestamp"                           | new OracleDatabase()   | "TIMESTAMP"                                    | TimestampType | false
+        "java.sql.Timestamp(6)"                        | new OracleDatabase()   | "TIMESTAMP(6)"                                 | TimestampType | false
+        "java.sql.Types.TIMESTAMP"                     | new OracleDatabase()   | "TIMESTAMP"                                    | TimestampType | false
+        "java.sql.Types.TIMESTAMP(6)"                  | new OracleDatabase()   | "TIMESTAMP(6)"                                 | TimestampType | false
+        "java.sql.Types.TIMESTAMP_WITH_TIMEZONE"       | new OracleDatabase()   | "TIMESTAMP WITH TIMEZONE"                      | TimestampType | false
+        "java.sql.Types.TIMESTAMP_WITH_TIMEZONE(6)"    | new OracleDatabase()   | "TIMESTAMP(6) WITH TIMEZONE"                   | TimestampType | false
         "xml"                                          | new PostgresDatabase() | "XML"                                          | XMLType       | false
+        "timestamp"                                    | new PostgresDatabase() | "TIMESTAMP WITHOUT TIME ZONE"                  | TimestampType | false
+        "timestamp(6)"                                 | new PostgresDatabase() | "TIMESTAMP(6) WITHOUT TIME ZONE"               | TimestampType | false
+        "timestamp with timezone"                      | new PostgresDatabase() | "TIMESTAMP WITH TIME ZONE"                     | TimestampType | false
+        "timestamp(6) with timezone"                   | new PostgresDatabase() | "TIMESTAMP(6) WITH TIME ZONE"                  | TimestampType | false
+        "timestamp without timezone"                   | new PostgresDatabase() | "TIMESTAMP WITHOUT TIME ZONE"                  | TimestampType | false
+        "timestamp(6) without timezone"                | new PostgresDatabase() | "TIMESTAMP(6) WITHOUT TIME ZONE"               | TimestampType | false
+        "timestamptz"                                  | new PostgresDatabase() | "TIMESTAMP WITH TIME ZONE"                     | TimestampType | false
+        "timestamptz(6)"                               | new PostgresDatabase() | "TIMESTAMP(6) WITH TIME ZONE"                  | TimestampType | false
+        "java.sql.Timestamp"                           | new PostgresDatabase() | "TIMESTAMP WITHOUT TIME ZONE"                  | TimestampType | false
+        "java.sql.Timestamp(6)"                        | new PostgresDatabase() | "TIMESTAMP(6) WITHOUT TIME ZONE"               | TimestampType | false
+        "java.sql.Types.TIMESTAMP"                     | new PostgresDatabase() | "TIMESTAMP WITHOUT TIME ZONE"                  | TimestampType | false
+        "java.sql.Types.TIMESTAMP(6)"                  | new PostgresDatabase() | "TIMESTAMP(6) WITHOUT TIME ZONE"               | TimestampType | false
+        "java.sql.Types.TIMESTAMP_WITH_TIMEZONE"       | new PostgresDatabase() | "TIMESTAMP WITH TIME ZONE"                     | TimestampType | false
+        "java.sql.Types.TIMESTAMP_WITH_TIMEZONE(6)"    | new PostgresDatabase() | "TIMESTAMP(6) WITH TIME ZONE"                  | TimestampType | false
         "BINARY(16)"                                   | new H2Database()       | "BINARY(16)"                                   | BlobType      | false
+        "timestamp"                                    | new H2Database()       | "TIMESTAMP"                                    | TimestampType | false
+        "timestamp(6)"                                 | new H2Database()       | "TIMESTAMP(6)"                                 | TimestampType | false
+        "TIMESTAMP WITH TIMEZONE"                      | new H2Database()       | "TIMESTAMP WITH TIMEZONE"                      | TimestampType | false
+        "TIMESTAMP(6) WITH TIMEZONE"                   | new H2Database()       | "TIMESTAMP(6) WITH TIMEZONE"                   | TimestampType | false
+        "timestamp without timezone"                   | new H2Database()       | "TIMESTAMP"                                    | TimestampType | false
+        "timestamp(6) without timezone"                | new H2Database()       | "TIMESTAMP(6)"                                 | TimestampType | false
+        "timestamptz"                                  | new H2Database()       | "TIMESTAMP"                                    | TimestampType | false
+        "timestamptz(6)"                               | new H2Database()       | "TIMESTAMP(6)"                                 | TimestampType | false
+        "java.sql.Timestamp"                           | new H2Database()       | "TIMESTAMP"                                    | TimestampType | false
+        "java.sql.Timestamp(6)"                        | new H2Database()       | "TIMESTAMP(6)"                                 | TimestampType | false
+        "java.sql.Types.TIMESTAMP"                     | new H2Database()       | "TIMESTAMP"                                    | TimestampType | false
+        "java.sql.Types.TIMESTAMP(6)"                  | new H2Database()       | "TIMESTAMP(6)"                                 | TimestampType | false
+        "java.sql.Types.TIMESTAMP_WITH_TIMEZONE"       | new H2Database()       | "TIMESTAMP WITH TIMEZONE"                      | TimestampType | false
+        "java.sql.Types.TIMESTAMP_WITH_TIMEZONE(6)"    | new H2Database()       | "TIMESTAMP(6) WITH TIMEZONE"                   | TimestampType | false
     }
 
     @Unroll("#featureName: #object for #database")

--- a/liquibase-core/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
@@ -242,8 +242,8 @@ class DataTypeFactoryTest extends Specification {
         "BINARY(16)"                                   | new H2Database()       | "BINARY(16)"                                   | BlobType      | false
         "timestamp"                                    | new H2Database()       | "TIMESTAMP"                                    | TimestampType | false
         "timestamp(6)"                                 | new H2Database()       | "TIMESTAMP(6)"                                 | TimestampType | false
-        "TIMESTAMP WITH TIMEZONE"                      | new H2Database()       | "TIMESTAMP WITH TIMEZONE"                      | TimestampType | false
-        "TIMESTAMP(6) WITH TIMEZONE"                   | new H2Database()       | "TIMESTAMP(6) WITH TIMEZONE"                   | TimestampType | false
+        "TIMESTAMP WITH TIMEZONE"                      | new H2Database()       | "TIMESTAMP WITH TIME ZONE"                      | TimestampType | false
+        "TIMESTAMP(6) WITH TIMEZONE"                   | new H2Database()       | "TIMESTAMP(6) WITH TIME ZONE"                   | TimestampType | false
         "timestamp without timezone"                   | new H2Database()       | "TIMESTAMP"                                    | TimestampType | false
         "timestamp(6) without timezone"                | new H2Database()       | "TIMESTAMP(6)"                                 | TimestampType | false
         "timestamptz"                                  | new H2Database()       | "TIMESTAMP"                                    | TimestampType | false
@@ -252,8 +252,8 @@ class DataTypeFactoryTest extends Specification {
         "java.sql.Timestamp(6)"                        | new H2Database()       | "TIMESTAMP(6)"                                 | TimestampType | false
         "java.sql.Types.TIMESTAMP"                     | new H2Database()       | "TIMESTAMP"                                    | TimestampType | false
         "java.sql.Types.TIMESTAMP(6)"                  | new H2Database()       | "TIMESTAMP(6)"                                 | TimestampType | false
-        "java.sql.Types.TIMESTAMP_WITH_TIMEZONE"       | new H2Database()       | "TIMESTAMP WITH TIMEZONE"                      | TimestampType | false
-        "java.sql.Types.TIMESTAMP_WITH_TIMEZONE(6)"    | new H2Database()       | "TIMESTAMP(6) WITH TIMEZONE"                   | TimestampType | false
+        "java.sql.Types.TIMESTAMP_WITH_TIMEZONE"       | new H2Database()       | "TIMESTAMP WITH TIME ZONE"                      | TimestampType | false
+        "java.sql.Types.TIMESTAMP_WITH_TIMEZONE(6)"    | new H2Database()       | "TIMESTAMP(6) WITH TIME ZONE"                   | TimestampType | false
     }
 
     @Unroll("#featureName: #object for #database")


### PR DESCRIPTION
Liquibase does not currently support the `java.sql.Types.TIMESTAMP_WITH_TIMEZONE` type. For example, using `java.sql.Types.TIMESTAMP_WITH_TIMEZONE` as the column type in Liquibase generates a column with the `TIMESTAMP WITHOUT TIME ZONE` type in PostgreSQL.

Add support for the `java.sql.Types.TIMESTAMP_WITH_TIMEZONE` type to Liquibase so the correct SQL is generated for databases supporting timestamps with timezones.

## Repo Steps
1. Create a createTable changeSet with a column having `type="java.sql.Types.TIMESTAMP_WITH_TIMEZONE"` 
1. Run changeSet against postgresql or another database that supports timestamp with timezone types
1. Check that the table column was created as timestamp with timezone information

## QA Manual Test Requirements
* Execute the steps as described in repro and assert the correct dataype is created on the database.

## QA Automated Test Requirements
* Write a Postgres regression test following the repro steps.



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-34) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 3.10.2
