### PR TITLE
Fix varchar(max) extrainfo in 3.10 branch

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/ClobType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/ClobType.java
@@ -50,8 +50,14 @@ public class ClobType extends LiquibaseDataType {
                 DatabaseDataType type = new DatabaseDataType(database.escapeDataTypeName("varchar"));
                 // If there is additional specification after ntext (e.g.  COLLATE), import that.
                 String originalExtraInfo = originalDefinition.replaceFirst("^(?i)\\[?text\\]?\\s*", "");
-                type.addAdditionalInformation("(max)"
-                        + (StringUtils.isEmpty(originalExtraInfo) ? "" : " " + originalExtraInfo));
+                type.addAdditionalInformation("(max)");
+                if(!StringUtil.isEmpty(originalExtraInfo)) {
+                    //if we still have something like (25555) remove it
+                    //since we already set it to max, otherwise add collate or other info
+                    if(originalExtraInfo.lastIndexOf(")") < (originalExtraInfo.length() - 1)) {
+                        type.addAdditionalInformation(originalExtraInfo.substring(originalExtraInfo.lastIndexOf(")") + 1));
+                    }
+                }
                 return type;
             }
         }
@@ -78,8 +84,14 @@ public class ClobType extends LiquibaseDataType {
                 DatabaseDataType type = new DatabaseDataType(database.escapeDataTypeName("nvarchar"));
                 // If there is additional specification after ntext (e.g.  COLLATE), import that.
                 String originalExtraInfo = originalDefinition.replaceFirst("^(?i)\\[?ntext\\]?\\s*", "");
-                type.addAdditionalInformation("(max)"
-                    + (StringUtils.isEmpty(originalExtraInfo) ? "" : " " + originalExtraInfo));
+                type.addAdditionalInformation("(max)");
+                if(!StringUtil.isEmpty(originalExtraInfo)) {
+                    //if we still have something like (25555) remove it
+                    //since we already set it to max, otherwise add collate or other info
+                    if(originalExtraInfo.lastIndexOf(")") < (originalExtraInfo.length() - 1)) {
+                        type.addAdditionalInformation(originalExtraInfo.substring(originalExtraInfo.lastIndexOf(")") + 1));
+                    }
+                }
                 return type;
             }
             if ("nclob".equals(originalDefinition.toLowerCase(Locale.US))) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/ClobType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/ClobType.java
