### PR TITLE
Support `onFailMessage` and `onErrorMessage` in formatted SQL

### DIFF
--- a/liquibase-core/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
@@ -95,9 +95,12 @@ public class FormattedSqlChangeLogParser implements ChangeLogParser {
             Pattern runInTransactionPattern = Pattern.compile(".*runInTransaction:(\\w+).*", Pattern.CASE_INSENSITIVE);
             Pattern dbmsPattern = Pattern.compile(".*dbms:([^,][\\w!,]+).*", Pattern.CASE_INSENSITIVE);
             Pattern failOnErrorPattern = Pattern.compile(".*failOnError:(\\w+).*", Pattern.CASE_INSENSITIVE);
+
             Pattern onFailPattern = Pattern.compile(".*onFail:(\\w+).*", Pattern.CASE_INSENSITIVE);
             Pattern onErrorPattern = Pattern.compile(".*onError:(\\w+).*", Pattern.CASE_INSENSITIVE);
             Pattern onUpdateSqlPattern = Pattern.compile(".*onUpdateSQL:(\\w+).*", Pattern.CASE_INSENSITIVE);
+            Pattern onFailMessagePattern = Pattern.compile(".*onFailMessage:((?:\\\\\\s|\\S)+).*", Pattern.CASE_INSENSITIVE); // allows escaped spaces
+            Pattern onErrorMessagePattern = Pattern.compile(".*onErrorMessage:((?:\\\\\\s|\\S)+).*", Pattern.CASE_INSENSITIVE); // allows escaped spaces
 
             boolean rollbackSplitStatements = true;
             String rollbackEndDelimiter = null;
@@ -234,11 +237,19 @@ public class FormattedSqlChangeLogParser implements ChangeLogParser {
                                 Matcher onFailMatcher = onFailPattern.matcher(body);
                                 Matcher onErrorMatcher = onErrorPattern.matcher(body);
                                 Matcher onUpdateSqlMatcher = onUpdateSqlPattern.matcher(body);
+                                Matcher onFailMessageMatcher = onFailMessagePattern.matcher(body);
+                                Matcher onErrorMessageMatcher = onErrorMessagePattern.matcher(body);
 
                                 PreconditionContainer pc = new PreconditionContainer();
                                 pc.setOnFail(StringUtil.trimToNull(parseString(onFailMatcher)));
                                 pc.setOnError(StringUtil.trimToNull(parseString(onErrorMatcher)));
                                 pc.setOnSqlOutput(StringUtil.trimToNull(parseString(onUpdateSqlMatcher)));
+                                String onFailMessage = StringUtil.trimToNull(parseString(onFailMessageMatcher));
+                                if (onFailMessage != null)
+                                    pc.setOnFailMessage(onFailMessage.replaceAll("\\\\(\\s)", "$1"));
+                                String onErrorMessage = StringUtil.trimToNull(parseString(onErrorMessageMatcher));
+                                if (onErrorMessage != null)
+                                    pc.setOnErrorMessage(onErrorMessage.replaceAll("\\\\(\\s)", "$1"));
                                 changeSet.setPreconditions(pc);
                             }
                         } else if (preconditionMatcher.matches()) {


### PR DESCRIPTION
Introduce two new attributes of the `preconditions` element:
--preconditions onFailMessage:fail\ message onErrorMessage:error_message
to set the respective xml attributes.

Whitespace can be used in messages if escaped with a backslash.

- - -
name: Pull Request
about: Create a report to help us improve
title: ''
labels: Status:Discovery
assignees: ''

- - -
<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->

## Environment
**Liquibase Version**: 3.8.9 (applies to lower versions as well)

**Database Vendor & Version**: Any (tested on Oracle)

**Operating System Type & Version**: Any (tested on Linux)

## Pull Request Type
<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->

* [ ] Bug fix (non-breaking change which fixes an issue.)
* [x] Enhancement/New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
From the SO question: https://stackoverflow.com/questions/61748020/on-fail-message-for-sql-formatted-changesets
we find that it is currently impossible to set the `onFailMessage` and `onErrorMessage` attributes from formatted SQL changesets. This PR introduces said support, via:
`--preconditions onFailMessage:fail\ message onErrorMessage:error_message`.

## Steps To Reproduce
Try to use `onFailMessage` and `onErrorMessage` attributes from formatted SQL changesets

## Actual Behavior
No matter what you write, you can't set those attributes (as no code path that sets them exists)

## Expected/Desired Behavior
By using `--preconditions onFailMessage:fail\ message onErrorMessage:error_message` you can set the fail message to `fail message` and the error message to `error_message`.

## Additional Context
The patch is really basic, it would be more efficient to write a proper subparser instead of throwing the same string under a regex per every tag, but I did the minimum here, can refactor if asked to.
I wanted to allow whitespace, so I decided to allow escaping it with a `\`. If other whitespace systems are preferred (i.e. quoting the whole message), just ask.

This is the same as #1150 , but against the right branch, sorry for the annoyance.

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->

* [x] Build is successful and all new and existing tests pass
* [ ] Added Unit Test(s) -> AFAICT there is no dedicated formatted SQL unit testing, beside reparsing a generated SQL file
* [ ] Added Integration Test(s)
* [ ] Documentation Updated -> the documentation at https://www.liquibase.org/documentation/sql_format.html should include this change, but I couldn't find where the site source is stored (if accessible).

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)

