### PR TITLE
Introduce new config diffColumnDefaultValueConstraintName

### DIFF
--- a/liquibase-core/src/main/java/liquibase/GlobalConfiguration.java
+++ b/liquibase-core/src/main/java/liquibase/GlobalConfiguration.java
@@ -43,6 +43,7 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
     public static final ConfigurationDefinition<Boolean> STRICT;
     public static final ConfigurationDefinition<Integer> DDL_LOCK_TIMEOUT;
     public static final ConfigurationDefinition<Boolean> SECURE_PARSING;
+    public static final ConfigurationDefinition<Boolean> DIFF_COLUMN_DEFAULT_VALUE_CONSTRAINT_NAME;
 
     static {
         ConfigurationDefinition.Builder builder = new ConfigurationDefinition.Builder("liquibase");
@@ -204,6 +205,11 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
         DUPLICATE_FILE_MODE = builder.define("duplicateFileMode", DuplicateFileMode.class)
                 .setDescription("How to handle multiple files being found in the search path that have duplicate paths. Options are WARN (log warning and choose one at random) or ERROR (fail current operation)")
                 .setDefaultValue(DuplicateFileMode.ERROR)
+                .build();
+
+        DIFF_COLUMN_DEFAULT_VALUE_CONSTRAINT_NAME = builder.define("diffColumnDefaultValueConstraintName", Boolean.class)
+                .setDescription("Should Liquibase compare column default value constraint name in diff operation?")
+                .setDefaultValue(true)
                 .build();
     }
 

--- a/liquibase-core/src/main/java/liquibase/diff/compare/core/ColumnComparator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/compare/core/ColumnComparator.java
@@ -81,6 +81,10 @@ public class ColumnComparator implements DatabaseObjectComparator {
             exclude.add("order");
         }
 
+        if (!GlobalConfiguration.DIFF_COLUMN_DEFAULT_VALUE_CONSTRAINT_NAME.getCurrentValue()) {
+            exclude.add("defaultValueConstraintName");
+        }
+
         ObjectDifferences differences = chain.findDifferences(databaseObject1, databaseObject2, accordingTo, compareControl, exclude);
 
         differences.compare("name", databaseObject1, databaseObject2, new ObjectDifferences.DatabaseObjectNameCompareFunction(Column.class, accordingTo));


### PR DESCRIPTION
## Environment
**Liquibase Version**: 4.3.2

**Liquibase Integration & Version**: CLI

**Liquibase Extension(s) & Version**: NA

**Database Vendor & Version**: MSSQL

**Operating System Type & Version**: All

## Pull Request Type
* [ ] Bug fix (non-breaking change which fixes an issue.)
* [x] Enhancement/New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
When execute exact same table DDL on two MSSQL servers, the MSSQL engine will generate column default value constraint name with pattern `DF__<table name>__<column name>__<random string>`, which cause `diff` command generate many useless messages about default value constraint name changed on columns.
Introduce a new global config `diffColumnDefaultValueConstraintName`, default `true`, when this configuration is passed as `false` (e.g: `-Dliquibase.diffColumnDefaultValueConstraintName=false`), the `ColumnComparator` will ignore `defaultValueConstraintName` attribute when compare on columns.

## Steps To Reproduce
1. Prepare 2 mssql server databases.
1. Execute the following DDL on each databases:

```
create table T1
(
	lastLoginDate bigint default 0
)
go
```

1. Inspect the default value constraint name generated on each databases, they should looks like the following:

```
# database 1:
DF__T1__lastLoginDat__3FA7F1A5
# database 2:
DF__T1__lastLoginDat__41903A17
```

1. Run liquibase diff against 2 databases

## Actual Behavior
We inspect the messages similar to the following from `diff` command output

```
Changed Column(s):
     dbo.T1.lastLoginDate
          defaultValueConstraintName changed from 'DF__T1__lastLogi__3FA7F1A5' to 'DF__T1__lastLogi__41903A17'
```

## Expected/Desired Behavior
Run `diff` command with `-Dliquibase.diffColumnDefaultValueConstraintName=false`, expect no default value constraint name changed messages populated in diff output. 

## Screenshots (if appropriate)
![](https://user-images.githubusercontent.com/1191662/109449272-f930e380-7a82-11eb-8de1-08474696c552.png)

## Additional Context
The design is exact same as existing global config `diffColumnOrder`.

## Fast Track PR Acceptance Checklist:
* [x] Build is successful and all new and existing tests pass
* [ ] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
* [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
* [ ] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls)
* [ ] Documentation Updated

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)

