### PR TITLE
Allow empty string for defaultValue attribute

### DIFF
--- a/liquibase-core/src/main/java/liquibase/exception/ValidationErrors.java
+++ b/liquibase-core/src/main/java/liquibase/exception/ValidationErrors.java
@@ -37,20 +37,46 @@ public class ValidationErrors {
         return this.change;
     }
 
+    /**
+     * Convenience method for {@link #checkRequiredField(String, Object, String, boolean)} with allowEmptyValue=false
+     */
     public ValidationErrors checkRequiredField(String requiredFieldName, Object value) {
-        return checkRequiredField(requiredFieldName, value, null);
+        return checkRequiredField(requiredFieldName, value, false);
     }
 
+    /**
+     * Convenience method for {@link #checkRequiredField(String, Object, String, boolean)} with a null postfix
+     */
+    public ValidationErrors checkRequiredField(String requiredFieldName, Object value, boolean allowEmptyValue) {
+        return checkRequiredField(requiredFieldName, value, null, allowEmptyValue);
+    }
+
+    /**
+     * Convenience method for {@link #checkRequiredField(String, Object, String, boolean)} with allowEmptyValue=false
+     */
     public ValidationErrors checkRequiredField(String requiredFieldName, Object value, String postfix) {
+        return checkRequiredField(requiredFieldName, value, postfix, false);
+    }
+
+    /**
+     * Checks that the the given value is set.
+     * @param allowEmptyValue  If true, empty string and empty arrays are allowed. If false, they are not.
+     */
+    public ValidationErrors checkRequiredField(String requiredFieldName, Object value, String postfix, boolean allowEmptyValue) {
         String err = null;
         if (value == null) {
             err = requiredFieldName + " is required";
-        } else if ((value instanceof Collection && ((Collection<?>) value).isEmpty())
-                || (value instanceof Object[] && ((Object[]) value).length == 0)) {
-            err = "No " + requiredFieldName + " defined";
-        } else if (value instanceof String && StringUtil.trimToNull((String) value) == null) {
-            err = requiredFieldName + " is empty";
         }
+
+        if (!allowEmptyValue) {
+            if ((value instanceof Collection && ((Collection<?>) value).isEmpty())
+                    || (value instanceof Object[] && ((Object[]) value).length == 0)) {
+                err = "No " + requiredFieldName + " defined";
+            } else if (value instanceof String && StringUtil.trimToNull((String) value) == null) {
+                err = requiredFieldName + " is empty";
+            }
+        }
+
         if (err != null) {
             addError(err + (this.change == null ? "" : " for " + this.change)
                     + (postfix == null ? "" : postfix));

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddDefaultValueGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AddDefaultValueGenerator.java
@@ -24,7 +24,7 @@ public class AddDefaultValueGenerator extends AbstractSqlGenerator<AddDefaultVal
         Object defaultValue = addDefaultValueStatement.getDefaultValue();
 
         ValidationErrors validationErrors = new ValidationErrors();
-        validationErrors.checkRequiredField("defaultValue", defaultValue);
+        validationErrors.checkRequiredField("defaultValue", defaultValue, true);
         validationErrors.checkRequiredField("columnName", addDefaultValueStatement.getColumnName());
         validationErrors.checkRequiredField("tableName", addDefaultValueStatement.getTableName());
         if (!database.supportsSequences() && (defaultValue instanceof SequenceNextValueFunction)) {

--- a/liquibase-core/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
@@ -782,7 +782,7 @@ public class LoadDataChangeTest extends StandardChangeTest {
                 file     : "liquibase/change/core/sample.data1.csv",
                 tableName: ""
         ]).setValue([
-                [column: [name: "a", header:"", index:1, type: "STRING"]],
+                [column: [name: "a", header:"", index:1, type: "STRING", defaultValue: ""]],
                 [column: [name: "", type: ""]],
                 [column: []]
         ]), new ClassLoaderResourceAccessor())


### PR DESCRIPTION
## Overview
Fixes #1920

I added the ability to allow empty values for required fields as needed, although it will still default to not allowing it. Searching through the code, I only found addDefaultValue with the "required" check being done for a value that could be empty, so that is all I fixed.

## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: [https://github.com/liquibase/liquibase/issues/1920](https://github.com/liquibase/liquibase/issues/1920)
* Local Branch: [https://github.com/liquibase/liquibase/tree/allow-empty-defaultValue](https://github.com/liquibase/liquibase/tree/allow-empty-defaultValue)
* Unit Tests: [https://github.com/liquibase/liquibase/pull/1963/checks](https://github.com/liquibase/liquibase/pull/1963/checks)
* Integration Tests: (shown in Unit Tests link above)
* Functional Tests: [https://jenkins.datical.net/job/liquibase-pro/job/allow-empty-defaultValue/](https://jenkins.datical.net/job/liquibase-pro/job/allow-empty-defaultValue/)

#### Testing
* Steps to Reproduce: [https://github.com/liquibase/liquibase/issues/1920](https://github.com/liquibase/liquibase/issues/1920)
* Guidance: 
  * Change only impacts addDefaultValue
  * Change applies to all databases

#### Dev Verification
Running with update-sql on h2 successfully generates:

```java
ALTER TABLE PUBLIC.MyTable ALTER COLUMN  MyColumn SET DEFAULT '';
```

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: [https://github.com/liquibase/liquibase/issues/1920](https://github.com/liquibase/liquibase/issues/1920)
* Local Branch: [https://github.com/liquibase/liquibase/tree/allow-empty-defaultValue](https://github.com/liquibase/liquibase/tree/allow-empty-defaultValue)
* Unit Tests: [https://github.com/liquibase/liquibase/pull/](https://github.com/liquibase/liquibase/pull/){PR ID}/checks
* Integration Tests: (shown in Unit Tests link above)
* Functional Tests: [https://jenkins.datical.net/job/liquibase-pro/job/](https://jenkins.datical.net/job/liquibase-pro/job/){BRANCH}/

#### Testing
* Steps to Reproduce: {LINK TO ISSUE OR "See above"}
* Guidance: 
  * (see above)

#### Dev Verification
(did not save output at the time)

#### Test Requirements (Internal Liquibase QA) 
Manual tests should be executed against the JSON, XML and YAML changelogs.

_Manual_

* Verify an updateSQL of a createTable with an empty-string defaultValue generates 
* Verify an update of a createTable with an empty-string defaultValue does not throw a validation error. 
  * At the end of the operation, the table is created on the database.

```
<changeSet author="me" id="1">
    <createTable tableName="MyTable">
        <column name="MyColumn" type="VARCHAR(64)"/>
    </createTable>
    <addDefaultValue columnName="MyColumn" tableName="MyTable" defaultValue=""/>
</changeSet>
```

* Verify an update of a createTable with a value specified in defaultValue does not throw a validation error.
  * At the end of the update, the table is created on the database.
  * The value specified is what was in the defaultValue property.

```
<changeSet author="me" id="1">
    <createTable tableName="MyTable">
        <column name="MyColumn" type="VARCHAR(64)"/>
    </createTable>
    <addDefaultValue columnName="MyColumn" tableName="MyTable" defaultValue="myvalue"/>
</changeSet>
```

_Automated Functional Test_

* This change does not warrant the addition of a heavy/costly functional test.

_Test Harness Test_

* The test harness is the right place to add a test for this feature.
* Add a changelog named addNullDefaultValue.xml to  [https://github.com/liquibase/liquibase-test-harness/blob/main/src/main/resources/liquibase/harness/change/changelogs](https://github.com/liquibase/liquibase-test-harness/blob/main/src/main/resources/liquibase/harness/change/changelogs/addDefaultValue.xml) The changeset should look something like:

```
<?xml version="1.0" encoding="UTF-8"?>
<databaseChangeLog
        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
<!--https://docs.liquibase.com/change-types/community/add-default-value.html-->
        <changeSet author="liquibase" id="1">
            <addDefaultValue  tableName="posts"
                              columnName="title"
                              columnDataType="varchar(255)"
                              defaultValue=""/>
        </changeSet>
</databaseChangeLog>
```

* Add expected SQL for MSSQL, Oracle, Postgres, MySQL and MariaDB in the [https://github.com/liquibase/liquibase-test-harness/tree/main/src/main/resources/liquibase/harness/change/expectedSql](https://github.com/liquibase/liquibase-test-harness/tree/main/src/main/resources/liquibase/harness/change/expectedSql|smart-link)  directory.
* Verify addNullDefaultValue is successful for all five platforms.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-1904) by [Unito](https://www.unito.io)
┆Fix Versions: Liquibase 4.4.2
