### PR TITLE
Changes databasechangelog sql to use legacy mode

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/ClearDatabaseChangeLogTableGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/ClearDatabaseChangeLogTableGenerator.java
@@ -1,6 +1,7 @@
 package liquibase.sqlgenerator.core;
 
 import liquibase.database.Database;
+import liquibase.database.ObjectQuotingStrategy;
 import liquibase.exception.ValidationErrors;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
@@ -25,9 +26,16 @@ public class ClearDatabaseChangeLogTableGenerator extends AbstractSqlGenerator<C
         } else {
             schemaName = database.getLiquibaseSchemaName();
         }
-        return new Sql[] {
-                new UnparsedSql("DELETE FROM " + database.escapeTableName(database.getLiquibaseCatalogName(), schemaName, database.getDatabaseChangeLogTableName()),
-                        getAffectedTable(database, schemaName)) };
+        // use LEGACY quoting since we're dealing with system objects
+        ObjectQuotingStrategy currentStrategy = database.getObjectQuotingStrategy();
+        database.setObjectQuotingStrategy(ObjectQuotingStrategy.LEGACY);
+        try {
+            return new Sql[] {
+                    new UnparsedSql("DELETE FROM " + database.escapeTableName(database.getLiquibaseCatalogName(), schemaName, database.getDatabaseChangeLogTableName()),
+                                    getAffectedTable(database, schemaName)) };
+        } finally {
+            database.setObjectQuotingStrategy(currentStrategy);
+        }
     }
 
     protected Relation getAffectedTable(Database database, String schemaName) {

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateDatabaseChangeLogLockTableGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateDatabaseChangeLogLockTableGenerator.java
@@ -1,6 +1,7 @@
 package liquibase.sqlgenerator.core;
 
 import liquibase.database.Database;
+import liquibase.database.ObjectQuotingStrategy;
 import liquibase.database.core.MSSQLDatabase;
 import liquibase.datatype.DataTypeFactory;
 import liquibase.exception.ValidationErrors;
@@ -29,7 +30,14 @@ public class CreateDatabaseChangeLogLockTableGenerator extends AbstractSqlGenera
                 .addColumn("LOCKGRANTED", DataTypeFactory.getInstance().fromDescription(dateTimeTypeString, database))
                 .addColumn("LOCKEDBY", DataTypeFactory.getInstance().fromDescription(charTypeName + "(255)", database));
 
-        return SqlGeneratorFactory.getInstance().generateSql(createTableStatement, database);
+        // use LEGACY quoting since we're dealing with system objects
+        ObjectQuotingStrategy currentStrategy = database.getObjectQuotingStrategy();
+        database.setObjectQuotingStrategy(ObjectQuotingStrategy.LEGACY);
+        try {
+            return SqlGeneratorFactory.getInstance().generateSql(createTableStatement, database);
+        } finally {
+            database.setObjectQuotingStrategy(currentStrategy);
+        }
     }
 
     protected String getCharTypeName(Database database) {

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateDatabaseChangeLogTableGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateDatabaseChangeLogTableGenerator.java
@@ -1,6 +1,7 @@
 package liquibase.sqlgenerator.core;
 
 import liquibase.database.Database;
+import liquibase.database.ObjectQuotingStrategy;
 import liquibase.database.core.MSSQLDatabase;
 import liquibase.database.core.SybaseDatabase;
 import liquibase.datatype.DataTypeFactory;
@@ -45,7 +46,14 @@ public class CreateDatabaseChangeLogTableGenerator extends AbstractSqlGenerator<
                 .addColumn("LABELS", DataTypeFactory.getInstance().fromDescription(charTypeName + "("+getLabelsSize()+")", database))
                 .addColumn("DEPLOYMENT_ID", DataTypeFactory.getInstance().fromDescription(charTypeName+"(10)", database));
 
-        return SqlGeneratorFactory.getInstance().generateSql(createTableStatement, database);
+        // use LEGACY quoting since we're dealing with system objects
+        ObjectQuotingStrategy currentStrategy = database.getObjectQuotingStrategy();
+        database.setObjectQuotingStrategy(ObjectQuotingStrategy.LEGACY);
+        try {
+            return SqlGeneratorFactory.getInstance().generateSql(createTableStatement, database);
+        } finally {
+            database.setObjectQuotingStrategy(currentStrategy);
+        }
     }
 
     protected String getCharTypeName(Database database) {

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateDatabaseChangeLogTableGeneratorSybase.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateDatabaseChangeLogTableGeneratorSybase.java
@@ -1,6 +1,7 @@
 package liquibase.sqlgenerator.core;
 
 import liquibase.database.Database;
+import liquibase.database.ObjectQuotingStrategy;
 import liquibase.database.core.SybaseDatabase;
 import liquibase.datatype.DataTypeFactory;
 import liquibase.exception.ValidationErrors;
@@ -29,24 +30,30 @@ public class CreateDatabaseChangeLogTableGeneratorSybase extends AbstractSqlGene
 
     @Override
     public Sql[] generateSql(CreateDatabaseChangeLogTableStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
-        return new Sql[]{
-                new UnparsedSql("CREATE TABLE " + database.escapeTableName(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogTableName()) + " (ID VARCHAR(150) NOT NULL, " +
-                        "AUTHOR VARCHAR(150) NOT NULL, " +
-                        "FILENAME VARCHAR(255) NOT NULL, " +
-                        "DATEEXECUTED " + DataTypeFactory.getInstance().fromDescription("datetime", database).toDatabaseDataType(database) + " NOT NULL, " +
-                        "ORDEREXECUTED INT NOT NULL, " +
-                        "EXECTYPE VARCHAR(10) NOT NULL, " +
-                        "MD5SUM VARCHAR(35) NULL, " +
-                        "DESCRIPTION VARCHAR(255) NULL, " +
-                        "COMMENTS VARCHAR(255) NULL, " +
-                        "TAG VARCHAR(255) NULL, " +
-                        "LIQUIBASE VARCHAR(20) NULL, " +
-                        "CONTEXTS VARCHAR(255) NULL, " +
-                        "LABELS VARCHAR(255) NULL, " +
-                        "DEPLOYMENT_ID VARCHAR(10) NULL, " +
-                        "PRIMARY KEY(ID, AUTHOR, FILENAME))",
-                        getAffectedTable(database))
-        };
+        ObjectQuotingStrategy currentStrategy = database.getObjectQuotingStrategy();
+        database.setObjectQuotingStrategy(ObjectQuotingStrategy.LEGACY);
+        try {
+            return new Sql[]{
+                    new UnparsedSql("CREATE TABLE " + database.escapeTableName(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogTableName()) + " (ID VARCHAR(150) NOT NULL, " +
+                            "AUTHOR VARCHAR(150) NOT NULL, " +
+                            "FILENAME VARCHAR(255) NOT NULL, " +
+                            "DATEEXECUTED " + DataTypeFactory.getInstance().fromDescription("datetime", database).toDatabaseDataType(database) + " NOT NULL, " +
+                            "ORDEREXECUTED INT NOT NULL, " +
+                            "EXECTYPE VARCHAR(10) NOT NULL, " +
+                            "MD5SUM VARCHAR(35) NULL, " +
+                            "DESCRIPTION VARCHAR(255) NULL, " +
+                            "COMMENTS VARCHAR(255) NULL, " +
+                            "TAG VARCHAR(255) NULL, " +
+                            "LIQUIBASE VARCHAR(20) NULL, " +
+                            "CONTEXTS VARCHAR(255) NULL, " +
+                            "LABELS VARCHAR(255) NULL, " +
+                            "DEPLOYMENT_ID VARCHAR(10) NULL, " +
+                            "PRIMARY KEY(ID, AUTHOR, FILENAME))",
+                            getAffectedTable(database))
+            };
+        } finally {
+            database.setObjectQuotingStrategy(currentStrategy);
+        }
     }
 
     protected Relation getAffectedTable(Database database) {

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/InitializeDatabaseChangeLogLockTableGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/InitializeDatabaseChangeLogLockTableGenerator.java
@@ -1,6 +1,7 @@
 package liquibase.sqlgenerator.core;
 
 import liquibase.database.Database;
+import liquibase.database.ObjectQuotingStrategy;
 import liquibase.exception.ValidationErrors;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
@@ -22,16 +23,22 @@ public class InitializeDatabaseChangeLogLockTableGenerator extends AbstractSqlGe
 
     @Override
     public Sql[] generateSql(InitializeDatabaseChangeLogLockTableStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
-        DeleteStatement deleteStatement = new DeleteStatement(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogLockTableName());
-        InsertStatement insertStatement = new InsertStatement(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogLockTableName())
-                .addColumnValue("ID", 1)
-                .addColumnValue("LOCKED", Boolean.FALSE);
+        ObjectQuotingStrategy currentStrategy = database.getObjectQuotingStrategy();
+        database.setObjectQuotingStrategy(ObjectQuotingStrategy.LEGACY);
+        try {
+            DeleteStatement deleteStatement = new DeleteStatement(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogLockTableName());
+            InsertStatement insertStatement = new InsertStatement(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogLockTableName())
+                    .addColumnValue("ID", 1)
+                    .addColumnValue("LOCKED", Boolean.FALSE);
 
-        List<Sql> sql = new ArrayList<>();
+            List<Sql> sql = new ArrayList<>();
 
-        sql.addAll(Arrays.asList(SqlGeneratorFactory.getInstance().generateSql(deleteStatement, database)));
-        sql.addAll(Arrays.asList(SqlGeneratorFactory.getInstance().generateSql(insertStatement, database)));
+            sql.addAll(Arrays.asList(SqlGeneratorFactory.getInstance().generateSql(deleteStatement, database)));
+            sql.addAll(Arrays.asList(SqlGeneratorFactory.getInstance().generateSql(insertStatement, database)));
 
-        return sql.toArray(new Sql[sql.size()]);
+            return sql.toArray(new Sql[sql.size()]);
+        } finally {
+            database.setObjectQuotingStrategy(currentStrategy);
+        }
     }
 }

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/LockDatabaseChangeLogGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/LockDatabaseChangeLogGenerator.java
@@ -1,6 +1,7 @@
 package liquibase.sqlgenerator.core;
 
 import liquibase.database.Database;
+import liquibase.database.ObjectQuotingStrategy;
 import liquibase.datatype.DataTypeFactory;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.exception.ValidationErrors;
@@ -39,13 +40,20 @@ public class LockDatabaseChangeLogGenerator extends AbstractSqlGenerator<LockDat
     	String liquibaseSchema = database.getLiquibaseSchemaName();
         String liquibaseCatalog = database.getLiquibaseCatalogName();
 
-        UpdateStatement updateStatement = new UpdateStatement(liquibaseCatalog, liquibaseSchema, database.getDatabaseChangeLogLockTableName());
-        updateStatement.addNewColumnValue("LOCKED", true);
-        updateStatement.addNewColumnValue("LOCKGRANTED", new Timestamp(new java.util.Date().getTime()));
-        updateStatement.addNewColumnValue("LOCKEDBY", hostname + hostDescription + " (" + hostaddress + ")");
-        updateStatement.setWhereClause(database.escapeColumnName(liquibaseCatalog, liquibaseSchema, database.getDatabaseChangeLogTableName(), "ID") + " = 1 AND " + database.escapeColumnName(liquibaseCatalog, liquibaseSchema, database.getDatabaseChangeLogTableName(), "LOCKED") + " = "+ DataTypeFactory.getInstance().fromDescription("boolean", database).objectToSql(false, database));
+        // use LEGACY quoting since we're dealing with system objects
+        ObjectQuotingStrategy currentStrategy = database.getObjectQuotingStrategy();
+        database.setObjectQuotingStrategy(ObjectQuotingStrategy.LEGACY);
+        try {
+            UpdateStatement updateStatement = new UpdateStatement(liquibaseCatalog, liquibaseSchema, database.getDatabaseChangeLogLockTableName());
+            updateStatement.addNewColumnValue("LOCKED", true);
+            updateStatement.addNewColumnValue("LOCKGRANTED", new Timestamp(new java.util.Date().getTime()));
+            updateStatement.addNewColumnValue("LOCKEDBY", hostname + hostDescription + " (" + hostaddress + ")");
+            updateStatement.setWhereClause(database.escapeColumnName(liquibaseCatalog, liquibaseSchema, database.getDatabaseChangeLogTableName(), "ID") + " = 1 AND " + database.escapeColumnName(liquibaseCatalog, liquibaseSchema, database.getDatabaseChangeLogTableName(), "LOCKED") + " = "+ DataTypeFactory.getInstance().fromDescription("boolean", database).objectToSql(false, database));
 
-        return SqlGeneratorFactory.getInstance().generateSql(updateStatement, database);
+            return SqlGeneratorFactory.getInstance().generateSql(updateStatement, database);
+        } finally {
+            database.setObjectQuotingStrategy(currentStrategy);
+        }
 
     }
 }

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/MarkChangeSetRanGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/MarkChangeSetRanGenerator.java
@@ -7,6 +7,7 @@ import liquibase.changelog.ChangeLogHistoryServiceFactory;
 import liquibase.changelog.ChangeSet;
 import liquibase.changelog.column.LiquibaseColumn;
 import liquibase.database.Database;
