### PR TITLE
Enable snapshotByDefault for Data if output directory specified DAT-4129

### DIFF
--- a/liquibase-core/src/main/java/liquibase/configuration/GlobalConfiguration.java
+++ b/liquibase-core/src/main/java/liquibase/configuration/GlobalConfiguration.java
@@ -22,6 +22,7 @@ public class GlobalConfiguration extends AbstractConfigurationContainer {
     public static final String ALWAYS_OVERRIDE_STORED_LOGIC_SCHEMA = "alwaysOverrideStoredLogicSchema";
     public static final String GENERATED_CHANGESET_IDS_INCLUDE_DESCRIPTION = "generatedChangeSetIdsContainsDescription";
     public static final String INCLUDE_CATALOG_IN_SPECIFICATION = "includeCatalogInSpecification";
+    public static final String SHOULD_SNAPSHOT_DATA = "shouldSnapshotData";
 
     public GlobalConfiguration() {
         super("liquibase");
@@ -95,6 +96,10 @@ public class GlobalConfiguration extends AbstractConfigurationContainer {
         getContainer().addProperty(INCLUDE_CATALOG_IN_SPECIFICATION, Boolean.class)
                 .setDescription("Should Liquibase include the catalog name when determining equality?")
                 .setDefaultValue(false);
+
+        getContainer().addProperty(SHOULD_SNAPSHOT_DATA, Boolean.class)
+                .setDescription("Should Liquibase snapshot data by default?")
+                .setDefaultValue(false);
     }
 
     /**
@@ -166,6 +171,20 @@ public class GlobalConfiguration extends AbstractConfigurationContainer {
 
     public GlobalConfiguration setLiquibaseTablespaceName(String name) {
         getContainer().setValue(LIQUIBASE_TABLESPACE_NAME, name);
+        return this;
+    }
+
+    /**
+     *
+     * Should Liquibase snapshot data for table by default
+     *
+     */
+    public boolean getShouldSnapshotData() {
+        return getContainer().getValue(SHOULD_SNAPSHOT_DATA, Boolean.class);
+    }
+
+    public GlobalConfiguration setShouldSnapshotData(boolean shouldSnapshotData) {
+        getContainer().setValue(SHOULD_SNAPSHOT_DATA, shouldSnapshotData);
         return this;
     }
 

--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -1384,6 +1384,11 @@ public class Main {
                 );
                 return;
             } else if (COMMANDS.GENERATE_CHANGELOG.equalsIgnoreCase(command)) {
+                //
+                // Set the global configuration option based on presence of the dataOutputDirectory
+                //
+                boolean b = dataOutputDirectory != null;
+                LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).setShouldSnapshotData(b);
                 String currentChangeLogFile = this.changeLogFile;
                 if (currentChangeLogFile == null) {
                     //will output to stdout:
@@ -1881,6 +1886,8 @@ public class Main {
                 defSchemaName = value;
             } else if (OPTIONS.DATA_OUTPUT_DIRECTORY.equalsIgnoreCase(attributeName)) {
                 dataOutputDirectory = value;
+                boolean b = dataOutputDirectory != null;
+                LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).setShouldSnapshotData(b);
             }
         }
 

--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -1341,6 +1341,12 @@ public class Main {
                                 OPTIONS.EXCLUDE_OBJECTS, OPTIONS.INCLUDE_OBJECTS));
             }
 
+            //
+            // Set the global configuration option based on presence of the dataOutputDirectory
+            //
+            boolean b = dataOutputDirectory != null;
+            LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).setShouldSnapshotData(b);
+
             ObjectChangeFilter objectChangeFilter = null;
             CompareControl.ComputedSchemas computedSchemas = CompareControl.computeSchemas(
                     schemas,
@@ -1384,11 +1390,6 @@ public class Main {
                 );
                 return;
             } else if (COMMANDS.GENERATE_CHANGELOG.equalsIgnoreCase(command)) {
-                //
-                // Set the global configuration option based on presence of the dataOutputDirectory
-                //
-                boolean b = dataOutputDirectory != null;
-                LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).setShouldSnapshotData(b);
                 String currentChangeLogFile = this.changeLogFile;
                 if (currentChangeLogFile == null) {
                     //will output to stdout:
@@ -1886,8 +1887,6 @@ public class Main {
                 defSchemaName = value;
             } else if (OPTIONS.DATA_OUTPUT_DIRECTORY.equalsIgnoreCase(attributeName)) {
                 dataOutputDirectory = value;
-                boolean b = dataOutputDirectory != null;
-                LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).setShouldSnapshotData(b);
             }
         }
 

--- a/liquibase-core/src/main/java/liquibase/structure/core/Data.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/Data.java
@@ -1,5 +1,7 @@
 package liquibase.structure.core;
 
+import liquibase.configuration.GlobalConfiguration;
+import liquibase.configuration.LiquibaseConfiguration;
 import liquibase.structure.AbstractDatabaseObject;
 import liquibase.structure.DatabaseObject;
 
@@ -7,7 +9,7 @@ public class Data extends AbstractDatabaseObject {
 
     @Override
     public boolean snapshotByDefault() {
-        return false;
+        return LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).getShouldSnapshotData();
     }
 
     public Table getTable() {

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseGenerateChangeLogMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseGenerateChangeLogMojo.java
@@ -1,6 +1,8 @@
 package org.liquibase.maven.plugins;
 
 import liquibase.Liquibase;
+import liquibase.configuration.GlobalConfiguration;
+import liquibase.configuration.LiquibaseConfiguration;
 import liquibase.database.Database;
 import liquibase.diff.output.DiffOutputControl;
 import liquibase.diff.output.StandardObjectChangeFilter;
@@ -110,6 +112,12 @@ public class LiquibaseGenerateChangeLogMojo extends
             if (diffIncludeObjects != null) {
                 diffOutputControl.setObjectChangeFilter(new StandardObjectChangeFilter(StandardObjectChangeFilter.FilterType.INCLUDE, diffIncludeObjects));
             }
+
+            //
+            // Set the global configuration option based on presence of the dataOutputDirectory
+            //
+            boolean b = dataDir != null;
+            LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).setShouldSnapshotData(b);
 
             CommandLineUtils.doGenerateChangeLog(outputChangeLogFile, database, defaultCatalogName, defaultSchemaName, StringUtils.trimToNull(diffTypes),
                     StringUtils.trimToNull(changeSetAuthor), StringUtils.trimToNull(changeSetContext), StringUtils.trimToNull(dataDir), diffOutputControl);


### PR DESCRIPTION
THIS IS A “DUPLICATE” ticket that was automatically created when Wes created the PR to fix DAT-4129, which has been moved to LB-185.

Please allow this to move along as a zero point ticket that tracks LB-185

As a user who wants to export ALL the data from my db when i run generatechangelog, i want to use the
--dataOutputDirectory=<mydatadir> flag and by default have all the data in csv files in a named directory.
Previously, if no --diffTypes argument is specified, the output directory was not created.  Now, the output directory is
always created if the --dataOutputDirectory is specified.