### PR TITLE
DAT-8203: allow supplying a current value when prompting using UIService

### DIFF
--- a/liquibase-core/src/main/java/liquibase/ui/ConsoleUIService.java
+++ b/liquibase-core/src/main/java/liquibase/ui/ConsoleUIService.java
@@ -68,6 +68,11 @@ public class ConsoleUIService extends AbstractExtensibleObject implements UIServ
 
     @Override
     public <T> T prompt(String prompt, T defaultValue, InputHandler<T> inputHandler, Class<T> type) {
+        return prompt(prompt, defaultValue, null, inputHandler, type);
+    }
+
+    @Override
+    public <T> T prompt(String prompt, T defaultValue, T currentValue, InputHandler<T> inputHandler, Class<T> type) {
         //
         // Check the allowPrompt flag
         //
@@ -87,9 +92,14 @@ public class ConsoleUIService extends AbstractExtensibleObject implements UIServ
             inputHandler = new DefaultInputHandler<>();
         }
 
+        T valueIfEnterHit = null;
         String initialMessage = prompt;
-        if (defaultValue != null) {
+        if (currentValue != null) {
+            initialMessage += " (current \"" + currentValue + "\")";
+            valueIfEnterHit = currentValue;
+        } else if (defaultValue != null) {
             initialMessage += " (default \"" + defaultValue + "\")";
+            valueIfEnterHit = defaultValue;
         }
         this.sendMessage(initialMessage + ": ");
 
@@ -98,7 +108,7 @@ public class ConsoleUIService extends AbstractExtensibleObject implements UIServ
             try {
                 if (input == null) {
                     if (inputHandler.shouldAllowEmptyInput()) {
-                        return defaultValue;
+                        return valueIfEnterHit;
                     } else {
                         throw new IllegalArgumentException("Empty values are not permitted.");
                     }

--- a/liquibase-core/src/main/java/liquibase/ui/ConsoleUIService.java
+++ b/liquibase-core/src/main/java/liquibase/ui/ConsoleUIService.java
@@ -67,39 +67,29 @@ public class ConsoleUIService extends AbstractExtensibleObject implements UIServ
     }
 
     @Override
-    public <T> T prompt(String prompt, T defaultValue, InputHandler<T> inputHandler, Class<T> type) {
-        return prompt(prompt, defaultValue, null, inputHandler, type);
-    }
-
-    @Override
-    public <T> T prompt(String prompt, T defaultValue, T currentValue, InputHandler<T> inputHandler, Class<T> type) {
+    public <T> T prompt(String prompt, T valueIfNoEntry, InputHandler<T> inputHandler, Class<T> type) {
         //
         // Check the allowPrompt flag
         //
         Logger log = Scope.getCurrentScope().getLog(getClass());
         if (! allowPrompt) {
             log.fine("No prompt for input is allowed at this time");
-            return defaultValue;
+            return valueIfNoEntry;
         }
         final ConsoleWrapper console = getConsole();
 
         if (!console.supportsInput()) {
-            log.fine("No console attached. Skipping interactive prompt: '" + prompt + "'. Using default value '" + defaultValue + "'");
-            return defaultValue;
+            log.fine("No console attached. Skipping interactive prompt: '" + prompt + "'. Using default value '" + valueIfNoEntry + "'");
+            return valueIfNoEntry;
         }
 
         if (inputHandler == null) {
             inputHandler = new DefaultInputHandler<>();
         }
 
-        T valueIfEnterHit = null;
         String initialMessage = prompt;
-        if (currentValue != null) {
-            initialMessage += " (current \"" + currentValue + "\")";
-            valueIfEnterHit = currentValue;
-        } else if (defaultValue != null) {
-            initialMessage += " (default \"" + defaultValue + "\")";
-            valueIfEnterHit = defaultValue;
+        if (valueIfNoEntry != null) {
+            initialMessage += " [" + valueIfNoEntry + "]";
         }
         this.sendMessage(initialMessage + ": ");
 
@@ -108,7 +98,7 @@ public class ConsoleUIService extends AbstractExtensibleObject implements UIServ
             try {
                 if (input == null) {
                     if (inputHandler.shouldAllowEmptyInput()) {
-                        return valueIfEnterHit;
+                        return valueIfNoEntry;
                     } else {
                         throw new IllegalArgumentException("Empty values are not permitted.");
                     }

--- a/liquibase-core/src/main/java/liquibase/ui/LoggerUIService.java
+++ b/liquibase-core/src/main/java/liquibase/ui/LoggerUIService.java
@@ -56,6 +56,11 @@ public class LoggerUIService extends AbstractExtensibleObject implements UIServi
         return defaultValue;
     }
 
+    @Override
+    public <T> T prompt(String prompt, T defaultValue, T currentValue, InputHandler<T> inputHandler, Class<T> type) {
+        return defaultValue;
+    }
+
     public Level getStandardLogLevel() {
         return standardLogLevel;
     }

--- a/liquibase-core/src/main/java/liquibase/ui/LoggerUIService.java
+++ b/liquibase-core/src/main/java/liquibase/ui/LoggerUIService.java
@@ -52,13 +52,8 @@ public class LoggerUIService extends AbstractExtensibleObject implements UIServi
      * This implementation simply returns the default value, since it cannot prompt the user.
      */
     @Override
-    public <T> T prompt(String prompt, T defaultValue, InputHandler<T> inputHandler, Class<T> type) {
-        return defaultValue;
-    }
-
-    @Override
-    public <T> T prompt(String prompt, T defaultValue, T currentValue, InputHandler<T> inputHandler, Class<T> type) {
-        return defaultValue;
+    public <T> T prompt(String prompt, T valueIfNoEntry, InputHandler<T> inputHandler, Class<T> type) {
+        return valueIfNoEntry;
     }
 
     public Level getStandardLogLevel() {

--- a/liquibase-core/src/main/java/liquibase/ui/UIService.java
+++ b/liquibase-core/src/main/java/liquibase/ui/UIService.java
@@ -34,25 +34,11 @@ public interface UIService extends ExtensibleObject, Plugin {
      * If inputHandler is null, {@link DefaultInputHandler} will be used.<br>
      * If inputHandler throws an {@link IllegalArgumentException}, the user will be given the chance to re-enter the value.<br>
      * If the inputHandler returns true for {@link InputHandler#shouldAllowEmptyInput()} and the user enters an empty value
-     * when prompted, or hits "enter", the defaultValue will be returned. If the inputHandler returns false for
+     * when prompted, or hits "enter", the valueIfNoEntry will be returned. If the inputHandler returns false for
      * {@link InputHandler#shouldAllowEmptyInput()}, the user will be reprompted until they enter a non-empty value,
      * which will then be returned.
      */
-    <T> T prompt(String prompt, T defaultValue, InputHandler<T> inputHandler, Class<T> type);
-
-    /**
-     * Prompt the user with the message and wait for a response.<br>
-     * If this UIService implementation does not support user prompts, return the default value.<br>
-     * If inputHandler is null, {@link DefaultInputHandler} will be used.<br>
-     * If inputHandler throws an {@link IllegalArgumentException}, the user will be given the chance to re-enter the value.<br>
-     * If the inputHandler returns true for {@link InputHandler#shouldAllowEmptyInput()} and the user enters an empty value
-     * when prompted, or hits "enter", the defaultValue will be returned. If the inputHandler returns false for
-     * {@link InputHandler#shouldAllowEmptyInput()}, the user will be reprompted until they enter a non-empty value,
-     * which will then be returned.
-     * If a currentValue is provided, it will be used instead of the defaultValue, if the user chooses to strike
-     * "enter" at the prompt to enter a value, and the inputHandler allows empty values.
-     */
-    <T> T prompt(String prompt, T defaultValue, T currentValue, InputHandler<T> inputHandler, Class<T> type);
+    <T> T prompt(String prompt, T valueIfNoEntry, InputHandler<T> inputHandler, Class<T> type);
 
     /**
      *

--- a/liquibase-core/src/main/java/liquibase/ui/UIService.java
+++ b/liquibase-core/src/main/java/liquibase/ui/UIService.java
@@ -41,6 +41,20 @@ public interface UIService extends ExtensibleObject, Plugin {
     <T> T prompt(String prompt, T defaultValue, InputHandler<T> inputHandler, Class<T> type);
 
     /**
+     * Prompt the user with the message and wait for a response.<br>
+     * If this UIService implementation does not support user prompts, return the default value.<br>
+     * If inputHandler is null, {@link DefaultInputHandler} will be used.<br>
+     * If inputHandler throws an {@link IllegalArgumentException}, the user will be given the chance to re-enter the value.<br>
+     * If the inputHandler returns true for {@link InputHandler#shouldAllowEmptyInput()} and the user enters an empty value
+     * when prompted, or hits "enter", the defaultValue will be returned. If the inputHandler returns false for
+     * {@link InputHandler#shouldAllowEmptyInput()}, the user will be reprompted until they enter a non-empty value,
+     * which will then be returned.
+     * If a currentValue is provided, it will be used instead of the defaultValue, if the user chooses to strike
+     * "enter" at the prompt to enter a value, and the inputHandler allows empty values.
+     */
+    <T> T prompt(String prompt, T defaultValue, T currentValue, InputHandler<T> inputHandler, Class<T> type);
+
+    /**
      *
      * Method to set flag indicating whether prompting is allowed
      *

--- a/liquibase-core/src/test/groovy/liquibase/ui/ConsoleUIServiceTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/ui/ConsoleUIServiceTest.groovy
@@ -24,13 +24,13 @@ class ConsoleUIServiceTest extends Specification {
 
         where:
         input                     | defaultValue     | expectedOutput   | expectedPrompts                                                                             | type
-        "a string"                | "something else" | "a string"       | "Prompt here (default \"something else\"): "                                                | String
-        ""                        | "something else" | "something else" | "Prompt here (default \"something else\"): "                                                | String
+        "a string"                | "something else" | "a string"       | "Prompt here [something else]: "                                                            | String
+        ""                        | "something else" | "something else" | "Prompt here [something else]: "                                                            | String
         ""                        | null             | null             | "Prompt here: "                                                                             | String
         "x"                       | null             | "x"              | "Prompt here: "                                                                             | String
         "1234"                    | null             | 1234             | "Prompt here: "                                                                             | Integer
-        ["x", "1234"] as String[] | 0                | 1234             | "Prompt here (default \"0\"): \nInvalid value: 'x': For input string: \"x\"\nPrompt here: "  | Integer
-        "true"                    | false            | true             | "Prompt here (default \"false\"): "                                  | Boolean
-        "false"                   | false            | false            | "Prompt here (default \"false\"): "                                  | Boolean
+        ["x", "1234"] as String[] | 0                | 1234             | "Prompt here [0]: \nInvalid value: 'x': For input string: \"x\"\nPrompt here: "             | Integer
+        "true"                    | false            | true             | "Prompt here [false]: "                                                                     | Boolean
+        "false"                   | false            | false            | "Prompt here [false]: "                                                                     | Boolean
     }
 }

--- a/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/command/CommandTests.groovy
+++ b/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/command/CommandTests.groovy
@@ -933,13 +933,8 @@ Long Description: ${commandDefinition.getLongDescription() ?: "NOT SET"}
         }
 
         @Override
-        def <T> T prompt(String prompt, T defaultValue, InputHandler<T> inputHandler, Class<T> type) {
-            return consoleUIService.prompt(prompt, defaultValue, inputHandler, type)
-        }
-
-        @Override
-        def <T> T prompt(String prompt, T defaultValue, T currentValue, InputHandler<T> inputHandler, Class<T> type) {
-            return consoleUIService.prompt(prompt, defaultValue, currentValue, inputHandler, type)
+        def <T> T prompt(String prompt, T valueIfNoEntry, InputHandler<T> inputHandler, Class<T> type) {
+            return consoleUIService.prompt(prompt, valueIfNoEntry, inputHandler, type)
         }
 
         class ConsoleUIServiceWrapper extends ConsoleUIService {
@@ -1031,13 +1026,8 @@ Long Description: ${commandDefinition.getLongDescription() ?: "NOT SET"}
         }
 
         @Override
-        def <T> T prompt(String prompt, T defaultValue, InputHandler<T> inputHandler, Class<T> type) {
-            return defaultValue
-        }
-
-        @Override
-        def <T> T prompt(String prompt, T defaultValue, T currentValue, InputHandler<T> inputHandler, Class<T> type) {
-            return defaultValue
+        def <T> T prompt(String prompt, T valueIfNoEntry, InputHandler<T> inputHandler, Class<T> type) {
+            return valueIfNoEntry
         }
 
         @Override

--- a/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/command/CommandTests.groovy
+++ b/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/command/CommandTests.groovy
@@ -937,6 +937,11 @@ Long Description: ${commandDefinition.getLongDescription() ?: "NOT SET"}
             return consoleUIService.prompt(prompt, defaultValue, inputHandler, type)
         }
 
+        @Override
+        def <T> T prompt(String prompt, T defaultValue, T currentValue, InputHandler<T> inputHandler, Class<T> type) {
+            return consoleUIService.prompt(prompt, defaultValue, currentValue, inputHandler, type)
+        }
+
         class ConsoleUIServiceWrapper extends ConsoleUIService {
             ConsoleUIServiceWrapper(ConsoleUIService.ConsoleWrapper console) {
                 super(console)
@@ -1027,6 +1032,11 @@ Long Description: ${commandDefinition.getLongDescription() ?: "NOT SET"}
 
         @Override
         def <T> T prompt(String prompt, T defaultValue, InputHandler<T> inputHandler, Class<T> type) {
+            return defaultValue
+        }
+
+        @Override
+        def <T> T prompt(String prompt, T defaultValue, T currentValue, InputHandler<T> inputHandler, Class<T> type) {
             return defaultValue
         }
 


### PR DESCRIPTION
Allow specifying a `currentValue` when using the `prompt` method in the `UIService`. If a non-null `currentValue` is provided, it will be shown instead of the `defaultValue`. If the input handler allows empty inputs, and the user strikes enter at the prompt when a `currentValue` is shown, that value will be returned.