### PR TITLE
Fix root paths for Spring Boot fat jar

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/spring/SpringLiquibase.java
+++ b/liquibase-core/src/main/java/liquibase/integration/spring/SpringLiquibase.java
@@ -25,10 +25,12 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ResourceLoaderAware;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.core.io.support.ResourcePatternUtils;
 
 import javax.sql.DataSource;
 import java.io.*;
+import java.net.URL;
 import java.net.URLConnection;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -498,38 +500,24 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
         protected void init() {
             super.init();
             try {
-                Resource[] resources = getResources("");
-                if ((resources.length != 0) && ((resources.length != 1) || resources[0].exists())) {
-                    for (Resource res : resources) {
-                        addRootPath(res.getURL());
-                    }
-                    return;
-                }
-                //sometimes not able to look up by empty string, try all the liquibase packages
-                Set<String> liquibasePackages = new HashSet<>();
-                for (Resource manifest : getResources("META-INF/MANIFEST.MF")) {
-                    liquibasePackages.addAll(getPackagesFromManifest(manifest));
-                }
-
-                if (liquibasePackages.isEmpty()) {
-                    LogService.getLog(getClass()).warning(LogType.LOG,
-                        "No Liquibase-Packages entry found in MANIFEST.MF. " +
-                        "Using fallback of entire 'liquibase' package");
-                    liquibasePackages.add("liquibase");
-                }
-
-                for (String foundPackage : liquibasePackages) {
-                    for (Resource res : getResources(foundPackage)) {
-                        if (res.exists()) {
-                            addRootPath(res.getURL());
-                        } else {
-                            LogService.getLog(getClass()).warning(LogType.LOG,
-                                "Resource does not exist: " +
-                                res.getDescription());
+                final ResourcePatternResolver resolver = ResourcePatternUtils.getResourcePatternResolver(resourceLoader);
+                for (final String ending : new String[]{"xml", "yml", "yaml"}) {
+                    Resource[] resources = resolver.getResources("classpath*:**/*." + ending);
+                    for (Resource resource : resources) {
+                        String url = resource.getURL().toExternalForm();
+                        if (!url.startsWith("jar:")) {
+                            continue;
+                        }
+                        url = url.substring(4, url.indexOf('!'));
+                        url = url.replace("\\", "/");
+                        if (url.startsWith("file:") && url.charAt(5) != '/') {
+                            url = "file:/" + url.substring(5) + "/";
+                        }
+                        if (!getRootPaths().contains(url)) {
+                            addRootPath(new URL(url));
                         }
                     }
                 }
-
             } catch (IOException e) {
                 LogService.getLog(getClass()).warning(LogType.LOG, "Error initializing SpringLiquibase", e);
             }


### PR DESCRIPTION
- - -
name: Fix root paths for spring boot fat jar
about: replace using getResource("")
title: 'Fix root paths for spring boot fat jar'
labels: Status:Discovery
assignees: ''

- - -
<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->

## Environment
**Liquibase Version**: 3.8.9

**Liquibase Integration & Version**: spring boot

**Liquibase Extension(s) & Version**: -

**Database Vendor & Version**: -

**Operating System Type & Version**: -

## Pull Request Type
<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->

* [x] Bug fix (non-breaking change which fixes an issue.)
* [ ] Enhancement/New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
The includeAll feature doesn't work with spring-boot packaged jar files.
Running getResources("") is probably supposed to return the root folders of all jars. However it's lacking some of them. I guess using this method with an empty string (addressing the Spring Boot ResourcePatternResolver) isn't really supported.
This issue appears on windows OS as well as in a linux container performing the build.

The issue came up before, for example https://github.com/liquibase/liquibase/pull/698. Solution there doesn't seem to work in all cases.

## Steps To Reproduce
* have a spring boot multi module project in place
* use includeAll, for example classpath*:/changelogs
* have a changelog file in multiple jars

Running the jar, for example withe gradle bootRun, will not find all changelog files and thus produce errors.

## Actual Behavior
## Expected/Desired Behavior
## Screenshots (if appropriate)
## Additional Context
Described it in my blog http://www.it-surmann.com/spring-boot/fix-liquibase-includeall-in-a-spring-boot-project_1002.html also.

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->

* [x] Build is successful and all new and existing tests pass
* [ ] Added Unit Test(s)
* [ ] Added Integration Test(s)
* [ ] Documentation Updated

## QA Manual Test Requirements
##### Setup
* Create a spring boot app with a root changelog having includeAll="classpath*:/changelogs
  * Have multiple jars with changelogs in a /changelogs dir

##### Validations
_Verify Liquibase applies changes from all changelogs on application start._
ASSERT ::

* Changes from the first jar are applied to the database
* Changes from the nth jar are applied to the database.
* There are no errors during update.
:information_source: Nathan will need to set up all of this to test his fix, and he'll share it with QA.

## QA Automated Test Requirements
* None.



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-251) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 3.10.3
