### PR TITLE
Added quotes around ${JAVA_PATH} in liquibase shell script to avoid spaces in path issues

### DIFF
--- a/liquibase-dist/src/main/archive/liquibase
+++ b/liquibase-dist/src/main/archive/liquibase
@@ -74,4 +74,4 @@ fi
 # add any JVM options here
 JAVA_OPTS="${JAVA_OPTS-}"
 
-${JAVA_PATH} -cp "$CP" $JAVA_OPTS liquibase.integration.commandline.Main ${1+"$@"}
+"${JAVA_PATH}" -cp "$CP" $JAVA_OPTS liquibase.integration.commandline.Main ${1+"$@"}


### PR DESCRIPTION
**Branch: Liquibase/master**

Added quotes around ${JAVA_PATH} in line 77 to avoid issues when there are spaces in the JAVA_PATH when using Emulators like "Git bash for Windows".

This fix will prevent having issues with spaces in JAVA_PATH.  For example: when running Liquibase commands in Windows with Linux/Unix like Emulators such as: "Git bash for Windows" or "Minimalist GNU for Windows" with preexisting spaces in the JAVA_PATH.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-173) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Community 4.x
