### PR TITLE
Global help should be displayed if no command.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -252,6 +252,10 @@ public class Main {
 
             try {
                 main.parseOptions(args);
+                if (main.command == null) {
+                    main.printHelp(System.out);
+                    return 0;
+                }
             } catch (CommandLineParsingException e) {
                 log.info(LogType.USER_MESSAGE, CommandLineUtils.getBanner());
                 log.warning(LogType.USER_MESSAGE, coreBundle.getString("how.to.display.help"));
@@ -1125,7 +1129,8 @@ public class Main {
     private void parseOptionArgument(String arg, boolean okIfNotAField) throws CommandLineParsingException {
         final String PROMPT_FOR_VALUE = "PROMPT";
 
-        if (arg.toLowerCase().startsWith("--" + OPTIONS.VERBOSE)) {
+        if (arg.toLowerCase().startsWith("--" + OPTIONS.VERBOSE) ||
+            arg.toLowerCase().startsWith("--" + OPTIONS.HELP)) {
             return;
         }
 


### PR DESCRIPTION
Global help should be displayed if no command.

closes #1070

┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-168) by [Unito](https://www.unito.io/learn-more)
