### PR TITLE
Class cast exception in standard lock service

### DIFF
--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -47,7 +47,14 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.3.3</version>
+            <version>3.8.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>3.8.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/liquibase-core/src/main/java/liquibase/lockservice/StandardLockService.java
+++ b/liquibase-core/src/main/java/liquibase/lockservice/StandardLockService.java
@@ -26,6 +26,8 @@ import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.Table;
 
 import java.text.DateFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.*;
 
 import static java.util.ResourceBundle.getBundle;
@@ -387,10 +389,17 @@ public class StandardLockService implements LockService {
                     locked = (Boolean) lockedValue;
                 }
                 if ((locked != null) && locked) {
+                    Object lockGranted = columnMap.get("LOCKGRANTED");
+                    final Date castedLockGranted;
+                    if (lockGranted instanceof LocalDateTime) {
+                        castedLockGranted = Date.from(((LocalDateTime) lockGranted).atZone(ZoneId.systemDefault()).toInstant());
+                    } else {
+                        castedLockGranted = (Date)lockGranted;
+                    }
                     allLocks.add(
                             new DatabaseChangeLogLock(
                                     ((Number) columnMap.get("ID")).intValue(),
-                                    (Date) columnMap.get("LOCKGRANTED"),
+                                    castedLockGranted,
                                     (String) columnMap.get("LOCKEDBY")
                             )
                     );


### PR DESCRIPTION
## Environment
**Liquibase Version**:
4.3.1 -> 4.4.0

**Liquibase Integration & Version**: <Pick one: CLI, maven, gradle, spring boot, servlet, etc.>
At least spring boot, but all should be impacted

**Liquibase Extension(s) & Version**: 

**Database Vendor & Version**:
MySQL with driver 8.0.23

**Operating System Type & Version**:
All

## Pull Request Type
* \[x] Bug fix (non-breaking change which fixes an issue.)
* \[ ] Enhancement/New feature (non-breaking change which adds functionality)
* \[ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
The issue #1749 occurs when the locks are listed (after the lock times out). This fixes the cast issue. This PR also include a unit test to ensure it works with java.sql.Date and LocalDateTime.
To test it, it was not easy to mock the ExecutorService as the Scope does not allow to override a singleton. Thus I upgraded Mockito in order to use it's new mock static ability.

## Steps To Reproduce
List the steps to reproduce the behavior.

* Use a MySQL DB with driver 8.0.23
* Create a Liquibase lock with a proper LOCKGRANTED date
* Run the migration (it will be locked) wait for the timeout

## Actual Behavior
A class cast exception is thrown (see #1749)

## Expected/Desired Behavior
The locks are listed without any exception

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<

!--- If you're unsure about any of these, just ask us in a comment. We're here to help|width=200,height=183!

-->

* \[x] Build is successful and all new and existing tests pass
* \[x] Added [Unit Test(s)]
* \[ ] Added [Integration Test(s)]
* \[ ] Added [Test Harness Test(s)]
* \[ ] Documentation Updated

Fixes #1749

## Test Requirements (Internal Liquibase QA)
* Verify all automated functional tests pass on Jenkins branch.
* No new automated functional test required for this fix; the unit test is sufficient (and the proper level for a fix of this nature).

_Manual Test Setup_

* On a MySQL database, UPDATE the DATABASECHANGELOGLOCk table to lock the DATABASECHANGELOG table:

```java
UPDATE testdb1.DATABASECHANGELOGLOCK SET `LOCKED` = 1, LOCKEDBY = 'gemfire-PC (192.168.50.238)', LOCKGRANTED = '2021-06-10 12:15:14.553' WHERE ID = 1 AND `LOCKED` = 0;
```

* Execute a Liquibase CLI update (which will hang, waiting on the lock to release).

**CLI**
_Verify list-locks does not throw a stack trace._
_Verify list-locks returns the lock information to the console._
_Verify when the update times out due to the lock, there is no stack trace thrown._

**Spring Boot (Start the Application while database is locked)**

_Verify list-locks does not throw a stack trace._
_Verify list-locks returns the lock information to the console._

## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: [https://github.com/liquibase/liquibase/issues/1749](https://github.com/liquibase/liquibase/issues/1749)
* Local Branch: [https://github.com/liquibase/liquibase/tree/jocmer-evooq-ClassCastException-in-StandardLockService](https://github.com/liquibase/liquibase/tree/jocmer-evooq-ClassCastException-in-StandardLockService)
* Unit Tests: [https://github.com/liquibase/liquibase/pull/1878/checks](https://github.com/liquibase/liquibase/pull/1878/checks)
* Integration Tests: (shown in Unit Tests link above)
* Functional Tests: [https://jenkins.datical.net/job/liquibase-pro/job/jocmer-evooq-ClassCastException-in-StandardLockService](https://jenkins.datical.net/job/liquibase-pro/job/jocmer-evooq-ClassCastException-in-StandardLockService)

#### Testing
* Steps to Reproduce: Specified best in the PR
* Guidance: 
  * Changes only impact the list-locks command

#### Dev Verification
Ran the list-locks command pre-fix to see it fail, and post-fix to see it pass.
(Did not save output at the time)



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-1777) by [Unito](https://www.unito.io)
