### PR TITLE
Added space before ']' in lines 8 and 16 to make bash happy (otherwise a syntax error).

### DIFF
--- a/liquibase-dist/src/main/archive/examples/start-h2
+++ b/liquibase-dist/src/main/archive/examples/start-h2
@@ -5,7 +5,7 @@ if [ -z "${LIQUIBASE_HOME}" ]; then
 
   LIQUIBASE_PATH="$(which liquibase)"
 
-  if [ -z "${LIQUIBASE_PATH}"]; then
+  if [ -z "${LIQUIBASE_PATH}" ]; then
     echo "Must set LIQUIBASE_HOME environment variable, or have liquibase in your PATH"
     exit 1
   fi
@@ -13,7 +13,7 @@ if [ -z "${LIQUIBASE_HOME}" ]; then
   LIQUIBASE_HOME=$(dirname "$(which liquibase)")
 fi
 
-if [ -z "${JAVA_HOME}"]; then
+if [ -z "${JAVA_HOME}" ]; then
   #JAVA_HOME not set, try to find a bundled version
   if [ -d "${LIQUIBASE_HOME}/jre" ]; then
     JAVA_HOME="$LIQUIBASE_HOME/jre"


### PR DESCRIPTION
---
Liquibase Version: '3.8.8'
Liquibase Integration: 'CLI' 
Liquibase Extension(s) & Version: ''
Database Vendor & Version: ''
Operating System Type & Version: 'Linux, MacOS - bash'
---

<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->
- [x] Bug fix (non-breaking change which fixes an issue.)
- [ ] Enhancement/New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

A clear and concise description of the issue being addressed.
- Add spaces after the closing ']' brackets to avoid a syntax error. 
- Ensure private information is redacted.

## Steps To Reproduce

List the steps to reproduce the behavior.
- Run ./start-h2

## Actual Behavior
A clear and concise description of what happens in the software **before** this pull request.
- bash throws an error "line 8: [: missing `]'"

## Expected/Desired Behavior
No syntax errors.

## Screenshots (if appropriate)
If applicable, add screenshots to help explain your problem.

## Additional Context
Add any other context about the problem here.

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->
- [x] Build is successful and all new and existing tests pass
- [ ] Added Unit Test(s)
- [ ] Added Integration Test(s)
- [ ] Documentation Updated

┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-193) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 3.10.1
