### PR TITLE
Removing quotes around JAVA_HOME in liquibase.bat script

### DIFF
--- a/liquibase-dist/src/main/archive/liquibase.bat
+++ b/liquibase-dist/src/main/archive/liquibase.bat
@@ -12,6 +12,8 @@ for /R %LIQUIBASE_HOME%\lib %%f in (*.jar) do set CP=!CP!;%%f
 
 rem remove quotes around LIQUIBASE_HOME
 set LIQUIBASE_HOME=%LIQUIBASE_HOME:"=%
+rem remove quotes around JAVA_HOME
+set JAVA_HOME=%JAVA_HOME:"=%
 
 rem set JAVA_HOME to local jre dir if not set
 if exist "%LIQUIBASE_HOME%\jre" if "%JAVA_HOME%"=="" (


### PR DESCRIPTION
- - -
name: Pull Request
about: Create a report to help us improve
title: ''
labels: Status:smiley:iscovery
assignees: ''

- - -
## Environment
Windows
**Liquibase Version**:
Any version
**Liquibase Integration & Version**: 
CLI
**Operating System Type & Version**:
Windows

## Pull Request Type
* \[x] Bug fix (non-breaking change which fixes an issue.)
* \[ ] Enhancement/New feature (non-breaking change which adds functionality)
* \[ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
When running liquibase commands in Windows, the liquibase.bat file is called.
Part of the logic in the liquibase.bat is to add quotes the the JAVA_HOME.  However if the JAVA_HOME was previously set with quotes, then the liquibase.bat will add an extra quotes around it, causing it the command to fail.

This fix will avoid any issues when the user already has his JAVA_HOME path set with quotes around it prior to running any liquibase.bat commands by stripping the existing quotes if quotes exist, but if they don’t exist then it will do nothing.

## Steps To Reproduce
Set your JAVA_HOME environment variable with quotes around the path.
For example:
set JAVA_HOME="C:\Program Files\Java\jre1.8.0_241\"

## Actual Behavior
C:\Users\Administrator>liquibase --version
Files\Java\jre1.8.0_241""=="" was unexpected at this time.

## Expected/Desired Behavior
C:\Users\Administrator>liquibase --version
Starting Liquibase at Fri, 24 Apr 2020 16:45:49 CDT (version 3.8.7 #55 built at Mon Feb 24 03:04:51 UTC 2020)
Liquibase Version: 3.8.7
Liquibase Community 3.8.7 by Datical
Running Java under C:\Program Files\Java\jre1.8.0_241 (Version 1.8.0_241)

## Fast Track PR Acceptance Checklist:
* \[ ] Build is successful and all new and existing tests pass
* \[ ] Added Unit Test(s)
* \[ ] Added Integration Test(s)
* \[ ] Documentation Updated



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-224) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 3.10
