### PR TITLE
Speed up the Change factory initialization

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/ChangeFactory.java
+++ b/liquibase-core/src/main/java/liquibase/change/ChangeFactory.java
@@ -68,15 +68,13 @@ public class ChangeFactory implements SingletonObject {
      */
     public void register(Class<? extends Change> changeClass) {
         try {
-            Change instance = changeClass.newInstance();
-            ChangeMetaData metaData = getChangeMetaData(instance);
-            String name = metaData.getName();
+            String name = changeClass.getAnnotation(DatabaseChange.class).name();
             if (registry.get(name) == null) {
                 registry.put(name, new TreeSet<>(new Comparator<Class<? extends Change>>() {
                     @Override
                     public int compare(Class<? extends Change> o1, Class<? extends Change> o2) {
                         try {
-                            return -1 * Integer.valueOf(getChangeMetaData(o1.newInstance()).getPriority()).compareTo(getChangeMetaData(o2.newInstance()).getPriority());
+                            return o2.getAnnotation(DatabaseChange.class).priority() - o1.getAnnotation(DatabaseChange.class).priority();
                         } catch (Exception e) {
                             throw new UnexpectedLiquibaseException(e);
                         }

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/SqlGeneratorFactory.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/SqlGeneratorFactory.java
@@ -106,10 +106,7 @@ public class SqlGeneratorFactory {
         String key = statement.getClass().getName()+":"+ databaseName+":"+ version;
 
         if (generatorsByKey.containsKey(key) && !generatorsByKey.get(key).isEmpty()) {
-            SortedSet<SqlGenerator> result = new TreeSet<>(new SqlGeneratorComparator());
-            result.addAll(generatorsByKey.get(key));
-            result.retainAll(getGenerators());
-            return result;
+            return Collections.unmodifiableSortedSet(generatorsByKey.get(key));
         }
 
         SortedSet<SqlGenerator> validGenerators = new TreeSet<>(new SqlGeneratorComparator());


### PR DESCRIPTION
Turns out `Change.createChangeMetaData()` is rather slow – `AbstractChange.createChangeParameterMetadata()` to be more precise.  Creating this metadata for all `Change` types upfront unnecessary wastes time and causes slower feedback, considering not all `Change` types may be actually used.  So just do the minimal work necessary for the initial registration.

  \+ Avoid some copying in `SqlGeneratorFactory.getGenerators()`