### PR TITLE
Improve synchronization of LockServiceFactory reset

### DIFF
--- a/liquibase-core/src/main/java/liquibase/lockservice/LockServiceFactory.java
+++ b/liquibase-core/src/main/java/liquibase/lockservice/LockServiceFactory.java
@@ -81,10 +81,10 @@ public class LockServiceFactory {
         return openLockServices.get(database);
     }
 
-    public synchronized void resetAll() {
+    public void resetAll() {
         for (LockService lockService : registry) {
             lockService.reset();
         }
-        instance = null;
+        reset();
     }
 }


### PR DESCRIPTION
Fixes #1568

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: https://github.com/liquibase/liquibase/issues/1568
* Local Branch: https://github.com/liquibase/liquibase/tree/lockservice_reset_sync
* Unit Tests: https://github.com/liquibase/liquibase/pull/1991/checks
* Integration Tests: (shown in Unit Tests link above)
* Functional Tests: https://jenkins.datical.net/job/liquibase-pro/job/lockservice_reset_sync/

#### Testing
* Steps to Reproduce: https://github.com/liquibase/liquibase/issues/1568
* Guidance: 
  * Newly added unit test caught error before fix, passes after fix

#### Dev Verification
New unit test passes



┆Issue is synchronized with this [Jiraserver Bug](https://datical.atlassian.net/browse/LB-1973) by [Unito](https://www.unito.io)
