### PR TITLE
Fix createSequence for h2 when dataType is specified

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateSequenceGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateSequenceGenerator.java
@@ -45,6 +45,10 @@ public class CreateSequenceGenerator extends AbstractSqlGenerator<CreateSequence
         validationErrors.checkDisallowedField("ordered", statement.getOrdered(), database, HsqlDatabase.class, PostgresDatabase.class);
         validationErrors.checkDisallowedField("dataType", statement.getDataType(), database, DB2Database.class, HsqlDatabase.class, OracleDatabase.class, MySQLDatabase.class, MSSQLDatabase.class);
 
+        if (database instanceof H2Database && statement.getDataType() != null && !statement.getDataType().equalsIgnoreCase("bigint")) {
+            validationErrors.addWarning("H2 only crates BIGINT sequences. Ignoring requested type "+statement.getDataType());
+        }
+
         return validationErrors;
     }
 
@@ -67,7 +71,9 @@ public class CreateSequenceGenerator extends AbstractSqlGenerator<CreateSequence
         if (database instanceof HsqlDatabase || database instanceof Db2zDatabase) {
             queryStringBuilder.append(" AS BIGINT ");
         } else if (statement.getDataType() != null) {
-            queryStringBuilder.append(" AS " + statement.getDataType());
+            if (!(database instanceof H2Database)) {
+                queryStringBuilder.append(" AS " + statement.getDataType());
+            }
         }
         if (!(database instanceof MariaDBDatabase) && statement.getStartValue() != null) {
             queryStringBuilder.append(" START WITH ").append(statement.getStartValue());


### PR DESCRIPTION
Fixes #1570

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: https://github.com/liquibase/liquibase/issues/1570
* Local Branch: https://github.com/liquibase/liquibase/tree/h2-createsequence-datatype-fix
* Unit Tests: https://github.com/liquibase/liquibase/pull/1992/checks
* Integration Tests: (shown in Unit Tests link above)
* Functional Tests: https://jenkins.datical.net/job/liquibase-pro/job/h2-createsequence-datatype-fix/

#### Testing
* Steps to Reproduce: https://github.com/liquibase/liquibase/issues/1570
* Guidance: 
  * Only impacts h2

#### Dev Verification
Added unit test, plus ran `update` with a changeSet with dataType specified

```
Starting Liquibase at 11:22:43 (version 4.4.2-local-SNAPSHOT #0 built at 2021-07-18 03:14+0000)
Liquibase Version: 4.4.2-local-SNAPSHOT
Liquibase Community 4.4.2-local-SNAPSHOT by Datical
Liquibase command 'update' was executed successfully.
```



┆Issue is synchronized with this [Jiraserver Bug](https://datical.atlassian.net/browse/LB-1972) by [Unito](https://www.unito.io)
