### PR TITLE
Work for CORE-3457 to allow MariaDB Sequences

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/MariaDBDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MariaDBDatabase.java
@@ -96,7 +96,9 @@ public class MariaDBDatabase extends MySQLDatabase {
     @Override
     public boolean supportsSequences() {
         try {
-            return getDatabaseMajorVersion() >= 10 && getDatabaseMinorVersion() >= 3;
+            // From https://liquibase.jira.com/browse/CORE-3457 (by Lijun Liao) corrected
+            int majorVersion = getDatabaseMajorVersion();
+            return majorVersion > 10 || (majorVersion == 10 && getDatabaseMinorVersion() >= 3);
         } catch (DatabaseException e) {
             Scope.getCurrentScope().getLog(getClass()).fine(LogType.LOG, "Cannot retrieve database version", e);
             return false;

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
@@ -250,6 +250,7 @@ public class SequenceSnapshotGenerator extends JdbcSnapshotGenerator {
             .queryForList(new RawSqlStatement("select SUBSTRING( NAME FROM LOCATE( '/' ,NAME ) + 1 ) AS SEQUENCE_NAME "
                 + "from information_schema.INNODB_SYS_TABLES "
                 + "where NAME like '" + schema.getName() +"/%' AND FLAG & 12288 ;"));
+            // see https://mariadb.com/kb/en/information-schema-innodb_sys_tables-table/#flag for 12288 value of (3 << 12)
             if (res.size() == 0) {
               return "SELECT name AS SEQUENCE_NAME WHERE 1=0";
             }


### PR DESCRIPTION
Sequences appeared in MariaDB 10.3.
Existing logic does not reflect that, as a major version > 10 would also need a minor version >= 3

Reflects logic change pointed out by [Lijun Liao](https://liquibase.jira.com/jira/people/557058:563e7647-7f5f-43c8-a410-159804f19377) in issue [CORE-3457](https://liquibase.jira.com/browse/CORE-3457)

This would require some help with testing.

