### PR TITLE
fix postgres smallint syntax

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/SmallIntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/SmallIntType.java
@@ -55,6 +55,9 @@ public class SmallIntType extends LiquibaseDataType {
                 if (majorVersion < 10) {
                     return new DatabaseDataType("SMALLSERIAL");
                 }
+            } 
+            else {
+                return new DatabaseDataType("SMALLINT");
             }
         }
 


### PR DESCRIPTION
A change in the previous commit to master broke smallint generation for postgres.  This PR fixes it.  More details in the issue link.
This should close issue: https://github.com/liquibase/liquibase/issues/1015

Built and tested locally.