### PR TITLE
Firebird3Database supports true Boolean, so isNumericBoolean should return false.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -37,12 +37,12 @@ List the steps to reproduce the behavior.
   - Exact commands used - CLI, maven, gradle, spring boot, servlet, etc.
 
 ## Actual Behavior
-A clear and concise description of what happens in the software **before** this pull request.
+A clear and concise description of what happens in the software with the **version used**.
 - Include console output if relevant
 - Include log files if available.
 
 ## Expected/Desired Behavior
-A clear and concise description of what happens in the software **after** this pull request.
+A clear and concise description of what happens in the software **after** a fix is created and merged.
 
 ## Screenshots (if appropriate)
 If applicable, add screenshots to help explain your problem.

--- a/liquibase-integration-tests/src/test/java/liquibase/statementexecute/UnlockDatabaseChangeLogExecuteTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/statementexecute/UnlockDatabaseChangeLogExecuteTest.java
@@ -22,7 +22,7 @@ public class UnlockDatabaseChangeLogExecuteTest extends AbstractExecuteTest {
         assertCorrect("update [databasechangeloglock] set [locked] = 0, [lockedby] = null, [lockgranted] = null where [id] = 1", MSSQLDatabase.class, SybaseDatabase.class);
         assertCorrect("update [databasechangeloglock] set [locked] = 0, [lockedby] = null, [lockgranted] = null where [id] = 1", MSSQLDatabase.class, SybaseASADatabase.class);
         assertCorrect("update [databasechangeloglock] set [locked] = 'f', [lockedby] = null, [lockgranted] = null where [id] = 1", InformixDatabase.class);
-        assertCorrect("update [databasechangeloglock] set [locked] = false, [lockedby] = null, [lockgranted] = null where [id] = 1", PostgresDatabase.class, CockroachDatabase.class, HsqlDatabase.class, H2Database.class, Ingres9Database.class);
+        assertCorrect("update [databasechangeloglock] set [locked] = false, [lockedby] = null, [lockgranted] = null where [id] = 1", PostgresDatabase.class, CockroachDatabase.class, HsqlDatabase.class, H2Database.class, Ingres9Database.class, Firebird3Database.class);
         assertCorrectOnRest("update [databasechangeloglock] set [locked] = 0, [lockedby] = null, [lockgranted] = null where [id] = 1");
     }
 }


### PR DESCRIPTION
## Issue
Fixes #1872

## Environment
**Liquibase Version**: 3.10.3 / 4.3.4

**Liquibase Integration & Version**: gradle - 5.6

**Liquibase Extension(s) & Version**:  - 

**Database Vendor & Version**: FireBird - 3.0.7

**Operating System Type & Version**: Windows 10, 64bit, version - 1909

## Description
Liquibase fails to apply change set with following error:
nested exception is liquibase.exception.LockException: liquibase.exception.DatabaseException: conversion error from string "0" [SQLState:22018, ISC error code:335544334] [Failed SQL: (335544334) INSERT INTO DATABASECHANGELOGLOCK (ID, LOCKED) VALUES (1, 0)]

## Steps To Reproduce
Install FireBird 3.0.7. Create user and grand permission to this user to create database. Create a database and table. Try to apply any change set.

## Actual Behavior
Change set is not getting applied. It fails to create DATABASECHANGELOGLOCK record. 

## Reason
Firebird 3 supports true Boolean (value - true/false) whereas Firebird 2 supports Numeric Boolean (value - 0/1). Using Firebird3, When DATABASECHANGELOGLOCK table is created, CreateTableGenerator calls BooleanType::toDatabaseDataType which returns Boolean type for Firebird3Database. So, the LOCKED field in DATABASECHANGELOGLOCK is created as Boolean type.
In summary LOCKED filed is Boolean type.
But, when any record is inserted, InsertGenerator::generateValues calls isNumericBoolean. This method is not checking Firebird3Database (rather checking instanceof FirebirdDatabase) and returns numeric Boolean for all firebird. So, the value in the insert sql contains 0/1 for LOCKED field. This is not matching as the field type is Boolean. So, insert fails with error.

## Expected/Desired Behavior
Change set should be applied.
isNumericBoolean should check Firebird3Database instance type and return Boolean for Firebird 3.

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: https://github.com/liquibase/liquibase/issues/1872
* Local Branch: https://github.com/liquibase/liquibase/tree/koushikd02-Firebird3BooleanDataType
* Unit Tests: https://github.com/liquibase/liquibase/pull/1875/checks
* Integration Tests: (shown in Unit Tests link above)
* Functional Tests: https://jenkins.datical.net/job/liquibase-pro/job/koushikd02-Firebird3BooleanDataType/

#### Testing
* Steps to Reproduce: https://github.com/liquibase/liquibase/issues/1872
* Guidance: 
  * Only impacts firebird 3+

#### Dev Verification
Ran boolean changelogs on firebird 3 to ensure they work as defined in the isssue.
(No output was saved at the time)



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-1764) by [Unito](https://www.unito.io)
