### PR TITLE
Fix Race Condititons During Liquibase Initialization

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/Database.java
@@ -453,5 +453,13 @@ public interface Database extends PrioritizedService {
     String unescapeDataTypeString(String dataTypeString);
 
     ValidationErrors validate();
+
+    default boolean isTableExistsException(DatabaseException e) {
+        return false;
+    }
+
+    default boolean isUniqueConstraintException(DatabaseException e) {
+        return false;
+    }
 }
 

--- a/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MSSQLDatabase.java
@@ -662,4 +662,14 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
                 "VALUES", "VARYING", "VIEW",
                 "WAITFOR", "WHEN", "WHERE", "WHILE", "WITH", "WITHIN GROUP", "WRITETEXT");
     }
+
+    @Override
+    public boolean isTableExistsException(DatabaseException e) {
+        return "S0001".equals(e.getSqlState());
+    }
+
+    @Override
+    public boolean isUniqueConstraintException(DatabaseException e) {
+        return "23000".equals(e.getSqlState());
+    }
 }

--- a/liquibase-core/src/main/java/liquibase/database/core/MySQLDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/MySQLDatabase.java
@@ -661,4 +661,14 @@ public class MySQLDatabase extends AbstractJdbcDatabase {
         }
         return precision;
     }
+
+    @Override
+    public boolean isTableExistsException(DatabaseException e) {
+        return "42S01".equals(e.getSqlState());
+    }
+
+    @Override
+    public boolean isUniqueConstraintException( DatabaseException e ) {
+        return "40001".equals(e.getSqlState());
+    }
 }

--- a/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/OracleDatabase.java
@@ -668,4 +668,8 @@ public class OracleDatabase extends AbstractJdbcDatabase {
 
     }
 
+    @Override
+    public boolean isTableExistsException(DatabaseException e) {
+        return "42000".equals(e.getSqlState());
+    }
 }

--- a/liquibase-core/src/main/java/liquibase/database/core/PostgresDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/PostgresDatabase.java
@@ -432,4 +432,14 @@ public class PostgresDatabase extends AbstractJdbcDatabase {
         return enterpriseDb ? DbTypes.EDB : DbTypes.COMMUNITY;
     }
 
+    @Override
+    public boolean isTableExistsException(DatabaseException e) {
+        return "42P07".equals(e.getSqlState());
+    }
+
+    @Override
+    public boolean isUniqueConstraintException(DatabaseException e)
+    {
+        return "23505".equals(e.getSqlState());
+    }
 }

--- a/liquibase-core/src/main/java/liquibase/exception/DatabaseException.java
+++ b/liquibase-core/src/main/java/liquibase/exception/DatabaseException.java
@@ -3,19 +3,37 @@ package liquibase.exception;
 public class DatabaseException extends LiquibaseException {
 
     private static final long serialVersionUID = 1L;
-    
+
+    private final String sqlState;
+
     public DatabaseException() {
+        this.sqlState = null;
     }
 
     public DatabaseException(String message) {
         super(message);
+        this.sqlState = null;
     }
 
     public DatabaseException(String message, Throwable cause) {
         super(message, cause);
+        this.sqlState = null;
     }
 
     public DatabaseException(Throwable cause) {
         super(cause);
+        this.sqlState = null;
+    }
+
+    public DatabaseException(String message, String sqlState, Throwable cause) {
+        super(message, cause);
+        this.sqlState = sqlState;
+    }
+
+    /**
+     * @see java.sql.SQLException#getSQLState()
+     */
+    public String getSqlState() {
+        return sqlState;
     }
 }

--- a/liquibase-core/src/main/java/liquibase/executor/jvm/JdbcExecutor.java
+++ b/liquibase-core/src/main/java/liquibase/executor/jvm/JdbcExecutor.java
@@ -327,8 +327,10 @@ public class JdbcExecutor extends AbstractExecutor {
                         JdbcUtil.closeStatement(stmt);
                     }
                 }
