### PR TITLE
Fix varchar(max) (extrainfo) issue gh1158

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/ClobType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/ClobType.java
@@ -67,8 +67,14 @@ public class ClobType extends LiquibaseDataType {
                 DatabaseDataType type = new DatabaseDataType(database.escapeDataTypeName("varchar"));
                 // If there is additional specification after ntext (e.g.  COLLATE), import that.
                 String originalExtraInfo = originalDefinition.replaceFirst("^(?i)\\[?text\\]?\\s*", "");
-                type.addAdditionalInformation("(max)"
-                        + (StringUtil.isEmpty(originalExtraInfo) ? "" : " " + originalExtraInfo));
+                type.addAdditionalInformation("(max)");
+                if(!StringUtil.isEmpty(originalExtraInfo)) {
+                    //if we still have something like (25555) remove it
+                    //since we already set it to max, otherwise add collate or other info
+                    if(originalExtraInfo.lastIndexOf(")") < (originalExtraInfo.length() - 1)) {
+                        type.addAdditionalInformation(originalExtraInfo.substring(originalExtraInfo.lastIndexOf(")") + 1));
+                    }
+                }
                 return type;
             }
             if (originalDefinition.toLowerCase(Locale.US).startsWith("ntext")
@@ -78,8 +84,14 @@ public class ClobType extends LiquibaseDataType {
                 DatabaseDataType type = new DatabaseDataType(database.escapeDataTypeName("nvarchar"));
                 // If there is additional specification after ntext (e.g.  COLLATE), import that.
                 String originalExtraInfo = originalDefinition.replaceFirst("^(?i)\\[?ntext\\]?\\s*", "");
-                type.addAdditionalInformation("(max)"
-                    + (StringUtil.isEmpty(originalExtraInfo) ? "" : " " + originalExtraInfo));
+                type.addAdditionalInformation("(max)");
+                if(!StringUtil.isEmpty(originalExtraInfo)) {
+                    //if we still have something like (25555) remove it
+                    //since we already set it to max, otherwise add collate or other info
+                    if(originalExtraInfo.lastIndexOf(")") < (originalExtraInfo.length() - 1)) {
+                        type.addAdditionalInformation(originalExtraInfo.substring(originalExtraInfo.lastIndexOf(")") + 1));
+                    }
+                }
                 return type;
             }
             if ("nclob".equals(originalDefinition.toLowerCase(Locale.US))) {


### PR DESCRIPTION
- - -
name: Pull Request
about: Create a report to help us improve
title: 'Fix for varchar extrainfo issue gh1158'
labels: Status:Discovery
assignees: ''

- - -
<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->

## Environment
**Liquibase Version**:4.0-beta

**Liquibase Integration & Version**: CLI

**Liquibase Extension(s) & Version**: None

**Database Vendor & Version**: MS SQL Server

**Operating System Type & Version**: All

## Pull Request Type
<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->

* [x] Bug fix (non-breaking change which fixes an issue.)
* [ ] Enhancement/New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
FIx for GH Issue 1158

## Steps To Reproduce
## Steps To Reproduce
Use Liquibase with the following change log:

```xml
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
    <changeSet author="bburke@redhat.com" id="1.3.0">
        <createTable tableName="ADMIN_EVENT_ENTITY">
            <column name="ID" type="VARCHAR(36)">
                <constraints nullable="false"/>
            </column>
            <column name="ADMIN_EVENT_TIME" type="BIGINT"/>
            <column name="REALM_ID" type="VARCHAR(255)"/>
            <column name="OPERATION_TYPE" type="VARCHAR(255)"/>
            <column name="AUTH_REALM_ID" type="VARCHAR(255)"/>
            <column name="AUTH_CLIENT_ID" type="VARCHAR(255)"/>
            <column name="AUTH_USER_ID" type="VARCHAR(255)"/>
            <column name="IP_ADDRESS" type="VARCHAR(255)"/>
            <column name="RESOURCE_PATH" type="VARCHAR(2550)"/>
            <column name="REPRESENTATION" type="TEXT(25500)"/>
            <column name="ERROR" type="VARCHAR(255)"/>
        </createTable>
    </changeSet>
</databaseChangeLog>
```

## Actual Behavior
```
Error: Incorrect syntax near '('. 
[Failed SQL: CREATE TABLE ADMIN_EVENT_ENTITY (
    ID varchar(36) NOT NULL,
    ADMIN_EVENT_TIME bigint,
    REALM_ID varchar(255), 
    OPERATION_TYPE varchar(255), 
    AUTH_REALM_ID varchar(255), 
    AUTH_CLIENT_ID varchar(255), 
    AUTH_USER_ID varchar(255), 
    IP_ADDRESS varchar(255), 
    RESOURCE_PATH varchar(2550), 
    REPRESENTATION varchar (max) (25500), 
    ERROR varchar(255)
)] 
```

## Expected/Desired Behavior
Table created in MsSql okay

## Screenshots (if appropriate)
If applicable, add screenshots to help explain your problem.

## Additional Context
Add any other context about the problem here.

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->

* [ ] Build is successful and all new and existing tests pass
* [ ] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
* [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
* [ ] Documentation Updated

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-300) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Community 4.2.x
