### PR TITLE
Make LoadData statements extensible

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sql/ParameterizedSql.java
+++ b/liquibase-core/src/main/java/liquibase/sql/ParameterizedSql.java
@@ -1,0 +1,10 @@
+package liquibase.sql;
+
+import liquibase.change.ColumnConfig;
+
+import java.util.List;
+
+public interface ParameterizedSql extends Sql {
+
+    List<ColumnConfig> getColumns();
+}

--- a/liquibase-core/src/main/java/liquibase/sql/UnparsedParameterizedSql.java
+++ b/liquibase-core/src/main/java/liquibase/sql/UnparsedParameterizedSql.java
@@ -1,0 +1,21 @@
+package liquibase.sql;
+
+import liquibase.change.ColumnConfig;
+import liquibase.structure.DatabaseObject;
+
+import java.util.List;
+
+public class UnparsedParameterizedSql extends UnparsedSql implements ParameterizedSql {
+
+    private final List<ColumnConfig> columns;
+
+    public UnparsedParameterizedSql(String sql, List<ColumnConfig> columns, DatabaseObject... affectedDatabaseObjects) {
+        super(sql, affectedDatabaseObjects);
+        this.columns = columns;
+    }
+
+    @Override
+    public List<ColumnConfig> getColumns() {
+        return columns;
+    }
+}

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/BatchDmlExecutablePreparedStatementGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/BatchDmlExecutablePreparedStatementGenerator.java
@@ -3,8 +3,14 @@ package liquibase.sqlgenerator.core;
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
 import liquibase.sql.Sql;
+import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.sqlgenerator.SqlGeneratorFactory;
 import liquibase.statement.BatchDmlExecutablePreparedStatement;
+import liquibase.statement.ExecutablePreparedStatementBase;
+
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 /**
  * Dummy SQL generator for ${@link liquibase.statement.BatchDmlExecutablePreparedStatement}
@@ -17,6 +23,22 @@ public class BatchDmlExecutablePreparedStatementGenerator extends AbstractSqlGen
 
     @Override
     public Sql[] generateSql(BatchDmlExecutablePreparedStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
-        return new Sql[0];
+        // By convention, all of the statements are the same except the bind values. So it is sufficient to simply
+        // return the first collected statement for generation.
+        ExecutablePreparedStatementBase preparedStatement = statement.getIndividualStatements().get(0);
+        SqlGenerator<ExecutablePreparedStatementBase> generator = getGenerator(database, preparedStatement);
+        if (generator == null) {
+            // TODO: double-check
+            return new Sql[0];
+        }
+        return generator.generateSql(preparedStatement, database, new SqlGeneratorChain<>(new TreeSet<>()));
+    }
+
+    protected SqlGenerator<ExecutablePreparedStatementBase> getGenerator(Database database, ExecutablePreparedStatementBase preparedStatement) {
+        SortedSet<SqlGenerator> generators = SqlGeneratorFactory.getInstance().getGenerators(preparedStatement, database);
+        if ((generators == null) || generators.isEmpty()) {
+            return null;
+        }
+        return (SqlGenerator<ExecutablePreparedStatementBase>) generators.iterator().next();
     }
 }

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/InsertDataChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/InsertDataChangeGenerator.java
@@ -1,22 +1,58 @@
 package liquibase.sqlgenerator.core;
 
+import liquibase.change.ColumnConfig;
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
+import liquibase.sql.ParameterizedSql;
 import liquibase.sql.Sql;
+import liquibase.sql.UnparsedParameterizedSql;
+import liquibase.sql.UnparsedSql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.statement.DatabaseFunction;
 import liquibase.statement.InsertExecutablePreparedStatement;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Dummy SQL generator for <code>InsertDataChange.ExecutableStatement</code><br>
  */
 public class InsertDataChangeGenerator extends AbstractSqlGenerator<InsertExecutablePreparedStatement> {
+
     @Override
     public ValidationErrors validate(InsertExecutablePreparedStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
         return new ValidationErrors();
     }
 
     @Override
-    public Sql[] generateSql(InsertExecutablePreparedStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
-        return new Sql[0];
+    public ParameterizedSql[] generateSql(InsertExecutablePreparedStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+        List<ColumnConfig> columns = new ArrayList<>(statement.getColumns().size());
+        StringBuilder sql = new StringBuilder("INSERT INTO ");
+        StringBuilder params = new StringBuilder("VALUES(");
+        sql.append(database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()));
+        sql.append("(");
+        for(ColumnConfig column : statement.getColumns()) {
+            if(database.supportsAutoIncrement()
+                    && Boolean.TRUE.equals(column.isAutoIncrement())) {
+                continue;
+            }
+            sql.append(database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), column.getName()));
+            sql.append(", ");
+            if (column.getValueObject() instanceof DatabaseFunction) {
+                params.append(column.getValueObject()).append(", ");
+            } else {
+                params.append("?, ");
+                columns.add(column);
+            }
+        }
+        sql.deleteCharAt(sql.lastIndexOf(" "));
+        sql.deleteCharAt(sql.lastIndexOf(","));
+        params.deleteCharAt(params.lastIndexOf(" "));
+        params.deleteCharAt(params.lastIndexOf(","));
+        params.append(")");
+        sql.append(") ");
+        sql.append(params);
+        return new ParameterizedSql[] {new UnparsedParameterizedSql(sql.toString(), columns)};
+
     }
 }

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/UpdateDataChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/UpdateDataChangeGenerator.java
@@ -1,15 +1,25 @@
 package liquibase.sqlgenerator.core;
 
