### PR TITLE
Postgres smallint fix

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/PostgresDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/PostgresDatabase.java
@@ -68,7 +68,7 @@ public class PostgresDatabase extends AbstractJdbcDatabase {
                 "UNIQUE", "USER", "USING", "VARIADIC", "VERBOSE", "WHEN", "WHERE", "WINDOW", "WITH"));
         super.sequenceNextValueFunction = "nextval('%s')";
         super.sequenceCurrentValueFunction = "currval('%s')";
-        super.unmodifiableDataTypes.addAll(Arrays.asList("bool", "int4", "int8", "float4", "float8", "bigserial", "serial", "oid", "bytea", "date", "timestamptz", "text"));
+        super.unmodifiableDataTypes.addAll(Arrays.asList("bool", "int4", "int8", "float4", "float8", "bigserial", "serial", "oid", "bytea", "date", "timestamptz", "text", "smallint"));
         super.unquotedObjectsAreUppercased=false;
     }
 

--- a/liquibase-core/src/main/java/liquibase/datatype/core/SmallIntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/SmallIntType.java
@@ -55,6 +55,9 @@ public class SmallIntType extends LiquibaseDataType {
                 if (majorVersion < 10) {
                     return new DatabaseDataType("SMALLSERIAL");
                 }
+            } 
+            else {
+                return new DatabaseDataType("SMALLINT");
             }
         }
 


### PR DESCRIPTION
Adds smallint to the unmodifiable list of datatypes.  Changelog generation was identifying the length of the smallint which causes a syntax error.