### PR TITLE
Fix/load relative file (fixes child of #1277)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/CreateProcedureChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/CreateProcedureChange.java
@@ -212,7 +212,7 @@ public class CreateProcedureChange extends AbstractChange implements DbmsTargete
             String relativeTo = null;
             final Boolean isRelative = isRelativeToChangelogFile();
             if (isRelative != null && isRelative) {
-                relativeTo = getChangeSet().getFilePath();
+                relativeTo = getChangeSet().getChangeLog().getPhysicalFilePath();
             }
             return Scope.getCurrentScope().getResourceAccessor().openStream(relativeTo, path);
         } catch (IOException e) {

--- a/liquibase-core/src/main/java/liquibase/change/core/CreateViewChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/CreateViewChange.java
@@ -166,7 +166,7 @@ public class CreateViewChange extends AbstractChange {
             String path = getPath();
             String relativeTo = null;
             if (ObjectUtil.defaultIfNull(getRelativeToChangelogFile(), false)) {
-                relativeTo = getChangeSet().getFilePath();
+                relativeTo = getChangeSet().getChangeLog().getPhysicalFilePath();
             }
             return Scope.getCurrentScope().getResourceAccessor().openStream(relativeTo, path);
         } catch (IOException e) {

--- a/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
@@ -791,7 +791,7 @@ public class LoadDataChange extends AbstractTableChange implements ChangeWithCol
     protected String getRelativeTo() {
         String relativeTo = null;
         if (ObjectUtil.defaultIfNull(isRelativeToChangelogFile(), false)) {
-            relativeTo = getChangeSet().getFilePath();
+            relativeTo = getChangeSet().getChangeLog().getPhysicalFilePath();
         }
         return relativeTo;
     }

--- a/liquibase-core/src/test/groovy/liquibase/change/core/CreateProcedureChangeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/core/CreateProcedureChangeTest.groovy
@@ -1,12 +1,18 @@
 package liquibase.change.core
 
+import liquibase.Scope
 import liquibase.change.StandardChangeTest
+import liquibase.changelog.ChangeSet
+import liquibase.changelog.DatabaseChangeLog
 import liquibase.database.core.OracleDatabase
 import liquibase.parser.core.ParsedNode
 import liquibase.database.core.MockDatabase
 import liquibase.sdk.resource.MockResourceAccessor
 import liquibase.snapshot.MockSnapshotGeneratorFactory
 import liquibase.snapshot.SnapshotGeneratorFactory
+import liquibase.test.JUnitResourceAccessor
+import liquibase.util.StreamUtil
+import spock.lang.Unroll
 
 public class CreateProcedureChangeTest extends StandardChangeTest {
 
@@ -38,5 +44,33 @@ public class CreateProcedureChangeTest extends StandardChangeTest {
 
         then:
         change.serialize().toString() == "createProcedure[procedureBody=create procedure sql]"
+    }
+
+    @Unroll
+    def "load correct file"() {
+        when:
+        def changelog = new DatabaseChangeLog("com/example/changelog.xml")
+
+        def changeset = new ChangeSet("1", "auth", false, false, logicalFilePath, null, null, changelog)
+
+        def change = new CreateProcedureChange()
+        change.path = sqlPath
+        change.relativeToChangelogFile = relativeToChangelogFile
+        change.setChangeSet(changeset)
+
+        String fileContents = Scope.child([(Scope.Attr.resourceAccessor.name()): new JUnitResourceAccessor()], {
+            return StreamUtil.readStreamAsString(change.openSqlStream())
+        } as Scope.ScopedRunnerWithReturn<String>)
+
+        then:
+        fileContents.trim() == "My Logic Here"
+
+        where:
+        sqlPath                   | logicalFilePath      | relativeToChangelogFile
+        "com/example/my-logic.sql" | null                 | false
+        "com/example/my-logic.sql" | "a/logical/path.xml" | false
+        "my-logic.sql"             | null                 | true
+        "my-logic.sql"             | "a/logical/path.xml" | true
+
     }
 }

--- a/liquibase-core/src/test/groovy/liquibase/change/core/CreateViewChangeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/core/CreateViewChangeTest.groovy
@@ -1,13 +1,19 @@
 package liquibase.change.core
 
+import liquibase.Scope
 import liquibase.change.ChangeStatus
 import liquibase.change.StandardChangeTest
+import liquibase.changelog.ChangeSet
+import liquibase.changelog.DatabaseChangeLog
 import liquibase.database.core.MockDatabase
 import liquibase.exception.SetupException
 import liquibase.parser.core.ParsedNodeException
 import liquibase.snapshot.MockSnapshotGeneratorFactory
 import liquibase.snapshot.SnapshotGeneratorFactory
 import liquibase.structure.core.View
+import liquibase.test.JUnitResourceAccessor
+import liquibase.util.StreamUtil
+import spock.lang.Unroll
 
 public class CreateViewChangeTest extends StandardChangeTest {
 
@@ -55,5 +61,33 @@ public class CreateViewChangeTest extends StandardChangeTest {
         then:
         change.viewName == "my_view"
         change.selectQuery == "select * from test"
+    }
+
+    @Unroll
+    def "openSqlStream correctly opens files"() {
+        when:
+        def changelog = new DatabaseChangeLog("com/example/changelog.xml")
+
+        def changeset = new ChangeSet("1", "auth", false, false, logicalFilePath, null, null, changelog)
+
+        def change = new CreateViewChange()
+        change.path = sqlPath
+        change.relativeToChangelogFile = relativeToChangelogFile
+        change.setChangeSet(changeset)
+
+        String fileContents = Scope.child([(Scope.Attr.resourceAccessor.name()): new JUnitResourceAccessor()], {
+            return StreamUtil.readStreamAsString(change.openSqlStream())
+        } as Scope.ScopedRunnerWithReturn<String>)
+
+        then:
+        fileContents.trim() == "My Logic Here"
+
+        where:
+        sqlPath | logicalFilePath | relativeToChangelogFile
+        "com/example/my-logic.sql" | null                 | false
+        "com/example/my-logic.sql" | "a/logical/path.xml" | false
+        "my-logic.sql"             | null                 | true
+        "my-logic.sql"             | "a/logical/path.xml" | true
+
     }
 }

--- a/liquibase-core/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
@@ -26,7 +26,6 @@ import liquibase.structure.core.DataType
 import liquibase.structure.core.Table
 import liquibase.test.JUnitResourceAccessor
 import liquibase.test.TestContext
-import liquibase.util.StreamUtil
 import liquibase.util.csv.CSVReader
 import spock.lang.Unroll
 
@@ -352,9 +351,10 @@ public class LoadDataChangeTest extends StandardChangeTest {
 
     def "relativeToChangelogFile works"() throws Exception {
         when:
+        def changelog = new DatabaseChangeLog("liquibase/changelog.xml")
         ChangeSet changeSet = new ChangeSet(null, null, true, false,
-                "liquibase/empty.changelog.xml",
-                null, null, false, null, null);
+                "logical or physical file name",
+                null, null, false, null, changelog);
 
         LoadDataChange relativeChange = new LoadDataChange();
 

--- a/liquibase-core/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
@@ -1,8 +1,10 @@
 package liquibase.change.core
 
+import liquibase.Scope
 import liquibase.change.ChangeStatus
 import liquibase.change.StandardChangeTest
 import liquibase.changelog.ChangeSet
+import liquibase.changelog.DatabaseChangeLog
 import liquibase.database.DatabaseConnection
 import liquibase.database.DatabaseFactory
 import liquibase.database.core.MSSQLDatabase
@@ -22,7 +24,10 @@ import liquibase.structure.DatabaseObject
 import liquibase.structure.core.Column
 import liquibase.structure.core.DataType
 import liquibase.structure.core.Table
+import liquibase.test.JUnitResourceAccessor
 import liquibase.test.TestContext
+import liquibase.util.StreamUtil
+import liquibase.util.csv.CSVReader
 import spock.lang.Unroll
 
 import java.sql.Timestamp
@@ -373,6 +378,34 @@ public class LoadDataChangeTest extends StandardChangeTest {
         assert relativeStatements != null
         assert nonRelativeStatements != null
         assert relativeStatements.size() == nonRelativeStatements.size()
+    }
+
+    @Unroll
+    def "openSqlStream correctly opens files"() {
+        when:
+        def changelog = new DatabaseChangeLog("com/example/changelog.xml")
+
+        def changeset = new ChangeSet("1", "auth", false, false, logicalFilePath, null, null, changelog)
+
+        def change = new LoadDataChange()
+        change.file = csvPath
+        change.relativeToChangelogFile = relativeToChangelogFile
+        change.setChangeSet(changeset)
+
+        CSVReader csvReader = Scope.child([(Scope.Attr.resourceAccessor.name()): new JUnitResourceAccessor()], {
+            return change.getCSVReader()
+        } as Scope.ScopedRunnerWithReturn<CSVReader>)
+
+        then:
+        csvReader != null
+
+        where:
+        csvPath                   | logicalFilePath      | relativeToChangelogFile
+        "com/example/users.csv"   | null                 | false
+        "com/example/users.csv"   | "a/logical/path.xml" | false
+        "users.csv"               | null                 | true
+        "users.csv"               | "a/logical/path.xml" | true
+
     }
 
     def "checksum does not change when no comments in CSV and comment property changes"() {


### PR DESCRIPTION
## Environment

**Liquibase Version**: 4.4.3 (and all 4.x before)

**Liquibase Integration & Version**: any

**Liquibase Extension(s) & Version**:  liquibase-core

**Database Vendor & Version**: H2 (and all others)

**Operating System Type & Version**: Windows 10 (and all others)

## Pull Request Type

- [x] Bug fix (non-breaking change which fixes an issue.) https://github.com/liquibase/liquibase/pull/1798 fixed the problem of loading files relative for SQLFileChange, but not for LoadDataChange,  CreateProcedureChange or CreateViewChange. This PR solves this.
- [ ] Enhancement/New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

See #1277, but for  LoadDataChange,  CreateProcedureChange or CreateViewChange.
Testcases showing the problem are included in this PR.

## Steps To Reproduce

List the steps to reproduce the behavior.
- create a changelog file with these change sets
  ```
  <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
				     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
				     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.10.xsd"
				     logicalFilePath="a-logical-file-path"
  >
	  <changeSet id="1" author="author">
		  <loadData file="data/some_data.csv" tableName="a_tabe"
				   relativeToChangelogFile="true"></loadData>
	  </changeSet>
  
	  <changeSet id="2" author="author">
		  <createProcedure path="sql/proc.sql"
						   relativeToChangelogFile="true"></createProcedure>
	  </changeSet>
  
	  <changeSet id="3" author="author">
		  <createView path="sql/view.sql" viewName="a_view"
					  relativeToChangelogFile="true"></createView>
	  </changeSet>
  
  </databaseChangeLog>
  ```
-  Create these files  (may be empty)
    -  `data/some_data.csv`
    -  `sql/proc.sql `
    -  `sql/view.sql`
- Run liquibase update against the db
 ```
liquibase --driver=com.microsoft.sqlserver.jdbc.SQLServerDriver --url="jdbc:sqlserver://localhost:1433;database=the_database" --changeLogFile=changelog.xml  --username=the_username --password=thepassword --logLevel=debug update
  ```
- See it fail 
- Comment the changeset and repeat (fails for all three)

## Actual Behavior

Liquibase throws an exception complaining about missing file (a different one for each changeset):
```
liquibase.exception.LiquibaseException: liquibase.exception.UnexpectedLiquibaseException: File 'data/some_data.csv' not found
```
## Expected/Desired Behavior

Liquibase does not complain about missing files and works flawlessly.

## Additional Context
Same bug has already been fixed in  https://github.com/liquibase/liquibase/pull/1798 for a diffenent change. The changes above have been overlooked.

I had to fix an existing testcase which used a changeset not included in an changelog. 

## Fast Track PR Acceptance Checklist:
- [x] Build is successful and all new and existing tests pass (all in liquibase.core)
- [x] Added [Unit Test(s)] Enhanced existing unit tests 
- [ ] Added [Integration Test(s)]
- [ ] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls)
- [ ] Documentation Updated

