### PR TITLE
adding regex for ignoring class loader urls that are occurring when executing a Spring Boot repackaged .war file

### DIFF
--- a/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
@@ -74,8 +74,9 @@ public class ClassLoaderResourceAccessor extends AbstractResourceAccessor {
                             Scope.getCurrentScope().getLog(getClass()).info("No filesystem provider for URL " + url.toExternalForm() + ". Will rely on classloader logic for listing files.");
                         }
                     } catch (FileSystemNotFoundException fsnfe) {
-                        if (url.toExternalForm().matches(".*!.*!.*")) {
-                            //spring sometimes sets up urls with nested urls like jar:file:/path/to/demo-0.0.1-SNAPSHOT.jar!/BOOT-INF/lib/mssql-jdbc-8.2.2.jre8.jar!/ which are not readable.
+                        if (url.toExternalForm().matches("(?:.*!.*!.*)|(?:.*\\*.*)")) {
+                            //spring sometimes sets up urls with nested urls like jar:file:/path/to/demo-0.0.1-SNAPSHOT.jar!/BOOT-INF/lib/mssql-jdbc-8.2.2.jre8.jar!/
+                            //or war:file:/path/to/demo-0.0.1-SNAPSHOT.war*/WEB-INF/lib/httpclient-4.5.13.jar which are not readable.
                             //That is expected, and will be handled by the SpringResourceAccessor
                         } else {
                             Scope.getCurrentScope().getLog(getClass()).info("Configured classpath location " + url.toString() + " does not exist");


### PR DESCRIPTION
<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->

## Pull Request Type

<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->
- [ ] Bug fix (non-breaking change which fixes an issue.)
- [x] Enhancement/New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Prevents flooding the log with liquibase originated INFO logs when starting up a Spring Boot repackaged, `executed .war` file when the said Spring Boot application contains liquibase.

Executing a Spring Boot repackaged `.war` leads to class loader urls that are of the nature like `war:file:/path/to/demo-0.0.1-SNAPSHOT.war*/WEB-INF/lib/httpclient-4.5.13.jar`. 

These are tried to be handled by the `ClassLoaderResourceAccessor.java` which results in a lot of INFO logs from liquibase upon startup:
```sh
[...]
2021-08-04 18:49:39.110  INFO 4490 --- [           main] l.r.ClassLoaderResourceAccessor          : Configured classpath location war:file:/Users/alice/git/project/target/repackaged_spring_boot.war*/WEB-INF/lib/velocity-engine-core-2.3.jar does not exist
2021-08-04 18:49:39.110  INFO 4490 --- [           main] l.r.ClassLoaderResourceAccessor          : Configured classpath location war:file:/Users/alice/git/project/target/repackaged_spring_boot.war*/WEB-INF/lib/micrometer-core-1.7.2.jar does not exist
2021-08-04 18:49:39.110  INFO 4490 --- [           main] l.r.ClassLoaderResourceAccessor          : Configured classpath location war:file:/Users/alice/git/project/target/repackaged_spring_boot.war*/WEB-INF/lib/batik-css-1.12.jar does not exist
2021-08-04 18:49:39.110  INFO 4490 --- [           main] l.r.ClassLoaderResourceAccessor          : Configured classpath location war:file:/Users/alice/git/project/target/repackaged_spring_boot.war*/WEB-INF/lib/webjars-locator-core-0.46.jar does not exist
2021-08-04 18:49:39.110  INFO 4490 --- [           main] l.r.ClassLoaderResourceAccessor          : Configured classpath location war:file:/Users/alice/git/project/target/repackaged_spring_boot.war*/WEB-INF/lib/log4j-core-2.14.1.jar does not exist
[...]
```

From my point of view they should be ignored such as as the `jar:file:/path/to/demo-0.0.1-SNAPSHOT.jar!/BOOT-INF/lib/mssql-jdbc-8.2.2.jre8.jar!/` ones already are.

**I did not provide any test case for this since the `ClassLoaderResourceAccessorTest.groovy` does not contain any tests regarding the above mentioned Spring Boot typical `jar:file:[...]![...]!/` class loader urls. Also i am not sure what they would be testing besides a log not being fired.**

If you disagree i am more than happy to provide a pragmatic test case for this enhanced behaviour.

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->
- [x] Build is successful and all new and existing tests pass
- [ ] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
- [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
- [ ] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls)
- [ ] Documentation Updated

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)