+            } catch (SQLException e) {
+                throw new DatabaseException(e.getMessage() + " [Failed SQL: (" + e.getErrorCode() + ", " + e.getSQLState() + ") " + sql.toSql() + "]", e.getSQLState(), e);
             } catch (Exception e) {
-                throw new DatabaseException(e.getMessage() + " [Failed SQL: " + getErrorCode(e) + sql.toSql() + "]", e);
+                throw new DatabaseException(e.getMessage() + " [Failed SQL: " + sql.toSql() + "]", e);
             }
         }
     }
@@ -345,13 +347,6 @@ public class JdbcExecutor extends AbstractExecutor {
             }
             throw new DatabaseException(message.toString());
         }
-    }
-
-    String getErrorCode(Throwable e) {
-        if (e instanceof SQLException) {
-            return "(" + ((SQLException)e).getErrorCode() + ") ";
-        }
-        return "";
     }
 
     private class ExecuteStatementCallback implements StatementCallback {
@@ -388,8 +383,10 @@ public class JdbcExecutor extends AbstractExecutor {
                     if (!stmt.execute(statement)) {
                         log.fine(Integer.toString(stmt.getUpdateCount()) + " row(s) affected");
                     }
+                } catch (SQLException e) {
+                    throw new DatabaseException(e.getMessage() + " [Failed SQL: (" + e.getErrorCode() + ", " + e.getSQLState() + ") " + statement + "]", e.getSQLState(), e);
                 } catch (Throwable e) {
-                    throw new DatabaseException(e.getMessage()+ " [Failed SQL: " + getErrorCode(e) + statement+"]", e);
+                    throw new DatabaseException(e.getMessage() + " [Failed SQL: " + statement + "]", e);
                 }
                 try {
                     int updateCount = 0;
@@ -402,8 +399,10 @@ public class JdbcExecutor extends AbstractExecutor {
                         }
                     } while (updateCount != -1);
 
+                } catch (SQLException e) {
+                    throw new DatabaseException(e.getMessage() + " [Failed SQL: (" + e.getErrorCode() + ", " + e.getSQLState() + ") " + statement + "]", e.getSQLState(), e);
                 } catch (Exception e) {
-                    throw new DatabaseException(e.getMessage()+ " [Failed SQL: "+ getErrorCode(e) + statement+"]", e);
+                    throw new DatabaseException(e.getMessage()+ " [Failed SQL: " + statement +"]", e);
                 }
             }
             return null;

--- a/liquibase-core/src/main/java/liquibase/hub/HubUpdater.java
+++ b/liquibase-core/src/main/java/liquibase/hub/HubUpdater.java
@@ -429,22 +429,26 @@ public class HubUpdater {
         } catch (LockException e) {
             Scope.getCurrentScope().getLog(HubUpdater.class).warning(Liquibase.MSG_COULD_NOT_RELEASE_LOCK);
         }
-        String promptString =
-                "Do you want to see this operation's report in Liquibase Hub, which improves team collaboration? \n" +
-                        "If so, enter your email. If not, enter [N] to no longer be prompted, or [S] to skip for now, but ask again next time";
-        String input = Scope.getCurrentScope().getUI().prompt(promptString, "S", (input1, returnType) -> {
-            input1 = input1.trim().toLowerCase();
-            if (!(input1.equals("s") || input1.equals("n") || input1.contains("@"))) {
-                throw new IllegalArgumentException("Invalid input '" + input1 + "'");
-            }
-            return input1;
-        }, String.class);
 
-        //
-        // Re-lock before proceeding
-        //
-        LockService lockService = LockServiceFactory.getInstance().getLockService(database);
-        lockService.waitForLock();
+        String input;
+        try {
+            String promptString =
+               "Do you want to see this operation's report in Liquibase Hub, which improves team collaboration? \n" +
+                  "If so, enter your email. If not, enter [N] to no longer be prompted, or [S] to skip for now, but ask again next time";
+            input = Scope.getCurrentScope().getUI().prompt(promptString, "S", (input1, returnType) -> {
+                input1 = input1.trim().toLowerCase();
+                if (!(input1.equals("s") || input1.equals("n") || input1.contains("@"))) {
+                    throw new IllegalArgumentException("Invalid input '" + input1 + "'");
+                }
+                return input1;
+            }, String.class);
+        } finally {
+            //
+            // Re-lock before proceeding
+            //
+            LockService lockService = LockServiceFactory.getInstance().getLockService(database);
+            lockService.waitForLock();
+        }
 
         String defaultsFilePath = Scope.getCurrentScope().get("defaultsFile", String.class);
         File defaultsFile = null;

