### PR TITLE
DAT-7954: fix incorrect line breaks in TableOutput

### DIFF
--- a/liquibase-core/src/main/java/liquibase/util/TableOutput.java
+++ b/liquibase-core/src/main/java/liquibase/util/TableOutput.java
@@ -183,7 +183,7 @@ public class TableOutput {
         StringBuilder result = new StringBuilder();
         for (String part : parts) {
             if (runningWidth + part.length() > maxWidth) {
-               for (int i=0; i < (maxWidth - runningWidth + 2); i++) {
+               for (int i=0; i < (maxWidth - runningWidth); i++) {
                    result.append(" ");
                }
                runningWidth = 0;


### PR DESCRIPTION
Previously, the table output class would incorrectly split very long strings like this:

```
+--------------------------------+-----------------------+--------------------------------+---------+------------------+
| Warn on Detection of 'REVOKE…' | SqlRevokeWarn         | This check warns a user when   | true    | <None>           |
|   Statements                   |                       |   generated or raw SQL contain |         |                  |
|                                |                       | s   'REVOKE…' statements so th |         |                  |
|                                |                       | at    they can ensure that the |         |                  |
|                                |                       |         privilege being revoke |         |                  |
|                                |                       | d won't   lead to data access  |         |                  |
|                                |                       | and         dependency issues. |         |                  |
+--------------------------------+-----------------------+--------------------------------+---------+------------------+
```

This PR resolves that incorrect splitting.