### PR TITLE
Fixes #1477 missing uniqueconstraints in snapshot

### DIFF
--- a/base.pom.xml
+++ b/base.pom.xml
@@ -319,7 +319,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.5.201505241946</version>
+                <version>0.8.5</version>
                 <executions>
                     <execution>
                     <goals>

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
@@ -342,6 +342,14 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
                 columnCache = new HashMap<>();
                 snapshot.setScratchData(cacheKey, columnCache);
                 for (Map<String, ?> row : rows) {
+                    if (!row.containsKey("CONSTRAINT_CONTAINER"))
+                    {
+                        throw new IllegalArgumentException("Missing 'CONSTRAINT_CONTAINER' for bulk query!");
+                    }
+                    if (!row.containsKey("CONSTRAINT_NAME"))
+                    {
+                        throw new IllegalArgumentException("Missing 'CONSTRAINT_NAME' for bulk query!");
+                    }
                     String key = row.get("CONSTRAINT_CONTAINER") + "_" + row.get("CONSTRAINT_NAME");
                     List<Map<String, ?>> constraintRows = columnCache.get(key);
                     if (constraintRows == null) {

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
@@ -170,7 +170,7 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
             snapshot.setScratchData(queryCountKey, columnQueryCount + 1);
 
             if ((database instanceof MySQLDatabase) || (database instanceof HsqlDatabase)) {
-                sql = "select const.CONSTRAINT_NAME, COLUMN_NAME "
+                sql = "select const.CONSTRAINT_NAME, COLUMN_NAME, const.constraint_schema as CONSTRAINT_CONTAINER "
                         + "from " + database.getSystemSchema() + ".table_constraints const "
                         + "join " + database.getSystemSchema() + ".key_column_usage col "
                         + "on const.constraint_schema=col.constraint_schema "
@@ -183,7 +183,7 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
                 }
                 sql += "order by ordinal_position";
             } else if (database instanceof PostgresDatabase) {
-                sql = "select const.CONSTRAINT_NAME, COLUMN_NAME "
+                sql = "select const.CONSTRAINT_NAME, COLUMN_NAME, const.constraint_schema as CONSTRAINT_CONTAINER "
                         + "from " + database.getSystemSchema() + ".table_constraints const "
                         + "join " + database.getSystemSchema() + ".key_column_usage col "
                         + "on const.constraint_schema=col.constraint_schema "
@@ -237,7 +237,7 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
                         "order by ucc.position";
             } else if (database instanceof DB2Database) {
                 if (database.getDatabaseProductName().startsWith("DB2 UDB for AS/400")) {
-                    sql = "select T1.constraint_name as CONSTRAINT_NAME, T2.COLUMN_NAME as COLUMN_NAME from QSYS2.TABLE_CONSTRAINTS T1, QSYS2.SYSCSTCOL T2\n"
+                    sql = "select T1.constraint_name as CONSTRAINT_NAME, T2.COLUMN_NAME as COLUMN_NAME, T1.CONSTRAINT_SCHEMA as CONSTRAINT_CONTAINER from QSYS2.TABLE_CONSTRAINTS T1, QSYS2.SYSCSTCOL T2\n"
                             + "where T1.CONSTRAINT_TYPE='UNIQUE' and T1.CONSTRAINT_NAME=T2.CONSTRAINT_NAME\n"
                             + "and T1.CONSTRAINT_SCHEMA='" + database.correctObjectName(schema.getName(), Schema.class) + "'\n"
                             + "and T2.CONSTRAINT_SCHEMA='" + database.correctObjectName(schema.getName(), Schema.class) + "'\n"
@@ -246,7 +246,7 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
                             + "order by T2.COLUMN_NAME\n";
 
                 } else {
-                    sql = "select k.colname as column_name from syscat.keycoluse k, syscat.tabconst t "
+                    sql = "select k.constname as constraint_name, k.colname as column_name, t.tabschema as constraint_container from syscat.keycoluse k, syscat.tabconst t "
                             + "where k.constname = t.constname "
                             + "and k.tabschema = t.tabschema "
                             + "and t.type='U' "
@@ -317,7 +317,7 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
                 String schemaName = database.correctObjectName(schema.getName(), Schema.class);
                 String constraintName = database.correctObjectName(name, UniqueConstraint.class);
                 String tableName = database.correctObjectName(table.getName(), Table.class);
-                sql = "select CONSTRAINT_NAME, COLUMN_LIST as COLUMN_NAME "
+                sql = "select CONSTRAINT_NAME, COLUMN_LIST as COLUMN_NAME, constraint_schema as CONSTRAINT_CONTAINER "
                         + "from " + database.getSystemSchema() + ".constraints "
                         + "where constraint_type='UNIQUE' ";
                 if (catalogName != null) {


### PR DESCRIPTION
- - -
name: Fix #1477 missing constraints in snapshot
about: Fixes the bug as described in #1477
title: ''
labels: Status:Discovery
assignees: ''

- - -
<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->

## Environment
**Liquibase Version**: 4.1.0

**Liquibase Integration & Version**: 

**Liquibase Extension(s) & Version**: 
liquibase-hibernate5 4.1.0

**Database Vendor & Version**:
Postgres 12

**Operating System Type & Version**:
Linux

## Pull Request Type
<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->

* [x] Bug fix (non-breaking change which fixes an issue.)  closes #1477 
* [ ] Enhancement/New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
As described in #1477, this PR fixes an issue where due to incorrect caching of batch-query results every uniqueconstraint after the first four was ignored for a number of databases when building a snapshot, leading to incorrect snapshots/diff/changelog-generation.

This PR:

* Adds a check with explicit exception when trying to save a batch-query result while the CONSTRAINT_CONTAINER and/or CONSTRAINT_NAME are not present in the query result (which would lead to an incorrect cachekey).
* Adds said fields to a number of queries for specific databases where they were missing and I felt sure enough of what I was doing to add it.

Note that those fields are still missing from some of the queries and therefore this code will probably start throwing exceptions on some platforms! Though these are all cases where the code would previously generate incorrect results, and fail-fast is probably a better option. 

In cases where the query can't (easily) provide a CONSTRAINT_CONTAINER you might be able to workaround that by "hardcoding" it in the query set to the current schema name. Something like 

```java
query = "select " + database.correctObjectName(schema.getName(), Schema.class) + " AS CONSTRAINT_CONTAINER, "
```

In cases where the CONSTRAINT_NAME is missing the query has to be fixed to provide that or the UniqueConstraintSnapshotGenerator has to be modified to never use (and cache) batch-queries for those RDBMSs. 

## Steps To Reproduce
See #1477 

## Actual Behavior
For any RDBMS, if the "get columns for unique constraint ( UniqueConstraintSnapshotGenerator.listColumns ) query has been executed more than 4 times, it will execute without filtering for a specific constraint, ie it will try to get the columns for all constraints at once, and then cache these results per constraint. However, if the CONSTRAINT_CONTAINER or CONSTRAINT_NAME fields are missing from the query-results it will cache these under an incorrect (and potentially non-unique) cachekey. 

When the generator then tries to retrieve the columns for a UniqueConstraint, it will see there are results cached, but will be unable to retrieve results for the specific constraint, leading it to conclude there are no columns for that constraint and it wil ignore the constraint and not add it to the snapshot (it gets added to the "always null" collection).

This then leads to invalid/incorrect results when using this snapshot to diff against another snapshot or generate a changelog.

## Expected/Desired Behavior
When creating a database snapshot, the snapshot will either succeed, meaning it gathered the correct number of unique constraints, or it will fail explicitly with an error if this is not possible. It will not create invalid data, leading to difficult-to-track-down errors further down the line.

## Screenshots (if appropriate)
If applicable, add screenshots to help explain your problem.

## Additional Context
Confirmed to solve the problem for us, when building a snapshot of a postgres 12 database to diff against another database (that wasn't affected by this bug, nor by the solution).

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->

* [x] Build is successful and all new and existing tests pass   (locally, most integration tests auto-skipped)
* [ ] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
* [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
* [ ] Documentation Updated

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-822) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Community 4.x
