### PR TITLE
Replace backslashes with forward slashes when normalizing a path

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -628,9 +628,9 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
 
     protected String normalizePath(String filePath) {
         if (ignoreClasspathPrefix) {
-            return filePath.replaceFirst("^classpath:", "");
+            return filePath.replaceFirst("^classpath:", "").replace("\\","/");
         }
-        return filePath;
+        return filePath.replace("\\","/");
     }
 
     public void clearCheckSums() {

--- a/liquibase-core/src/main/java/liquibase/changelog/filter/RanChangeSetFilter.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/filter/RanChangeSetFilter.java
@@ -27,8 +27,8 @@ public abstract class RanChangeSetFilter implements ChangeSetFilter {
     }
     protected String normalizePath(String filePath) {
         if (ignoreClasspathPrefix) {
-            return filePath.replaceFirst("^classpath:", "");
+            return filePath.replaceFirst("^classpath:", "").replace("\\","/");
         }
-        return filePath;
+        return filePath.replace("\\","/");
     }
 }

--- a/liquibase-core/src/main/java/liquibase/changelog/filter/ShouldRunChangeSetFilter.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/filter/ShouldRunChangeSetFilter.java
@@ -110,8 +110,8 @@ public class ShouldRunChangeSetFilter implements ChangeSetFilter {
             return null;
         }
         if (ignoreClasspathPrefix) {
-            return filePath.replaceFirst("^classpath:", "");
+            return filePath.replaceFirst("^classpath:", "").replace("\\","/");
         }
-        return filePath;
+        return filePath.replace("\\","/");
     }
 }

--- a/liquibase-core/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
@@ -88,8 +88,8 @@ public class ValidatingVisitor implements ChangeSetVisitor {
         return result;
     }
         