@@ -51,7 +51,7 @@ public class ClobType extends LiquibaseDataType {
                 // If there is additional specification after ntext (e.g.  COLLATE), import that.
                 String originalExtraInfo = originalDefinition.replaceFirst("^(?i)\\[?text\\]?\\s*", "");
                 type.addAdditionalInformation("(max)");
-                if(!StringUtil.isEmpty(originalExtraInfo)) {
+                if(!StringUtils.isEmpty(originalExtraInfo)) {
                     //if we still have something like (25555) remove it
                     //since we already set it to max, otherwise add collate or other info
                     if(originalExtraInfo.lastIndexOf(")") < (originalExtraInfo.length() - 1)) {
@@ -73,8 +73,14 @@ public class ClobType extends LiquibaseDataType {
                 DatabaseDataType type = new DatabaseDataType(database.escapeDataTypeName("varchar"));
                 // If there is additional specification after ntext (e.g.  COLLATE), import that.
                 String originalExtraInfo = originalDefinition.replaceFirst("^(?i)\\[?text\\]?\\s*", "");
-                type.addAdditionalInformation("(max)"
-                        + (StringUtils.isEmpty(originalExtraInfo) ? "" : " " + originalExtraInfo));
+                type.addAdditionalInformation("(max)");
+                if(!StringUtils.isEmpty(originalExtraInfo)) {
+                    //if we still have something like (25555) remove it
+                    //since we already set it to max, otherwise add collate or other info
+                    if(originalExtraInfo.lastIndexOf(")") < (originalExtraInfo.length() - 1)) {
+                        type.addAdditionalInformation(originalExtraInfo.substring(originalExtraInfo.lastIndexOf(")") + 1));
+                    }
+                }
                 return type;
             }
             if (originalDefinition.toLowerCase(Locale.US).startsWith("ntext")
@@ -85,7 +91,7 @@ public class ClobType extends LiquibaseDataType {
                 // If there is additional specification after ntext (e.g.  COLLATE), import that.
                 String originalExtraInfo = originalDefinition.replaceFirst("^(?i)\\[?ntext\\]?\\s*", "");
                 type.addAdditionalInformation("(max)");
-                if(!StringUtil.isEmpty(originalExtraInfo)) {
+                if(!StringUtils.isEmpty(originalExtraInfo)) {
                     //if we still have something like (25555) remove it
                     //since we already set it to max, otherwise add collate or other info
                     if(originalExtraInfo.lastIndexOf(")") < (originalExtraInfo.length() - 1)) {

--- a/liquibase-core/src/test/groovy/liquibase/datatype/core/ClobTypeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/core/ClobTypeTest.groovy
@@ -1,0 +1,72 @@
+package liquibase.datatype.core
+
+import liquibase.database.core.*
+import liquibase.sdk.database.MockDatabase
+import liquibase.statement.DatabaseFunction
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class ClobTypeTest extends Specification {
+    @Unroll
+    def "toDatabaseType"() {
+        when:
+        def type = new ClobType()
+
+        type.finishInitialization(origdef)
+
+
+        then:
+        type.toDatabaseDataType(database).toString() == expected
+
+        where:
+        origdef       | database               | expected
+        ["TEXT(25500)"] | new MSSQLDatabase()    | "varchar (max)"
+        ["Text"] | new MSSQLDatabase()    | "varchar (max)"
+        ["[Text]"] | new MSSQLDatabase()    | "varchar (max)"
+        ["NText"] | new MSSQLDatabase()    | "nvarchar (max)"
+        ["[NText]"] | new MSSQLDatabase()    | "nvarchar (max)"
+        ["TEXT COLLATE Latin1_General_BIN"] | new MSSQLDatabase()    | "varchar (max) COLLATE Latin1_General_BIN"
+        ["nclob"] | new MSSQLDatabase()    | "nvarchar(MAX)"
+        [""] | new MSSQLDatabase()    | "varchar(MAX)"
+        [""] | new FirebirdDatabase()    | "BLOB SUB_TYPE TEXT"
+        [""] | new SybaseASADatabase()    | "LONG VARCHAR"
+        [""] | new SybaseASADatabase()    | "LONG VARCHAR"
+        ["text"] | new MySQLDatabase()    | "TEXT"
+        ["tinytext"] | new MySQLDatabase()    | "TINYTEXT"
+        ["mediumtext"] | new MySQLDatabase()    | "MEDIUMTEXT"
+        ["nclob"] | new MySQLDatabase()    | "LONGTEXT CHARACTER SET utf8"
+        [""] | new MySQLDatabase()    | "LONGTEXT"
+        ["longvarchar"] | new H2Database()    | "LONGVARCHAR"
+        ["java.sql.Types.LONGVARCHAR"] | new H2Database()    | "LONGVARCHAR"
+        ["longvarchar"] | new HsqlDatabase()    | "LONGVARCHAR"
+        ["java.sql.Types.LONGVARCHAR"] | new HsqlDatabase()    | "LONGVARCHAR"
+        [""] | new H2Database()    | "CLOB"
+        [""] | new HsqlDatabase()    | "CLOB"
+        [""] | new PostgresDatabase()    | "TEXT"
+        [""] | new SQLiteDatabase()    | "TEXT"
+        [""] | new SybaseDatabase()    | "TEXT"
+        [""] | new OracleDatabase()    | "CLOB"
+        ["nclob"] | new OracleDatabase()    | "NCLOB"
+        ["text"] | new InformixDatabase()    | "TEXT"
+
+
+    }
+
+    @Unroll
+    def "objectToSql"() {
+        when:
+        def type = new ClobType()
+
+        then:
+        type.objectToSql(object, database) == expected
+
+        where:
+        object          | database            | expected
+        null            | new MockDatabase()  | null
+        "'"            | new MockDatabase()  | "'"
+        'text'            | new MockDatabase()  | 'text'
+        ""            | new MSSQLDatabase()  | "'"
+        //new DatabaseFunction()            | new MockDatabase()  | ""
+
+    }
+}

--- a/liquibase-core/src/test/groovy/liquibase/datatype/core/ClobTypeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/core/ClobTypeTest.groovy
@@ -64,9 +64,9 @@ class ClobTypeTest extends Specification {
         object          | database            | expected
         null            | new MockDatabase()  | null
         "'"            | new MockDatabase()  | "'"
-        'text'            | new MockDatabase()  | 'text'
-        ""            | new MSSQLDatabase()  | "'"
-        //new DatabaseFunction()            | new MockDatabase()  | ""
-
+        'text'            | new MockDatabase()  | /'text'/
+        ""            | new MSSQLDatabase()  | /''/
+        new DatabaseFunction("NEWID()")                         | new MockDatabase() | "NEWID()"
+        new DatabaseFunction("NEWSEQUENTIALID()")               | new MockDatabase() | "NEWSEQUENTIALID()"
     }
 }


### PR DESCRIPTION
## Environment
Java 8

**Liquibase Version**:
3.6.3

**Liquibase Integration & Version**: 
Gradle

**Liquibase Extension(s) & Version**:
N/A

**Database Vendor & Version**:
MsSql 2017

**Operating System Type & Version**:
Ubuntu 16.04.3 LTS

## Description
When creating a table with column: 

```xml
<column name="REPRESENTATION" type="TEXT(25500)"/>
```

Liquibase converts `TEXT` to `varchar (max) (25500)`

## Steps To Reproduce
Use Liquibase with the following change log:

```xml
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
    <changeSet author="bburke@redhat.com" id="1.3.0">
        <createTable tableName="ADMIN_EVENT_ENTITY">
            <column name="ID" type="VARCHAR(36)">
                <constraints nullable="false"/>
            </column>
            <column name="ADMIN_EVENT_TIME" type="BIGINT"/>
            <column name="REALM_ID" type="VARCHAR(255)"/>
            <column name="OPERATION_TYPE" type="VARCHAR(255)"/>
            <column name="AUTH_REALM_ID" type="VARCHAR(255)"/>
            <column name="AUTH_CLIENT_ID" type="VARCHAR(255)"/>
            <column name="AUTH_USER_ID" type="VARCHAR(255)"/>
            <column name="IP_ADDRESS" type="VARCHAR(255)"/>
            <column name="RESOURCE_PATH" type="VARCHAR(2550)"/>
            <column name="REPRESENTATION" type="TEXT(25500)"/>
            <column name="ERROR" type="VARCHAR(255)"/>
        </createTable>
    </changeSet>
</databaseChangeLog>
```

## Actual Behavior
```
Error: Incorrect syntax near '('. 
[Failed SQL: CREATE TABLE ADMIN_EVENT_ENTITY (
    ID varchar(36) NOT NULL,
    ADMIN_EVENT_TIME bigint,
    REALM_ID varchar(255), 
    OPERATION_TYPE varchar(255), 
    AUTH_REALM_ID varchar(255), 
    AUTH_CLIENT_ID varchar(255), 
    AUTH_USER_ID varchar(255), 
    IP_ADDRESS varchar(255), 
    RESOURCE_PATH varchar(2550), 
    REPRESENTATION varchar (max) (25500), 
    ERROR varchar(255)
)] 
```

## Expected/Desired Behavior
Table created in MsSql okay

┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-570) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 3.10.3
