### PR TITLE
Fix: Directory with dot not recognized correctly when loading data (b…

### DIFF
--- a/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
@@ -139,13 +139,6 @@ public class ClassLoaderResourceAccessor extends AbstractResourceAccessor {
             relativeTo = relativeTo.replaceFirst("^classpath\\*?:", "");
             relativeTo = relativeTo.replaceAll("//+", "/");
 
-            if (!relativeTo.endsWith("/")) {
-                String lastPortion = relativeTo.replaceFirst(".+/", "");
-                if (lastPortion.contains(".")) {
-                    relativeTo = relativeTo.replaceFirst("/[^/]+?$", "");
-                }
-            }
-
             //
             // If this is a simple file name then set the
             // relativeTo value as if it is a root path
@@ -153,6 +146,18 @@ public class ClassLoaderResourceAccessor extends AbstractResourceAccessor {
             if (!relativeTo.contains("/") && relativeTo.contains(".")) {
                 relativeTo = "/";
             }
+
+            //
+            // If this is not a simple file name and the last component
+            // of the path contains a '.' remove the last component
+            //
+            if (!relativeTo.endsWith("/")) {
+                String lastPortion = relativeTo.replaceFirst(".+/", "");
+                if (lastPortion.contains(".")) {
+                    relativeTo = relativeTo.replaceFirst("/[^/]+?$", "");
+                }
+            }
+
             streamPath = relativeTo + "/" + streamPath;
         }
 

--- a/liquibase-core/src/test/groovy/liquibase/resource/ClassLoaderResourceAccessorTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/resource/ClassLoaderResourceAccessorTest.groovy
@@ -33,6 +33,7 @@ class ClassLoaderResourceAccessorTest extends Specification {
         "com/example/other.file"           | "/my/test.sql"                   | "com/example/my/test.sql"
         "classpath:com/example/other.file" | "my/test.sql"                    | "com/example/my/test.sql"
         "changelog.xml"                    | "sql/function.sql"               | "sql/function.sql"
+        "db-change.log/changelog.xml"      | "data/file.csv"                  | "db-change.log/data/file.csv"
     }
 
     @Unroll("#featureName: #relativeTo #streamPath")


### PR DESCRIPTION
<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->
## Environment

**Liquibase Version**: 4.4.3 (same error with all 4.x, no error with 3.10.x and before)

**Liquibase Integration & Version**: any

**Liquibase Extension(s) & Version**: none

**Database Vendor & Version**: H2 (and all others)

**Operating System Type & Version**: Windows 10 (and all others)

## Pull Request Type

- [x] Bug fix (non-breaking change which fixes an issue.) closes #2056
- [ ] Enhancement/New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

The loadData change does not find csv files when they are resolved relative to a path which contains a dot character ('.') in the last part (i.e. db-change.log/db-changelog.xml loads a data file in db-change.log/data/file.csv).
Other lookups may be affected too by this error. See #2056

## Steps To Reproduce

- clone / download https://github.com/smainz/liquibase-bug-dot-in-path
- make sure maven is installed
- run mvn test
- take a look at the README.md
- run mvn test "-Dliquibase.version=3.10.3" to see the test pass with liquibase version 3.x

## Actual Behavior
- Liquibase can not find the file data/file.csv in the resource directory db-change.log in test case testLiquibaseScriptWithDotInPath()
- Liquibase can find the file data/file.csv in the resource directory db-changelog in test case testLiquibaseScriptWithoutDotInPath()

```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running de.dynaware.vcheck.db.liquibase.LiquibaseTest
Aug. 31, 2021 9:22:57 VORM. liquibase.database
INFORMATION: Set default schema name to PUBLIC
Aug. 31, 2021 9:22:57 VORM. liquibase.lockservice
INFORMATION: Changelog-Protokoll erfolgreich gesperrt.
Aug. 31, 2021 9:22:57 VORM. liquibase.servicelocator
INFORMATION: Cannot load service: liquibase.parser.ChangeLogParser: liquibase.parser.core.json.JsonChangeLogParser Unable to get public no-arg constructor
Aug. 31, 2021 9:22:58 VORM. liquibase.servicelocator
INFORMATION: Cannot load service: liquibase.parser.ChangeLogParser: liquibase.parser.core.yaml.YamlChangeLogParser Unable to get public no-arg constructor
Aug. 31, 2021 9:22:58 VORM. liquibase.changelog
INFORMATION: Creating database history table with name: PUBLIC.DATABASECHANGELOG
Aug. 31, 2021 9:22:58 VORM. liquibase.changelog
INFORMATION: Reading from PUBLIC.DATABASECHANGELOG
Aug. 31, 2021 9:22:58 VORM. liquibase.lockservice
INFORMATION: Successfully released change log lock
Aug. 31, 2021 9:22:58 VORM. liquibase.database
INFORMATION: Set default schema name to PUBLIC
Aug. 31, 2021 9:22:58 VORM. liquibase.lockservice
INFORMATION: Changelog-Protokoll erfolgreich gesperrt.
Aug. 31, 2021 9:22:58 VORM. liquibase.changelog
INFORMATION: Creating database history table with name: PUBLIC.DATABASECHANGELOG
Aug. 31, 2021 9:22:58 VORM. liquibase.changelog
INFORMATION: Reading from PUBLIC.DATABASECHANGELOG
Aug. 31, 2021 9:22:58 VORM. liquibase.servicelocator
INFORMATION: Cannot load service: liquibase.hub.HubService: Provider liquibase.hub.core.StandardHubService could not be instantiated
Aug. 31, 2021 9:22:58 VORM. liquibase.changelog
INFORMATION: Table kalender created
Aug. 31, 2021 9:22:58 VORM. liquibase.changelog
INFORMATION: Index kalender_idx_datum created
Aug. 31, 2021 9:22:58 VORM. liquibase.changelog
INFORMATION: ChangeSet db-changelog/db-changelog-master.xml::Kalender::S. Mainz ran successfully in 16ms
Aug. 31, 2021 9:22:58 VORM. liquibase.statement
INFORMATION: Executing JDBC DML batch was successful. 8 operations were executed, 1 individual UPDATE events were confirmed by the database.
Aug. 31, 2021 9:22:58 VORM. liquibase.changelog
INFORMATION: Data loaded from 'data/some_data.csv' into table 'kalender'
Aug. 31, 2021 9:22:58 VORM. liquibase.changelog
INFORMATION: ChangeSet db-changelog/db-changelog-master.xml::Import Data::S. Mainz ran successfully in 15ms
Aug. 31, 2021 9:22:58 VORM. liquibase.lockservice
INFORMATION: Successfully released change log lock
Tests run: 2, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 1.672 sec <<< FAILURE!
testLiquibaseScriptWithDotInPath(de.dynaware.vcheck.db.liquibase.LiquibaseTest)  Time elapsed: 1.505 sec  <<< ERROR!
liquibase.exception.LiquibaseException: liquibase.exception.UnexpectedLiquibaseException: File 'data/some_data.csv' not found
        at liquibase.changelog.ChangeLogIterator.run(ChangeLogIterator.java:124)
        at liquibase.changelog.DatabaseChangeLog.validate(DatabaseChangeLog.java:292)
        at liquibase.Liquibase.lambda$update$1(Liquibase.java:231)
        at liquibase.Scope.lambda$child$0(Scope.java:166)
        at liquibase.Scope.child(Scope.java:175)
        at liquibase.Scope.child(Scope.java:165)
        at liquibase.Scope.child(Scope.java:144)
        at liquibase.Liquibase.runInScope(Liquibase.java:2404)
        at liquibase.Liquibase.update(Liquibase.java:211)
        at liquibase.Liquibase.update(Liquibase.java:197)
        at liquibase.Liquibase.update(Liquibase.java:193)
        at liquibase.Liquibase.update(Liquibase.java:185)
        at de.dynaware.vcheck.db.liquibase.LiquibaseTest.testLiquibaseScriptWithDotInPath(LiquibaseTest.java:41)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
        at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
        at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
        at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
        at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
        at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
        at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
        at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
        at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
        at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:252)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:141)
        at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:112)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
        at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
        at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)
Caused by: liquibase.exception.UnexpectedLiquibaseException: File 'data/some_data.csv' not found
        at liquibase.change.core.LoadDataChange.generateCheckSum(LoadDataChange.java:846)
        at liquibase.changelog.ChangeSet.generateCheckSum(ChangeSet.java:306)
        at liquibase.changelog.ChangeSet.toString(ChangeSet.java:909)
        at liquibase.changelog.ChangeLogIterator.createKey(ChangeLogIterator.java:178)
        at liquibase.changelog.ChangeLogIterator.alreadySaw(ChangeLogIterator.java:186)
        at liquibase.changelog.ChangeLogIterator$2.lambda$run$1(ChangeLogIterator.java:95)
        at liquibase.Scope.lambda$child$0(Scope.java:166)
        at liquibase.Scope.child(Scope.java:175)
        at liquibase.Scope.child(Scope.java:165)
        at liquibase.Scope.child(Scope.java:144)
        at liquibase.Scope.child(Scope.java:228)
        at liquibase.changelog.ChangeLogIterator$2.run(ChangeLogIterator.java:94)
        at liquibase.Scope.lambda$child$0(Scope.java:166)
        at liquibase.Scope.child(Scope.java:175)
        at liquibase.Scope.child(Scope.java:165)
        at liquibase.Scope.child(Scope.java:144)
        at liquibase.Scope.child(Scope.java:228)
        at liquibase.Scope.child(Scope.java:232)
        at liquibase.changelog.ChangeLogIterator.run(ChangeLogIterator.java:66)
        ... 46 more


Results :

Tests in error:
  testLiquibaseScriptWithDotInPath(de.dynaware.vcheck.db.liquibase.LiquibaseTest): liquibase.exception.UnexpectedLiquibaseException: File 'data/some_data.csv' not found

Tests run: 2, Failures: 0, Errors: 1, Skipped: 0
```

## Expected/Desired Behavior
Both test cases pass and the file `data/file.csv` is found even if the change log is in a directory wich contains a dot like `db-chenge.log`.

## Fast Track PR Acceptance Checklist:

- [ ] Build is successful and all new and existing tests pass (New test passes, existing test - unrelated to this fix -fails) 
- [x] Added [Unit Test(s)] added condition to existing test case. 
- [ ] Added [Integration Test(s)
- [ ] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls)
- [ ] Documentation Updated

