### PR TITLE
liquibase.sqlplus.path line in liquibase/examples/xml/liquibase.sqlplus.conf should be commented out

### DIFF
--- a/liquibase-dist/src/main/archive/examples/xml/liquibase.sqlplus.conf
+++ b/liquibase-dist/src/main/archive/examples/xml/liquibase.sqlplus.conf
@@ -24,7 +24,7 @@
 # Sample linux path
 # liquibase.sqlplus.path=/apps/app/12.2.0.1.0/oracle/product/12.2.0.1.0/client_1/bin/sqlplus
 # Sample windows path
-# liquibase.sqlplus.path=c:\oracle\product\11.2.0\client_1\bin\sqlplus.exe
+# liquibase.sqlplus.path=c:\\oracle\\product\\11.2.0\\client_1\\bin\\sqlplus.exe
 
 # A valid timeout value for the execution of the SQLPLUS tool
 liquibase.sqlplus.timeout=-1

--- a/liquibase-dist/src/main/archive/examples/xml/liquibase.sqlplus.conf
+++ b/liquibase-dist/src/main/archive/examples/xml/liquibase.sqlplus.conf
@@ -21,7 +21,10 @@
 ####
 
 # The full path to the SQLPLUS executable.
+# Sample linux path
 # liquibase.sqlplus.path=/apps/app/12.2.0.1.0/oracle/product/12.2.0.1.0/client_1/bin/sqlplus
+# Sample windows path
+# liquibase.sqlplus.path=c:\oracle\product\11.2.0\client_1\bin\sqlplus.exe
 
 # A valid timeout value for the execution of the SQLPLUS tool
 liquibase.sqlplus.timeout=-1

--- a/liquibase-dist/src/main/archive/examples/xml/liquibase.sqlplus.conf
+++ b/liquibase-dist/src/main/archive/examples/xml/liquibase.sqlplus.conf
@@ -21,7 +21,7 @@
 ####
 
 # The full path to the SQLPLUS executable.
-liquibase.sqlplus.path=/apps/app/12.2.0.1.0/oracle/product/12.2.0.1.0/client_1/bin/sqlplus
+# liquibase.sqlplus.path=/apps/app/12.2.0.1.0/oracle/product/12.2.0.1.0/client_1/bin/sqlplus
 
 # A valid timeout value for the execution of the SQLPLUS tool
 liquibase.sqlplus.timeout=-1


### PR DESCRIPTION
Closes #1416

## Liquibase Internal QA Test Requirements
* Verify the liquibase.sqlplus.path is commented out in the Windows installer.
* Verify the liquibase.sqlplus.path is commented out in the Mac installer.



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-746) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Community 4.3.2,Liquibase 4.3.2
