### PR TITLE
add postgres smallint to unmodifiable types

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/PostgresDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/PostgresDatabase.java
@@ -68,7 +68,7 @@ public class PostgresDatabase extends AbstractJdbcDatabase {
                 "UNIQUE", "USER", "USING", "VARIADIC", "VERBOSE", "WHEN", "WHERE", "WINDOW", "WITH"));
         super.sequenceNextValueFunction = "nextval('%s')";
         super.sequenceCurrentValueFunction = "currval('%s')";
-        super.unmodifiableDataTypes.addAll(Arrays.asList("bool", "int4", "int8", "float4", "float8", "bigserial", "serial", "oid", "bytea", "date", "timestamptz", "text"));
+        super.unmodifiableDataTypes.addAll(Arrays.asList("bool", "int4", "int8", "float4", "float8", "bigserial", "serial", "oid", "bytea", "date", "timestamptz", "text", "smallint"));
         super.unquotedObjectsAreUppercased=false;
     }
 


### PR DESCRIPTION
The smallint length was being added to the sql script generation, leading to incorrect syntax.  Adding this to the list of unmodifiable types.

Built and tested locally.

Closes https://github.com/liquibase/liquibase/issues/1015



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-139) by [Unito](https://www.unito.io)
