### PR TITLE
relative bug fix for sql files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -37,12 +37,12 @@ List the steps to reproduce the behavior.
   - Exact commands used - CLI, maven, gradle, spring boot, servlet, etc.
 
 ## Actual Behavior
-A clear and concise description of what happens in the software **before** this pull request.
+A clear and concise description of what happens in the software with the **version used**.
 - Include console output if relevant
 - Include log files if available.
 
 ## Expected/Desired Behavior
-A clear and concise description of what happens in the software **after** this pull request.
+A clear and concise description of what happens in the software **after** a fix is created and merged.
 
 ## Screenshots (if appropriate)
 If applicable, add screenshots to help explain your problem.

--- a/liquibase-core/src/main/java/liquibase/change/core/SQLFileChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/SQLFileChange.java
@@ -114,27 +114,17 @@ public class SQLFileChange extends AbstractSQLChange {
             return null;
         }
 
-        InputStream inputStream = null;
+        InputStream inputStream;
         try {
-
-
-            StringBuilder newPath=new StringBuilder();
             String relativeTo = null;
             if (ObjectUtil.defaultIfNull(isRelativeToChangelogFile(), false)) {
                 relativeTo = getChangeSet().getChangeLog().getPhysicalFilePath();
-                newPath.append(relativeTo.substring(0,relativeTo.lastIndexOf("/")+1));
-                int loc=path.lastIndexOf("/");
-                if (loc>=0) {
-                    newPath.append(path.substring(loc+1));
-                }
-                else {
-                    newPath.append(path);
-                }
             }
-            inputStream = Scope.getCurrentScope().getResourceAccessor().openStream(null, newPath.toString());
+            inputStream = Scope.getCurrentScope().getResourceAccessor().openStream(relativeTo, path);
         } catch (IOException e) {
             throw new IOException("Unable to read file '" + path + "'", e);
         }
+
         if (inputStream != null) {
             return inputStream;
         }

--- a/liquibase-core/src/test/resources/com/example/my-logic.sql
+++ b/liquibase-core/src/test/resources/com/example/my-logic.sql
@@ -1,0 +1,1 @@
+My Logic Here


### PR DESCRIPTION
Fixes #1277 
Fixes #1353

<!--- This environment context section helps us quickly review your PR. 
Please take a minute to fill-out this information. -->

## Environment
liquibase
**Liquibase Version**:
4.3.3 and above, this PR was code code checked out on master today which was v4.4.0 level
**Liquibase Integration & Version**: <Pick one: CLI, maven, gradle, spring boot, servlet, etc.>
Liquibase-core
**Liquibase Extension(s) & Version**: 

**Database Vendor & Version**:
oracle 19c
**Operating System Type & Version**:
ubuntu 18.04

## Pull Request Type
bug fix    sqlfile relative paths
<!--- What types of changes does your code introduce?
Put an `x` in all the boxes that apply: 
If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->

