### PR TITLE
Add MariaDB sequence support to the 3.10.x branch

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/MariaDBDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MariaDBDatabase.java
@@ -96,8 +96,9 @@ public class MariaDBDatabase extends MySQLDatabase {
     @Override
     public boolean supportsSequences() {
         try {
-            return getDatabaseMajorVersion() >= 10 && getDatabaseMinorVersion() >= 3;
-        } catch (DatabaseException e) {
+            // From https://liquibase.jira.com/browse/CORE-3457 (by Lijun Liao) corrected
+            int majorVersion = getDatabaseMajorVersion();
+            return majorVersion > 10 || (majorVersion == 10 && getDatabaseMinorVersion() >= 3);        } catch (DatabaseException e) {
             LogService.getLog(getClass()).debug(LogType.LOG, "Cannot retrieve database version", e);
             return false;
         }

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
@@ -19,6 +19,7 @@ import liquibase.structure.core.Sequence;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
+import java.util.StringJoiner;
 
 /**
  * Snapshot generator for a SEQUENCE object in a JDBC-accessible database
@@ -233,6 +234,32 @@ public class SequenceSnapshotGenerator extends JdbcSnapshotGenerator {
                     "CAST(INCREMENT AS BIGINT) AS INCREMENT_BY, " +
                     "CYCLE_OPTION AS WILL_CYCLE " +
                     "FROM INFORMATION_SCHEMA.SEQUENCES WHERE SEQUENCE_SCHEMA = '" + schema.getName() + "'";
+        } else if (database instanceof MariaDBDatabase) {
+            StringJoiner j = new StringJoiner(" \n UNION\n");
+            try {
+                List<Map<String, ?>> res = ExecutorService.getInstance()
+                        .getExecutor(database)
+                        .queryForList(new RawSqlStatement("select table_name AS SEQUENCE_NAME " +
+                                                        "from information_schema.TABLES " +
+                                                        "where TABLE_SCHEMA = '" + schema.getName() +"' " +
+                                                        "and TABLE_TYPE = 'SEQUENCE' order by table_name;"));
+                if (res.size() == 0) {
+                    return "SELECT 'name' AS SEQUENCE_NAME from dual WHERE 1=0";
+                }
+                for (Map<String, ?> e : res) {
+                    String seqName = (String) e.get("SEQUENCE_NAME");
+                    j.add(String.format("SELECT '%s' AS SEQUENCE_NAME, " +
+                            "START_VALUE AS START_VALUE, " +
+                            "MINIMUM_VALUE AS MIN_VALUE, " +
+                            "MAXIMUM_VALUE AS MAX_VALUE, " +
+                            "INCREMENT AS INCREMENT_BY, " +
+                            "CYCLE_OPTION AS WILL_CYCLE " +
+                            "FROM %s ", seqName, seqName));
+                }
+            } catch (DatabaseException e) {
+                throw new UnexpectedLiquibaseException("Could not get list of schemas ", e);
+            }
+            return j.toString();
         } else if (database instanceof SybaseASADatabase) {
         	return "SELECT SEQUENCE_NAME, " +
                     "START_WITH AS START_VALUE, " +


### PR DESCRIPTION
This is basically a port of [PR 1024](https://github.com/liquibase/liquibase/pull/1024), but for the 3.10.x branch.  Since MariaDB is effectively broken for MariaDB 10.3 and up, I don't think this should wait for 4.0.

I did use slightly different SQL than the original PR to account for permission problems in the innodb tables.

- - -
name: Add MariaDB 10.3 sequence suport
about: This fix will allow MariaDB users on 10.3 and up to use Liquibase.
title: ''
labels: Status:Discovery
assignees: ''

- - -
<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->

## Environment
**Liquibase Version**: 3.10.x

**Liquibase Integration & Version**: 

**Liquibase Extension(s) & Version**: 

**Database Vendor & Version**: MariaDB 10.3 and up

**Operating System Type & Version**:

## Pull Request Type
<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->

* [x] Bug fix (non-breaking change which fixes an issue.)
* [ ] Enhancement/New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
MariaDB added support for sequences, Liquibase knows about the support (MariaDBDatabase.supportsSequences returns true), but the SequenceSnapshotGenerator doesn't know how to get them, causing Liquibase to fail completely in that environment - even if there are no actual sequences in the database.

## Steps To Reproduce
List the steps to reproduce the behavior.

1. Create a MariaDB 10.3 database.  Nothing needs to be in it, it just needs to exist.
1. Run the dropAll action against it.
1. (optional) Create a changelog with a createSequence change.
1. Run the update action against it.

## Actual Behavior
Liquibase throws an exception at step 2.

## Expected/Desired Behavior
Liquibase succeeds.  DropAll won't do anything, but that is fine.  Step 4 will result in a sequence being created in the database.

## Screenshots (if appropriate)
If applicable, add screenshots to help explain your problem.

## Additional Context
No new tests were added, but it doesn't look like any existing tests target MariaDB databases.  This change is being discussed in a sister PR 1024.

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->

* [x] Build is successful and all new and existing tests pass
* [ ] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
* [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
* [ ] Documentation Updated

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-287) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 3.10.2
