### PR TITLE
Fixed the issue that was preventing dropAll from working in Postgres (#1212)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -754,8 +754,11 @@ public abstract class AbstractJdbcDatabase implements Database {
                 typesToInclude.remove(PrimaryKey.class);
                 typesToInclude.remove(UniqueConstraint.class);
 
-                if (supportsForeignKeyDisable()) {
+                if (supportsForeignKeyDisable() || getShortName().equals("postgresql")) {
                     //We do not remove ForeignKey because they will be disabled and removed as parts of tables.
+                    // Postgress is treated as if we can disable foreign keys because we can't drop
+                    // the foreign keys of a partitioned table, as discovered in
+                    // https://github.com/liquibase/liquibase/issues/1212
                     typesToInclude.remove(ForeignKey.class);
                 }
 

--- a/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -972,6 +972,8 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                         return queryMssql(catalogAndSchema, table);
                     } else if (database instanceof Db2zDatabase) {
                         return queryDb2Zos(catalogAndSchema, table);
+                    } else if ( database instanceof PostgresDatabase) {
+                        return queryPostgres(catalogAndSchema, table);
                     }
 
                     String catalog = ((AbstractJdbcDatabase) database).getJdbcCatalogName(catalogAndSchema);
@@ -990,11 +992,14 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                         return queryMssql(catalogAndSchema, null);
                     } else if (database instanceof Db2zDatabase) {
                         return queryDb2Zos(catalogAndSchema, null);
+                    } else if ( database instanceof PostgresDatabase) {
+                        return queryPostgres(catalogAndSchema, table);
                     }
 
                     String catalog = ((AbstractJdbcDatabase) database).getJdbcCatalogName(catalogAndSchema);
                     String schema = ((AbstractJdbcDatabase) database).getJdbcSchemaName(catalogAndSchema);
                     return extract(databaseMetaData.getTables(catalog, schema, SQL_FILTER_MATCH_ALL, new String[]{"TABLE"}));
+
                 }
 
                 private List<CachedRow> queryMssql(CatalogAndSchema catalogAndSchema, String tableName) throws DatabaseException, SQLException {
@@ -1073,6 +1078,13 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                     }
 
                     return executeAndExtract(sql, database);
+                }
+                private List<CachedRow> queryPostgres(CatalogAndSchema catalogAndSchema, String tableName) throws SQLException {
+                    String catalog = ((AbstractJdbcDatabase) database).getJdbcCatalogName(catalogAndSchema);
+                    String schema = ((AbstractJdbcDatabase) database).getJdbcSchemaName(catalogAndSchema);
+                    return extract(databaseMetaData.getTables(catalog, schema, ((tableName == null) ?
+                            SQL_FILTER_MATCH_ALL : tableName), new String[]{"TABLE", "PARTITIONED TABLE"}));
+
                 }
             });
         }

--- a/liquibase-integration-tests/src/test/resources/changelogs/pgsql/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/pgsql/complete/root.changelog.xml
@@ -359,4 +359,43 @@
         <comment>Auto increment the primary keys</comment>
         <addAutoIncrement tableName="cp1_table" columnName="id" columnDataType="int"/>
     </changeSet>
+    <!--
+      Change sets to test  https://github.com/liquibase/liquibase/issues/1212.
+      To test this, we'll need 3 things:
+      1. A parent table to reference.
+      2. A partitioned table with a foreign key to the parent table.
+      3. A default partition in the table.
+      These tables don't need any data.  We just need the structure to make sure we can
+      drop all the objects without having trouble with foreign keys.
+   -->
+    <changeSet id="issue-1212-parent" author="ssaliman">
+        <createTable tableName="partition_parent">
+            <column name="id" type="bigint">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="parent_data" type="varchar(50)"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="issue-1212-child" author="ssaliman">
+        <createTable tableName="partitioned_child">
+            <column name="partition_key" type="datetime">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="parent_id" type="bigint"/>
+            <column name="some_data" type="varchar(2000)"/>
+        </createTable>
+        <modifySql>
+            <append value="PARTITION BY RANGE (partition_key)"/>
+        </modifySql>
+    </changeSet>
+    <changeSet id="issue-1212-partition" author="ssaliman">
+        <sql>create table partitioned_childp partition of partitioned_child default;</sql>
+    </changeSet>
+    <changeSet id="issue-1212-constraint" author="ssaliman">
+        <addForeignKeyConstraint baseTableName="partitioned_child"
+                                 baseColumnNames="parent_id"
+                                 constraintName="fk_child_parent"
+                                 referencedTableName="partition_parent"
+                                 referencedColumnNames="id"/>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
This fix is being pushed to both the 4.2.x and 4.3.x branches because the master branch wasn't passing its tests, and I wanted to make sure that this fix goes out in the next release of Liquibase.

<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->

## Environment
**Liquibase Version**: 4.2.2

**Liquibase Integration & Version**: N/A

**Liquibase Extension(s) & Version**: N/A

**Database Vendor & Version**: Postgres

**Operating System Type & Version**: All

## Pull Request Type
<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->

* [x] Bug fix (non-breaking change which fixes an issue.)
* [ ] Enhancement/New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
A clear and concise description of the issue being addressed.  Additional guidance [here](https://liquibase.jira.com/wiki/spaces/LB/pages/1274904896/How+to+Contribute+Code+to+Liquibase+Core).
Running `dropAll` in a Postgres database doesn't drop partitioned tables because the Postgres JDBC driver doesn't return partitioned tables by default when asking for tables, and you can't drop inherited foreign constraints.

## Steps To Reproduce
List the steps to reproduce the behavior.
This pull request includes some changeSets in liquibase-integration-tests/src/test/resources/changelogs/pgsql/complete/root.changelog.xml that create a partitioned table with a foreign key constraint to a parent table.  This will introduce two problems in the pre-patched code.

1. running `dropAll` will fail because Postgres can't drop the inherited constraint.  This has something to do with the way Postgres does partitions.
1. Without the change set that makes the foreign key constraint, `dropAll` will succeed, it won't drop the partitioned table, causing future `update` commands to fail because the object will still exist.

## Actual Behavior
## Expected/Desired Behavior
Running `dropAll` should result in all objects being dropped from the database.  This behavior now happens as a result of the pull request, as verified by the integration tests that now include a partitioned table.  I verified that the tests were failing with the new changeSets before the code fix, and succeeding after the code fix.

## Screenshots (if appropriate)
If applicable, add screenshots to help explain your problem.

## Additional Context
Add any other context about the problem here.

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->

* [x] Build is successful and all new and existing tests pass
* [ ] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
* [x] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
* [ ] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls)
* [ ] Documentation Updated

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-1147) by [Unito](https://www.unito.io/learn-more)
┆Fix Versions: Community 4.4.0,Liquibase 4.4.0