+import liquibase.database.ObjectQuotingStrategy;
 import liquibase.exception.LiquibaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.exception.ValidationErrors;
@@ -18,7 +19,6 @@ import liquibase.statement.SqlStatement;
 import liquibase.statement.core.InsertStatement;
 import liquibase.statement.core.MarkChangeSetRanStatement;
 import liquibase.statement.core.UpdateStatement;
-import liquibase.structure.core.Column;
 import liquibase.util.LiquibaseUtil;
 import liquibase.util.StringUtils;
 
@@ -45,65 +45,72 @@ public class MarkChangeSetRanGenerator extends AbstractSqlGenerator<MarkChangeSe
         ChangeSet changeSet = statement.getChangeSet();
 
         SqlStatement runStatement;
+        // use LEGACY quoting since we're dealing with system objects
+        ObjectQuotingStrategy currentStrategy = database.getObjectQuotingStrategy();
+        database.setObjectQuotingStrategy(ObjectQuotingStrategy.LEGACY);
         try {
-            if (statement.getExecType().equals(ChangeSet.ExecType.FAILED) || statement.getExecType().equals(ChangeSet.ExecType.SKIPPED)) {
-                return new Sql[0]; //don't mark
+            try {
+                if (statement.getExecType().equals(ChangeSet.ExecType.FAILED) || statement.getExecType().equals(ChangeSet.ExecType.SKIPPED)) {
+                    return new Sql[0]; //don't mark
+                }
+
+                String tag = null;
+                for (Change change : changeSet.getChanges()) {
+                    if (change instanceof TagDatabaseChange) {
+                        TagDatabaseChange tagChange = (TagDatabaseChange) change;
+                        tag = tagChange.getTag();
+                    }
+                }
+
+                if (statement.getExecType().ranBefore) {
+                    runStatement = new UpdateStatement(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogTableName())
+                            .addNewColumnValue("DATEEXECUTED", new DatabaseFunction(dateValue))
+                            .addNewColumnValue("ORDEREXECUTED", ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database).getNextSequenceValue())
+                            .addNewColumnValue("MD5SUM", changeSet.generateCheckSum().toString())
+                            .addNewColumnValue("EXECTYPE", statement.getExecType().value)
+                            .addNewColumnValue("DEPLOYMENT_ID", ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database).getDeploymentId())
+                            .setWhereClause(database.escapeObjectName("ID", LiquibaseColumn.class) + " = ? " +
+                                                    "AND " + database.escapeObjectName("AUTHOR", LiquibaseColumn.class) + " = ? " +
+                                                    "AND " + database.escapeObjectName("FILENAME", LiquibaseColumn.class) + " = ?")
+                            .addWhereParameters(changeSet.getId(), changeSet.getAuthor(), changeSet.getFilePath());
+
+                    if (tag != null) {
+                        ((UpdateStatement) runStatement).addNewColumnValue("TAG", tag);
+                    }
+                } else {
+                    runStatement = new InsertStatement(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogTableName())
+                            .addColumnValue("ID", changeSet.getId())
+                            .addColumnValue("AUTHOR", changeSet.getAuthor())
+                            .addColumnValue("FILENAME", changeSet.getFilePath())
+                            .addColumnValue("DATEEXECUTED", new DatabaseFunction(dateValue))
+                            .addColumnValue("ORDEREXECUTED", ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database).getNextSequenceValue())
+                            .addColumnValue("MD5SUM", changeSet.generateCheckSum().toString())
+                            .addColumnValue("DESCRIPTION", limitSize(changeSet.getDescription()))
+                            .addColumnValue("COMMENTS", limitSize(StringUtils.trimToEmpty(changeSet.getComments())))
+                            .addColumnValue("EXECTYPE", statement.getExecType().value)
+                            .addColumnValue("CONTEXTS", ((changeSet.getContexts() == null) || changeSet.getContexts()
+                                                                                                       .isEmpty()) ? null : buildFullContext(changeSet))
+                            .addColumnValue("LABELS", ((changeSet.getLabels() == null) || changeSet.getLabels().isEmpty()
+                            ) ? null : changeSet.getLabels().toString())
+                            .addColumnValue("LIQUIBASE", StringUtils.limitSize(LiquibaseUtil.getBuildVersion()
+                                                                                            .replaceAll("SNAPSHOT", "SNP")
+                                                                                            .replaceAll("beta", "b")
+                                                                                            .replaceAll("alpha", "b"), 20)
+                            )
+                            .addColumnValue("DEPLOYMENT_ID", ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database).getDeploymentId());
+
+                    if (tag != null) {
+                        ((InsertStatement) runStatement).addColumnValue("TAG", tag);
+                    }
+                }
+            } catch (LiquibaseException e) {
+                throw new UnexpectedLiquibaseException(e);
             }
 
