### PR TITLE
MSSQL exclude schema name when diff view definition

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ViewSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ViewSnapshotGenerator.java
@@ -86,10 +86,16 @@ public class ViewSnapshotGenerator extends JdbcSnapshotGenerator {
 
                     if (database instanceof MSSQLDatabase && definition != null
                             && view.getSchema() != null && view.getSchema().getName() != null) {
-                        // Strip the schema name in definition, because it can be optional from OBJECT_DEFINITION
+                        // Strip the schema name in definition, because it can be optional from OBJECT_DEFINITION.
+                        // Pass 1: strip "[schema]." prefix when present.
                         definition = definition.replaceFirst("(?i)(create\\s+view\\s+)\\[?"
                                 + Pattern.quote(view.getSchema().getName())
-                                + "\\]?\\.(?=\\[?[^\\]\\s]+\\]?)", "$1");
+                                + "\\]?\\.", "$1");
+                        // Pass 2: normalize brackets on the view name itself (handles both
+                        // "[view_name]" returned without schema prefix and the result of pass 1),
+                        // so "[view_name]" and "view_name" compare as equal.
+                        definition = definition.replaceFirst(
+                                "(?i)(create\\s+view\\s+)\\[([^\\]\\s]+)\\]", "$1$2");
                     }
 
                     definition = StringUtil.trimToNull(definition);

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ViewSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ViewSnapshotGenerator.java
@@ -89,7 +89,7 @@ public class ViewSnapshotGenerator extends JdbcSnapshotGenerator {
                         // Strip the schema name in definition, because it can be optional from OBJECT_DEFINITION
                         definition = definition.replaceFirst("(?i)(create\\s+view\\s+)\\[?"
                                 + Pattern.quote(view.getSchema().getName())
-                                + "\\]?\\.\\[?([^\\]\\s]+)\\]?", "$1$2");
+                                + "\\]?\\.(?=\\[?[^\\]\\s]+\\]?)", "$1");
                     }
 
                     definition = StringUtil.trimToNull(definition);

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ViewSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ViewSnapshotGenerator.java
@@ -23,6 +23,7 @@ import liquibase.util.StringUtil;
 
 import java.sql.SQLException;
 import java.util.List;
+import java.util.regex.Pattern;
 
 public class ViewSnapshotGenerator extends JdbcSnapshotGenerator {
 
@@ -83,11 +84,12 @@ public class ViewSnapshotGenerator extends JdbcSnapshotGenerator {
                         definition = definition.replaceAll("(?i)\""+view.getSchema().getName()+"\"\\.", "");
                     }
 
-                    if (database instanceof MSSQLDatabase && definition != null) {
+                    if (database instanceof MSSQLDatabase && definition != null
+                            && view.getSchema() != null && view.getSchema().getName() != null) {
                         // Strip the schema name in definition, because it can be optional from OBJECT_DEFINITION
                         definition = definition.replaceFirst("(?i)(create\\s+view\\s+)\\[?"
-                                + view.getSchema().getName()
-                                + "\\]?\\.\\[?([a-z][a-z0-9_$#@]*)\\]?", "$1$2");
+                                + Pattern.quote(view.getSchema().getName())
+                                + "\\]?\\.\\[?([^\\]\\s]+)\\]?", "$1$2");
                     }
 
                     definition = StringUtil.trimToNull(definition);

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ViewSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ViewSnapshotGenerator.java
@@ -8,6 +8,7 @@ import liquibase.database.ObjectQuotingStrategy;
 import liquibase.database.core.InformixDatabase;
 import liquibase.database.core.MariaDBDatabase;
 import liquibase.database.core.MySQLDatabase;
+import liquibase.database.core.MSSQLDatabase;
 import liquibase.database.core.OracleDatabase;
 import liquibase.exception.DatabaseException;
 import liquibase.snapshot.CachedRow;
@@ -80,6 +81,13 @@ public class ViewSnapshotGenerator extends JdbcSnapshotGenerator {
 
                         // Strip the schema definition because it can optionally be included in the tag attribute
                         definition = definition.replaceAll("(?i)\""+view.getSchema().getName()+"\"\\.", "");
+                    }
+
+                    if (database instanceof MSSQLDatabase && definition != null) {
+                        // Strip the schema name in definition, because it can be optional from OBJECT_DEFINITION
+                        definition = definition.replaceFirst("(?i)(create\\s+view\\s+)\\[?"
+                                + view.getSchema().getName()
+                                + "\\]?\\.\\[?([a-z][a-z0-9_$#@]*)\\]?", "$1$2");
                     }
 
                     definition = StringUtil.trimToNull(definition);


### PR DESCRIPTION
…ancies.

<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->
## Environment

**Liquibase Version**: 4.4

**Liquibase Integration & Version**: CLI

**Liquibase Extension(s) & Version**: NA

**Database Vendor & Version**: MSSQL

**Operating System Type & Version**: All

## Pull Request Type

<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->
- [ ] Bug fix (non-breaking change which fixes an issue.)
- [x] Enhancement/New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
Liquibase report schema diff discrepancy due to "schema" (e.g: `dbo`) are included in the view definition.


## Steps To Reproduce
Create the following view in 2 MSSQL database (all in default dbo schema):


```
SET ANSI_NULLS ON
GO
SET QUOTED_IDENTIFIER ON
GO
create view [dbo].[view_demo] with schemabinding as select col1 as col1, col2 as col2 from dbo.table_demo where age > 1
GO
```

Execute liquibase diff command result in the following discrepancy:


```
Changed View(s): 
     view_demo
          definition changed from 'create view view_demo with schemabinding as select col1 as col1, col2 as col2 from dbo.table_demo where age > 1' to 'create view [dbo].[view_demo] with schemabinding as select col1 as col1, col2 as col2 from dbo.table_demo where age > 1'
```

## Actual Behavior
Liquibase report view changed.

## Expected/Desired Behavior
Liquibase should not report such discrepancy.

## Screenshots (if appropriate)
NA

## Additional Context
The 2 views are created on 2 different server version, maybe this is the root cause?

Server1: `13.00.4422`
Server2: `13.00.5026`

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->
- [x] Build is successful and all new and existing tests pass
- [ ] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
- [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
- [ ] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls)
- [ ] Documentation Updated

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)
