### PR TITLE
LiquibaseServletListener.contextInitialized() should not shut Embedded Derby down

### DIFF
--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -38,6 +38,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derby</artifactId>
+            <version>10.14.2.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant-antunit</artifactId>
             <version>1.3</version>

--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -38,6 +38,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derby</artifactId>
+            <version>10.14.2.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>3.3.3</version>

--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -38,9 +38,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derby</artifactId>
-            <version>10.14.2.0</version>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.3.3</version>
             <scope>test</scope>
         </dependency>
 

--- a/liquibase-core/src/main/java/liquibase/database/core/DerbyDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/DerbyDatabase.java
@@ -25,6 +25,7 @@ public class DerbyDatabase extends AbstractJdbcDatabase {
     protected int driverVersionMajor;
     protected int driverVersionMinor;
     private Logger log = LogService.getLog(getClass());
+    private boolean shutdownEmbeddedDerby = true;
 
     public DerbyDatabase() {
         super.setCurrentDateTimeFunction("CURRENT_TIMESTAMP");
@@ -89,6 +90,14 @@ public class DerbyDatabase extends AbstractJdbcDatabase {
         return "derby";
     }
 
+    public boolean getShutdownEmbeddedDerby() {
+        return shutdownEmbeddedDerby;
+    }
+
+    public void setShutdownEmbeddedDerby(boolean shutdown) {
+        this.shutdownEmbeddedDerby = shutdown;
+    }
+
     @Override
     public boolean supportsSequences() {
         return ((driverVersionMajor == 10) && (driverVersionMinor >= 6)) || (driverVersionMajor >= 11);
@@ -131,7 +140,7 @@ public class DerbyDatabase extends AbstractJdbcDatabase {
         String url = getConnection().getURL();
         String driverName = getDefaultDriver(url);
         super.close();
-        if ((driverName != null) && driverName.toLowerCase().contains("embedded")) {
+        if (getShutdownEmbeddedDerby() && (driverName != null) && driverName.toLowerCase().contains("embedded")) {
             try {
                 if (url.contains(";")) {
                     url = url.substring(0, url.indexOf(";")) + ";shutdown=true";

--- a/liquibase-core/src/main/java/liquibase/integration/servlet/LiquibaseServletListener.java
+++ b/liquibase-core/src/main/java/liquibase/integration/servlet/LiquibaseServletListener.java
@@ -9,6 +9,7 @@ import liquibase.configuration.GlobalConfiguration;
 import liquibase.configuration.LiquibaseConfiguration;
 import liquibase.database.Database;
 import liquibase.database.DatabaseFactory;
+import liquibase.database.core.DerbyDatabase;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.LiquibaseException;
 import liquibase.logging.LogService;
@@ -239,6 +240,9 @@ public class LiquibaseServletListener implements ServletContextListener {
             }
 
             liquibase.update(new Contexts(getContexts()), new LabelExpression(getLabels()));
+            if (database instanceof DerbyDatabase) {
+                ((DerbyDatabase) database).setShutdownEmbeddedDerby(false);
+            }
         }
         finally {
             if (database != null) {

--- a/liquibase-core/src/test/java/liquibase/database/core/DerbyDatabaseTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/core/DerbyDatabaseTest.java
@@ -1,7 +1,12 @@
 package liquibase.database.core;
 
+import java.sql.Connection;
+import javax.sql.DataSource;
+import org.apache.derby.jdbc.BasicEmbeddedDataSource40;
+
 import junit.framework.TestCase;
 import liquibase.database.Database;
+import liquibase.database.jvm.JdbcConnection;
 
 public class DerbyDatabaseTest extends TestCase {
     public void testGetDefaultDriver() {
@@ -17,6 +22,38 @@ public class DerbyDatabaseTest extends TestCase {
         assertEquals("TIMESTAMP('2008-01-25 13:57:41.300000')", new DerbyDatabase().getDateLiteral("2008-01-25 13:57:41.3"));
         assertEquals("TIMESTAMP('2008-01-25 13:57:41.340000')", new DerbyDatabase().getDateLiteral("2008-01-25 13:57:41.34"));
         assertEquals("TIMESTAMP('2008-01-25 13:57:41.347000')", new DerbyDatabase().getDateLiteral("2008-01-25 13:57:41.347"));
+    }
+
+    public void testCloseShutsEmbeddedDerbyDown() throws Exception {
+        DataSource ds = newDataSource();
+        try (Connection pooled = ds.getConnection()) {
+
+            Database database = new DerbyDatabase();
+            database.setConnection(new JdbcConnection(ds.getConnection()));
+            database.close();
+
+            assertEquals("connection.closed", true, pooled.isClosed());
+        }
+    }
+
+    public void testCloseDoesNotShutEmbeddedDerbyDown() throws Exception {
+        DataSource ds = newDataSource();
+        try (Connection connection = ds.getConnection()) {
+
+            DerbyDatabase database = new DerbyDatabase();
+            database.setShutdownEmbeddedDerby(false);
+            database.setConnection(new JdbcConnection(ds.getConnection()));
+            database.close();
+
+            assertEquals("connection.closed", false, connection.isClosed());
+        }
+    }
+
+    private BasicEmbeddedDataSource40 newDataSource() {
+        BasicEmbeddedDataSource40 ds = new BasicEmbeddedDataSource40();
+        ds.setDatabaseName("memory:Foo");
+        ds.setCreateDatabase("create");
+        return ds;
     }
 
 }

--- a/liquibase-core/src/test/java/liquibase/integration/servlet/LiquibaseServletListenerTest.java
+++ b/liquibase-core/src/test/java/liquibase/integration/servlet/LiquibaseServletListenerTest.java
@@ -1,0 +1,78 @@
+package liquibase.integration.servlet;
+
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.util.Arrays;
+import java.util.Collections;
+
+import javax.naming.Context;
+import javax.naming.NamingException;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.sql.DataSource;
+
+import org.apache.derby.jdbc.BasicEmbeddedDataSource40;
+
+import junit.extensions.TestSetup;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+public class LiquibaseServletListenerTest extends TestCase {
+
+    private static final String LIQUIBASE_CHANGELOG = "liquibase.changelog";
+    private static final String LIQUIBASE_DATASOURCE = "liquibase.datasource";
+
+    static DataSource dataSource;
+
+    private LiquibaseServletListener servletListener;
+    private ServletContext servletContext;
+    private Context namingContext;
+
+    public static Test suite() {
+        return new TestSetup(new TestSuite(LiquibaseServletListenerTest.class)) {
+            @Override protected void setUp() {
+                TestInitialContextFactory.install();
+                BasicEmbeddedDataSource40 ds = new BasicEmbeddedDataSource40();
+                ds.setDatabaseName("memory:foo");
+                ds.setCreateDatabase("create");
+                dataSource = ds;
+            }
+            @Override protected void tearDown() {
+                dataSource = null;
+                TestInitialContextFactory.uninstall();
+            }
+        };
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        servletListener = new LiquibaseServletListener();
+
+        servletContext = mock(ServletContext.class);
+        when(servletContext.getInitParameter(LIQUIBASE_DATASOURCE)).thenReturn("myDS");
+        when(servletContext.getInitParameter(LIQUIBASE_CHANGELOG))
+                .thenReturn("liquibase/integration/servlet/simple-changelog.xml");
+        when(servletContext.getInitParameterNames()).then(invocation ->
+                Collections.enumeration(Arrays.asList(LIQUIBASE_DATASOURCE, LIQUIBASE_CHANGELOG)));
+
+        Context env = mock(Context.class);
+        when(env.lookup(anyString())).thenThrow(NamingException.class);
+
+        namingContext = mock(Context.class);
+        when(namingContext.lookup("java:comp/env")).thenReturn(env);
+        when(namingContext.lookup("myDS")).thenReturn(dataSource);
+        TestInitialContextFactory.setInitialContext(namingContext);
+    }
+
+    public void testShouldNotShutEmbeddedDerbyDown() throws Exception {
+        try (Connection pooled = dataSource.getConnection()) {
+            servletListener.contextInitialized(new ServletContextEvent(servletContext));
+            assertEquals("connection.closed", false, pooled.isClosed());
+        }
+    }
+
+}

--- a/liquibase-core/src/test/java/liquibase/integration/servlet/TestInitialContextFactory.java
+++ b/liquibase-core/src/test/java/liquibase/integration/servlet/TestInitialContextFactory.java
@@ -1,0 +1,39 @@
+package liquibase.integration.servlet;
+
+import static javax.naming.Context.INITIAL_CONTEXT_FACTORY;
+
+import java.util.Hashtable;
+
+import javax.naming.Context;
+import javax.naming.spi.InitialContextFactory;
+
+public class TestInitialContextFactory implements InitialContextFactory {
+
+    private static String originalFactory;
+
+    private static Context initialContext;
+
+    public static void install() {
+        originalFactory = System.getProperty(INITIAL_CONTEXT_FACTORY);
+        System.setProperty(INITIAL_CONTEXT_FACTORY,
+                           TestInitialContextFactory.class.getName());
+    }
+
+    public static void uninstall() {
+        if (originalFactory == null) {
+            System.getProperties().remove(INITIAL_CONTEXT_FACTORY);
+        } else {
+            System.setProperty(INITIAL_CONTEXT_FACTORY, originalFactory);
+        }
+    }
+
+    public static void setInitialContext(Context context) {
+        initialContext = context;
+    }
+
+    @Override
+    public Context getInitialContext(Hashtable<?, ?> environment) {
+        return initialContext;
+    }
+
+}

--- a/liquibase-core/src/test/resources/liquibase/integration/servlet/simple-changelog.xml
+++ b/liquibase-core/src/test/resources/liquibase/integration/servlet/simple-changelog.xml
@@ -1,0 +1,6 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.2.xsd">
+    <!-- No changes -->
+</databaseChangeLog>


### PR DESCRIPTION
---
name: Pull Request
about: Create a report to help us improve
title: 'LiquibaseServletListener.contextInitialized() should not shut Embedded Derby down'
labels: Status:Discovery
assignees: ''

---

## Environment

**Liquibase Version**: 3.8.x

**Liquibase Integration & Version**: servlet

**Liquibase Extension(s) & Version**: 

**Database Vendor & Version**: Apache Derby 10.14

**Operating System Type & Version**:

## Pull Request Type

- [x] Bug fix (non-breaking change which fixes an issue.)
- [x] Enhancement/New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

In certain configurations using `LiquibaseServletListener` with Embedded Derby application may fail with `java.sql.SQLNonTransientConnectionException: No current connection.`.

Full details of *Steps To Reproduce*, *Actual Behavior*, *Expected/Desired Behavior* and *Additional Context* have been given to [CORE-3540][].  This is my suggestion of how it could be addressed.

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->
- [x] Build is successful and all new and existing tests pass
- [x] Added Unit Test(s)
- [ ] Added Integration Test(s)
- [ ] Documentation Updated

[CORE-3540]: https://liquibase.jira.com/browse/CORE-3540

┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-232) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 3.10.1
