### PR TITLE
resolved issue #1529 by parsing yml property files as yml

### DIFF
--- a/liquibase-maven-plugin/src/test/java/org/liquibase/maven/plugins/LiquibaseUpdateMojoTest.java
+++ b/liquibase-maven-plugin/src/test/java/org/liquibase/maven/plugins/LiquibaseUpdateMojoTest.java
@@ -1,8 +1,9 @@
 package org.liquibase.maven.plugins;
 
+import org.apache.commons.io.FileUtils;
 import org.codehaus.plexus.configuration.PlexusConfiguration;
-import org.junit.Test;
 
+import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -20,7 +21,7 @@ public class LiquibaseUpdateMojoTest extends AbstractLiquibaseMojoTest {
   private static final Map<String, Object> DIRECTORY_PROPERTIES;
 
   static {
-    DEFAULT_PROPERTIES = new HashMap<String, Object>();
+    DEFAULT_PROPERTIES = new HashMap<>();
     DEFAULT_PROPERTIES.put("changeLogFile", "org/liquibase/changelog.xml");
     DEFAULT_PROPERTIES.put("driver", "com.mysql.cj.jdbc.Driver");
     DEFAULT_PROPERTIES.put("url", "jdbc:mysql://localhost/eformat");
@@ -31,7 +32,7 @@ public class LiquibaseUpdateMojoTest extends AbstractLiquibaseMojoTest {
     DEFAULT_PROPERTIES.put("outputDefaultCatalog", false);
     DEFAULT_PROPERTIES.put("outputFileEncoding", "UTF-8");
 
-    DIRECTORY_PROPERTIES = new HashMap<String, Object>();
+    DIRECTORY_PROPERTIES = new HashMap<>();
     DIRECTORY_PROPERTIES.put("changeLogDirectory", "org/liquibase/");
     DIRECTORY_PROPERTIES.put("changeLogFile", "changelog.xml");
     DIRECTORY_PROPERTIES.put("driver", "com.mysql.jdbc.Driver");
@@ -48,127 +49,149 @@ public class LiquibaseUpdateMojoTest extends AbstractLiquibaseMojoTest {
 
   }
 
-//  public void testNoPropertiesFile() throws Exception {
-//    testCommonNoPropertiesFile(CONFIG_FILE, DEFAULT_PROPERTIES);
-//  }
-//
-//  public void testDirectoryNoPropertiesFile() throws Exception {
-//    testCommonNoPropertiesFile(DIRECTORY_CONFIG_FILE, DIRECTORY_PROPERTIES);
-//  }
-//
-//  private void testCommonNoPropertiesFile(String configFileName, Map<String, Object> properties) throws Exception {
-//    LiquibaseUpdate mojo = createUpdateMojo(configFileName);
-//    // Clear out any settings for the property file that may be set
-//    setVariableValueToObject(mojo, "propertyFile", null);
-//    setVariableValueToObject(mojo, "propertyFileWillOverride", false);
-//
-//    loadPropertiesFileIfPresent(mojo);
-//
-//    Map values = getVariablesAndValuesFromObject(mojo);
-//    checkValues(properties, values);
-//  }
-//
-//
-//  public void testOverrideAllWithPropertiesFile() throws Exception {
-//    testCommonOverideAllWithPropertiesFile(CONFIG_FILE);
-//  }
-//
-//  public void testDirectoryOverideAllWithPropertiesFile() throws Exception {
-//    testCommonOverideAllWithPropertiesFile(DIRECTORY_CONFIG_FILE);
-//  }
-//
-//  private void testCommonOverideAllWithPropertiesFile(String configFileName) throws Exception {
-//    // Create the properties file for this test
-//    Properties props = new Properties();
-//    props.setProperty("driver", "properties_driver_value");
-//    props.setProperty("url", "properties_url_value");
-//    props.setProperty("username", "properties_user_value");
-//    props.setProperty("password", "properties_password_value");
-//    props.setProperty("changeLogFile", "properties_changeLogFile_value");
-//    createPropertiesFile("update/test.properties", props);
-//
-//    LiquibaseUpdate mojo = createUpdateMojo(configFileName);
-//    setVariableValueToObject(mojo, "propertyFile", "update/test.properties");
-//    setVariableValueToObject(mojo, "propertyFileWillOverride", true);
-//    loadPropertiesFileIfPresent(mojo);
-//
-//    Map values = super.getVariablesAndValuesFromObject(mojo);
-//    checkValues(props, values);
-//  }
-//
-//  public void testOverrideAllButDriverWithPropertiesFile() throws Exception {
-//    testCommonOverrideAllButDriverWithPropertiesFile(CONFIG_FILE, DEFAULT_PROPERTIES);
-//  }
-//
-//  public void testDirectoryOverrideAllButDriverWithPropertiesFile() throws Exception {
-//    testCommonOverrideAllButDriverWithPropertiesFile(DIRECTORY_CONFIG_FILE, DIRECTORY_PROPERTIES);
-//  }
-//
-//  public void testCommonOverrideAllButDriverWithPropertiesFile(String configFileName, Map<String, Object> properties) throws Exception {
-//    // Create the properties file for this test
-//    Properties props = new Properties();
-//    props.setProperty("url", "properties_url_value");
-//    props.setProperty("username", "properties_user_value");
-//    props.setProperty("password", "properties_password_value");
-//    props.setProperty("changeLogDirectory", "properties_changeLogDirectory_value");
-//    props.setProperty("changeLogFile", "properties_changeLogFile_value");
-//    createPropertiesFile("update/test.properties", props);
-//
-//    LiquibaseUpdate mojo = createUpdateMojo(configFileName);
-//    setVariableValueToObject(mojo, "propertyFile", "update/test.properties");
-//    setVariableValueToObject(mojo, "propertyFileWillOverride", true);
-//    loadPropertiesFileIfPresent(mojo);
-//
-//    Map values = getVariablesAndValuesFromObject(mojo);
-//    checkValues(props, values);
-//
-//    // Ensure that the properties file has not overridden the driver value as it was not
-//    // specified in the properties.
-//    assertEquals("Driver should be set to the default value",
-//        properties.get("driver"),
-//                 values.get("driver"));
-//  }
-//
-//  public void testPropertiesFilePresentWithNoOverrideAndMissingProperty() throws Exception {
-//    testCommonPropertiesFilePresentWithNoOverrideAndMissingProperty(CONFIG_FILE, DEFAULT_PROPERTIES);
-//  }
-//
-//  public void testDirectoryPropertiesFilePresentWithNoOverrideAndMissingProperty() throws Exception {
-//    testCommonPropertiesFilePresentWithNoOverrideAndMissingProperty(DIRECTORY_CONFIG_FILE, DIRECTORY_PROPERTIES);
-//  }
-//
-//  public void testCommonPropertiesFilePresentWithNoOverrideAndMissingProperty(String configFileName, Map<String, Object> properties) throws Exception {
-//    // Create the properties file for this test
-//    Properties props = new Properties();
-//    props.setProperty("url", "properties_url_value");
-//    props.setProperty("username", "properties_user_value");
-//    props.setProperty("password", "properties_password_value");
-//    props.setProperty("changeLogDirectory", "properties_changeLogDirectory_value");
-//    props.setProperty("changeLogFile", "properties_changeLogFile_value");
-//    createPropertiesFile("update/test.properties", props);
-//
-//    LiquibaseUpdate mojo = createUpdateMojo(configFileName);
-//    setVariableValueToObject(mojo, "propertyFile", "update/test.properties");
-//    setVariableValueToObject(mojo, "propertyFileWillOverride", false);
-//    loadPropertiesFileIfPresent(mojo);
-//
-//    Map values = super.getVariablesAndValuesFromObject(mojo);
-//    // The password is not specified in the configuration XML so we expect the password
-//    // from the properties file to be injected into the mojo.
-//    Map expected = new HashMap<String, Object>(properties);
-//    expected.put("password", props.getProperty("password"));
-//    checkValues(expected, values);
-//  }
-//
-//
-//  /*-------------------------------------------------------------------------*\
-//   * PRIVATE METHODS
-//  \*-------------------------------------------------------------------------*/
-//
-//  private LiquibaseUpdate createUpdateMojo(String configFileName) throws Exception {
-//    LiquibaseUpdate mojo = new LiquibaseUpdate();
-//    PlexusConfiguration config = loadConfiguration(configFileName);
-//    configureMojo(mojo, config);
-//    return mojo;
-//  }
+  public void testNoPropertiesFile() throws Exception {
+    testCommonNoPropertiesFile(CONFIG_FILE, DEFAULT_PROPERTIES);
+  }
+
+  public void testDirectoryNoPropertiesFile() throws Exception {
+    testCommonNoPropertiesFile(DIRECTORY_CONFIG_FILE, DIRECTORY_PROPERTIES);
+  }
+
+  private void testCommonNoPropertiesFile(String configFileName, Map<String, Object> properties) throws Exception {
+    LiquibaseUpdate mojo = createUpdateMojo(configFileName);
+    // Clear out any settings for the property file that may be set
+    setVariableValueToObject(mojo, "propertyFile", null);
+    setVariableValueToObject(mojo, "propertyFileWillOverride", false);
+
+    loadPropertiesFileIfPresent(mojo);
+
+    Map<String, Object> values = getVariablesAndValuesFromObject(mojo);
+    checkValues(properties, values);
+  }
+
+
+  public void testOverrideAllWithPropertiesFile() throws Exception {
+    testCommonOverideAllWithPropertiesFile(CONFIG_FILE);
+  }
+
+  public void testDirectoryOverideAllWithPropertiesFile() throws Exception {
+    testCommonOverideAllWithPropertiesFile(DIRECTORY_CONFIG_FILE);
+  }
+
+  private void testCommonOverideAllWithPropertiesFile(String configFileName) throws Exception {
+    // Create the properties file for this test
+    Properties props = new Properties();
+    props.setProperty("driver", "properties_driver_value");
+    props.setProperty("url", "properties_url_value");
+    props.setProperty("username", "properties_user_value");
+    props.setProperty("password", "properties_password_value");
+    props.setProperty("changeLogFile", "properties_changeLogFile_value");
+    createPropertiesFile("update/test.properties", props);
+
+    LiquibaseUpdate mojo = createUpdateMojo(configFileName);
+    setVariableValueToObject(mojo, "propertyFile", "update/test.properties");
+    setVariableValueToObject(mojo, "propertyFileWillOverride", true);
+    loadPropertiesFileIfPresent(mojo);
+
+    Map<String, Object> values = super.getVariablesAndValuesFromObject(mojo);
+    checkValues(props, values);
+  }
+
+  public void testOverrideAllButDriverWithPropertiesFile() throws Exception {
+    testCommonOverrideAllButDriverWithPropertiesFile(CONFIG_FILE, DEFAULT_PROPERTIES);
+  }
+
+  public void testDirectoryOverrideAllButDriverWithPropertiesFile() throws Exception {
+    testCommonOverrideAllButDriverWithPropertiesFile(DIRECTORY_CONFIG_FILE, DIRECTORY_PROPERTIES);
+  }
+
+  private void testCommonOverrideAllButDriverWithPropertiesFile(String configFileName, Map<String, Object> properties) throws Exception {
+    // Create the properties file for this test
+    Properties props = new Properties();
+    props.setProperty("url", "properties_url_value");
+    props.setProperty("username", "properties_user_value");
+    props.setProperty("password", "properties_password_value");
+    props.setProperty("changeLogDirectory", "properties_changeLogDirectory_value");
+    props.setProperty("changeLogFile", "properties_changeLogFile_value");
+    createPropertiesFile("update/test.properties", props);
+
+    LiquibaseUpdate mojo = createUpdateMojo(configFileName);
+    setVariableValueToObject(mojo, "propertyFile", "update/test.properties");
+    setVariableValueToObject(mojo, "propertyFileWillOverride", true);
+    loadPropertiesFileIfPresent(mojo);
+
+    Map<String, Object> values = getVariablesAndValuesFromObject(mojo);
+    checkValues(props, values);
+
+    // Ensure that the properties file has not overridden the driver value as it was not
+    // specified in the properties.
+    assertEquals("Driver should be set to the default value",
+        properties.get("driver"),
+                 values.get("driver"));
+  }
+
+  public void testPropertiesFilePresentWithNoOverrideAndMissingProperty() throws Exception {
+    testCommonPropertiesFilePresentWithNoOverrideAndMissingProperty(CONFIG_FILE, DEFAULT_PROPERTIES);
+  }
+
+  public void testDirectoryPropertiesFilePresentWithNoOverrideAndMissingProperty() throws Exception {
+    testCommonPropertiesFilePresentWithNoOverrideAndMissingProperty(DIRECTORY_CONFIG_FILE, DIRECTORY_PROPERTIES);
+  }
+
+  private void testCommonPropertiesFilePresentWithNoOverrideAndMissingProperty(String configFileName, Map<String, Object> properties) throws Exception {
+    // Create the properties file for this test
+    Properties props = new Properties();
+    props.setProperty("url", "properties_url_value");
+    props.setProperty("username", "properties_user_value");
+    props.setProperty("password", "properties_password_value");
+    props.setProperty("changeLogDirectory", "properties_changeLogDirectory_value");
+    props.setProperty("changeLogFile", "properties_changeLogFile_value");
+    createPropertiesFile("update/test.properties", props);
+
+    LiquibaseUpdate mojo = createUpdateMojo(configFileName);
+    setVariableValueToObject(mojo, "propertyFile", "update/test.properties");
+    setVariableValueToObject(mojo, "propertyFileWillOverride", false);
+    loadPropertiesFileIfPresent(mojo);
+
+    Map<String, Object> values = super.getVariablesAndValuesFromObject(mojo);
+    // The password is not specified in the configuration XML so we expect the password
+    // from the properties file to be injected into the mojo.
+    Map<String, Object> expected = new HashMap<>(properties);
+    expected.put("password", props.getProperty("password"));
+    checkValues(expected, values);
+  }
+
+  public void testYamlProperties() throws Exception{
+      String yamlContent = "" +
+              "first:\n" +
+              "  nested:\n" +
+              "    username: first-nested-username\n" +
+              "username: correct-username\n" +
+              "second:\n" +
+              "  nested:\n" +
+              "    username: second-nested-username\n" +
+              "inline.nested.username: inline-nested-username";
+      String propertiesYamlName = "update/properties.yml";
+      FileUtils.writeStringToFile(new File(getBasedir(), "/target/test-classes/" + propertiesYamlName), yamlContent);
+      LiquibaseUpdate mojo = createUpdateMojo(CONFIG_FILE);
+      setVariableValueToObject(mojo, "propertyFile", propertiesYamlName);
+      setVariableValueToObject(mojo, "propertyFileWillOverride", true);
+
+      loadPropertiesFileIfPresent(mojo);
+
+      Map<String, Object> propertyValues = getVariablesAndValuesFromObject(mojo);
+      assertEquals("correct-username", propertyValues.get("username"));
+  }
+
+
+  /*-------------------------------------------------------------------------*\
+   * PRIVATE METHODS
+  \*-------------------------------------------------------------------------*/
+
+  private LiquibaseUpdate createUpdateMojo(String configFileName) throws Exception {
+    LiquibaseUpdate mojo = new LiquibaseUpdate();
+    PlexusConfiguration config = loadConfiguration(configFileName);
+    configureMojo(mojo, config);
+    return mojo;
+  }
 }


### PR DESCRIPTION
- - -
name: Pull Request
about: Create a report to help us improve
title: Maven Plugin -- bugfixing #1529 by parsing yml property files as yml
labels: Status:Discovery
assignees: ''

- - -
<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->

## Environment
**Liquibase Version**:
4.2.1-local-snapshot
**Liquibase Integration & Version**: <Pick one: CLI, maven, gradle, spring boot, servlet, etc.>
N/A
**Liquibase Extension(s) & Version**: 
N/A
**Database Vendor & Version**:
N/A
**Operating System Type & Version**:
N/A

## Pull Request Type
<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->
Closes #1529 

* [x] Bug fix (non-breaking change which fixes an issue.)
* [ ] Enhancement/New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
As described in #1529, yml property files are currently parsed as if they were "plain" key-value property files. Hierarchy is ignored. If a key (such as `username`) appears multiple times under multiple hierarchies, then each line is interpreted as a "duplicate" `username` key and only the last is applied. This is non-intuitive, and can create errors for apps using yml files for `propertyFile`.

## Steps To Reproduce
See the new test case in this PR.

Define a yml file like the below, and use it as a `propertyFile` for any arbitrary plugin execution.

```yaml
first:
  nested:
    username: first-nested-username
username: correct-username
second:
  nested:
    username: second-nested-username
inline.nested.username: inline-nested-username
```

## Actual Behavior
The property `username` will have value `second-nested-username`.

## Expected/Desired Behavior
Tthe property `username` will have value `correct-username`.

## Screenshots (if appropriate)
N/A

## Additional Context
N/A

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->

* [x] Build is successful and all new and existing tests pass
* [x] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
* [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
* [ ] Documentation Updated

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)

