### PR TITLE
fix-1499: allow custom LogService implementation

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -273,8 +273,7 @@ public class Main {
                     java.util.logging.Logger liquibaseLogger = java.util.logging.Logger.getLogger("liquibase");
                     liquibaseLogger.setParent(rootLogger);
 
-                    final JavaLogService logService = (JavaLogService) Scope.getCurrentScope().get(Scope.Attr.logService, LogService.class);
-                    logService.setParent(liquibaseLogger);
+                    final LogService logService = Scope.getCurrentScope().get(Scope.Attr.logService, LogService.class);
 
                     if (main.logLevel == null) {
                         String defaultLogLevel = System.getProperty("liquibase.log.level");


### PR DESCRIPTION
The Liquibase CLI is expecting the default LogService implementation - JavaLogService.
This commit allows the use of custom LogService implementation.

- - -
name: Pull Request
about: fix cast exception using a gradle task for the liquibase's command line command
title: 'Issues with the logger cast #1499'
labels: Status:Discovery
assignees: 'EEM86'

- - -
<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->

## Environment
**Liquibase Version**: 4.1.2

**Liquibase Integration & Version**: maven

**Liquibase Extension(s) & Version**: 

**Database Vendor & Version**: h2

**Operating System Type & Version**: Windows 10 Pro

## Pull Request Type
<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->

* [x] Bug fix (non-breaking change which fixes an issue.)
* [ ] Enhancement/New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
Error on implementation a gradle task using liquibase's command line command. [Example of an issue](https://github.com/mattbertolini/liquibase-slf4j/issues/11)

## Steps To Reproduce
   Create a gradle task using liquibase command line:

```
 tasks.register<JavaExec>("liquibaseDiffChangelog") {
     description = "Runs Liquidbase diff between schema and current changeSet"
     group = "liquibase"
     classpath = sourceSets["main"].runtimeClasspath + configurations["liquidbase"]
     main = "liquibase.integration.commandline.Main"

     args("--changeLogFile=" + project.projectDir.toString() + "/src/main/resources/changelog-changesets.xml")
     args("--referenceUrl=hibernate:spring:**redacted**?dialect=org.hibernate.dialect.MySQL57Dialect")
     args("--username=sa")
     args("--password=sa")
     args("--url=jdbc:mysql://localhost:3306/**redacted**?useSSL=false&nullNamePatternMatchesAll=true")
     args("--driver=com.mysql.cj.jdbc.Driver")
     args("diffChangeLog")
 }
```

Task will fail with java.lang.ClassCastException

## Actual Behavior
```
    2020-10-13 16:38:12.850 [main   ] ERROR l.integration.commandline.Main$1 - Unexpected error running Liquibase: class com.mattbertolini.liquibase.logging.slf4j.Slf4jLogService cannot be cast to class liquibase.logging.core.JavaLogService (com.mattbertolini.liquibase.logging.slf4j.Slf4jLogService and liquibase.logging.core.JavaLogService are in unnamed module of loader 'app')
java.lang.ClassCastException: class com.mattbertolini.liquibase.logging.slf4j.Slf4jLogService cannot be cast to class liquibase.logging.core.JavaLogService (com.mattbertolini.liquibase.logging.slf4j.Slf4jLogService and liquibase.logging.core.JavaLogService are in unnamed module of loader 'app')
```

## Expected/Desired Behavior
The task will finish with success.

## Additional Context
Changes will affect the possibility for set a parent to the LogService. But according to the further code, such parent object will not required, only filters will be set to the root loger in `setLevel(LogService logService, java.util.logging.Logger rootLogger, java.util.logging.Logger liquibaseLogger, Level level)`.

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->

* [x] Build is successful and all new and existing tests pass
* [x] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
* [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
* [ ] Documentation Updated

