### PR TITLE
fix loading clob data into postgres

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
@@ -466,9 +466,10 @@ public class LoadDataChange extends AbstractTableChange implements ChangeWithCol
                 //     of whether the 'usePreparedStatement' is set to false
                 // 2. The database supports batched statements (for improved performance) AND we are not in an
                 //    "SQL" mode (i.e. we generate an SQL file instead of actually modifying the database).
-                if
-                ((needsPreparedStatement && (databaseSupportsBatchUpdates && ! isLoggingExecutor(database))) &&
-                        hasPreparedStatementsImplemented()) {
+                if (
+                        (needsPreparedStatement || (databaseSupportsBatchUpdates && !isLoggingExecutor(database)))
+                                && hasPreparedStatementsImplemented()
+                ) {
                     anyPreparedStatements = true;
                     ExecutablePreparedStatementBase stmt =
                         this.createPreparedStatement(

--- a/liquibase-core/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
@@ -489,38 +489,7 @@ public class LoadDataChangeTest extends StandardChangeTest {
         "TABLE_NAME" == ((ExecutablePreparedStatementBase) sqlStatements[1]).getTableName()
 
     }
-    def "DB NO Batch Update Support usePrepared True produces InsertSetStatement"() throws Exception {
-        when:
-        LoadDataChange loadDataChange = new LoadDataChange();
-        loadDataChange.setSchemaName("SCHEMA_NAME");
-        loadDataChange.setTableName("TABLE_NAME");
-        loadDataChange.setUsePreparedStatements(Boolean.TRUE);
-        loadDataChange.setFile("liquibase/change/core/sample.data1.csv");
 
-        SqlStatement[] sqlStatement = loadDataChange.generateStatements(new MSSQLDatabase());
-
-        then:
-        sqlStatement.length == 1
-        assert sqlStatement[0] instanceof InsertSetStatement
-
-        when:
-        SqlStatement[] sqlStatements = ((InsertSetStatement) sqlStatement[0]).getStatementsArray();
-
-        then:
-        sqlStatements.length == 2
-        assert sqlStatements[0] instanceof InsertStatement
-        assert sqlStatements[1] instanceof InsertStatement
-
-        "SCHEMA_NAME" == ((InsertStatement) sqlStatements[0]).getSchemaName()
-        "TABLE_NAME" == ((InsertStatement) sqlStatements[0]).getTableName()
-        "Bob Johnson" == ((InsertStatement) sqlStatements[0]).getColumnValue("name")
-        "bjohnson" == ((InsertStatement) sqlStatements[0]).getColumnValue("username")
-
-        "SCHEMA_NAME" == ((InsertStatement) sqlStatements[1]).getSchemaName()
-        "TABLE_NAME" == ((InsertStatement) sqlStatements[1]).getTableName()
-        "John Doe" == ((InsertStatement) sqlStatements[1]).getColumnValue("name")
-        "jdoe" == ((InsertStatement) sqlStatements[1]).getColumnValue("username")
-    }
     def "DB Batch Update Support usePrepared False produces InsertSetStatement"() throws Exception {
         when:
         LoadDataChange loadDataChange = new LoadDataChange();

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/pgsql/PostgreSQLIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/pgsql/PostgreSQLIntegrationTest.java
@@ -1,6 +1,5 @@
 package liquibase.dbtest.pgsql;
 
-import liquibase.CatalogAndSchema;
 import liquibase.Scope;
 import liquibase.change.Change;
 import liquibase.change.core.CreateTableChange;
@@ -13,9 +12,6 @@ import liquibase.diff.compare.CompareControl;
 import liquibase.diff.output.DiffOutputControl;
 import liquibase.diff.output.changelog.DiffToChangeLog;
 import liquibase.executor.ExecutorService;
-import liquibase.snapshot.DatabaseSnapshot;
-import liquibase.snapshot.SnapshotControl;
-import liquibase.snapshot.SnapshotGeneratorFactory;
 import liquibase.statement.core.RawSqlStatement;
 import org.junit.Assert;
 import org.junit.Test;
@@ -26,6 +22,18 @@ public class PostgreSQLIntegrationTest extends AbstractIntegrationTest {
 
     public PostgreSQLIntegrationTest() throws Exception {
         super("pgsql", DatabaseFactory.getInstance().getDatabase("postgresql"));
+    }
+
+    /**
+     * Postgresql caches info including enum oid mappings in the connection. When we do a lot of dropping/re-creating in the tests it gets confused.
+     * Closing the connection
+     */
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        if (getDatabase() != null && getDatabase().getConnection() != null) {
+            getDatabase().getConnection().close();
+        }
     }
 
     @Override


### PR DESCRIPTION
Data loaded from CLOB type columns is not loaded properly into PostgreSQL.
Instead of loading the content of the CLOB file, the filename is loaded.

See issue #1790 

When the data needs a prepared statement to be executed (example CLOB) and the database does not support batch mode (example PostgreSQL), the statement is executed as a normal statement and the the text string (the filename of the clob) is inserted instead of the content of the CLOB. 

<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->

## Environment
**Liquibase Version**:
4.4.0

**Liquibase Integration & Version**: <Pick one: CLI, maven, gradle, spring boot, servlet, etc.>
CLI and Spring boot

**Liquibase Extension(s) & Version**: 

**Database Vendor & Version**:
PostgreSQL

**Operating System Type & Version**:
Windows 10 (irrelevent)

## Pull Request Type
<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->

* [x] Bug fix (non-breaking change which fixes an issue.)
* [ ] Enhancement/New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
See issue #1790 

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->

* [x] Build is successful and all new and existing tests pass
* [ ] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
* [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
* [ ] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls)
* [ ] Documentation Updated

## Test Requirements (Internal Liquibase QA)
**Automated Functional Test Requirements**

* Add a functional regression test for Postgres
  * Replicate the steps and expected outcome listed in the Manual Test Requirements section.

**Manual Test Requirements**

For the following tests, use the attached changelog lb-1423.xml and  files lb-1423.txt and fake-data.txt.

_Verify update~~sql shows the contents of fake~~data.txt in the insert for the clob column._

_Verify update is successful._

_Verify the table1 has the contents of fake-data.txt in the clob column._

---

## Dev Handoff Notes (Internal Use)

#### Links

- Fixed Issue: https://github.com/liquibase/liquibase/issues/1790
- Local Branch: https://github.com/liquibase/liquibase/tree/jidma-fix-loading-clob
- Unit Tests: https://github.com/liquibase/liquibase/pull/1791/checks
- Integration Tests: (shown in Unit Tests link above)
- Functional Tests: https://jenkins.datical.net/job/liquibase-pro/job/jidma-fix-loading-clob/

#### Testing

- Steps to Reproduce: https://github.com/liquibase/liquibase/issues/1790
- Guidance:
  - The fix had a lot of back and forth making sure it worked correctly by default, and also respected the usePreparedStatements flag. Read through the comments on this ticket as well.
  - Fix impacts postgresql primarily, but cleans up logic that is used by all databases.

#### Dev Verification

Did not save output, but did testing with postgresql, mysql, and oracle beyond what done with the automated tests.

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)

┆Issue is synchronized with this [Jiraserver Story](https://datical.atlassian.net/browse/LB-1423) by [Unito](https://www.unito.io)
