### PR TITLE
CORE-3594 Automatic dropping of default values on MS SQL

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/DropColumnGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/DropColumnGenerator.java
@@ -64,8 +64,16 @@ public class DropColumnGenerator extends AbstractSqlGenerator<DropColumnStatemen
             }
             result.add(new UnparsedSql(alterTable, getAffectedColumns(columns)));
         } else {
-            for (DropColumnStatement column : columns) {
-                result.add(generateSingleColumnSql(column, database)[0]);
+            if (database instanceof MSSQLDatabase) {
+                for (DropColumnStatement column : columns) {
+                    final Sql[] sqls = generateSingleColumnSql(column, database);
+                    result.add(sqls[0]);
+                    result.add(sqls[1]);
+                }
+            } else {
+                for (DropColumnStatement column : columns) {
+                    result.add(generateSingleColumnSql(column, database)[0]);
+                }
             }
         }
         return result.toArray(new Sql[result.size()]);
@@ -77,6 +85,12 @@ public class DropColumnGenerator extends AbstractSqlGenerator<DropColumnStatemen
         } else if ((database instanceof SybaseDatabase) || (database instanceof SybaseASADatabase) || (database
             instanceof FirebirdDatabase) || (database instanceof InformixDatabase)) {
             return new Sql[] {new UnparsedSql("ALTER TABLE " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + " DROP " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()), getAffectedColumn(statement))};
+        } else if (database instanceof MSSQLDatabase) {
+            return new Sql[] {
+                    generateDropDV(statement, database),
+                    new UnparsedSql("ALTER TABLE " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + " DROP COLUMN " +
+                            database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()), getAffectedColumn(statement))
+            };
         }
         return new Sql[] {new UnparsedSql("ALTER TABLE " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + " DROP COLUMN " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()), getAffectedColumn(statement))};
     }
@@ -91,5 +105,10 @@ public class DropColumnGenerator extends AbstractSqlGenerator<DropColumnStatemen
 
     protected Column getAffectedColumn(DropColumnStatement statement) {
         return new Column().setName(statement.getColumnName()).setRelation(new Table().setName(statement.getTableName()).setSchema(statement.getCatalogName(), statement.getSchemaName()));
+    }
+
+    private UnparsedSql generateDropDV(DropColumnStatement statement, Database database) {
+        return new UnparsedSql((String) DropDefaultValueGenerator.DROP_DF_MSSQL.apply(database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()),
+                database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName())));
     }
 }

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/DropDefaultValueGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/DropDefaultValueGenerator.java
@@ -10,7 +10,20 @@ import liquibase.statement.core.DropDefaultValueStatement;
 import liquibase.structure.core.Column;
 import liquibase.structure.core.Table;
 
