### PR TITLE
Fix for PR 1001 in 3.10.x branch

### DIFF
--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
@@ -209,16 +209,16 @@ public class SequenceSnapshotGenerator extends JdbcSnapshotGenerator {
                 log.warning("Failed to retrieve database version: " + ignore);
             }
             if (version < 10) { // 'pg_sequence' view does not exists yet
-                return "SELECT c.relname AS SEQUENCE_NAME FROM pg_class c " +
+                return "SELECT c.relname AS \"SEQUENCE_NAME\" FROM pg_class c " +
                         "join pg_namespace on c.relnamespace = pg_namespace.oid " +
                         "WHERE c.relkind='S' " +
                         "AND nspname = '" + schema.getName() + "' " +
                         "AND c.oid not in (select d.objid FROM pg_depend d where d.refobjsubid > 0)";
             } else {
-                return "SELECT c.relname AS SEQUENCE_NAME, " +
-                        "  s.seqmin AS MIN_VALUE, s.seqmax AS MAX_VALUE, s.seqincrement AS INCREMENT_BY, " +
-                        "  s.seqcycle AS WILL_CYCLE, s.seqstart AS START_VALUE, s.seqcache AS CACHE_SIZE, " +
-                        "  pg_catalog.format_type(s.seqtypid, NULL) AS SEQ_TYPE " +
+                return "SELECT c.relname AS \"SEQUENCE_NAME\", " +
+                    "  s.seqmin AS \"MIN_VALUE\", s.seqmax AS \"MAX_VALUE\", s.seqincrement AS \"INCREMENT_BY\", " +
+                    "  s.seqcycle AS \"WILL_CYCLE\", s.seqstart AS \"START_VALUE\", s.seqcache AS \"CACHE_SIZE\", " +
+                    "  pg_catalog.format_type(s.seqtypid, NULL) AS \"SEQ_TYPE\" " +
                         "FROM pg_class c " +
                         "JOIN pg_namespace ns on c.relnamespace = ns.oid " +
                         "JOIN pg_sequence s on c.oid = s.seqrelid " +


### PR DESCRIPTION
This is a copy of the change in PR https://github.com/liquibase/liquibase/pull/1001 for the 3.10.x branch
To retrieve sequence information from the database, Liquibase issues a SQL query and then retrieves the result expecting uppercase field names.

However, PostgreSQL converts all column names to lowercase, so the sequence information retrieval fails and the output of the diff command is something like this on a PostgreSQL:

Changed Sequence(s):
     catalog_item_history_sequence
          cacheSize changed from 'null' to '1'
          dataType changed from 'null' to 'bigint'
          maxValue changed from 'null' to '9223372036854775807'
          minValue changed from 'null' to '1'
          willCycle changed from 'null' to 'false'

This in turn results in CORE-2495, because the changelog being created contains no actual changes and is invalid.

To preserve the case in the column names returned by PostgreSQL, the names in the query need to be quoted.
Steps to Reproduce

```
Create a sequence on the url connection with uppercase attribute names (as given in the PostgresSQL Documentation):
{CODE}
CREATE SEQUENCE IF NOT EXISTS catalog_item_history_sequence
MINVALUE minvalue 1 MAXVALUE 100 CYCLE;
{CODE}
Create a sequence on the referenceUrl connection with changes to the catalog_item_history_sequence sequence.
{CODE}
CREATE SEQUENCE IF NOT EXISTS catalog_item_history_sequence
MINVALUE minvalue 2 MAXVALUE 200 NO CYCLE;
{CODE}
Execute a Liquibase diff.
```

Expected Results

The diff returns:
minvalue changed from 2 to 1
maxvalue changed from 200 to 100
cycle changed from false to true.
Automated Test Requirements

```
Write an automated regression test for Postgres
    Test Name: Sequence diffs return expected differences in attributes.
    Description: Jira ticket number
```

Manual Test Requirements

```
Execute the Steps to Reproduce with the old/broken Liquibase version to verify those steps are correct.
Do a desk check with the developer
Execute the Steps to Reproduce with the new build to verify diff is fixed.
```



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-629) by [Unito](https://www.unito.io/learn-more)
