### PR TITLE
Add deprecated LogFactory.getInstance() to smooth upgrade to 4.x

### DIFF
--- a/liquibase-core/src/main/java/liquibase/logging/LogFactory.java
+++ b/liquibase-core/src/main/java/liquibase/logging/LogFactory.java
@@ -33,4 +33,11 @@ public class LogFactory extends AbstractPluginFactory<LogService> {
     public static Logger getLogger() {
         return Scope.getCurrentScope().getLog(LogFactory.class);
     }
+
+    /**
+     * @deprecated Use {@link Scope#getSingleton(Class)}
+     */
+    public static LogFactory getInstance() {
+        return Scope.getCurrentScope().getSingleton(LogFactory.class);
+    }
 }

--- a/liquibase-core/src/test/groovy/liquibase/logging/LogFactoryTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/logging/LogFactoryTest.groovy
@@ -1,0 +1,12 @@
+package liquibase.logging
+
+
+import spock.lang.Specification
+
+class LogFactoryTest extends Specification {
+
+    def getInstance() {
+        expect:
+        LogFactory.getInstance() != null
+    }
+}


### PR DESCRIPTION
Fixes #1641



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-1134) by [Unito](https://www.unito.io/learn-more)
