### PR TITLE
Fixes #1277 sqlFile + relativeToChangelogFile fails when using a logicalFilePath

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/SQLFileChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/SQLFileChange.java
@@ -118,7 +118,7 @@ public class SQLFileChange extends AbstractSQLChange {
         try {
             String relativeTo = null;
             if (ObjectUtil.defaultIfNull(isRelativeToChangelogFile(), false)) {
-                relativeTo = getChangeSet().getFilePath();
+                relativeTo = getChangeSet().getChangeLog().getPhysicalFilePath();
             }
             inputStream = Scope.getCurrentScope().getResourceAccessor().openStream(relativeTo, path);
         } catch (IOException e) {

--- a/liquibase-core/src/test/resources/liquibase/change/core/SQLFileChange.sql
+++ b/liquibase-core/src/test/resources/liquibase/change/core/SQLFileChange.sql
@@ -1,0 +1,1 @@
+create table sql_table;


### PR DESCRIPTION
- - -
name: Fixes #1277 sqlFile + relativeToChangelogFile fails when using a logicalFilePath
about: Fixes bug #1277 and potentially #1353 
title: ''
labels: Status:Discovery
assignees: ''

- - -
<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->

## Environment
**Liquibase Version**: 4.1.1

**Liquibase Integration & Version**: any

**Liquibase Extension(s) & Version**:  n/a

**Database Vendor & Version**: any

**Operating System Type & Version**: n/a

## Pull Request Type
<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->

* [x] Bug fix (non-breaking change which fixes an issue.)
* [ ] Enhancement/New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
See #1277 

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->

* [x] (Local) Build is successful and all new and existing tests pass (only unit tests, integration tests are all skipped)
* [x] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
* [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
* [ ] Documentation Updated

