### PR TITLE
#1066 addNotNullConstraint / dropNotNullConstraint not supported on Firebird

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/SetNullableGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/SetNullableGenerator.java
@@ -77,7 +77,7 @@ public class SetNullableGenerator extends AbstractSqlGenerator<SetNullableStatem
         } else if (database instanceof FirebirdDatabase && !(database instanceof Firebird3Database)) {
             // For Firebird database prior to Firebird 3 the ALTER TABLE syntax is not working
             // As a workaround we can modify the system table entry directly (see http://www.firebirdfaq.org/faq103/)
-            sql = "UPDATE RDB$RELATION_FIELDS SET RDB$NULL_FLAG = " + (statement.isNullable() ? "1" : "NULL") + " WHERE RDB$RELATION_NAME = '" + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + "' AND RDB$FIELD_NAME = '" + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + "'";
+            sql = "UPDATE RDB$RELATION_FIELDS SET RDB$NULL_FLAG = " + (statement.isNullable() ? "NULL" : "1") + " WHERE RDB$RELATION_NAME = '" + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + "' AND RDB$FIELD_NAME = '" + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + "'";
         } else {
             sql = "ALTER TABLE " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + " ALTER COLUMN  " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + (statement.isNullable() ? " DROP NOT NULL" : " SET NOT NULL");
         }

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/SetNullableGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/SetNullableGenerator.java
@@ -75,6 +75,8 @@ public class SetNullableGenerator extends AbstractSqlGenerator<SetNullableStatem
             }
             sql = "ALTER TABLE " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + " MODIFY (" + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " " + DataTypeFactory.getInstance().fromDescription(statement.getColumnDataType(), database).toDatabaseDataType(database) + nullableString + ")";
         } else if (database instanceof FirebirdDatabase && !(database instanceof Firebird3Database)) {
+            // For Firebird database prior to Firebird 3 the ALTER TABLE syntax is not working
+            // As a workaround we can modify the system table entry directly (see http://www.firebirdfaq.org/faq103/)
             sql = "UPDATE RDB$RELATION_FIELDS SET RDB$NULL_FLAG = " + (statement.isNullable() ? "1" : "NULL") + " WHERE RDB$RELATION_NAME = " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + " AND RDB$FIELD_NAME = " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName());
         } else {
             sql = "ALTER TABLE " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + " ALTER COLUMN  " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + (statement.isNullable() ? " DROP NOT NULL" : " SET NOT NULL");

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/SetNullableGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/SetNullableGenerator.java
@@ -77,7 +77,7 @@ public class SetNullableGenerator extends AbstractSqlGenerator<SetNullableStatem
         } else if (database instanceof FirebirdDatabase && !(database instanceof Firebird3Database)) {
             // For Firebird database prior to Firebird 3 the ALTER TABLE syntax is not working
             // As a workaround we can modify the system table entry directly (see http://www.firebirdfaq.org/faq103/)
-            sql = "UPDATE RDB$RELATION_FIELDS SET RDB$NULL_FLAG = " + (statement.isNullable() ? "1" : "NULL") + " WHERE RDB$RELATION_NAME = " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + " AND RDB$FIELD_NAME = " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName());
+            sql = "UPDATE RDB$RELATION_FIELDS SET RDB$NULL_FLAG = " + (statement.isNullable() ? "1" : "NULL") + " WHERE RDB$RELATION_NAME = '" + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + "' AND RDB$FIELD_NAME = '" + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + "'";
         } else {
             sql = "ALTER TABLE " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + " ALTER COLUMN  " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + (statement.isNullable() ? " DROP NOT NULL" : " SET NOT NULL");
         }

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/SetNullableGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/SetNullableGenerator.java
@@ -31,7 +31,7 @@ public class SetNullableGenerator extends AbstractSqlGenerator<SetNullableStatem
             //cannot check
         }
 
-        return !((database instanceof FirebirdDatabase) || (database instanceof SQLiteDatabase));
+        return !(database instanceof SQLiteDatabase);
     }
 
     @Override
@@ -74,6 +74,8 @@ public class SetNullableGenerator extends AbstractSqlGenerator<SetNullableStatem
                 nullableString = "";
             }
             sql = "ALTER TABLE " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + " MODIFY (" + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " " + DataTypeFactory.getInstance().fromDescription(statement.getColumnDataType(), database).toDatabaseDataType(database) + nullableString + ")";
