### PR TITLE
Handle case sensitive primary key names in dropPrimaryKey for postgresql

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/DropPrimaryKeyGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/DropPrimaryKeyGenerator.java
@@ -61,7 +61,7 @@ public class DropPrimaryKeyGenerator extends AbstractSqlGenerator<DropPrimaryKey
 						+ "    FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc\n"
 						+ "    WHERE CONSTRAINT_TYPE = 'PRIMARY KEY'\n"
 						+ "      AND TABLE_NAME = '%2$s' AND TABLE_SCHEMA = '%1$s';\n"
-						+ "    EXECUTE 'alter table %3$s.%4$s drop constraint ' || constraint_name;\n"
+						+ "    EXECUTE 'alter table %3$s.%4$s drop constraint \"' || constraint_name || '\"';\n"
 						+ "END $$;"
 						, schemaName, tableName
 						, database.escapeObjectName(schemaName, Schema.class), database.escapeObjectName(tableName, Table.class));


### PR DESCRIPTION
Fixes #1933

