### PR TITLE
LB-133 ⁃ Change Liquibase#close to throw DatabaseException

### DIFF
--- a/liquibase-core/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-core/src/main/java/liquibase/Liquibase.java
@@ -1678,7 +1678,7 @@ public class Liquibase implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() throws LiquibaseException {
         if (database != null) {
             database.close();
         }


### PR DESCRIPTION
There is no need to force callers to handle Exception.
The implementation of the close method can currently throw only a DatabaseException. But since the library has a parent exception class - LiquibaseException - it is used instead to not force callers to change their catch clauses if additional logic is added in the future.