### PR TITLE
Support --schemas flag both before and after the "snapshot" command

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -1417,7 +1417,7 @@ public class Main {
                 SnapshotCommand snapshotCommand = (SnapshotCommand) CommandFactory.getInstance()
                         .getCommand(COMMANDS.SNAPSHOT);
                 snapshotCommand.setDatabase(database);
-                snapshotCommand.setSchemas(getSchemaParams());
+                snapshotCommand.setSchemas(getSchemaParams(database));
                 snapshotCommand.setSerializerFormat(getCommandParam(OPTIONS.SNAPSHOT_FORMAT, null));
                 Writer outputWriter = getOutputWriter();
                 String result = snapshotCommand.execute().print();
@@ -1442,7 +1442,7 @@ public class Main {
                         .getCommand(COMMANDS.SNAPSHOT);
                 Database referenceDatabase = createReferenceDatabaseFromCommandParams(commandParams, fileOpener);
                 snapshotCommand.setDatabase(referenceDatabase);
-                snapshotCommand.setSchemas(getSchemaParams());
+                snapshotCommand.setSchemas(getSchemaParams(database));
                 snapshotCommand.setSerializerFormat(getCommandParam(OPTIONS.SNAPSHOT_FORMAT, null));
                 Writer outputWriter = getOutputWriter();
                 outputWriter.write(snapshotCommand.execute().print());
@@ -1583,7 +1583,7 @@ public class Main {
                 DropAllCommand dropAllCommand = (DropAllCommand) CommandFactory.getInstance().getCommand
                         (COMMANDS.DROP_ALL);
                 dropAllCommand.setDatabase(liquibase.getDatabase());
-                dropAllCommand.setSchemas(getSchemaParams());
+                dropAllCommand.setSchemas(getSchemaParams(database));
                 LogService.getLog(getClass()).info(LogType.USER_MESSAGE, dropAllCommand.execute().print());
                 return;
             } else if (COMMANDS.STATUS.equalsIgnoreCase(command)) {
@@ -1766,8 +1766,8 @@ public class Main {
         }
     }
 
-    private String getSchemaParams() throws CommandLineParsingException {
-        return getCommandParam(OPTIONS.SCHEMAS, schemas);
+    private String getSchemaParams(Database database) throws CommandLineParsingException {
+        return getCommandParam(OPTIONS.SCHEMAS, database.getDefaultSchema().getSchemaName());
     }
 
     private LiquibaseCommand createLiquibaseCommand(Database database, Liquibase liquibase, String commandName, Map<String, Object> argsMap)

--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -1767,7 +1767,11 @@ public class Main {
     }
 
     private String getSchemaParams(Database database) throws CommandLineParsingException {
-        return getCommandParam(OPTIONS.SCHEMAS, database.getDefaultSchema().getSchemaName());
+        String schemaParams = getCommandParam(OPTIONS.SCHEMAS, schemas);
+        if (schemaParams == null || schemaParams.isEmpty()) {
+            return database.getDefaultSchema().getSchemaName();
+        }
+        return schemaParams;
     }
 
     private LiquibaseCommand createLiquibaseCommand(Database database, Liquibase liquibase, String commandName, Map<String, Object> argsMap)

--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -18,7 +18,6 @@ import liquibase.changelog.ChangeLogParameters;
 import liquibase.changelog.visitor.ChangeExecListener;
 import liquibase.command.AbstractSelfConfiguratingCommand;
 import liquibase.command.CommandFactory;
-import liquibase.command.CommandResult;
 import liquibase.command.LiquibaseCommand;
 import liquibase.command.core.DropAllCommand;
 import liquibase.command.core.ExecuteSqlCommand;
@@ -1418,11 +1417,7 @@ public class Main {
                 SnapshotCommand snapshotCommand = (SnapshotCommand) CommandFactory.getInstance()
                         .getCommand(COMMANDS.SNAPSHOT);
                 snapshotCommand.setDatabase(database);
-                snapshotCommand.setSchemas(
-                        getCommandParam(
-                                OPTIONS.SCHEMAS, database.getDefaultSchema().getSchemaName()
-                        )
-                );
+                snapshotCommand.setSchemas(getSchemaParams());
                 snapshotCommand.setSerializerFormat(getCommandParam(OPTIONS.SNAPSHOT_FORMAT, null));
                 Writer outputWriter = getOutputWriter();
                 String result = snapshotCommand.execute().print();
@@ -1447,11 +1442,7 @@ public class Main {
                         .getCommand(COMMANDS.SNAPSHOT);
                 Database referenceDatabase = createReferenceDatabaseFromCommandParams(commandParams, fileOpener);
                 snapshotCommand.setDatabase(referenceDatabase);
-                snapshotCommand.setSchemas(
-                        getCommandParam(
-                                OPTIONS.SCHEMAS, referenceDatabase.getDefaultSchema().getSchemaName()
-                        )
-                );
+                snapshotCommand.setSchemas(getSchemaParams());
                 snapshotCommand.setSerializerFormat(getCommandParam(OPTIONS.SNAPSHOT_FORMAT, null));
                 Writer outputWriter = getOutputWriter();
                 outputWriter.write(snapshotCommand.execute().print());
@@ -1592,10 +1583,7 @@ public class Main {
                 DropAllCommand dropAllCommand = (DropAllCommand) CommandFactory.getInstance().getCommand
                         (COMMANDS.DROP_ALL);
                 dropAllCommand.setDatabase(liquibase.getDatabase());
-                dropAllCommand.setSchemas(getCommandParam(
-                        OPTIONS.SCHEMAS, database.getDefaultSchema().getSchemaName())
-                );
-
+                dropAllCommand.setSchemas(getSchemaParams());
                 LogService.getLog(getClass()).info(LogType.USER_MESSAGE, dropAllCommand.execute().print());
                 return;
             } else if (COMMANDS.STATUS.equalsIgnoreCase(command)) {
@@ -1776,6 +1764,10 @@ public class Main {
                         LogType.LOG, coreBundle.getString("problem.closing.connection"), e);
             }
         }
+    }
+
+    private String getSchemaParams() throws CommandLineParsingException {
+        return getCommandParam(OPTIONS.SCHEMAS, schemas);
     }
 
     private LiquibaseCommand createLiquibaseCommand(Database database, Liquibase liquibase, String commandName, Map<String, Object> argsMap)


### PR DESCRIPTION
##Overall: 
`--schemas` will only work for snapshot when to the right of the command, but for other liquibase commands, like `generatechangelog`, it works and is documented as working to the left (in the "global commands" space). we need to make sure --schemas works to the standard usage (to the left of the command).

## Context
A Liquibase client was having issue running a diff between a snapshot and multiple schemas.
The user workflow was as follows:
1. Snapshot the target database with multiple schemas using the flags: "--schema=<schema1,schema2,schema3>"
2. The user conducts a few changes to the target database.
3. The user then runs a diffChangeLog between the snapshot and the target database.
Unfortunately the resulting diffChangeLog did not carry all the changes that were made in all of the schemas specified while doing the original snapshot. 
After support conducted a few tests, it appears that when running the snapshot command, Liquibase does NOT include all the schemas specified with the "--schema<schema1,schema2,schema3>" flag in the snapshot file.
Instead, it only contains the default schema.