### PR TITLE
Makes "No Cycle" SQL syntax cross-DB compatible. Fixes #1990

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AlterSequenceGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AlterSequenceGenerator.java
@@ -84,7 +84,7 @@ public class AlterSequenceGenerator extends AbstractSqlGenerator<AlterSequenceSt
             if (statement.getCycle()) {
                 buffer.append(" CYCLE ");
             } else {
-                buffer.append(" NOCYCLE ");
+                buffer.append(" NO CYCLE ");
             }
         }
 

--- a/liquibase-core/src/test/java/liquibase/sqlgenerator/core/AlterSequenceGeneratorTest.java
+++ b/liquibase-core/src/test/java/liquibase/sqlgenerator/core/AlterSequenceGeneratorTest.java
@@ -2,7 +2,9 @@ package liquibase.sqlgenerator.core;
 
 import liquibase.database.Database;
 import liquibase.database.DatabaseConnection;
+import liquibase.database.core.CockroachDatabase;
 import liquibase.database.core.OracleDatabase;
+import liquibase.database.core.PostgresDatabase;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.AbstractSqlGeneratorTest;
 import liquibase.statement.core.AlterSequenceStatement;
@@ -19,31 +21,16 @@ public class AlterSequenceGeneratorTest extends AbstractSqlGeneratorTest<AlterSe
     protected static final String SEQUENCE_NAME = "SEQUENCE_NAME";
     protected static final String CATALOG_NAME = "CATALOG_NAME";
     protected static final String SCHEMA_NAME = "SCHEMA_NAME";
-//	private DatabaseConnection mockedUnsupportedMinMaxSequenceConnection;
-//    private DatabaseConnection mockedSupportedMinMaxSequenceConnection;
+
     public AlterSequenceGeneratorTest() throws Exception {
         super(new AlterSequenceGenerator());
     }
 
-//    @Before
-//    public void setUpMocks() throws DatabaseException {
-//
-//        mockedUnsupportedMinMaxSequenceConnection = mock(DatabaseConnection.class);
-//        when(mockedUnsupportedMinMaxSequenceConnection.getDatabaseMajorVersion()).thenReturn(1);
-//        when(mockedUnsupportedMinMaxSequenceConnection.getDatabaseMinorVersion()).thenReturn(3);
-//        when(mockedUnsupportedMinMaxSequenceConnection.getDatabaseProductVersion()).thenReturn("1.3.174 (2013-10-19)");
-//
-//        mockedSupportedMinMaxSequenceConnection = mock(DatabaseConnection.class);
-//        when(mockedSupportedMinMaxSequenceConnection.getDatabaseMajorVersion()).thenReturn(1);
-//        when(mockedSupportedMinMaxSequenceConnection.getDatabaseMinorVersion()).thenReturn(3);
-//        when(mockedSupportedMinMaxSequenceConnection.getDatabaseProductVersion()).thenReturn("1.3.175 (2014-01-18)");
-//    }
-
     @Test
