### PR TITLE
Change namespace for changeAttributes type to be namespace="##other"

### DIFF
--- a/liquibase-core/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.0.xsd
+++ b/liquibase-core/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.0.xsd
@@ -281,7 +281,7 @@
 
     <!-- Attributes for changes -->
     <xsd:attributeGroup name="changeAttributes">
-        <xsd:anyAttribute namespace="##any" processContents="lax"/>
+        <xsd:anyAttribute namespace="##other" processContents="lax"/>
     </xsd:attributeGroup>
 
     <!-- Attributes for constraints -->


### PR DESCRIPTION
Change namespace for changeAttributes type to be namespace="##other" which will cause validation of attributes

┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-175) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 4.0 beta 2
