### PR TITLE
[1133] Add changelogSyncToTag and changelogSyncToTagSQL commands

### DIFF
--- a/liquibase-core/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-core/src/main/java/liquibase/Liquibase.java
@@ -61,6 +61,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.io.*;
 import java.text.DateFormat;
 import java.util.*;
+import java.util.function.Supplier;
 
 import static java.util.ResourceBundle.getBundle;
 
@@ -386,6 +387,28 @@ public class Liquibase implements AutoCloseable {
                 new LabelChangeSetFilter(labelExpression),
                 new DbmsChangeSetFilter(database),
                 new IgnoreChangeSetFilter());
+    }
+
+    protected ChangeLogIterator buildChangeLogIterator(String tag, DatabaseChangeLog changeLog, Contexts contexts,
+                                                       LabelExpression labelExpression) throws DatabaseException {
+
+        if (tag == null) {
+            return new ChangeLogIterator(changeLog,
+                new NotRanChangeSetFilter(database.getRanChangeSetList()),
+                new ContextChangeSetFilter(contexts),
+                new LabelChangeSetFilter(labelExpression),
+                new IgnoreChangeSetFilter(),
+                new DbmsChangeSetFilter(database));
+        } else {
+            List<RanChangeSet> ranChangeSetList = database.getRanChangeSetList();
+            return new ChangeLogIterator(changeLog,
+                new NotRanChangeSetFilter(database.getRanChangeSetList()),
+                new ContextChangeSetFilter(contexts),
+                new LabelChangeSetFilter(labelExpression),
+                new IgnoreChangeSetFilter(),
+                new DbmsChangeSetFilter(database),
+                new UpToTagChangeSetFilter(tag, ranChangeSetList));
+        }
     }
 
     public void update(String contexts, Writer output) throws LiquibaseException {
@@ -1337,32 +1360,10 @@ public class Liquibase implements AutoCloseable {
     }
 
     public void changeLogSync(Contexts contexts, LabelExpression labelExpression, Writer output)
-            throws LiquibaseException {
-        changeLogParameters.setContexts(contexts);
-        changeLogParameters.setLabels(labelExpression);
+        throws LiquibaseException {
 
-        runInScope(new Scope.ScopedRunner() {
-            @Override
-            public void run() throws Exception {
-
-                LoggingExecutor outputTemplate = new LoggingExecutor(
-                        Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor(database), output, database
-                );
-
-                /* We have no other choice than to save the current Executer here. */
-                @SuppressWarnings("squid:S1941")
-                Executor oldTemplate = getAndReplaceJdbcExecutor(output);
-
-                outputHeader("SQL to add all changesets to database history table");
-
-                changeLogSync(contexts, labelExpression);
-
-                flushOutputWriter(output);
-
-                Scope.getCurrentScope().getSingleton(ExecutorService.class).setExecutor("jdbc", database, oldTemplate);
-                resetServices();
-            }
-        });
+        doChangeLogSyncSql(null, contexts, labelExpression, output,
+            () -> "SQL to add all changesets to database history table");
     }
 
     private void flushOutputWriter(Writer output) throws LiquibaseException {
@@ -1390,6 +1391,14 @@ public class Liquibase implements AutoCloseable {
     }
 
     public void changeLogSync(Contexts contexts, LabelExpression labelExpression) throws LiquibaseException {
+        changeLogSync(null, contexts, labelExpression);
+    }
+
+    public void changeLogSync(String tag, String contexts) throws LiquibaseException {
+        changeLogSync(tag, new Contexts(contexts), new LabelExpression());
+    }
+
+    public void changeLogSync(String tag, Contexts contexts, LabelExpression labelExpression) throws LiquibaseException {
         changeLogParameters.setContexts(contexts);
         changeLogParameters.setLabels(labelExpression);
 
@@ -1422,12 +1431,7 @@ public class Liquibase implements AutoCloseable {
                     // Create an iterator which will be used with a ListVisitor
                     // to grab the list of change sets for the update
                     //
-                    ChangeLogIterator listLogIterator = new ChangeLogIterator(changeLog,
-                            new NotRanChangeSetFilter(database.getRanChangeSetList()),
-                            new ContextChangeSetFilter(contexts),
-                            new LabelChangeSetFilter(labelExpression),
-                            new IgnoreChangeSetFilter(),
-                            new DbmsChangeSetFilter(database));
+                    ChangeLogIterator listLogIterator = buildChangeLogIterator(tag, changeLog, contexts, labelExpression);
 
                     //
                     // Create or retrieve the Connection
@@ -1446,16 +1450,9 @@ public class Liquibase implements AutoCloseable {
                         changeLogSyncListener = new HubChangeExecListener(changeLogSyncOperation, changeExecListener);
                     }
 
-                    ChangeLogIterator runChangeLogSyncIterator = new ChangeLogIterator(changeLog,
-                            new NotRanChangeSetFilter(database.getRanChangeSetList()),
-                            new ContextChangeSetFilter(contexts),
-                            new LabelChangeSetFilter(labelExpression),
-                            new IgnoreChangeSetFilter(),
-                            new DbmsChangeSetFilter(database));
-
                     CompositeLogService compositeLogService = new CompositeLogService(true, bufferLog);
                     Scope.child(Scope.Attr.logService.name(), compositeLogService, () -> {
-                        runChangeLogSyncIterator.run(new ChangeLogSyncVisitor(database, changeLogSyncListener),
+                        listLogIterator.run(new ChangeLogSyncVisitor(database, changeLogSyncListener),
                                 new RuntimeEnvironment(database, contexts, labelExpression));
                     });
                     hubUpdater.postUpdateHub(changeLogSyncOperation, bufferLog);
@@ -1475,6 +1472,45 @@ public class Liquibase implements AutoCloseable {
                     setChangeExecListener(null);
                 }
             }
+        });
+
+    }
+
+    public void changeLogSync(String tag, String contexts, Writer output) throws LiquibaseException {
+        changeLogSync(tag, new Contexts(contexts), new LabelExpression(), output);
+    }
+
+    public void changeLogSync(String tag, Contexts contexts, LabelExpression labelExpression, Writer output)
+        throws LiquibaseException {
+
+        doChangeLogSyncSql(tag, contexts, labelExpression, output,
+            () -> "SQL to add changesets upto '" + tag + "' to database history table");
+    }
+
+    private void doChangeLogSyncSql(String tag, Contexts contexts, LabelExpression labelExpression, Writer output,
+                                    Supplier<String> header) throws LiquibaseException {
+
+        changeLogParameters.setContexts(contexts);
+        changeLogParameters.setLabels(labelExpression);
+
+        runInScope(() -> {
+
+            LoggingExecutor outputTemplate = new LoggingExecutor(
+                    Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor(database), output, database
+            );
+
+                /* We have no other choice than to save the current Executer here. */
+                @SuppressWarnings("squid:S1941")
+                Executor oldTemplate = getAndReplaceJdbcExecutor(output);
+
+                outputHeader("SQL to add all changesets to database history table");
+
+            changeLogSync(tag, contexts, labelExpression);
+
+            flushOutputWriter(output);
+
+            Scope.getCurrentScope().getSingleton(ExecutorService.class).setExecutor("jdbc", database, oldTemplate);
+            resetServices();
         });
 
     }

--- a/liquibase-core/src/main/java/liquibase/integration/ant/ChangeLogSyncTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/ChangeLogSyncTask.java
@@ -12,6 +12,8 @@ import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
 
 public class ChangeLogSyncTask extends AbstractChangeLogBasedTask {
+    private String toTag;
+
     @Override
     public void executeWithLiquibaseClassloader() throws BuildException {
         Liquibase liquibase = getLiquibase();
@@ -20,9 +22,9 @@ public class ChangeLogSyncTask extends AbstractChangeLogBasedTask {
             FileResource outputFile = getOutputFile();
             if (outputFile != null) {
                 writer = new OutputStreamWriter(outputFile.getOutputStream(), getOutputEncoding());
-                liquibase.changeLogSync(new Contexts(getContexts()), getLabels(), writer);
+                liquibase.changeLogSync(toTag, new Contexts(getContexts()), getLabels(), writer);
             } else {
-                liquibase.changeLogSync(new Contexts(getContexts()), getLabels());
+                liquibase.changeLogSync(toTag, new Contexts(getContexts()), getLabels());
             }
         } catch (UnsupportedEncodingException e) {
             throw new BuildException("Unable to generate sync SQL. Encoding [" + getOutputEncoding() + "] is not supported.", e);
@@ -33,5 +35,13 @@ public class ChangeLogSyncTask extends AbstractChangeLogBasedTask {
         } finally {
             FileUtils.close(writer);
         }
+    }
+
+    public String getToTag() {
+        return toTag;
+    }
+
+    public void setToTag(String toTag) {
+        this.toTag = toTag;
     }
 }

--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -527,6 +527,7 @@ public class Main {
         return COMMANDS.SNAPSHOT.equalsIgnoreCase(command)
                 || COMMANDS.SNAPSHOT_REFERENCE.equalsIgnoreCase(command)
                 || COMMANDS.CHANGELOG_SYNC_SQL.equalsIgnoreCase(command)
+                || COMMANDS.CHANGELOG_SYNC_TO_TAG_SQL.equalsIgnoreCase(command)
                 || COMMANDS.MARK_NEXT_CHANGESET_RAN_SQL.equalsIgnoreCase(command)
                 || COMMANDS.UPDATE_COUNT_SQL.equalsIgnoreCase(command)
                 || COMMANDS.UPDATE_TO_TAG_SQL.equalsIgnoreCase(command)
@@ -556,6 +557,8 @@ public class Main {
                 || COMMANDS.VALIDATE.equalsIgnoreCase(command)
                 || COMMANDS.CHANGELOG_SYNC.equalsIgnoreCase(command)
                 || COMMANDS.CHANGELOG_SYNC_SQL.equalsIgnoreCase(command)
+                || COMMANDS.CHANGELOG_SYNC_TO_TAG.equalsIgnoreCase(command)
+                || COMMANDS.CHANGELOG_SYNC_TO_TAG_SQL.equalsIgnoreCase(command)
                 || COMMANDS.GENERATE_CHANGELOG.equalsIgnoreCase(command)
                 || COMMANDS.UNEXPECTED_CHANGESETS.equalsIgnoreCase(command)
                 || COMMANDS.DIFF_CHANGELOG.equalsIgnoreCase(command)
@@ -611,6 +614,8 @@ public class Main {
                 || COMMANDS.DB_DOC.equalsIgnoreCase(arg)
                 || COMMANDS.CHANGELOG_SYNC.equalsIgnoreCase(arg)
                 || COMMANDS.CHANGELOG_SYNC_SQL.equalsIgnoreCase(arg)
+                || COMMANDS.CHANGELOG_SYNC_TO_TAG.equalsIgnoreCase(arg)
+                || COMMANDS.CHANGELOG_SYNC_TO_TAG_SQL.equalsIgnoreCase(arg)
                 || COMMANDS.MARK_NEXT_CHANGESET_RAN.equalsIgnoreCase(arg)
                 || COMMANDS.MARK_NEXT_CHANGESET_RAN_SQL.equalsIgnoreCase(arg)
                 || COMMANDS.ROLLBACK_ONE_CHANGE_SET.equalsIgnoreCase(arg)
@@ -821,7 +826,9 @@ public class Main {
                 || COMMANDS.CALCULATE_CHECKSUM.equalsIgnoreCase(command)
                 || COMMANDS.DB_DOC.equalsIgnoreCase(command)
                 || COMMANDS.TAG.equalsIgnoreCase(command)
-                || COMMANDS.TAG_EXISTS.equalsIgnoreCase(command)) {
+                || COMMANDS.TAG_EXISTS.equalsIgnoreCase(command)
+                || COMMANDS.CHANGELOG_SYNC_TO_TAG.equalsIgnoreCase(command)
+                || COMMANDS.CHANGELOG_SYNC_TO_TAG_SQL.equalsIgnoreCase(command)) {
 
             if ((!commandParams.isEmpty()) && commandParams.iterator().next().startsWith("-")) {
                 messages.add(coreBundle.getString(ERRORMSG_UNEXPECTED_PARAMETERS) + commandParams);
@@ -1766,6 +1773,24 @@ public class Main {
                     liquibase.changeLogSync(new Contexts(contexts), new LabelExpression(labels));
                 } else if (COMMANDS.CHANGELOG_SYNC_SQL.equalsIgnoreCase(command)) {
                     liquibase.changeLogSync(new Contexts(contexts), new LabelExpression(labels), getOutputWriter());
+                } else if (COMMANDS.CHANGELOG_SYNC_TO_TAG.equalsIgnoreCase(command)) {
+                    if ((commandParams == null) || commandParams.isEmpty()) {
+                        throw new CommandLineParsingException(
+                            String.format(coreBundle.getString("command.requires.tag"),
+                                COMMANDS.CHANGELOG_SYNC_TO_TAG));
+                    }
+
+                    liquibase.changeLogSync(commandParams.iterator().next(), new Contexts(contexts),
+                        new LabelExpression(labels));
+                } else if (COMMANDS.CHANGELOG_SYNC_TO_TAG_SQL.equalsIgnoreCase(command)) {
+                    if ((commandParams == null) || commandParams.isEmpty()) {
+                        throw new CommandLineParsingException(
+                            String.format(coreBundle.getString("command.requires.tag"),
+                                COMMANDS.CHANGELOG_SYNC_TO_TAG_SQL));
+                    }
+
+                    liquibase.changeLogSync(commandParams.iterator().next(), new Contexts(contexts),
+                        new LabelExpression(labels), getOutputWriter());
                 } else if (COMMANDS.MARK_NEXT_CHANGESET_RAN.equalsIgnoreCase(command)) {
                     liquibase.markNextChangeSetRan(new Contexts(contexts), new LabelExpression(labels));
                 } else if (COMMANDS.MARK_NEXT_CHANGESET_RAN_SQL.equalsIgnoreCase(command)) {
@@ -2117,6 +2142,8 @@ public class Main {
         private static final String CALCULATE_CHECKSUM = "calculateCheckSum";
         private static final String CHANGELOG_SYNC = "changelogSync";
         private static final String CHANGELOG_SYNC_SQL = "changelogSyncSQL";
+        private static final String CHANGELOG_SYNC_TO_TAG = "changelogSyncToTag";
+        private static final String CHANGELOG_SYNC_TO_TAG_SQL = "changelogSyncToTagSQL";
         private static final String CLEAR_CHECKSUMS = "clearCheckSums";
         private static final String DB_DOC = "dbDoc";
         private static final String DIFF = "diff";

--- a/liquibase-core/src/main/resources/liquibase/i18n/liquibase-commandline-helptext.xml
+++ b/liquibase-core/src/main/resources/liquibase/i18n/liquibase-commandline-helptext.xml
@@ -122,28 +122,38 @@ Documentation Commands
                                  grouped by default according to their update
                                  command's "deployment_id" value.
 Maintenance Commands
- tag <tag string>          'Tags' the current database state for future rollback
- tagExists <tag string>    Checks whether the given tag is already existing
- status [--verbose]        Outputs count (list if --verbose) of unrun changesets
+ tag <tag string>            'Tags' the current database state for future
+                             rollback
+ tagExists <tag string>      Checks whether the given tag is already existing
+ status [--verbose]          Outputs count (list if --verbose) of unrun
+                             changesets
  unexpectedChangeSets [--verbose]
-                           Outputs count (list if --verbose) of changesets run
-                           in the database that do not exist in the changelog.
- validate                  Checks changelog for errors
- calculateCheckSum <id>    Calculates and prints a checksum for the changeset
-                           with the given id in the format filepath::id::author.
- clearCheckSums            Removes all saved checksums from database log.
-                           Useful for 'MD5Sum Check Failed' errors
- changelogSync             Mark all changes as executed in the database
- changelogSyncSQL          Writes SQL to mark all changes as executed
-                           in the database to STDOUT
- markNextChangeSetRan      Mark the next change changes as executed
-                           in the database
- markNextChangeSetRanSQL   Writes SQL to mark the next change
-                           as executed in the database to STDOUT
- listLocks                 Lists who currently has locks on the
-                           database changelog
- releaseLocks              Releases all locks on the database changelog
- dropAll                   Drop all database objects owned by user
+                             Outputs count (list if --verbose) of changesets
+                             run
+                             in the database that do not exist in the
+                             changelog.
+ validate                    Checks changelog for errors
+ calculateCheckSum <id>      Calculates and prints a checksum for the changeset
+                             with the given id in the format
+                             filepath::id::author.
+ clearCheckSums              Removes all saved checksums from database log.
+                             Useful for 'MD5Sum Check Failed' errors
+ changelogSync               Mark all changes as executed in the database
+ changelogSyncSQL            Writes SQL to mark all changes as executed
+                             in the database to STDOUT
+ changelogSyncToTag <tag>    Mark all changes, upto and including the specified
+                             tag, as executed in the database
+ changelogSyncToTagSQL <tag> Write SQL to mark all changes, upto and including
+                             the specified tag, as executed in the database to
+                             STDOUT
+ markNextChangeSetRan        Mark the next change changes as executed
+                             in the database
+ markNextChangeSetRanSQL     Writes SQL to mark the next change
+                             as executed in the database to STDOUT
+ listLocks                   Lists who currently has locks on the
+                             database changelog
+ releaseLocks                Releases all locks on the database changelog
+ dropAll                     Drop all database objects owned by user
 
 Required Parameters:
  --changeLogFile=<path and filename>        Migration file

--- a/liquibase-core/src/test/groovy/liquibase/LiquibaseTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/LiquibaseTest.groovy
@@ -1,27 +1,36 @@
 package liquibase
 
-
 import liquibase.changelog.ChangeLogIterator
 import liquibase.changelog.DatabaseChangeLog
 import liquibase.configuration.HubConfiguration
 import liquibase.configuration.LiquibaseConfiguration
 import liquibase.database.Database
 import liquibase.database.core.MockDatabase
+import liquibase.database.jvm.JdbcConnection
+import liquibase.exception.DatabaseException
 import liquibase.exception.LiquibaseException
 import liquibase.hub.HubService
 import liquibase.hub.HubServiceFactory
 import liquibase.hub.core.MockHubService
-import liquibase.hub.model.Connection
 import liquibase.lockservice.LockService
 import liquibase.lockservice.LockServiceFactory
 import liquibase.parser.ChangeLogParser
 import liquibase.parser.ChangeLogParserFactory
 import liquibase.parser.MockChangeLogParser
+import liquibase.resource.ClassLoaderResourceAccessor
 import liquibase.sdk.resource.MockResourceAccessor
+import liquibase.snapshot.SnapshotGeneratorFactory
 import liquibase.ui.ConsoleUIService
-import liquibase.ui.ConsoleUIServiceTest
 import spock.lang.Specification
 
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.PreparedStatement
+import java.sql.SQLException
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+import static java.lang.String.format
 import static org.junit.Assert.*
 
 class LiquibaseTest extends Specification {
@@ -38,7 +47,10 @@ class LiquibaseTest extends Specification {
     private DatabaseChangeLog mockChangeLog
     private ChangeLogIterator mockChangeLogIterator
 
+    JdbcConnection h2Connection
+
     def setup() {
+        h2Connection = null;
         mockResourceAccessor = new MockResourceAccessor()
 //        mockDatabase = mock(Database.class);
 //        mockLockService = mock(LockService.class);
@@ -95,6 +107,10 @@ class LiquibaseTest extends Specification {
         ChangeLogParserFactory.reset()
         Scope.exit(setupScopeId)
         ChangeLogParserFactory.reset()
+
+        if (h2Connection != null) {
+            h2Connection.close()
+        }
     }
 
 
@@ -109,20 +125,20 @@ class LiquibaseTest extends Specification {
         assertNotNull("change log object may not be null", liquibase.getLog())
 
         assertEquals("correct name of the change log file is returned",
-        "com/example/test.xml", liquibase.getChangeLogFile())
+                "com/example/test.xml", liquibase.getChangeLogFile())
 
         assertSame("ressourceAccessor property is set as requested",
-            resourceAccessor, liquibase.getResourceAccessor())
+                resourceAccessor, liquibase.getResourceAccessor())
 
         assertNotNull("parameters list for the change log is not null",
-            liquibase.getChangeLogParameters())
+                liquibase.getChangeLogParameters())
         assertEquals("Standard database changelog parameters were not set",
-            "DATABASECHANGELOGLOCK",
-            liquibase.getChangeLogParameters().getValue("database.databaseChangeLogLockTableName", null)
+                "DATABASECHANGELOGLOCK",
+                liquibase.getChangeLogParameters().getValue("database.databaseChangeLogLockTableName", null)
         )
 
         assertSame("database object for the change log is set as requested",
-            mockDatabase, liquibase.getDatabase())
+                mockDatabase, liquibase.getDatabase())
     }
 
     def testConstructorChangelogPathsStandardize() throws Exception {
@@ -131,19 +147,19 @@ class LiquibaseTest extends Specification {
 
         then:
         assertEquals("Windows path separators are translated correctly",
-            "path/with/windows/separators.xml", liquibase.getChangeLogFile())
+                "path/with/windows/separators.xml", liquibase.getChangeLogFile())
 
         when:
         liquibase = new Liquibase("path/with/unix/separators.xml", mockResourceAccessor, mockDatabase)
         then:
         assertEquals("Unix path separators are left intact",
-            "path/with/unix/separators.xml", liquibase.getChangeLogFile())
+                "path/with/unix/separators.xml", liquibase.getChangeLogFile())
 
         when:
         liquibase = new Liquibase("/absolute/path/remains.xml", mockResourceAccessor, mockDatabase)
         then:
         assertEquals("An absolute path is left intact",
-            "/absolute/path/remains.xml", liquibase.getChangeLogFile())
+                "/absolute/path/remains.xml", liquibase.getChangeLogFile())
     }
 
 //    @Test
@@ -170,7 +186,7 @@ class LiquibaseTest extends Specification {
 
         then:
         assertSame("ressourceAccessor is set as requested",
-            liquibase.getResourceAccessor(), liquibase.getResourceAccessor())
+                liquibase.getResourceAccessor(), liquibase.getResourceAccessor())
     }
 
 //    @Test
@@ -194,7 +210,7 @@ class LiquibaseTest extends Specification {
 
         then:
         mockHubService.sentObjects.toString() ==
-            "[setRanChangeSets/Connection jdbc://test ($MockHubService.randomUUID):[test/changelog.xml::1::mock-author, test/changelog.xml::2::mock-author, test/changelog.xml::3::mock-author], startOperation/$MockHubService.randomUUID:[$MockHubService.operationCreateDate]]"
+                "[setRanChangeSets/Connection jdbc://test ($MockHubService.randomUUID):[test/changelog.xml::1::mock-author, test/changelog.xml::2::mock-author, test/changelog.xml::3::mock-author], startOperation/$MockHubService.randomUUID:[$MockHubService.operationCreateDate]]"
 
     }
 
@@ -244,9 +260,9 @@ class LiquibaseTest extends Specification {
         then:
         connection == null
         message ==
-          "WARNING: The API key 'API_KEY' was found, but no changelog ID exists.\n" +
-          "No operations will be reported. Register this changelog with Liquibase Hub to generate free deployment reports.\n" +
-          "Learn more at https://hub.liquibase.com."
+                "WARNING: The API key 'API_KEY' was found, but no changelog ID exists.\n" +
+                "No operations will be reported. Register this changelog with Liquibase Hub to generate free deployment reports.\n" +
+                "Learn more at https://hub.liquibase.com."
     }
 
 //    @Test(expected = LockException.class)
@@ -309,8 +325,209 @@ class LiquibaseTest extends Specification {
 //        });
 //    }
 
+
+    def syncChangeLogForUnmanagedDatabase() throws Exception {
+        when:
+        h2Connection = getInMemoryH2DatabaseConnection();
+
+        Liquibase liquibase = createUnmanagedDatabase(h2Connection);
+        assertFalse(hasDatabaseChangeLogTable(liquibase));
+
+        liquibase.changeLogSync("");
+
+        then:
+        assert hasDatabaseChangeLogTable(liquibase);
+        assertTags(liquibase, "1.0", "1.1", "2.0");
+    }
+
+    def syncChangeLogToTagForUnmanagedDatabase() throws Exception {
+        when:
+        h2Connection = getInMemoryH2DatabaseConnection();
+
+        Liquibase liquibase = createUnmanagedDatabase(h2Connection);
+
+        then:
+        assert !hasDatabaseChangeLogTable(liquibase)
+
+        when:
+        liquibase.changeLogSync("1.1", "");
+
+        then:
+        assert hasDatabaseChangeLogTable(liquibase);
+        assertTags(liquibase, "1.0", "1.1");
+    }
+
+    def syncChangeLogForManagedDatabase() throws Exception {
+        when:
+        h2Connection = getInMemoryH2DatabaseConnection();
+
+        Liquibase liquibase = createDatabaseAtTag(h2Connection, "1.0");
+
+        then:
+        assert hasDatabaseChangeLogTable(liquibase)
+
+        when:
+        liquibase.changeLogSync("");
+
+        then:
+        assertTags(liquibase, "1.0", "1.1", "2.0");
+    }
+
+    def syncChangeLogToTagForManagedDatabase() throws Exception {
+        when:
+        h2Connection = getInMemoryH2DatabaseConnection();
+
+        Liquibase liquibase = createDatabaseAtTag(h2Connection, "1.0");
+        then:
+        assert hasDatabaseChangeLogTable(liquibase);
+
+        when:
+        liquibase.changeLogSync("1.1", "");
+
+        then:
+        assertTags(liquibase, "1.0", "1.1");
+    }
+
+    def syncChangeLogSqlForUnmanagedDatabase() throws Exception {
+        when:
+        h2Connection = getInMemoryH2DatabaseConnection();
+        StringWriter writer = new StringWriter();
+
+        Liquibase liquibase = createUnmanagedDatabase(h2Connection);
+
+        then:
+        assert !hasDatabaseChangeLogTable(liquibase);
+
+        when:
+        liquibase.changeLogSync("", writer);
+
+        then:
+        assert !hasDatabaseChangeLogTable(liquibase);
+        assertSqlOutputAppliesTags(writer.toString(), "1.0", "1.1", "2.0");
+    }
+
+    def syncChangeLogToTagSqlForUnmanagedDatabase() throws Exception {
+        when:
+        h2Connection = getInMemoryH2DatabaseConnection();
+        StringWriter writer = new StringWriter();
+
+        Liquibase liquibase = createUnmanagedDatabase(h2Connection);
+
+        then:
+        assert !hasDatabaseChangeLogTable(liquibase);
+
+        when:
+        liquibase.changeLogSync("1.1", "", writer);
+
+        then:
+        !hasDatabaseChangeLogTable(liquibase);
+        assertSqlOutputAppliesTags(writer.toString(), "1.0", "1.1");
+    }
+
+    def syncChangeLogSqlForManagedDatabase() throws Exception {
+        when:
+        h2Connection = getInMemoryH2DatabaseConnection();
+        StringWriter writer = new StringWriter();
+
+        Liquibase liquibase = createDatabaseAtTag(h2Connection, "1.0");
+
+        then:
+        assert hasDatabaseChangeLogTable(liquibase);
+
+        when:
+        liquibase.changeLogSync("", writer);
+
+        then:
+        assertSqlOutputAppliesTags(writer.toString(), "1.1", "2.0");
+    }
+
+    def syncChangeLogToTagSqlForManagedDatabase() throws Exception {
+        when:
+        h2Connection = getInMemoryH2DatabaseConnection();
+        StringWriter writer = new StringWriter();
+
+        Liquibase liquibase = createDatabaseAtTag(h2Connection, "1.0");
+
+        then:
+        assertTrue(hasDatabaseChangeLogTable(liquibase));
+
+        when:
+        liquibase.changeLogSync("1.1", "", writer);
+
+        then:
+        assertSqlOutputAppliesTags(writer.toString(), "1.1");
+    }
+
+    private JdbcConnection getInMemoryH2DatabaseConnection() throws SQLException {
+        String urlFormat = "jdbc:h2:mem:%s";
+        return new JdbcConnection(DriverManager.getConnection(format(urlFormat, UUID.randomUUID().toString())));
+    }
+
+    private Liquibase createUnmanagedDatabase(JdbcConnection connection) throws SQLException, LiquibaseException {
+        String createTableSql = "CREATE TABLE PUBLIC.TABLE_A (ID INTEGER);";
+
+        PreparedStatement stmt = connection.getUnderlyingConnection().prepareStatement(createTableSql)
+        try {
+            stmt.execute();
+        } finally {
+            stmt.close()
+        }
+
+        return new Liquibase("liquibase/tagged-changelog.xml", new ClassLoaderResourceAccessor(), connection);
+    }
+
+    private Liquibase createDatabaseAtTag(JdbcConnection connection, String tag) throws LiquibaseException {
+        Liquibase liquibase = new Liquibase("liquibase/tagged-changelog.xml", new ClassLoaderResourceAccessor(),
+                connection);
+        liquibase.update(tag, "");
+        return liquibase;
+    }
+
+    private boolean hasDatabaseChangeLogTable(Liquibase liquibase) throws DatabaseException {
+        return SnapshotGeneratorFactory.getInstance().hasDatabaseChangeLogTable(liquibase.database);
+    }
+
+    private void assertTags(Liquibase liquibase, String... expectedTags) throws DatabaseException {
+        def actualTags = []
+        for (def ranChangeset : liquibase.database.getRanChangeSetList()) {
+            if (ranChangeset.getTag() != null) {
+                actualTags.add(ranChangeset.getTag())
+            }
+        }
+
+        assertEquals(Arrays.asList(expectedTags), actualTags);
+    }
+
+    private void assertSqlOutputAppliesTags(String output, String... expectedTags) throws IOException {
+        String insertTagH2SqlTemplate =
+                "INSERT INTO PUBLIC\\.DATABASECHANGELOG \\(.*, DESCRIPTION,.*, TAG\\) VALUES \\(.*, 'tagDatabase',.*, '%s'\\);";
+
+        List<Pattern> patterns = []
+
+        for (def tag : expectedTags) {
+            patterns.add(Pattern.compile(String.format(insertTagH2SqlTemplate, tag)))
+        }
+
+        BufferedReader reader = new BufferedReader(new StringReader(output))
+        try {
+            String line;
+            int index = 0;
+
+            while ((line = reader.readLine()) != null && index < patterns.size()) {
+                Matcher matcher = patterns.get(index).matcher(line);
+                if (matcher.matches()) {
+                    index++;
+                }
+            }
+            assertTrue(index > 0 && index == patterns.size());
+        } finally {
+            reader.close()
+        }
+    }
+
     public static class TestConsoleUIService extends ConsoleUIService {
         private List<String> messages = new ArrayList<>()
+
         @Override
         void sendMessage(String message) {
             messages.add(message)

--- a/liquibase-core/src/test/groovy/liquibase/integration/ant/test/LiquibaseTagExistsCondition.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/integration/ant/test/LiquibaseTagExistsCondition.groovy
@@ -1,0 +1,49 @@
+package liquibase.integration.ant.test
+
+import groovy.sql.Sql
+import org.apache.tools.ant.BuildException
+import org.apache.tools.ant.ProjectComponent
+import org.apache.tools.ant.taskdefs.condition.Condition
+
+class LiquibaseTagExistsCondition extends ProjectComponent implements Condition {
+    private String driver
+    private String url
+    private String user
+    private String password
+    private String tag
+
+    @Override
+    boolean eval() throws BuildException {
+        Sql sql = null
+        try {
+            sql = Sql.newInstance(url, user, password, driver)
+            def result = false
+            sql.query("SELECT TAG FROM DATABASECHANGELOG WHERE TAG IS NOT NULL AND TAG = $tag;") {
+                result = it.next()
+            }
+            return result
+        } finally {
+            sql?.close()
+        }
+    }
+
+    void setDriver(String driver) {
+        this.driver = driver
+    }
+
+    void setUrl(String url) {
+        this.url = url
+    }
+
+    void setUser(String user) {
+        this.user = user
+    }
+
+    void setPassword(String password) {
+        this.password = password
+    }
+
+    void setTag(String tag) {
+        this.tag = tag
+    }
+}

--- a/liquibase-core/src/test/resources/liquibase/integration/ant/ChangeLogSyncTaskTest.xml
+++ b/liquibase-core/src/test/resources/liquibase/integration/ant/ChangeLogSyncTaskTest.xml
@@ -44,6 +44,8 @@
         </lb:changeLogSync>
         <db:assertTableExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
                               table="DATABASECHANGELOG"/>
+        <db:assertTagExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                            tag="version_2.0"/>
     </target>
 
     <target name="testChangeLogSyncDatabaseRef">
@@ -52,11 +54,65 @@
         <lb:changeLogSync databaseref="test-db" changelogfile="${liquibase.test.ant.basedir}/changelog/simple-changelog.xml"/>
         <db:assertTableExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
                               table="DATABASECHANGELOG"/>
+        <db:assertTagExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                            tag="version_2.0"/>
     </target>
 
     <target name="testChangeLogSyncToOutputFile">
         <lb:changeLogSync changelogfile="${liquibase.test.ant.basedir}/changelog/simple-changelog.xml"
                           outputfile="${temp.dir}/sync.sql">
+            <lb:database driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"/>
+        </lb:changeLogSync>
+        <au:assertFileExists file="${temp.dir}/sync.sql"/>
+    </target>
+
+    <target name="testChangeLogSyncToTag">
+        <db:assertTableDoesntExist driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                                   table="DATABASECHANGELOG"/>
+        <lb:changeLogSync changelogfile="${liquibase.test.ant.basedir}/changelog/simple-changelog.xml"
+                          toTag="version_1.0">
+            <lb:database driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"/>
+        </lb:changeLogSync>
+        <db:assertTableExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                              table="DATABASECHANGELOG"/>
+        <db:assertTagExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                            tag="version_1.0"/>
+        <db:assertTagNotExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                            tag="version_2.0"/>
+    </target>
+
+    <target name="testChangeLogSyncToLatestTag">
+        <db:assertTableDoesntExist driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                                   table="DATABASECHANGELOG"/>
+        <lb:changeLogSync changelogfile="${liquibase.test.ant.basedir}/changelog/simple-changelog.xml"
+                          toTag="version_2.0">
+            <lb:database driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"/>
+        </lb:changeLogSync>
+        <db:assertTableExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                              table="DATABASECHANGELOG"/>
+        <db:assertTagExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                            tag="version_1.0"/>
+        <db:assertTagExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                            tag="version_2.0"/>
+    </target>
+
+    <target name="testChangeLogSyncToTagDatabaseRef">
+        <db:assertTableDoesntExist driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                                   table="DATABASECHANGELOG"/>
+        <lb:changeLogSync databaseref="test-db" changelogfile="${liquibase.test.ant.basedir}/changelog/simple-changelog.xml"
+                          toTag="version_1.0"/>
+        <db:assertTableExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                              table="DATABASECHANGELOG"/>
+        <db:assertTagExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                            tag="version_1.0"/>
+        <db:assertTagNotExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                               tag="version_2.0"/>
+    </target>
+
+    <target name="testChangeLogSyncToTagToOutputFile">
+        <lb:changeLogSync changelogfile="${liquibase.test.ant.basedir}/changelog/simple-changelog.xml"
+                          outputfile="${temp.dir}/sync.sql"
+                          toTag="version_1.0">
             <lb:database driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"/>
         </lb:changeLogSync>
         <au:assertFileExists file="${temp.dir}/sync.sql"/>
@@ -87,6 +143,8 @@
         </lb:changeLogSync>
         <db:assertTableExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
                               table="DATABASECHANGELOG"/>
+        <db:assertTagExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                            tag="version_2.0"/>
     </target>
 
 	<target name="testChangeLogSyncChangeLogDirectoryDoesNotExist">
@@ -111,6 +169,44 @@
         <lb:changeLogSync databaseref="test-db" changelogdirectory="${liquibase.test.ant.basedir}/changelog" changelogfile="simple-changelog.xml"/>
         <db:assertTableExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
                               table="DATABASECHANGELOG"/>
+        <db:assertTagExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                            tag="version_1.0"/>
+    </target>
+
+    <target name="testChangeLogSyncToTagChangeLogDirectory">
+        <db:assertTableDoesntExist driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                                   table="DATABASECHANGELOG"/>
+        <lb:changeLogSync changelogdirectory="${liquibase.test.ant.basedir}/changelog" changelogfile="simple-changelog.xml"
+                          toTag="version_1.0">
+            <lb:database driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"/>
+        </lb:changeLogSync>
+        <db:assertTableExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                              table="DATABASECHANGELOG"/>
+        <db:assertTagExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                            tag="version_1.0"/>
+        <db:assertTagNotExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                               tag="version_2.0"/>
+    </target>
+
+    <target name="testChangeLogSyncToTagChangeLogDirectoryToOutputFile">
+        <lb:changeLogSync changelogdirectory="${liquibase.test.ant.basedir}/changelog" changelogfile="simple-changelog.xml"
+                          outputfile="${temp.dir}/sync.sql" toTag="version_1.0">
+            <lb:database driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"/>
+        </lb:changeLogSync>
+        <au:assertFileExists file="${temp.dir}/sync.sql"/>
+    </target>
+
+    <target name="testChangeLogSyncToTagDatabaseRefChangeLogDirectory">
+        <db:assertTableDoesntExist driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                                   table="DATABASECHANGELOG"/>
+        <lb:changeLogSync databaseref="test-db" changelogdirectory="${liquibase.test.ant.basedir}/changelog" changelogfile="simple-changelog.xml"
+                          toTag="version_1.0"/>
+        <db:assertTableExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                              table="DATABASECHANGELOG"/>
+        <db:assertTagExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                            tag="version_1.0"/>
+        <db:assertTagNotExists driver="${jdbc.driver}" url="${jdbc.url}" user="${db.user}" password="${db.password}"
+                               tag="version_2.0"/>
     </target>
 
 </project>

--- a/liquibase-core/src/test/resources/liquibase/integration/ant/changelog/simple-changelog.xml
+++ b/liquibase-core/src/test/resources/liquibase/integration/ant/changelog/simple-changelog.xml
@@ -8,4 +8,20 @@
             <column name="last_name" value="name"/>
         </insert>
     </changeSet>
+    
+    <changeSet id="2" author="testuser">
+        <tagDatabase tag="version_1.0"/>
+    </changeSet>
+
+    <changeSet id="3" author="testuser">
+        <createTable tableName="groups">
+            <column name="name" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="4" author="testuser">
+        <tagDatabase tag="version_2.0"/>
+    </changeSet>
 </databaseChangeLog>

--- a/liquibase-core/src/test/resources/liquibase/integration/ant/test/antlib.xml
+++ b/liquibase-core/src/test/resources/liquibase/integration/ant/test/antlib.xml
@@ -3,6 +3,7 @@
     <typedef name="tableExists" classname="liquibase.integration.ant.test.TableExistsCondition"/>
     <typedef name="columnExists" classname="liquibase.integration.ant.test.ColumnExistsCondition"/>
     <typedef name="rowCountEquals" classname="liquibase.integration.ant.test.RowCountEqualsCondition"/>
+    <typedef name="tagExists" classname="liquibase.integration.ant.test.LiquibaseTagExistsCondition"/>
 
     <macrodef name="assertTableExists" backtrace="false">
         <attribute name="driver"/>
@@ -74,6 +75,34 @@
             <au:assertTrue message="@{message}">
                 <current:rowCountEquals driver="@{driver}" url="@{url}" user="@{user}" password="@{password}" table="@{table}" count="@{count}"/>
             </au:assertTrue>
+        </sequential>
+    </macrodef>
+
+    <macrodef name="assertTagExists" backtrace="false">
+        <attribute name="driver"/>
+        <attribute name="url"/>
+        <attribute name="user"/>
+        <attribute name="password"/>
+        <attribute name="tag"/>
+        <attribute name="message" default="Assertion failed"/>
+        <sequential>
+            <au:assertTrue message="@{message}">
+                <current:tagExists driver="@{driver}" url="@{url}" user="@{user}" password="@{password}" tag="@{tag}"/>
+            </au:assertTrue>
+        </sequential>
+    </macrodef>
+
+    <macrodef name="assertTagNotExists" backtrace="false">
+        <attribute name="driver"/>
+        <attribute name="url"/>
+        <attribute name="user"/>
+        <attribute name="password"/>
+        <attribute name="tag"/>
+        <attribute name="message" default="Assertion failed"/>
+        <sequential>
+            <au:assertFalse message="@{message}">
+                <current:tagExists driver="@{driver}" url="@{url}" user="@{user}" password="@{password}" tag="@{tag}"/>
+            </au:assertFalse>
         </sequential>
     </macrodef>
 </antlib>

--- a/liquibase-core/src/test/resources/liquibase/tagged-changelog.xml
+++ b/liquibase-core/src/test/resources/liquibase/tagged-changelog.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.0.xsd">
+
+    <changeSet id="1" author="liquibase">
+        <createTable tableName="TABLE_A" schemaName="PUBLIC">
+            <column name="ID" type="INTEGER"/>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="2" author="liquibase">
+        <tagDatabase tag="1.0"/>
+    </changeSet>
+
+    <changeSet id="3" author="liquibase">
+        <addColumn tableName="TABLE_A">
+            <column name="COL_1" type="VARCHAR(10)"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="4" author="liquibase">
+        <tagDatabase tag="1.1"/>
+    </changeSet>
+
+    <changeSet id="5" author="liquibase">
+        <tagDatabase tag="2.0"/>
+    </changeSet>
+</databaseChangeLog>

--- a/liquibase-dist/src/main/archive/lib/liquibase_autocomplete.sh
+++ b/liquibase-dist/src/main/archive/lib/liquibase_autocomplete.sh
@@ -7,13 +7,13 @@ _liquibase()
 
     # Liquibase options, has to be improved to be more context aware
     opts="
-  help 
-  update 
-  updateSQL 
-  updateCount 
-  updateCountSQL 
-  updateToTag 
-  updateToTagSQL 
+  help
+  update
+  updateSQL
+  updateCount
+  updateCountSQL
+  updateToTag
+  updateToTagSQL
   status
   registerChangeLog
   syncHub
@@ -46,6 +46,8 @@ _liquibase()
   clearCheckSums
   changelogSync
   changelogSyncSQL
+changeLogSyncToTag
+changeLogSyncToTagSQL
   markNextChangeSetRan
   markNextChangeSetRanSQL
   listLocks

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseChangeLogSyncMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseChangeLogSyncMojo.java
@@ -13,10 +13,16 @@ import liquibase.exception.LiquibaseException;
  */
 public class LiquibaseChangeLogSyncMojo extends AbstractLiquibaseChangeLogMojo {
 
+	/**
+	 * Update to the changeSet with the given tag command.
+	 * @parameter property="liquibase.toTag"
+	 */
+	protected String toTag;
+
   	@Override
   	protected void performLiquibaseTask(Liquibase liquibase)
   			throws LiquibaseException {
     		super.performLiquibaseTask(liquibase);
-	    	liquibase.changeLogSync(new Contexts(contexts), new LabelExpression(labels));
+	    	liquibase.changeLogSync(toTag, new Contexts(contexts), new LabelExpression(labels));
 	  }
 }

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseChangeLogSyncSQLMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseChangeLogSyncSQLMojo.java
@@ -5,7 +5,6 @@ import liquibase.LabelExpression;
 import liquibase.Liquibase;
 import liquibase.database.Database;
 import liquibase.exception.LiquibaseException;
-import liquibase.resource.ResourceAccessor;
 import org.apache.maven.plugin.MojoExecutionException;
 
 import java.io.File;
@@ -31,13 +30,19 @@ public class LiquibaseChangeLogSyncSQLMojo extends
 	 */
 	protected File migrationSqlOutputFile;
 
+	/**
+	 * Update to the changeSet with the given tag command.
+	 * @parameter property="liquibase.toTag"
+	 */
+	protected String toTag;
+
 	/** The writer for writing the migration SQL. */
 	private Writer outputWriter;
 
 	@Override
 	protected void performLiquibaseTask(Liquibase liquibase)
 			throws LiquibaseException {
-		liquibase.changeLogSync(new Contexts(contexts), new LabelExpression(labels), outputWriter);
+		liquibase.changeLogSync(toTag, new Contexts(contexts), new LabelExpression(labels), outputWriter);
 	}
 
 	@Override


### PR DESCRIPTION
Add a `changelogSyncToTag` command to allow only those changeSets up to and including the specified tag to be marked as ran in the database. A similar command, `changelogSyncToTagSQL` should output the SQL to mark all changeSets upto the specified tag as ran.

Provide support for running the new commands via either the Liquibase command line, an Ant Task or the Maven plugin.

### Examples
#### Command Line
1. changelogSyncToTag
Mark all changeSets as ran in database `test` up to and including the `version_2.0` tag.

```
./liquibase \
    --driver=org.postgresql.Driver \
    --classpath=/tmp/postgresql-42.1.1.jre7.jar \
    --url=jdbc:postgresql://localhost:5432/test \
    --username=bob \
    --password=t0pS3cret \
    --changeLogFile=/tmp/db-changelog.xml \
    changelogSyncToTag version_2.0
```

1. changeLogSyncToTagSQL
Output to STDOUT the SQL to mark all changeSets as ran in database `test` up to and including the `version_2.0` tag.

```
./liquibase \
    --driver=org.postgresql.Driver \
    --classpath=/tmp/postgresql-42.1.1.jre7.jar \
    --url=jdbc:postgresql://localhost:5432/test \
    --username=bob \
    --password=t0pS3cret \
    --changeLogFile=/tmp/db-changelog.xml \
    changelogSyncToTagSQL version_2.0
```

#### Maven
1. changelogSyncToTag
Mark all changeSets as ran in database `test` up to and including the `version_2.0` tag.

```xml
<plugin>
    <groupId>org.liquibase</groupId>
    <artifactId>liquibase-maven-plugin</artifactId>
    <version>4.0.0-beta2-local-SNAPSHOT</version>
    <configuration>
        <changeLogFile>db-changelog.xml</changeLogFile>
        <driver>org.postgresql.Driver</driver>
        <url>jdbc:postgresql://localhost:5432/test</url>
        <username>bob</username>
        <password>t0pS3cret</password>
    </configuration>
    <executions>
        <execution>
            <phase>process-resources</phase>
            <goals>
                <goal>changelogSync</goal>
            </goals>
            <configuration>
                <toTag>version_2.0</toTag>
            </configuration>
        </execution>
    </executions>
</plugin>
```

1. changeLogSyncToTagSQL
Output to `${project.build.directory}/liquibase/migrate.sql` the SQL to mark all changeSets as ran in database `test` up to and including the `version_2.0` tag.

```xml
<plugin>
    <groupId>org.liquibase</groupId>
    <artifactId>liquibase-maven-plugin</artifactId>
    <version>4.0.0-beta2-local-SNAPSHOT</version>
    <configuration>
        <changeLogFile>db-changelog.xml</changeLogFile>
        <driver>org.postgresql.Driver</driver>
        <url>jdbc:postgresql://localhost:5432/test</url>
        <username>bob</username>
        <password>t0pS3cret</password>
    </configuration>
    <executions>
        <execution>
            <phase>process-resources</phase>
            <goals>
                <goal>changelogSyncSQL</goal>
            </goals>
            <configuration>
                <toTag>version_2.0</toTag>
            </configuration>
        </execution>
    </executions>
</plugin>
```

#### Ant
1. changelogSyncToTag
Mark all changeSets as ran in database `test` up to and including the `version_2.0` tag.

```xml
<liquibase:changeLogSync changeLogFile="db-changeLog.xml" toTag="version_2.0">
    <liquibase:database driver="org.postgresql.Driver"
                        url="jdbc:postgresql://localhost:5432/test"
                        user="${db.user}"
                        password="${db.pasword}"/>
</liquibase:changeLogSync>
```

1. changeLogSyncToTagSQL
Output to `/tmp/sync.sql` the SQL to mark all changeSets as ran in database `test` up to and including the `version_2.0` tag.

```xml
<liquibase:changeLogSync changeLogFile="db-changeLog.xml" outputfile="/tmp/sync.sql" toTag="version_2.0">
    <liquibase:database driver="org.postgresql.Driver"
                        url="jdbc:postgresql://localhost:5432/test"
                        user="${db.user}"
                        password="${db.pasword}"/>
</liquibase:changeLogSync>
```

## **LIQUIBASE INTERNAL QA REQUIREMENTS**
##### Test Cases
0. Validate that the two new commands appear in Liquibase help.
1. Manually validate the fix using the reproduction steps in the ticket description.


* MVN
  * changeLogSyncToTagSQL
  * changeLogSyncToTag
* CLI
  * changeLogSyncToTagSQL
  * changeLogSyncToTag
* Ant (manual execution only)
  * changeLogSyncToTagSQL
  * changeLogSyncToTag

2. When passing manually, add a Liquibase functional regression test.


* Configure test to execute against Postgres, MySQL and MariaDB.
  * MVN
  * CLI 

Follow the new standards for calling liquibase.CLI and liquibase.MVN instead of the deprecated 'execute.'


##### Note to Community: The functional Liquibase tests run on our internal build system and are not visible to the broader community.


┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-249) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Community 4.x,Liquibase 4.3.2
