### PR TITLE
[LB-704] fixed generating sequences for postgre versions prior to 10

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateSequenceGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateSequenceGenerator.java
@@ -38,6 +38,10 @@ public class CreateSequenceGenerator extends AbstractSqlGenerator<CreateSequence
             validationErrors.checkDisallowedField("maxValue", statement.getMaxValue(), database, FirebirdDatabase.class, H2Database.class, HsqlDatabase.class);
         }
 
+        if (isPostgreWithoutAsDatatypeSupport(database)) {
+            validationErrors.checkDisallowedField("AS", statement.getDataType(), database, PostgresDatabase.class);
+        }
+
         validationErrors.checkDisallowedField("ordered", statement.getOrdered(), database, HsqlDatabase.class, PostgresDatabase.class);
         validationErrors.checkDisallowedField("dataType", statement.getDataType(), database, DB2Database.class, HsqlDatabase.class, OracleDatabase.class, MySQLDatabase.class, MSSQLDatabase.class);
 
@@ -120,5 +124,14 @@ public class CreateSequenceGenerator extends AbstractSqlGenerator<CreateSequence
     private boolean isH2WithMinMaxSupport(Database database) {
         return H2Database.class.isAssignableFrom(database.getClass())
                 && ((H2Database) database).supportsMinMaxForSequences();
+    }
+
+    private boolean isPostgreWithoutAsDatatypeSupport(Database database) {
+        try {
+            return database instanceof PostgresDatabase && database.getDatabaseMajorVersion() < 10;
+        } catch (DatabaseException e) {
+            // we can't determinate the PostgreSQL version so we shouldn't throw validation error as it might work for this DB
+            return false;
+        }
     }
 }

--- a/liquibase-core/src/test/java/liquibase/sqlgenerator/core/CreateSequenceGeneratorTest.java
+++ b/liquibase-core/src/test/java/liquibase/sqlgenerator/core/CreateSequenceGeneratorTest.java
@@ -1,20 +1,20 @@
 package liquibase.sqlgenerator.core;
 
-import static org.mockito.Mockito.*;
-
-import java.math.BigInteger;
-
-import org.assertj.core.api.Assertions;
-import org.junit.Test;
-
 import liquibase.database.Database;
 import liquibase.database.DatabaseConnection;
 import liquibase.database.core.PostgresDatabase;
 import liquibase.exception.DatabaseException;
+import liquibase.exception.ValidationErrors;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.AbstractSqlGeneratorTest;
 import liquibase.sqlgenerator.MockSqlGeneratorChain;
 import liquibase.statement.core.CreateSequenceStatement;
+import org.junit.Test;
+
+import java.math.BigInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 public class CreateSequenceGeneratorTest extends AbstractSqlGeneratorTest<CreateSequenceStatement> {
 
@@ -48,24 +48,60 @@ public class CreateSequenceGeneratorTest extends AbstractSqlGeneratorTest<Create
 
         // verify that for version <= 9.4 no IF NOT EXISTS is not in the statement
         Sql[] sql = new CreateSequenceGenerator().generateSql(createSequenceStatement, database, new MockSqlGeneratorChain());
-        Assertions.assertThat(sql).isNotEmpty().hasSize(1);
-        Assertions.assertThat(sql[0].toSql()).doesNotContain("IF NOT EXISTS");
+        assertThat(sql).isNotEmpty().hasSize(1);
+        assertThat(sql[0].toSql()).doesNotContain("IF NOT EXISTS");
 
         // verify that if no version is available the optional no IF NOT EXISTS is not in the statement
         reset(dbConnection);
         when(dbConnection.getDatabaseMajorVersion()).thenThrow(DatabaseException.class);
 
         sql = new CreateSequenceGenerator().generateSql(createSequenceStatement, database, new MockSqlGeneratorChain());
-        Assertions.assertThat(sql).isNotEmpty().hasSize(1);
-        Assertions.assertThat(sql[0].toSql()).doesNotContain("IF NOT EXISTS");
+        assertThat(sql).isNotEmpty().hasSize(1);
+        assertThat(sql[0].toSql()).doesNotContain("IF NOT EXISTS");
 
         reset(dbConnection);
         when(dbConnection.getDatabaseMajorVersion()).thenReturn(9);
         when(dbConnection.getDatabaseMinorVersion()).thenReturn(5);
 
         sql = new CreateSequenceGenerator().generateSql(createSequenceStatement, database, new MockSqlGeneratorChain());
-        Assertions.assertThat(sql).isNotEmpty().hasSize(1);
-        Assertions.assertThat(sql[0].toSql()).contains("IF NOT EXISTS");
+        assertThat(sql).isNotEmpty().hasSize(1);
+        assertThat(sql[0].toSql()).contains("IF NOT EXISTS");
+    }
+
+    @Test
+    public void postgresDatabaseSupportAsStructureByVersion() throws Exception {
+        DatabaseConnection dbConnection = mock(DatabaseConnection.class);
+        ValidationErrors errors;
+        PostgresDatabase postgresDatabase = spy(new PostgresDatabase());
+        postgresDatabase.setConnection(dbConnection);
+        doReturn(SEQUENCE_NAME).when(postgresDatabase).escapeSequenceName(CATALOG_NAME, SCHEMA_NAME, SEQUENCE_NAME);
+
+        // verify that for version < 10 validate() method returns error
+        when(dbConnection.getDatabaseMajorVersion()).thenReturn(9);
+        when(dbConnection.getDatabaseMinorVersion()).thenReturn(6);
+
+        CreateSequenceStatement createSequenceStatement = createSampleSqlStatement();
+        createSequenceStatement.setStartValue(new BigInteger("1"));
+        createSequenceStatement.setDataType("int");
+
+        errors = new CreateSequenceGenerator().validate(createSequenceStatement, postgresDatabase, new MockSqlGeneratorChain());
+        assertThat(errors.getErrorMessages()).contains("AS is not allowed on postgresql");
+
+
+        // verify that if no version is available the validate() method passes
+        reset(dbConnection);
+        when(dbConnection.getDatabaseMajorVersion()).thenThrow(DatabaseException.class);
+        errors = new CreateSequenceGenerator().validate(createSequenceStatement, postgresDatabase, new MockSqlGeneratorChain());
+        assertThat(errors.getErrorMessages()).isEmpty();
+
+
+        // verify that for version >= 10 the validate() method passes
+        reset(dbConnection);
+        when(dbConnection.getDatabaseMajorVersion()).thenReturn(10);
+        when(dbConnection.getDatabaseMinorVersion()).thenReturn(0);
+
+        errors = new CreateSequenceGenerator().validate(createSequenceStatement, postgresDatabase, new MockSqlGeneratorChain());
+        assertThat(errors.getErrorMessages()).isEmpty();
     }
 
 //    @Before


