### PR TITLE
[2054] fix OSGI support (manifest, class loading)

### DIFF
--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -57,13 +57,13 @@
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
-
+        
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
             <scope>provided</scope>
-            <version>4.3.1</version>
-        </dependency>
+            <version>5.0.0</version>
+        </dependency>        
 
         <dependency>
             <groupId>org.springframework</groupId>
@@ -155,10 +155,11 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>5.1.2</version>
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>org.liquibase.core</Bundle-SymbolicName>
+                        <Bundle-Activator>liquibase.Activator</Bundle-Activator>
                         <Import-Package>
                             javax.activation*;resolution:=optional,
                             javax.servlet.*;version="[2.6,4)";resolution:=optional,
@@ -167,6 +168,66 @@
                             org.yaml.snakeyaml.*,
                             *;resolution:=optional
                         </Import-Package>
+                        <Provide-Capability>
+                          osgi.serviceloader; osgi.serviceloader=liquibase.serializer.ChangeLogSerializer,
+                          osgi.serviceloader; osgi.serviceloader=liquibase.parser.NamespaceDetails,
+                          osgi.serviceloader; osgi.serviceloader=liquibase.database.Database,
+                          osgi.serviceloader; osgi.serviceloader=liquibase.change.Change,
+                          osgi.serviceloader; osgi.serviceloader=liquibase.database.DatabaseConnection,
+                          osgi.serviceloader; osgi.serviceloader=liquibase.precondition.Precondition,
+                          osgi.serviceloader; osgi.serviceloader=liquibase.serializer.SnapshotSerializer,
+                          osgi.serviceloader; osgi.serviceloader=liquibase.configuration.AutoloadedConfigurations,
+                          osgi.serviceloader; osgi.serviceloader=liquibase.diff.DiffGenerator,
+                          osgi.serviceloader; osgi.serviceloader=liquibase.lockservice.LockService,
+                          osgi.serviceloader; osgi.serviceloader=liquibase.changelog.ChangeLogHistoryService,
+                          osgi.serviceloader; osgi.serviceloader=liquibase.datatype.LiquibaseDataType,
+                          osgi.serviceloader; osgi.serviceloader=liquibase.configuration.ConfigurationValueProvider,
+                          osgi.serviceloader; osgi.serviceloader=liquibase.logging.LogService,
+                          osgi.serviceloader; osgi.serviceloader=liquibase.snapshot.SnapshotGenerator,
+                          osgi.serviceloader; osgi.serviceloader=liquibase.parser.ChangeLogParser,
+                          osgi.serviceloader; osgi.serviceloader=liquibase.servicelocator.ServiceLocator,
+                          osgi.serviceloader; osgi.serviceloader=liquibase.diff.compare.DatabaseObjectComparator,
+                          osgi.serviceloader; osgi.serviceloader=liquibase.command.LiquibaseCommand,
+                          osgi.serviceloader; osgi.serviceloader=liquibase.license.LicenseService,
+                          osgi.serviceloader; osgi.serviceloader=liquibase.diff.output.changelog.ChangeGenerator,
+                          osgi.serviceloader; osgi.serviceloader=liquibase.executor.Executor,
+                          osgi.serviceloader; osgi.serviceloader=liquibase.structure.DatabaseObject,
+                          osgi.serviceloader; osgi.serviceloader=liquibase.parser.SnapshotParser,
+                          osgi.serviceloader; osgi.serviceloader=liquibase.hub.HubService,
+                          osgi.serviceloader; osgi.serviceloader=liquibase.command.CommandStep,
+                          osgi.serviceloader; osgi.serviceloader=liquibase.sqlgenerator.SqlGenerator
+                        </Provide-Capability>
+                        <Require-Capability>
+                        osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)",
+                        osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)",
+                        osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.serializer.ChangeLogSerializer)"; cardinality:=multiple,
+                        osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.parser.NamespaceDetails)"; cardinality:=multiple,
+                        osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.database.Database)"; cardinality:=multiple,
+                        osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.change.Change)"; cardinality:=multiple,
+                        osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.database.DatabaseConnection)"; cardinality:=multiple,
+                        osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.precondition.Precondition)"; cardinality:=multiple,
+                        osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.serializer.SnapshotSerializer)"; cardinality:=multiple,
+                        osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.configuration.AutoloadedConfigurations)"; cardinality:=multiple,
+                        osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.diff.DiffGenerator)"; cardinality:=multiple,
+                        osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.lockservice.LockService)"; cardinality:=multiple,
+                        osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.changelog.ChangeLogHistoryService)"; cardinality:=multiple,
+                        osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.datatype.LiquibaseDataType)"; cardinality:=multiple,
+                        osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.configuration.ConfigurationValueProvider)"; cardinality:=multiple,
+                        osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.logging.LogService)"; cardinality:=multiple,
+                        osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.snapshot.SnapshotGenerator)"; cardinality:=multiple,
+                        osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.parser.ChangeLogParser)"; cardinality:=multiple,
+                        osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.servicelocator.ServiceLocator)"; cardinality:=multiple,
+                        osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.diff.compare.DatabaseObjectComparator)"; cardinality:=multiple,
+                        osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.command.LiquibaseCommand)"; cardinality:=multiple,
+                        osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.license.LicenseService)"; cardinality:=multiple,
+                        osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.diff.output.changelog.ChangeGenerator)"; cardinality:=multiple,
+                        osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.executor.Executor)"; cardinality:=multiple,
+                        osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.structure.DatabaseObject)"; cardinality:=multiple,
+                        osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.parser.SnapshotParser)"; cardinality:=multiple,
+                        osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.hub.HubService)"; cardinality:=multiple,
+                        osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.command.CommandStep)"; cardinality:=multiple,
+                        osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.sqlgenerator.SqlGenerator)"; cardinality:=multiple
+                        </Require-Capability>
                     </instructions>
                 </configuration>
                 <executions>