* \[x] Bug fix (non-breaking change which fixes an issue.)
* \[ ] Enhancement/New feature (non-breaking change which adds functionality)
* \[ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
A clear and concise description of the issue being addressed.  Additional guidance [here](https://liquibase.jira.com/wiki/spaces/LB/pages/1274904896/How+to+Contribute+Code+to+Liquibase+Core).

* Describe the actual problematic behavior.
* Ensure private information is redacted.
when specifying sqlfile path  in databasechangelog xml file

```<sqlFile path="./acp_phase5_step3_1.sql" stripComments="false" splitStatements="true" encoding="utf8" endDelimiter="\n/" relativeToChangelogFile="true"/>```

the change in databasechangelog looks like this
```<changeSet id="9_tag" author="PierreN" logicalFilePath="V004/07_ACP_PHASE5_step5.xml">```

the sql file is in the same folder V004 as the xml file which is found.
this has been broken from the 1st version  of liquibase version 4

## Steps To Reproduce
perform liquibase    "update"

```$JAVA_HOME/bin/java -Dexec.args="-Duser.timezone=US/Eastern" -Duser.timezone=US/Eastern -cp "$CLASSPATH" liquibase.integration.commandline.Main --changeLogFile=src/main/resources/liquibase/db/changelog/local_update.xml --contexts=local --logFile=./lb_update.log --outputDefaultSchema=true --logLevel=debug  update```

## Actual Behavior
A clear and concise description of what happens in the software **before** this pull request.
Unexpected error running Liquibase: java.io.IOException: The file ./acp_phase5_step3_1.sql was not found in

* C:\Program Files\Java\jdk1.8.0_221\jre\lib\charsets.jar
* C:\Program Files\Java\jdk1.8.0_221\jre\lib\deploy.jar
* C:\Program Files\Java\jdk1.8.0_221\jre\lib\ext\access-bridge-64.jar
* C:\Program Files\Java\jdk1.8.0_221\jre\lib\ext\cldrdata.jar
* C:\Program Files\Java\jdk1.8.0_221\jre\lib\ext\dnsns.jar
* C:\Program Files\Java\jdk1.8.0_221\jre\lib\ext\jaccess.jar
* C:\Program Files\Java\jdk1.8.0_221\jre\lib\ext\jfxrt.jar
* C:\Program Files\Java\jdk1.8.0_221\jre\lib\ext\localedata.jar
* C:\Program Files\Java\jdk1.8.0_221\jre\lib\ext\nashorn.jar
* C:\Program Files\Java\jdk1.8.0_221\jre\lib\ext\sunec.jar
* C:\Program Files\Java\jdk1.8.0_221\jre\lib\ext\sunjce_provider.jar
* C:\Program Files\Java\jdk1.8.0_221\jre\lib\ext\sunmscapi.jar
* C:\Program Files\Java\jdk1.8.0_221\jre\lib\ext\sunpkcs11.jar
* C:\Program Files\Java\jdk1.8.0_221\jre\lib\ext\zipfs.jar
* C:\Program Files\Java\jdk1.8.0_221\jre\lib\javaws.jar
* C:\Program Files\Java\jdk1.8.0_221\jre\lib\javaws.jar
* C:\Program Files\Java\jdk1.8.0_221\jre\lib\jce.jar
* C:\Program Files\Java\jdk1.8.0_221\jre\lib\jfr.jar
* C:\Program Files\Java\jdk1.8.0_221\jre\lib\jfxswt.jar
* C:\Program Files\Java\jdk1.8.0_221\jre\lib\jsse.jar
* C:\Program Files\Java\jdk1.8.0_221\jre\lib\management-agent.jar
* C:\Program Files\Java\jdk1.8.0_221\jre\lib\plugin.jar
* C:\Program Files\Java\jdk1.8.0_221\jre\lib\resources.jar
* C:\Program Files\Java\jdk1.8.0_221\jre\lib\rt.jar
* C:\Program Files\Java\jdk1.8.0_221\src.zip
....more jars...

## Expected/Desired Behavior
no Java exception, process liquibase script to completion

## Screenshots (if appropriate)
If applicable, add screenshots to help explain your problem.

## Additional Context
fix is specific to find sqlfiles

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<

!--- If you're unsure about any of these, just ask us in a comment. We're here to help|width=200,height=183!

-->

* \[x] Build is successful and all new and existing tests pass
* \[ ] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
* \[ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
* \[ ] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls)
* \[ ] Documentation Updated

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)

## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issues: 
  * [https://github.com/liquibase/liquibase/issues/1277](https://github.com/liquibase/liquibase/issues/1277) 
  * [https://github.com/liquibase/liquibase/issues/1353](https://github.com/liquibase/liquibase/issues/1353)
* Local Branch: [https://github.com/liquibase/liquibase/tree/pierre2113-sqlfile_relative_path_fix](https://github.com/liquibase/liquibase/tree/pierre2113-sqlfile_relative_path_fix)
* Unit Tests: [https://github.com/liquibase/liquibase/pull/1798/checks](https://github.com/liquibase/liquibase/pull/1798/checks)
* Integration Tests: (shown in Unit Tests link above)
* Functional Tests: [https://jenkins.datical.net/job/liquibase-pro/job/pierre2113-sqlfile_relative_path_fix/](https://jenkins.datical.net/job/liquibase-pro/job/pierre2113-sqlfile_relative_path_fix/)

#### Testing
* Steps to Reproduce: [https://github.com/liquibase/liquibase/issues/1277](https://github.com/liquibase/liquibase/issues/1277) and [https://github.com/liquibase/liquibase/issues/1353](https://github.com/liquibase/liquibase/issues/1353)
* Guidance: 
  * Impacts only formatted SQL files include'ed and includeAll'ed

#### Dev Verification
(did not save output)

## Test Requirements (Internal Liquibase QA)
* No new automated tests required for this fix; integration test is sufficient.

**Manual Test Requirements**

Test using the attached lb-1469.xml changelog and lb-1469.sql, lb-1469b.sql files.
_Verify update is successful for a sqlFile change where logicalFilePath differs from physical file path._

* No exception is thrown
* The table lb1469_tbl is created on the database
* The function lb1469n is created on the database

_Verify update is successful for a createTable change where logicalFilePath differs from physical file path._

* No exception is thrown
* The table lfpchangeset1 is created on the database

_Verify update is successful for sqlFile changes where logicalFilePath differs from physical file path._

* No exception is thrown
* The table lb1469_tbl is created on the database
* The function lb1469n is created on the database

_Verify the DATABASECHANGELOG table has the correct filename for each changeset._

* The filename is the logical file path applied for each changeset; in this case, the logical file paths do not match the name of the physical changelog.

|**Changeset**|**DATABASECHANGELOG.FILENAME**|
|----|----|
|1::lfpChangelog|a~~logical~~file-path|
|1:lfpChangeSet|lfp2|
|2:lfpChangeSet|lfp3|



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-1469) by [Unito](https://www.unito.io)
