### PR TITLE
CLI no longer reading defaultsFile from classpath

### DIFF
--- a/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
+++ b/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
@@ -24,10 +24,7 @@ import liquibase.util.LiquibaseUtil;
 import liquibase.util.StringUtil;
 import picocli.CommandLine;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
+import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -405,7 +402,7 @@ public class LiquibaseCommandLine {
         return returnList.toArray(new String[0]);
     }
 
-    private List<ConfigurationValueProvider> registerValueProviders(String[] args) {
+    private List<ConfigurationValueProvider> registerValueProviders(String[] args) throws IOException {
         final LiquibaseConfiguration liquibaseConfiguration = Scope.getCurrentScope().getSingleton(LiquibaseConfiguration.class);
         List<ConfigurationValueProvider> returnList = new ArrayList<>();
 
@@ -420,10 +417,18 @@ public class LiquibaseCommandLine {
             liquibaseConfiguration.registerProvider(fileProvider);
             returnList.add(fileProvider);
         } else {
-            Scope.getCurrentScope().getLog(getClass()).fine("Cannot find defaultsFile " + defaultsFile.getAbsolutePath());
-            if (!defaultsFileConfig.wasDefaultValueUsed()) {
-                //can't use UI since it's not configured correctly yet
-                System.err.println("Could not find defaults file " + defaultsFile.getAbsolutePath());
+            final InputStream defaultsStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(defaultsFileConfig.getValue());
+            if (defaultsStream == null) {
+                Scope.getCurrentScope().getLog(getClass()).fine("Cannot find defaultsFile " + defaultsFile.getAbsolutePath());
+                if (!defaultsFileConfig.wasDefaultValueUsed()) {
+                    //can't use UI since it's not configured correctly yet
+                    System.err.println("Could not find defaults file " + defaultsFileConfig.getValue());
+                }
+            } else {
+                final DefaultsFileValueProvider fileProvider = new DefaultsFileValueProvider(defaultsStream, "File in classpath "+defaultsFileConfig.getValue());
+                liquibaseConfiguration.registerProvider(fileProvider);
+                returnList.add(fileProvider);
+
             }
         }
 

--- a/liquibase-core/src/main/java/liquibase/configuration/core/DefaultsFileValueProvider.java
+++ b/liquibase-core/src/main/java/liquibase/configuration/core/DefaultsFileValueProvider.java
@@ -10,9 +10,7 @@ import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.servicelocator.LiquibaseService;
 import liquibase.util.StringUtil;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
+import java.io.*;
 import java.util.Map;
 import java.util.Properties;
 import java.util.SortedSet;
@@ -24,15 +22,25 @@ public class DefaultsFileValueProvider extends AbstractMapConfigurationValueProv
     private final Properties properties;
     private final String sourceDescription;
 
-    public DefaultsFileValueProvider(File path) {
+    protected DefaultsFileValueProvider(Properties properties) {
+        this.properties = properties;
+        sourceDescription = "Passed default properties";
+    }
+
+    public DefaultsFileValueProvider(InputStream stream, String sourceDescription) throws IOException {
+        this.sourceDescription = sourceDescription;
+        this.properties = new Properties();
+        this.properties.load(stream);
+        trimAllProperties();
+    }
+
+    public DefaultsFileValueProvider(File path) throws IOException {
         this.sourceDescription = "File " + path.getAbsolutePath();
 
         try (InputStream stream = new FileInputStream(path)) {
             this.properties = new Properties();
             this.properties.load(stream);
             trimAllProperties();
-        } catch (Exception e) {
-            throw new UnexpectedLiquibaseException(e);
         }
     }
 
@@ -109,11 +117,6 @@ public class DefaultsFileValueProvider extends AbstractMapConfigurationValueProv
             }
             properties.put(key, StringUtil.trimToEmpty((String) value));
         });
-    }
-
-    protected DefaultsFileValueProvider(Properties properties) {
-        this.properties = properties;
-        sourceDescription = "Passed default properties";
     }
 
     @Override

--- a/liquibase-core/src/test/groovy/liquibase/configuration/core/DefaultsFileValueProviderTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/configuration/core/DefaultsFileValueProviderTest.groovy
@@ -6,6 +6,19 @@ import spock.lang.Unroll
 
 class DefaultsFileValueProviderTest extends Specification {
 
+    def "can load from stream"() {
+        when:
+        def stream = new ByteArrayInputStream("""
+long.key: Long Key
+long.multiWord: Long MultiWord
+""".getBytes())
+        def provider = new DefaultsFileValueProvider(stream, "Test stream")
+
+        then:
+        provider.getProvidedValue("long.key").getValue() == "Long Key"
+        provider.getProvidedValue("long.multiWord").getValue() == "Long MultiWord"
+    }
+
     @Unroll
     def "getProvidedValue"() {
         setup:


### PR DESCRIPTION
Fixes #1892

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: liquibase/liquibase#1892
* Local Branch: [https://github.com/liquibase/liquibase/tree/LB-1795](https://github.com/liquibase/liquibase/tree/LB-1795)
* Unit Tests: [https://github.com/liquibase/liquibase/pull/1893/checks](https://github.com/liquibase/liquibase/pull/1893/checks)
* Integration Tests: (shown in Unit Tests link above)
* Functional Tests: [https://jenkins.datical.net/job/liquibase-pro/job/LB-1795/](https://jenkins.datical.net/job/liquibase-pro/job/LB-1795/)

#### Testing
* Steps to Reproduce: liquibase/liquibase#1892
* Guidance:
  * Change only impacts CLI

#### Dev Verification
(did not save output at the time)

## Test Requirements (Liquibase Internal QA)
**Manual Tests**

:: SETUP :: 

This test requires a non-executable Jar containing the liquibase.properties and changelog file. We will create this Jar and add it to the Java classpath when we run Liquibase. Use the attached changelog during the setup steps and also when running the tests. 

* Put your properties file, database driver and the the liquibase/lib directory in one directory.
  * This makes the command line easier to write/read without having a bunch of long paths.
  * The attached changelog is fairly generic, although the createView may fail to deploy if you are not running on Postgres.
* Create the Liquibase resources Jar
  * Include only the changelog and the properties file.
  * `jar cvf liquibase-stuff.jar liquibase.properties postgres_community_changelog.xml`
* Put the liquibase.jar in the same directory as the liquibase-stuff.jar

_Verify liquibase update reads properties and changelog within liquibase-stuff.jar._

* `java -cp "liquibase.jar;lib/*;liquibase-stuff.jar;postgresql-42.2.5.jar" liquibase.integration.commandline.Main --logLevel=info update`
* Successful output from  3.5.3 is attached; it should look similar in the fix build.

**Automated Tests**

No new functional tests required for this fix; the PR submitter created an integration test: testParseDefaultPropertyFilesFromResources. I love seeing tests!!



┆Issue is synchronized with this [Jira Story](https://datical.atlassian.net/browse/LB-1796) by [Unito](https://www.unito.io)