+        } else if (database instanceof FirebirdDatabase && !(database instanceof Firebird3Database)) {
+            sql = "UPDATE RDB$RELATION_FIELDS SET RDB$NULL_FLAG = " + (statement.isNullable() ? "1" : "NULL") + " WHERE RDB$RELATION_NAME = " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + " AND RDB$FIELD_NAME = " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName());
         } else {
             sql = "ALTER TABLE " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + " ALTER COLUMN  " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + (statement.isNullable() ? " DROP NOT NULL" : " SET NOT NULL");
         }

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addLookupTable/firebird.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addLookupTable/firebird.sql
@@ -1,0 +1,9 @@
+-- Database: firebird
+-- Change Parameter: existingColumnName=state
+-- Change Parameter: existingTableName=address
+-- Change Parameter: newColumnName=abbreviation
+-- Change Parameter: newTableName=state
+CREATE TABLE state AS SELECT DISTINCT state AS abbreviation FROM address WHERE state IS NOT NULL;
+ALTER TABLE state ALTER COLUMN  abbreviation SET NOT NULL;
+ALTER TABLE state ADD PRIMARY KEY (abbreviation);
+ALTER TABLE address ADD CONSTRAINT FK_ADDRESS_STATE FOREIGN KEY (state) REFERENCES state (abbreviation);

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addNotNullConstraint/firebird.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/addNotNullConstraint/firebird.sql
@@ -1,0 +1,4 @@
+-- Database: firebird
+-- Change Parameter: columnName=id
+-- Change Parameter: tableName=person
+ALTER TABLE person ALTER COLUMN  id SET NOT NULL;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropNotNullConstraint/firebird.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/dropNotNullConstraint/firebird.sql
@@ -1,0 +1,4 @@
+-- Database: firebird
+-- Change Parameter: columnName=id
+-- Change Parameter: tableName=person
+ALTER TABLE person ALTER COLUMN  id DROP NOT NULL;

--- a/liquibase-integration-tests/src/test/resources/changelogs/common/common.tests.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/common/common.tests.changelog.xml
@@ -155,10 +155,10 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="nullable-1" author="nvoxland" dbms="!firebird">
+    <changeSet id="nullable-1" author="nvoxland">
         <addNotNullConstraint tableName="compoundPKTest" columnName="name" columnDataType="varchar(255)" defaultNullValue="testValue"/>
     </changeSet>
-    <changeSet id="nullable-2" author="nvoxland" dbms="!firebird">
+    <changeSet id="nullable-2" author="nvoxland">
         <dropNotNullConstraint tableName="compoundPKTest" columnName="name" columnDataType="varchar(255)"/>
     </changeSet>
 
@@ -222,7 +222,7 @@
         </preConditions>
         <sql>More invalid SQL. should not run due to "continue"</sql>
     </changeSet>
-    
+
     <changeSet id="add-column-test1" author="alan">
         <preConditions onFail="MARK_RAN">
             <not>
@@ -338,11 +338,11 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="makeNotnulltest" author="nvoxland" dbms="!firebird">
+    <changeSet id="makeNotnulltest" author="nvoxland">
         <addNotNullConstraint tableName="commonTypesTest" columnName="intColumn" columnDataType="int"/>
     </changeSet>
 
-    <changeSet id="makenulltest" author="nvoxland" dbms="!firebird">
+    <changeSet id="makenulltest" author="nvoxland">
         <dropNotNullConstraint tableName="commonTypesTest" columnName="intColumn" columnDataType="int"/>
     </changeSet>
 
@@ -998,7 +998,7 @@
 
 
     <sql>
