### PR TITLE
Some small fixes about ConstraintsConfig

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/ColumnConfig.java
+++ b/liquibase-core/src/main/java/liquibase/change/ColumnConfig.java
@@ -878,7 +878,6 @@ public class ColumnConfig extends AbstractLiquibaseSerializable {
         constraints.setReferencedColumnNames(constraintsNode.getChildValue(null, "referencedColumnNames", String.class));
         constraints.setUnique(constraintsNode.getChildValue(null, "unique", Boolean.class));
         constraints.setUniqueConstraintName(constraintsNode.getChildValue(null, "uniqueConstraintName", String.class));
-        constraints.setNotNullConstraintName(constraintsNode.getChildValue(null, "notNullConstraintName", String.class));
         constraints.setCheckConstraint(constraintsNode.getChildValue(null, "checkConstraint", String.class));
         constraints.setDeleteCascade(constraintsNode.getChildValue(null, "deleteCascade", Boolean.class));
         constraints.setForeignKeyName(constraintsNode.getChildValue(null, "foreignKeyName", String.class));

--- a/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
@@ -383,7 +383,7 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
                 constraintsElement.setAttribute("referencedTableName", constraints.getReferencedTableName());
             }
             if (constraints.getReferencedColumnNames() != null) {
-                constraintsElement.setAttribute("referencedTableName", constraints.getReferencedColumnNames());
+                constraintsElement.setAttribute("referencedColumnNames", constraints.getReferencedColumnNames());
             }
             if (constraints.isDeferrable() != null) {
                 constraintsElement.setAttribute("deferrable", constraints.isDeferrable().toString());

--- a/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
@@ -415,17 +415,23 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
             if (constraints.isUnique() != null) {
                 constraintsElement.setAttribute("unique", constraints.isUnique().toString());
             }
-
             if (constraints.getUniqueConstraintName() != null) {
                 constraintsElement.setAttribute("uniqueConstraintName", constraints.getUniqueConstraintName());
             }
-
             if (constraints.getPrimaryKeyName() != null) {
                 constraintsElement.setAttribute("primaryKeyName", constraints.getPrimaryKeyName());
             }
-
             if (constraints.getPrimaryKeyTablespace() != null) {
                 constraintsElement.setAttribute("primaryKeyTablespace", constraints.getPrimaryKeyTablespace());
+            }
+            if (constraints.getNotNullConstraintName() != null) {
+                constraintsElement.setAttribute("notNullConstraintName", constraints.getNotNullConstraintName());
+            }
+            if (constraints.getReferencedTableCatalogName() != null) {
+                constraintsElement.setAttribute("referencedTableCatalogName", constraints.getReferencedTableCatalogName());
+            }
+            if (constraints.getReferencedTableSchemaName() != null) {
+                constraintsElement.setAttribute("referencedTableSchemaName", constraints.getReferencedTableSchemaName());
             }
             element.appendChild(constraintsElement);
         }

--- a/liquibase-core/src/test/java/liquibase/serializer/core/xml/XMLChangeLogSerializerTest.java
+++ b/liquibase-core/src/test/java/liquibase/serializer/core/xml/XMLChangeLogSerializerTest.java
@@ -65,7 +65,6 @@ public class XMLChangeLogSerializerTest {
         assertEquals("column", ((Element) columns.item(0)).getTagName());
         assertEquals("NEWCOL", ((Element) columns.item(0)).getAttribute("name"));
         assertEquals("TYP", ((Element) columns.item(0)).getAttribute("type"));
-
     }
 
     @Test
@@ -182,7 +181,7 @@ public class XMLChangeLogSerializerTest {
         assertEquals("COL_HERE", node.getAttribute("columnNames"));
         assertEquals("PK_NAME", node.getAttribute("constraintName"));
         assertEquals("TABLESPACE_NAME", node.getAttribute("tablespace"));
-        assertEquals("TABLESPACE_NAME", node.getAttribute("tablespace"));
+        assertEquals("true", node.getAttribute("disabled"));
         assertEquals("true", node.getAttribute("deferrable"));
         assertEquals("true", node.getAttribute("initiallyDeferred"));
         assertEquals("true", node.getAttribute("validate"));
@@ -268,7 +267,6 @@ public class XMLChangeLogSerializerTest {
         assertEquals("true", constraintsElement.getAttribute("primaryKey"));
         assertEquals("state(id)", constraintsElement.getAttribute("references"));
         assertEquals("true", constraintsElement.getAttribute("unique"));
-
     }
 
     @Test
@@ -746,7 +744,7 @@ public class XMLChangeLogSerializerTest {
         assertEquals("OLD_NAME", node.getAttribute("oldTableName"));
         assertEquals("NEW_NAME", node.getAttribute("newTableName"));
     }
-    
+
     @Test
     public void createNode_RenameSequenceChange() throws Exception {
         RenameSequenceChange refactoring = new RenameSequenceChange();


### PR DESCRIPTION
* fix: duplicate line for `notNullConstraintName` in **ColumnConfig.java**
* fix: `referencedColumnNames` instead of `referencedTableName` in **XMLChangeLogSerializer.java**
* fix: add `notNullConstraintName`,  `referencedTableCatalogName` & `referencedTableSchemaName` in **XMLChangeLogSerializer.java**
* fix: duplicate assertion in `createNode_AddUniqueConstraintChange `test in **XMLChangeLogSerializerTest.java**