### PR TITLE
Add missing "labels" field to serializable ChangeLogInclude

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeLogInclude.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeLogInclude.java
@@ -1,6 +1,7 @@
 package liquibase.changelog;
 
 import liquibase.ContextExpression;
+import liquibase.LabelExpression;
 import liquibase.serializer.AbstractLiquibaseSerializable;
 
 import java.util.Arrays;
@@ -11,10 +12,11 @@ public class ChangeLogInclude extends AbstractLiquibaseSerializable implements C
     private String file;
     private Boolean relativeToChangelogFile;
     private ContextExpression context;
+    private LabelExpression labels;
 
     @Override
     public Set<String> getSerializableFields() {
-        return new LinkedHashSet<>(Arrays.asList("file", "relativeToChangelogFile", "context"));
+        return new LinkedHashSet<>(Arrays.asList("file", "relativeToChangelogFile", "context", "labels"));
     }
 
     @Override
@@ -49,5 +51,13 @@ public class ChangeLogInclude extends AbstractLiquibaseSerializable implements C
 
     public void setContext(ContextExpression context) {
         this.context = context;
+    }
+
+    public LabelExpression getLabels() {
+        return labels;
+    }
+
+    public void setLabels(LabelExpression labels) {
+        this.labels = labels;
     }
 }


### PR DESCRIPTION
I need this in the context of [CORE-3549][], but it appears a general omission.

[CORE-3549]: https://liquibase.jira.com/browse/CORE-3549 (Implement "compileChangeLogXml" command)

┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-18) by [Unito](https://www.unito.io/learn-more)
