### PR TITLE
Fix CockroachDB Tests

### DIFF
--- a/.travis/databases.docker-compose.yml
+++ b/.travis/databases.docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - "./postgres-init.sh:/docker-entrypoint-initdb.d/postgres-init.sh"
 
   cockroachdb:
-    image: cockroachdb/cockroach-unstable:v20.2.0-alpha.3
+    image: cockroachdb/cockroach-unstable:v20.2.0-rc.2
     command: start-single-node --logtostderr --insecure
     ports:
       - "26257:26257"

--- a/liquibase-core/src/main/java/liquibase/change/core/AddPrimaryKeyChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/AddPrimaryKeyChange.java
@@ -142,7 +142,7 @@ public class AddPrimaryKeyChange extends AbstractChange {
         if (getValidate() != null) {
             shouldValidate = getValidate();
         }
-        AddPrimaryKeyStatement statement = new AddPrimaryKeyStatement(getCatalogName(), getSchemaName(), getTableName(), getColumnNames(), getConstraintName());
+        AddPrimaryKeyStatement statement = new AddPrimaryKeyStatement(getCatalogName(), getSchemaName(), getTableName(), ColumnConfig.arrayFromNames(getColumnNames()), getConstraintName());
         statement.setTablespace(getTablespace());
         statement.setClustered(getClustered());
         statement.setForIndexName(getForIndexName());

--- a/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -1307,6 +1307,7 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                                     "  result.a_attnum = (result.keys).x " +
                                     "ORDER BY " +
                                     "  result.table_name, result.pk_name, result.key_seq";
+
                             try {
                                 return executeAndExtract(sql, database);
                             } catch (DatabaseException e) {

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/DropUniqueConstraintGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/DropUniqueConstraintGenerator.java
@@ -2,6 +2,7 @@ package liquibase.sqlgenerator.core;
 
 import liquibase.change.ColumnConfig;
 import liquibase.database.Database;
+import liquibase.database.core.CockroachDatabase;
 import liquibase.database.core.MySQLDatabase;
 import liquibase.database.core.OracleDatabase;
 import liquibase.database.core.SQLiteDatabase;
@@ -43,6 +44,8 @@ public class DropUniqueConstraintGenerator extends AbstractSqlGenerator<DropUniq
             sql = "ALTER TABLE "
                     + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName())
                     + " DROP CONSTRAINT " + database.escapeConstraintName(statement.getConstraintName());
+        } else if (database instanceof CockroachDatabase) {
+            sql = "DROP INDEX " + database.escapeConstraintName(statement.getConstraintName()) + " CASCADE";
         } else {
             sql = "ALTER TABLE " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + " DROP CONSTRAINT " + database.escapeConstraintName(statement.getConstraintName());
         }

--- a/liquibase-core/src/main/java/liquibase/statement/core/AddPrimaryKeyStatement.java
+++ b/liquibase-core/src/main/java/liquibase/statement/core/AddPrimaryKeyStatement.java
@@ -1,6 +1,8 @@
 package liquibase.statement.core;
 
+import liquibase.change.ColumnConfig;
 import liquibase.statement.AbstractSqlStatement;