-    private String normalizePath(String filePath) {
-        return filePath.replaceFirst("^classpath:", "");
+    String normalizePath(String filePath) {
+        return filePath.replaceFirst("^classpath:", "").replace("\\","/");
     }
 
         @Override

--- a/liquibase-core/src/test/groovy/liquibase/changelog/DatabaseChangeLogTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/changelog/DatabaseChangeLogTest.groovy
@@ -4,6 +4,7 @@ import liquibase.ContextExpression;
 import liquibase.LabelExpression;
 import liquibase.change.core.CreateTableChange
 import liquibase.change.core.RawSQLChange
+import liquibase.changelog.filter.ShouldRunChangeSetFilter
 import liquibase.exception.SetupException
 import liquibase.parser.core.ParsedNode
 import liquibase.precondition.core.OrPrecondition
@@ -14,6 +15,9 @@ import liquibase.sdk.supplier.resource.ResourceSupplier
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
+
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertEquals
 
 class DatabaseChangeLogTest extends Specification {
 
@@ -341,4 +345,19 @@ create view sql_view as select * from sql_table;'''
 
     }
 
+    def "normalizePath removes 'classpath:' and replaces backslashes with forward slashes"() {
+        when:
+        def changeLogFile = new DatabaseChangeLog("com/example/root.xml")
+        changeLogFile.setIgnoreClasspathPrefix(true)
+        then:
+        changeLogFile.normalizePath("classpath:alpha\\bravo\\charlie") == "alpha/bravo/charlie"
+    }
+
+    def "normalizePath replaces backslashes with forward slashes"() {
+        when:
+        def changeLogFile = new DatabaseChangeLog("com/example/root.xml")
+        changeLogFile.setIgnoreClasspathPrefix(false)
+        then:
+        changeLogFile.normalizePath("alpha\\bravo\\charlie") == "alpha/bravo/charlie"
+    }
 }

--- a/liquibase-core/src/test/groovy/liquibase/changelog/filter/ShouldRunChangeSetFilterTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/changelog/filter/ShouldRunChangeSetFilterTest.groovy
@@ -10,6 +10,7 @@ import liquibase.executor.Executor
 import liquibase.executor.ExecutorService
 import spock.lang.Specification
 
+import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertTrue
 
@@ -89,6 +90,12 @@ public class ShouldRunChangeSetFilterTest extends Specification {
 //    }
 
 
+    private Database given_a_database_with_no_executed_changesets() throws DatabaseException {
+        ArrayList<RanChangeSet> ranChanges = new ArrayList<RanChangeSet>();
+
+        return mock_database(ranChanges);
+    }
+
     private Database given_a_database_with_two_executed_changesets() throws DatabaseException {
         ArrayList<RanChangeSet> ranChanges = new ArrayList<RanChangeSet>();
         RanChangeSet ranChangeSet1 = new RanChangeSet("path/changelog", "1", "testAuthor", CheckSum.parse("12345"), new Date(), null, null, null, null, null, null, null);
@@ -134,5 +141,27 @@ public class ShouldRunChangeSetFilterTest extends Specification {
         then:
         ChangeSet changeSet = new ChangeSet("1", "testAuthor", false, true, "path/changelog", null, null, null)
         assertFalse("RunOnChange not changed changeset should NOT be accepted", filter.accepts(changeSet).isAccepted())
+    }
+
+    public void should_normalize_path_when_ignoring_classpath_prefix() {
+        when:
+        given_a_database_with_no_executed_changesets()
+        ShouldRunChangeSetFilter filter = new ShouldRunChangeSetFilter(database, true)
+
+        then:
+        String actual = filter.normalizePath("classpath:alpha\\bravo\\charlie")
+        String expected = "alpha/bravo/charlie"
+        assertEquals(expected, actual)
+    }
+
+    public void should_normalize_path_when_not_ignoring_classpath_prefix() {
+        when:
+        given_a_database_with_no_executed_changesets()
+        ShouldRunChangeSetFilter filter = new ShouldRunChangeSetFilter(database, false)
+
+        then:
+        String actual = filter.normalizePath("alpha\\bravo\\charlie")
+        String expected = "alpha/bravo/charlie"
+        assertEquals(expected, actual)
     }
 }

--- a/liquibase-core/src/test/java/liquibase/changelog/filter/AlreadyRanChangeSetFilterTest.java
+++ b/liquibase-core/src/test/java/liquibase/changelog/filter/AlreadyRanChangeSetFilterTest.java
@@ -1,5 +1,12 @@
 package liquibase.changelog.filter;
 
+import liquibase.changelog.RanChangeSet;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+
 public class AlreadyRanChangeSetFilterTest {
 
 //    private Database database = createMock(Database.class);
@@ -67,4 +74,21 @@ public class AlreadyRanChangeSetFilterTest {
 
     }
 
+    @Test
+    public void should_normalize_path_when_ignoring_classpath_prefix() {
+        RanChangeSetFilter filter = new AlreadyRanChangeSetFilter(new ArrayList<RanChangeSet>(), true);
+
+        String actual = filter.normalizePath("classpath:alpha\\bravo\\charlie");
+        String expected = "alpha/bravo/charlie";
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void should_normalize_path_when_not_ignoring_classpath_prefix() {
+        RanChangeSetFilter filter = new AlreadyRanChangeSetFilter(new ArrayList<RanChangeSet>(), true);
+
+        String actual = filter.normalizePath("alpha\\bravo\\charlie");
+        String expected = "alpha/bravo/charlie";
+        assertEquals(expected, actual);
+    }
 }

--- a/liquibase-core/src/test/java/liquibase/changelog/visitor/ValidatingVisitorTest.java
+++ b/liquibase-core/src/test/java/liquibase/changelog/visitor/ValidatingVisitorTest.java
@@ -129,4 +129,13 @@ public class ValidatingVisitorTest {
 
         assertTrue(handler.validationPassed());
     }
+
+    @Test
+    public void normalize_path() {
+        ValidatingVisitor visitor = new ValidatingVisitor(new ArrayList<>());
+
+        String actual = visitor.normalizePath("classpath:alpha\\bravo\\charlie");
+        String expected = "alpha/bravo/charlie";
+        assertEquals(expected, actual);
+    }
 }


### PR DESCRIPTION
name: Pull Request
about: Create a report to help us improve
title: ''
labels: Status:smiley:iscovery
assignees: ''

**Environment**
Liquibase Version: 3.8.9 and master

Liquibase Integration & Version: <Pick one: CLI, maven, gradle, spring boot, servlet, etc.>

Liquibase Extension(s) & Version: n/a

Database Vendor & Version: MySQL

Operating System Type & Version: Windows

**Pull Request Type**
[ x ] Bug fix (non-breaking change which fixes an issue.)
[ ] Enhancement/New feature (non-breaking change which adds functionality)
[ ]Breaking change (fix or feature that would cause existing functionality to change)

**Description**
The OpenMRS core module moved away from the Liquibase change logs that contained all database migrations since day one and introduced change logs that represent snapshots of the underlying database. In that context Liquibase was upgraded from 2.0.5 to 3.8.9.

New change log files were created in a nested package structure underneath a resource folder, such as:

openmrs-core/api/src/main/*resources*/org/openmrs/liquibase/snapshots/schema-only/liquibase-schema-only-2.3.x.xml

When processing that change log file on a Windows machine for the first time, all goes well and the filename is stored in the liquibasechangelog table using backslashes as separators.

However upon restarting OpenMRS, the core module checks for un-run change sets. In that context all change sets that had been successfully processed before are not recognised and marked as "un-run" change sets.

Debugging revealed that the class liquibase/changelog/visitor/ValidatingVisitor.java compares two different flavours of the filename: one with forward slashes (derived from the resource file) and another one with backward slashes (which is the one stored in the liquibasechangelogtable mentioned above). These filenames do not match and as a consequence all change sets in the change log file are marked as "un-run".

**To be clear, all this happens on a Windows machine.**

This bug is resolved by replacing backslashes with forward slashes when normalising file paths. This happens in four places in the Liquibase codebase.

**Steps To Reproduce**

1. Create a change log file that belongs to a nested package structure.
1. Process that change log file for the first time on Windows.
1. Look for un-run change sets in that change log file on Windows.

**Actual Behavior**
Change sets that were executed before are not recognised and considered to be "un-run".

**Expected/Desired Behavior**
Change sets that were executed before are recognised as such and considered to be "run".

**Screenshots (if appropriate)**
n/a

**Additional Context**
n/a

****Fast Track PR Acceptance Checklist:
[ x ] Build is successful and all new and existing tests pass
[ x ] Added Unit Test(s)
[ n/a ] Added Integration Test(s)
[ n/a ] Documentation Updated

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)

## QA Manual Test Requirements
##### Setup
:information_source: Make sure you're testing on a Windows machine!!

* Configure a Spring Boot project to connect to  your MySQL database.
  * Example Spring Boot project in datical/daticaldb-testing repository (liquibase-spring-boot)
  * The application.properties file is in src/main/resources

* In src/main/resources/db/changelog, create a nested directory structure like: level1/level2/level3/level4/
* Drop the attached changelog into src/main/resources/db/changelog/level1/level2/level3/level4 :
* Update the name and location of the changelog referenced in application.properties.

* During deskcheck, confirm with the Developer that the solution is to normalize to forward slashes. Depending on the answer, that might effect some of the test assertions.
* During deskcheck, confirm wit the Developer that testing against on integration (Liquibase Spring Boot) is sufficient.

**Rollbacks**

* Add a test case to make sure there are no regressions around rollback functionality. 
  * The use case would be to build and deploy via Maven, but to rollback via the CLI, because rollbacks are more commonly invoked manually.

##### Validations
_Verify Liquibase writes the correct path to changelog in tracking table on application start._
ASSERT :: DATABASECHANGELOG.filename field contains /db/changelog/level1/level2/level3/level4/changelog.xml
ASSERT :: All changes are marked EXECUTED in DATABASECHANGELOG.exectype

_Verify Liquibase finds no changes to deploy on application start._
ASSERT :: There are no errors about objects already existing during the update.
ASSESRT :: Messaging indicates that no changes were found and/or database is up to date.

## QA Automated Test Requirements
* None.



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-276) by [Unito](https://www.unito.io/learn-more)
┆Attachments: <a href="https://share.unito.io/Tf5hzcRLT11RrkT-PdVg0B6HQMegiMoz54oYQwzKi4du">project.zip</a>
┆Fix Versions: Liquibase 3.10.3
