### PR TITLE
Restore update testing rollback command

### DIFF
--- a/liquibase-core/src/main/java/liquibase/command/core/UpdateTestingRollbackCommandStep.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/UpdateTestingRollbackCommandStep.java
@@ -1,0 +1,69 @@
+package liquibase.command.core;
+
+import liquibase.command.*;
+import liquibase.configuration.ConfigurationValueObfuscator;
+import liquibase.exception.CommandExecutionException;
+
+public class UpdateTestingRollbackCommandStep extends AbstractCliWrapperCommandStep {
+
+    public static final String[] COMMAND_NAME = {"updateTestingRollback"};
+
+    public static final CommandArgumentDefinition<String> CHANGELOG_FILE_ARG;
+    public static final CommandArgumentDefinition<String> URL_ARG;
+    public static final CommandArgumentDefinition<String> DEFAULT_SCHEMA_NAME;
+    public static final CommandArgumentDefinition<String> DEFAULT_CATALOG_NAME_ARG;
+    public static final CommandArgumentDefinition<String> USERNAME_ARG;
+    public static final CommandArgumentDefinition<String> PASSWORD_ARG;
+    public static final CommandArgumentDefinition<String> LABELS_ARG;
+    public static final CommandArgumentDefinition<String> CONTEXTS_ARG;
+    public static final CommandArgumentDefinition<String> CHANGE_EXEC_LISTENER_CLASS_ARG;
+    public static final CommandArgumentDefinition<String> CHANGE_EXEC_LISTENER_PROPERTIES_FILE_ARG;
+    public static final CommandArgumentDefinition<String> DRIVER_ARG;
+    public static final CommandArgumentDefinition<String> DRIVER_PROPERTIES_FILE_ARG;
+
+    static {
+        CommandBuilder builder = new CommandBuilder(COMMAND_NAME);
+
+        URL_ARG = builder.argument("url", String.class).required()
+                .description("The JDBC database connection URL").build();
+        DEFAULT_SCHEMA_NAME = builder.argument("defaultSchemaName", String.class)
+                .description("The default schema name to use for the database connection").build();
+        DEFAULT_CATALOG_NAME_ARG = builder.argument("defaultCatalogName", String.class)
+                .description("The default catalog name to use for the database connection").build();
+        DRIVER_ARG = builder.argument("driver", String.class)
+                .description("The JDBC driver class").build();
+        DRIVER_PROPERTIES_FILE_ARG = builder.argument("driverPropertiesFile", String.class)
+                .description("The JDBC driver properties file").build();
+        USERNAME_ARG = builder.argument("username", String.class)
+                .description("Username to use to connect to the database").build();
+        PASSWORD_ARG = builder.argument("password", String.class)
+                .description("Password to use to connect to the database")
+                .setValueObfuscator(ConfigurationValueObfuscator.STANDARD)
+                .build();
+        CHANGELOG_FILE_ARG = builder.argument("changelogFile", String.class).required()
+                .description("The root changelog").build();
+        LABELS_ARG = builder.argument("labels", String.class)
+                .description("Changeset labels to match").build();
+        CONTEXTS_ARG = builder.argument("contexts", String.class)
+                .description("Changeset contexts to match").build();
+        CHANGE_EXEC_LISTENER_CLASS_ARG = builder.argument("changeExecListenerClass", String.class)
+                .description("Fully-qualified class which specifies a ChangeExecListener").build();
+        CHANGE_EXEC_LISTENER_PROPERTIES_FILE_ARG = builder.argument("changeExecListenerPropertiesFile", String.class)
+                .description("Path to a properties file for the ChangeExecListenerClass").build();
+    }
+
+    @Override
+    public String[][] defineCommandNames() {
+        return new String[][] { COMMAND_NAME };
+    }
+
+    @Override
+    protected String[] collectArguments(CommandScope commandScope) throws CommandExecutionException {
+        return collectArguments(commandScope, null, null);
+    }
+
+    @Override
+    public void adjustCommandDefinition(CommandDefinition commandDefinition) {
+        commandDefinition.setShortDescription("Updates database, then rolls back changes before updating again. Useful for testing rollback support");
+    }
+}

