### PR TITLE
Include column data type to SetColumnRemarksChange for MySQL support

### DIFF
--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/ChangedColumnChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/ChangedColumnChangeGenerator.java
@@ -6,6 +6,7 @@ import liquibase.change.Change;
 import liquibase.change.core.*;
 import liquibase.database.Database;
 import liquibase.database.core.MSSQLDatabase;
+import liquibase.database.core.MySQLDatabase;
 import liquibase.database.core.OracleDatabase;
 import liquibase.database.core.PostgresDatabase;
 import liquibase.datatype.DataTypeFactory;
@@ -76,6 +77,9 @@ public class ChangedColumnChangeGenerator extends AbstractChangeGenerator implem
             }
             if (control.getIncludeSchema()) {
                 change.setSchemaName(column.getSchema().getName());
+            }
+            if (comparisonDatabase instanceof MySQLDatabase) {
+                change.setColumnDataType(column.getType().toString());
             }
             change.setTableName(column.getRelation().getName());
             change.setColumnName(column.getName());


### PR DESCRIPTION
<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->
## Environment

**Liquibase Version**: 4.5.1-local-SNAPSHOT

**Database Vendor & Version**: MySQL 8

**Operating System Type & Version**: macOS 11.6

## Pull Request Type

<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->
- [x] Bug fix (non-breaking change which fixes an issue.)
- [ ] Enhancement/New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

MySQL needs column data type along with a column remark change. Even if the `columnDataType` is not actually changed, the type is required for MySQL to modify a remark on the column. So I included it in `SetColumnRemarksChange`.

## Steps To Reproduce

To reproduce a problem this PR is trying to fix:

1. Prepare two empty MySQL databases(comparison, reference respectively) 
2. Create a table `tester`, with columns `INT(10) id` as pk and `VARCHAR(10) name`, on both databases.
2. Add a comment to the `name` column on the reference database.
2. Create a `diffChangeLog` in SQL.

These steps will make a `NullPointerException`:
```
Caused by: java.lang.NullPointerException
        at liquibase.sqlgenerator.core.SetColumnRemarksGenerator.generateSql(SetColumnRemarksGenerator.java:50)
        at liquibase.sqlgenerator.core.SetColumnRemarksGenerator.generateSql(SetColumnRemarksGenerator.java:15)
        at liquibase.sqlgenerator.SqlGeneratorChain.generateSql(SqlGeneratorChain.java:30)
        at liquibase.sqlgenerator.SqlGeneratorFactory.generateSql(SqlGeneratorFactory.java:220)
        at liquibase.sqlgenerator.SqlGeneratorFactory.generateSql(SqlGeneratorFactory.java:206)
        at liquibase.serializer.core.formattedsql.FormattedSqlChangeLogSerializer.serialize(FormattedSqlChangeLogSerializer.java:58)
        at liquibase.serializer.core.formattedsql.FormattedSqlChangeLogSerializer.write(FormattedSqlChangeLogSerializer.java:104)
        at liquibase.diff.output.changelog.DiffToChangeLog.print(DiffToChangeLog.java:248)
        at liquibase.diff.output.changelog.DiffToChangeLog$1.run(DiffToChangeLog.java:137)
        ... 21 more
```

The line that throws the exception requires a column data type, which does not exist, because the data type is not actually changed.
https://github.com/liquibase/liquibase/blob/256675bca43a089e32c940e10ed8ed7a5f9d66f6/liquibase-core/src/main/java/liquibase/sqlgenerator/core/SetColumnRemarksGenerator.java#L50
