### PR TITLE
render failed CommandTests in a format that Intellij Idea expects

### DIFF
--- a/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/command/CommandTests.groovy
+++ b/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/command/CommandTests.groovy
@@ -36,6 +36,7 @@ import liquibase.util.StringUtil
 import org.codehaus.groovy.control.CompilerConfiguration
 import org.junit.Assert
 import org.junit.Assume
+import org.junit.ComparisonFailure
 import org.junit.Test
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -421,8 +422,10 @@ Long Description: ${commandDefinition.getLongDescription() ?: "NOT SET"}
                 }
 
                 if (expectedOutputCheck instanceof String) {
-                    assert fullOutput.replaceAll(/\s+/," ")
-                            .contains(StringUtil.standardizeLineEndings(StringUtil.trimToEmpty(expectedOutputCheck)).replaceAll(/\s+/," ")): "$outputDescription does not contain: '$expectedOutputCheck'"
+                    if (!fullOutput.replaceAll(/\s+/," ")
+                            .contains(StringUtil.standardizeLineEndings(StringUtil.trimToEmpty(expectedOutputCheck)).replaceAll(/\s+/," "))) {
+                        throw new ComparisonFailure("$outputDescription does not contain expected", expectedOutputCheck, fullOutput)
+                    }
                 } else if (expectedOutputCheck instanceof Pattern) {
                     String patternString = StringUtil.standardizeLineEndings(StringUtil.trimToEmpty(((Pattern) expectedOutputCheck).pattern()))
                     //expectedOutputCheck = Pattern.compile(patternString, Pattern.MULTILINE | Pattern.DOTALL)


### PR DESCRIPTION
This change complies with how Intellij Idea expects failed tests to report their "expected" and "actual" values. The ultimate purpose here is so that Intellij will add a `<Click to see difference>` button to the console output that, when clicked, will show a diff between the expected and actual.