### PR TITLE
Fix missing includeSchema and includeCatalog arguments

### DIFF
--- a/liquibase-core/src/main/java/liquibase/command/CommandScope.java
+++ b/liquibase-core/src/main/java/liquibase/command/CommandScope.java
@@ -90,11 +90,14 @@ public class CommandScope {
         ConfigurationDefinition<T> configDef = createConfigurationDefinition(argument, true);
         ConfiguredValue<T> providedValue = configDef.getCurrentConfiguredValue();
 
-        if (!providedValue.found()) {
-            configDef = createConfigurationDefinition(argument, false);
-            providedValue = configDef.getCurrentConfiguredValue();
+        if (!providedValue.found() || providedValue.wasDefaultValueUsed()) {
+            ConfigurationDefinition<T> noCommandConfigDef = createConfigurationDefinition(argument, false);
+            ConfiguredValue<T> noCommandNameProvidedValue = noCommandConfigDef.getCurrentConfiguredValue();
+            if (noCommandNameProvidedValue.found() && !noCommandNameProvidedValue.wasDefaultValueUsed()) {
+                configDef = noCommandConfigDef;
+                providedValue = noCommandNameProvidedValue;
+            }
         }
-
 
         providedValue.override(commandScopeValueProvider.getProvidedValue(configDef.getKey(), argument.getName()));
 

--- a/liquibase-core/src/main/java/liquibase/command/core/DiffChangelogCommandStep.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/DiffChangelogCommandStep.java
@@ -22,6 +22,8 @@ public class DiffChangelogCommandStep extends AbstractCliWrapperCommandStep {
     public static final CommandArgumentDefinition<String> EXCLUDE_OBJECTS_ARG;
     public static final CommandArgumentDefinition<String> INCLUDE_OBJECTS_ARG;
     public static final CommandArgumentDefinition<String> SCHEMAS_ARG;
+    public static final CommandArgumentDefinition<Boolean> INCLUDE_SCHEMA_ARG;
+    public static final CommandArgumentDefinition<Boolean> INCLUDE_CATALOG_ARG;
     public static final CommandArgumentDefinition<String> DIFF_TYPES_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_PROPERTIES_FILE_ARG;
@@ -63,6 +65,12 @@ public class DiffChangelogCommandStep extends AbstractCliWrapperCommandStep {
                 .description("Objects to include in diff").build();
         SCHEMAS_ARG = builder.argument("schemas", String.class)
                 .description("Schemas to include in diff").build();
+        INCLUDE_SCHEMA_ARG = builder.argument("includeSchema", Boolean.class)
+                .defaultValue(false)
+                .description("If true, the schema will be included in generated changeSets").build();
+        INCLUDE_CATALOG_ARG = builder.argument("includeCatalog", Boolean.class)
+                .defaultValue(false)
+                .description("If true, the catalog will be included in generated changeSets").build();
         DIFF_TYPES_ARG = builder.argument("diffTypes", String.class)
                 .description("Types of objects to compare").build();
     }

--- a/liquibase-core/src/main/java/liquibase/command/core/GenerateChangelogCommandStep.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/GenerateChangelogCommandStep.java
@@ -17,6 +17,8 @@ public class GenerateChangelogCommandStep extends AbstractCliWrapperCommandStep 
     public static final CommandArgumentDefinition<String> DATA_OUTPUT_DIRECTORY;
     public static final CommandArgumentDefinition<String> EXCLUDE_OBJECTS_ARG;
     public static final CommandArgumentDefinition<String> INCLUDE_OBJECTS_ARG;
+    public static final CommandArgumentDefinition<Boolean> INCLUDE_SCHEMA_ARG;
+    public static final CommandArgumentDefinition<Boolean> INCLUDE_CATALOG_ARG;
     public static final CommandArgumentDefinition<String> SCHEMAS_ARG;
     public static final CommandArgumentDefinition<String> DIFF_TYPES_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_ARG;
@@ -47,6 +49,12 @@ public class GenerateChangelogCommandStep extends AbstractCliWrapperCommandStep 
                 .description("Objects to include in diff").build();
         SCHEMAS_ARG = builder.argument("schemas", String.class)
                 .description("Schemas to include in diff").build();
+        INCLUDE_SCHEMA_ARG = builder.argument("includeSchema", Boolean.class)
+                .defaultValue(false)
+                .description("If true, the schema will be included in generated changeSets").build();
+        INCLUDE_CATALOG_ARG = builder.argument("includeCatalog", Boolean.class)
+                .defaultValue(false)
+                .description("If true, the catalog will be included in generated changeSets").build();
         DIFF_TYPES_ARG = builder.argument("diffTypes", String.class)
                 .description("Types of objects to compare").build();
         OVERWRITE_OUTPUT_FILE_ARG = builder.argument("overwriteOutputFile", String.class)

--- a/liquibase-core/src/test/groovy/liquibase/command/CommandScopeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/command/CommandScopeTest.groovy
@@ -17,6 +17,7 @@ class CommandScopeTest extends Specification {
         when:
         def scope = new CommandScope("mock")
 
+        Scope.getCurrentScope().getSingleton(CommandFactory.class).unregister("mock command")
         def arg = new CommandBuilder([["mock command"]] as String[][]).argument(argumentName, String).defaultValue(defaultValue).build()
 
         def scopeId = Scope.enter([
@@ -41,15 +42,17 @@ class CommandScopeTest extends Specification {
         Scope.exit(scopeId)
 
         where:
-        argumentName        | defaultValue               | passedArg              | passedValue       | expectedValue          | expectedActualKey                        | expectedSource                            | expectedRequestedKey
-        "arg1"              | null                       | "arg1"                 | "arg 1"           | "arg 1"                | "arg1"                                   | "Command argument"                        | "liquibase.command.arg1"
-        "unsetArg"          | null                       | null                   | null              | null                   | "liquibase.command.unsetArg"             | "No configured value found" | "liquibase.command.unsetArg"
-        "argWithDefault"    | "default value"            | null                   | null              | "default value"        | "liquibase.command.mock.argWithDefault"  | "Default value"                           | "liquibase.command.mock.argWithDefault"
-        "setArgWithDefault" | "overridden default value" | "setArgWithDefault"    | "set arg value"   | "set arg value"        | "setArgWithDefault"                      | "Command argument"                        | "liquibase.command.mock.setArgWithDefault"
-        "argSetFromScope"   | null                       | null                   | null              | "value from scope"     | "liquibase.command.mock.argSetFromScope" | "Scoped value"                            | "liquibase.command.mock.argSetFromScope"
-        "otherArgInScope"   | null                       | null                   | null              | "other value in scope" | "liquibase.command.otherArgInScope"      | "Scoped value"                            | "liquibase.command.otherArgInScope"
-        "argSavedKabobCase" | null                       | "arg-saved-kabob-case" | "kabob value"     | "kabob value"          | "arg-saved-kabob-case"                   | "Command argument"                        | "liquibase.command.argSavedKabobCase"
-        "argSavedUpperCase" | null                       | "ARGSAVEDUPPERCASE"    | "uppercase value" | "uppercase value"      | "ARGSAVEDUPPERCASE"                      | "Command argument"                        | "liquibase.command.argSavedUpperCase"
+        argumentName        | defaultValue               | passedArg              | passedValue       | expectedValue          | expectedActualKey                        | expectedSource              | expectedRequestedKey
+        "arg1"              | null                       | "arg1"                 | "arg 1"           | "arg 1"                | "arg1"                                   | "Command argument"          | "liquibase.command.mock.arg1"
+        "unsetArg"          | null                       | null                   | null              | null                   | "liquibase.command.mock.unsetArg"        | "No configured value found" | "liquibase.command.mock.unsetArg"
+        "argWithDefault"    | "default value"            | null                   | null              | "default value"        | "liquibase.command.mock.argWithDefault"  | "Default value"             | "liquibase.command.mock.argWithDefault"
+        "setArgWithDefault" | "overridden default value" | "setArgWithDefault"    | "set arg value"   | "set arg value"        | "setArgWithDefault"                      | "Command argument"          | "liquibase.command.mock.setArgWithDefault"
+        "argSetFromScope"   | "default value"            | null                   | null              | "value from scope"     | "liquibase.command.mock.argSetFromScope" | "Scoped value"              | "liquibase.command.mock.argSetFromScope"
+        "argSetFromScope"   | null                       | null                   | null              | "value from scope"     | "liquibase.command.mock.argSetFromScope" | "Scoped value"              | "liquibase.command.mock.argSetFromScope"
+        "otherArgInScope"   | null                       | null                   | null              | "other value in scope" | "liquibase.command.otherArgInScope"      | "Scoped value"              | "liquibase.command.otherArgInScope"
+        "otherArgInScope"   | "default value"            | null                   | null              | "other value in scope" | "liquibase.command.otherArgInScope"      | "Scoped value"              | "liquibase.command.otherArgInScope"
+        "argSavedKabobCase" | null                       | "arg-saved-kabob-case" | "kabob value"     | "kabob value"          | "arg-saved-kabob-case"                   | "Command argument"          | "liquibase.command.mock.argSavedKabobCase"
+        "argSavedUpperCase" | null                       | "ARGSAVEDUPPERCASE"    | "uppercase value" | "uppercase value"      | "ARGSAVEDUPPERCASE"                      | "Command argument"          | "liquibase.command.mock.argSavedUpperCase"
     }
 
     def "constructor fails for unknown commands"() {

--- a/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/diffChangelog.test.groovy
+++ b/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/diffChangelog.test.groovy
@@ -33,8 +33,12 @@ Optional Args:
     Default: null
   excludeObjects (String) Objects to exclude from diff
     Default: null
+  includeCatalog (Boolean) If true, the catalog will be included in generated changeSets
+    Default: false
   includeObjects (String) Objects to include in diff
     Default: null
+  includeSchema (Boolean) If true, the schema will be included in generated changeSets
+    Default: false
   password (String) The target database password
     Default: null
     OBFUSCATED

--- a/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/generateChangelog.test.groovy
+++ b/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/generateChangelog.test.groovy
@@ -24,8 +24,12 @@ Optional Args:
     Default: null
   excludeObjects (String) Objects to exclude from diff
     Default: null
+  includeCatalog (Boolean) If true, the catalog will be included in generated changeSets
+    Default: false
   includeObjects (String) Objects to include in diff
     Default: null
+  includeSchema (Boolean) If true, the schema will be included in generated changeSets
+    Default: false
   overwriteOutputFile (String) Flag to allow overwriting of output changelog file
     Default: null
   password (String) Password to use to connect to the database


### PR DESCRIPTION
In 4.4, GenerateChangelog and DiffChangeLog the includeCatalog and includeSchema arguments are missing

DAT-8133