### PR TITLE
fix DB2 LUW supports boolean data type

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/BooleanType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/BooleanType.java
@@ -22,7 +22,7 @@ public class BooleanType extends LiquibaseDataType {
             return new DatabaseDataType("BOOLEAN");
         }
 
-        if ((database instanceof AbstractDb2Database) || (database instanceof FirebirdDatabase)) {
+        if ((database instanceof Db2zDatabase) || (database instanceof FirebirdDatabase)) {
             return new DatabaseDataType("SMALLINT");
         } else if (database instanceof MSSQLDatabase) {
             return new DatabaseDataType(database.escapeDataTypeName("bit"));


### PR DESCRIPTION
In my last PR https://github.com/liquibase/liquibase/pull/865 I forgot a line of code to activate the boolean support.

## Test Requirements
* Do a desk check with the developer
* Verify unit or integration tests exist.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-28) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Community 4.x
