### PR TITLE
Update CreateSequenceGenerator.java

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateSequenceGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateSequenceGenerator.java
@@ -47,9 +47,9 @@ public class CreateSequenceGenerator extends AbstractSqlGenerator<CreateSequence
     public Sql[] generateSql(CreateSequenceStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
         StringBuilder queryStringBuilder = new StringBuilder();
         queryStringBuilder.append("CREATE SEQUENCE ");
-        if (database instanceof PostgresDatabase) {
-            queryStringBuilder.append(" IF NOT EXISTS ");
-        }
+       // if (database instanceof PostgresDatabase) {
+       //     queryStringBuilder.append(" IF NOT EXISTS ");
+       // }
         queryStringBuilder.append(database.escapeSequenceName(statement.getCatalogName(), statement.getSchemaName(), statement.getSequenceName()));
         if (database instanceof HsqlDatabase || database instanceof Db2zDatabase) {
             queryStringBuilder.append(" AS BIGINT ");


### PR DESCRIPTION
I executed below changeset(1001) using liquibase 3.6.3 version.
Precondition to check existence of sequence and create sequence was working absolutely fine.

<changeSet author="Karishma" id="1001"
 <preConditions onFail="MARK_RAN"
      <not
        <sequenceExists sequenceName="sec_uid_sq" schemaName="${schema-name}"/
      </not
    </preConditions
      <createSequence sequenceName="sec_uid_sq"/
  </changeSet

I upgraded liquibase to version 3.8.4 and the same changeset started failing with below mentioned error:
Reason: liquibase.exception.DatabaseException: ERROR: syntax error at or near "NOT"
  Position: 21 [Failed SQL: (0) CREATE SEQUENCE  IF NOT EXISTS liquidb.sec_uid_sq]

IF NOT EXISTS condition doesnt work in all version of postgres. 
Why IF NOT EXISTS is appended to sql query in 3.8.* version of liquibase.

Liquibase query should work on old (9.4) as well as new (9.5+)version to avoid BWC break. 
note: IF NOT EXISTS work only for version higher than 9.4 version of postgresql.

Thanks,
Karishma Jain

┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-27) by [Unito](https://www.unito.io/learn-more)
