### PR TITLE
XMLSerializer: Correct Map value serialization

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/custom/CustomChangeWrapper.java
+++ b/liquibase-core/src/main/java/liquibase/change/custom/CustomChangeWrapper.java
@@ -273,7 +273,7 @@ public class CustomChangeWrapper extends AbstractChange {
             case "class":
                 return SerializationType.NAMED_FIELD;
             case "param":
-                return SerializationType.NESTED_OBJECT;
+                return SerializationType.NAMED_FIELD;
             default:
                 throw new UnexpectedLiquibaseException("Unexpected CustomChangeWrapper field " + field);
         }

--- a/liquibase-core/src/main/java/liquibase/change/custom/CustomChangeWrapper.java
+++ b/liquibase-core/src/main/java/liquibase/change/custom/CustomChangeWrapper.java
@@ -42,7 +42,7 @@ public class CustomChangeWrapper extends AbstractChange {
 
     private SortedSet<String> params = new TreeSet<>();
 
-    private Map<String, String> paramValues = new HashMap<>();
+    private Map<String, String> paramValues = new LinkedHashMap<>();
 
     private ClassLoader classLoader;
 

--- a/liquibase-core/src/main/java/liquibase/precondition/CustomPreconditionWrapper.java
+++ b/liquibase-core/src/main/java/liquibase/precondition/CustomPreconditionWrapper.java
@@ -10,8 +10,11 @@ import liquibase.parser.core.ParsedNodeException;
 import liquibase.resource.ResourceAccessor;
 import liquibase.util.ObjectUtil;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
@@ -100,13 +103,24 @@ public class CustomPreconditionWrapper extends AbstractPrecondition {
     }
 
     @Override
+    public Set<String> getSerializableFields() {
+        return new LinkedHashSet<>(Arrays.asList("className", "param"));
+    }
+
+    @Override
+    public Object getSerializableFieldValue(String field) {
+        return field.equals("param") ? paramValues
+                                     : super.getSerializableFieldValue(field);
+    }
+
+    @Override
     public String getName() {
         return "customPrecondition";
     }
 
     @Override
     protected boolean shouldAutoLoad(ParsedNode node) {
-        if ("params".equals(node.getName())) {
+        if ("params".equals(node.getName()) || "param".equals(node.getName())) {
             return false;
         }
         return super.shouldAutoLoad(node);

--- a/liquibase-core/src/main/java/liquibase/precondition/CustomPreconditionWrapper.java
+++ b/liquibase-core/src/main/java/liquibase/precondition/CustomPreconditionWrapper.java
@@ -12,6 +12,7 @@ import liquibase.util.ObjectUtil;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -24,7 +25,7 @@ public class CustomPreconditionWrapper extends AbstractPrecondition {
     private ClassLoader classLoader;
 
     private SortedSet<String> params = new TreeSet<>();
-    private Map<String, String> paramValues = new HashMap<>();
+    private Map<String, String> paramValues = new LinkedHashMap<>();
 
     public String getClassName() {
         return className;

--- a/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
@@ -13,6 +13,7 @@ import liquibase.parser.NamespaceDetailsFactory;
 import liquibase.parser.core.xml.LiquibaseEntityResolver;
 import liquibase.serializer.ChangeLogSerializer;
 import liquibase.serializer.LiquibaseSerializable;
+import liquibase.serializer.LiquibaseSerializable.SerializationType;
 import liquibase.util.ISODateFormat;
 import liquibase.util.StreamUtil;
 import liquibase.util.StringUtils;
@@ -197,7 +198,12 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
         } else if (value instanceof Map) {
             for (Map.Entry entry : (Set<Map.Entry>) ((Map) value).entrySet()) {
                 Element mapNode = currentChangeLogFileDOM.createElementNS(LiquibaseSerializable.STANDARD_CHANGELOG_NAMESPACE, qualifyName(objectName, objectNamespace, parentNamespace));
-                setValueOnNode(mapNode, objectNamespace, (String) entry.getKey(), entry.getValue(), serializationType, objectNamespace);
+                if (serializationType == SerializationType.NESTED_OBJECT) {
+                    setValueOnNode(mapNode, objectNamespace, (String) entry.getKey(), entry.getValue(), serializationType, objectNamespace);
+                } else {
+                    setValueOnNode(mapNode, objectNamespace, "name", entry.getKey(), SerializationType.NAMED_FIELD, objectNamespace);
+                    setValueOnNode(mapNode, objectNamespace, "value", entry.getValue(), serializationType, objectNamespace);
+                }
                 node.appendChild(mapNode);
             }
         } else if (value instanceof LiquibaseSerializable) {


### PR DESCRIPTION
Found while working on [CORE-3549][]...

Given test:

```java
import liquibase.change.custom.CustomChangeWrapper;
import liquibase.precondition.CustomPreconditionWrapper;
import liquibase.serializer.core.xml.XMLChangeLogSerializer;

        CustomPreconditionWrapper customPrecondition = new CustomPreconditionWrapper();
        customPrecondition.setClassName("liquibase.precondition.ExampleCustomPrecondition");
        customPrecondition.setParam("name", "test_1");
        customPrecondition.setParam("count", "31");

        CustomChangeWrapper customChange = new CustomChangeWrapper();
        customChange.setClassLoader(Thread.currentThread().getContextClassLoader());
        customChange.setClass("liquibase.change.custom.ExampleCustomSqlChange");
        customChange.setParam("tableName", "tab_name");
        customChange.setParam("columnName", "col_name");
        customChange.setParam("newValue", "");
        
        XMLChangeLogSerializer xmlSerializer = new XMLChangeLogSerializer();
        System.out.println(xmlSerializer.serialize(customPrecondition, true));
        System.out.println(xmlSerializer.serialize(customChange, true));
```

Actual result:

```xml
<customPrecondition className="liquibase.precondition.ExampleCustomPrecondition" params="name">
    <paramValues name="test_1"/>
    <paramValues count="31"/>
</customPrecondition>
<customChange class="liquibase.change.custom.ExampleCustomSqlChange">
    <param>
        <newValue/>
    </param>
    <param>
        <tableName>tab_name</tableName>
    </param>
    <param>
        <columnName>col_name</columnName>
    </param>
</customChange>
```

Expected result:

```xml
<customPrecondition className="liquibase.precondition.ExampleCustomPrecondition">
    <param name="name" value="test_1"/>
    <param name="count" value="31"/>
</customPrecondition>
<customChange class="liquibase.change.custom.ExampleCustomSqlChange">
    <param name="tableName" value="tab_name"/>
    <param name="columnName" value="col_name"/>
    <param name="newValue" value=""/>
</customChange>
```

[CORE-3549]: https://liquibase.jira.com/browse/CORE-3549 (Implement "compileChangeLogXml" command)

┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-17) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 3.10.1
