### PR TITLE
Fix #2133 and preserve CORE-2971 (Liquibase endDelimiter does not work after upgrading from 3.10.x to 4.x)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/util/StringUtil.java
+++ b/liquibase-core/src/main/java/liquibase/util/StringUtil.java
@@ -159,7 +159,7 @@ public class StringUtil {
         } else {
             if (endDelimiter.length() == 1) {
                 if ("/".equals(endDelimiter)) {
-                    if (previousPiece != null && !previousPiece.endsWith("\n")) {
+                    if (previousPiece != null && previousPiece.endsWith("*")) {
                         return false;
                     }
                 }
@@ -917,6 +917,7 @@ public class StringUtil {
         return trimRight(str.toString());
     }
 
+ 
     /**
      * Concatenates the addition string to the baseString string, adjusting the case of "addition" to match the base string.
      * If the string is all caps, append addition in all caps. If all lower case, append in all lower case. If baseString is mixed case, make no changes to addition.

--- a/liquibase-core/src/test/groovy/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.groovy
@@ -5,6 +5,7 @@ import liquibase.change.core.RawSQLChange
 import liquibase.changelog.ChangeLogParameters
 import liquibase.changelog.ChangeSet
 import liquibase.changelog.DatabaseChangeLog
+import liquibase.database.core.MockDatabase
 import liquibase.exception.ChangeLogParseException
 import liquibase.precondition.core.PreconditionContainer
 import liquibase.precondition.core.SqlPrecondition
@@ -80,6 +81,23 @@ create table my_table (
 select 1
 """.trim()
 
+    private static final String END_DELIMITER_CHANGELOG = """
+--liquibase formatted sql
+
+-- changeset abcd:1 runOnChange:true endDelimiter:/
+CREATE OR REPLACE PROCEDURE any_procedure_name is
+BEGIN
+    DBMS_MVIEW.REFRESH('LEAD_INST_FOS_MV', method => '?', atomic_refresh => FALSE, out_of_place => true);
+END reany_procedure_name;
+/
+
+
+grant /*Beware, this comment should not be seen as a delimiter! */
+    execute on any_procedure_name to ANY_USER1/
+grant execute on any_procedure_name to ANY_USER2/
+grant execute on any_procedure_name to ANY_USER3/
+-- rollback drop PROCEDURE refresh_all_fos_permission_views/
+"""
 
     private static final String INVALID_CHANGELOG = "select * from table1"
     private static final String INVALID_CHANGELOG_INVALID_PRECONDITION = "--liquibase formatted sql\n" +
@@ -291,6 +309,24 @@ select 1
         "--liquibase formatted sql\n\n--changeset John Doe:12345 dbms:db2, db2i\ncreate table test (id int);\n" | ["db2"]
         "--liquibase formatted sql\n\n--changeset John Doe:12345 dbms:db2,\ncreate table test (id int);\n"      | ["db2"]
         "--liquibase formatted sql\n\n--changeset John Doe:12345 dbms:,db2,\ncreate table test (id int);\n"     | null
+    }
+
+    def parse_withEndDelimiter() throws Exception {
+        expect:
+        ChangeLogParameters params = new ChangeLogParameters()
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(END_DELIMITER_CHANGELOG).parse("asdf.sql", params, new JUnitResourceAccessor())
+
+        changeLog.getLogicalFilePath() == "asdf.sql"
+        changeLog.getChangeSets().size() == 1
+        changeLog.getChangeSets().get(0).getChanges().size() == 1
+        def statements = changeLog.getChangeSets().get(0).getChanges().get(0).generateStatements(new MockDatabase())
+        statements.size() == 4
+        statements[0].toString() == "CREATE OR REPLACE PROCEDURE any_procedure_name is\nBEGIN\n" +
+                "    DBMS_MVIEW.REFRESH('LEAD_INST_FOS_MV', method => '?', atomic_refresh => FALSE, out_of_place => true);\n" +
+                "END reany_procedure_name;"
+        statements[1].toString() == "grant \n    execute on any_procedure_name to ANY_USER1"
+        statements[2].toString() == "grant execute on any_procedure_name to ANY_USER2"
+        statements[3].toString() == "grant execute on any_procedure_name to ANY_USER3"
     }
 
     @Unroll("#featureName: #example")


### PR DESCRIPTION
## Environment
**Liquibase Version**: Latest (4.5.1?)

**Liquibase Integration & Version**: core

## Pull Request Type
* [x] Bug fix (non-breaking change which fixes an issue.)
* [ ] Enhancement/New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
Fixes #2133 while preserving (and testing) CORE-2971.
It's a tad less aggressive regarding end delimiters.

## Steps To Reproduce
All steps are clearly listed in the Github issue.

## Fast Track PR Acceptance Checklist:
* [x] Build is successful and all new and existing tests pass
* [x] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
* [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
* [ ] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls)
* [ ] Documentation Updated

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: https://github.com/liquibase/liquibase/issues/2133
* Test Results: https://github.com/liquibase/liquibase/pull/2135/checks

#### Testing
* Steps to Reproduce: https://github.com/liquibase/liquibase/issues/2133 while not impacting https://liquibase.jira.com/browse/CORE-2971
* Guidance:
  * Impact: changes the handling of delimiters in parsed sql, whether it is in formatted sql or a sql/sqlFile tag

#### Dev Verification
Reviewed code and verified that automated tests now check the described problem



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-2186) by [Unito](https://www.unito.io)
