### PR TITLE
#1979 liquibase resource accessor fix

### DIFF
--- a/liquibase-core/src/main/java/liquibase/parser/core/xml/LiquibaseEntityResolver.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/xml/LiquibaseEntityResolver.java
@@ -34,9 +34,11 @@ public class LiquibaseEntityResolver implements EntityResolver2 {
                 .replace("http://www.liquibase.org/xml/ns/migrator/", "http://www.liquibase.org/xml/ns/dbchangelog/")
                 .replaceFirst("https?://", "");
 
+        InputStreamList streams = Scope.getCurrentScope().getResourceAccessor().openStreams(null, path);
+        if (streams.isEmpty()) {
+            streams.addAll(fallbackResourceAccessor.openStreams(null, path));
+        }
 
-        ResourceAccessor resourceAccessor = new CompositeResourceAccessor(Scope.getCurrentScope().getResourceAccessor(), fallbackResourceAccessor);
-        InputStreamList streams = resourceAccessor.openStreams(null, path);
         if (streams.isEmpty()) {
             log.fine("Unable to resolve XML entity locally. Will load from network.");
             return null;


### PR DESCRIPTION
## Pull Request Type
- [x] Bug fix (non-breaking change which fixes an issue.)
- [ ] Enhancement/New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Fixed issue #1979 by only using the fallbackResourceAccessor when no streams are returned by provided resource accessor

## Fast Track PR Acceptance Checklist:
- [ ] Build is successful and all new and existing tests pass
- [ ] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
- [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
- [ ] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls)
- [ ] Documentation Updated