### PR TITLE
Add automatic module names (JPMS)

### DIFF
--- a/liquibase-cdi/pom.xml
+++ b/liquibase-cdi/pom.xml
@@ -34,6 +34,17 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>liquibase.integration.cdi</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
                 <version>1.1.0</version>
@@ -43,8 +54,8 @@
                     <flattenedPomFilename>release.pom.xml</flattenedPomFilename>
                     <pomElements>
                         <profiles>remove</profiles>
-                        <organization/>
-                        <issueManagement/>
+                        <organization />
+                        <issueManagement />
                     </pomElements>
                     <flattenMode>ossrh</flattenMode>
                 </configuration>

--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -126,6 +126,17 @@
         </resources>
 
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>liquibase</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
             <!-- need to build javadocs for other module javadocs to reference -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,8 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>                <executions>
+                <version>3.0.1</version>
+                <executions>
                     <execution>
                         <id>root-source-aggregate</id>
                         <goals>
@@ -84,7 +85,7 @@
 
 
 
-            <!--            <plugin>-->
+<!--            <plugin>-->
 <!--                <artifactId>maven-install-plugin</artifactId>-->
 <!--                <version>2.5.2</version>-->
 <!--                <configuration>-->
@@ -100,15 +101,20 @@
 <!--            </plugin>-->
 
         </plugins>
-<!--        <pluginManagement>-->
-<!--            <plugins>-->
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
 <!--                <plugin>-->
 <!--                    <groupId>org.jacoco</groupId>-->
 <!--                    <artifactId>jacoco-maven-plugin</artifactId>-->
 <!--                    <version>0.8.5</version>-->
 <!--                </plugin>-->
-<!--            </plugins>-->
-<!--        </pluginManagement>-->
+            </plugins>
+        </pluginManagement>
 
     </build>
 </project>


### PR DESCRIPTION
---
name: Add automatic module names (JPMS)
about: See description below
title: ''
labels: Status:Discovery
assignees: ''

---

## Environment

**Liquibase Version**: 4.1.1

**Liquibase Integration & Version**: N/A

**Liquibase Extension(s) & Version**: N/A

**Database Vendor & Version**: N/A

**Operating System Type & Version**: N/A

## Pull Request Type

<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->
- [ ] Bug fix (non-breaking change which fixes an issue.)
- [x] Enhancement/New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This is how this library is consumed in a Java 11 project:
```
module foo {
    requires liquibase.core;
}
```
Unfortunately, this produces the following warning:
>Name of automatic module 'liquibase.core' is unstable, it is derived from the module's file name.

That's because when a JAR does not contain a `module-info.class` Java assigns an automatic module name based on the JAR's name (for example, `liquibase-core-4.1.1.jar` -> `liquibase.core`). The cheapest way to remove this warning is to define a custom automatic module name with the help of the `maven-jar-plugin`. That way, Java wouldn't have to infer the module's name from the name of the JAR.

See http://branchandbound.net/blog/java/2017/12/automatic-module-name/ for more info.

I've used the package names as module names, since that's what's recommended by Mark Reinhold (see [Proposal: #AutomaticModuleNames (revised)](http://mail.openjdk.java.net/pipermail/jpms-spec-experts/2017-May/000687.html)):
>Strongly recommend that all modules be named according to the reverse Internet domain-name convention.  A module's name should correspond to the name of its principal exported API package, which should also follow that convention.  If a module does not have such a package, or if for legacy reasons it must have a name that does not correspond to one of its exported packages, then its name should at least start with the reversed form of an Internet domain with which the author is associated.

With this PR, the library would be consumable in the following way:
```
module foo {
    requires liquibase;
}
```
**This could be considered a breaking change depending on your perspective.** On one hand, people that actually have a module-info file in their project AND required this library explicitly would have to adapt, but on the other, they should've known that this was very likely to happen, as every IDE and even Maven would've warned them about it.

If don't want to break compatibility for these users, then I can modify the PR and rename the `liquibase` module to `liquibase.core` even though that would go against the convention I linked above.

## Steps To Reproduce

Create a Java 11 project with a module-info file and try to require one of the liquibase modules.

## Screenshots

![liquibase-modules](https://user-images.githubusercontent.com/16129525/96088093-953fc100-0ecd-11eb-91ec-0181eec927d6.png)

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->
- [x] Build is successful and all new and existing tests pass
- [ ] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
- [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
- [ ] Documentation Updated - **I'm not sure whether that's necessary, as IDEs auto-complete when requiring modules, so the liquibase modules would be easily discoverable, but if you want me to document this somewhere just let me know and I'll do it.**
