### PR TITLE
Fix 1039 sequence statement generation for PostgreSQL <= 9.4

### DIFF
--- a/base.pom.xml
+++ b/base.pom.xml
@@ -111,6 +111,13 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.3.3</version>
+            <scope>test</scope>
+        </dependency>
+
 
         <dependency> <!-- use a specific Groovy version rather than the one specified by spock-core -->
             <groupId>org.codehaus.groovy</groupId>


### PR DESCRIPTION
## Environment

**Liquibase Version**: 3.8.9

**Liquibase Integration & Version**: CLI, maven

**Database Vendor & Version**: PostgreSQL 9.4

**Operating System Type & Version**: Windows 10

## Pull Request Type

- [x] Bug fix (non-breaking change which fixes an issue.)
- [ ] Enhancement/New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This fix the issue #1039 New liquibase version introduce a IF NOT EXIST in the sequence statement that is not supported for db version <= 9.4 as documented [here](https://www.postgresql.org/docs/9.5/sql-createsequence.html)

## Fast Track PR Acceptance Checklist:
- [ ] Build is successful and all new and existing tests pass
- [ ] Added Unit Test(s)
- [ ] Added Integration Test(s)
- [ ] Documentation Updated

This was tested against my local db and newer version using docker image of postgresql 10.16 and 12

┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-207) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 3.10.1