+import liquibase.util.StringUtils;
 
 public class AddPrimaryKeyStatement extends AbstractSqlStatement {
 
@@ -8,7 +10,7 @@ public class AddPrimaryKeyStatement extends AbstractSqlStatement {
     private String schemaName;
     private String tableName;
     private String tablespace;
-    private String columnNames;
+    private ColumnConfig[] columns;
     private String constraintName;
     private Boolean clustered;
 
@@ -17,11 +19,11 @@ public class AddPrimaryKeyStatement extends AbstractSqlStatement {
     private String forIndexCatalogName;
     private boolean shouldValidate = true;
 
-    public AddPrimaryKeyStatement(String catalogName, String schemaName, String tableName, String columnNames, String constraintName) {
+    public AddPrimaryKeyStatement(String catalogName, String schemaName, String tableName, ColumnConfig[] columns, String constraintName) {
         this.catalogName = catalogName;
         this.schemaName = schemaName;
         this.tableName = tableName;
-        this.columnNames = columnNames;
+        this.columns = columns;
         this.constraintName = constraintName;
     }
 
@@ -46,9 +48,19 @@ public class AddPrimaryKeyStatement extends AbstractSqlStatement {
         return this;
     }
 
-    public String getColumnNames() {
-        return columnNames;
+    public ColumnConfig[] getColumns() {
+        return columns;
     }
+
+    public String getColumnNames() {
+        return StringUtils.join(columns, ", ", new StringUtils.StringUtilsFormatter<ColumnConfig>() {
+            @Override
+            public String toString(ColumnConfig obj) {
+                return obj.getName() + (obj.getDescending() != null && obj.getDescending() ? " DESC" : "");
+            }
+        });
+    }
+
 
     public String getConstraintName() {
         return constraintName;

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/cockroachdb/CockroachDBIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/cockroachdb/CockroachDBIntegrationTest.java
@@ -11,6 +11,7 @@ import liquibase.statement.core.RawSqlStatement;
 import liquibase.structure.core.Column;
 import liquibase.structure.core.PrimaryKey;
 import liquibase.structure.core.Table;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
@@ -26,6 +27,7 @@ public class CockroachDBIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Override
+    @Before
     public void setUp() throws Exception {
         super.setUp();
 
@@ -98,5 +100,13 @@ public class CockroachDBIntegrationTest extends AbstractIntegrationTest {
         assertNull(columns.get(1).getDescending());
         assertEquals("c", columns.get(2).getName());
         assertTrue(columns.get(2).getDescending());
+    }
+
+    @Test
+    @Override
+    public void testRunUpdateOnOldChangelogTableFormat() throws Exception {
+        // This test is skipped because CockroachDB doesn't allow the columns of the same table to be altered
+        // concurrently.
+        // See https://github.com/cockroachdb/cockroach/issues/47137
     }
 }

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/cockroachdb/CockroachDBIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/cockroachdb/CockroachDBIntegrationTest.java
@@ -1,36 +1,60 @@
 package liquibase.dbtest.cockroachdb;
 
-import liquibase.CatalogAndSchema;
 import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
 import liquibase.dbtest.AbstractIntegrationTest;
-import liquibase.exception.DatabaseException;
 import liquibase.executor.ExecutorService;
-import liquibase.logging.LogService;
-import liquibase.logging.LogType;
 import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.SnapshotControl;
 import liquibase.snapshot.SnapshotGeneratorFactory;
 import liquibase.statement.core.RawSqlStatement;
 import liquibase.structure.core.Column;
 import liquibase.structure.core.PrimaryKey;
-import liquibase.structure.core.Schema;
 import liquibase.structure.core.Table;
 import org.junit.Test;
 
-import java.sql.SQLSyntaxErrorException;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
 
 public class CockroachDBIntegrationTest extends AbstractIntegrationTest {
 
     public CockroachDBIntegrationTest() throws Exception {
         super("cockroachdb", DatabaseFactory.getInstance().getDatabase("cockroachdb"));
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        ((JdbcConnection) getDatabase().getConnection()).getUnderlyingConnection().createStatement().executeUpdate(
+                "CREATE USER IF NOT EXISTS lbuser"
+        );
+        ((JdbcConnection) getDatabase().getConnection()).getUnderlyingConnection().createStatement().executeUpdate(
+                "CREATE DATABASE IF NOT EXISTS lbcat"
+        );
+        ((JdbcConnection) getDatabase().getConnection()).getUnderlyingConnection().createStatement().executeUpdate(
+                "CREATE DATABASE IF NOT EXISTS lbcat2"
+        );
+        // Create schemas for tests testRerunDiffChangeLogAltSchema
+        ((JdbcConnection) getDatabase().getConnection()).getUnderlyingConnection().createStatement().executeUpdate(
+                "CREATE SCHEMA IF NOT EXISTS lbcat2"
+        );
+        ((JdbcConnection) getDatabase().getConnection()).getUnderlyingConnection().createStatement().executeUpdate(
+                "GRANT ALL PRIVILEGES ON DATABASE lbcat TO lbuser"
+        );//
+        ((JdbcConnection) getDatabase().getConnection()).getUnderlyingConnection().createStatement().executeUpdate(
+                "GRANT ALL PRIVILEGES ON DATABASE lbcat2 TO lbuser"
+        );
+        // Create schemas for tests testRerunDiffChangeLogAltSchema
+        ((JdbcConnection) getDatabase().getConnection()).getUnderlyingConnection().createStatement().executeUpdate(
+                "GRANT ALL PRIVILEGES ON SCHEMA lbcat2 TO lbuser"
+        );
+
+        getDatabase().commit();
+
     }
 
     @Override

--- a/liquibase-integration-tests/src/test/java/liquibase/statementexecute/AddUniqueConstraintExecutorTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/statementexecute/AddUniqueConstraintExecutorTest.java
@@ -104,6 +104,7 @@ public class AddUniqueConstraintExecutorTest extends AbstractExecuteTest {
         assertCorrect("alter table \"adduqtest\" add constraint uq_test unique (\"coltomakeuq\")", PostgresDatabase.class, CockroachDatabase.class);
         assertCorrect("alter table adduqtest add constraint uq_test unique (coltomakeuq)", DerbyDatabase.class);
         assertCorrect("alter table [adduqtest] add constraint [uq_test] unique ([coltomakeuq])");
+        assertCorrect(" alter table adduqtest add constraint \"primary\" primary key (id ASC, coltomakeuq DESC)", CockroachDatabase.class);
     }
 
     @SuppressWarnings("unchecked")

--- a/liquibase-integration-tests/src/test/resources/changelogs/cockroachdb/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/cockroachdb/complete/root.changelog.xml
@@ -297,7 +297,7 @@
     <changeSet id="50" author="rafiss" runInTransaction="false">
         <sql>SET enable_experimental_alter_column_type_general = true</sql>
         <modifyDataType tableName="address" columnName="postalcode" newDataType="varchar(20)"/>
-    </changeSet>    
+    </changeSet>
 
     <include file="changelogs/cockroachdb/complete/included.changelog.xml"/>
 
@@ -319,7 +319,7 @@
     </changeSet>
     <changeSet id="58" author="nvoxland">
         <customChange class="liquibase.change.custom.ExampleCustomTaskChange" helloTo="world"/>
-    </changeSet>    
+    </changeSet>
 
     <changeSet id="60" author="nvoxland">
         <executeCommand executable="getmac" os="Windows XP">
@@ -334,7 +334,7 @@
             <column name="bigSerialColumn" type="bigserial"/>
             <column name="bitVarColumn" type="bit varying(10)"/>
             <column name="doubleColumn" type="double precision"/>
-            <column name="realColumn" type="real"/>            
+            <column name="realColumn" type="real"/>
         </createTable>
     </changeSet>
 

--- a/liquibase-integration-tests/src/test/resources/changelogs/cockroachdb/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/cockroachdb/complete/root.changelog.xml
@@ -166,10 +166,10 @@
 
     <changeSet id="19" author="nvoxland">
         <createView viewName="personView">
-            select id, firstname, lastname from public.person
+            select id, firstname, lastname from person
         </createView>
         <createView viewName="personView" replaceIfExists="true">
-            select id, firstname, lastname from public.person
+            select id, firstname, lastname from person
         </createView>
     </changeSet>
 

--- a/liquibase-integration-tests/src/test/resources/changelogs/cockroachdb/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/cockroachdb/complete/root.changelog.xml
@@ -291,7 +291,7 @@
     </changeSet>
 
     <changeSet id="35" author="nvoxland">
-        <sql>DROP INDEX defaultdb.uq_address_line1line2 CASCADE</sql>
+        <sql>DROP INDEX uq_address_line1line2 CASCADE</sql>
     </changeSet>
 
     <changeSet id="50" author="rafiss" runInTransaction="false">

--- a/liquibase-integration-tests/src/test/resources/changelogs/cockroachdb/rollback/rollbackable.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/cockroachdb/rollback/rollbackable.changelog.xml
@@ -122,11 +122,13 @@
         </createTable>
     </changeSet>
 
-    <changeSet id="17" author="nvoxland">
+    <!-- CockroachDB (as of 20.2) does not support dropping a primary key. -->
+    <!-- https://github.com/cockroachdb/cockroach/issues/48026 -->
+<!--    <changeSet id="17" author="nvoxland">-->
         <!-- CockroachDB has an issue where the PK constraint always is named primary, even if another name is specified -->
         <!-- https://github.com/cockroachdb/cockroach/issues/52833 -->
-        <addPrimaryKey tableName="page" columnNames="id" constraintName="primary"/>
-    </changeSet>
+<!--        <addPrimaryKey tableName="page" columnNames="id" constraintName="primary"/>-->
+<!--    </changeSet>-->
 
     <changeSet id="18" author="nvoxland">
         <addUniqueConstraint tableName="publication" columnNames="title" constraintName="uq_publication_title"/>

--- a/liquibase-integration-tests/src/test/resources/changelogs/cockroachdb/rollback/rollbackable.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/cockroachdb/rollback/rollbackable.changelog.xml
@@ -123,7 +123,9 @@
     </changeSet>
 
     <changeSet id="17" author="nvoxland">
-        <addPrimaryKey tableName="page" columnNames="id" constraintName="pk_page"/>
+        <!-- CockroachDB has an issue where the PK constraint always is named primary, even if another name is specified -->
+        <!-- https://github.com/cockroachdb/cockroach/issues/52833 -->
+        <addPrimaryKey tableName="page" columnNames="id" constraintName="primary"/>
     </changeSet>
 
     <changeSet id="18" author="nvoxland">


### PR DESCRIPTION
* Create test database and schemas in integration test setup
* Make AddPrimaryKeyStatement account for DESC primary key
* Use DROP INDEX to drop unique constraints in CockroachDB
* Fix CREATE VIEW test changeset to not reference a different schema
* Skip rollback PK test for CockroachDB
* Stop referencing DB explicitly in CockroachDB test changeset
* Skip CockroachDB testRunUpdateOnOldChangelogTableFormat

┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-856) by [Unito](https://www.unito.io/learn-more)
