### PR TITLE
Fix usage of AntTaskLogger

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/ant/AntTaskLogService.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/AntTaskLogService.java
@@ -1,11 +1,8 @@
 package liquibase.integration.ant;
 
-import liquibase.integration.ant.AntTaskLogger;
 import liquibase.logging.LogService;
 import liquibase.logging.Logger;
 import org.apache.tools.ant.Task;
-
-import java.util.logging.Level;
 
 /**
  * An implementation of the Liquibase LogService that logs all messages to the given Ant task. This should only be used
@@ -13,7 +10,7 @@ import java.util.logging.Level;
  */
 public final class AntTaskLogService implements LogService {
 
-    private AntTaskLogger logger;
+    private final AntTaskLogger logger;
 
     public AntTaskLogService(Task task) {
         logger = new AntTaskLogger(task);

--- a/liquibase-core/src/main/java/liquibase/integration/ant/BaseLiquibaseTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/BaseLiquibaseTask.java
@@ -42,6 +42,8 @@ import static java.util.ResourceBundle.getBundle;
 public abstract class BaseLiquibaseTask extends Task {
     private static ResourceBundle coreBundle = getBundle("liquibase/i18n/liquibase-core");
 
+    private final Map<String, Object> scopeValues = new HashMap<>();
+
     private AntClassLoader classLoader;
     private Liquibase liquibase;
 
@@ -56,7 +58,7 @@ public abstract class BaseLiquibaseTask extends Task {
 
     @Override
     public void init() throws BuildException {
-//        LogService.setLoggerFactory(new AntTaskLogService(this));
+        scopeValues.put(Scope.Attr.logService.name(), new AntTaskLogService(this));
         classpath = new Path(getProject());
     }
 
@@ -71,7 +73,6 @@ public abstract class BaseLiquibaseTask extends Task {
         final Database[] database = {null};
         try {
             ResourceAccessor resourceAccessor = createResourceAccessor(classLoader);
-            Map<String, Object> scopeValues = new HashMap<>();
             scopeValues.put(Scope.Attr.resourceAccessor.name(), resourceAccessor);
             scopeValues.put(Scope.Attr.classLoader.name(), classLoader);
 


### PR DESCRIPTION
- - -
name: Pull Request
about: Create a report to help us improve
title: ''
labels: Status:Discovery
assignees: ''

- - -
<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->

## Environment
**Liquibase Version**:

**Liquibase Integration & Version**: Ant

**Liquibase Extension(s) & Version**: 

**Database Vendor & Version**:

**Operating System Type & Version**:

## Pull Request Type
<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->

* [x] Bug fix (non-breaking change which fixes an issue.)
* [ ] Enhancement/New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
### Motivation
Liquibase has a fairly new logging abstraction and it wasn't entirely working with the Ant tasks. The tasks were reverting to standard out logging which might make it difficult to control log levels correctly in Ant tasks.

### Modifications
I leveraged the new Scope system (pretty neat!) to add the AntLogService manually. This log service creates the AntTaskLogger correctly so the logger delegates to Ant's logger again.

### Result
The ant tasks once again handle Liquibase logs correctly.

## Steps To Reproduce
List the steps to reproduce the behavior.

Run any any Ant task. The execution of the unit tests will demonstrate the problem.

## Actual Behavior
The output will be on two lines which is how you can tell its using stdout instead. Example:

```
[lb:updateDatabase] Jul 25, 2020 9:29:39 AM liquibase.lockservice
[lb:updateDatabase] INFO: Successfully acquired change log lock
```

## Expected/Desired Behavior
Expected behavior is to have message on one line with the Ant task pattern taking priority. Example:

```
[lb:updateDatabase] Successfully acquired change log lock
```

## Screenshots (if appropriate)
N/A

## Additional Context
N/A

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->

* [x] Build is successful and all new and existing tests pass
* [ ] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
* [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
* [ ] Documentation Updated

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-522) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 4.1.1
