### PR TITLE
Add code to allow for multiple column unique constraints on table creation.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateTableGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateTableGenerator.java
@@ -33,7 +33,13 @@ import liquibase.structure.core.Table;
 import liquibase.util.StringUtil;
 
 import java.math.BigInteger;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
 
 public class CreateTableGenerator extends AbstractSqlGenerator<CreateTableStatement> {
 

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateTableGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateTableGenerator.java
@@ -33,9 +33,7 @@ import liquibase.structure.core.Table;
 import liquibase.util.StringUtil;
 
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 public class CreateTableGenerator extends AbstractSqlGenerator<CreateTableStatement> {
 
@@ -295,7 +293,38 @@ public class CreateTableGenerator extends AbstractSqlGenerator<CreateTableStatem
             buffer.append(",");
         }
 
+        /*
+         * In the current syntax, UNIQUE constraints can only be set per column on table creation.
+         * To alleviate this problem we combine the columns of unique constraints that have the same name.
+         */
+        HashMap<String, UniqueConstraint> uniqueConstraintMap = new HashMap<>();
+        List<UniqueConstraint> aggregatedUniqueConstraints = new LinkedList<>();
         for (UniqueConstraint uniqueConstraint : statement.getUniqueConstraints()) {
+            if (uniqueConstraint.getConstraintName() == null) {  // Only combine uniqueConstraints that have a name.
+                aggregatedUniqueConstraints.add(uniqueConstraint);}
+            else {
+                String constraintName = uniqueConstraint.getConstraintName();
+                if (uniqueConstraintMap.containsKey(constraintName)) { // if we have seen the uniqueContraint before ..
+                    UniqueConstraint oldUniqueConstraint = uniqueConstraintMap.get(constraintName);
+                    // check if it is really the same constraint
+                    if (oldUniqueConstraint.shouldValidateUnique() != uniqueConstraint.shouldValidateUnique()) {
+                        aggregatedUniqueConstraints.add(uniqueConstraint);  // if not, add it to the aggregated constraints
+                    }
+                    else { // if yes, check which columns are new and add these to the constraint. Put the newly generated constraint back in the map.
+                        Set<String> newColumns = new HashSet<>(uniqueConstraint.getColumns());
+                        newColumns.removeAll(oldUniqueConstraint.getColumns());
+                        for (String column: newColumns) {
+                            oldUniqueConstraint.addColumns(column);
+                        }
+                        uniqueConstraintMap.put(constraintName, oldUniqueConstraint);
+                    }
+                }
+                else uniqueConstraintMap.put(constraintName, uniqueConstraint);  // if we haven't seen the constraint before put it in the map.
+            }
+        }
+        aggregatedUniqueConstraints.addAll(uniqueConstraintMap.values());
+
+        for (UniqueConstraint uniqueConstraint : aggregatedUniqueConstraints) {
             if (uniqueConstraint.getConstraintName() != null) {
                 buffer.append(" CONSTRAINT ");
                 buffer.append(database.escapeConstraintName(uniqueConstraint.getConstraintName()));

--- a/liquibase-core/src/test/java/liquibase/sqlgenerator/core/CreateTableGeneratorTest.java
+++ b/liquibase-core/src/test/java/liquibase/sqlgenerator/core/CreateTableGeneratorTest.java
@@ -4,7 +4,11 @@ import static org.junit.Assert.assertEquals;
 
 import java.math.BigInteger;
 
+import com.example.liquibase.change.UniqueConstraintConfig;
+import liquibase.change.ConstraintsConfig;
 import liquibase.database.MockDatabaseConnection;
+import liquibase.datatype.LiquibaseDataType;
+import liquibase.statement.*;
 import org.junit.Test;
 
 import liquibase.change.ColumnConfig;
@@ -24,11 +28,6 @@ import liquibase.datatype.DataTypeFactory;
 import liquibase.datatype.core.IntType;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.AbstractSqlGeneratorTest;
-import liquibase.statement.AutoIncrementConstraint;
-import liquibase.statement.ColumnConstraint;
-import liquibase.statement.DatabaseFunction;
-import liquibase.statement.ForeignKeyConstraint;
-import liquibase.statement.NotNullConstraint;
 import liquibase.statement.core.CreateTableStatement;
 import liquibase.test.TestContext;
 
@@ -990,5 +989,26 @@ public class CreateTableGeneratorTest extends AbstractSqlGeneratorTest<CreateTab
         statement.addColumnConstraint(new ForeignKeyConstraint("fk_test_parent", TABLE_NAME + "(id)").setColumn("id"));
         Sql[] generatedSql = this.generatorUnderTest.generateSql(statement, database, null);
         assertEquals("CREATE TABLE SCHEMA_NAME.TABLE_NAME (, CONSTRAINT fk_test_parent FOREIGN KEY (id) REFERENCES \"my-schema\".TABLE_NAME(id))", generatedSql[0].toSql());
+    }
+
+    @Test
+    public void combineUniqueConstraints() {
+        Database database = new SQLiteDatabase();
+        database.setOutputDefaultSchema(true);
+        LiquibaseDataType integerType = DataTypeFactory.getInstance().fromDescription("INTEGER", database);
+
+        CreateTableStatement statement = new CreateTableStatement(CATALOG_NAME, SCHEMA_NAME, TABLE_NAME);
+        statement.addColumn("MY_KEY", integerType, new UniqueConstraint("SAME"));
+        statement.addColumn("MY_OTHER_KEY", integerType, new UniqueConstraint("SAME"));
+        statement.addColumn("SINGLE_UNIQUE_KEY", integerType, new UniqueConstraint("DIFFERENT"));
+        statement.addColumn("UNIQUE_NO_CONSTRAINT_NAME", integerType, new UniqueConstraint());
+        Sql[] generatedSql = this.generatorUnderTest.generateSql(statement, database, null);
+        String expectedSql = "CREATE TABLE CATALOG_NAME.TABLE_NAME " +
+                "(MY_KEY INTEGER, MY_OTHER_KEY INTEGER, " +
+                "SINGLE_UNIQUE_KEY INTEGER, UNIQUE_NO_CONSTRAINT_NAME INTEGER, " +
+                "UNIQUE (UNIQUE_NO_CONSTRAINT_NAME), " +
+                "CONSTRAINT SAME UNIQUE (MY_KEY, MY_OTHER_KEY), " +
+                "CONSTRAINT DIFFERENT UNIQUE (SINGLE_UNIQUE_KEY))";
+        assertEquals(expectedSql, generatedSql[0].toSql());
     }
 }


### PR DESCRIPTION
Hi! SQLite does not allow adding unique constraints after table creation. So the addUniqueConstraint clause can not be used. The createTable syntax only allows single-column unique constraints even if these have the same name: see #1056 . 

My proposed solution here is to combine all the columns for uniqueConstraints that have the same name. These should be the same constraint. I do not think there is a use case for defining single-column unique constraints with the exact same constraint name. I have added a test as well.

I am not a Java programmer (experience in Scala and Python) so I apologize for the clunky Java. There is probably some syntactic sugar that can be used to make the code less verbose and more readable.

Also, wow! Such readable code in this project! It was quite easy to implement something in the right place.

EDIT: I have a question: to which branch should I add this? Given that this adds a new feature it should be on 3.9.x which is master. Or if this is seen as a bugfix then it can be on 3.8.x. I'd prefer the latter, since this is blocking for SQLite on the project I am working on, but I defer to your judgement.