### PR TITLE
Add Class-Path entry to the manifest file to simplify command line execution

### DIFF
--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -190,7 +190,14 @@
                     <archive>
                         <manifest>
                             <addClasspath>true</addClasspath>
+                            <mainClass>liquibase.integration.commandline.Main</mainClass>
                         </manifest>
+                        <manifestEntries>
+                            <Build-Time>${build.timestamp}</Build-Time>
+                            <Build-Number>${build.number}</Build-Number>
+                            <Liquibase-Package>liquibase.change,liquibase.command,liquibase.changelog,liquibase.database,liquibase.parser,liquibase.precondition,liquibase.datatype,liquibase.serializer,liquibase.sqlgenerator,liquibase.executor,liquibase.snapshot,liquibase.logging,liquibase.diff,liquibase.structure,liquibase.structurecompare,liquibase.lockservice,liquibase.sdk.database,liquibase.ext,liquibase.pro,com.datical.liquibase</Liquibase-Package>
+                            <Liquibase-Version>${project.version}</Liquibase-Version>
+                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>

--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -186,8 +186,14 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                        </manifest>
+                    </archive>
+                </configuration>
             </plugin>
-
         </plugins>
     </build>
 </project>

--- a/liquibase-dist/pom.xml
+++ b/liquibase-dist/pom.xml
@@ -134,7 +134,16 @@
                         <descriptor>src/main/assembly/assembly-bin.xml</descriptor>
                     </descriptors>
                     <archive>
-                        <manifestFile>src/main/assembly/MANIFEST.MF</manifestFile>
+						<manifest>
+							<addClasspath>true</addClasspath>
+                            <mainClass>liquibase.integration.commandline.Main</mainClass>
+						</manifest>
+                        <manifestEntries>
+                            <Build-Time>${build.timestamp}</Build-Time>
+                            <Build-Number>${build.number}</Build-Number>
+                            <Liquibase-Package>liquibase.change,liquibase.command,liquibase.changelog,liquibase.database,liquibase.parser,liquibase.precondition,liquibase.datatype,liquibase.serializer,liquibase.sqlgenerator,liquibase.executor,liquibase.snapshot,liquibase.logging,liquibase.diff,liquibase.structure,liquibase.structurecompare,liquibase.lockservice,liquibase.sdk.database,liquibase.ext,liquibase.pro,com.datical.liquibase</Liquibase-Package>
+                            <Liquibase-Version>${project.version}</Liquibase-Version>
+                        </manifestEntries>
                     </archive>
                 </configuration>
                 <executions>


### PR DESCRIPTION
* CORE-3566 Class-Path entry in the jar could simplify execution
* Fix: `Build-Time, Build-Number, Liquibase-Version` attributes were not set in the manifest file



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-25) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 3.10.1
