### PR TITLE
Concurrency fixes - use ConcurrentHashMap to hold executors

### DIFF
--- a/liquibase-core/src/main/java/liquibase/executor/ExecutorService.java
+++ b/liquibase-core/src/main/java/liquibase/executor/ExecutorService.java
@@ -1,18 +1,16 @@
 package liquibase.executor;
 
-import liquibase.Scope;
-import liquibase.change.ChangeMetaData;
 import liquibase.database.Database;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.plugin.AbstractPluginFactory;
 import liquibase.plugin.Plugin;
-import liquibase.servicelocator.ServiceLocator;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ExecutorService extends AbstractPluginFactory<Executor>  {
 
-    private Map<String, Executor> executors = new HashMap<>();
+    private final Map<String, Executor> executors = new ConcurrentHashMap<>();
 
     private ExecutorService() {
     }
@@ -33,17 +31,12 @@ public class ExecutorService extends AbstractPluginFactory<Executor>  {
 
     }
 
-    private String createKey(String executorName, Database database) {
+    private static String createKey(String executorName, Database database) {
         String key = executorName.toLowerCase() + "#" + System.identityHashCode(database);
         return key;
     }
 
-    private Executor getExecutorValue(String executorName, Database database) throws UnexpectedLiquibaseException {
-        String key = createKey(executorName, database);
-        if (executors.containsKey(key)) {
-            return executors.get(key);
-        }
-
+    private Executor createExecutor(String executorName, Database database) throws UnexpectedLiquibaseException {
         final Executor plugin = getPlugin(executorName.toLowerCase(), database);
         try {
             return plugin.getClass().newInstance();
@@ -64,7 +57,7 @@ public class ExecutorService extends AbstractPluginFactory<Executor>  {
     public Executor getExecutor(final String name, final Database database) {
         Executor returnExecutor = executors.computeIfAbsent(createKey(name, database), db -> {
             try {
-                Executor executor = getExecutorValue(name, database);
+                Executor executor = createExecutor(name, database);
                 executor.setDatabase(database);
                 return executor;
             } catch (Exception e) {


### PR DESCRIPTION
This PR is against current master, since this file have changed a lot. See PR against 3.10.x at https://github.com/liquibase/liquibase/pull/1456. 

- - -
name: Pull Request
about: Create a report to help us improve
title: ''
labels: Status:Discovery
assignees: ''

- - -
<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->

## Environment
**Liquibase Version**: 3.10.2
**Liquibase Integration & Version**: maven

**Database Vendor & Version**: postgres

**Operating System Type & Version**: macos 10.15

## Pull Request Type
<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->

* [x] Bug fix (non-breaking change which fixes an issue.) Closes https://github.com/liquibase/liquibase/issues/1455
* [ ] Enhancement/New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
Fixing concurrent access to executors by using ConcurrentHashMap to store executors

## Steps To Reproduce
We have a test that tries to execute migrations in 8+ parallel threads. I cannot share the test, but the gist of it - each thread creates a liquibase migrator (same migration script), and tries to call `update` over it.

## Actual Behavior
Multiple ConcurrentModification exceptions

```
Exception in thread "Thread-22" java.util.ConcurrentModificationException
	at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1134)
	at liquibase.executor.ExecutorService.getExecutor(ExecutorService.java:93)
	at liquibase.lockservice.StandardLockService.acquireLock(StandardLockService.java:248)
	at liquibase.lockservice.StandardLockService.waitForLock(StandardLockService.java:213)
	at liquibase.Liquibase.update(Liquibase.java:183)
	at liquibase.Liquibase.update(Liquibase.java:178)
	at liquibase.Liquibase.update(Liquibase.java:174)
       ... our code that invokes it ...
```

## Expected/Desired Behavior
No exceptions and only one update successfully executed.

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->

* [x] Build is successful and all new and existing tests pass
* [ ] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
* [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
* [ ] Documentation Updated

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)

