### PR TITLE
CORE-3596  Use LinkedHashMap for a deterministic iteration order in DependencyUtil.java

### DIFF
--- a/liquibase-core/src/main/java/liquibase/util/DependencyUtil.java
+++ b/liquibase-core/src/main/java/liquibase/util/DependencyUtil.java
@@ -4,7 +4,7 @@ import liquibase.Scope;
 import liquibase.logging.LogType;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
 
@@ -13,7 +13,7 @@ public class DependencyUtil {
 
     public static class DependencyGraph<T> {
 
-        private HashMap<T, GraphNode<T>> nodes = new HashMap<>();
+        private LinkedHashMap<T, GraphNode<T>> nodes = new LinkedHashMap<>();
         private NodeValueListener<T> listener;
         private List<GraphNode<T>> evaluatedNodes = new ArrayList<>();
 


### PR DESCRIPTION
This PR aims to fix https://liquibase.jira.com/browse/CORE-3596

The fix is to change HashMap to LinkedHashMap so that the iteration order remains stable and the assertion failure in `liquibase.util.DependencyUtilTest#testIndependentBranchesCase` will not occur any more. In this way, the test will be more stable.