### PR DESCRIPTION
## Environment
**Liquibase Version**:  4.4.0

**Liquibase Integration & Version**: <Pick one: CLI, maven, gradle, spring boot, servlet, etc.>

**Liquibase Extension(s) & Version**: 

**Database Vendor & Version**: PostgreSQL version < 10

**Operating System Type & Version**: Mac OS Catalina 10.15.7

## Pull Request Type
* [x] Bug fix (non-breaking change which fixes an issue.) closes #1429  https://datical.atlassian.net/browse/LB-704
* [ ] Enhancement/New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
PostreSQL doesn't support "AS datatype" structure in sequences prior to version 10. So SQL that Liquibase generates with "AS [datatype]" fails for those postgreSQL versions. Added validation that throws error if `datatype` property in changeset is used for versions of postgre that don't support this structure.

## Steps To Reproduce
* run PostreSQL 9.5 on perm, in docker container or elsewhere
* take changelog file from test harness https://github.com/liquibase/liquibase-test-harness/blob/974f3adeac5225929fef9580bede0ed7c72b7733/src/main/resources/liquibase/harness/change/changelogs/postgresql/createSequence.xml or create your own with **createSequence** changeType
* run Liquibase update command for such file against PostreSQL 9.5 
* verify it fails with query "CREATE SEQUENCE  IF NOT EXISTS test_sequence AS int START WITH 1 INCREMENT BY 1 MINVALUE 1"

with [test harness](https://github.com/liquibase/liquibase-test-harness)
1) Make sure you have a docker container up and running first
2) Go to `src/test/resources/docker` and run `docker-compose up -d`. 
Wait until the databases start up.
3) run mvn test -DchangeObjects=createSequence,dropSequence
4) _createSequence_ and _dropSequence_ tests fails for postre 9 & 9.5

## Actual Behavior
 Liquibase generates "CREATE SEQUENCE  IF NOT EXISTS test_sequence AS int START WITH 1 INCREMENT BY 1 MINVALUE 1" for all PostgreSQL versions and this query fails for version prior to 10

## Expected/Desired Behavior
for PostgreSQL 10 and later nothing should change, query should remains the same, for PostgreSQL prior to version 10 there should be validation error "AS is not allowed on postgresql"

## Fast Track PR Acceptance Checklist:
* [x] Build is successful and all new and existing tests pass
* [x] Added [Unit Test(s)]
* [ ] Added [Integration Test(s)]
* [x] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls) - didn't add, they already exist there. test harness helped to find this issue https://github.com/liquibase/liquibase-test-harness/blob/974f3adeac5225929fef9580bede0ed7c72b7733/src/main/resources/liquibase/harness/change/changelogs/postgresql/createSequence.xml checked with local liquibase-core snapshot - with this fix it works for PostreSQL 9, 9.5, 10, 11, 12, 13
[ ] Documentation Updated

