### PR TITLE
Make Liquibase AutoCloseable

### DIFF
--- a/liquibase-core/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-core/src/main/java/liquibase/Liquibase.java
@@ -59,7 +59,7 @@ import static java.util.ResourceBundle.getBundle;
  * Primary facade class for interacting with Liquibase.
  * The built in command line, Ant, Maven and other ways of running Liquibase are wrappers around methods in this class.
  */
-public class Liquibase {
+public class Liquibase implements AutoCloseable {
 
     private static final Logger LOG = Scope.getCurrentScope().getLog(Liquibase.class);
     protected static final int CHANGESET_ID_NUM_PARTS = 3;
@@ -1677,5 +1677,11 @@ public class Liquibase {
         }
     }
 
+    @Override
+    public void close() throws Exception {
+        if (database != null) {
+            database.close();
+        }
+    }
 }
 


### PR DESCRIPTION
Hi,

I am working on the Liquibase extension for the [QuarkusIO](https://quarkus.io/) framework. 
Liquibase extension PR: https://github.com/quarkusio/quarkus/pull/6334
For better integration and handling of the database connection it would be much better if the liquibase.Liquibase implements AutoClosable interface.

```
public class Liquibase implements AutoCloseable {
    @Override
    public void close() throws Exception {
        if (database != null) {
            database.close();
        }
    }
}
```

Would it suit you?

Regards,
Andrej