-    public void testAlterSequenceDatabase() throws Exception {
+    public void testAlterSequenceDatabase(){
         for (Database database : TestContext.getInstance().getAllDatabases()) {
             if (database instanceof OracleDatabase) {
-                AlterSequenceStatement statement =  createSampleSqlStatement();
+                AlterSequenceStatement statement = createSampleSqlStatement();
                 statement.setCacheSize(BigInteger.valueOf(3000L));
 
                 Sql[] generatedSql = this.generatorUnderTest.generateSql(statement, database, null);
@@ -53,58 +40,23 @@ public class AlterSequenceGeneratorTest extends AbstractSqlGeneratorTest<AlterSe
         }
     }
 
-//    @Test
-//	public void h2DatabaseSupportsSequenceMaxValue() throws Exception {
-//
-//		H2Database h2Database = new H2Database();
-//        h2Database.setConnection(mockedSupportedMinMaxSequenceConnection);
-//
-//		AlterSequenceStatement alterSequenceStatement = createSampleSqlStatement();
-//		alterSequenceStatement.setMaxValue(new BigInteger("1000"));
-//
-//		assertFalse(generatorUnderTest.validate(alterSequenceStatement, h2Database, new MockSqlGeneratorChain()).hasErrors());
-//	}
+    @Test
+    public void testAlterSequenceCycleDatabase() {
+        for (Database database : TestContext.getInstance().getAllDatabases()) {
+            AlterSequenceStatement statement = createSampleSqlStatement();
+            statement.setCycle(false);
+            Sql[] generatedSql = this.generatorUnderTest.generateSql(statement, database, null);
+            if (database instanceof OracleDatabase) {
+                assertEquals("ALTER SEQUENCE CATALOG_NAME.SEQUENCE_NAME NO CYCLE", generatedSql[0].toSql());
+            } else if (database instanceof PostgresDatabase || database instanceof CockroachDatabase) {
+                assertEquals("ALTER SEQUENCE SCHEMA_NAME.SEQUENCE_NAME NO CYCLE", generatedSql[0].toSql());
+            }
+        }
+    }
 
-//    @Test
-//    public void h2DatabaseDoesNotSupportsSequenceMaxValue() throws Exception {
-//
-//        H2Database h2Database = new H2Database();
-//        h2Database.setConnection(mockedUnsupportedMinMaxSequenceConnection);
-//
-//        AlterSequenceStatement alterSequenceStatement = createSampleSqlStatement();
-//        alterSequenceStatement.setMaxValue(new BigInteger("1000"));
-//
-//        assertTrue(generatorUnderTest.validate(alterSequenceStatement, h2Database, new MockSqlGeneratorChain()).hasErrors());
-//    }
-
-//	@Test
-//	public void h2DatabaseSupportsSequenceMinValue() throws Exception {
-//
-//		H2Database h2Database = new H2Database();
-//        h2Database.setConnection(mockedSupportedMinMaxSequenceConnection);
-//
-//		AlterSequenceStatement alterSequenceStatement = createSampleSqlStatement();
-//		alterSequenceStatement.setMinValue(new BigInteger("10"));
-//
-//		assertFalse(generatorUnderTest.validate(alterSequenceStatement, h2Database, new MockSqlGeneratorChain()).hasErrors());
-//	}
-//
-//    @Test
-//    public void h2DatabaseDoesNotSupportsSequenceMinValue() throws Exception {
-//
-//        H2Database h2Database = new H2Database();
-//        h2Database.setConnection(mockedUnsupportedMinMaxSequenceConnection);
-//
-//        AlterSequenceStatement alterSequenceStatement = createSampleSqlStatement();
-//        alterSequenceStatement.setMinValue(new BigInteger("10"));
-//
-//        assertTrue(generatorUnderTest.validate(alterSequenceStatement, h2Database, new MockSqlGeneratorChain()).hasErrors());
-//    }
-
-	@Override
+    @Override
     protected AlterSequenceStatement createSampleSqlStatement() {
-        AlterSequenceStatement statement = new AlterSequenceStatement(CATALOG_NAME, SCHEMA_NAME, SEQUENCE_NAME);
-        return statement;
+        return new AlterSequenceStatement(CATALOG_NAME, SCHEMA_NAME, SEQUENCE_NAME);
     }
 
     @Override


### PR DESCRIPTION
Removes commented code.

<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->


## Environment
**Liquibase Version**:
4.1.0
Also latest master
**Liquibase Integration & Version**: <Pick one: CLI, maven, gradle, spring boot, servlet, etc.>
gradle, unknown version
**Liquibase Extension(s) & Version**: 

**Database Vendor & Version**:
Postgres, Oracle, CockroachDb

**Operating System Type & Version**:
Will occur on all supported OS

## Pull Request Type
<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->


* [X ] Bug fix (non-breaking change which fixes an issue.)
* [ ] Enhancement/New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
When `cycle`  is set to `false` the generated statement looks like the following 

`ALTER SEQUENCE SCHEMA_NAME.SEQUENCE_NAME NOCYCLE`

It is missing the space character in NOCYCLE. All supporting databases require it. And the generated sql should like the following.

`ALTER SEQUENCE SCHEMA_NAME.SEQUENCE_NAME NO CYCLE`

## Steps To Reproduce
Include the following change in any liquibase migration on Postgres
`<alterSequence cycle="true" schemaName="public" sequenceName="sequence_that_exists"/>`

## Actual Behavior
SQL Generated:
ALTER SEQUENCE public.sequence_that_exists NOCYCLE;
This is not valid in Postgres, Cockroach or Oracle (these are the only databases, where it is supported right now)

## Expected/Desired Behavior
xpected SQL generated:
ALTER SEQUENCE public.sequence_that_exists NO CYCLE;

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->


* [ ] Build is successful and all new and existing tests pass
* [x] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
* [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
* [ ] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls)
* [ ] Documentation Updated

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-2121) by [Unito](https://www.unito.io)
