### PR TITLE
Reintroduce support for "-D" arguments in CLI

### DIFF
--- a/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
+++ b/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
@@ -304,6 +304,17 @@ public class LiquibaseCommandLine {
                         Scope.getCurrentScope().getUI().sendMessage(Scope.getCurrentScope().getSingleton(LicenseServiceFactory.class).getLicenseService().getLicenseInfo());
                     }
 
+                    CommandLine.ParseResult subcommandParseResult = commandLine.getParseResult();
+                    while (subcommandParseResult.hasSubcommand()) {
+                        subcommandParseResult = subcommandParseResult.subcommand();
+                    }
+
+                    Map<String, String> changelogParameters = subcommandParseResult.matchedOptionValue("-D", new HashMap<>());
+                    if (changelogParameters.size() != 0) {
+                        Main.newCliChangelogParameters = changelogParameters;
+                    }
+
+
                     int response = commandLine.execute(finalArgs);
 
                     if (!wasHelpOrVersionRequested()) {
@@ -688,6 +699,15 @@ public class LiquibaseCommandLine {
                     }
 
                     subCommandSpec.addOption(builder.build());
+
+                    if (argName.equals("--changelog-file")) {
+                        final CommandLine.Model.OptionSpec.Builder paramBuilder = (CommandLine.Model.OptionSpec.Builder) CommandLine.Model.OptionSpec.builder("-D")
+                                .required(false)
+                                .type(HashMap.class)
+                                .description("Pass a name/value pair for substitution in the changelog(s).\nPass as -D<property.name>=<property.value>\n[deprecated: set changelog properties in defaults file or environment variables]")
+                                .mapFallbackValue("");
+                        subCommandSpec.add(paramBuilder.build());
+                    }
                 }
             }
 

--- a/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
+++ b/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
@@ -704,7 +704,7 @@ public class LiquibaseCommandLine {
                         final CommandLine.Model.OptionSpec.Builder paramBuilder = (CommandLine.Model.OptionSpec.Builder) CommandLine.Model.OptionSpec.builder("-D")
                                 .required(false)
                                 .type(HashMap.class)
-                                .description("Pass a name/value pair for substitution in the changelog(s).\nPass as -D<property.name>=<property.value>\n[deprecated: set changelog properties in defaults file or environment variables]")
+                                .description("Pass a name/value pair for substitution in the changelog(s)\nPass as -D<property.name>=<property.value>\n[deprecated: set changelog properties in defaults file or environment variables]")
                                 .mapFallbackValue("");
                         subCommandSpec.add(paramBuilder.build());
                     }

--- a/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineTest.groovy
+++ b/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineTest.groovy
@@ -3,6 +3,7 @@ package liquibase.integration.commandline
 
 import liquibase.command.CommandBuilder
 import liquibase.configuration.ConfigurationDefinition
+import picocli.CommandLine
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -53,5 +54,14 @@ class LiquibaseCommandLineTest extends Specification {
         ["future-rollback-from-tag-sql", "my-tag"] | ["future-rollback-from-tag-sql", "--tag", "my-tag"]
 
         ["--log-level","DEBUG","--log-file","06V21.txt","--defaultsFile=liquibase.h2-mem.properties","update","--changelog-file","postgres_lbpro_master_changelog.xml","--labels","setup"] | ["--log-level","DEBUG","--log-file","06V21.txt","--defaultsFile=liquibase.h2-mem.properties","update","--changelog-file","postgres_lbpro_master_changelog.xml","--labels","setup"]
+    }
+
+    def "accepts -D subcommand arguments for changelog parameters"() {
+        when:
+        def subcommands = new LiquibaseCommandLine().commandLine.getSubcommands()
+
+        then:
+        subcommands["update"].commandSpec.findOption("-D") != null
+        subcommands["snapshot"].commandSpec.findOption("-D") == null
     }
 }

--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -64,6 +64,9 @@ public class Main {
     //set by new CLI to signify it is handling some of the configuration
     public static boolean runningFromNewCli;
 
+    //temporary work-around to pass -D changelog parameters from new CLI to here
+    public static Map<String, String> newCliChangelogParameters;
+
     private static PrintStream outputStream = System.out;
 
     private static final String ERRORMSG_UNEXPECTED_PARAMETERS = "unexpected.command.parameters";
@@ -1674,6 +1677,11 @@ public class Main {
             }
 
             Liquibase liquibase = new Liquibase(changeLogFile, fileOpener, database);
+            if (Main.newCliChangelogParameters != null) {
+                for (Map.Entry<String, String> param : Main.newCliChangelogParameters.entrySet()) {
+                    liquibase.setChangeLogParameter(param.getKey(), param.getValue());
+                }
+            }
             try {
                 if (hubConnectionId != null) {
                     try {


### PR DESCRIPTION
Fixes #1907 

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: [https://github.com/liquibase/liquibase/issues/1907](https://github.com/liquibase/liquibase/issues/1907)
* Local Branch: [https://github.com/liquibase/liquibase/tree/reintroduce-d-arguments-in-cli](https://github.com/liquibase/liquibase/tree/reintroduce-d-arguments-in-cli)
* Unit Tests: [https://github.com/liquibase/liquibase/pull/1943/checks](https://github.com/liquibase/liquibase/pull/1943/checks)
* Integration Tests: (shown in Unit Tests link above)
* Functional Tests: [https://jenkins.datical.net/job/liquibase-pro/job/reintroduce-d-arguments-in-cli/](https://jenkins.datical.net/job/liquibase-pro/job/reintroduce-d-arguments-in-cli/)

#### Testing
* Steps to Reproduce: [https://github.com/liquibase/liquibase/issues/1907](https://github.com/liquibase/liquibase/issues/1907)
* Guidance: 
  * Only impacts CLI
  * Follows same priority CLI and liquibase.properties as other settings

#### Dev Verification
(did not save output at the time)

#### Test Requirements (Internal Liquibase QA)
_Manual_

* Verify a successful update with the schemaName as a Java property on the command line.
  * This is the customer-reported workflow.
```
/liquibase/liquibase \
       --driver=org.postgresql.Driver \
       --changeLogFile="db.changelog-master.xml" \
       --url=<redacted> \
       --username=<redacted> \
       --password=<redacted> \
       update \
       -Dcoreschema="${core_schema}"
```


* Verify a successful update with all properties required properties passed as Java properties on the command line.
  * Use the 4.4.0 syntax for arguments, i.e., --changelog-file=changelog.xml.

_Automated Functional Test_

* Add a test to liquibase-pro-tests to [UpdateCommunityTests.java](https://github.com/Datical/liquibase-pro-tests/blob/master/src/test/java/tests/functional/update/UpdateCommunityTests.java) for the customer workflow.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-1909) by [Unito](https://www.unito.io)
