### PR TITLE
Update to allow sequences in MariaDB >= 10.3

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/MariaDBDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MariaDBDatabase.java
@@ -96,7 +96,8 @@ public class MariaDBDatabase extends MySQLDatabase {
     @Override
     public boolean supportsSequences() {
         try {
-            return getDatabaseMajorVersion() >= 10 && getDatabaseMinorVersion() >= 3;
+            // From https://liquibase.jira.com/browse/CORE-3457 (by Lijun Liao) corrected 
+            return majorVersion > 10 || (majorVersion == 10 && getDatabaseMinorVersion() >= 3);
         } catch (DatabaseException e) {
             Scope.getCurrentScope().getLog(getClass()).fine(LogType.LOG, "Cannot retrieve database version", e);
             return false;

--- a/liquibase-core/src/main/java/liquibase/database/core/MariaDBDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MariaDBDatabase.java
@@ -97,6 +97,7 @@ public class MariaDBDatabase extends MySQLDatabase {
     public boolean supportsSequences() {
         try {
             // From https://liquibase.jira.com/browse/CORE-3457 (by Lijun Liao) corrected 
+            int majorVersion = getDatabaseMajorVersion();
             return majorVersion > 10 || (majorVersion == 10 && getDatabaseMinorVersion() >= 3);
         } catch (DatabaseException e) {
             Scope.getCurrentScope().getLog(getClass()).fine(LogType.LOG, "Cannot retrieve database version", e);


### PR DESCRIPTION
Sequences appeared in MariaDB 10.3.
Existing logic does not reflect that, as a major version > 10 would also need a minor version >= 3

Reflects logic change pointed out by [Lijun Liao](https://liquibase.jira.com/jira/people/557058:563e7647-7f5f-43c8-a410-159804f19377) in issue [CORE-3457](https://liquibase.jira.com/browse/CORE-3457)