### PR TITLE
Fixed mysql merge columns query

### DIFF
--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/mergeColumns/mariadb.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/mergeColumns/mariadb.sql
@@ -5,6 +5,6 @@
 -- Change Parameter: finalColumnType=varchar(255)
 -- Change Parameter: tableName=person
 ALTER TABLE person ADD full_name VARCHAR(255) NULL;
-UPDATE person SET full_name = CONCAT_WS(first_name, 'null', last_name);
+UPDATE person SET full_name = CONCAT_WS('null', first_name, last_name);
 ALTER TABLE person DROP COLUMN first_name;
 ALTER TABLE person DROP COLUMN last_name;

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/mergeColumns/mysql.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/mergeColumns/mysql.sql
@@ -5,6 +5,6 @@
 -- Change Parameter: finalColumnType=varchar(255)
 -- Change Parameter: tableName=person
 ALTER TABLE person ADD full_name VARCHAR(255) NULL;
-UPDATE person SET full_name = CONCAT_WS(first_name, 'null', last_name);
+UPDATE person SET full_name = CONCAT_WS('null', first_name, last_name);
 ALTER TABLE person DROP COLUMN first_name;
 ALTER TABLE person DROP COLUMN last_name;


### PR DESCRIPTION
[https://forum.liquibase.org/t/mergecolumns-mysql/4669](https://forum.liquibase.org/t/mergecolumns-mysql/4669)

- - -
name: Pull Request
about: Fix merge column on MySql
title: Fix merge column on MySql
labels: Status:Fixed
assignees: ''

- - -
<!--- This environment context section helps us quickly review your PR. 
Please take a minute to fill-out this information. -->

## Environment
**Liquibase Version**: 4.0.1-local-SNAPSHOT

**Liquibase Integration & Version**: CLI

**Liquibase Extension(s) & Version**: 

**Database Vendor & Version**:

**Operating System Type & Version**: Windows 10 pro

## Pull Request Type
<!--- What types of changes does your code introduce?
Put an `x` in all the boxes that apply: 
If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->

* [x ] Bug fix (non-breaking change which fixes an issue.)
* \[ ] Enhancement/New feature (non-breaking change which adds functionality)
* \[ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
Using MySql db, and using mergeColumns chanset the result column is not correctly merged. 

##### Changesets
```java
<changeSet author="Liquibase"  id="1::tableForLb738" labels="lb738">
        <createTable tableName="tbl_lb738">
            <column name="t1" type="VARCHAR(20)"/>
            <column name="t2" type="VARCHAR(20)"/>
        </createTable>
	</changeSet>

	<changeSet author="Liquibase" id="1::loadDataLB738">
    <loadUpdateData file="data/dataLb738.csv" tableName="tbl_lb738" primaryKey="t1" relativeToChangelogFile="true"/>
	</changeSet>

	<changeSet author="Liquibase"  id="1::mergeColumnsLb738" labels="lb738">
      <mergeColumns tableName="tbl_lb738" column1Name = "t1" column2Name = "t2" finalColumnName = "t12" finalColumnType = "varchar (100)" joinString = "---" />
	</changeSet>
```

##### The file data/dataLb738.csv should have the following data:
```java
t1,t2
m,k
```

## Steps To Reproduce
Using MySql db, create a changeset with mergeColumns (see example in description).

## Actual Behavior
The column is merged with the string delimiter at the beginning and not between merged columns.
Resulting column data is "---mk" (three dashes at beginning)

## Expected/Desired Behavior
The string delimiter must be between merged columns.
Resulting column data should be "m---k" (three dashes in the middle)

## Screenshots (if appropriate)
![width=200,height=183](https://user-images.githubusercontent.com/18529174/94697195-2fcdcb00-0338-11eb-9b14-308e3f5201be.PNG)

## Additional Context
Add any other context about the problem here.

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<

!--- If you're unsure about any of these, just ask us in a comment. We're here to help|width=200,height=183!

-->

* [ x] Build is successful and all new and existing tests pass
* \[ ] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
* \[ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
* \[ ] Documentation Updated

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-738) by [Unito](https://www.unito.io)
┆Attachments: <a href="https://share.unito.io/DaxEJis3mNOm6Mwrd_nU95OUo93yJpxdfr5zMtS0C5GP">LB-738.png</a>
┆Fix Versions: Community 4.4.0,Liquibase 4.x
