### PR TITLE
minor bash fixes in start-h2 & user experience requests

### DIFF
--- a/liquibase-dist/src/main/archive/examples/start-h2
+++ b/liquibase-dist/src/main/archive/examples/start-h2
@@ -5,7 +5,7 @@ if [ -z "${LIQUIBASE_HOME}" ]; then
 
   LIQUIBASE_PATH="$(which liquibase)"
 
-  if [ -z "${LIQUIBASE_PATH}"]; then
+  if [ -z "${LIQUIBASE_PATH}" ]; then
     echo "Must set LIQUIBASE_HOME environment variable, or have liquibase in your PATH"
     exit 1
   fi
@@ -13,7 +13,7 @@ if [ -z "${LIQUIBASE_HOME}" ]; then
   LIQUIBASE_HOME=$(dirname "$(which liquibase)")
 fi
 
-if [ -z "${JAVA_HOME}"]; then
+if [ -z "${JAVA_HOME}" ]; then
   #JAVA_HOME not set, try to find a bundled version
   if [ -d "${LIQUIBASE_HOME}/jre" ]; then
     JAVA_HOME="$LIQUIBASE_HOME/jre"


### PR DESCRIPTION
- - -
name: Pull Request
about: Bug fixes and User Experience
title: 'Fix some low hanging bugs; Suggest other more in-depth fixes'
labels: Status:Discovery
assignees: ''

- - -
<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->

## Environment
**Liquibase Version**: 3.10.0

**Liquibase Integration & Version**: CLI

**Liquibase Extension(s) & Version**: n/a

**Database Vendor & Version**: n/a

**Operating System Type & Version**: macOS Catalina v10.15.4

## Pull Request Type
<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->

* [x] Bug fix (non-breaking change which fixes an issue.)
* [ ] Enhancement/New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
I'm brand new to Liquibase and trying to start up the examples shell on macOS Catalina.

### User Experience Problem <i>#</i>1
My initial problem was when I called the `start-h2` script, I got the following:

```sh
~ % /usr/local/opt/liquibase/examples/start-h2
/usr/local/opt/liquibase/examples/start-h2: line 8: [: missing `]'
/usr/local/opt/liquibase/examples/start-h2: line 16: [: missing `]'
Starting Example H2 Database...
NOTE: The database does not persist data, so stopping and restarting this process will reset it back to a blank database

Error starting H2
java.lang.reflect.InvocationTargetException
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:564)
        at liquibase.example.StartH2Main.startWebServer(StartH2Main.java:75)
        at liquibase.example.StartH2Main.main(StartH2Main.java:29)
Caused by: org.h2.jdbc.JdbcSQLNonTransientConnectionException: Exception opening port "8090" (port may be in use), cause: "java.net.BindException: Address already in use" [90061-200]
        at org.h2.message.DbException.getJdbcSQLException(DbException.java:622)
        at org.h2.message.DbException.getJdbcSQLException(DbException.java:429)
        at org.h2.message.DbException.get(DbException.java:194)
        at org.h2.util.NetUtils.createServerSocketTry(NetUtils.java:180)
        at org.h2.util.NetUtils.createServerSocket(NetUtils.java:146)
        at org.h2.server.web.WebServer.start(WebServer.java:389)
        at org.h2.tools.Server.start(Server.java:511)
        ... 6 more
Caused by: java.net.BindException: Address already in use
        at java.base/sun.nio.ch.Net.bind0(Native Method)
        at java.base/sun.nio.ch.Net.bind(Net.java:479)
        at java.base/sun.nio.ch.Net.bind(Net.java:468)
        at java.base/sun.nio.ch.NioSocketImpl.bind(NioSocketImpl.java:643)
        at java.base/java.net.ServerSocket.bind(ServerSocket.java:396)
        at java.base/java.net.ServerSocket.<init>(ServerSocket.java:282)
        at java.base/java.net.ServerSocket.<init>(ServerSocket.java:173)
        at org.h2.util.NetUtils.createServerSocketTry(NetUtils.java:176)
        ... 9 more
```

The first problem I tackled was the `Exception opening port "8090" (port may be in use)`.

It turns out that this is the port used by Docker Desktop for Macs, which was running in the background.

Some type of port check and clearer notification really would have been appreciated here!

#### Part of a possible solution
Something like the following at the beginning of the `start-h2` file will work for macOS users, but you should obviously have a more platform-agnostic approach, hence no PR for this portion.

```sh
PORT="8090" # I assume you can pass this in from where ever it is actually set

# the PORT_IN_USE check works on Mac, and presumably other POSIX systems,
# but it probably won't work on Windows machines
PORT_IN_USE=$(lsof -i TCP:$PORT | grep LISTEN | awk '{print $2}')
if [ $PORT_IN_USE ]; then
  echo "Must stop process running on port $PORT"
  exit 1
fi
```

- - -
### Bug <i>#</i>1
Once I had closed my Docker Desktop, I reran the `sh start-h2` script and I got this:

```sh
examples % sh start-h2                                  
start-h2: line 8: [: missing `]'
start-h2: line 16: [: missing `]'
Starting Example H2 Database...
NOTE: The database does not persist data, so stopping and restarting this process will reset it back to a blank database

Connection Information:
  Dev database: 
    JDBC URL: jdbc:h2:tcp://localhost:9090/mem:dev
    Username: dbuser
    Password: letmein
  Integration database: 
    JDBC URL: jdbc:h2:tcp://localhost:9090/mem:integration
    Username: dbuser
    Password: letmein

Opening Database Console in Browser...
  Dev Web URL: http://localhost:8090/frame.jsp?jsessionid=dddfc09b9992bd48221f72c3f3b8b33d
  Integration Web URL: http://localhost:8090/frame.jsp?jsessionid=800d161e8249f7eccdf6af62ba7ae1d3
```

The lines in question actually have an error in the formatting of the `if` statements.

```sh
# Instead of:   
                if [ -z "${LIQUIBASE_PATH}"]; then
# it should be:   
                if [ -z "${LIQUIBASE_PATH}" ]; then
# Likewise,
# instead of:   
                if [ -z "${JAVA_HOME}"]; then
# it should be:    
                if [ -z "${JAVA_HOME}" ]; then
```

**_This PR should fixes these._**

- - -
### User Experience Problem <i>#</i>2
Frankly, the [Tutorial for Beginners: Using the Liquibase Installer](https://www.liquibase.org/get-started/using-the-liquibase-installer) page is particularly not useful.

For example, nowhere does it indicate that `sh start-h2` should be run.

I also still have no idea what "To get started, download your database’s JDBC driver to the lib directory, then run the Liquibase script in the root of this directory." means or where to look for JDBC drivers.

- - -
## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->

* [ ] Build is successful and all new and existing tests pass
* [ ] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
* [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
* [ ] Documentation Updated

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)

