### PR TITLE
Use "numeric" (without parameters) data type in PostgreSQL

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/NumberType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/NumberType.java
@@ -53,7 +53,7 @@ public class NumberType extends LiquibaseDataType {
                         return new DatabaseDataType("numeric");
                     }
                 } catch (NumberFormatException e) {
-                    return new DatabaseDataType("numeric");
+                    return new DatabaseDataType("numeric", getParameters());
                 }
             }
             return new DatabaseDataType("numeric", getParameters());

--- a/liquibase-core/src/test/groovy/liquibase/datatype/core/NumberTypeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/core/NumberTypeTest.groovy
@@ -23,6 +23,6 @@ class NumberTypeTest extends Specification {
         [1]        | new PostgresDatabase() | "numeric(1)"
         [2000]     | new PostgresDatabase() | "numeric"
         ["1", "2"] | new PostgresDatabase() | "numeric(1, 2)"
-        ["*", "0"] | new PostgresDatabase() | "numeric"
+        ["*", "0"] | new PostgresDatabase() | "numeric(*, 0)"
     }
 }

--- a/liquibase-core/src/test/groovy/liquibase/datatype/core/NumberTypeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/core/NumberTypeTest.groovy
@@ -1,0 +1,28 @@
+package liquibase.datatype.core
+
+import liquibase.database.core.PostgresDatabase
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class NumberTypeTest extends Specification {
+
+    @Unroll
+    def "toDatabaseDataType"() {
+        when:
+        def type = new NumberType()
+        for (def param : params) {
+            type.addParameter(param)
+        }
+
+        then:
+        type.toDatabaseDataType(database).toSql() == expected
+
+        where:
+        params     | database               | expected
+        []         | new PostgresDatabase() | "numeric"
+        [1]        | new PostgresDatabase() | "numeric(1)"
+        [2000]     | new PostgresDatabase() | "numeric"
+        ["1", "2"] | new PostgresDatabase() | "numeric(1, 2)"
+        ["*", "0"] | new PostgresDatabase() | "numeric"
+    }
+}


### PR DESCRIPTION
when input data type has char parameters in the data type (like NUMBER(*,0) in Oracle)

catch NumberFormatException

Steps:


1. Create a table with NUMBER(*,0) type column in Oracle schema.

```sql
CREATE TABLE TEST_ASTERISK (
COLUMN1 NUMBER(*,0)
);
```

1. Try to compare this Oracle schema with any PostgreSQL schema.
Actual result: catch NumberFormatException

Hello from DBeaver.