+import liquibase.change.ColumnConfig;
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
+import liquibase.sql.ParameterizedSql;
 import liquibase.sql.Sql;
+import liquibase.sql.UnparsedParameterizedSql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.statement.DatabaseFunction;
 import liquibase.statement.UpdateExecutablePreparedStatement;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static liquibase.util.SqlUtil.replacePredicatePlaceholders;
 
 /**
  * Dummy SQL generator for <code>UpdateDataChange.ExecutableStatement</code><br>
  */
 public class UpdateDataChangeGenerator extends AbstractSqlGenerator<UpdateExecutablePreparedStatement> {
+
     @Override
     public ValidationErrors validate(UpdateExecutablePreparedStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
         ValidationErrors validationErrors = new ValidationErrors();
@@ -21,7 +31,28 @@ public class UpdateDataChangeGenerator extends AbstractSqlGenerator<UpdateExecut
     }
 
     @Override
-    public Sql[] generateSql(UpdateExecutablePreparedStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
-        return new Sql[0];
+    public ParameterizedSql[] generateSql(UpdateExecutablePreparedStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+        List<ColumnConfig> columns = new ArrayList<>(statement.getColumns().size());
+        StringBuilder sql = new StringBuilder("UPDATE ").append(database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()));
+
+        StringBuilder params = new StringBuilder(" SET ");
+        for(ColumnConfig column : statement.getColumns()) {
+            params.append(database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), column.getName()));
+            params.append(" = ");
+            if (column.getValueObject() instanceof DatabaseFunction) {
+                params.append(column.getValueObject()).append(", ");
+            } else {
+                params.append("?, ");
+                columns.add(column);
+            }
+        }
+        params.deleteCharAt(params.lastIndexOf(" "));
+        params.deleteCharAt(params.lastIndexOf(","));
+        sql.append(params);
+        if (statement.getWhereClause() != null) {
+            sql.append(" WHERE ").append(replacePredicatePlaceholders(database, statement.getWhereClause(), statement.getWhereColumnNames(), statement.getWhereParameters()));
+        }
+
+        return new ParameterizedSql[] {new UnparsedParameterizedSql(sql.toString(), columns)};
     }
 }

--- a/liquibase-core/src/main/java/liquibase/statement/BatchDmlExecutablePreparedStatement.java
+++ b/liquibase-core/src/main/java/liquibase/statement/BatchDmlExecutablePreparedStatement.java
@@ -53,13 +53,6 @@ public class BatchDmlExecutablePreparedStatement extends ExecutablePreparedState
     }
 
     @Override
-    protected String generateSql(List<ColumnConfig> cols) {
-        // By convention, all of the statements are the same except the bind values. So it is sufficient to simply
-        // return the first collected statement for generation.
-        return collectedStatements.get(0).generateSql(cols);
-    }
-
-    @Override
     protected void executePreparedStatement(PreparedStatement stmt) throws SQLException {
         int updateCounts[] = stmt.executeBatch();
         long sumUpdateCounts = 0;

--- a/liquibase-core/src/main/java/liquibase/statement/InsertExecutablePreparedStatement.java
+++ b/liquibase-core/src/main/java/liquibase/statement/InsertExecutablePreparedStatement.java
@@ -24,33 +24,4 @@ public class InsertExecutablePreparedStatement extends ExecutablePreparedStateme
         return false;
     }
 
