### PR TITLE
Ensure that the root scope is initialized correctly regardless of whether a scope manager has been configured yet or not.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/Scope.java
+++ b/liquibase-core/src/main/java/liquibase/Scope.java
@@ -63,6 +63,8 @@ public class Scope {
     public static Scope getCurrentScope() {
         if (scopeManager == null) {
             scopeManager = new SingletonScopeManager();
+        }
+        if (scopeManager.getCurrentScope() == null) {
             Scope rootScope = new Scope();
             scopeManager.setCurrentScope(rootScope);
 


### PR DESCRIPTION
## Environment
**Liquibase Version**: 4.3.1

**Liquibase Integration & Version**: spring boot

**Liquibase Extension(s) & Version**: N/A

**Database Vendor & Version**: MySQL 5.7.12-log

**Operating System Type & Version**: Amazon AWS RDS

## Pull Request Type
* [x] Bug fix (non-breaking change which fixes an issue.)
* [ ] Enhancement/New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
We have a Spring Boot command line application that applies the same Liquibase changset concurrently to two different database instances using the Liquibase Java API. Currently this fails due to a Liquibase scope collision.

## Steps To Reproduce
The Liquibase.update() method is run with the Java ExecutorService on two different threads. Currently the liquibase Scope class defaults to the SingletonScopeManager if no ScopeManager has been defined. This causes a problem in a multi-threaded application. Therefore we implemented a ThreadLocalScopeManager to ensure that each thread maintains it's own scope.

```
public class ThreadLocalScopeManager extends ScopeManager {

    private ThreadLocal<Scope> currentScope = new ThreadLocal<>();

    @Override
    public Scope getCurrentScope() {
        return currentScope.get();
    }

    @Override
    protected Scope init(Scope scope) {
        return scope;
    }

    @Override
    protected void setCurrentScope(Scope scope) {
        this.currentScope.set(scope);
    }
}
```

Then we set the ScopeManager using the following code prior to creating the worker threads:

```
ThreadLocalScopeManager threadLocalScopeManager = new ThreadLocalScopeManager();
Scope.setScopeManager(threadLocalScopeManager);
```

However, there is a bug in that the liquibase.Scope.getCurrentScope method does not initialize the root scope properly if the ScopeManager was already set externally:

```
    public static Scope getCurrentScope() {
        if (scopeManager == null) {
            scopeManager = new SingletonScopeManager();

            // if scopeManager != null then this code is never reached
            Scope rootScope = new Scope();
            scopeManager.setCurrentScope(rootScope);

            LogService overrideLogService = rootScope.getSingleton(LogServiceFactory.class).getDefaultLogService();
            if (overrideLogService == null) {
                throw new UnexpectedLiquibaseException("Cannot find default log service");
            }
            rootScope.values.put(Attr.logService.name(), overrideLogService);

            //check for higher-priority serviceLocator
            ServiceLocator serviceLocator = rootScope.getServiceLocator();
            for (ServiceLocator possibleLocator : serviceLocator.findInstances(ServiceLocator.class)) {
                if (possibleLocator.getPriority() > serviceLocator.getPriority()) {
                    serviceLocator = possibleLocator;
                }
            }

            rootScope.values.put(Attr.serviceLocator.name(), serviceLocator);
        }
        return scopeManager.getCurrentScope();
    }
```

## Actual Behavior
If we run the code without using a ThreadLocalScopeManager:

```
2021-03-17T10:15:49,478Z [Trace ID: b9c5991cbecc31b] [pool-1-thread-2,] ERROR com.acme.liquibase.runner.Application - java.lang.RuntimeException: Cannot end scope plhquanuwg when currently at scope imsoofofys
liquibase.exception.LiquibaseException: java.lang.RuntimeException: Cannot end scope plhquanuwg when currently at scope imsoofofys
	at liquibase.Liquibase.runInScope(Liquibase.java:2327)
	at liquibase.Liquibase.update(Liquibase.java:216)
	at liquibase.Liquibase.update(Liquibase.java:202)
	at liquibase.Liquibase.update(Liquibase.java:198)
	at liquibase.Liquibase.update(Liquibase.java:190)
	at com.acme.liquibase.runner.Application.applyLiquibase(Application.java:156)
	at com.acme.liquibase.runner.Application.lambda$run$0(Application.java:103)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1736)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.RuntimeException: Cannot end scope plhquanuwg when currently at scope imsoofofys
	at liquibase.Scope.exit(Scope.java:212)
	at liquibase.Scope.child(Scope.java:174)
	at liquibase.Scope.child(Scope.java:162)
	at liquibase.Scope.child(Scope.java:141)
	at liquibase.Liquibase.runInScope(Liquibase.java:2322)
	... 10 common frames omitted
2021-03-17T10:15:49,478Z [Trace ID: ba93d282817ab953] [pool-1-thread-1,] ERROR com.acme.liquibase.runner.Application - java.lang.RuntimeException: Cannot end scope pyolzqgxeg when currently at scope imsoofofys
liquibase.exception.LiquibaseException: java.lang.RuntimeException: Cannot end scope pyolzqgxeg when currently at scope imsoofofys
	at liquibase.Liquibase.runInScope(Liquibase.java:2327)
	at liquibase.Liquibase.update(Liquibase.java:216)
	at liquibase.Liquibase.update(Liquibase.java:202)
	at liquibase.Liquibase.update(Liquibase.java:198)
	at liquibase.Liquibase.update(Liquibase.java:190)
	at com.acme.liquibase.runner.Application.applyLiquibase(Application.java:156)
	at com.acme.liquibase.runner.Application.lambda$run$0(Application.java:103)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1736)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.RuntimeException: Cannot end scope pyolzqgxeg when currently at scope imsoofofys
	at liquibase.Scope.exit(Scope.java:212)
	at liquibase.Scope.child(Scope.java:174)
	at liquibase.Scope.child(Scope.java:162)
	at liquibase.Scope.child(Scope.java:141)
	at liquibase.Liquibase.runInScope(Liquibase.java:2322)
	... 10 common frames omitted
```

If we set the ScopeManager as follows prior to creating the separate threads:

```
ThreadLocalScopeManager threadLocalScopeManager = new ThreadLocalScopeManager();
Scope.setScopeManager(threadLocalScopeManager);
```

then we get the below exception in this line of code prior to running the Liquibase update due to the root scope not being properly initialized:

```
FileSystemResourceAccessor fileSystemResourceAccessor = new FileSystemResourceAccessor(new File(changeLogRoot));
```

```
2021-03-17T12:50:40,663Z [Trace ID: 890973329e850749] [pool-1-thread-2,] ERROR com.acme.liquibase.runner.Application - null
java.lang.NullPointerException: null
	at liquibase.resource.FileSystemResourceAccessor.addRootPath(FileSystemResourceAccessor.java:54)
	at liquibase.resource.FileSystemResourceAccessor.<init>(FileSystemResourceAccessor.java:36)
	at com.acme.liquibase.runner.Application.applyLiquibase(Application.java:157)
	at com.acme.liquibase.runner.Application.lambda$run$0(Application.java:104)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1736)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
2021-03-17T12:50:40,663Z [Trace ID: 246c4e7f0188f22c] [pool-1-thread-1,] ERROR com.acme.liquibase.runner.Application - null
java.lang.NullPointerException: null
	at liquibase.resource.FileSystemResourceAccessor.addRootPath(FileSystemResourceAccessor.java:54)
	at liquibase.resource.FileSystemResourceAccessor.<init>(FileSystemResourceAccessor.java:36)
	at com.acme.liquibase.runner.Application.applyLiquibase(Application.java:157)
	at com.acme.liquibase.runner.Application.lambda$run$0(Application.java:104)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1736)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```

## Expected/Desired Behavior
Once we applied the changes in this pull request and configured our custom ThreadLocalScopeManager the Liquibase changsets are updated concurrently without any errors and the Spring Boot command line application completes successfully.

## Screenshots (if appropriate)
If applicable, add screenshots to help explain your problem.

## Additional Context
Add any other context about the problem here.

## Fast Track PR Acceptance Checklist:
* [x] Build is successful and all new and existing tests pass
* [ ] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
* [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
* [ ] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls)
* [ ] Documentation Updated

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)

---

## Dev Handoff Notes (Internal Use)

#### Links

- Fixed Issue: Standalone PR
- Local Branch: https://github.com/liquibase/liquibase/tree/rudolfv-fix_scope_multithreading_bug
- Unit Tests: https://github.com/liquibase/liquibase/pull/1768/checks
- Integration Tests: (shown in Unit Tests link above)
- Functional Tests: https://jenkins.datical.net/job/liquibase-pro/job/rudolfv-fix_scope_multithreading_bug/

#### Testing

- Steps to Reproduce: See above
- Guidance: 
  - Does not change functionality, just throws exception if code is called incorrectly
  
#### Dev Verification

Code review and automated tests

┆Issue is synchronized with this [Jiraserver Story](https://datical.atlassian.net/browse/LB-1359) by [Unito](https://www.unito.io)
