### PR TITLE
Fix HistoryCommandTest to run on systems having a non-US default locale

### DIFF
--- a/liquibase-core/src/test/groovy/liquibase/command/core/HistoryCommandTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/command/core/HistoryCommandTest.groovy
@@ -10,7 +10,15 @@ import spock.lang.Unroll
 
 class HistoryCommandTest extends Specification {
 
+    def lastDefaultLocale;
+
+    def setup() {
+        lastDefaultLocale = Locale.getDefault()
+        Locale.setDefault(Locale.US)
+    }
+
     def cleanup() {
+        Locale.setDefault(lastDefaultLocale);
         ChangeLogHistoryServiceFactory.reset()
     }
 


### PR DESCRIPTION
**Branch: Liquibase/master**

<!--- What types of changes does your code introduce?
Put an `x` in all the boxes that apply: -->

* \[x] Bug fix (non-breaking change which fixes an issue)
* \[ ] Enhancement/New feature (non-breaking change which adds functionality)
* \[ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
The HistoryCommandTest fails on systems with a non-US default Locale because the date in the history is formatted in a locale-specific way

## Steps To Reproduce
* Run the test case on a system with e.g. German as default Locale

## Actual Behavior
With German the test produces:
> Database updated at 09.07.19 12:15.

## Expected/Desired Behavior
No matter on which system the test is running, it produces:
> Database updated at 7/9/19 12:15 PM.

## Fast Track PR Acceptance Checklist:
* \[x] Build is successful and all new and existing tests pass
* \[ ] Added Unit Test(s)
* \[ ] Added Integration Test(s)
* \[ ] Documentation Updated



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-189) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Community 4.2.x
