### PR TITLE
    CORE-3643: fixed the 'shouldValidateX' methods in the Constarints…

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/ColumnConfig.java
+++ b/liquibase-core/src/main/java/liquibase/change/ColumnConfig.java
@@ -98,7 +98,7 @@ public class ColumnConfig extends AbstractLiquibaseSerializable {
 
         if ((columnSnapshot.isNullable() != null) && !columnSnapshot.isNullable()) {
             constraints.setNullable(columnSnapshot.isNullable());
-            constraints.setShouldValidateNullable(columnSnapshot.shouldValidateNullable());
+            constraints.setValidateNullable(columnSnapshot.getValidateNullable());
             nonDefaultConstraints = true;
         }
 
@@ -880,10 +880,10 @@ public class ColumnConfig extends AbstractLiquibaseSerializable {
         constraints.setForeignKeyName(constraintsNode.getChildValue(null, "foreignKeyName", String.class));
         constraints.setInitiallyDeferred(constraintsNode.getChildValue(null, "initiallyDeferred", Boolean.class));
         constraints.setDeferrable(constraintsNode.getChildValue(null, "deferrable", Boolean.class));
-        constraints.setShouldValidateNullable(constraintsNode.getChildValue(null, "validateNullable", Boolean.class));
-        constraints.setShouldValidateUnique(constraintsNode.getChildValue(null, "validateUnique", Boolean.class));
-        constraints.setShouldValidatePrimaryKey(constraintsNode.getChildValue(null, "validatePrimaryKey", Boolean.class));
-        constraints.setShouldValidateForeignKey(constraintsNode.getChildValue(null, "validateForeignKey", Boolean.class));
+        constraints.setValidateNullable(constraintsNode.getChildValue(null, "validateNullable", Boolean.class));
+        constraints.setValidateUnique(constraintsNode.getChildValue(null, "validateUnique", Boolean.class));
+        constraints.setValidatePrimaryKey(constraintsNode.getChildValue(null, "validatePrimaryKey", Boolean.class));
+        constraints.setValidateForeignKey(constraintsNode.getChildValue(null, "validateForeignKey", Boolean.class));
         setConstraints(constraints);
     }
 

--- a/liquibase-core/src/main/java/liquibase/change/ConstraintsConfig.java
+++ b/liquibase-core/src/main/java/liquibase/change/ConstraintsConfig.java
@@ -250,101 +250,101 @@ public class ConstraintsConfig extends AbstractLiquibaseSerializable {
     }
 
     /**
-     * Set the shouldValidate field based on the passed string.
+     * Set the validateNullable field based on the passed string.
      * Sets true if the passed string is 1 or true or TRUE.
      * Sets false if the passed string is 0 or false or FALSE.
      * Sets null if the passed string is null or "null" or "NULL".
      * Throws an {@link UnexpectedLiquibaseException} if an invalid value is passed
      */
-    public ConstraintsConfig setShouldValidateNullable(String validateNullable) {
+    public ConstraintsConfig setValidateNullable(String validateNullable) {
         this.validateNullable = parseBoolean(validateNullable);
         return this;
     }
 
     /**
      * Returns whether a NotNullConst defined for this column should validate.
-     * Returns null if not setShouldValidate has not been called.
+     * Returns null if not setValidateNullable has not been called.
      */
-    public Boolean shouldValidateNullable() {
+    public Boolean getValidateNullable() {
         return validateNullable;
     }
 
-    public ConstraintsConfig setShouldValidateNullable(Boolean validateNullable) {
+    public ConstraintsConfig setValidateNullable(Boolean validateNullable) {
         this.validateNullable = validateNullable;
         return this;
     }
 
     /**
-     * Set the shouldValidate field based on the passed string.
+     * Set the validateUnique field based on the passed string.
      * Sets true if the passed string is 1 or true or TRUE.
      * Sets false if the passed string is 0 or false or FALSE.
      * Sets null if the passed string is null or "null" or "NULL".
      * Throws an {@link UnexpectedLiquibaseException} if an invalid value is passed
      */
-    public ConstraintsConfig setShouldValidateUnique(String validateUnique) {
+    public ConstraintsConfig setValidateUnique(String validateUnique) {
         this.validateUnique = parseBoolean(validateUnique);
         return this;
     }
 
     /**
      * Returns whether a UniqueConst defined for this column should validate.
-     * Returns null if not setShouldValidate has not been called.
+     * Returns null if not setValidateUnique has not been called.
      */
-    public Boolean shouldValidateUnique() {
+    public Boolean getValidateUnique() {
         return validateUnique;
     }
 
-    public ConstraintsConfig setShouldValidateUnique(Boolean validateUnique) {
+    public ConstraintsConfig setValidateUnique(Boolean validateUnique) {
         this.validateUnique = validateUnique;
         return this;
     }
 
     /**
-     * Set the shouldValidate field based on the passed string.
+     * Set the validatePrimaryKey field based on the passed string.
      * Sets true if the passed string is 1 or true or TRUE.
      * Sets false if the passed string is 0 or false or FALSE.
      * Sets null if the passed string is null or "null" or "NULL".
      * Throws an {@link UnexpectedLiquibaseException} if an invalid value is passed
      */
-    public ConstraintsConfig setShouldValidatePrimaryKey(String validatePrimaryKey) {
+    public ConstraintsConfig setValidatePrimaryKey(String validatePrimaryKey) {
         this.validatePrimaryKey = parseBoolean(validatePrimaryKey);
         return this;
     }
 
     /**
      * Returns whether a PrimaryKeyConst defined for this column should validate.
-     * Returns null if not setShouldValidate has not been called.
+     * Returns null if not setValidatePrimaryKey has not been called.
      */
-    public Boolean shouldValidatePrimaryKey() {
+    public Boolean getValidatePrimaryKey() {
         return validatePrimaryKey;
     }
 
-    public ConstraintsConfig setShouldValidatePrimaryKey(Boolean validatePrimaryKey) {
+    public ConstraintsConfig setValidatePrimaryKey(Boolean validatePrimaryKey) {
         this.validatePrimaryKey = validatePrimaryKey;
         return this;
     }
 
     /**
-     * Set the shouldValidate field based on the passed string.
+     * Set the validateForeignKey field based on the passed string.
      * Sets true if the passed string is 1 or true or TRUE.
      * Sets false if the passed string is 0 or false or FALSE.
      * Sets null if the passed string is null or "null" or "NULL".
      * Throws an {@link UnexpectedLiquibaseException} if an invalid value is passed
      */
-    public ConstraintsConfig setShouldValidateForeignKey(String validateForeignKey) {
+    public ConstraintsConfig setValidateForeignKey(String validateForeignKey) {
         this.validateForeignKey= parseBoolean(validateForeignKey);
         return this;
     }
 
     /**
      * Returns whether a ForeignKeyConst defined for this column should validate.
-     * Returns null if not setShouldValidate has not been called.
+     * Returns null if not setValidateForeignKey has not been called.
      */
-    public Boolean shouldValidateForeignKey() {
+    public Boolean getValidateForeignKey() {
         return validateForeignKey;
     }
 
-    public ConstraintsConfig setShouldValidateForeignKey(Boolean validateForeignKey) {
+    public ConstraintsConfig setValidateForeignKey(Boolean validateForeignKey) {
         this.validateForeignKey = validateForeignKey;
         return this;
     }

--- a/liquibase-core/src/main/java/liquibase/change/core/AddColumnChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/AddColumnChange.java
@@ -101,7 +101,7 @@ public class AddColumnChange extends AbstractChange implements ChangeWithColumns
             if (constraintsConfig != null) {
                 if ((constraintsConfig.isNullable() != null) && !constraintsConfig.isNullable()) {
                     NotNullConstraint notNullConstraint = new NotNullConstraint();
-                    if (constraintsConfig.shouldValidateNullable()!=null && !constraintsConfig.shouldValidateNullable()) {
+                    if (constraintsConfig.getValidateNullable()!=null && !constraintsConfig.getValidateNullable()) {
                         notNullConstraint.setValidateNullable(false);
                     }
                     notNullConstraint.setConstraintName(constraintsConfig.getNotNullConstraintName());
@@ -109,14 +109,14 @@ public class AddColumnChange extends AbstractChange implements ChangeWithColumns
                 }
                 if (constraintsConfig.isUnique() != null && constraintsConfig.isUnique()) {
                     UniqueConstraint uniqueConstraint = new UniqueConstraint();
-                    if (constraintsConfig.shouldValidateUnique()!=null && !constraintsConfig.shouldValidateUnique()) {
+                    if (constraintsConfig.getValidateUnique()!=null && !constraintsConfig.getValidateUnique()) {
                         uniqueConstraint.setValidateUnique(false);
                     }
                     constraints.add(uniqueConstraint);
                 }
                 if ((constraintsConfig.isPrimaryKey() != null) && constraintsConfig.isPrimaryKey()) {
                     PrimaryKeyConstraint primaryKeyConstraint = new PrimaryKeyConstraint(constraintsConfig.getPrimaryKeyName());
-                    if (constraintsConfig.shouldValidatePrimaryKey()!=null && !constraintsConfig.shouldValidatePrimaryKey()) {
+                    if (constraintsConfig.getValidatePrimaryKey()!=null && !constraintsConfig.getValidatePrimaryKey()) {
                         primaryKeyConstraint.setValidatePrimaryKey(false);
                     }
                     constraints.add(primaryKeyConstraint);
@@ -127,7 +127,7 @@ public class AddColumnChange extends AbstractChange implements ChangeWithColumns
                     ForeignKeyConstraint foreignKeyConstraint = new ForeignKeyConstraint(constraintsConfig.getForeignKeyName(),
                         constraintsConfig.getReferences(), constraintsConfig.getReferencedTableName(),
                         constraintsConfig.getReferencedColumnNames());
-                    if (constraintsConfig.shouldValidateForeignKey()!=null && !constraintsConfig.shouldValidateForeignKey()) {
+                    if (constraintsConfig.getValidateForeignKey()!=null && !constraintsConfig.getValidateForeignKey()) {
                         foreignKeyConstraint.setValidateForeignKey(false);
                     }
                     constraints.add(foreignKeyConstraint);

--- a/liquibase-core/src/main/java/liquibase/change/core/CreateTableChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/CreateTableChange.java
@@ -69,7 +69,7 @@ public class CreateTableChange extends AbstractChange implements ChangeWithColum
 
             LiquibaseDataType columnType = DataTypeFactory.getInstance().fromDescription(column.getType() + (isAutoIncrement ? "{autoIncrement:true}" : ""), database);
             if ((constraints != null) && (constraints.isPrimaryKey() != null) && constraints.isPrimaryKey()) {
-                statement.addPrimaryKeyColumn(column.getName(), columnType, defaultValue, constraints.shouldValidatePrimaryKey(),
+                statement.addPrimaryKeyColumn(column.getName(), columnType, defaultValue, constraints.getValidatePrimaryKey(),
                     constraints.getPrimaryKeyName(),constraints.getPrimaryKeyTablespace());
 
             } else {
@@ -85,7 +85,7 @@ public class CreateTableChange extends AbstractChange implements ChangeWithColum
                 if (constraints.isNullable() != null && !constraints.isNullable()) {
                     NotNullConstraint notNullConstraint = new NotNullConstraint(column.getName())
                             .setConstraintName(constraints.getNotNullConstraintName())
-                            .setValidateNullable(constraints.shouldValidateNullable() == null ? true : constraints.shouldValidateNullable());
+                            .setValidateNullable(constraints.getValidateNullable() == null ? true : constraints.getValidateNullable());
                     statement.addColumnConstraint(notNullConstraint);
                 }
 
@@ -105,16 +105,16 @@ public class CreateTableChange extends AbstractChange implements ChangeWithColum
                     fkConstraint.setInitiallyDeferred((constraints.isInitiallyDeferred() != null) && constraints
                         .isInitiallyDeferred());
                     fkConstraint.setDeferrable((constraints.isDeferrable() != null) && constraints.isDeferrable());
-                    Boolean validate = constraints.shouldValidateForeignKey();
+                    Boolean validate = constraints.getValidateForeignKey();
                     if (validate!=null) {
-                        fkConstraint.setValidateForeignKey(constraints.shouldValidateForeignKey());
+                        fkConstraint.setValidateForeignKey(constraints.getValidateForeignKey());
                     }
                     statement.addColumnConstraint(fkConstraint);
                 }
 
                 if ((constraints.isUnique() != null) && constraints.isUnique()) {
                     statement.addColumnConstraint(new UniqueConstraint(constraints.getUniqueConstraintName(),
-                        constraints.shouldValidateUnique()==null?true:constraints.shouldValidateUnique()).addColumns(column.getName()));
+                        constraints.getValidateUnique()==null?true:constraints.getValidateUnique()).addColumns(column.getName()));
                 }
             }
 

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/ChangedColumnChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/ChangedColumnChangeGenerator.java
@@ -115,7 +115,7 @@ public class ChangedColumnChangeGenerator extends AbstractChangeGenerator implem
                 change.setTableName(column.getRelation().getName());
                 change.setColumnName(column.getName());
                 change.setColumnDataType(DataTypeFactory.getInstance().from(column.getType(), comparisonDatabase).toString());
-                change.setValidate(column.shouldValidate());
+                change.setValidate(column.getValidate());
                 change.setConstraintName(column.getAttribute("notNullConstraintName", String.class));
                 changes.add(change);
             }

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingColumnChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingColumnChangeGenerator.java
@@ -89,8 +89,8 @@ public class MissingColumnChangeGenerator extends AbstractChangeGenerator implem
             }
             constraintsConfig.setNullable(false);
             constraintsConfig.setNotNullConstraintName(column.getAttribute("notNullConstraintName", String.class));
-            if (!column.shouldValidateNullable()) {
-                constraintsConfig.setShouldValidateNullable(false);
+            if (!column.getValidateNullable()) {
+                constraintsConfig.setValidateNullable(false);
             }
         }
         if (constraintsConfig != null) {

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingTableChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingTableChangeGenerator.java
@@ -190,8 +190,8 @@ public class MissingTableChangeGenerator extends AbstractChangeGenerator impleme
                     constraintsConfig = new ConstraintsConfig();
                 }
                 constraintsConfig.setNullable(false);
-                if (!column.shouldValidateNullable()) {
-                    constraintsConfig.setShouldValidateNullable(false);
+                if (!column.getValidateNullable()) {
+                    constraintsConfig.setValidateNullable(false);
                 }
                 constraintsConfig.setNotNullConstraintName(column.getAttribute("notNullConstraintName", String.class));
             }

--- a/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
@@ -375,17 +375,17 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
             if (constraints.isDeferrable() != null) {
                 constraintsElement.setAttribute("deferrable", constraints.isDeferrable().toString());
             }
-            if (constraints.shouldValidateNullable() != null) {
-                constraintsElement.setAttribute("validateNullable", constraints.shouldValidateNullable().toString());
+            if (constraints.getValidateNullable() != null) {
+                constraintsElement.setAttribute("validateNullable", constraints.getValidateNullable().toString());
             }
-            if (constraints.shouldValidateUnique() != null) {
-                constraintsElement.setAttribute("validateUnique", constraints.shouldValidateUnique().toString());
+            if (constraints.getValidateUnique() != null) {
+                constraintsElement.setAttribute("validateUnique", constraints.getValidateUnique().toString());
             }
-            if (constraints.shouldValidatePrimaryKey() != null) {
-                constraintsElement.setAttribute("validatePrimaryKey", constraints.shouldValidatePrimaryKey().toString());
+            if (constraints.getValidatePrimaryKey() != null) {
+                constraintsElement.setAttribute("validatePrimaryKey", constraints.getValidatePrimaryKey().toString());
             }
-            if (constraints.shouldValidateForeignKey() != null) {
-                constraintsElement.setAttribute("validateForeignKey", constraints.shouldValidateForeignKey().toString());
+            if (constraints.getValidateForeignKey() != null) {
+                constraintsElement.setAttribute("validateForeignKey", constraints.getValidateForeignKey().toString());
             }
             if (constraints.isDeleteCascade() != null) {
                 constraintsElement.setAttribute("deleteCascade", constraints.isDeleteCascade().toString());

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
@@ -130,7 +130,7 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
                         && searchCondition.matches("\"?\\w+\" IS NOT NULL")) {
                     // not validated not null constraint found
                     column.setNullable(false);
-                    column.setShouldValidateNullable(false);
+                    column.setValidateNullable(false);
                 }
                 if (Boolean.FALSE.equals(column.isNullable()) && hasValidObjectName(constraintName)) {
                     column.setAttribute("notNullConstraintName", constraintName);

--- a/liquibase-core/src/main/java/liquibase/structure/core/Column.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/Column.java
@@ -54,7 +54,7 @@ public class Column extends AbstractDatabaseObject {
         ConstraintsConfig constraints = columnConfig.getConstraints();
         if (constraints != null) {
             setNullable(constraints.isNullable());
-            setShouldValidateNullable(constraints.shouldValidateNullable());
+            setValidateNullable(constraints.getValidateNullable());
         }
 
         setRemarks(columnConfig.getRemarks());
@@ -191,19 +191,19 @@ public class Column extends AbstractDatabaseObject {
      * should be checked if it refers to a valid row or not.
      * @return true if ENABLE VALIDATE (this is the default), or false if ENABLE NOVALIDATE.
      */
-    public boolean shouldValidate() {
+    public boolean getValidate() {
         return getAttribute("validate", true);
     }
 
     /**
-     * @param shouldValidateNullable - if shouldValidateNullable is set to FALSE then the constraint will be created
+     * @param validateNullable - if validateNullable is set to FALSE then the constraint will be created
      * with the 'ENABLE NOVALIDATE' mode. This means the constraint would be created, but that no
      * check will be done to ensure old data has valid not null constraint - only new data would be checked
      * to see if it complies with the constraint logic. The default state for not null constraint is to
      * have 'ENABLE VALIDATE' set.
      */
-    public Column setShouldValidateNullable(Boolean shouldValidateNullable) {
-        this.setAttribute("validateNullable", shouldValidateNullable);
+    public Column setValidateNullable(Boolean validateNullable) {
+        this.setAttribute("validateNullable", validateNullable);
         return this;
     }
 
@@ -212,7 +212,7 @@ public class Column extends AbstractDatabaseObject {
      * otherwise returns true.
      * @return
      */
-    public boolean shouldValidateNullable() {
+    public boolean getValidateNullable() {
         return getAttribute("validateNullable", true);
     }
 

--- a/liquibase-core/src/test/groovy/liquibase/change/ConstraintsConfigTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/ConstraintsConfigTest.groovy
@@ -174,72 +174,72 @@ public class ConstraintsConfigTest extends Specification {
         thrown(UnexpectedLiquibaseException)
     }
 
-    def setShouldValidateNullable_string() {
+    def setValidateNullable_string() {
         expect:
-        assert new ConstraintsConfig().setShouldValidateNullable("true").shouldValidateNullable()
-        assert new ConstraintsConfig().setShouldValidateNullable("TRUE").shouldValidateNullable()
-        assert new ConstraintsConfig().setShouldValidateNullable("1").shouldValidateNullable()
+        assert new ConstraintsConfig().setValidateNullable("true").validateNullable
+        assert new ConstraintsConfig().setValidateNullable("TRUE").validateNullable
+        assert new ConstraintsConfig().setValidateNullable("1").validateNullable
 
-        assert !new ConstraintsConfig().setShouldValidateNullable("false").shouldValidateNullable()
-        assert !new ConstraintsConfig().setShouldValidateNullable("FALSE").shouldValidateNullable()
-        assert !new ConstraintsConfig().setShouldValidateNullable("0").shouldValidateNullable()
+        assert !new ConstraintsConfig().setValidateNullable("false").validateNullable
+        assert !new ConstraintsConfig().setValidateNullable("FALSE").validateNullable
+        assert !new ConstraintsConfig().setValidateNullable("0").validateNullable
 
-        new ConstraintsConfig().setShouldValidateNullable("").shouldValidateNullable() == null
-        new ConstraintsConfig().setShouldValidateNullable("null").shouldValidateNullable() == null
-        new ConstraintsConfig().setShouldValidateNullable("NULL").shouldValidateNullable() == null
-        def constraint = new ConstraintsConfig().setShouldValidateNullable((String) null)
-        constraint.shouldValidateNullable() == null
+        new ConstraintsConfig().setValidateNullable("").validateNullable == null
+        new ConstraintsConfig().setValidateNullable("null").validateNullable == null
+        new ConstraintsConfig().setValidateNullable("NULL").validateNullable == null
+        def constraint = new ConstraintsConfig().setValidateNullable((String) null)
+        constraint.validateNullable == null
     }
 
-    def setShouldValidateUnique_string() {
+    def setValidateUnique_string() {
         expect:
-        assert new ConstraintsConfig().setShouldValidateUnique("true").shouldValidateUnique()
-        assert new ConstraintsConfig().setShouldValidateUnique("TRUE").shouldValidateUnique()
-        assert new ConstraintsConfig().setShouldValidateUnique("1").shouldValidateUnique()
+        assert new ConstraintsConfig().setValidateUnique("true").validateUnique
+        assert new ConstraintsConfig().setValidateUnique("TRUE").validateUnique
+        assert new ConstraintsConfig().setValidateUnique("1").validateUnique
 
-        assert !new ConstraintsConfig().setShouldValidateUnique("false").shouldValidateUnique()
-        assert !new ConstraintsConfig().setShouldValidateUnique("FALSE").shouldValidateUnique()
-        assert !new ConstraintsConfig().setShouldValidateUnique("0").shouldValidateUnique()
+        assert !new ConstraintsConfig().setValidateUnique("false").validateUnique
+        assert !new ConstraintsConfig().setValidateUnique("FALSE").validateUnique
+        assert !new ConstraintsConfig().setValidateUnique("0").validateUnique
 
-        new ConstraintsConfig().setShouldValidateUnique("").shouldValidateUnique() == null
-        new ConstraintsConfig().setShouldValidateUnique("null").shouldValidateUnique() == null
-        new ConstraintsConfig().setShouldValidateUnique("NULL").shouldValidateUnique() == null
-        def constraint = new ConstraintsConfig().setShouldValidateUnique((String) null)
-        constraint.shouldValidateUnique() == null
+        new ConstraintsConfig().setValidateUnique("").validateUnique == null
+        new ConstraintsConfig().setValidateUnique("null").validateUnique == null
+        new ConstraintsConfig().setValidateUnique("NULL").validateUnique == null
+        def constraint = new ConstraintsConfig().setValidateUnique((String) null)
+        constraint.validateUnique == null
     }
 
-    def setShouldValidateForeignKey_string() {
+    def setValidateForeignKey_string() {
         expect:
-        assert new ConstraintsConfig().setShouldValidateForeignKey("true").shouldValidateForeignKey()
-        assert new ConstraintsConfig().setShouldValidateForeignKey("TRUE").shouldValidateForeignKey()
-        assert new ConstraintsConfig().setShouldValidateForeignKey("1").shouldValidateForeignKey()
+        assert new ConstraintsConfig().setValidateForeignKey("true").validateForeignKey
+        assert new ConstraintsConfig().setValidateForeignKey("TRUE").validateForeignKey
+        assert new ConstraintsConfig().setValidateForeignKey("1").validateForeignKey
 
-        assert !new ConstraintsConfig().setShouldValidateForeignKey("false").shouldValidateForeignKey()
-        assert !new ConstraintsConfig().setShouldValidateForeignKey("FALSE").shouldValidateForeignKey()
-        assert !new ConstraintsConfig().setShouldValidateForeignKey("0").shouldValidateForeignKey()
+        assert !new ConstraintsConfig().setValidateForeignKey("false").validateForeignKey
+        assert !new ConstraintsConfig().setValidateForeignKey("FALSE").validateForeignKey
+        assert !new ConstraintsConfig().setValidateForeignKey("0").validateForeignKey
 
-        new ConstraintsConfig().setShouldValidateForeignKey("").shouldValidateForeignKey() == null
-        new ConstraintsConfig().setShouldValidateForeignKey("null").shouldValidateForeignKey() == null
-        new ConstraintsConfig().setShouldValidateForeignKey("NULL").shouldValidateForeignKey() == null
-        def constraint = new ConstraintsConfig().setShouldValidateForeignKey((String) null)
-        constraint.shouldValidateForeignKey() == null
+        new ConstraintsConfig().setValidateForeignKey("").validateForeignKey == null
+        new ConstraintsConfig().setValidateForeignKey("null").validateForeignKey == null
+        new ConstraintsConfig().setValidateForeignKey("NULL").validateForeignKey == null
+        def constraint = new ConstraintsConfig().setValidateForeignKey((String) null)
+        constraint.validateForeignKey == null
     }
 
-    def setShouldValidatePrimaryKey_string() {
+    def setValidatePrimaryKey_string() {
         expect:
-        assert new ConstraintsConfig().setShouldValidatePrimaryKey("true").shouldValidatePrimaryKey()
-        assert new ConstraintsConfig().setShouldValidatePrimaryKey("TRUE").shouldValidatePrimaryKey()
-        assert new ConstraintsConfig().setShouldValidatePrimaryKey("1").shouldValidatePrimaryKey()
+        assert new ConstraintsConfig().setValidatePrimaryKey("true").validatePrimaryKey
+        assert new ConstraintsConfig().setValidatePrimaryKey("TRUE").validatePrimaryKey
+        assert new ConstraintsConfig().setValidatePrimaryKey("1").validatePrimaryKey
 
-        assert !new ConstraintsConfig().setShouldValidatePrimaryKey("false").shouldValidatePrimaryKey()
-        assert !new ConstraintsConfig().setShouldValidatePrimaryKey("FALSE").shouldValidatePrimaryKey()
-        assert !new ConstraintsConfig().setShouldValidatePrimaryKey("0").shouldValidatePrimaryKey()
+        assert !new ConstraintsConfig().setValidatePrimaryKey("false").validatePrimaryKey
+        assert !new ConstraintsConfig().setValidatePrimaryKey("FALSE").validatePrimaryKey
+        assert !new ConstraintsConfig().setValidatePrimaryKey("0").validatePrimaryKey
 
-        new ConstraintsConfig().setShouldValidatePrimaryKey("").shouldValidatePrimaryKey() == null
-        new ConstraintsConfig().setShouldValidatePrimaryKey("null").shouldValidatePrimaryKey() == null
-        new ConstraintsConfig().setShouldValidatePrimaryKey("NULL").shouldValidatePrimaryKey() == null
-        def constraint = new ConstraintsConfig().setShouldValidatePrimaryKey((String) null)
-        constraint.shouldValidatePrimaryKey() == null
+        new ConstraintsConfig().setValidatePrimaryKey("").validatePrimaryKey == null
+        new ConstraintsConfig().setValidatePrimaryKey("null").validatePrimaryKey == null
+        new ConstraintsConfig().setValidatePrimaryKey("NULL").validatePrimaryKey == null
+        def constraint = new ConstraintsConfig().setValidatePrimaryKey((String) null)
+        constraint.validatePrimaryKey == null
     }
 
     def setPrimaryKeyName() {

--- a/liquibase-core/src/test/java/liquibase/serializer/core/xml/XMLChangeLogSerializerTest.java
+++ b/liquibase-core/src/test/java/liquibase/serializer/core/xml/XMLChangeLogSerializerTest.java
@@ -234,10 +234,10 @@ public class XMLChangeLogSerializerTest {
 
         ConstraintsConfig constraints = new ConstraintsConfig();
         constraints.setDeferrable(Boolean.TRUE);
-        constraints.setShouldValidateNullable(Boolean.TRUE);
-        constraints.setShouldValidateUnique(Boolean.TRUE);
-        constraints.setShouldValidatePrimaryKey(Boolean.TRUE);
-        constraints.setShouldValidateForeignKey(Boolean.TRUE);
+        constraints.setValidateNullable(Boolean.TRUE);
+        constraints.setValidateUnique(Boolean.TRUE);
+        constraints.setValidatePrimaryKey(Boolean.TRUE);
+        constraints.setValidateForeignKey(Boolean.TRUE);
         constraints.setDeleteCascade(true);
         constraints.setForeignKeyName("FK_NAME");
         constraints.setInitiallyDeferred(true);


### PR DESCRIPTION
This is the same as my previous pull requests (#908 and #917),  for this issue, but this time done against the 3.10.x branch.



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-288) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 3.10.2