-    @Override
-    protected String generateSql(List<ColumnConfig> cols) {
-        StringBuilder sql = new StringBuilder("INSERT INTO ");
-        StringBuilder params = new StringBuilder("VALUES(");
-        sql.append(database.escapeTableName(getCatalogName(), getSchemaName(), getTableName()));
-        sql.append("(");
-        for(ColumnConfig column : getColumns()) {
-            if(database.supportsAutoIncrement()
-                && Boolean.TRUE.equals(column.isAutoIncrement())) {
-                continue;
-            }
-            sql.append(database.escapeColumnName(getCatalogName(), getSchemaName(), getTableName(), column.getName()));
-            sql.append(", ");
-			if (column.getValueObject() instanceof DatabaseFunction) {
-				params.append(column.getValueObject()).append(", ");
-			} else {
-				params.append("?, ");
-				cols.add(column);
-			}
-        }
-        sql.deleteCharAt(sql.lastIndexOf(" "));
-        sql.deleteCharAt(sql.lastIndexOf(","));
-        params.deleteCharAt(params.lastIndexOf(" "));
-        params.deleteCharAt(params.lastIndexOf(","));
-        params.append(")");
-        sql.append(") ");
-        sql.append(params);
-        return sql.toString();
-    }
 }

--- a/liquibase-core/src/main/java/liquibase/statement/UpdateExecutablePreparedStatement.java
+++ b/liquibase-core/src/main/java/liquibase/statement/UpdateExecutablePreparedStatement.java
@@ -27,32 +27,6 @@ public class UpdateExecutablePreparedStatement extends ExecutablePreparedStateme
         return false;
     }
 
-    @Override
-	protected String generateSql(List<ColumnConfig> cols) {
-
-		StringBuilder sql = new StringBuilder("UPDATE ").append(database.escapeTableName(getCatalogName(), getSchemaName(), getTableName()));
-
-		StringBuilder params = new StringBuilder(" SET ");
-	    for(ColumnConfig column : getColumns()) {
-	    	params.append(database.escapeColumnName(getCatalogName(), getSchemaName(), getTableName(), column.getName()));
-	    	params.append(" = ");
-			if (column.getValueObject() instanceof DatabaseFunction) {
-				params.append(column.getValueObject()).append(", ");
-			} else {
-				params.append("?, ");
-				cols.add(column);
-			}
-	    }
-	    params.deleteCharAt(params.lastIndexOf(" "));
-	    params.deleteCharAt(params.lastIndexOf(","));
-	    sql.append(params);
-        if (getWhereClause() != null) {
-            sql.append(" WHERE ").append(replacePredicatePlaceholders(database, getWhereClause(), getWhereColumnNames(), getWhereParameters()));
-        }
-
-		return sql.toString();
-	}
-
 
     public String getWhereClause() {
         return whereClause;

--- a/liquibase-core/src/test/java/liquibase/statement/ExecutablePreparedStatementBaseTest.java
+++ b/liquibase-core/src/test/java/liquibase/statement/ExecutablePreparedStatementBaseTest.java
@@ -43,11 +43,6 @@ public class ExecutablePreparedStatementBaseTest {
             public boolean continueOnError() {
                 return false;
             }
-            
-            @Override
-            protected String generateSql(List<ColumnConfig> cols) {
-                return null;
-            }
         };
         
         DummyPreparedStatement stmt;


### PR DESCRIPTION
Signed-off-by: Florent Biville <florent.biville@neo4j.com>

<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->
## Environment

**Liquibase Version**: 4.5.0-local-SNAPSHOT

**Liquibase Integration & Version**: core

**Liquibase Extension(s) & Version**:  N/A

**Database Vendor & Version**: N/A

**Operating System Type & Version**: N/A

## Pull Request Type

<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->
- [ ] Bug fix (non-breaking change which fixes an issue.)
- [x] Enhancement/New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

These changes should allow any Liquibase plugin to support `<loadData />` since all the statements it uses are now extensible.
The plugin we have in mind at the moment is the Neo4j plugin for Liquibase, since that would help its integration into JHipster (which by default generates a change log with <loadData />).