--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -159,7 +159,7 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>org.liquibase.core</Bundle-SymbolicName>
-                        <Bundle-Activator>liquibase.Activator</Bundle-Activator>
+                        <Bundle-Activator>liquibase.osgi.Activator</Bundle-Activator>
                         <Import-Package>
                             javax.activation*;resolution:=optional,
                             javax.servlet.*;version="[2.6,4)";resolution:=optional,

--- a/liquibase-core/src/main/java/liquibase/Activator.java
+++ b/liquibase-core/src/main/java/liquibase/Activator.java
@@ -1,0 +1,108 @@
+package liquibase;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import liquibase.Activator.LiquibaseBundle;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleEvent;
+import org.osgi.util.tracker.BundleTracker;
+import org.osgi.util.tracker.BundleTrackerCustomizer;
+
+public class Activator implements BundleActivator, BundleTrackerCustomizer<LiquibaseBundle> {
+
+    private static final String LIQUIBASE_CUSTOM_CHANGE_WRAPPER_PACKAGES = "Liquibase-Custom-Change-Packages";
+    private BundleTracker<LiquibaseBundle> bundleTracker;
+    private static final List<LiquibaseBundle> liquibaseBundles = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void start(final BundleContext bc) throws Exception {
+        OSGIContainerChecker.osgiPlatform();
+        bundleTracker = new BundleTracker<>(bc, Bundle.ACTIVE, this);
+        bundleTracker.open();
+    }
+
+    @Override
+    public void stop(BundleContext context) throws Exception {
+        bundleTracker.close();
+        liquibaseBundles.clear();
+    }
+
+    public static List<LiquibaseBundle> getLiquibaseBundles() {
+        return Collections.unmodifiableList(liquibaseBundles);
+    }
+
+    @Override
+    public LiquibaseBundle addingBundle(Bundle bundle, BundleEvent event) {
+        if (bundle.getBundleId() == 0) {
+            return null;
+        }
+        String customWrapperPackages = (String) bundle.getHeaders().get(LIQUIBASE_CUSTOM_CHANGE_WRAPPER_PACKAGES);
+        if (customWrapperPackages != null) {
+            LiquibaseBundle lb = new LiquibaseBundle(bundle, customWrapperPackages);
+            liquibaseBundles.add(lb);
+            return lb;
+        }
+        return null;
+    }
+
+    @Override
+    public void modifiedBundle(Bundle bundle, BundleEvent event, LiquibaseBundle liquibaseBundle) {
+        // nothing to do
+    }
+
+    @Override
+    public void removedBundle(Bundle bundle, BundleEvent event, LiquibaseBundle liquibaseBundle) {
+        if (liquibaseBundle != null) {
+            liquibaseBundles.remove(liquibaseBundle);
+        }
+    }
+
+    public static class LiquibaseBundle {
+
+        private final Bundle bundle;
+        private final List<String> allowedPackages;
+
+        public LiquibaseBundle(Bundle bundle, String allowedPackages) {
+            if (bundle == null) {
+                throw new IllegalArgumentException("bundle cannot be empty");
+            }
+            if (allowedPackages == null || allowedPackages.isEmpty()) {
+                throw new IllegalArgumentException("packages cannot be empty");
+            }
+            this.bundle = bundle;
+            this.allowedPackages = Collections.unmodifiableList(Arrays.asList(allowedPackages.split(",")));
+        }
+
+        public Bundle getBundle() {
+            return bundle;
+        }
+
+        public boolean allowedAllPackages() {
+            return allowedPackages.size() == 1
+                    && "*".equals(allowedPackages.get(0));
+        }
+
+        public List<String> getAllowedPackages() {
+            return allowedPackages;
+        }
+
+    }
+
+    public static class OSGIContainerChecker {
+
+        private static volatile boolean osgiPlatform = false;
+
+        public static boolean isOsgiPlatform() {
+            return osgiPlatform;
+        }
+
+        static void osgiPlatform() {
+            osgiPlatform = true;
+        }
+    }
+
+}

