### PR TITLE
Fix: Java 1.9+ versions require jaxb as separate dependency

### DIFF
--- a/liquibase-maven-plugin/pom.xml
+++ b/liquibase-maven-plugin/pom.xml
@@ -15,6 +15,11 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.3.0</version>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
 			<version>2.0</version>


### PR DESCRIPTION
Without explicit jaxb dependency the maven plugin cannot be built with java 1.9+

┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-26) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 3.10.1
