### PR TITLE
Adjust assembly plugin configuration to allow MacOS builds (fix #2065)

### DIFF
--- a/liquibase-dist/pom.xml
+++ b/liquibase-dist/pom.xml
@@ -230,6 +230,7 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>3.4.2</version>
 				<configuration>
+                    <tarLongFileMode>posix</tarLongFileMode>
                     <finalName>liquibase-${project.version}</finalName>
                     <appendAssemblyId>false</appendAssemblyId>
                     <attach>false</attach>


### PR DESCRIPTION
<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->
## Environment

**Liquibase Version**: Any

**Liquibase Integration & Version**: maven

**Operating System Type & Version**: MacOS

## Pull Request Type

<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->
- [ ] Bug fix (non-breaking change which fixes an issue.)
- [x] Enhancement/New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

In #2065, OP reported Liquibase does not build on MacOS and suggested a maven setting. Here it is

## Steps To Reproduce

Clearly stated in #2065 

## Fast Track PR Acceptance Checklist:
- [ ] Build is successful and all new and existing tests pass
- [ ] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
- [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
- [ ] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls)
- [ ] Documentation Updated