### PR TITLE
Improve ChangeFactory initialization time

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/AbstractChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/AbstractChange.java
@@ -81,7 +81,7 @@ public abstract class AbstractChange implements Change {
                 if ((readMethod != null) && (writeMethod != null)) {
                     DatabaseChangeProperty annotation = readMethod.getAnnotation(DatabaseChangeProperty.class);
                     if ((annotation == null) || annotation.isChangeProperty()) {
-                        params.add(createChangeParameterMetadata(property.getDisplayName()));
+                        params.add(createChangeParameterMetadata(property, readMethod));
                     }
                 }
 
@@ -113,9 +113,6 @@ public abstract class AbstractChange implements Change {
     protected ChangeParameterMetaData createChangeParameterMetadata(String parameterName) {
 
         try {
-            String displayName = parameterName.replaceAll("([A-Z])", " $1");
-            displayName = displayName.substring(0, 1).toUpperCase() + displayName.substring(1);
-
             PropertyDescriptor property = null;
             for (PropertyDescriptor prop : PropertyUtils.getInstance().getDescriptors(getClass())) {
                 if (prop.getDisplayName().equals(parameterName)) {
@@ -131,6 +128,18 @@ public abstract class AbstractChange implements Change {
             if (readMethod == null) {
                 readMethod = getClass().getMethod("is" + StringUtils.upperCaseFirst(property.getName()));
             }
+            return createChangeParameterMetadata(property, readMethod);
+        } catch (IntrospectionException|NoSuchMethodException|SecurityException e) {
+            throw new UnexpectedLiquibaseException(e);
+        }
+    }
+
+    private ChangeParameterMetaData createChangeParameterMetadata(PropertyDescriptor property, Method readMethod) {
+        try {
+            String parameterName = property.getDisplayName();
+            String displayName = parameterName.replaceAll("([A-Z])", " $1");
+            displayName = displayName.substring(0, 1).toUpperCase() + displayName.substring(1);
+
             Type type = readMethod.getGenericReturnType();
 
             DatabaseChangeProperty changePropertyAnnotation = readMethod.getAnnotation(DatabaseChangeProperty.class);
@@ -146,9 +155,9 @@ public abstract class AbstractChange implements Change {
             String[] supportsDatabase = createSupportedDatabasesMetaData(parameterName, changePropertyAnnotation);
 
             return new ChangeParameterMetaData(this, parameterName, displayName, description, examples, since,
-                type, requiredForDatabase, supportsDatabase, mustEqualExisting, serializationType);
-        } catch (IntrospectionException|UnexpectedLiquibaseException|NoSuchMethodException|SecurityException e) {
-            throw new UnexpectedLiquibaseException(e);
+                type, requiredForDatabase, supportsDatabase, mustEqualExisting, serializationType).withAccessors(readMethod, property.getWriteMethod());
+        } catch (UnexpectedLiquibaseException e) {
+            throw e;
         }
     }
 

--- a/liquibase-core/src/main/java/liquibase/change/ChangeParameterMetaData.java
+++ b/liquibase-core/src/main/java/liquibase/change/ChangeParameterMetaData.java
@@ -42,6 +42,8 @@ public class ChangeParameterMetaData {
     private Set<String> supportedDatabases;
     private String mustEqualExisting;
     private LiquibaseSerializable.SerializationType serializationType;
+    private String[] requiredForDatabaseArg;
+    private String[] supportedDatabasesArg;
 
     public ChangeParameterMetaData(Change change, String parameterName, String displayName, String description,
                                    Map<String, Object> exampleValues, String since, Type dataType,
@@ -84,8 +86,8 @@ public class ChangeParameterMetaData {
         this.serializationType = serializationType;
         this.since = since;
 
-        this.supportedDatabases = Collections.unmodifiableSet(analyzeSupportedDatabases(supportedDatabases));
-        this.requiredForDatabase = Collections.unmodifiableSet(analyzeRequiredDatabases(requiredForDatabase));
+        this.supportedDatabasesArg = supportedDatabases;
+        this.requiredForDatabaseArg = requiredForDatabase;
     }
 
     protected Set<String> analyzeSupportedDatabases(String[] supportedDatabases) {
@@ -234,10 +236,16 @@ public class ChangeParameterMetaData {
      * This method will never return a null value
      */
     public Set<String> getRequiredForDatabase() {
+        if (requiredForDatabase == null) {
+            requiredForDatabase = Collections.unmodifiableSet(analyzeRequiredDatabases(requiredForDatabaseArg));
+        }
         return requiredForDatabase;
     }
 
     public Set<String> getSupportedDatabases() {
+        if (supportedDatabases == null) {
+            supportedDatabases = Collections.unmodifiableSet(analyzeSupportedDatabases(supportedDatabasesArg));
+        }
         return supportedDatabases;
     }
 
@@ -247,11 +255,11 @@ public class ChangeParameterMetaData {
      * required database list contains the string "all"
      */
     public boolean isRequiredFor(Database database) {
-        return requiredForDatabase.contains("all") || requiredForDatabase.contains(database.getShortName());
+        return getRequiredForDatabase().contains("all") || getRequiredForDatabase().contains(database.getShortName());
     }
 
     public boolean supports(Database database) {
-        return supportedDatabases.contains("all") || supportedDatabases.contains(database.getShortName());
+        return getSupportedDatabases().contains("all") || getSupportedDatabases().contains(database.getShortName());
     }
 
 

--- a/liquibase-core/src/main/java/liquibase/change/ChangeParameterMetaData.java
+++ b/liquibase-core/src/main/java/liquibase/change/ChangeParameterMetaData.java
@@ -94,6 +94,12 @@ public class ChangeParameterMetaData {
         this.requiredForDatabaseArg = requiredForDatabase;
     }
 
+    public ChangeParameterMetaData withAccessors(Method readMethod, Method writeMethod) {
+        this.readMethodRef = (readMethod == null) ? NO_METHOD_REF : readMethod;
+        this.writeMethodRef = (writeMethod == null) ? NO_METHOD_REF : writeMethod;
+        return this;
+    }
+
     protected Set<String> analyzeSupportedDatabases(String[] supportedDatabases) {
         if (supportedDatabases == null) {
             supportedDatabases = new String[]{ChangeParameterMetaData.COMPUTE};


### PR DESCRIPTION
This is currently taking most of the Liquibase initialization time on my side, which is rather slow especially when included during the startup of an application.  I've identified the following time-gobbling areas:

-   Every `Change` type is loaded and initialized (can't change much about it currently), including very slow meta-data initialization;
-   Most time-consuming `analyzeSupportedDatabases()` and `analyzeRequiredDatabases()` during the construction of `ChangeParameterMetaData` – these can be lazily evaluated, which also avoids evaluating them for any `Change` types which don't end up used;
-   Multiple unnecessary bean introspections for the same type – lesser performance impact, still unnecessary adds up:
    -   `AbstractChange.createChangeMetaData()` obtains full property info, then for each property `createChangeParameterMetadata()` obtains full property info copy on its own; next
    -   `ChangeParameterMetaData.getCurrentValue()` / `setValue()` obtain full property info copy on every invocation.

Considering the following simple test:

```java
        long startTime = System.currentTimeMillis();
        ChangeFactory.getInstance();
        long elapsedTime = System.currentTimeMillis() - startTime;
        System.out.println("Time [sec]: " + elapsedTime / 1E3);
```

I get improvement from originally ~3.1 sec down to ~1.3 sec.  In my production case, I'm getting originally ~3.5 sec down to ~1.5 sec.  So I think this is a rather significant win – please consider merging it upstream.

__
<sup>This is my second take on this matter, after my previous premature attempt #958.</sup>

┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-15) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 3.10.1
