### PR TITLE
Fix sqlFile encoding attribute handling

### DIFF
--- a/liquibase-core/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.6.xsd
+++ b/liquibase-core/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.6.xsd
@@ -598,7 +598,7 @@
     <xsd:attributeGroup name="loadDataAttributes">
         <xsd:attribute name="relativeToChangelogFile" type="booleanExp"/>
         <xsd:attribute name="file" type="nonEmptyString" use="required"/>
-        <xsd:attribute name="encoding" type="xsd:NMTOKEN" default="UTF-8"/>
+        <xsd:attribute name="encoding" type="xsd:NMTOKEN"/>
         <xsd:attribute name="separator" type="nonEmptyString" default=","/>
         <xsd:attribute name="quotchar" type="nonEmptyString" default="&quot;"/>
         <xsd:attribute name="commentLineStartsWith" type="nonEmptyString" default="#"/>
@@ -1125,7 +1125,7 @@
             <xsd:attribute name="path" type="xsd:string" use="required"/>
             <xsd:attribute name="stripComments" type="booleanExp"/>
             <xsd:attribute name="splitStatements" type="booleanExp"/>
-            <xsd:attribute name="encoding" type="xsd:string" default="UTF-8"/>
+            <xsd:attribute name="encoding" type="xsd:string"/>
             <xsd:attribute name="endDelimiter" type="xsd:string"/>
             <xsd:attribute name="relativeToChangelogFile" type="booleanExp"/>
             <xsd:attribute name="dbms" type="xsd:string"/>


### PR DESCRIPTION
## Pull Request Type
<!--- What types of changes does your code introduce?
Put an `x` in all the boxes that apply: 
If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->

* \[x] Bug fix (non-breaking change which fixes an issue.)
* \[ ] Enhancement/New feature (non-breaking change which adds functionality)
* \[ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
Fixes #1760 with fix suggested by ckulenkampff  ([https://github.com/liquibase/liquibase/issues/1760#issuecomment-796692112)](https://github.com/liquibase/liquibase/issues/1760#issuecomment-796692112)).

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<

!--- If you're unsure about any of these, just ask us in a comment. We're here to help|width=200,height=183!

-->

* \[ ] Build is successful and all new and existing tests pass
* \[ ] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
* \[ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
* \[ ] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls)
* \[ ] Documentation Updated

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: [https://github.com/liquibase/liquibase/issues/1941](https://github.com/liquibase/liquibase/issues/1941)
* Local Branch: [https://github.com/liquibase/liquibase/tree/meisenla-fix-1760](https://github.com/liquibase/liquibase/tree/meisenla-fix-1760)
* Unit Tests: [https://github.com/liquibase/liquibase/pull/1941/checks](https://github.com/liquibase/liquibase/pull/1941/checks)
* Integration Tests: (shown in Unit Tests link above)
* Functional Tests: [https://jenkins.datical.net/job/liquibase-pro/job/meisenla-fix-1760/](https://jenkins.datical.net/job/liquibase-pro/job/meisenla-fix-1760/)

#### Testing
* Steps to Reproduce: [https://github.com/liquibase/liquibase/issues/1760](https://github.com/liquibase/liquibase/issues/1760|smart-link) 
  * Create a changelog with a changeset containing a <sqlFile> change that refers to some SQL file with UTF-8 encoded special characters.
  * Set encoding attribute to UTF-8 (which is an example value directly from the XSD schema)
  * Generate SQL with Liquibase while using a default file encoding for the JVM other than UTF-8.
* Guidance:
  * Impact: change->sql
  * This requires XSD coordination; verify with dev prior to testing to make sure XSD updates are complete. 
  * The code fix only impacts how sqlFile loads files, but also updated the 4.6.xsd to not have a default different than the new liquibase.fileEncoding default

#### Dev Verification
Created a sqlFile referencing a file with UTF-8 chars in it like {{("B8D03DBA-A8D0-40BD-ABE6-D7413802D811", "assets’}}ÐᲐ	market capitalisation.")`

Making sure to use the 4.6.xsd so there isn't a UTF-8 default encoding, I ran `update-sql` to see how the non-ascii chars are output. I ran with --fileEncoding=UTF-8 and --fileEncoding=ASCII without an encoding attribute to make sure it respected the default. 

I also tested with --fileEncoding=ASCII and encoding=UTF-8 to ensure the encoding attribute is respected.

The XSD change also removed the encodingDefault from loadData, I made sure the encoding attribute was respected in that code (which it was).

## Test Requirements (Internal Liquibase QA)
**Automated Test Requirements**

* None. This test does not fit nicely into the test-harness nor into the functional test suite.

**Manual Test Requirements**

Use the attached changelog and SQL file to test this fix. 

_Verify update~~sql passed the~~ ~~file~~encoding utf-8 does not produce incorrect characters for sqlFile change containing UTF8 characters._

* `liquibase --file-encoding utf-8 update-sql --changelog-file lb2122-changelog.xml`

_Verify update~~sql passed the~~ ~~file~~encoding ASCII does produce incorrect characters for sqlFile change containing UTF8 characters._

* `liquibase --file-encoding ascii update-sql --changelog-file lb2122-changelog.xml`

_Verify update passed the -~~file~~encoding utf-8 is successful._

* `liquibase --file-encoding utf-8 update --changelog-file lb2122-changelog.xml`

_Verify the row inserted into tbl_lb2122 has the correct representation of the UTF8 characters_

* `SELECT * FROM tbl_lb2122`

#### Github Users
`FILL`



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-2122) by [Unito](https://www.unito.io)
