### PR TITLE
Add standard file writing support to Liquibase

### DIFF
--- a/liquibase-core/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-core/src/main/java/liquibase/Liquibase.java
@@ -2125,7 +2125,7 @@ public class Liquibase implements AutoCloseable {
                     DBDocVisitor visitor = new DBDocVisitor(database);
                     logIterator.run(visitor, new RuntimeEnvironment(database, contexts, labelExpression));
 
-                    visitor.writeHTML(new File(outputDirectory), resourceAccessor);
+                    visitor.writeHTML(outputDirectory, resourceAccessor);
                 } catch (IOException e) {
                     throw new LiquibaseException(e);
                 } finally {

--- a/liquibase-core/src/main/java/liquibase/Scope.java
+++ b/liquibase-core/src/main/java/liquibase/Scope.java
@@ -11,7 +11,9 @@ import liquibase.logging.Logger;
 import liquibase.logging.core.JavaLogService;
 import liquibase.logging.core.LogServiceFactory;
 import liquibase.resource.ClassLoaderResourceAccessor;
+import liquibase.resource.FileSystemResouceWriter;
 import liquibase.resource.ResourceAccessor;
+import liquibase.resource.ResourceWriter;
 import liquibase.servicelocator.ServiceLocator;
 import liquibase.servicelocator.StandardServiceLocator;
 import liquibase.ui.ConsoleUIService;
@@ -39,6 +41,7 @@ public class Scope {
         logService,
         ui,
         resourceAccessor,
+        resourceWriter,
         classLoader,
         database,
         quotingStrategy,
@@ -111,6 +114,7 @@ public class Scope {
     private Scope() {
         values.put(Attr.logService.name(), new JavaLogService());
         values.put(Attr.resourceAccessor.name(), new ClassLoaderResourceAccessor());
+        values.put(Attr.resourceWriter.name(), new FileSystemResouceWriter());
         values.put(Attr.serviceLocator.name(), new StandardServiceLocator());
         values.put(Attr.ui.name(), new ConsoleUIService());
     }
@@ -343,6 +347,10 @@ public class Scope {
 
     public ResourceAccessor getResourceAccessor() {
         return get(Attr.resourceAccessor, ResourceAccessor.class);
+    }
+
+    public ResourceWriter getResourceWriter() {
+        return get(Attr.resourceWriter, ResourceWriter.class);
     }
 
     public String getLineSeparator() {

--- a/liquibase-core/src/main/java/liquibase/database/OfflineConnection.java
+++ b/liquibase-core/src/main/java/liquibase/database/OfflineConnection.java
@@ -162,7 +162,7 @@ public class OfflineConnection implements DatabaseConnection {
     }
 
     protected ChangeLogHistoryService createChangeLogHistoryService(Database database) {
-        return new OfflineChangeLogHistoryService(database, new File(changeLogFile),
+        return new OfflineChangeLogHistoryService(database, changeLogFile,
                 outputLiquibaseSql != OutputLiquibaseSql.NONE, // Output DML
                 outputLiquibaseSql == OutputLiquibaseSql.ALL   // Output DDL
         );

--- a/liquibase-core/src/main/java/liquibase/dbdoc/AuthorListWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/AuthorListWriter.java
@@ -1,10 +1,10 @@
 package liquibase.dbdoc;
 
-import java.io.File;
+import java.nio.file.Path;
 
 public class AuthorListWriter extends HTMLListWriter {
 
-    public AuthorListWriter(File outputDir) {
+    public AuthorListWriter(Path outputDir) {
         super("All Authors", "authors.html", "authors", outputDir);
     }
 

--- a/liquibase-core/src/main/java/liquibase/dbdoc/AuthorWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/AuthorWriter.java
@@ -3,15 +3,15 @@ package liquibase.dbdoc;
 import liquibase.change.Change;
 import liquibase.database.Database;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
+import java.nio.file.Path;
 import java.util.List;
 
 public class AuthorWriter extends HTMLWriter {
 
-    public AuthorWriter(File rootOutputDir, Database database) {
-        super(new File(rootOutputDir, "authors"), database);
+    public AuthorWriter(Path rootOutputDir, Database database) {
+        super(rootOutputDir.resolve("authors"), database);
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/dbdoc/ChangeLogListWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/ChangeLogListWriter.java
@@ -1,10 +1,10 @@
 package liquibase.dbdoc;
 
-import java.io.File;
+import java.nio.file.Path;
 
 public class ChangeLogListWriter extends HTMLListWriter {
 
-    public ChangeLogListWriter(File outputDir) {
+    public ChangeLogListWriter(Path outputDir) {
         super("All Change Logs", "changelogs.html", "changelogs", outputDir);
     }
 

--- a/liquibase-core/src/main/java/liquibase/dbdoc/ChangeLogWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/ChangeLogWriter.java
@@ -5,24 +5,28 @@ import liquibase.configuration.LiquibaseConfiguration;
 import liquibase.resource.ResourceAccessor;
 import liquibase.util.StreamUtil;
 
-import java.io.*;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 public class ChangeLogWriter {
-    protected File outputDir;
+    protected Path outputDir;
     private ResourceAccessor resourceAccessor;
     
-    public ChangeLogWriter(ResourceAccessor resourceAccessor, File rootOutputDir) {
-        this.outputDir = new File(rootOutputDir, "changelogs");
+    public ChangeLogWriter(ResourceAccessor resourceAccessor, Path rootOutputDir) {
+        this.outputDir = rootOutputDir.resolve("changelogs");
         this.resourceAccessor = resourceAccessor;
     }
     
     public void writeChangeLog(String changeLog, String physicalFilePath) throws IOException {
         String changeLogOutFile = changeLog.replace(":", "_");
-        File xmlFile = new File(outputDir, changeLogOutFile.toLowerCase() + ".html");
-        xmlFile.getParentFile().mkdirs();
+        Path xmlFile = outputDir.resolve(changeLogOutFile.toLowerCase() + ".html");
+        xmlFile.getParent().toFile().mkdirs();
         
-        BufferedWriter changeLogStream = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(xmlFile,
-        false), LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).getOutputEncoding()));
+        BufferedWriter changeLogStream = new BufferedWriter(new OutputStreamWriter(Files.newOutputStream(xmlFile), LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).getOutputEncoding()));
         try (InputStream stylesheet = resourceAccessor.openStream(null, physicalFilePath)) {
             if (stylesheet == null) {
                 throw new IOException("Can not find " + changeLog);

--- a/liquibase-core/src/main/java/liquibase/dbdoc/ColumnWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/ColumnWriter.java
@@ -3,16 +3,16 @@ package liquibase.dbdoc;
 import liquibase.change.Change;
 import liquibase.database.Database;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
+import java.nio.file.Path;
 import java.util.List;
 
 public class ColumnWriter extends HTMLWriter {
 
 
-    public ColumnWriter(File rootOutputDir, Database database) {
-        super(new File(rootOutputDir, "columns"), database);
+    public ColumnWriter(Path rootOutputDir, Database database) {
+        super(rootOutputDir.resolve("columns"), database);
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/dbdoc/HTMLListWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/HTMLListWriter.java
@@ -4,27 +4,32 @@ import liquibase.configuration.GlobalConfiguration;
 import liquibase.configuration.LiquibaseConfiguration;
 import liquibase.util.StringUtil;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.SortedSet;
 
 public class HTMLListWriter {
-    private File outputDir;
+    private Path outputDir;
     private String directory;
     private String filename;
     private String title;
 
-    public HTMLListWriter(String title, String filename, String subdir, File outputDir) {
+    public HTMLListWriter(String title, String filename, String subdir, Path outputDir) {
         this.title = title;
         this.outputDir = outputDir;
         this.filename = filename;
-        if (!outputDir.exists()) {
-            outputDir.mkdir();
+
+        if (!Files.exists(outputDir)) {
+            outputDir.toFile().mkdirs();
         }
         this.directory = subdir;
     }
 
     public void writeHTML(SortedSet objects) throws IOException {
-        Writer fileWriter = new OutputStreamWriter(new FileOutputStream(new File(outputDir, filename)), LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).getOutputEncoding());
+        Writer fileWriter = new OutputStreamWriter(Files.newOutputStream(outputDir.resolve(filename)), LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).getOutputEncoding());
 
         try {
             fileWriter.append("<HTML>\n" + "<HEAD><meta charset=\"utf-8\"/>\n" + "<TITLE>\n");

--- a/liquibase-core/src/main/java/liquibase/dbdoc/HTMLWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/HTMLWriter.java
@@ -10,27 +10,31 @@ import liquibase.exception.DatabaseHistoryException;
 import liquibase.util.LiquibaseUtil;
 import liquibase.util.StringUtil;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.text.DateFormat;
 import java.util.Date;
 import java.util.List;
 
 public abstract class HTMLWriter {
-    protected File outputDir;
+    protected Path outputDir;
     protected Database database;
 
-    public HTMLWriter(File outputDir, Database database) {
+    public HTMLWriter(Path outputDir, Database database) {
         this.outputDir = outputDir;
         this.database = database;
-        if (!outputDir.exists()) {
-            outputDir.mkdirs();
+        if (!Files.exists(outputDir)) {
+            outputDir.toFile().mkdirs();
         }
     }
 
     protected abstract void writeCustomHTML(Writer fileWriter, Object object, List<Change> changes, Database database) throws IOException;
 
     private Writer createFileWriter(Object object) throws IOException {
-        return new OutputStreamWriter(new FileOutputStream(new File(outputDir, DBDocUtil.toFileName(object.toString().toLowerCase()) + ".html")), LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).getOutputEncoding());
+        return new OutputStreamWriter(Files.newOutputStream(outputDir.resolve(DBDocUtil.toFileName(object.toString().toLowerCase()) + ".html")), LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class).getOutputEncoding());
     }
 
     public void writeHTML(Object object, List<Change> ranChanges, List<Change> changesToRun, String changeLog) throws IOException, DatabaseHistoryException, DatabaseException {

--- a/liquibase-core/src/main/java/liquibase/dbdoc/PendingChangesWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/PendingChangesWriter.java
@@ -5,15 +5,15 @@ import liquibase.database.Database;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.DatabaseHistoryException;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
+import java.nio.file.Path;
 import java.util.List;
 
 public class PendingChangesWriter extends HTMLWriter {
 
-    public PendingChangesWriter(File rootOutputDir, Database database) {
-        super(new File(rootOutputDir, "pending"), database);
+    public PendingChangesWriter(Path rootOutputDir, Database database) {
+        super(rootOutputDir.resolve("pending"), database);
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/dbdoc/PendingSQLWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/PendingSQLWriter.java
@@ -13,17 +13,17 @@ import liquibase.executor.Executor;
 import liquibase.executor.ExecutorService;
 import liquibase.executor.LoggingExecutor;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
+import java.nio.file.Path;
 import java.util.List;
 
 public class PendingSQLWriter extends HTMLWriter {
 
     private DatabaseChangeLog databaseChangeLog;
 
-    public PendingSQLWriter(File rootOutputDir, Database database, DatabaseChangeLog databaseChangeLog) {
-        super(new File(rootOutputDir, "pending"), database);
+    public PendingSQLWriter(Path rootOutputDir, Database database, DatabaseChangeLog databaseChangeLog) {
+        super(rootOutputDir.resolve("pending"), database);
         this.databaseChangeLog = databaseChangeLog;
     }
 

--- a/liquibase-core/src/main/java/liquibase/dbdoc/RecentChangesWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/RecentChangesWriter.java
@@ -5,15 +5,15 @@ import liquibase.database.Database;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.DatabaseHistoryException;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
+import java.nio.file.Path;
 import java.util.List;
 
 public class RecentChangesWriter extends HTMLWriter {
 
-    public RecentChangesWriter(File rootOutputDir, Database database) {
-        super(new File(rootOutputDir, "recent"), database);
+    public RecentChangesWriter(Path rootOutputDir, Database database) {
+        super(rootOutputDir.resolve("recent"), database);
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/dbdoc/TableListWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/TableListWriter.java
@@ -1,10 +1,10 @@
 package liquibase.dbdoc;
 
-import java.io.File;
+import java.nio.file.Path;
 
 public class TableListWriter extends HTMLListWriter {
 
-    public TableListWriter(File outputDir) {
+    public TableListWriter(Path outputDir) {
         super("Current Tables", "currenttables.html", "tables", outputDir);
     }
 

--- a/liquibase-core/src/main/java/liquibase/dbdoc/TableWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/TableWriter.java
@@ -4,17 +4,17 @@ import liquibase.change.Change;
 import liquibase.database.Database;
 import liquibase.structure.core.*;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 public class TableWriter extends HTMLWriter {
 
-    public TableWriter(File rootOutputDir, Database database) {
-        super(new File(rootOutputDir, "tables"), database);
+    public TableWriter(Path rootOutputDir, Database database) {
+        super(rootOutputDir.resolve("tables"), database);
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingDataExternalFileChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingDataExternalFileChangeGenerator.java
@@ -1,5 +1,6 @@
 package liquibase.diff.output.changelog.core;
 
+import liquibase.Scope;
 import liquibase.change.Change;
 import liquibase.change.core.LoadDataChange;
 import liquibase.change.core.LoadDataColumnConfig;
@@ -18,7 +19,12 @@ import liquibase.util.ISODateFormat;
 import liquibase.util.JdbcUtils;
 import liquibase.util.csv.CSVWriter;
 
-import java.io.*;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -76,18 +82,18 @@ public class MissingDataExternalFileChangeGenerator extends MissingDataChangeGen
                 if (dataDir != null) {
                     fileName = dataDir + "/" + fileName;
 
-                    File parentDir = new File(dataDir);
-                    if (!parentDir.exists()) {
-                        parentDir.mkdirs();
+                    Path parentDir = Scope.getCurrentScope().getResourceWriter().getPath(dataDir);
+                    if (!Files.exists(parentDir)) {
+                        parentDir.toFile().mkdirs();
                     }
-                    if (!parentDir.isDirectory()) {
-                        throw new IOException(parentDir.getAbsolutePath() + " is not a valid directory");
+                    if (!Files.isDirectory(parentDir)) {
+                        throw new IOException(parentDir.toAbsolutePath().toString() + " is not a valid directory");
                     }
                 }
 
                 String[] dataTypes = new String[0];
                 try (
-                        FileOutputStream fileOutputStream = new FileOutputStream(fileName);
+                        OutputStream fileOutputStream = Files.newOutputStream(Scope.getCurrentScope().getResourceWriter().getPath(fileName));
                         OutputStreamWriter outputStreamWriter = new OutputStreamWriter(
                                 fileOutputStream,
                                 LiquibaseConfiguration.getInstance().getConfiguration(GlobalConfiguration.class)

--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -27,7 +27,6 @@ import liquibase.logging.LogMessageFilter;
 import liquibase.logging.LogService;
 import liquibase.logging.Logger;
 import liquibase.logging.core.JavaLogService;
-import liquibase.resource.ClassLoaderResourceAccessor;
 import liquibase.resource.CompositeResourceAccessor;
 import liquibase.resource.FileSystemResourceAccessor;
 import liquibase.resource.ResourceAccessor;
@@ -178,7 +177,7 @@ public class Main {
         for (String arg : args) {
             if (arg.startsWith("--")) {
                 String[] splitArg = arg.split("=", 2);
-                String argKey = "argument__"+splitArg[0].replaceFirst("^--", "");
+                String argKey = "argument__" + splitArg[0].replaceFirst("^--", "");
                 if (splitArg.length == 2) {
                     integrationDetails.setParameter(argKey, splitArg[1]);
                 } else {
@@ -215,7 +214,7 @@ public class Main {
                         main.command = "";
                         main.parseDefaultPropertyFiles();
                         Scope.getCurrentScope().getUI().sendMessage(CommandLineUtils.getBanner());
-                        Scope.getCurrentScope().getUI().sendMessage(String.format(coreBundle.getString("version.number"), LiquibaseUtil.getBuildVersion() ));
+                        Scope.getCurrentScope().getUI().sendMessage(String.format(coreBundle.getString("version.number"), LiquibaseUtil.getBuildVersion()));
 
                         LicenseService licenseService = Scope.getCurrentScope().getSingleton(LicenseServiceFactory.class).getLicenseService();
                         if (licenseService != null && main.liquibaseProLicenseKey != null) {
@@ -316,19 +315,19 @@ public class Main {
                             LicenseInstallResult result = licenseService.installLicense(licenseKeyLocation);
                             if (result.code != 0) {
                                 String allMessages = String.join("\n", result.messages);
-                                Scope.getCurrentScope().getUI().sendMessage( allMessages);
+                                Scope.getCurrentScope().getUI().sendMessage(allMessages);
                             } else {
                                 main.liquibaseProLicenseValid = true;
                             }
                         }
 
-                       //
-                       // Check to see if we have an expired license
-                       //
-                       if (licenseService.daysTilExpiration() < 0) {
-                           main.liquibaseProLicenseValid = false;
-                       }
-                       Scope.getCurrentScope().getUI().sendMessage(licenseService.getLicenseInfo());
+                        //
+                        // Check to see if we have an expired license
+                        //
+                        if (licenseService.daysTilExpiration() < 0) {
+                            main.liquibaseProLicenseValid = false;
+                        }
+                        Scope.getCurrentScope().getUI().sendMessage(licenseService.getLicenseInfo());
                     }
 
                     Scope.getCurrentScope().getUI().sendMessage(CommandLineUtils.getBanner());
@@ -357,7 +356,7 @@ public class Main {
                     }
 
                     main.applyDefaults();
-                    Scope.child(Scope.Attr.resourceAccessor, new ClassLoaderResourceAccessor(main.configureClassLoader()), () -> {
+                    Scope.child(Scope.Attr.resourceAccessor, main.getResourceAccessor(), () -> {
                         main.doMigration();
 
                         if (COMMANDS.UPDATE.equals(main.command)) {
@@ -399,9 +398,9 @@ public class Main {
                 }
 
                 if (isHubEnabled(main.command) &&
-                    LiquibaseConfiguration.getInstance().getConfiguration(HubConfiguration.class).getLiquibaseHubApiKey() != null &&
-                    !Scope.getCurrentScope().getSingleton(HubServiceFactory.class).isOnline()) {
-                    ui.sendMessage("WARNING: The command "+main.command+" operations were not synced with your Liquibase Hub account because: " + StringUtil.lowerCaseFirst(Scope.getCurrentScope().getSingleton(HubServiceFactory.class).getOfflineReason()));
+                        LiquibaseConfiguration.getInstance().getConfiguration(HubConfiguration.class).getLiquibaseHubApiKey() != null &&
+                        !Scope.getCurrentScope().getSingleton(HubServiceFactory.class).isOnline()) {
+                    ui.sendMessage("WARNING: The command " + main.command + " operations were not synced with your Liquibase Hub account because: " + StringUtil.lowerCaseFirst(Scope.getCurrentScope().getSingleton(HubServiceFactory.class).getOfflineReason()));
                 }
 
                 return 0;
@@ -413,7 +412,7 @@ public class Main {
         if (main.command.toLowerCase().startsWith(COMMANDS.REGISTER_CHANGELOG.toLowerCase())) {
             return false;
         }
-        if (! main.commandParams.contains("--help")) {
+        if (!main.commandParams.contains("--help")) {
             return true;
         }
         return !main.command.toLowerCase().startsWith(COMMANDS.ROLLBACK_ONE_CHANGE_SET.toLowerCase()) &&
@@ -497,28 +496,25 @@ public class Main {
      *
      * @param command the command to check
      * @return true if this command has Hub integration false if not
-     *
      */
     private static boolean isHubEnabled(String command) {
         return COMMANDS.CHANGELOG_SYNC_SQL.equalsIgnoreCase(command)
-            || COMMANDS.UPDATE_COUNT.equalsIgnoreCase(command)
-            || COMMANDS.UPDATE_TO_TAG.equalsIgnoreCase(command)
-            || COMMANDS.UPDATE.equalsIgnoreCase(command)
-            || COMMANDS.ROLLBACK.equalsIgnoreCase(command)
-            || COMMANDS.ROLLBACK_TO_DATE.equalsIgnoreCase(command)
-            || COMMANDS.ROLLBACK_COUNT.equalsIgnoreCase(command)
-            || COMMANDS.ROLLBACK_ONE_CHANGE_SET.equalsIgnoreCase(command)
-            || COMMANDS.ROLLBACK_ONE_UPDATE.equalsIgnoreCase(command)
-            || COMMANDS.DROP_ALL.equalsIgnoreCase(command);
+                || COMMANDS.UPDATE_COUNT.equalsIgnoreCase(command)
+                || COMMANDS.UPDATE_TO_TAG.equalsIgnoreCase(command)
+                || COMMANDS.UPDATE.equalsIgnoreCase(command)
+                || COMMANDS.ROLLBACK.equalsIgnoreCase(command)
+                || COMMANDS.ROLLBACK_TO_DATE.equalsIgnoreCase(command)
+                || COMMANDS.ROLLBACK_COUNT.equalsIgnoreCase(command)
+                || COMMANDS.ROLLBACK_ONE_CHANGE_SET.equalsIgnoreCase(command)
+                || COMMANDS.ROLLBACK_ONE_UPDATE.equalsIgnoreCase(command)
+                || COMMANDS.DROP_ALL.equalsIgnoreCase(command);
     }
 
     /**
-     *
      * Returns true if the given command requires stdout
      *
      * @param command the command to check
      * @return true if stdout needs for a command, false if not
-     *
      */
     private static boolean isStandardOutputRequired(String command) {
         return COMMANDS.SNAPSHOT.equalsIgnoreCase(command)
@@ -1013,18 +1009,17 @@ public class Main {
                     // then set the property value
                     //
                     final String[] splitKey = ((String) entry.getKey()).split("\\.", 3);
-                    String namespace="";
-                    for (int i=0; i < splitKey.length-1; i++) {
-                        if (! namespace.equals("")) {
+                    String namespace = "";
+                    for (int i = 0; i < splitKey.length - 1; i++) {
+                        if (!namespace.equals("")) {
                             namespace += ".";
                         }
                         namespace += splitKey[i];
                     }
-                    String valueKey = splitKey[splitKey.length-1];
+                    String valueKey = splitKey[splitKey.length - 1];
                     try {
                         LiquibaseConfiguration.getInstance().getConfiguration(namespace).setValue(valueKey, entry.getValue());
-                    }
-                    catch (Exception e) {
+                    } catch (Exception e) {
                         if (strict) {
                             throw new CommandLineParsingException(
                                     String.format(coreBundle.getString("parameter.unknown"), entry.getKey())
@@ -1036,7 +1031,7 @@ public class Main {
                         }
                     }
                 } else {
-                    Field field = getDeclaredField((String)entry.getKey());
+                    Field field = getDeclaredField((String) entry.getKey());
                     Object currentValue = field.get(this);
 
                     if (currentValue == null) {
@@ -1171,7 +1166,7 @@ public class Main {
         final String PROMPT_FOR_VALUE = "PROMPT";
 
         if (arg.toLowerCase().startsWith("--" + OPTIONS.VERBOSE) ||
-            arg.toLowerCase().startsWith("--" + OPTIONS.HELP)) {
+                arg.toLowerCase().startsWith("--" + OPTIONS.HELP)) {
             return;
         }
 
@@ -1372,10 +1367,10 @@ public class Main {
         String formatValue = getCommandParam(OPTIONS.FORMAT, null);
         if (isLicenseableCommand(formatValue)) {
             if (isFormattedDiff()) {
-                if (formatValue != null && ! formatValue.equalsIgnoreCase("json")) {
+                if (formatValue != null && !formatValue.equalsIgnoreCase("json")) {
                     String messageString =
-                        "\nWARNING: The diff command optional Pro parameter '--format' " +
-                        "currently supports only 'TXT' or 'JSON' as values.  (Blank defaults to 'TXT')";
+                            "\nWARNING: The diff command optional Pro parameter '--format' " +
+                                    "currently supports only 'TXT' or 'JSON' as values.  (Blank defaults to 'TXT')";
                     throw new LiquibaseException(String.format(messageString));
                 }
             }
@@ -1399,10 +1394,7 @@ public class Main {
             throw new CommandLineParsingException(e.getMessage(), e);
         }
 
-        CompositeResourceAccessor fileOpener = new CompositeResourceAccessor(
-                new FileSystemResourceAccessor(Paths.get(".").toAbsolutePath().toFile()),
-                new CommandLineResourceAccessor(classLoader)
-                );
+        ResourceAccessor fileOpener = Scope.getCurrentScope().getResourceAccessor();
 
         Database database = null;
         if (dbConnectionNeeded(command) && this.url != null) {
@@ -1566,11 +1558,11 @@ public class Main {
                     try {
                         liquibase.setHubConnectionId(UUID.fromString(hubConnectionId));
                     } catch (IllegalArgumentException e) {
-                        throw new LiquibaseException("The command '"+command+"' failed because parameter 'hubConnectionId' has invalid value '"+hubConnectionId+"' Learn more at https://hub.liquibase.com");
+                        throw new LiquibaseException("The command '" + command + "' failed because parameter 'hubConnectionId' has invalid value '" + hubConnectionId + "' Learn more at https://hub.liquibase.com");
                     }
                 }
-            } catch (IllegalArgumentException  e) {
-                throw new LiquibaseException("Unexpected hubConnectionId format: "+hubConnectionId, e);
+            } catch (IllegalArgumentException e) {
+                throw new LiquibaseException("Unexpected hubConnectionId format: " + hubConnectionId, e);
             }
             ChangeExecListener listener = ChangeExecListenerUtils.getChangeExecListener(
                     liquibase.getDatabase(), liquibase.getResourceAccessor(),
@@ -1660,19 +1652,19 @@ public class Main {
             } else if (COMMANDS.REGISTER_CHANGELOG.equalsIgnoreCase(command)) {
                 Map<String, Object> argsMap = new HashMap<>();
                 RegisterChangeLogCommand liquibaseCommand =
-                   (RegisterChangeLogCommand)createLiquibaseCommand(database, liquibase, COMMANDS.REGISTER_CHANGELOG, argsMap);
+                        (RegisterChangeLogCommand) createLiquibaseCommand(database, liquibase, COMMANDS.REGISTER_CHANGELOG, argsMap);
                 liquibaseCommand.setChangeLogFile(changeLogFile);
                 try {
                     if (hubProjectId != null) {
                         try {
                             liquibaseCommand.setHubProjectId(UUID.fromString(hubProjectId));
                         } catch (IllegalArgumentException e) {
-                            throw new LiquibaseException("The command '"+command+
-                                    "' failed because parameter 'hubProjectId' has invalid value '"+hubProjectId+"'. Learn more at https://hub.liquibase.com");
+                            throw new LiquibaseException("The command '" + command +
+                                    "' failed because parameter 'hubProjectId' has invalid value '" + hubProjectId + "'. Learn more at https://hub.liquibase.com");
                         }
                     }
-                } catch (IllegalArgumentException  e) {
-                    throw new LiquibaseException("Unexpected hubProjectId format: "+hubProjectId, e);
+                } catch (IllegalArgumentException e) {
+                    throw new LiquibaseException("Unexpected hubProjectId format: " + hubProjectId, e);
                 }
                 CommandResult result = liquibaseCommand.execute();
 
@@ -1688,14 +1680,14 @@ public class Main {
             } else if (COMMANDS.DROP_ALL.equals(command)) {
                 String liquibaseHubApiKey = hubConfiguration.getLiquibaseHubApiKey();
                 String hubMode = hubConfiguration.getLiquibaseHubMode();
-                if (liquibaseHubApiKey != null && ! hubMode.toLowerCase().equals("off")) {
+                if (liquibaseHubApiKey != null && !hubMode.toLowerCase().equals("off")) {
                     if (hubConnectionId == null && changeLogFile == null) {
                         String warningMessage =
-                           "The dropAll command used with a hub.ApiKey and hub.mode='" + hubMode + "'\n" +
-                           "can send reports to your Hub project. To enable this, please add the \n" +
-                           "'--hubConnectionId=<hubConnectionId>' parameter to the CLI, or ensure\n" +
-                           "a registered changelog file is passed in your defaults file or in the CLI.\n" +
-                           "Learn more at https://hub.liquibase.com";
+                                "The dropAll command used with a hub.ApiKey and hub.mode='" + hubMode + "'\n" +
+                                        "can send reports to your Hub project. To enable this, please add the \n" +
+                                        "'--hubConnectionId=<hubConnectionId>' parameter to the CLI, or ensure\n" +
+                                        "a registered changelog file is passed in your defaults file or in the CLI.\n" +
+                                        "Learn more at https://hub.liquibase.com";
                         Scope.getCurrentScope().getUI().sendMessage("\nWARNING: " + warningMessage);
                         LOG.warning("\n" + warningMessage);
                     }
@@ -1890,6 +1882,13 @@ public class Main {
         }
     }
 
+    protected ResourceAccessor getResourceAccessor() throws CommandLineParsingException {
+        return new CompositeResourceAccessor(
+                new FileSystemResourceAccessor(Paths.get(".").toAbsolutePath().toFile()),
+                new CommandLineResourceAccessor(configureClassLoader())
+        );
+    }
+
     private void executeSyncHub(Database database, Liquibase liquibase) throws CommandLineParsingException, LiquibaseException, liquibase.command.CommandExecutionException {
         Map<String, Object> argsMap = new HashMap<>();
         SyncHubCommand liquibaseCommand = (SyncHubCommand) createLiquibaseCommand(database, liquibase, COMMANDS.SYNC_HUB, argsMap);
@@ -1907,15 +1906,15 @@ public class Main {
     }
 
     private boolean dbConnectionNeeded(String command) {
-        return ! COMMANDS.REGISTER_CHANGELOG.equalsIgnoreCase(command);
+        return !COMMANDS.REGISTER_CHANGELOG.equalsIgnoreCase(command);
     }
 
     private boolean isLicenseableCommand(String formatValue) {
         return COMMANDS.ROLLBACK_ONE_CHANGE_SET.equalsIgnoreCase(command) ||
-               COMMANDS.ROLLBACK_ONE_CHANGE_SET_SQL.equalsIgnoreCase(command) ||
-               COMMANDS.ROLLBACK_ONE_UPDATE.equalsIgnoreCase(command) ||
-               COMMANDS.ROLLBACK_ONE_UPDATE_SQL.equalsIgnoreCase(command) ||
-               (COMMANDS.DIFF.equalsIgnoreCase(command) && formatValue != null && ! formatValue.toLowerCase().equals("txt"));
+                COMMANDS.ROLLBACK_ONE_CHANGE_SET_SQL.equalsIgnoreCase(command) ||
+                COMMANDS.ROLLBACK_ONE_UPDATE.equalsIgnoreCase(command) ||
+                COMMANDS.ROLLBACK_ONE_UPDATE_SQL.equalsIgnoreCase(command) ||
+                (COMMANDS.DIFF.equalsIgnoreCase(command) && formatValue != null && !formatValue.toLowerCase().equals("txt"));
     }
 
     private void loadChangeSetInfoToMap(Map<String, Object> argsMap) throws CommandLineParsingException {
@@ -1926,7 +1925,7 @@ public class Main {
 
     private boolean isFormattedDiff() throws CommandLineParsingException {
         String formatValue = getCommandParam(OPTIONS.FORMAT, "txt");
-        return ! formatValue.equalsIgnoreCase("txt") && ! formatValue.isEmpty();
+        return !formatValue.equalsIgnoreCase("txt") && !formatValue.isEmpty();
     }
 
     private String getSchemaParams(Database database) throws CommandLineParsingException {

--- a/liquibase-core/src/main/java/liquibase/integration/spring/SpringResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/integration/spring/SpringResourceAccessor.java
@@ -9,6 +9,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.io.support.ResourcePatternUtils;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
@@ -158,5 +159,11 @@ public class SpringResourceAccessor extends AbstractResourceAccessor {
 
         return searchPath;
     }
+
+    @Override
+    protected File getOutputFile(String relativeTo, String path) {
+        return null;
+    }
+
 
 }

--- a/liquibase-core/src/main/java/liquibase/integration/spring/SpringResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/integration/spring/SpringResourceAccessor.java
@@ -9,7 +9,6 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.io.support.ResourcePatternUtils;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
@@ -159,11 +158,4 @@ public class SpringResourceAccessor extends AbstractResourceAccessor {
 
         return searchPath;
     }
-
-    @Override
-    protected File getOutputFile(String relativeTo, String path) {
-        return null;
-    }
-
-
 }

--- a/liquibase-core/src/main/java/liquibase/resource/AbstractResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/AbstractResourceAccessor.java
@@ -4,8 +4,8 @@ import liquibase.AbstractExtensibleObject;
 import liquibase.Scope;
 import liquibase.util.StringUtil;
 
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
+import java.util.SortedSet;
 
 /**
  * Convenience base class for {@link ResourceAccessor} implementations.
@@ -20,10 +20,42 @@ public abstract class AbstractResourceAccessor extends AbstractExtensibleObject 
             return null;
         } else if (streamList.size() > 1) {
             streamList.close();
-            Scope.getCurrentScope().getLog(getClass()).warning("ResourceAccessor roots: "+Scope.getCurrentScope().getResourceAccessor().getClass().getName());
-            throw new IOException("Found " + streamList.size() + " files that match " + streamPath+": "+ StringUtil.join(streamList.getURIs(), ", ", new StringUtil.ToStringFormatter()));
+            Scope.getCurrentScope().getLog(getClass()).warning("ResourceAccessor roots: " + Scope.getCurrentScope().getResourceAccessor().getClass().getName());
+            throw new IOException("Found " + streamList.size() + " files that match " + streamPath + ": " + StringUtil.join(streamList.getURIs(), ", ", new StringUtil.ToStringFormatter()));
         } else {
             return streamList.iterator().next();
+        }
+    }
+
+    /**
+     * Open the given path for writing. If the file path cannot be written to, return null.
+     */
+    @Override
+    public OutputStream openOutputStream(String relativeTo, String path, boolean append) throws IOException {
+        File outputFile = getOutputFile(relativeTo, path);
+        if (outputFile == null) {
+            return null;
+        }
+
+        if (!outputFile.getParentFile().mkdirs()) {
+            throw new IOException("Cannot create directory " + outputFile.getParentFile().getAbsolutePath());
+        }
+
+        Scope.getCurrentScope().getLog(getClass()).fine("Opening file " + outputFile.getAbsolutePath() + " for writing");
+        return new FileOutputStream(outputFile, append);
+    }
+
+    protected abstract File getOutputFile(String relativeTo, String path);
+
+    @Override
+    public boolean exists(String relativeTo, String path) {
+        try {
+            final SortedSet<String> list = list(relativeTo, path, false, true, true);
+
+            return list.size() > 0;
+        } catch (IOException e) {
+            Scope.getCurrentScope().getLog(getClass()).fine("Cannot check existence of " + path + " relative to " + relativeTo + ": " + e.getMessage(), e);
+            return false;
         }
     }
 }

--- a/liquibase-core/src/main/java/liquibase/resource/AbstractResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/AbstractResourceAccessor.java
@@ -4,8 +4,8 @@ import liquibase.AbstractExtensibleObject;
 import liquibase.Scope;
 import liquibase.util.StringUtil;
 
-import java.io.*;
-import java.util.SortedSet;
+import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * Convenience base class for {@link ResourceAccessor} implementations.
@@ -25,38 +25,6 @@ public abstract class AbstractResourceAccessor extends AbstractExtensibleObject 
             throw new IOException("Found " + streamList.size() + " files that match " + streamPath + ": " + StringUtil.join(streamList.getURIs(), ", ", new StringUtil.ToStringFormatter()));
         } else {
             return streamList.iterator().next();
-        }
-    }
-
-    /**
-     * Open the given path for writing. If the file path cannot be written to, return null.
-     */
-    @Override
-    public OutputStream openOutputStream(String relativeTo, String path, boolean append) throws IOException {
-        File outputFile = getOutputFile(relativeTo, path);
-        if (outputFile == null) {
-            return null;
-        }
-
-        if (!outputFile.getParentFile().mkdirs()) {
-            throw new IOException("Cannot create directory " + outputFile.getParentFile().getAbsolutePath());
-        }
-
-        Scope.getCurrentScope().getLog(getClass()).fine("Opening file " + outputFile.getAbsolutePath() + " for writing");
-        return new FileOutputStream(outputFile, append);
-    }
-
-    protected abstract File getOutputFile(String relativeTo, String path);
-
-    @Override
-    public boolean exists(String relativeTo, String path) {
-        try {
-            final SortedSet<String> list = list(relativeTo, path, false, true, true);
-
-            return list.size() > 0;
-        } catch (IOException e) {
-            Scope.getCurrentScope().getLog(getClass()).fine("Cannot check existence of " + path + " relative to " + relativeTo + ": " + e.getMessage(), e);
-            return false;
         }
     }
 }

--- a/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
@@ -2,7 +2,6 @@ package liquibase.resource;
 
 import liquibase.Scope;
 import liquibase.changelog.DatabaseChangeLog;
-import liquibase.logging.Logger;
 import liquibase.util.StreamUtil;
 
 import java.io.File;
@@ -289,23 +288,5 @@ public class ClassLoaderResourceAccessor extends AbstractResourceAccessor {
         init();
 
         return description;
-    }
-
-    @Override
-    protected File getOutputFile(String relativeTo, String path) {
-        final Logger log = Scope.getCurrentScope().getLog(getClass());
-        for (FileSystem root : rootPaths) {
-            if (root.isReadOnly()) {
-                log.fine("Cannot write to "+root +": is read-only");
-                continue;
-            }
-
-            try {
-                return root.getPath(path).toFile();
-            } catch (Exception e) {
-                log.fine("Cannot write to "+root +": "+e.getMessage());
-            }
-        }
-        return null;
     }
 }

--- a/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
@@ -2,6 +2,7 @@ package liquibase.resource;
 
 import liquibase.Scope;
 import liquibase.changelog.DatabaseChangeLog;
+import liquibase.logging.Logger;
 import liquibase.util.StreamUtil;
 
 import java.io.File;
@@ -287,5 +288,23 @@ public class ClassLoaderResourceAccessor extends AbstractResourceAccessor {
         init();
 
         return description;
+    }
+
+    @Override
+    protected File getOutputFile(String relativeTo, String path) {
+        final Logger log = Scope.getCurrentScope().getLog(getClass());
+        for (FileSystem root : rootPaths) {
+            if (root.isReadOnly()) {
+                log.fine("Cannot write to "+root +": is read-only");
+                continue;
+            }
+
+            try {
+                return root.getPath(path).toFile();
+            } catch (Exception e) {
+                log.fine("Cannot write to "+root +": "+e.getMessage());
+            }
+        }
+        return null;
     }
 }

--- a/liquibase-core/src/main/java/liquibase/resource/CompositeResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/CompositeResourceAccessor.java
@@ -2,7 +2,9 @@ package liquibase.resource;
 
 import liquibase.util.CollectionUtil;
 
+import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.*;
 
 /**
@@ -13,7 +15,7 @@ public class CompositeResourceAccessor extends AbstractResourceAccessor {
     private List<ResourceAccessor> resourceAccessors;
 
     public CompositeResourceAccessor(ResourceAccessor... resourceAccessors) {
-        this.resourceAccessors = Arrays.asList(CollectionUtil.createIfNull(resourceAccessors));
+        this.resourceAccessors = new ArrayList<>(Arrays.asList(CollectionUtil.createIfNull(resourceAccessors)));
     }
 
     public CompositeResourceAccessor(Collection<ResourceAccessor> resourceAccessors) {
@@ -57,5 +59,25 @@ public class CompositeResourceAccessor extends AbstractResourceAccessor {
         }
 
         return returnSet;
+    }
+
+    @Override
+    public OutputStream openOutputStream(String relativeTo, String path, boolean append) throws IOException {
+        for (ResourceAccessor accessor : resourceAccessors) {
+            OutputStream outputStream = accessor.openOutputStream(relativeTo, path, append);
+            if (outputStream != null) {
+                return outputStream;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Unused by this implementation of {@link ResourceAccessor#openOutputStream(String, String, boolean)}
+     */
+    @Override
+    protected File getOutputFile(String relativeTo, String path) {
+        return null;
     }
 }

--- a/liquibase-core/src/main/java/liquibase/resource/CompositeResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/CompositeResourceAccessor.java
@@ -2,9 +2,7 @@ package liquibase.resource;
 
 import liquibase.util.CollectionUtil;
 
-import java.io.File;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.*;
 
 /**
@@ -60,25 +58,5 @@ public class CompositeResourceAccessor extends AbstractResourceAccessor {
         }
 
         return returnSet;
-    }
-
-    @Override
-    public OutputStream openOutputStream(String relativeTo, String path, boolean append) throws IOException {
-        for (ResourceAccessor accessor : resourceAccessors) {
-            OutputStream outputStream = accessor.openOutputStream(relativeTo, path, append);
-            if (outputStream != null) {
-                return outputStream;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Unused by this implementation of {@link ResourceAccessor#openOutputStream(String, String, boolean)}
-     */
-    @Override
-    protected File getOutputFile(String relativeTo, String path) {
-        return null;
     }
 }

--- a/liquibase-core/src/main/java/liquibase/resource/FileSystemResouceWriter.java
+++ b/liquibase-core/src/main/java/liquibase/resource/FileSystemResouceWriter.java
@@ -1,0 +1,27 @@
+package liquibase.resource;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+
+public class FileSystemResouceWriter implements ResourceWriter {
+
+    private Path rootPath;
+
+    public FileSystemResouceWriter() {
+        rootPath = FileSystems.getDefault().getPath(".").toAbsolutePath();
+    }
+
+    public FileSystemResouceWriter(Path root) throws IOException {
+        this();
+        rootPath = root;
+    }
+
+    @Override
+    public Path getPath(String path) {
+        return rootPath.resolve(path);
+    }
+
+}

--- a/liquibase-core/src/main/java/liquibase/resource/FileSystemResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/FileSystemResourceAccessor.java
@@ -309,4 +309,8 @@ public class FileSystemResourceAccessor extends AbstractResourceAccessor {
         }
     }
 
+    @Override
+    protected File getOutputFile(String relativeTo, String path) {
+        return new File(rootPaths.iterator().next().toFile(), path);
+    }
 }

--- a/liquibase-core/src/main/java/liquibase/resource/FileSystemResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/FileSystemResourceAccessor.java
@@ -6,6 +6,7 @@ import liquibase.util.StringUtil;
 
 import java.io.*;
 import java.net.URI;
+import java.nio.file.FileSystem;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collections;
@@ -310,8 +311,4 @@ public class FileSystemResourceAccessor extends AbstractResourceAccessor {
         }
     }
 
-    @Override
-    protected File getOutputFile(String relativeTo, String path) {
-        return new File(rootPaths.iterator().next().toFile(), path);
-    }
 }

--- a/liquibase-core/src/main/java/liquibase/resource/ResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/ResourceAccessor.java
@@ -2,6 +2,7 @@ package liquibase.resource;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.SortedSet;
 
 /**
@@ -59,4 +60,7 @@ public interface ResourceAccessor {
      */
     SortedSet<String> describeLocations();
 
+    OutputStream openOutputStream(String relativeTo, String path, boolean append) throws IOException;
+
+    boolean exists(String relativeTo, String path);
 }

--- a/liquibase-core/src/main/java/liquibase/resource/ResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/ResourceAccessor.java
@@ -2,7 +2,6 @@ package liquibase.resource;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.SortedSet;
 
 /**
@@ -59,8 +58,4 @@ public interface ResourceAccessor {
      * Returns a description of the places this classloader will look for paths. Used in error messages and other troubleshooting cases.
      */
     SortedSet<String> describeLocations();
-
-    OutputStream openOutputStream(String relativeTo, String path, boolean append) throws IOException;
-
-    boolean exists(String relativeTo, String path);
 }

--- a/liquibase-core/src/main/java/liquibase/resource/ResourceWriter.java
+++ b/liquibase-core/src/main/java/liquibase/resource/ResourceWriter.java
@@ -1,0 +1,30 @@
+package liquibase.resource;
+
+import java.io.IOException;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+
+/**
+ * Standardized interface for interacting writing files.
+ * The {@link ResourceAccessor} is a read-only interface, where files may be scattered across multiple locations and combined into one view.
+ * For writing files, there needs to be more direct control over exactly where files are being written to.
+ * <br><br>
+ * This interface works through the {@link java.nio.file.Path} interface to provide an abstraction around the underlying storage.
+ * Use standard path functions like {@link java.nio.file.Files#newOutputStream(Path, OpenOption...)} etc.to work with the path objects returned.
+ * <br><br>
+ * Implementations of this interface may define ways to specify "root" directories that they work from for relative paths.
+ * <br><br>
+ * <b>NOTE: while you are able to read from the Paths returned by this interface, you should usually be using the {@link ResourceAccessor} for all file reading.</b>
+ * The only time you would want to read from this interface is if you think there may be a difference between what is configured in the ResourceAccessor vs. the file you are going to write to.
+ */
+public interface ResourceWriter {
+
+    /**
+     * Return a {@link java.nio.file.Path} object for the given filePath. If filePath is relative, it is up to the implementation to determine what it is relative to.
+     * It is up to the implementation to decide if they wish to support absolute paths or not.
+     *
+     * @throws IOException if the given filePath is invalid or cannot be converted to a path.
+     */
+    Path getPath(String filePath) throws IOException;
+
+}

--- a/liquibase-core/src/main/java/liquibase/sdk/resource/MockResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/sdk/resource/MockResourceAccessor.java
@@ -6,7 +6,6 @@ import liquibase.resource.AbstractResourceAccessor;
 import liquibase.resource.InputStreamList;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -55,10 +54,4 @@ public class MockResourceAccessor extends AbstractResourceAccessor {
     public SortedSet<String> describeLocations() {
         return new TreeSet<String>(Collections.singletonList("MockResourceAccessor.java"));
     }
-
-    @Override
-    protected File getOutputFile(String relativeTo, String path) {
-        return null;
-    }
-
 }

--- a/liquibase-core/src/main/java/liquibase/sdk/resource/MockResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/sdk/resource/MockResourceAccessor.java
@@ -6,6 +6,7 @@ import liquibase.resource.AbstractResourceAccessor;
 import liquibase.resource.InputStreamList;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -52,6 +53,12 @@ public class MockResourceAccessor extends AbstractResourceAccessor {
 
     @Override
     public SortedSet<String> describeLocations() {
-        return new TreeSet<String>(Collections.singletonList("MockResouceAccessor.java"));
+        return new TreeSet<String>(Collections.singletonList("MockResourceAccessor.java"));
     }
+
+    @Override
+    protected File getOutputFile(String relativeTo, String path) {
+        return null;
+    }
+
 }

--- a/liquibase-core/src/main/java/liquibase/sdk/supplier/resource/ResourceSupplier.java
+++ b/liquibase-core/src/main/java/liquibase/sdk/supplier/resource/ResourceSupplier.java
@@ -11,6 +11,7 @@ import liquibase.resource.InputStreamList;
 import liquibase.resource.ResourceAccessor;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -64,5 +65,11 @@ public class ResourceSupplier {
         public SortedSet<String> describeLocations() {
             return new TreeSet<>(Arrays.asList("Logic in ResourceSupplier.java"));
         }
+
+        @Override
+        protected File getOutputFile(String relativeTo, String path) {
+            return null;
+        }
+
     }
 }

--- a/liquibase-core/src/main/java/liquibase/sdk/supplier/resource/ResourceSupplier.java
+++ b/liquibase-core/src/main/java/liquibase/sdk/supplier/resource/ResourceSupplier.java
@@ -11,7 +11,6 @@ import liquibase.resource.InputStreamList;
 import liquibase.resource.ResourceAccessor;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -65,11 +64,5 @@ public class ResourceSupplier {
         public SortedSet<String> describeLocations() {
             return new TreeSet<>(Arrays.asList("Logic in ResourceSupplier.java"));
         }
-
-        @Override
-        protected File getOutputFile(String relativeTo, String path) {
-            return null;
-        }
-
     }
 }

--- a/liquibase-core/src/main/java/liquibase/serializer/ChangeLogSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/ChangeLogSerializer.java
@@ -12,5 +12,5 @@ import java.util.List;
 public interface ChangeLogSerializer extends LiquibaseSerializer, PrioritizedService {
     <T extends ChangeLogChild> void write(List<T> children, OutputStream out) throws IOException;
 
-    void append(ChangeSet changeSet, File changeLogFile) throws IOException;
+    void append(ChangeSet changeSet, String changeLogFilePath) throws IOException;
 }

--- a/liquibase-core/src/main/java/liquibase/serializer/core/formattedsql/FormattedSqlChangeLogSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/formattedsql/FormattedSqlChangeLogSerializer.java
@@ -110,7 +110,7 @@ public class FormattedSqlChangeLogSerializer  implements ChangeLogSerializer {
     }
 
     @Override
-    public void append(ChangeSet changeSet, File changeLogFile) throws IOException {
+    public void append(ChangeSet changeSet, String changeLogFilePath) throws IOException {
 
     }
 

--- a/liquibase-core/src/main/java/liquibase/serializer/core/string/StringChangeLogSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/string/StringChangeLogSerializer.java
@@ -160,7 +160,7 @@ public class StringChangeLogSerializer implements ChangeLogSerializer {
     }
 
     @Override
-    public void append(ChangeSet changeSet, File changeLogFile) throws IOException {
+    public void append(ChangeSet changeSet, String changeLogFilePath) throws IOException {
 
     }
 

--- a/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
@@ -13,6 +13,7 @@ import liquibase.parser.NamespaceDetails;
 import liquibase.parser.NamespaceDetailsFactory;
 import liquibase.parser.core.xml.LiquibaseEntityResolver;
 import liquibase.resource.ResourceAccessor;
+import liquibase.resource.ResourceWriter;
 import liquibase.serializer.ChangeLogSerializer;
 import liquibase.serializer.LiquibaseSerializable;
 import liquibase.serializer.LiquibaseSerializable.SerializationType;
@@ -31,6 +32,8 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -155,13 +158,14 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
     @Override
     public void append(ChangeSet changeSet, String changeLogFilePath) throws IOException {
         String existingChangeLog;
-        final ResourceAccessor resourceAccessor = Scope.getCurrentScope().getResourceAccessor();
+        final ResourceWriter resourceWriter = Scope.getCurrentScope().getResourceWriter();
+        final Path filePath = resourceWriter.getPath(changeLogFilePath);
 
-        try (InputStream in = resourceAccessor.openStream(null, changeLogFilePath)) {
+        try (InputStream in = Files.newInputStream(filePath)) {
             existingChangeLog = StreamUtil.readStreamAsString(in);
         }
 
-        try (OutputStream out = resourceAccessor.openOutputStream(null, changeLogFilePath, false)) {
+        try (OutputStream out = Files.newOutputStream(filePath)) {
             if (!existingChangeLog.contains("</databaseChangeLog>")) {
                 write(Arrays.asList(changeSet), out);
             } else {

--- a/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/xml/XMLChangeLogSerializer.java
@@ -1,5 +1,6 @@
 package liquibase.serializer.core.xml;
 
+import liquibase.Scope;
 import liquibase.change.ColumnConfig;
 import liquibase.change.ConstraintsConfig;
 import liquibase.changelog.ChangeLogChild;
@@ -11,6 +12,7 @@ import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.parser.NamespaceDetails;
 import liquibase.parser.NamespaceDetailsFactory;
 import liquibase.parser.core.xml.LiquibaseEntityResolver;
+import liquibase.resource.ResourceAccessor;
 import liquibase.serializer.ChangeLogSerializer;
 import liquibase.serializer.LiquibaseSerializable;
 import liquibase.serializer.LiquibaseSerializable.SerializationType;
@@ -28,12 +30,7 @@ import org.w3c.dom.NodeList;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
+import java.io.*;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -156,13 +153,15 @@ public class XMLChangeLogSerializer implements ChangeLogSerializer {
     }
 
     @Override
-    public void append(ChangeSet changeSet, File changeLogFile) throws IOException {
+    public void append(ChangeSet changeSet, String changeLogFilePath) throws IOException {
         String existingChangeLog;
-        try (FileInputStream in = new FileInputStream(changeLogFile)) {
+        final ResourceAccessor resourceAccessor = Scope.getCurrentScope().getResourceAccessor();
+
+        try (InputStream in = resourceAccessor.openStream(null, changeLogFilePath)) {
             existingChangeLog = StreamUtil.readStreamAsString(in);
         }
 
-        try (FileOutputStream out = new FileOutputStream(changeLogFile)) {
+        try (OutputStream out = resourceAccessor.openOutputStream(null, changeLogFilePath, false)) {
             if (!existingChangeLog.contains("</databaseChangeLog>")) {
                 write(Arrays.asList(changeSet), out);
             } else {

--- a/liquibase-core/src/main/java/liquibase/serializer/core/yaml/YamlChangeLogSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/yaml/YamlChangeLogSerializer.java
@@ -37,7 +37,7 @@ public class YamlChangeLogSerializer extends YamlSerializer implements ChangeLog
 
 
     @Override
-    public void append(ChangeSet changeSet, File changeLogFile) throws IOException {
+    public void append(ChangeSet changeSet, String changeLogFilePath) throws IOException {
         //To change body of implemented methods use File | Settings | File Templates.
     }
 

--- a/liquibase-core/src/test/groovy/liquibase/command/core/RegisterChangeLogCommandTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/command/core/RegisterChangeLogCommandTest.groovy
@@ -7,6 +7,7 @@ import liquibase.configuration.LiquibaseConfiguration
 import liquibase.hub.HubService
 import liquibase.hub.HubServiceFactory
 import liquibase.hub.core.MockHubService
+import liquibase.resource.FileSystemResouceWriter
 import liquibase.test.JUnitResourceAccessor
 import liquibase.util.FileUtil
 import spock.lang.Specification
@@ -54,6 +55,7 @@ class RegisterChangeLogCommandTest extends Specification {
         Map<String, Object> scopeMap = new HashMap<>()
         scopeMap.put(Scope.Attr.resourceAccessor.name(), testResourceAccessor)
         scopeMap.put("liquibase.plugin." + HubService.name, MockHubService)
+        scopeMap.put(Scope.Attr.resourceWriter.name(), new FileSystemResouceWriter(new File("target/test-classes").toPath()))
         scopeId = Scope.enter(scopeMap)
     }
 

--- a/liquibase-core/src/test/groovy/liquibase/resource/AbstractResourceAccessorTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/resource/AbstractResourceAccessorTest.groovy
@@ -22,12 +22,6 @@ class AbstractResourceAccessorTest extends Specification {
             SortedSet<String> describeLocations() {
                 return null
             }
-
-            @Override
-            protected File getOutputFile(String relativeTo, String path) {
-                return null;
-            }
-
         }
     }
 }

--- a/liquibase-core/src/test/groovy/liquibase/resource/AbstractResourceAccessorTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/resource/AbstractResourceAccessorTest.groovy
@@ -22,6 +22,12 @@ class AbstractResourceAccessorTest extends Specification {
             SortedSet<String> describeLocations() {
                 return null
             }
+
+            @Override
+            protected File getOutputFile(String relativeTo, String path) {
+                return null;
+            }
+
         }
     }
 }

--- a/liquibase-core/src/test/java/liquibase/serializer/MockChangeLogSerializer.java
+++ b/liquibase-core/src/test/java/liquibase/serializer/MockChangeLogSerializer.java
@@ -29,7 +29,7 @@ public class MockChangeLogSerializer implements ChangeLogSerializer {
     }
 
     @Override
-    public void append(ChangeSet changeSet, File changeLogFile) throws IOException {
+    public void append(ChangeSet changeSet, String changeLogFilePath) throws IOException {
     }
 
     @Override

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseChangeLogMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseChangeLogMojo.java
@@ -9,6 +9,7 @@ import liquibase.configuration.LiquibaseConfiguration;
 import liquibase.database.Database;
 import liquibase.exception.LiquibaseException;
 import liquibase.resource.ResourceAccessor;
+import liquibase.resource.ResourceWriter;
 import liquibase.util.StringUtil;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
@@ -10,8 +10,8 @@ import liquibase.exception.LiquibaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.integration.IntegrationDetails;
 import liquibase.integration.commandline.CommandLineUtils;
-import liquibase.resource.FileSystemResourceAccessor;
 import liquibase.resource.ResourceAccessor;
+import liquibase.resource.ResourceWriter;
 import liquibase.util.ui.UIFactory;
 import org.apache.maven.artifact.manager.WagonManager;
 import org.apache.maven.plugin.AbstractMojo;
@@ -331,6 +331,7 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
                 ClassLoader mavenClassLoader = getClassLoaderIncludingProjectClasspath();
                 Map<String, Object> scopeValues = new HashMap<>();
                 scopeValues.put(Scope.Attr.resourceAccessor.name(), getResourceAccessor(mavenClassLoader));
+                scopeValues.put(Scope.Attr.resourceWriter.name(), getResourceWriter());
                 scopeValues.put(Scope.Attr.classLoader.name(), getClassLoaderIncludingProjectClasspath());
 
             IntegrationDetails integrationDetails = new IntegrationDetails();
@@ -599,6 +600,11 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
     protected ResourceAccessor getResourceAccessor(ClassLoader cl) {
         return new MavenResourceAccessor(cl, project, null);
     }
+
+    protected ResourceWriter getResourceWriter() throws IOException {
+        return new MavenResourceWriter(project);
+    }
+
 
     /**
      * Performs some validation after the properties file has been loaded checking that all

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
@@ -10,7 +10,6 @@ import liquibase.exception.LiquibaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.integration.IntegrationDetails;
 import liquibase.integration.commandline.CommandLineUtils;
-import liquibase.resource.CompositeResourceAccessor;
 import liquibase.resource.FileSystemResourceAccessor;
 import liquibase.resource.ResourceAccessor;
 import liquibase.util.ui.UIFactory;
@@ -602,9 +601,7 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
     }
 
     protected ResourceAccessor getResourceAccessor(ClassLoader cl) {
-        ResourceAccessor mFO = new MavenResourceAccessor(cl);
-        ResourceAccessor fsFO = new FileSystemResourceAccessor(project.getBasedir());
-        return new CompositeResourceAccessor(mFO, fsFO);
+        return new MavenResourceAccessor(cl, project, null);
     }
 
     /**

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseDBDocMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseDBDocMojo.java
@@ -2,6 +2,9 @@ package org.liquibase.maven.plugins;
 
 import liquibase.Liquibase;
 import liquibase.exception.LiquibaseException;
+import liquibase.resource.ResourceWriter;
+
+import java.io.IOException;
 
 /**
  * <p>Generates dbDocs against the database.</p>
@@ -31,4 +34,8 @@ public class LiquibaseDBDocMojo extends AbstractLiquibaseChangeLogMojo {
         return outputDirectory;
     }
 
+    @Override
+    protected ResourceWriter getResourceWriter() throws IOException {
+        return new MavenResourceWriter(project, getOutputDirectory());
+    }
 }

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/MavenResourceAccessor.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/MavenResourceAccessor.java
@@ -1,35 +1,24 @@
 package org.liquibase.maven.plugins;
 
-import liquibase.resource.*;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import liquibase.resource.CompositeResourceAccessor;
+import liquibase.resource.FileSystemResourceAccessor;
 import org.apache.maven.project.MavenProject;
 
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Extension of {@link liquibase.resource.ClassLoaderResourceAccessor} for Maven which will use a default or user specified {@link ClassLoader} to load files/resources.
  */
 public class MavenResourceAccessor extends CompositeResourceAccessor {
 
-    private final MavenProject project;
-
     public MavenResourceAccessor(ClassLoader mavenClassloader, MavenProject project, String changeLogDirectory) {
-        this.project = project;
         if (changeLogDirectory != null) {
             this.addResourceAccessor(new FileSystemResourceAccessor(new File(calculateChangeLogDirectoryAbsolutePath(changeLogDirectory, project))));
         }
         this.addResourceAccessor(new FileSystemResourceAccessor(project.getBasedir()));
         this.addResourceAccessor(new ClassLoaderResourceAccessor(mavenClassloader));
         this.addResourceAccessor(new ClassLoaderResourceAccessor(getClass().getClassLoader()));
-    }
-
-    @Override
-    public OutputStream openOutputStream(String relativeTo, String path, boolean append) throws IOException {
-        return new FileOutputStream(new File("src/main/resources", path), append);
     }
 
     private String calculateChangeLogDirectoryAbsolutePath(String changeLogDirectory, MavenProject project) {

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/MavenResourceAccessor.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/MavenResourceAccessor.java
@@ -1,28 +1,50 @@
 package org.liquibase.maven.plugins;
 
-import liquibase.resource.ClassLoaderResourceAccessor;
-import liquibase.resource.InputStreamList;
+import liquibase.resource.*;
+import org.apache.maven.project.MavenProject;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.file.Path;
-import java.util.SortedSet;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Extension of {@link liquibase.resource.ClassLoaderResourceAccessor} for Maven which will use a default or user specified {@link ClassLoader} to load files/resources.
  */
-public class MavenResourceAccessor extends ClassLoaderResourceAccessor {
+public class MavenResourceAccessor extends CompositeResourceAccessor {
 
-    public MavenResourceAccessor(ClassLoader classLoader) {
-        super(classLoader);
+    private final MavenProject project;
+
+    public MavenResourceAccessor(ClassLoader mavenClassloader, MavenProject project, String changeLogDirectory) {
+        this.project = project;
+        if (changeLogDirectory != null) {
+            this.addResourceAccessor(new FileSystemResourceAccessor(new File(calculateChangeLogDirectoryAbsolutePath(changeLogDirectory, project))));
+        }
+        this.addResourceAccessor(new FileSystemResourceAccessor(project.getBasedir()));
+        this.addResourceAccessor(new ClassLoaderResourceAccessor(mavenClassloader));
+        this.addResourceAccessor(new ClassLoaderResourceAccessor(getClass().getClassLoader()));
     }
 
     @Override
-    public InputStreamList openStreams(String relativeTo, String streamPath) throws IOException {
-        return super.openStreams(relativeTo, streamPath);
+    public OutputStream openOutputStream(String relativeTo, String path, boolean append) throws IOException {
+        return new FileOutputStream(new File("src/main/resources", path), append);
     }
 
-    @Override
-    public SortedSet<String> list(String relativeTo, String path, boolean recursive, boolean includeFiles, boolean includeDirectories) throws IOException {
-        return super.list(relativeTo, path, recursive, includeFiles, includeDirectories);
+    private String calculateChangeLogDirectoryAbsolutePath(String changeLogDirectory, MavenProject project) {
+        if (changeLogDirectory != null) {
+            // convert to standard / if using absolute path on windows
+            changeLogDirectory = changeLogDirectory.trim().replace('\\', '/');
+            // try to know if it's an absolute or relative path : the absolute path case is simpler and don't need more actions
+            File changeLogDirectoryFile = new File(changeLogDirectory);
+            if (!changeLogDirectoryFile.isAbsolute()) {
+                // we are in the relative path case
+                changeLogDirectory = project.getBasedir().getAbsolutePath().replace('\\', '/') + "/" + changeLogDirectory;
+            }
+        }
+
+        return changeLogDirectory;
     }
+
 }

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/MavenResourceWriter.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/MavenResourceWriter.java
@@ -1,0 +1,22 @@
+package org.liquibase.maven.plugins;
+
+import liquibase.resource.*;
+import org.apache.maven.project.MavenProject;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Extension of {@link ResourceWriter} for Maven which will write to the src/main/resources directory.
+ */
+public class MavenResourceWriter extends FileSystemResouceWriter {
+
+    public MavenResourceWriter(MavenProject project) throws IOException {
+        this(project, "src/main/resources");
+    }
+
+    public MavenResourceWriter(MavenProject project, String rootPath) throws IOException {
+        super(new File(project.getBasedir(), rootPath).toPath());
+    }
+
+}


### PR DESCRIPTION
Currently, Liquibase has the ResourceAccessor which is designed around providing a standard way to READ files, regardless of the integration but no way to WRITE files.

The write support that we have is custom per way we try to write the files, and doesn't have any opportunity take into account differences between integrations. For example, the CLI may want to write files into the current working directory, but Maven may want to write files in src/main/resources.

