### PR TITLE
handle empty lines at start of formatted sql

### DIFF
--- a/liquibase-core/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
@@ -36,8 +36,13 @@ public class FormattedSqlChangeLogParser implements ChangeLogParser {
                 }
                 reader = new BufferedReader(StreamUtil.readStreamWithReader(fileStream, null));
 
-                String line = reader.readLine();
-                return (line != null) && line.matches("\\-\\-\\s*liquibase formatted.*");
+                String firstLine = reader.readLine();
+
+                while (firstLine.trim().isEmpty() && reader.ready()) {
+                    firstLine = reader.readLine();
+                }
+
+                return (firstLine != null) && firstLine.matches("\\-\\-\\s*liquibase formatted.*");
             } else {
                 return false;
             }

--- a/liquibase-core/src/test/groovy/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.groovy
@@ -89,7 +89,6 @@ select 1
             "--precondition-invalid-type 123\n" +
             "select 1;"
 
-
     def supports() throws Exception {
         expect:
         assert new MockFormattedSqlChangeLogParser(VALID_CHANGELOG).supports("asdf.sql", new JUnitResourceAccessor())
@@ -225,6 +224,21 @@ select 1
 
         changeLog.getChangeSets().get(9).getContexts().toString() == "a or b"
 
+    }
+
+    def parse_startsWithSpace() throws Exception {
+        when:
+        String changeLogWithSpace = "   \n\n" +
+                "--liquibase formatted sql\n\n" +
+                "--changeset John Doe:12345\n" +
+                "create table test (id int);\n"
+
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithSpace).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+
+        then:
+        changeLog.getChangeSets().size() == 1
+        changeLog.getChangeSets().get(0).getAuthor() == "John Doe"
+        changeLog.getChangeSets().get(0).getId() == "12345"
     }
 
     def parse_authorWithSpace() throws Exception {


### PR DESCRIPTION
<!--- This environment context section helps us quickly review your PR. 
Please take a minute to fill-out this information. -->

## Environment
**Liquibase Version**: 3.10.0

**Liquibase Integration & Version**: All

**Liquibase Extension(s) & Version**: N/A

**Database Vendor & Version**: N/A

**Operating System Type & Version**: All

## Pull Request Type
<!--- What types of changes does your code introduce?
Put an `x` in all the boxes that apply: 
If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->

* \[x] Bug fix (non-breaking change which fixes an issue.)
* \[ ] Enhancement/New feature (non-breaking change which adds functionality)
* \[ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
An issue spotted where empty space at the beginning of the formatted sql changelog would result in the changeset running as raw sql. This change is to find the first non empty string (or end of file) and perform the regex match to determine if the file is a formatted sql file so that the changeset is logged correctly. First time committing code here, thank you for any and all feedback. 

## Steps To Reproduce
1. Using a sql changelog file, include the following format where you have an empty first line (or many empty lines) before the '--liquibase formatted sql' 

```sql
--liquibase formatted sql

--changeset test:1
create table test1 (
    id int IDENTITY,
    text varchar(255)
);
--rollback drop table test1;
```

1. Run the updateSql command to inspect the sql that will run.
1. Verify that the sql is marked to includeAll and that it will run as raw sql.
1. Verify that the change set marked for the change is incorrect. Should be for test:1 but instead it will be for raw:includeAll.

cf. [Liquibase Forum Post](https://forum.liquibase.org/t/handling-whitespace-in-sql-formatted-changelog/4426)

## Actual Behavior
Before these changes, the changelog will run fine but save with raw:includeAll in the databasechangelog. The only issue with the changeset file is some whitespace at the beginning.

## Expected/Desired Behavior
A simple check to find the first non empty line in the sql file, and then run the test to see if the text starts with 'liquibase formatted sql'. Otherwise run the file as raw sql storing the changeset id:author as raw:includeAll.

## Screenshots (if appropriate)
screenshots on forum post:
cf. [Liquibase Forum Post](https://forum.liquibase.org/t/handling-whitespace-in-sql-formatted-changelog/4426)

## Additional Context
Add any other context about the problem here.

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<

!--- If you're unsure about any of these, just ask us in a comment. We're here to help|width=200,height=183!

-->

* \[x] Build is successful and all new and existing tests pass
* \[x] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
* \[ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
* \[ ] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls)
* \[ ] Documentation Updated

## Test Requirements (Internal Liquibase QA)
* No new automated functional tests required; unit test is sufficient.

**Manual Test Requirements**

For the following tests, use the attached formatted SQL changelog.

_Verify update-sql command returns the correct SQL to deploy changeset test:1._
_Verify update is successful._
_Verify DATABASECHANGELOG.ID=1-test1_

_Verify DATABASECHANGELOG.AUTHOR=bug_user._

--- 

## Dev Handoff Notes (Internal Use)

#### Links

- Fixed Issue: Stand alone PR
- Local Branch: https://github.com/liquibase/liquibase/tree/smith-xyz-empty-line-issue-sql
- Unit Tests: https://github.com/liquibase/liquibase/pull/1713/checks
- Integration Tests: (shown in Unit Tests link above)
- Functional Tests: https://jenkins.datical.net/job/liquibase-pro/job/smith-xyz-empty-line-issue-sql/

#### Testing

- Steps to Reproduce: See above
- Guidance:
  - Impacts only formatted SQL

#### Dev Verification

Code review and automated tests

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)

┆Issue is synchronized with this [Jiraserver Story](https://datical.atlassian.net/browse/LB-1269) by [Unito](https://www.unito.io)