-            String tag = null;
-            for (Change change : changeSet.getChanges()) {
-                if (change instanceof TagDatabaseChange) {
-                    TagDatabaseChange tagChange = (TagDatabaseChange) change;
-                    tag = tagChange.getTag();
-                }
-            }
-
-            if (statement.getExecType().ranBefore) {
-                runStatement = new UpdateStatement(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogTableName())
-                        .addNewColumnValue("DATEEXECUTED", new DatabaseFunction(dateValue))
-                        .addNewColumnValue("ORDEREXECUTED", ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database).getNextSequenceValue())
-                        .addNewColumnValue("MD5SUM", changeSet.generateCheckSum().toString())
-                        .addNewColumnValue("EXECTYPE", statement.getExecType().value)
-                        .addNewColumnValue("DEPLOYMENT_ID", ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database).getDeploymentId())
-                        .setWhereClause(database.escapeObjectName("ID", LiquibaseColumn.class) + " = ? " +
-                                                "AND " + database.escapeObjectName("AUTHOR", LiquibaseColumn.class) + " = ? " +
-                                                "AND " + database.escapeObjectName("FILENAME", LiquibaseColumn.class) + " = ?")
-                        .addWhereParameters(changeSet.getId(), changeSet.getAuthor(), changeSet.getFilePath());
-
-                if (tag != null) {
-                    ((UpdateStatement) runStatement).addNewColumnValue("TAG", tag);
-                }
-            } else {
-                runStatement = new InsertStatement(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogTableName())
-                        .addColumnValue("ID", changeSet.getId())
-                        .addColumnValue("AUTHOR", changeSet.getAuthor())
-                        .addColumnValue("FILENAME", changeSet.getFilePath())
-                        .addColumnValue("DATEEXECUTED", new DatabaseFunction(dateValue))
-                        .addColumnValue("ORDEREXECUTED", ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database).getNextSequenceValue())
-                        .addColumnValue("MD5SUM", changeSet.generateCheckSum().toString())
-                        .addColumnValue("DESCRIPTION", limitSize(changeSet.getDescription()))
-                        .addColumnValue("COMMENTS", limitSize(StringUtils.trimToEmpty(changeSet.getComments())))
-                        .addColumnValue("EXECTYPE", statement.getExecType().value)
-                        .addColumnValue("CONTEXTS", ((changeSet.getContexts() == null) || changeSet.getContexts()
-                            .isEmpty()) ? null : buildFullContext(changeSet))
-                        .addColumnValue("LABELS", ((changeSet.getLabels() == null) || changeSet.getLabels().isEmpty()
-                        ) ? null : changeSet.getLabels().toString())
-                        .addColumnValue("LIQUIBASE", StringUtils.limitSize(LiquibaseUtil.getBuildVersion()
-                                .replaceAll("SNAPSHOT", "SNP")
-                                .replaceAll("beta", "b")
-                                .replaceAll("alpha", "b"), 20)
-                        )
-                        .addColumnValue("DEPLOYMENT_ID", ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database).getDeploymentId());
-
-                if (tag != null) {
-                    ((InsertStatement) runStatement).addColumnValue("TAG", tag);
-                }
-            }
-        } catch (LiquibaseException e) {
-            throw new UnexpectedLiquibaseException(e);
+            return SqlGeneratorFactory.getInstance().generateSql(runStatement, database);
+        } finally {
+            database.setObjectQuotingStrategy(currentStrategy);
         }
