### PR TITLE
includeAll() resolve FileSystemResource when run with spring-boot:run…

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/spring/SpringResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/integration/spring/SpringResourceAccessor.java
@@ -102,7 +102,7 @@ public class SpringResourceAccessor extends AbstractResourceAccessor {
         } catch (IOException e) {
             //the path gets stored in the databasechangelog table, so if it gets returned incorrectly it will cause future problems.
             //so throw a breaking error now rather than wait for bigger problems down the line
-            throw new UnexpectedLiquibaseException("Cannot determine resource path for "+resource.getDescription());
+            throw new UnexpectedLiquibaseException("Cannot determine resource path for " + resource.getDescription());
         }
     }
 
@@ -150,12 +150,13 @@ public class SpringResourceAccessor extends AbstractResourceAccessor {
      * Default implementation adds "classpath:" and removes duplicated /'s and classpath:'s
      */
     protected String finalizeSearchPath(String searchPath) {
-        searchPath = "classpath:"+searchPath;
-        searchPath = searchPath
-                .replace("\\", "/")
-                .replaceAll("//+", "/")
-                .replace("classpath:classpath:", "classpath:");
-
+        if (!searchPath.startsWith("file:")) {
+            searchPath = "classpath:" + searchPath;
+            searchPath = searchPath
+                    .replace("\\", "/")
+                    .replaceAll("//+", "/")
+                    .replace("classpath:classpath:", "classpath:");
+        }
         return searchPath;
     }
 


### PR DESCRIPTION
…. But SpringResourceAccessor.openStream() alway add 'classpath:' prefix to resource string event if it has 'file:' url string already. it produce string like 'classpth:file:xxxxx' that wrong path. So it fail when getInputStream()

I fix by detect if it already has 'file:' no need to add extra 'classpath:'

<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->

## Environment
**Liquibase Version**: 4.2.2

**Liquibase Integration & Version**: maven

**Liquibase Extension(s) & Version**:  4.2.2

**Database Vendor & Version**: All

**Operating System Type & Version**: Linux

## Pull Request Type
<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->

* [x ] Bug fix (non-breaking change which fixes an issue.)
* [ ] Enhancement/New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
A clear and concise description of the issue being addressed.  Additional guidance [here](https://liquibase.jira.com/wiki/spaces/LB/pages/1274904896/How+to+Contribute+Code+to+Liquibase+Core).

* Describe the actual problematic behavior.
* Ensure private information is redacted

when `mvn spring-boot:run`  includeAll() will load all file with `ResourcePatternUtils.getResourcePatternResolver(resourceLoader).getResources(searchPath)` it return FileSystemResource ( file: prefix )
when `SpringResourceAccessor.openStream()` is call for each file it add additional `classpath:` prefix (in method `finalizeSearchPath()` ). it will look like 'classpath:file:xxxx" which is wrong path hence it produce FileNotFoundException ( exception was swallow).

I fixed by detect if url with `file:` prefix then skip add `classpath:` to url.

## Steps To Reproduce
List the steps to reproduce the behavior.

* Please be precise and ensure private information is redacted
* Include things like
  * Files used - sql scripts, changelog file(s), property file(s), config files, POM Files
  * Exact commands used - CLI, maven, gradle, spring boot, servlet, etc.

  add `<includeAll path="some-directory" errorIfMissingOrEmpty="true">`  to changelog file and run `mvn-spring-boot:run` it will cause error

  but it run fine  with same configuration with `java -jar Xxx.jar' 

## Actual Behavior
A clear and concise description of what happens in the software **before** this pull request.

* Include console output if relevant
* Include log files if available.
Demo project https://github.com/pramoth/liquibase-mvn-run-fail-demo

When use `<includeAll path="some-directory" errorIfMissingOrEmpty="true">` with mvn spring-boot:run  cause an error ( but it run fine with java -jar ) 
error message : 

```
Caused by: liquibase.exception.ChangeLogParseException: The file file:/home/pramoth/work/project/e-aquafeed/e-aquafeed-web/src/main/resources/db/changelog/data-master/0000_aquatic_animal_group.sql was not found in
   - Spring resources
Specifying files by absolute path was removed in Liquibase 4.0. Please use a relative path or add '/' to the classpath parameter.
       at liquibase.parser.core.sql.SqlChangeLogParser.parse(SqlChangeLogParser.java:40)
       at liquibase.changelog.DatabaseChangeLog.include(DatabaseChangeLog.java:586)
       at liquibase.changelog.DatabaseChangeLog.includeAll(DatabaseChangeLog.java:544)
       ... 35 common frames omitted
```

Log also wrong because it run fine with `java -jar` hence message not relevant

## Expected/Desired Behavior
A clear and concise description of what happens in the software **after** this pull request.
mvn spring-boot:run ---> PASS
java -jat Xxx.jar --> PASS

## Screenshots (if appropriate)
If applicable, add screenshots to help explain your problem.

## Additional Context
Add any other context about the problem here.

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->

* [ x] Build is successful and all new and existing tests pass
* [ ] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
* [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
* [ ] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls)
* [ ] Documentation Updated

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-1141) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Community 4.3.2,Liquibase 4.3.2