--- a/liquibase-core/src/main/java/liquibase/Scope.java
+++ b/liquibase-core/src/main/java/liquibase/Scope.java
@@ -11,6 +11,7 @@ import liquibase.logging.LogService;
 import liquibase.logging.Logger;
 import liquibase.logging.core.JavaLogService;
 import liquibase.logging.core.LogServiceFactory;
+import liquibase.osgi.Activator;
 import liquibase.resource.ClassLoaderResourceAccessor;
 import liquibase.resource.ResourceAccessor;
 import liquibase.servicelocator.ServiceLocator;
@@ -96,7 +97,7 @@ public class Scope {
             }
 
             rootScope.values.put(Attr.serviceLocator.name(), serviceLocator);
-            rootScope.values.put(Attr.osgiPlatform.name(),Activator.OSGIContainerChecker.isOsgiPlatform());
+            rootScope.values.put(Attr.osgiPlatform.name(), Activator.OSGIContainerChecker.isOsgiPlatform());
         }
         return scopeManager.getCurrentScope();
     }

--- a/liquibase-core/src/main/java/liquibase/Scope.java
+++ b/liquibase-core/src/main/java/liquibase/Scope.java
@@ -55,6 +55,7 @@ public class Scope {
         fileEncoding,
         databaseChangeLog,
         changeSet,
+        osgiPlatform
     }
 
     private static ScopeManager scopeManager;
@@ -95,6 +96,7 @@ public class Scope {
             }
 
             rootScope.values.put(Attr.serviceLocator.name(), serviceLocator);
+            rootScope.values.put(Attr.osgiPlatform.name(),Activator.OSGIContainerChecker.isOsgiPlatform());
         }
         return scopeManager.getCurrentScope();
     }

--- a/liquibase-core/src/main/java/liquibase/osgi/Activator.java
+++ b/liquibase-core/src/main/java/liquibase/osgi/Activator.java
@@ -1,10 +1,10 @@
-package liquibase;
+package liquibase.osgi;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-import liquibase.Activator.LiquibaseBundle;
+import liquibase.osgi.Activator.LiquibaseBundle;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;

--- a/liquibase-core/src/main/java/liquibase/util/OsgiUtil.java
+++ b/liquibase-core/src/main/java/liquibase/util/OsgiUtil.java
@@ -2,8 +2,8 @@ package liquibase.util;
 
 import java.util.List;
 import java.util.stream.Collectors;
