### PR TITLE
DAT-8052: add more explicit explanation for wrong number of params in test

### DIFF
--- a/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/command/CommandTests.groovy
+++ b/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/command/CommandTests.groovy
@@ -967,6 +967,9 @@ Long Description: ${commandDefinition.getLongDescription() ?: "NOT SET"}
             //
             // Get the answer, increment the counter
             //
+            if (answers.size() <= count) {
+                throw new Exception("The test specified " + answers.size() + " prompt response(s), but the CLI is asking for an additional prompt response. Something is broken.")
+            }
             String answer = answers[count]
             count++
             return answer


### PR DESCRIPTION
The CommandTests framework allows for supplying a list of interactive prompt responses, and sometimes, you don't specify them correctly or configure your rule correctly. In those cases, the CLI may prompt for more parameters than you've specified, and the error message is an ArrayIndexOutOfBounds exception, which isn't immediately obvious.