-      <![CDATA[  
+      <![CDATA[
         insert into testutf8insert (stringvalue) values ('€');
         insert into testutf8insert (stringvalue) values ('£');
         ]]>

--- a/liquibase-integration-tests/src/test/resources/changelogs/firebird/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/firebird/complete/root.changelog.xml
@@ -14,7 +14,7 @@
             You can add comments to changeSets.
             They can even be multiple lines if you would like.
             They aren't used to compute the changeSet MD5Sum, so you can update them whenever you want without causing problems.
-        </comment>        
+        </comment>
         <createTable tableName="person">
             <column name="id" type="int">
                 <constraints primaryKey="true" nullable="false"/>
@@ -82,20 +82,20 @@
             <column name="name" value="Widgets Inc."/>
         </insert>
     </changeSet>
-    <!--<changeSet id="7a" author="nvoxland">-->
-        <!--<addColumn tableName="company">-->
-            <!--<column name="company_id" type="int">-->
-                <!--<constraints nullable="true" foreignKeyName="fk_employee_company" references="employee(id)"/>-->
-            <!--</column>-->
-        <!--</addColumn>-->
-    <!--</changeSet>-->
-    <!--<changeSet id="8" author="bjohnson">-->
-        <!--<dropNotNullConstraint tableName="employee" columnName="name" columnDataType="varchar(50)"/>-->
-    <!--</changeSet>-->
-    <!--<changeSet id="8.1" author="bjohnson">-->
-        <!--<comment>I guess name needs to be not-null</comment>-->
-        <!--<addNotNullConstraint tableName='employee' columnName="name" defaultNullValue="UNKNOWN"/>-->
-    <!--</changeSet>-->
+    <changeSet id="7a" author="nvoxland">
+        <addColumn tableName="company">
+            <column name="company_id" type="int">
+                <constraints nullable="true" foreignKeyName="fk_employee_company" references="employee(id)"/>
+            </column>
+        </addColumn>
+    </changeSet>
+    <changeSet id="8" author="bjohnson">
+        <dropNotNullConstraint tableName="company" columnName="name"/>
+    </changeSet>
+    <changeSet id="8.1" author="bjohnson">
+        <comment>I guess name needs to be not-null</comment>
+        <addNotNullConstraint tableName='company' columnName="name" defaultNullValue="UNKNOWN"/>
+    </changeSet>
     <!--<changeSet id="9" author="nvoxland">-->
         <!--<renameTable oldTableName="employee" newTableName="company"/>-->
     <!--</changeSet>-->

--- a/liquibase-integration-tests/src/test/resources/changelogs/firebird/rollback/rollbackable.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/firebird/rollback/rollbackable.changelog.xml
@@ -29,9 +29,9 @@
             <column name="sku"/>
         </createIndex>
     </changeSet>
-    <!--<changeSet id="3" author="nvoxland">-->
-        <!--<dropNotNullConstraint tableName="magazine" columnName="title" columnDataType="varchar(50)"/>-->
-    <!--</changeSet>-->
+    <changeSet id="3" author="nvoxland">
+        <dropNotNullConstraint tableName="magazine" columnName="title"/>
+    </changeSet>
     <changeSet id="4" author="nvoxland">
         <renameColumn tableName="magazine" oldColumnName="sku" newColumnName="isbn"/>
     </changeSet>
@@ -68,9 +68,9 @@
             <column name="numPages" type="int"/>
         </addColumn>
     </changeSet>
-    <!--<changeSet id="8" author="nvoxland">-->
-        <!--<addNotNullConstraint tableName="publication" columnName="title" columnDataType="varchar(50)" defaultNullValue="-1"/>-->
-    <!--</changeSet>-->
+    <changeSet id="8" author="nvoxland">
+        <addNotNullConstraint tableName="publication" columnName="title" defaultNullValue="-1"/>
+    </changeSet>
 
     <changeSet id="9" author="nvoxland">
         <createSequence sequenceName="seq_magazine_id"/>
@@ -138,5 +138,5 @@
     <changeSet id="21" author="nvoxland">
         <customChange class="liquibase.change.custom.ExampleCustomTaskChange" helloTo="world"/>
     </changeSet>
-    
+
 </databaseChangeLog>


### PR DESCRIPTION
**Branch: Liquibase/master**

Content copied from issue #1066 

**Description**
The change addNotNullConstraint and dropNotNullConstraint are not available for Firebird databases.

**To Reproduce**
Add the commands to a change set and run it against a Firebird database. As a result there will be the following error messages:
addNotNullConstraint is not supported on firebird
dropNotNullConstraint is not supported on firebird

**Expected behavior**
The commands should be available for Firebird databases as well.

closes #1066

┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-178) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 4.0 beta 2