--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -1709,8 +1709,7 @@ public class Main {
                 liquibase.reportLocks(System.err);
                 return;
             } else if (COMMANDS.RELEASE_LOCKS.equalsIgnoreCase(command)) {
-                LockService lockService = LockServiceFactory.getInstance().getLockService(database);
-                lockService.forceReleaseLock();
+                liquibase.forceReleaseLocks();
                 Scope.getCurrentScope().getUI().sendMessage(String.format(
                         coreBundle.getString("successfully.released.database.change.log.locks"),
                         liquibase.getDatabase().getConnection().getConnectionUserName() +

--- a/liquibase-core/src/test/java/liquibase/executor/jvm/JdbcExecutorTest.java
+++ b/liquibase-core/src/test/java/liquibase/executor/jvm/JdbcExecutorTest.java
@@ -49,11 +49,4 @@ public class JdbcExecutorTest {
         assertTrue(Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", oracle1) != Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", mysql));
     }
 
-    @Test
-    public void testGetErrorCode() {
-        assertEquals("", new JdbcExecutor().getErrorCode(new RuntimeException()));
-        assertEquals("(123) ", new JdbcExecutor().getErrorCode(new SQLException("reason", "sqlState", 123)));
-        assertEquals("(0) ", new JdbcExecutor().getErrorCode(new SQLException()));
-    }
-
 }

--- a/liquibase-dist/pom.xml
+++ b/liquibase-dist/pom.xml
@@ -158,6 +158,9 @@
                         <manifestFile>${project.basedir}/../liquibase-core/target/classes/META-INF/MANIFEST.MF
                         </manifestFile>
                     </archive>
+
+                    <!-- Enables building Liquibase on MacOS -->
+                    <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>
                 <executions>
                     <execution>

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
@@ -1,5 +1,8 @@
 package liquibase.dbtest;
 
+import groovy.lang.Tuple2;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import liquibase.*;
 import liquibase.changelog.ChangeLogHistoryServiceFactory;
 import liquibase.changelog.ChangeSet;
@@ -26,7 +29,9 @@ import liquibase.hub.HubConfiguration;
 import liquibase.listener.SqlListener;
 import liquibase.lockservice.LockService;
 import liquibase.lockservice.LockServiceFactory;
+import liquibase.logging.LogService;
 import liquibase.logging.Logger;
+import liquibase.logging.core.JavaLogService;
 import liquibase.resource.FileSystemResourceAccessor;
 import liquibase.resource.ResourceAccessor;
 import liquibase.snapshot.DatabaseSnapshot;
@@ -1145,5 +1150,103 @@ public abstract class AbstractIntegrationTest {
 
     public void setDefaultSchemaName(String defaultSchemaName) {
         this.defaultSchemaName = defaultSchemaName;
+    }
+
+    @Test
+    public void testThatMultipleJVMsCanApplyChangelog() throws Exception {
+        clearDatabase();
+
+        List<ProcessBuilder> processBuilders = Arrays.asList(
+           prepareExternalLiquibaseProcess(),
+           prepareExternalLiquibaseProcess(),
+           prepareExternalLiquibaseProcess()
+        );
+
+        List<Process> processes = new ArrayList<>();
+        for (ProcessBuilder builder : processBuilders) {
+            Process process = builder.redirectErrorStream(true).start();
+            processes.add(process);
+        }
+
+        List<Tuple2<Integer, String>> outputs = new ArrayList<>();
+        for (Process process : processes) {
+            boolean exitedWithinTimeout = !process.waitFor(2, TimeUnit.MINUTES);
+
+            String output;
+            try (BufferedReader input = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                output = input.lines().limit(100).collect(Collectors.joining(System.lineSeparator()));
+            }
+
+            if (!exitedWithinTimeout) {
+                process.destroy();
+            }
+
+            outputs.add(new Tuple2<>(process.exitValue(), output));
+        }
+
+        for (Tuple2<Integer, String> output : outputs) {
+            if (output.getFirst() == 0) {
+                continue;
+            }
+
+            fail("Migration JVM failed with exit code " + output.getFirst() + ": " + output.getSecond());
+        }
+    }
+
+    private ProcessBuilder prepareExternalLiquibaseProcess() {
+        String javaHome = System.getProperty("java.home");
+        String javaBin = javaHome + File.separator + "bin" + File.separator + "java";
+        String classpath = System.getProperty("java.class.path");
+
+        List<String> command = new LinkedList<>();
+        command.add(javaBin);
+        command.add("-cp");
+        command.add(classpath);
+        command.add(ApplyTestChangelog.class.getName());
+
+        command.add(includedChangeLog);
+        command.add(jdbcUrl);
+        command.add(username);
+        command.add(password);
+        command.add(contexts);
+
+        return new ProcessBuilder(command);
+    }
+
+    public static final class ApplyTestChangelog {
+
+        private static void initLogLevel() {
+            java.util.logging.Logger liquibaseLogger = java.util.logging.Logger.getLogger("liquibase");
+
+            final JavaLogService logService = (JavaLogService) Scope.getCurrentScope().get(Scope.Attr.logService, LogService.class);
+            logService.setParent(liquibaseLogger);
+            java.util.logging.Logger rootLogger = java.util.logging.Logger.getLogger("");
+
+            rootLogger.setLevel(java.util.logging.Level.INFO);
+            liquibaseLogger.setLevel(java.util.logging.Level.INFO);
+
+            for (java.util.logging.Handler handler : rootLogger.getHandlers()) {
+                handler.setLevel(java.util.logging.Level.INFO);
+            }
+        }
+
+        public static void main(String[] args) throws Exception {
+            String changeLogFile = Objects.requireNonNull(args[0], "Changelog is required");
+            String url = Objects.requireNonNull(args[1], "JDBC url is required");
+            String username = Objects.requireNonNull(args[2], "JDBC username is required");
+            String password = Objects.requireNonNull(args[3], "JDBC password is required");
+            String contexts = Objects.requireNonNull(args[4], "Liquibase contexts is required");
+
+            initLogLevel();
+
+            DatabaseConnection connection = DatabaseTestContext.getInstance().getConnection(url, username, password);
+            Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(connection);
+
+            ResourceAccessor fileOpener = new JUnitResourceAccessor();
+
+            Liquibase liquibase = new Liquibase(changeLogFile, fileOpener, database);
+            liquibase.setChangeLogParameter("loginuser", username);
+            liquibase.update(contexts);
+        }
     }
 }


### PR DESCRIPTION
<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->


## Environment
**Liquibase Version**: 4.5.0

**Liquibase Integration & Version**: CLI

**Liquibase Extension(s) & Version**: 

**Database Vendor & Version**:

**Operating System Type & Version**:

## Pull Request Type
* Bug fix (non-breaking change which fixes an issue.)

## Description
When Liquibase tries to initialize the changelog lock table, multiple race conditions can arise. This commit fixes the following issues:

- [x] During table creation the exception is already handled when two concurrent JVM processes try to create the changelog lock table. However, the database transaction has to be aborted when the exception arises.
- [x] During initialization of the table a unique constraint exception can arise and the corresponding exception handling has been added.
- [x] The database lock could be temporarily handed over to another Liquibase instance on another JVM and then the cache of the changelog service would be invalid. Therefore, the cache will be reset before applying the changeset.
- [x] For certain DBMSs the SQL state will be evaluated so that Liquibase is able to detect these race conditions reliable

Fixes #1584 (steps to reproduce are provided there)

