### PR TITLE
EntityResolver should check the classpath

### DIFF
--- a/liquibase-core/src/main/java/liquibase/parser/core/xml/LiquibaseEntityResolver.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/xml/LiquibaseEntityResolver.java
@@ -7,7 +7,6 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.ext.EntityResolver2;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -34,7 +33,7 @@ public class LiquibaseEntityResolver implements EntityResolver2 {
                 .replaceFirst("https?://", "");
 
 
-        ResourceAccessor resourceAccessor = new CompositeResourceAccessor(new FileSystemResourceAccessor(new File("/tmp")), new ClassLoaderResourceAccessor());
+        ResourceAccessor resourceAccessor = new CompositeResourceAccessor(Scope.getCurrentScope().getResourceAccessor(), new ClassLoaderResourceAccessor());
         InputStreamList streams = resourceAccessor.openStreams(null, path);
         if (streams.isEmpty()) {
             log.fine("Unable to resolve XML entity locally. Will load from network.");

--- a/liquibase-core/src/main/java/liquibase/parser/core/xml/LiquibaseEntityResolver.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/xml/LiquibaseEntityResolver.java
@@ -2,14 +2,12 @@ package liquibase.parser.core.xml;
 
 import liquibase.Scope;
 import liquibase.logging.Logger;
-import liquibase.resource.ClassLoaderResourceAccessor;
-import liquibase.resource.CompositeResourceAccessor;
-import liquibase.resource.InputStreamList;
-import liquibase.resource.ResourceAccessor;
+import liquibase.resource.*;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.ext.EntityResolver2;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -35,7 +33,8 @@ public class LiquibaseEntityResolver implements EntityResolver2 {
                 .replace("http://www.liquibase.org/xml/ns/migrator/", "http://www.liquibase.org/xml/ns/dbchangelog/")
                 .replaceFirst("https?://", "");
 
-        ResourceAccessor resourceAccessor = Scope.getCurrentScope().getResourceAccessor();
+
+        ResourceAccessor resourceAccessor = new CompositeResourceAccessor(new FileSystemResourceAccessor(new File("/tmp")), new ClassLoaderResourceAccessor());
         InputStreamList streams = resourceAccessor.openStreams(null, path);
         if (streams.isEmpty()) {
             log.fine("Unable to resolve XML entity locally. Will load from network.");

--- a/liquibase-core/src/main/java/liquibase/parser/core/xml/XMLChangeLogSAXParser.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/xml/XMLChangeLogSAXParser.java
@@ -17,8 +17,6 @@ import java.io.InputStream;
 public class XMLChangeLogSAXParser extends AbstractChangeLogParser {
 
     public static final String LIQUIBASE_SCHEMA_VERSION = "4.1";
-    private static final boolean PREFER_INTERNAL_XSD = Boolean.getBoolean("liquibase.prefer.internal.xsd");
-    private static final String XSD_FILE = "dbchangelog-" + LIQUIBASE_SCHEMA_VERSION + ".xsd";
     private SAXParserFactory saxParserFactory;
 
     public XMLChangeLogSAXParser() {
@@ -47,8 +45,7 @@ public class XMLChangeLogSAXParser extends AbstractChangeLogParser {
 
     @Override
     protected ParsedNode parseToNode(String physicalChangeLogLocation, ChangeLogParameters changeLogParameters, ResourceAccessor resourceAccessor) throws ChangeLogParseException {
-        try (
-                InputStream inputStream = resourceAccessor.openStream(null, physicalChangeLogLocation)) {
+        try (InputStream inputStream = resourceAccessor.openStream(null, physicalChangeLogLocation)) {
             SAXParser parser = saxParserFactory.newSAXParser();
             trySetSchemaLanguageProperty(parser);
 


### PR DESCRIPTION
Even if the standard ResourceAccessor does not include it.

Fixes #1609



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-1100) by [Unito](https://www.unito.io/learn-more)