--- a/liquibase-core/src/main/java/liquibase/hub/HubUpdater.java
+++ b/liquibase-core/src/main/java/liquibase/hub/HubUpdater.java
@@ -48,6 +48,7 @@ public class HubUpdater {
 
     private static final String SEPARATOR_LINE = "\n----------------------------------------------------------------------\n";
     final HubService hubService = Scope.getCurrentScope().getSingleton(HubServiceFactory.class).getService();
+    private static Boolean skipAutoRegistration = null;
 
     public HubUpdater(Date startTime, DatabaseChangeLog changeLog, Database database) {
         this.startTime = startTime;
@@ -414,6 +415,10 @@ public class HubUpdater {
             return null;
         }
 
+        if (skipAutoRegistration != null && skipAutoRegistration) {
+            return null;
+        }
+
         //
         // Prompt user to connect with Hub
         // Release the lock before prompting
@@ -469,6 +474,7 @@ public class HubUpdater {
             String message = "Skipping auto-registration";
             Scope.getCurrentScope().getUI().sendMessage(message);
             Scope.getCurrentScope().getLog(getClass()).warning(message);
+            skipAutoRegistration = true;
         } else {
             //
             // Consider this an email

--- a/liquibase-core/src/main/resources/META-INF/services/liquibase.command.CommandStep
+++ b/liquibase-core/src/main/resources/META-INF/services/liquibase.command.CommandStep
@@ -45,6 +45,7 @@ liquibase.command.core.UpdateCommandStep
 liquibase.command.core.UpdateCountCommandStep
 liquibase.command.core.UpdateCountSqlCommandStep
 liquibase.command.core.UpdateSqlCommandStep
+liquibase.command.core.UpdateTestingRollbackCommandStep
 liquibase.command.core.UpdateToTagCommandStep
 liquibase.command.core.UpdateToTagSqlCommandStep
 liquibase.command.core.ValidateCommandStep

--- a/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/updateTestingRollback.test.groovy
+++ b/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/updateTestingRollback.test.groovy
@@ -1,0 +1,77 @@
+package liquibase.extension.testing.command
+
+import liquibase.exception.CommandValidationException
+
+import java.util.regex.Pattern
+
+CommandTests.define {
+    command = ["updateTestingRollback"]
+    signature = """
+Short Description: Updates database, then rolls back changes before updating again. Useful for testing rollback support
+Long Description: NOT SET
+Required Args:
+  changelogFile (String) The root changelog
+  url (String) The JDBC database connection URL
+Optional Args:
+  changeExecListenerClass (String) Fully-qualified class which specifies a ChangeExecListener
+    Default: null
+  changeExecListenerPropertiesFile (String) Path to a properties file for the ChangeExecListenerClass
+    Default: null
+  contexts (String) Changeset contexts to match
+    Default: null
+  defaultCatalogName (String) The default catalog name to use for the database connection
+    Default: null
+  defaultSchemaName (String) The default schema name to use for the database connection
+    Default: null
+  driver (String) The JDBC driver class
+    Default: null
+  driverPropertiesFile (String) The JDBC driver properties file
+    Default: null
+  labels (String) Changeset labels to match
+    Default: null
+  password (String) Password to use to connect to the database
+    Default: null
+    OBFUSCATED
+  username (String) Username to use to connect to the database
+    Default: null
+"""
+
+    run "Happy path with a simple changelog", {
+        arguments = [
+                url:        { it.url },
+                username:   { it.username },
+                password:   { it.password },
+                changelogFile: "changelogs/hsqldb/complete/rollback.changelog.xml"
+        ]
+
+        setup {
+            runChangelog "changelogs/hsqldb/complete/rollback.changelog.xml"
+            rollback 5, "changelogs/hsqldb/complete/rollback.changelog.xml"
+        }
+        expectedResults = [
+                statusCode   : 0
+        ]
+    }
+
+    run "Run without a URL throws an exception", {
+        arguments = [
+                url: ""
+        ]
+        expectedException = CommandValidationException.class
+    }
+
+    run "Run without a changeLogFile throws an exception", {
+        arguments = [
+                changelogFile: ""
+        ]
+        expectedException = CommandValidationException.class
+    }
+
+    run "Run without any argument throws an exception", {
+        arguments = [
+                url: "",
+                changelogFile: ""
+        ]
+        expectedException = CommandValidationException.class
+    }
+}


### PR DESCRIPTION
Fixes #1909 

Includes new integration test. I did some manual testing of it as well through the CLI.

Used the same arguments as `update` based on looking at old Main class

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: [https://github.com/liquibase/liquibase/issues/1909](https://github.com/liquibase/liquibase/issues/1909)
* Local Branch: [https://github.com/liquibase/liquibase/tree/restore-update-testing-rollback](https://github.com/liquibase/liquibase/tree/restore-update-testing-rollback)
* Unit Tests: [https://github.com/liquibase/liquibase/pull/1939/checks](https://github.com/liquibase/liquibase/pull/1939/checks)
* Integration Tests: (shown in Unit Tests link above)
* Functional Tests: [https://jenkins.datical.net/job/liquibase-pro/job/restore-update-testing-rollback/](https://jenkins.datical.net/job/liquibase-pro/job/restore-update-testing-rollback/)

#### Testing
* Steps to Reproduce: [https://github.com/liquibase/liquibase/issues/1909](https://github.com/liquibase/liquibase/issues/1909)
* Guidance: 
  * (see above)

#### Dev Verification
(did not save output at the time)

#### Test Requirements (Internal Liquibase QA)
Although the reported issue is on Mac, this issue will exist on any OS.
The way updateTestingRollbackSQL works is:

```
Given a changelog with three change sets to deploy, the following liquibase operations are performed for each change set:
1. update changeset1; update changeset2; update changeset3
2. rollback changeset3; rollback changeset2; rollback changeset1
3. update changeset1; update changeset2 update changeset3
The thing to note is that if any of the changesets fail rollback, any changesets that come _after_ the failed changesets are not tested or updated. Any changesets that come _before _the failed changests are created on the database. 
```

_Manual_

* Verify a successful updateTestingRollback for a table that can be rolled back. :white_check_mark: 
  * At the end of the operation, the table is created on the database.
* Verify a failed updateTestingRollback for a table that cannot be rolled back. :white_check_mark:
  * The failure can be achieved by providing a custom rollback script that has a syntax error.
  * At the end of the operation the table is created on the database.
    * The object exists because the rollback itself fails.
* Verify a failed updateTestingRollback for three tables, table1, table2 and table3. table1 can be rolled back. table2 cannot be rolled back. table3 can be rolled back. :white_check_mark:
  * At the end of the operation, both table1 and table2 are created on the database.
  * At the end of the operation, table3 is not created on the database.
    * Processing of changes to deploy stops after the first rollback failure.
* Verify a successful updateTestingRollback for a stored logic object that can be rolled back. :white_check_mark:
  * Ensure a Pro license is provided.
  * At the end of the operation, the stored logic object is created on the database.
* Verify a failed updateTestingRollback for a stored logic object that cannot be rolled back and a table that can be rolled back. :white_check_mark:
  * The table is second in the list of changes to deploy.
  * At the end of the operation, the stored logic object is created on the database.
  * At the end of the operation table is not created on the database.

_Automated Functional Test_

* Add a new test class liquibase-pro-tests/[src](https://github.com/Datical/liquibase-pro-tests/tree/master/src)/[test](https://github.com/Datical/liquibase-pro-tests/tree/master/src/test)/[java](https://github.com/Datical/liquibase-pro-tests/tree/master/src/test/java)/[tests](https://github.com/Datical/liquibase-pro-tests/tree/master/src/test/java/tests)/[functional](https://github.com/Datical/liquibase-pro-tests/tree/master/src/test/java/tests/functional)/*update*/. Call the class updateTestingRollback.
* This does not need to be a multi-db platform test; do not use the Oracle platform as it is our slowest platform to test.
* Add a test to validate a successful updateTestingRollback.
* Add a test to validate a failed updateTestingRollback.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-1910) by [Unito](https://www.unito.io)
