### PR TITLE
Use path instead of absolutePath for resources

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -789,7 +789,7 @@ public class Main {
     private void parseDefaultPropertyFileFromResource(File potentialPropertyFile) throws IOException,
             CommandLineParsingException {
         try (InputStream resourceAsStream = getClass().getClassLoader().getResourceAsStream
-                (potentialPropertyFile.getAbsolutePath())) {
+                (potentialPropertyFile.getPath())) {
             if (resourceAsStream != null) {
                 parsePropertiesFile(resourceAsStream);
             }


### PR DESCRIPTION
## Environment
**Liquibase Version**: 4.5.0
**Liquibase Integration & Version**: CLI

## Pull Request Type
[x] Bug fix (fixes #2121)

## Description
When trying to read properties files from the class path, `file.getAbsolutePath()` is used. The result is some absolute path which won't exist in the classpath on most systems.

## Steps To Reproduce
See the description in issue #2121

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: https://github.com/liquibase/liquibase/issues/2121
* Test Results: https://github.com/liquibase/liquibase/pull/2122/checks

#### Testing
* Steps to Reproduce: The steps in #2121 only worked when calling the old liquibase.integration.commandline.Main class directly and not using the new LiquibaseCommandLine class. So to reproduce you'll have to tweak the liquibase.bat script to use the old classname instead.
* Guidance:
  * Impact: Does not impact people using the new LiquibaseCommandLine class since the validation is done through different code now. The changed code is still called, even in the new code paths, but any values found are not used 

#### Dev Verification
Verified the issue when using Main directly and that the fix addresses it.
Verified the fix does not cause issues when using LiquibaseCommandLine and that the reported issue is still working with the fix



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-2207) by [Unito](https://www.unito.io)
