### PR TITLE
CORE-3558 Unique constraint name is ignored when using the addColumn change

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/AddColumnChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/AddColumnChange.java
@@ -108,7 +108,7 @@ public class AddColumnChange extends AbstractChange implements ChangeWithColumns
                     constraints.add(notNullConstraint);
                 }
                 if (constraintsConfig.isUnique() != null && constraintsConfig.isUnique()) {
-                    UniqueConstraint uniqueConstraint = new UniqueConstraint();
+                    UniqueConstraint uniqueConstraint = new UniqueConstraint(constraintsConfig.getUniqueConstraintName());
                     if (constraintsConfig.shouldValidateUnique()!=null && !constraintsConfig.shouldValidateUnique()) {
                         uniqueConstraint.setValidateUnique(false);
                     }

--- a/liquibase-core/src/test/java/liquibase/change/AddColumnChangeTest.java
+++ b/liquibase-core/src/test/java/liquibase/change/AddColumnChangeTest.java
@@ -52,4 +52,45 @@ public class AddColumnChangeTest {
         Assert.assertTrue(statements[1] instanceof ReorganizeTableStatement);
 
     }
+
+    @Test
+    public void generateStatements_singleColumn_uniqueConstraintName() {
+        String myUniqueConstraintName  = "my_unique_constraint";
+
+        AddColumnChange change = new AddColumnChange();
+        change.setTableName("my_table");
+        AddColumnConfig column = new AddColumnConfig();
+        column.setName("column1");
+        column.setType("integer");
+        ConstraintsConfig constraintsConfig = new ConstraintsConfig();
+        constraintsConfig.setUnique(true);
+        constraintsConfig.setUniqueConstraintName(myUniqueConstraintName);
+        column.setConstraints(constraintsConfig);
+        change.addColumn(column);
+
+        SqlStatement[] statements = change.generateStatements(new MockDatabase());
+        Assert.assertEquals(1, statements.length);
+        Assert.assertTrue(statements[0] instanceof AddColumnStatement);
+        AddColumnStatement stmt = (AddColumnStatement)statements[0];
+        Assert.assertEquals(myUniqueConstraintName, stmt.getUniqueStatementName());
+    }
+
+    @Test
+    public void generateStatements_singleColumn_null_uniqueConstraintName() {
+        AddColumnChange change = new AddColumnChange();
+        change.setTableName("my_table");
+        AddColumnConfig column = new AddColumnConfig();
+        column.setName("column1");
+        column.setType("integer");
+        ConstraintsConfig constraintsConfig = new ConstraintsConfig();
+        constraintsConfig.setUnique(true);
+        column.setConstraints(constraintsConfig);
+        change.addColumn(column);
+
+        SqlStatement[] statements = change.generateStatements(new MockDatabase());
+        Assert.assertEquals(1, statements.length);
+        Assert.assertTrue(statements[0] instanceof AddColumnStatement);
+        AddColumnStatement stmt = (AddColumnStatement)statements[0];
+        Assert.assertNull(stmt.getUniqueStatementName());
+    }
 }


### PR DESCRIPTION


┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-29) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 3.10.1
