### PR TITLE
Allow/ignore spaces after colon in formatted sql changeSet lines

### DIFF
--- a/liquibase-core/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
@@ -75,7 +75,7 @@ public class FormattedSqlChangeLogParser implements ChangeLogParser {
             ChangeSet changeSet = null;
             RawSQLChange change = null;
             Pattern changeLogPattern = Pattern.compile("\\-\\-\\s*liquibase formatted.*", Pattern.CASE_INSENSITIVE);
-            Pattern changeSetPattern = Pattern.compile("\\s*\\-\\-[\\s]*changeset\\s+([^:]+):(\\S+).*", Pattern.CASE_INSENSITIVE);
+            Pattern changeSetPattern = Pattern.compile("\\s*\\-\\-[\\s]*changeset\\s+([^:]+):\\s*(\\S+).*", Pattern.CASE_INSENSITIVE);
             Pattern rollbackPattern = Pattern.compile("\\s*\\-\\-[\\s]*rollback (.*)", Pattern.CASE_INSENSITIVE);
             Pattern preconditionsPattern = Pattern.compile("\\s*\\-\\-[\\s]*preconditions(.*)", Pattern.CASE_INSENSITIVE);
             Pattern preconditionPattern = Pattern.compile("\\s*\\-\\-[\\s]*precondition\\-([a-zA-Z0-9-]+) (.*)", Pattern.CASE_INSENSITIVE);

--- a/liquibase-core/src/test/groovy/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.groovy
@@ -5,7 +5,6 @@ import liquibase.change.core.RawSQLChange
 import liquibase.changelog.ChangeLogParameters
 import liquibase.changelog.ChangeSet
 import liquibase.changelog.DatabaseChangeLog
-import liquibase.configuration.LiquibaseConfiguration
 import liquibase.exception.ChangeLogParseException
 import liquibase.precondition.core.PreconditionContainer
 import liquibase.precondition.core.SqlPrecondition
@@ -287,10 +286,13 @@ select 1
 
         then:
         ((RawSQLChange) changeLog.changeSets[0].changes[0]).sql.replace("\r\n", "\n") == expected
+        changeLog.changeSets[0].author == "John Doe"
+        changeLog.changeSets[0].id == "12345"
 
         where:
-        example                                                                                                  | expected
-        "--liquibase formatted sql\n--changeset John Doe:12345\nCREATE PROC TEST\nAnother Line\nEND MY PROC;\n/" | "CREATE PROC TEST\nAnother Line\nEND MY PROC;\n/"
+        example                                                                                                       | expected
+        "--liquibase formatted sql\n--changeset John Doe:12345\nCREATE PROC TEST\nAnother Line\nEND MY PROC;\n/"      | "CREATE PROC TEST\nAnother Line\nEND MY PROC;\n/"
+        "--liquibase formatted sql\n--changeset John Doe: 12345\nCREATE PROC TEST\nAnother Line\nEND MY PROC;\n/" | "CREATE PROC TEST\nAnother Line\nEND MY PROC;\n/"
     }
 
     @LiquibaseService(skip = true)


### PR DESCRIPTION
Fixes #1919

---

## Dev Handoff Notes (Internal Use)

#### Links

- Fixed Issue: https://github.com/liquibase/liquibase/issues/1919
- Local Branch: https://github.com/liquibase/liquibase/tree/formattedsql-space-in-id
- Unit Tests: https://github.com/liquibase/liquibase/pull/{PR ID}/checks
- Integration Tests: (shown in Unit Tests link above)
- Functional Tests: https://jenkins.datical.net/job/liquibase-pro/job/formattedsql-space-in-id/

#### Testing

- Steps to Reproduce: https://github.com/liquibase/liquibase/issues/1919
- Guidance: 
  - Only impacts formatted sql
  - Added unit test
  
#### Dev Verification

Verified update-sql includes:
```
-- Changeset com/example/changelog.demo.sql::grant_test_employee_privs::author
create table test_table (id int);
```