-
-        return SqlGeneratorFactory.getInstance().generateSql(runStatement, database);
     }
 
     private String buildFullContext(ChangeSet changeSet) {

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/SelectFromDatabaseChangeLogGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/SelectFromDatabaseChangeLogGenerator.java
@@ -2,7 +2,12 @@ package liquibase.sqlgenerator.core;
 
 import liquibase.change.ColumnConfig;
 import liquibase.database.Database;
-import liquibase.database.core.*;
+import liquibase.database.ObjectQuotingStrategy;
+import liquibase.database.core.AbstractDb2Database;
+import liquibase.database.core.MSSQLDatabase;
+import liquibase.database.core.MySQLDatabase;
+import liquibase.database.core.OracleDatabase;
+import liquibase.database.core.PostgresDatabase;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.exception.ValidationErrors;
 import liquibase.sql.Sql;
@@ -28,63 +33,70 @@ public class SelectFromDatabaseChangeLogGenerator extends AbstractSqlGenerator<S
     @Override
     public Sql[] generateSql(SelectFromDatabaseChangeLogStatement statement, final Database database, SqlGeneratorChain sqlGeneratorChain) {
         List<ColumnConfig> columnsToSelect = Arrays.asList(statement.getColumnsToSelect());
-        String sql = "SELECT " + (database instanceof MSSQLDatabase && statement.getLimit() != null ? "TOP "+statement.getLimit()+" " : "") + StringUtils.join(columnsToSelect, ",", new StringUtils.StringUtilsFormatter<ColumnConfig>() {
-            @Override
-            public String toString(ColumnConfig column) {
-                if ((column.getComputed() != null) && column.getComputed()) {
-                    return column.getName();
-                } else {
-                    return database.escapeColumnName(null, null, null, column.getName());
+        // use LEGACY quoting since we're dealing with system objects
+        ObjectQuotingStrategy currentStrategy = database.getObjectQuotingStrategy();
+        database.setObjectQuotingStrategy(ObjectQuotingStrategy.LEGACY);
+        try {
+            String sql = "SELECT " + (database instanceof MSSQLDatabase && statement.getLimit() != null ? "TOP "+statement.getLimit()+" " : "") + StringUtils.join(columnsToSelect, ",", new StringUtils.StringUtilsFormatter<ColumnConfig>() {
+                @Override
+                public String toString(ColumnConfig column) {
+                    if ((column.getComputed() != null) && column.getComputed()) {
+                        return column.getName();
+                    } else {
+                        return database.escapeColumnName(null, null, null, column.getName());
+                    }
                 }
-            }
-        }).toUpperCase() + " FROM " +
-                database.escapeTableName(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogTableName());
+            }).toUpperCase() + " FROM " +
+                    database.escapeTableName(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogTableName());
 
-        SelectFromDatabaseChangeLogStatement.WhereClause whereClause = statement.getWhereClause();
-        if (whereClause != null) {
-            if (whereClause instanceof SelectFromDatabaseChangeLogStatement.ByTag) {
-                sql += " WHERE "+database.escapeColumnName(null, null, null, "TAG")+"='" + ((SelectFromDatabaseChangeLogStatement.ByTag) whereClause).getTagName() + "'";
-            } else if (whereClause instanceof SelectFromDatabaseChangeLogStatement.ByNotNullCheckSum) {
+            SelectFromDatabaseChangeLogStatement.WhereClause whereClause = statement.getWhereClause();
+            if (whereClause != null) {
+                if (whereClause instanceof SelectFromDatabaseChangeLogStatement.ByTag) {
+                    sql += " WHERE "+database.escapeColumnName(null, null, null, "TAG")+"='" + ((SelectFromDatabaseChangeLogStatement.ByTag) whereClause).getTagName() + "'";
+                } else if (whereClause instanceof SelectFromDatabaseChangeLogStatement.ByNotNullCheckSum) {
                     sql += " WHERE "+database.escapeColumnName(null, null, null, "MD5SUM")+" IS NOT NULL";
-            } else {
-                throw new UnexpectedLiquibaseException("Unknown where clause type: " + whereClause.getClass().getName());
-            }
-        }
-
-        if ((statement.getOrderByColumns() != null) && (statement.getOrderByColumns().length > 0)) {
-            sql += " ORDER BY ";
-            Iterator<String> orderBy = Arrays.asList(statement.getOrderByColumns()).iterator();
-
-            while (orderBy.hasNext()) {
-                String orderColumn = orderBy.next();
-                String[] orderColumnData = orderColumn.split(" ");
-                sql += database.escapeColumnName(null, null, null, orderColumnData[0]);
-                if (orderColumnData.length == 2) {
-                    sql += " ";
-                    sql += orderColumnData[1].toUpperCase();
-                }
-                if (orderBy.hasNext()) {
-                    sql += ", ";
-                }
-            }
-        }
-
-        if (statement.getLimit() != null) {
-            if (database instanceof OracleDatabase) {
-                if (whereClause == null) {
-                    sql += " WHERE ROWNUM="+statement.getLimit();
                 } else {
-                    sql += " AND ROWNUM="+statement.getLimit();
+                    throw new UnexpectedLiquibaseException("Unknown where clause type: " + whereClause.getClass().getName());
                 }
-            } else if ((database instanceof MySQLDatabase) || (database instanceof PostgresDatabase)) {
-                sql += " LIMIT "+statement.getLimit();
-            } else if (database instanceof AbstractDb2Database) {
-                sql += " FETCH FIRST "+statement.getLimit()+" ROWS ONLY";
             }
-        }
 
-        return new Sql[]{
-                new UnparsedSql(sql)
-        };
+            if ((statement.getOrderByColumns() != null) && (statement.getOrderByColumns().length > 0)) {
+                sql += " ORDER BY ";
+                Iterator<String> orderBy = Arrays.asList(statement.getOrderByColumns()).iterator();
+
+                while (orderBy.hasNext()) {
+                    String orderColumn = orderBy.next();
+                    String[] orderColumnData = orderColumn.split(" ");
+                    sql += database.escapeColumnName(null, null, null, orderColumnData[0]);
+                    if (orderColumnData.length == 2) {
+                        sql += " ";
+                        sql += orderColumnData[1].toUpperCase();
+                    }
+                    if (orderBy.hasNext()) {
+                        sql += ", ";
+                    }
+                }
+            }
+
+            if (statement.getLimit() != null) {
+                if (database instanceof OracleDatabase) {
+                    if (whereClause == null) {
+                        sql += " WHERE ROWNUM="+statement.getLimit();
+                    } else {
+                        sql += " AND ROWNUM="+statement.getLimit();
+                    }
+                } else if ((database instanceof MySQLDatabase) || (database instanceof PostgresDatabase)) {
+                    sql += " LIMIT "+statement.getLimit();
+                } else if (database instanceof AbstractDb2Database) {
+                    sql += " FETCH FIRST "+statement.getLimit()+" ROWS ONLY";
+                }
+            }
+
+            return new Sql[]{
+                    new UnparsedSql(sql)
+            };
+        } finally {
+            database.setObjectQuotingStrategy(currentStrategy);
+        }
     }
 }

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/TagDatabaseGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/TagDatabaseGenerator.java
@@ -1,6 +1,7 @@
 package liquibase.sqlgenerator.core;
 
 import liquibase.database.Database;
+import liquibase.database.ObjectQuotingStrategy;
 import liquibase.database.core.*;
 import liquibase.datatype.DataTypeFactory;
 import liquibase.exception.ValidationErrors;
@@ -24,106 +25,112 @@ public class TagDatabaseGenerator extends AbstractSqlGenerator<TagDatabaseStatem
 
     @Override
     public Sql[] generateSql(TagDatabaseStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
-        String tableNameEscaped = database.escapeTableName(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogTableName());
-        String orderColumnNameEscaped = database.escapeObjectName("ORDEREXECUTED", Column.class);
-        String dateColumnNameEscaped = database.escapeObjectName("DATEEXECUTED", Column.class);
-        String tagColumnNameEscaped = database.escapeObjectName("TAG", Column.class);
-        String tagEscaped = DataTypeFactory.getInstance().fromObject(statement.getTag(), database).objectToSql(statement.getTag(), database);
-        if (database instanceof MySQLDatabase) {
-            return new Sql[]{
-                    new UnparsedSql(
-                            "UPDATE " + tableNameEscaped + " AS C " +
-                                    "INNER JOIN (" +
-                                    "SELECT " + orderColumnNameEscaped + ", " + dateColumnNameEscaped + " " +
-                                    "FROM " + tableNameEscaped +
-                                    " order by " + dateColumnNameEscaped + " desc, " + orderColumnNameEscaped + " desc limit 1) AS D " +
-                                    "ON C." + orderColumnNameEscaped + " = D." + orderColumnNameEscaped + " " +
-                                    "SET C." + tagColumnNameEscaped + " = " + tagEscaped)
-            };
-        } else if (database instanceof PostgresDatabase) {
-            return new Sql[]{
-                    new UnparsedSql(
-                            "UPDATE " + tableNameEscaped + " t SET TAG=" + tagEscaped +
-                                    " FROM (SELECT " + dateColumnNameEscaped + ", " + orderColumnNameEscaped + " FROM " + tableNameEscaped + " ORDER BY " + dateColumnNameEscaped + " DESC, " + orderColumnNameEscaped + " DESC LIMIT 1) sub " +
-                                    "WHERE t." + dateColumnNameEscaped + "=sub." + dateColumnNameEscaped + " AND t." + orderColumnNameEscaped + "=sub." + orderColumnNameEscaped)
-            };
-        } else if (database instanceof InformixDatabase) {
-            String tempTableNameEscaped = database.escapeObjectName("max_order_temp", Table.class);
-            return new Sql[]{
-                    new UnparsedSql(
-                            "SELECT MAX(" + dateColumnNameEscaped + ") AS " + dateColumnNameEscaped +
-                                    ", MAX(" + orderColumnNameEscaped + ") AS " + orderColumnNameEscaped + " " +
-                                    "FROM " + tableNameEscaped + " " +
-                                    "INTO TEMP " + tempTableNameEscaped + " WITH NO LOG"),
-                    new UnparsedSql(
-                            "UPDATE " + tableNameEscaped + " " +
-                                    "SET TAG = " + tagEscaped + " " +
-                                    "WHERE " + dateColumnNameEscaped + " = (" +
-                                    "SELECT " + dateColumnNameEscaped + " " +
-                                    "FROM " + tempTableNameEscaped +
-                                    ") AND " +
-                                    orderColumnNameEscaped + " = (" +
-                                    "SELECT " + orderColumnNameEscaped + " " +
-                                    "FROM " + tempTableNameEscaped +
-                                    ");"),
-                    new UnparsedSql(
-                            "DROP TABLE " + tempTableNameEscaped + ";")
-            };
-        } else if (database instanceof MSSQLDatabase) {
-            String changelogAliasEscaped = database.escapeObjectName("changelog", Table.class);
-            String latestAliasEscaped = database.escapeObjectName("latest", Table.class);
-            String idColumnEscaped = database.escapeObjectName("ID", Column.class);
-            String authorColumnEscaped = database.escapeObjectName("AUTHOR", Column.class);
-            String filenameColumnEscaped = database.escapeObjectName("FILENAME", Column.class);
-
-            String topClause = "TOP (1)";
-
-            return new Sql[] {
-                    new UnparsedSql(
-                            "UPDATE " + changelogAliasEscaped + " " +
-                            "SET " + tagColumnNameEscaped + " = " + tagEscaped + " " +
-                            "FROM " + tableNameEscaped + " AS " + changelogAliasEscaped + " "  +
-                            "INNER JOIN (" +
-                                "SELECT " + topClause + " " + idColumnEscaped + ", " + authorColumnEscaped + ", " + filenameColumnEscaped + " " +
-                                "FROM " + tableNameEscaped + " " +
-                                "ORDER BY " + dateColumnNameEscaped + " DESC, " + orderColumnNameEscaped + " DESC" +
-                            ") AS " + latestAliasEscaped + " " +
-                            "ON " + latestAliasEscaped + "." + idColumnEscaped + " = " + changelogAliasEscaped + "." + idColumnEscaped + " " +
-                            "AND " + latestAliasEscaped + "." + authorColumnEscaped + " = " + changelogAliasEscaped + "." + authorColumnEscaped + " " +
-                            "AND " + latestAliasEscaped + "." + filenameColumnEscaped + " = " + changelogAliasEscaped + "." + filenameColumnEscaped)
+        ObjectQuotingStrategy currentStrategy = database.getObjectQuotingStrategy();
+        database.setObjectQuotingStrategy(ObjectQuotingStrategy.LEGACY);
+        try {
+            String tableNameEscaped = database.escapeTableName(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogTableName());
+            String orderColumnNameEscaped = database.escapeObjectName("ORDEREXECUTED", Column.class);
+            String dateColumnNameEscaped = database.escapeObjectName("DATEEXECUTED", Column.class);
+            String tagColumnNameEscaped = database.escapeObjectName("TAG", Column.class);
+            String tagEscaped = DataTypeFactory.getInstance().fromObject(statement.getTag(), database).objectToSql(statement.getTag(), database);
+            if (database instanceof MySQLDatabase) {
+                return new Sql[]{
+                        new UnparsedSql(
+                                "UPDATE " + tableNameEscaped + " AS C " +
+                                        "INNER JOIN (" +
+                                        "SELECT " + orderColumnNameEscaped + ", " + dateColumnNameEscaped + " " +
+                                        "FROM " + tableNameEscaped +
+                                        " order by " + dateColumnNameEscaped + " desc, " + orderColumnNameEscaped + " desc limit 1) AS D " +
+                                        "ON C." + orderColumnNameEscaped + " = D." + orderColumnNameEscaped + " " +
+                                        "SET C." + tagColumnNameEscaped + " = " + tagEscaped)
                 };
-        } else if ((database instanceof OracleDatabase) || (database instanceof DB2Database)) {
-            String selectClause = "SELECT";
-            String endClause = ")";
-            String delimiter = "";
-            if (database instanceof OracleDatabase) {
-                selectClause = "SELECT * FROM (SELECT";
-                endClause = ") where rownum=1)";
-            } else if (database instanceof AbstractDb2Database) {
-                endClause = " FETCH FIRST 1 ROWS ONLY)";
+            } else if (database instanceof PostgresDatabase) {
+                return new Sql[]{
+                        new UnparsedSql(
+                                "UPDATE " + tableNameEscaped + " t SET TAG=" + tagEscaped +
+                                        " FROM (SELECT " + dateColumnNameEscaped + ", " + orderColumnNameEscaped + " FROM " + tableNameEscaped + " ORDER BY " + dateColumnNameEscaped + " DESC, " + orderColumnNameEscaped + " DESC LIMIT 1) sub " +
+                                        "WHERE t." + dateColumnNameEscaped + "=sub." + dateColumnNameEscaped + " AND t." + orderColumnNameEscaped + "=sub." + orderColumnNameEscaped)
+                };
+            } else if (database instanceof InformixDatabase) {
+                String tempTableNameEscaped = database.escapeObjectName("max_order_temp", Table.class);
+                return new Sql[]{
+                        new UnparsedSql(
+                                "SELECT MAX(" + dateColumnNameEscaped + ") AS " + dateColumnNameEscaped +
+                                        ", MAX(" + orderColumnNameEscaped + ") AS " + orderColumnNameEscaped + " " +
+                                        "FROM " + tableNameEscaped + " " +
+                                        "INTO TEMP " + tempTableNameEscaped + " WITH NO LOG"),
+                        new UnparsedSql(
+                                "UPDATE " + tableNameEscaped + " " +
+                                        "SET TAG = " + tagEscaped + " " +
+                                        "WHERE " + dateColumnNameEscaped + " = (" +
+                                        "SELECT " + dateColumnNameEscaped + " " +
+                                        "FROM " + tempTableNameEscaped +
+                                        ") AND " +
+                                        orderColumnNameEscaped + " = (" +
+                                        "SELECT " + orderColumnNameEscaped + " " +
+                                        "FROM " + tempTableNameEscaped +
+                                        ");"),
+                        new UnparsedSql(
+                                "DROP TABLE " + tempTableNameEscaped + ";")
+                };
+            } else if (database instanceof MSSQLDatabase) {
+                String changelogAliasEscaped = database.escapeObjectName("changelog", Table.class);
+                String latestAliasEscaped = database.escapeObjectName("latest", Table.class);
+                String idColumnEscaped = database.escapeObjectName("ID", Column.class);
+                String authorColumnEscaped = database.escapeObjectName("AUTHOR", Column.class);
+                String filenameColumnEscaped = database.escapeObjectName("FILENAME", Column.class);
+
+                String topClause = "TOP (1)";
+
+                return new Sql[] {
+                        new UnparsedSql(
+                                "UPDATE " + changelogAliasEscaped + " " +
+                                "SET " + tagColumnNameEscaped + " = " + tagEscaped + " " +
+                                "FROM " + tableNameEscaped + " AS " + changelogAliasEscaped + " "  +
+                                "INNER JOIN (" +
+                                    "SELECT " + topClause + " " + idColumnEscaped + ", " + authorColumnEscaped + ", " + filenameColumnEscaped + " " +
+                                    "FROM " + tableNameEscaped + " " +
+                                    "ORDER BY " + dateColumnNameEscaped + " DESC, " + orderColumnNameEscaped + " DESC" +
+                                ") AS " + latestAliasEscaped + " " +
+                                "ON " + latestAliasEscaped + "." + idColumnEscaped + " = " + changelogAliasEscaped + "." + idColumnEscaped + " " +
+                                "AND " + latestAliasEscaped + "." + authorColumnEscaped + " = " + changelogAliasEscaped + "." + authorColumnEscaped + " " +
+                                "AND " + latestAliasEscaped + "." + filenameColumnEscaped + " = " + changelogAliasEscaped + "." + filenameColumnEscaped)
+                    };
+            } else if ((database instanceof OracleDatabase) || (database instanceof DB2Database)) {
+                String selectClause = "SELECT";
+                String endClause = ")";
+                String delimiter = "";
+                if (database instanceof OracleDatabase) {
+                    selectClause = "SELECT * FROM (SELECT";
+                    endClause = ") where rownum=1)";
+                } else if (database instanceof AbstractDb2Database) {
+                    endClause = " FETCH FIRST 1 ROWS ONLY)";
+                }
+
+                return new Sql[]{
+                        new UnparsedSql("MERGE INTO " + tableNameEscaped + " a " +
+                                "USING (" + selectClause + " " + orderColumnNameEscaped + ", " + dateColumnNameEscaped + " from " + tableNameEscaped + " order by " + dateColumnNameEscaped + " desc, " + orderColumnNameEscaped + " desc" + endClause + " b " +
+                                "ON ( a." + dateColumnNameEscaped + " = b." + dateColumnNameEscaped + " and a." + orderColumnNameEscaped + "=b." + orderColumnNameEscaped + " ) " +
+                                "WHEN MATCHED THEN " +
+                                "UPDATE SET  a.tag=" + tagEscaped + delimiter)
+                };
+            } else {
+
+                //Only uses dateexecuted as a default. Depending on the timestamp resolution, multiple rows may be tagged which normally works fine but can cause confusion and some issues.
+                //We cannot use orderexecuted alone because it is only guaranteed to be incrementing per update call.
+                //TODO: Better handle other databases to use dateexecuted desc, orderexecuted desc.
+                UpdateStatement updateStatement = new UpdateStatement(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogTableName())
+                        .addNewColumnValue("TAG", statement.getTag())
+                        .setWhereClause(
+                                dateColumnNameEscaped + " = (" +
+                                        "SELECT MAX(" + dateColumnNameEscaped + ") " +
+                                        "FROM " + tableNameEscaped +
+                                        ")");
+
+                return SqlGeneratorFactory.getInstance().generateSql(updateStatement, database);
             }
-
-            return new Sql[]{
-                    new UnparsedSql("MERGE INTO " + tableNameEscaped + " a " +
-                            "USING (" + selectClause + " " + orderColumnNameEscaped + ", " + dateColumnNameEscaped + " from " + tableNameEscaped + " order by " + dateColumnNameEscaped + " desc, " + orderColumnNameEscaped + " desc" + endClause + " b " +
-                            "ON ( a." + dateColumnNameEscaped + " = b." + dateColumnNameEscaped + " and a." + orderColumnNameEscaped + "=b." + orderColumnNameEscaped + " ) " +
-                            "WHEN MATCHED THEN " +
-                            "UPDATE SET  a.tag=" + tagEscaped + delimiter)
-            };
-        } else {
-
-            //Only uses dateexecuted as a default. Depending on the timestamp resolution, multiple rows may be tagged which normally works fine but can cause confusion and some issues.
-            //We cannot use orderexecuted alone because it is only guaranteed to be incrementing per update call.
-            //TODO: Better handle other databases to use dateexecuted desc, orderexecuted desc.
-            UpdateStatement updateStatement = new UpdateStatement(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogTableName())
-                    .addNewColumnValue("TAG", statement.getTag())
-                    .setWhereClause(
-                            dateColumnNameEscaped + " = (" +
-                                    "SELECT MAX(" + dateColumnNameEscaped + ") " +
-                                    "FROM " + tableNameEscaped +
-                                    ")");
-
-            return SqlGeneratorFactory.getInstance().generateSql(updateStatement, database);
+        } finally {
+            database.setObjectQuotingStrategy(currentStrategy);
         }
 
     }


### PR DESCRIPTION
When liquibase starts the very first time, the `databasechangelog` and `databasechangeloglock` are created using the default configuration which enforces object quoting strategy to LEGACY (this is not configurable)

However, when running a changelog that enforces a different quoting strategy (for instance `ALL`) this strategy overrides the default, and future interactions with the liquibase changelog tables will use the new strategy, thus resulting in errors like:

```java
Unexpected error running Liquibase: Error executing SQL SELECT MAX("ORDEREXECUTED") FROM "myschema"."databasechangelog": ERROR: column "ORDEREXECUTED" does not exist
  Position: 12
liquibase.exception.UnexpectedLiquibaseException: liquibase.exception.DatabaseException: Error executing SQL SELECT MAX("ORDEREXECUTED") FROM "myschema"."databasechangelog": ERROR: column "ORDEREXECUTED" does not exist
  Position: 12
	at liquibase.sqlgenerator.core.MarkChangeSetRanGenerator.generateSql(MarkChangeSetRanGenerator.java:99)
	at liquibase.sqlgenerator.core.MarkChangeSetRanGenerator.generateSql(MarkChangeSetRanGenerator.java:25)
	at liquibase.sqlgenerator.SqlGeneratorChain.generateSql(SqlGeneratorChain.java:30)
	at liquibase.sqlgenerator.SqlGeneratorFactory.generateSql(SqlGeneratorFactory.java:222)
	at liquibase.executor.AbstractExecutor.applyVisitors(AbstractExecutor.java:25)
	at liquibase.executor.jvm.JdbcExecutor.access$600(JdbcExecutor.java:40)
	at liquibase.executor.jvm.JdbcExecutor$ExecuteStatementCallback.doInStatement(JdbcExecutor.java:384)
	at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:59)
	at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:131)
	at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:111)
	at liquibase.changelog.StandardChangeLogHistoryService.setExecType(StandardChangeLogHistoryService.java:388)
	at liquibase.database.AbstractJdbcDatabase.markChangeSetExecStatus(AbstractJdbcDatabase.java:1133)
	at liquibase.changelog.visitor.UpdateVisitor.visit(UpdateVisitor.java:64)
	at liquibase.changelog.ChangeLogIterator.run(ChangeLogIterator.java:83)
	at liquibase.Liquibase.update(Liquibase.java:202)
	at liquibase.Liquibase.update(Liquibase.java:179)
	at liquibase.Liquibase.update(Liquibase.java:334)
	at liquibase.Liquibase.updateTestingRollback(Liquibase.java:1224)
	at liquibase.Liquibase.updateTestingRollback(Liquibase.java:1215)
	at liquibase.integration.commandline.Main.doMigration(Main.java:1585)
	at liquibase.integration.commandline.Main.run(Main.java:279)
	at liquibase.integration.commandline.Main.main(Main.java:157)
Caused by: liquibase.exception.DatabaseException: Error executing SQL SELECT MAX("ORDEREXECUTED") FROM "myschema"."databasechangelog": ERROR: column "ORDEREXECUTED" does not exist
  Position: 12
	at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:72)
	at liquibase.executor.jvm.JdbcExecutor.query(JdbcExecutor.java:145)
	at liquibase.executor.jvm.JdbcExecutor.query(JdbcExecutor.java:153)
	at liquibase.executor.jvm.JdbcExecutor.queryForObject(JdbcExecutor.java:161)
	at liquibase.executor.jvm.JdbcExecutor.queryForObject(JdbcExecutor.java:176)
	at liquibase.executor.jvm.JdbcExecutor.queryForInt(JdbcExecutor.java:197)
	at liquibase.executor.jvm.JdbcExecutor.queryForInt(JdbcExecutor.java:192)
	at liquibase.changelog.StandardChangeLogHistoryService.getNextSequenceValue(StandardChangeLogHistoryService.java:413)
	at liquibase.sqlgenerator.core.MarkChangeSetRanGenerator.generateSql(MarkChangeSetRanGenerator.java:82)
	... 21 common frames omitted
Caused by: org.postgresql.util.PSQLException: ERROR: column "ORDEREXECUTED" does not exist
  Position: 12
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2468)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2211)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:309)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:446)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:370)
	at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:311)
	at org.postgresql.jdbc.PgStatement.executeCachedSql(PgStatement.java:297)
	at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:274)
	at org.postgresql.jdbc.PgStatement.executeQuery(PgStatement.java:225)
	at liquibase.executor.jvm.JdbcExecutor$QueryStatementCallback.doInStatement(JdbcExecutor.java:465)
	at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:59)
	... 29 common frames omitted
```

This commit overrides all SQL against those tables to use the legacy mode, regardless.

## QA Manual Tests
##### Setup 
* Configure a connection to a Postgres database that Liquibase has never used (i.e., no Liquibase tracking tables are on the database).
* Create a changelog including the following change set:
```java
<changeSet author="Liquibase Pro User"  id="1::lowerCase">
<createTable tableName="LOWERCASETHIS">
<column name="LOWERCASETHAT" type="CHAR(20)"/>
</createTable>
</changeSet>
```


* ```java
<changeSet author="Liquibase Pro User"  id="2::upperCase" objectQuotingStrategy="QUOTE_ALL_OBJECTS">
<createTable tableName="UPPERCASETHIS">
<column name="UPPERCASETHAT" type="CHAR(20)"/>
</createTable>
</changeSet>
```



##### Validations
_Verify liquibase updateSQL of a createTable with objectQuotingStrategy=ALL produces expected results._
ASSERT ::

* The generated SQL has create table with name=UPPERCASETHIS and column=UPPERCASETHAT (in capital letters).
* The genereted SQL has DATABASECHANGELOG inserts with lower case table name and column names.

_Verify successful liquibase update of a createTable without specified objectQuotingStrategy on an untracked database creates tables with legacy mode._
_ASSERT ::_ 

* The table LOWERCASETHIS is created in lowercase (_lowercasethis_).
* The column LOWERCASETHAT is created in lowercase (_lowercasethat_).

_Verify successful liquibase update of a createTable with objectQuotingStrategy=ALL._
ASSERT ::

* There are no errors during update.
* The table UPPERCASETHIS is created (with that casing).
* The column UPPERCASETHAT is created (with that casing).
* The DATABASECHANGELOG table is updated with a new row for this change set.

## QA Automated Tests
* None required.



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-23) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 3.10.2
