### PR TITLE
NullPointerException when typo present in "changeSet" node

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -475,6 +475,14 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
 
                 break;
             }
+            default:
+                // we want to exclude child nodes that are not changesets or the other things
+                // and avoid failing when encountering "child" nodes of the databaseChangeLog which are just
+                // XML node attributes (like schemaLocation). If you don't understand, remove the if and run the tests
+                // and look at the error output or review the "node" object here with a debugger.
+                if (node.getChildren() != null && !node.getChildren().isEmpty()) {
+                    throw new ParsedNodeException("Unexpected node found under databaseChangeLog: " + nodeName);
+                }
         }
     }
 

--- a/liquibase-core/src/test/groovy/liquibase/parser/core/yaml/YamlChangeLogParser_RealFile_Test.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/parser/core/yaml/YamlChangeLogParser_RealFile_Test.groovy
@@ -114,6 +114,15 @@ public class YamlChangeLogParser_RealFile_Test extends Specification {
         change.columns[2].constraints == null
     }
 
+    def "throws a nice validation error when changeSet node has typo in name"() throws ChangeLogParseException {
+        def path = "liquibase/parser/core/yaml/typoChangeLog.yaml"
+        when:
+        new YamlChangeLogParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor());
+
+        then:
+        thrown(ChangeLogParseException.class)
+    }
+
     def "able to parse a changelog with multiple changeSets multiChangeSetChangeLog.yaml"() throws Exception {
         def path = "liquibase/parser/core/yaml/multiChangeSetChangeLog.yaml"
         when:

--- a/liquibase-core/src/test/resources/liquibase/parser/core/yaml/typoChangeLog.yaml
+++ b/liquibase-core/src/test/resources/liquibase/parser/core/yaml/typoChangeLog.yaml
@@ -1,0 +1,23 @@
+databaseChangeLog:
+    - changeSety:
+        id: 1
+        author: nvoxland
+        comment: "Some comments go here"
+        changes:
+            - createTable:
+                tableName: person_yaml
+                columns:
+                    - column:
+                        name: id
+                        type: int
+                        constraints:
+                            primaryKey: true
+                            nullable: false
+                    - column:
+                        name: name
+                        type: varchar(255)
+                        constraints:
+                            nullable: false
+                    - column:
+                        name: age
+                        type: int


### PR DESCRIPTION
- - -
name: Pull Request
about: The Liquibase changelog parser.
title: 'Better error message for typo in "changeSet" node'
labels: Status:Discovery
assignees: ''

- - -
<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->

## Environment
**Liquibase Version**: any

**Liquibase Integration & Version**: any

## Pull Request Type
<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->

* [x] Bug fix (non-breaking change which fixes an issue.)
* [ ] Enhancement/New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
When a typo in done in a changeSet, a NullPointerException is thrown, as follows:

```
java.lang.NullPointerException: Cannot get property 'changes' on null object
	at liquibase.parser.core.yaml.YamlChangeLogParser_RealFile_Test.throws a nice validation error when changeSet node has typo in name(YamlChangeLogParser_RealFile_Test.groovy:121)
```

instead of a better one.

## Steps To Reproduce
Run the unit test added in the first commit, without the second commit (or revert the second commit on this branch locally, which will show you how the test fails and the NullPointerException that is thrown.

## Actual Behavior
The case now throws a nicer exception:

```
liquibase.exception.ChangeLogParseException: Error parsing liquibase/parser/core/yaml/typoChangeLog.yaml

	at liquibase.parser.core.yaml.YamlChangeLogParser.parse(YamlChangeLogParser.java:83)
	at liquibase.parser.core.yaml.YamlChangeLogParser_RealFile_Test.throws a nice validation error when changeSet node has typo in name(YamlChangeLogParser_RealFile_Test.groovy:119)
Caused by: liquibase.parser.core.ParsedNodeException: Unexpected node found under databaseChangeLog: changeSety
```

## Expected/Desired Behavior
A better exception.

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->

* [x] Build is successful and all new and existing tests pass
* [x] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
* [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
* [ ] Documentation Updated

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: (stand alone PR)
* Local Branch: https://github.com/liquibase/liquibase/tree/danielthegray-better-error-message-for-typo
* Unit Tests: https://github.com/liquibase/liquibase/pull/1593/checks
* Integration Tests: (shown in Unit Tests link above)
* Functional Tests: https://jenkins.datical.net/job/liquibase-pro/job/danielthegray-better-error-message-for-typo/

#### Testing
* Steps to Reproduce: See above
* Guidance: 
  * Unit tests cover changes well

#### Dev Verification
Ran a few yaml files locally to see how well the fix covers other cases. Seemed to do a good job 
(did not save output at the time)

## Test Requirements
_Setup_
Use the yml file created for the unit test in your testing; it is also attached to the linked (internal) LB ticket.

_Verify Liquibase update does not throw an NPE when there is a typo in a YML changelog._
_Verify Liquibase update  returns a useful error when there is a typo in a YML changelog._

_Automated Functional Test Requirements_

* None; the unit test is sufficient. Thank you, danielthegray for adding the test!



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-1055) by [Unito](https://www.unito.io)