+import java.util.function.BiFunction;
+
 public class DropDefaultValueGenerator extends AbstractSqlGenerator<DropDefaultValueStatement> {
+
+    public static BiFunction DROP_DF_MSSQL = (tableName, columnName) -> {
+        return "DECLARE @sql [nvarchar](MAX)\r\n" +
+                "SELECT @sql = N'ALTER TABLE " + tableName + " DROP CONSTRAINT ' + QUOTENAME([df].[name]) " +
+                "FROM [sys].[columns] AS [c] " +
+                "INNER JOIN [sys].[default_constraints] AS [df] " +
+                "ON [df].[object_id] = [c].[default_object_id] " +
+                "WHERE [c].[object_id] = OBJECT_ID(N'" + tableName + "') " +
+                "AND [c].[name] = N'" + columnName + "'\r\n" +
+                "EXEC sp_executesql @sql";
+    };
 
     @Override
     public boolean supports(DropDefaultValueStatement statement, Database database) {
@@ -36,15 +49,7 @@ public class DropDefaultValueGenerator extends AbstractSqlGenerator<DropDefaultV
         String sql;
         String escapedTableName = database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName());
         if (database instanceof MSSQLDatabase) {
-            sql =
-                    "DECLARE @sql [nvarchar](MAX)\r\n" +
-                    "SELECT @sql = N'ALTER TABLE " + database.escapeStringForDatabase(escapedTableName) + " DROP CONSTRAINT ' + QUOTENAME([df].[name]) " +
-                    "FROM [sys].[columns] AS [c] " +
-                    "INNER JOIN [sys].[default_constraints] AS [df] " +
-                    "ON [df].[object_id] = [c].[default_object_id] " +
-                    "WHERE [c].[object_id] = OBJECT_ID(N'" + database.escapeStringForDatabase(escapedTableName) +  "') " +
-                    "AND [c].[name] = N'" + database.escapeStringForDatabase(statement.getColumnName()) +  "'\r\n" +
-                    "EXEC sp_executesql @sql";
+            sql = (String) DROP_DF_MSSQL.apply(database.escapeStringForDatabase(escapedTableName), database.escapeStringForDatabase(statement.getColumnName()));
         } else if (database instanceof MySQLDatabase) {
             sql = "ALTER TABLE " + escapedTableName + " ALTER " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " DROP DEFAULT";
         } else if (database instanceof OracleDatabase) {

--- a/liquibase-core/src/test/java/liquibase/sqlgenerator/core/DropColumnGeneratorTest.java
+++ b/liquibase-core/src/test/java/liquibase/sqlgenerator/core/DropColumnGeneratorTest.java
@@ -1,5 +1,6 @@
 package liquibase.sqlgenerator.core;
 
+import liquibase.database.core.MSSQLDatabase;
 import liquibase.database.core.MySQLDatabase;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.AbstractSqlGeneratorTest;
@@ -41,6 +42,30 @@ public class DropColumnGeneratorTest extends AbstractSqlGeneratorTest<DropColumn
         List<String> expectedNames = Arrays.asList(new String[]{"TEST_TABLE.col1", "TEST_TABLE.col2", "TEST_TABLE", "DEFAULT"});
         assertTrue(actualNames.containsAll(expectedNames));
         assertTrue(expectedNames.containsAll(actualNames));
+    }
+
+    @Test
+    public void testDropMultipleColumnsMSSQL() {
+        DropColumnStatement drop = new DropColumnStatement(Arrays.asList(new DropColumnStatement(null, null, "TEST_TABLE", "col1"), new DropColumnStatement(null, null, "TEST_TABLE", "col2")));
+
+        Assert.assertFalse(generatorUnderTest.validate(drop, new MSSQLDatabase(), new MockSqlGeneratorChain()).hasErrors());
+        Sql[] sql = generatorUnderTest.generateSql(drop, new MSSQLDatabase(), new MockSqlGeneratorChain());
+        Assert.assertEquals(4, sql.length);
+        Assert.assertTrue(sql[0].toSql().contains("TEST_TABLE") && sql[0].toSql().contains("col1"));
+        Assert.assertEquals("ALTER TABLE TEST_TABLE DROP COLUMN col1", sql[1].toSql());
+        Assert.assertTrue(sql[2].toSql().contains("TEST_TABLE") && sql[2].toSql().contains("col2"));
+        Assert.assertEquals("ALTER TABLE TEST_TABLE DROP COLUMN col2", sql[3].toSql());
+    }
+
+    @Test
+    public void testDropSimpleColumnsMSSQL() {
+        DropColumnStatement drop = new DropColumnStatement(Arrays.asList(new DropColumnStatement(null, null, "TEST_TABLE", "col1")));
+
+        Assert.assertFalse(generatorUnderTest.validate(drop, new MSSQLDatabase(), new MockSqlGeneratorChain()).hasErrors());
+        Sql[] sql = generatorUnderTest.generateSql(drop, new MSSQLDatabase(), new MockSqlGeneratorChain());
+        Assert.assertEquals(2, sql.length);
+        Assert.assertTrue(sql[0].toSql().contains("TEST_TABLE") && sql[0].toSql().contains("col1"));
+        Assert.assertEquals("ALTER TABLE TEST_TABLE DROP COLUMN col1", sql[1].toSql());
     }
 
 ////    @Test


### PR DESCRIPTION
https://liquibase.jira.com/projects/CORE/issues/CORE-3594

##### Error Message During Column Drop with Default Value
{CODE}
RROR Reason: liquibase.exception.DatabaseException: Error executing SQL ALTER TABLE TEST DROP COLUMN COL2: The object 'DF_GENERIC_ENTITY_COL2' is dependent on column 'COL2'.
{CODE}

## Steps to Reproduce
1. Create a changelog with the following changes:
{CODE}
<changeSet id="C1" labels="columnWithDefaultValue">
   <createTable tableName="TEST">
           <column name="COL1" type="int"  />
	   <column name="COL2" type="int" defaultValue="42" />
   </changeSet>

<changeSet id="C2" labels="dropColumnWithDefaultValue>
     <dropColumn tableName="TEST" columnName="COL2" />
</changeSet>
{CODE}
2. Execute a Liquibase update to deploy C1 to a SQL Server database:
{CODE}
liquibase --changeLogFile=mychangelog.xml --labels=columnWithDefaultValue update
{CODE}
3. Execute a second Liquibase update to deploy C2:
{CODE}
liquibase --changeLogFile=mychangelog.xml --labels=dropColumnWithDefaultValue update
{CODE}

## Expected Results
There is no error dropping the column.

## Actual Results
The error identified earlier in the description is output during dropColumn execution.

## Manual Test Criteria
* Validate the bug is reproducible following the Repro steps.
* Do a desk check with the developer.
* Verify the fix works on your machine.

## Automated Test Criteria
* Write an MSSQL regression test
  * Name: Drop column does not fail for a column with a default value.
  * Description: Ticket number.



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-11) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Community 4.2.x
