### PR TITLE
fixed invalid carriage return coming from oracle ojdbc8 12.2.0.1

### DIFF
--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/ViewSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/ViewSnapshotGenerator.java
@@ -130,7 +130,8 @@ public class ViewSnapshotGenerator extends JdbcSnapshotGenerator {
                     view.setName(row.getString("TABLE_NAME"));
                     view.setSchema(new Schema(catalogAndSchema.getCatalogName(), catalogAndSchema.getSchemaName()));
                     view.setRemarks(row.getString("REMARKS"));
-                    view.setDefinition(row.getString("OBJECT_BODY"));
+                    String definition = StringUtils.standardizeLineEndings(row.getString("OBJECT_BODY"));
+                    view.setDefinition(definition);
                     if(database instanceof OracleDatabase) {
                         view.setAttribute("editioning", "Y".equals(row.getString("EDITIONING_VIEW")));
                     }


### PR DESCRIPTION
After upgrading to Java 11 and comparing SqlServer with Oracle DB (ojdbc8 12.2.0.1) we discovered invalid 'carriage return' %#13; at the line ending of the SQL definition of oracle views.

This change makes sure that the lineendings are standardized.



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-22) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 3.10.2
