### PR TITLE
Support dropping named not null constraints in oracle.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/DropNotNullConstraintChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/DropNotNullConstraintChange.java
@@ -23,6 +23,7 @@ public class DropNotNullConstraintChange extends AbstractChange {
     private String tableName;
     private String columnName;
     private String columnDataType;
+    private String constraintName;
     private Boolean shouldValidate;
 
     @DatabaseChangeProperty(since = "3.0", mustEqualExisting ="notNullConstraint.table.catalog")
@@ -76,12 +77,21 @@ public class DropNotNullConstraintChange extends AbstractChange {
         this.columnDataType = columnDataType;
     }
 
+    @DatabaseChangeProperty(description = "Name of not null constraint")
+    public String getConstraintName() {
+        return constraintName;
+    }
+
+    public void setConstraintName(String constraintName) {
+        this.constraintName = constraintName;
+    }
+
     @Override
     public SqlStatement[] generateStatements(Database database) {
         return new SqlStatement[] { new SetNullableStatement(
                 getCatalogName(),
                 getSchemaName(),
-                getTableName(), getColumnName(), getColumnDataType(), true)
+                getTableName(), getColumnName(), getColumnDataType(), true, getConstraintName())
         };
     }
 
@@ -109,6 +119,7 @@ public class DropNotNullConstraintChange extends AbstractChange {
         inverse.setSchemaName(getSchemaName());
         inverse.setTableName(getTableName());
         inverse.setColumnDataType(getColumnDataType());
+        inverse.setConstraintName(getConstraintName());
 
         return new Change[]{
                 inverse

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/SetNullableGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/SetNullableGenerator.java
@@ -54,8 +54,12 @@ public class SetNullableGenerator extends AbstractSqlGenerator<SetNullableStatem
         String nullableString = statement.isNullable()?" NULL":" NOT NULL";
 
         if ((database instanceof OracleDatabase) && (statement.getConstraintName() != null)) {
-            nullableString += !statement.isValidate() ? " ENABLE NOVALIDATE " : "";
-            sql = "ALTER TABLE " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + " MODIFY " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " CONSTRAINT " + statement.getConstraintName() + nullableString;
+            if (!statement.isNullable()) {
+                nullableString += !statement.isValidate() ? " ENABLE NOVALIDATE " : "";
+                sql = "ALTER TABLE " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + " MODIFY " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " CONSTRAINT " + statement.getConstraintName() + nullableString;
+            } else {
+                sql = "ALTER TABLE " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + " DROP CONSTRAINT " + statement.getConstraintName();
+            }
         } else if ((database instanceof OracleDatabase) || (database instanceof SybaseDatabase) || (database
             instanceof SybaseASADatabase)) {
             nullableString += (database instanceof OracleDatabase)&&(!statement.isValidate()) ? " ENABLE NOVALIDATE " : "";

--- a/liquibase-core/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd
+++ b/liquibase-core/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd
@@ -911,6 +911,7 @@
             <xsd:attribute name="tableName" type="xsd:string" use="required"/>
             <xsd:attribute name="columnName" type="xsd:string" use="required"/>
             <xsd:attribute name="columnDataType" type="xsd:string"/>
+            <xsd:attribute name="constraintName" type="xsd:string"/>
         </xsd:complexType>
     </xsd:element>
 

--- a/liquibase-integration-tests/src/test/resources/changelogs/oracle/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/oracle/complete/root.changelog.xml
@@ -3,7 +3,7 @@
 <databaseChangeLog
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd">
     <preConditions>
             <dbms type="oracle"/>
             <runningAs username="${loginUser}"/>
@@ -299,12 +299,6 @@
             <param name="newValue" value="3"/>
         </customChange>
     </changeSet>
-    <changeSet id="57" author="nvoxland">
-        <customChange class="liquibase.change.custom.ExampleCustomSqlChange" tableName="person" columnName="employer_id" newValue="4"/>
-    </changeSet>
-    <changeSet id="58" author="nvoxland">
-        <customChange class="liquibase.change.custom.ExampleCustomTaskChange" helloTo="world"/>
-    </changeSet>
 
     <changeSet id="59" author="nvoxland">
         <createProcedure>
@@ -436,4 +430,31 @@ END testSP;
             END;
         </createProcedure>
     </changeSet>
+
+
+
+    <!-- check named not null constraints -->
+    <changeSet id="2" author="constraint-check">
+        <createTable tableName="named_constraint">
+            <column name="id" type="int"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="3" author="constraint-check">
+        <createTable tableName="unnamed_constraint">
+            <column name="id" type="int"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="5" author="constraint-check">
+        <addNotNullConstraint tableName="named_constraint" columnName="id" constraintName="ck_named_notnull"/>
+    </changeSet>
+    <changeSet id="6" author="constraint-check">
+        <addNotNullConstraint tableName="unnamed_constraint" columnName="id"/>
+    </changeSet>
+    <changeSet id="7" author="constraint-check">
+        <dropNotNullConstraint tableName="named_constraint" columnName="id" constraintName="ck_named_notnull"/>
+    </changeSet>
+    <changeSet id="8" author="constraint-check">
+        <dropNotNullConstraint tableName="unnamed_constraint" columnName="id"/>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## Overview

- Fixes #1492 
- Adds support for constraintName in dropNotNullConstraint
- Updates addNotNullConstraint's rollback logic to pass constraint name to the generated dropNotNullConstraint change