### PR TITLE
Update Ant Tasks to use DatabaseFactory rather than create connection itself

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/DatabaseFactory.java
+++ b/liquibase-core/src/main/java/liquibase/database/DatabaseFactory.java
@@ -140,6 +140,15 @@ public class DatabaseFactory {
         return this.findCorrectDatabaseImplementation(openConnection(url, username, password, driver, databaseClass, driverPropertiesFile, propertyProviderClass, resourceAccessor));
     }
 
+    public Database openDatabase(String url,
+                                 String username,
+                                 String driver,
+                                 String databaseClass,
+                                 Properties driverProperties,
+                                 ResourceAccessor resourceAccessor) throws DatabaseException {
+        return this.findCorrectDatabaseImplementation(openConnection(url, username, driver, databaseClass, driverProperties, resourceAccessor));
+    }
+
     public DatabaseConnection openConnection(String url,
                                              String username,
                                              String password,
@@ -254,10 +263,10 @@ public class DatabaseFactory {
         return selectedDriverClass;
     }
 
-    private Driver loadDriver(String selectedDriverClass) {
+    private Driver loadDriver(String driverClass) {
         Driver driverObject;
         try {
-            driverObject = (Driver) Class.forName(selectedDriverClass, true, Scope.getCurrentScope().getClassLoader()).getConstructor().newInstance();
+            driverObject = (Driver) Class.forName(driverClass, true, Scope.getCurrentScope().getClassLoader()).getConstructor().newInstance();
         } catch (Exception e) {
             throw new RuntimeException("Cannot find database driver: " + e.getMessage());
         }

--- a/liquibase-core/src/main/java/liquibase/integration/ant/AbstractDatabaseDiffTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/AbstractDatabaseDiffTask.java
@@ -21,7 +21,7 @@ public abstract class AbstractDatabaseDiffTask extends BaseLiquibaseTask {
     protected DiffResult getDiffResult() {
         Liquibase liquibase = getLiquibase();
         Database targetDatabase = liquibase.getDatabase();
-        Database referenceDatabase = createDatabaseFromType(referenceDatabaseType);
+        Database referenceDatabase = createDatabaseFromType(referenceDatabaseType, getResourceAccessor());
 
         CatalogAndSchema targetCatalogAndSchema = buildCatalogAndSchema(targetDatabase);
         CatalogAndSchema referenceCatalogAndSchema = buildCatalogAndSchema(referenceDatabase);

--- a/liquibase-core/src/main/java/liquibase/integration/ant/BaseLiquibaseTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/BaseLiquibaseTask.java
@@ -63,7 +63,7 @@ public abstract class BaseLiquibaseTask extends Task {
         validateParameters();
         final Database[] database = {null};
         try {
-            ResourceAccessor resourceAccessor = createResourceAccessor(classLoader);
+            resourceAccessor = createResourceAccessor(classLoader);
             scopeValues.put(Scope.Attr.resourceAccessor.name(), resourceAccessor);
             scopeValues.put(Scope.Attr.classLoader.name(), classLoader);
 

--- a/liquibase-core/src/main/java/liquibase/integration/ant/BaseLiquibaseTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/BaseLiquibaseTask.java
@@ -68,7 +68,7 @@ public abstract class BaseLiquibaseTask extends Task {
             scopeValues.put(Scope.Attr.classLoader.name(), classLoader);
 
             Scope.child(scopeValues, () -> {
-                database[0] = createDatabaseFromType(databaseType);
+                database[0] = createDatabaseFromType(databaseType, resourceAccessor);
                 liquibase = new Liquibase(getChangeLogFile(), resourceAccessor, database[0]);
                 if (changeLogParameters != null) {
                     changeLogParameters.applyParameters(liquibase);
@@ -95,11 +95,11 @@ public abstract class BaseLiquibaseTask extends Task {
     protected abstract void executeWithLiquibaseClassloader() throws BuildException;
 
     protected Database createDatabaseFromConfiguredDatabaseType() {
-        return createDatabaseFromType(databaseType);
+        return createDatabaseFromType(databaseType, getResourceAccessor());
     }
 
-    protected Database createDatabaseFromType(DatabaseType databaseType) {
-        return databaseType.createDatabase(classLoader);
+    protected Database createDatabaseFromType(DatabaseType databaseType, ResourceAccessor resourceAccessor) {
+        return databaseType.createDatabase(resourceAccessor);
     }
 
     protected Liquibase getLiquibase() {

--- a/liquibase-core/src/main/java/liquibase/integration/ant/BaseLiquibaseTask.java
+++ b/liquibase-core/src/main/java/liquibase/integration/ant/BaseLiquibaseTask.java
@@ -36,6 +36,7 @@ public abstract class BaseLiquibaseTask extends Task {
 
     private AntClassLoader classLoader;
     private Liquibase liquibase;
+    private ResourceAccessor resourceAccessor;
 
     private Path classpath;
     private DatabaseType databaseType;
@@ -105,6 +106,13 @@ public abstract class BaseLiquibaseTask extends Task {
         return liquibase;
     }
 
+    protected ResourceAccessor getResourceAccessor() {
+        if (resourceAccessor == null) {
+            throw new IllegalStateException("The ResourceAccessor has not been initialized. This usually means this " +
+                    "method has been called before the task's execute method has called.");
+        }
+        return resourceAccessor;
+    }
 
     /**
      * This method is designed to be overridden by subclasses when a change log is needed. By default it returns null.

--- a/liquibase-core/src/test/groovy/liquibase/change/core/DropAllForeignKeyConstraintsChangeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/core/DropAllForeignKeyConstraintsChangeTest.groovy
@@ -32,6 +32,8 @@ class DropAllForeignKeyConstraintsChangeTest extends Specification {
 
     @Unroll("SQL in #shortDbName for dropAllForeignKeys")
     def "GenerateStatements"() {
+        setup:
+        DatabaseFactory.reset()
         when:
         Database dbms = DatabaseFactory.getInstance().getDatabase(shortDbName)
         OfflineConnection conn = new OfflineConnection("offline:" + shortDbName, null)

--- a/liquibase-core/src/test/java/liquibase/database/DatabaseFactoryTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/DatabaseFactoryTest.java
@@ -59,6 +59,21 @@ public class DatabaseFactoryTest {
     }
 
     @Test
+    public void openConnectionUsesDriverArgument() throws Exception {
+        DatabaseConnection dbConnection = databaseFactory.openConnection("jdbc:h2:mem:DatabaseFactoryTest", "sa", "", "org.h2.Driver", null, null, null, resourceAccessor);
+        assertThat(dbConnection, notNullValue());
+    }
+
+    @Test
+    public void openConnectionThrowsExceptionWhenDriverCannotBeFoundByUrl() throws Exception {
+        expectedException.expect(instanceOf(DatabaseException.class));
+        expectedException.expectCause(instanceOf(RuntimeException.class));
+        expectedException.expectMessage(containsString("Driver class was not specified and could not be determined from the url"));
+
+        databaseFactory.openConnection("not:a:driver", "", "", null, resourceAccessor);
+    }
+
+    @Test
     public void openConnectionLoadsDriverPropertiesFromGivenFile() throws Exception {
         File propsFile = temporaryFolder.newFile("db-factory-test-connection-props.properties");
         Properties expectedProps = new Properties();
@@ -88,13 +103,12 @@ public class DatabaseFactoryTest {
 
         databaseFactory.openConnection("jdbc:h2:mem:DatabaseFactoryTest", "sa", "", null, null, "unknown file", null, resourceAccessor);
     }
-
-    // Misc
-    // TODO: Delete this test
+    
     @Test
-    public void name() throws Exception {
+    public void openConnectionReturnsAConnection() throws Exception {
         DatabaseConnection databaseConnection = databaseFactory.openConnection("jdbc:h2:mem:DatabaseFactoryTest", "sa", "", null, resourceAccessor);
-        assertNotNull(databaseConnection);
+        assertThat(databaseConnection, notNullValue());
+        assertThat(databaseConnection.getDatabaseProductName(), equalTo("H2"));
     }
 
     /**

--- a/liquibase-core/src/test/java/liquibase/database/DatabaseFactoryTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/DatabaseFactoryTest.java
@@ -35,6 +35,7 @@ public class DatabaseFactoryTest {
     @Before
     public void setUp() {
         resourceAccessor = mock(ResourceAccessor.class);
+        DatabaseFactory.reset();
         databaseFactory = DatabaseFactory.getInstance();
     }
 

--- a/liquibase-core/src/test/java/liquibase/database/DatabaseFactoryTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/DatabaseFactoryTest.java
@@ -1,13 +1,110 @@
 package liquibase.database;
 
+import liquibase.exception.DatabaseException;
+import liquibase.resource.ResourceAccessor;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.util.Properties;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class DatabaseFactoryTest {
-    
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private ResourceAccessor resourceAccessor;
+    private DatabaseFactory databaseFactory;
+
+    @Before
+    public void setUp() {
+        resourceAccessor = mock(ResourceAccessor.class);
+        databaseFactory = DatabaseFactory.getInstance();
+    }
+
+    @After
+    public void tearDown() {
+        temporaryFolder.delete();
+    }
+
     @Test
     public void getInstance() {
         assertNotNull(DatabaseFactory.getInstance());
+    }
+
+    // openConnection() method tests
+    @Test
+    public void openConnectionReturnsOfflineConnectionWhenUrlPrefixMatches() throws Exception {
+        String username = "sa";
+        DatabaseConnection dbConnection = databaseFactory.openConnection("offline:h2?param1=value1&aparam2=value2", username, "", null, resourceAccessor);
+        assertThat(dbConnection, notNullValue());
+        assertThat(dbConnection, instanceOf(OfflineConnection.class));
+        assertThat(dbConnection.getConnectionUserName(), equalTo(username));
+    }
+
+    @Test
+    public void openConnectionLoadsDriverPropertiesFromGivenFile() throws Exception {
+        File propsFile = temporaryFolder.newFile("db-factory-test-connection-props.properties");
+        Properties expectedProps = new Properties();
+        expectedProps.setProperty("param1", "value1");
+        expectedProps.setProperty("param2", "value2");
+        try (FileWriter writer = new FileWriter(propsFile)) {
+            expectedProps.store(writer, "connection properties");
+        }
+        String propsFilePath = propsFile.getAbsolutePath();
+
+        DatabaseConnection dbConnection = databaseFactory.openConnection("jdbc:h2:mem:DatabaseFactoryTest", "sa", "", null, null, propsFilePath, null, resourceAccessor);
+        assertThat(dbConnection, notNullValue());
+        // TODO: Figure out how to assert the properties are loaded
+    }
+
+    @Test
+    public void openConnectionCreatesCustomPropertyProviderClassWhenGiven() throws Exception {
+        DatabaseConnection databaseConnection = databaseFactory.openConnection("jdbc:h2:mem:DatabaseFactoryTest", "sa", "", "liquibase.database.DatabaseFactoryTest$CustomProperties", resourceAccessor);
+        assertThat(databaseConnection, notNullValue());
+    }
+
+    @Test
+    public void openConnectionThrowsRuntimeExceptionWhenDriverPropertiesFileNotFound() throws Exception {
+        expectedException.expect(instanceOf(DatabaseException.class));
+        expectedException.expectCause(instanceOf(RuntimeException.class));
+        expectedException.expectMessage(containsString("Can't open JDBC Driver specific properties from the file"));
+
+        databaseFactory.openConnection("jdbc:h2:mem:DatabaseFactoryTest", "sa", "", null, null, "unknown file", null, resourceAccessor);
+    }
+
+    // Misc
+    // TODO: Delete this test
+    @Test
+    public void name() throws Exception {
+        DatabaseConnection databaseConnection = databaseFactory.openConnection("jdbc:h2:mem:DatabaseFactoryTest", "sa", "", null, resourceAccessor);
+        assertNotNull(databaseConnection);
+    }
+
+    /**
+     * Simple type to test the propertyProviderClass
+     */
+    @SuppressWarnings({"unused", "RedundantSuppression"})
+    private static class CustomProperties extends Properties {
+        // Default constructor needed for reflective construction
+        public CustomProperties() {
+            super();
+        }
     }
 }

--- a/liquibase-core/src/test/java/liquibase/database/DatabaseFactoryTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/DatabaseFactoryTest.java
@@ -62,6 +62,7 @@ public class DatabaseFactoryTest {
     public void openConnectionUsesDriverArgument() throws Exception {
         DatabaseConnection dbConnection = databaseFactory.openConnection("jdbc:h2:mem:DatabaseFactoryTest", "sa", "", "org.h2.Driver", null, null, null, resourceAccessor);
         assertThat(dbConnection, notNullValue());
+        assertThat(dbConnection.getDatabaseProductName(), equalTo("H2"));
     }
 
     @Test
@@ -71,6 +72,13 @@ public class DatabaseFactoryTest {
         expectedException.expectMessage(containsString("Driver class was not specified and could not be determined from the url"));
 
         databaseFactory.openConnection("not:a:driver", "", "", null, resourceAccessor);
+    }
+
+    @Test
+    public void openConnectionLoadsGivenDatabaseClass() throws Exception {
+        DatabaseConnection dbConnection = databaseFactory.openConnection("jdbc:h2:mem:DatabaseFactoryTest", "sa", "", null, "liquibase.database.core.H2Database", null, null, resourceAccessor);
+        assertThat(dbConnection, notNullValue());
+        assertThat(dbConnection.getDatabaseProductName(), equalTo("H2"));
     }
 
     @Test
@@ -86,13 +94,15 @@ public class DatabaseFactoryTest {
 
         DatabaseConnection dbConnection = databaseFactory.openConnection("jdbc:h2:mem:DatabaseFactoryTest", "sa", "", null, null, propsFilePath, null, resourceAccessor);
         assertThat(dbConnection, notNullValue());
+        assertThat(dbConnection.getDatabaseProductName(), equalTo("H2"));
         // TODO: Figure out how to assert the properties are loaded
     }
 
     @Test
     public void openConnectionCreatesCustomPropertyProviderClassWhenGiven() throws Exception {
-        DatabaseConnection databaseConnection = databaseFactory.openConnection("jdbc:h2:mem:DatabaseFactoryTest", "sa", "", "liquibase.database.DatabaseFactoryTest$CustomProperties", resourceAccessor);
-        assertThat(databaseConnection, notNullValue());
+        DatabaseConnection dbConnection = databaseFactory.openConnection("jdbc:h2:mem:DatabaseFactoryTest", "sa", "", "liquibase.database.DatabaseFactoryTest$CustomProperties", resourceAccessor);
+        assertThat(dbConnection, notNullValue());
+        assertThat(dbConnection.getDatabaseProductName(), equalTo("H2"));
     }
 
     @Test
@@ -106,9 +116,9 @@ public class DatabaseFactoryTest {
     
     @Test
     public void openConnectionReturnsAConnection() throws Exception {
-        DatabaseConnection databaseConnection = databaseFactory.openConnection("jdbc:h2:mem:DatabaseFactoryTest", "sa", "", null, resourceAccessor);
-        assertThat(databaseConnection, notNullValue());
-        assertThat(databaseConnection.getDatabaseProductName(), equalTo("H2"));
+        DatabaseConnection dbConnection = databaseFactory.openConnection("jdbc:h2:mem:DatabaseFactoryTest", "sa", "", null, resourceAccessor);
+        assertThat(dbConnection, notNullValue());
+        assertThat(dbConnection.getDatabaseProductName(), equalTo("H2"));
     }
 
     /**


### PR DESCRIPTION
- - -
name: Pull Request
about: Create a report to help us improve
title: ''
labels: Status:Discovery
assignees: ''

- - -
<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->

## Environment
**Liquibase Version**: 3.10.x

**Liquibase Integration & Version**: Ant

**Liquibase Extension(s) & Version**: N/A

**Database Vendor & Version**: N/A

**Operating System Type & Version**: All

## Pull Request Type
<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->

* [x] Bug fix (non-breaking change which fixes an issue.)
* [ ] Enhancement/New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

Fixes #1378

## Description
I have been investigating #1378 and I believe the issue is the Ant tasks are creating the `DatabaseConnection` themselves and not respecting the logic found in the `DatabaseFactory`. This PR updates the Ant tasks to leverage the `DatabaseFactory` to keep consistent with the rest of the integration types (CLI, Maven, etc). 

This involved a small refactoring of the `DatabaseFactory` so it can accept a pre-configured `Properties` object as that is needed by Ant. The refactoring is entirely backward compatible and was accomplished using simple method and argument extraction. I added several unit tests before the refactor to make sure compatibility was maintained.

This would be good to backport into 3.10.x but I will leave that up to you.

## Steps To Reproduce
The bug is a bit difficult to reproduce. See #1378 for details. I believe there is a small race condition that can cause the exception where a pro connection is used in the tasks when its not desired. The changes in this PR should remove the race condition.

## Actual Behavior
A clear and concise description of what happens in the software **before** this pull request.

* Include console output if relevant
* Include log files if available.

## Expected/Desired Behavior
A clear and concise description of what happens in the software **after** this pull request.

## Screenshots (if appropriate)
If applicable, add screenshots to help explain your problem.

## Additional Context
Add any other context about the problem here.

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->

* [x] Build is successful and all new and existing tests pass
* [x] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
* [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
* [ ] Documentation Updated

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-701) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Liquibase 4.2.0