-import liquibase.Activator;
-import liquibase.Activator.LiquibaseBundle;
+import liquibase.osgi.Activator;
+import liquibase.osgi.Activator.LiquibaseBundle;
 
 public final class OsgiUtil {
 
@@ -13,7 +13,7 @@ public final class OsgiUtil {
     /**
      * try to load a class under OSGI environment. It will try to load the class
      * from all liquibase bundles registered via
-     * {@link liquibase.Activator Activator}
+     * {@link Activator Activator}
      *
      * @param <T>
      * @param className name of class
@@ -42,7 +42,7 @@ public final class OsgiUtil {
 
     /**
      *
-     * @param className
+     * @param clazz
      * @return true is a class is allowed
      * @throws java.lang.ClassNotFoundException
      */

--- a/liquibase-core/src/main/java/liquibase/util/OsgiUtil.java
+++ b/liquibase-core/src/main/java/liquibase/util/OsgiUtil.java
@@ -1,0 +1,65 @@
+package liquibase.util;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import liquibase.Activator;
+import liquibase.Activator.LiquibaseBundle;
+
+public final class OsgiUtil {
+
+    private OsgiUtil() {
+    }
+
+    /**
+     * try to load a class under OSGI environment. It will try to load the class
+     * from all liquibase bundles registered via
+     * {@link liquibase.Activator Activator}
+     *
+     * @param <T>
+     * @param className name of class
+     * @return
+     * @throws ClassNotFoundException
+     */
+    public static <T> Class<T> loadClass(String className) throws ClassNotFoundException {
+        List<LiquibaseBundle> liquibaseBundles = Activator.getLiquibaseBundles();
+        for (LiquibaseBundle lb : liquibaseBundles) {
+            try {
+                Class<T> clazz = (Class<T>) lb.getBundle().loadClass(className);
+                if (!isClassAllowed(lb, clazz)) {
+                    throw new ClassNotFoundException("Class is not allowed to load, class:" + className + " bundles:"
+                            + liquibaseBundles.stream().map(i -> i.getBundle().getSymbolicName())
+                                    .collect(Collectors.joining(",")));
+                }
+                return clazz;
+            } catch (ClassNotFoundException ex) {
+                // nothing to do
+            }
+        }
+        throw new ClassNotFoundException("Cannot find class:" + className + " bundles:"
+                + liquibaseBundles.stream().map(i -> i.getBundle().getSymbolicName())
+                        .collect(Collectors.joining(",")));
+    }
+
+    /**
+     *
+     * @param className
+     * @return true is a class is allowed
+     * @throws java.lang.ClassNotFoundException
+     */
+    private static boolean isClassAllowed(LiquibaseBundle liquibaseBundle, Class clazz) {
+        if (liquibaseBundle.allowedAllPackages()) {
+            return true;
+        }
+        for (String allowedPackage : liquibaseBundle.getAllowedPackages()) {
+            Package pkg = clazz.getPackage();
+            if (pkg != null) {
+                String pkgName = pkg.getName();
+                if (allowedPackage.equals(pkgName) || allowedPackage.startsWith(pkgName + ".")) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+}


### PR DESCRIPTION
see issue #2054

This patch fixes next things:
1) Java Service Loader issues -> I need to update MANIFEST file
2) loading of liquibase.build.properties file -> I need to load this file via bundle.getEntry
3) class loading problem for CustomChangeWrapper.java -> there is a problem that liquibase bundle cannot see classes from other bundles. This can be solved via dynamic import:* in MANIFEST.MF but it is not recommended way from OSGI point of view. So my solution is that there is a Activator class that is called when liquibase bundle is started or stopped. Under "start" method I registered  BundleTrackerCustomizer that checked all bundles if they contain a special manifest entry "Liquibase-Custom-Change-Packages". When the entry exists bundle will be used for searching of CustomChange class. 

Format for "Liquibase-Custom-Change-Packages" :


* <- all packages from bundle are allowed
com.xyz.test,com.xyz.test2 <- only CustomChange classes from bundle that lie in these two packages (or packages under these packages) are allowed.

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: https://github.com/liquibase/liquibase/issues/2054
* Test Results: https://github.com/liquibase/liquibase/pull/2081/checks

#### Testing
* Steps to Reproduce: https://github.com/liquibase/liquibase/issues/2054
* Guidance:
  * Impact: Isolated to OSGi support

#### Dev Verification
Relying on people who know OSGi better to verify it improves it vs. what is in 4.6.2



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-2184) by [Unito](https://www.unito.io)
