### PR TITLE
Fix logicalFilePath not being serialized - Fixes 1234

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
@@ -106,6 +106,12 @@ public class ChangeSet implements Conditional, ChangeLogChild {
      */
     private String filePath = "UNKNOWN CHANGE LOG";
 
+
+    /**
+     * A logicalFilePath if defined
+     */
+    private String logicalFilePath;
+
     /**
      * File path stored in the databasechangelog table. It should be the same as filePath, but not always.
      */
@@ -255,8 +261,23 @@ public class ChangeSet implements Conditional, ChangeLogChild {
         this.dbmsSet = DatabaseList.toDbmsSet(dbmsList);
     }
 
+    /**
+     * @return either this object's logicalFilePath or the changelog's filepath (logical or physical) if not.
+     */
     public String getFilePath() {
         return filePath;
+    }
+
+    /**
+     * The logical file path defined directly on this node. Return null if not set.
+     * @return
+     */
+    public String getLogicalFilePath() {
+        return logicalFilePath;
+    }
+
+    public void setLogicalFilePath(String logicalFilePath) {
+        this.logicalFilePath = logicalFilePath;
     }
 
     public String getStoredFilePath() {
@@ -331,7 +352,9 @@ public class ChangeSet implements Conditional, ChangeLogChild {
             this.objectQuotingStrategy = ObjectQuotingStrategy.LEGACY;
         }
 
-        this.filePath = StringUtil.trimToNull(node.getChildValue(null, "logicalFilePath", String.class));
+        this.logicalFilePath = StringUtil.trimToNull(node.getChildValue(null, "logicalFilePath", String.class));
+
+        this.filePath = logicalFilePath;
         if (filePath == null) {
             if (changeLog != null) {
                 filePath = changeLog.getFilePath();
@@ -1179,7 +1202,7 @@ public class ChangeSet implements Conditional, ChangeLogChild {
         }
 
         if ("logicalFilePath".equals(field)) {
-        	return getFilePath();
+        	return getLogicalFilePath();
         }
 
         if ("rollback".equals(field)) {

--- a/liquibase-core/src/test/java/liquibase/serializer/core/json/JsonChangeLogSerializerTest.java
+++ b/liquibase-core/src/test/java/liquibase/serializer/core/json/JsonChangeLogSerializerTest.java
@@ -46,7 +46,6 @@ public class JsonChangeLogSerializerTest {
                 "  \"changeSet\": {\n" +
                 "    \"id\": \"1\",\n" +
                 "    \"author\": \"nvoxland\",\n" +
-    			"    \"logicalFilePath\": \"path/to/file.json\",\n" +
                 "    \"objectQuotingStrategy\": \"LEGACY\",\n" +
                 "    \"preconditions\": {\n" +
                 "      \"preConditions\": {\n" +

--- a/liquibase-core/src/test/java/liquibase/serializer/core/xml/XMLChangeLogSerializerTest.java
+++ b/liquibase-core/src/test/java/liquibase/serializer/core/xml/XMLChangeLogSerializerTest.java
@@ -888,6 +888,7 @@ public class XMLChangeLogSerializerTest {
     	changeSet.setCreated("created");
     	changeSet.setFailOnError(true);
     	changeSet.setLabels(new Labels("label"));
+    	changeSet.setLogicalFilePath("path/to/file.json");
     	
     	
     	Element node = new XMLChangeLogSerializer(DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument()).createNode(changeSet);
@@ -933,7 +934,8 @@ public class XMLChangeLogSerializerTest {
     	changeSet.setCreated("created");
     	changeSet.setFailOnError(true);
     	changeSet.setLabels(new Labels("label"));
-    	
+    	changeSet.setLogicalFilePath("path/to/file.json");
+
     	String out = new XMLChangeLogSerializer().serialize(changeSet, true);
     	
     	assertEquals("<changeSet author=\"tms\"\n"


### PR DESCRIPTION
- - -
name: Pull Request
about: Create a report to help us improve
title: ''
labels: Status:Discovery
assignees: ''

- - -
<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->

## Environment
**Liquibase Version**: 3.10.3

**Liquibase Integration & Version**: maven

**Liquibase Extension(s) & Version**: mssql-jdbc-8.4.1.jre8.jar

**Database Vendor & Version**: MSSQL

**Operating System Type & Version**: Windows 10

## Pull Request Type
* [x] Bug fix (non-breaking change which fixes an issue.)
* [ ] Enhancement/New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Actual Behavior
The logicalFilePath attribute of a ChangeSet is not serialized.

## Expected/Desired Behavior
The logicalFilePath attribute of a ChangeSet is serialized.

## Additional Context
`<changeSet author="tms"  dbms="mssql" id="1" logicalFilePath="path/to/file.json"/>`

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->

* [x] Build is successful and all new and existing tests pass
* [x] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
* [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
* [ ] Documentation Updated

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: stand alone PR
* Local Branch: https://github.com/liquibase/liquibase/tree/LB-790
* Unit Tests: https://github.com/liquibase/liquibase/pull/1471/checks
* Integration Tests: (shown in Unit Tests link above)
* Functional Tests: https://jenkins.datical.net/job/liquibase-pro/job/LB-790/

#### Testing
* Steps to Reproduce: Have to create write custom code to serialize a changeSet with a logicalFilePath attribute set.
* Guidance: 
  * Tests check the serialization. Cannot check it with standard liquibase functionality
  * Changing serialization logic can impact checksums. I fixed the original PR to not introduce that problem.

#### Dev Verification
Wrote automated test to check serialization, ran other automated tests until they no longer caught regressions on checksums etc.
(no output was saved at the time)



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-790) by [Unito](https://www.unito.io)
