### PR TITLE
UniqueConstraintSnapshotGenerator - Add table name to OracleDB query

### DIFF
--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
@@ -226,7 +226,7 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
                             "[ic].[key_ordinal]";
 
             } else if (database instanceof OracleDatabase) {
-                sql = "select ucc.owner as constraint_container, ucc.constraint_name as constraint_name, ucc.column_name, f.validated as constraint_validate " +
+                sql = "select ucc.owner as constraint_container, ucc.constraint_name as constraint_name, ucc.column_name, f.validated as constraint_validate, ucc.table_name " +
                         "from all_cons_columns ucc " +
                         "INNER JOIN all_constraints f " +
                         "ON ucc.owner = f.owner " +


### PR DESCRIPTION
<!--- This environment context section helps us quickly review your PR. 
Please take a minute to fill-out this information. -->

## Environment
**Liquibase Version**: 4.5.0

**Liquibase Integration & Version**: <Pick one: CLI, maven, gradle, spring boot, servlet, etc.>

**Liquibase Extension(s) & Version**: 

**Database Vendor & Version**:

**Operating System Type & Version**:

## Pull Request Type
<!--- What types of changes does your code introduce?
Put an `x` in all the boxes that apply: 
If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->

* \[x] Bug fix (non-breaking change which fixes an issue.)
* \[ ] Enhancement/New feature (non-breaking change which adds functionality)
* \[ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
The query that is generated when retrieving all keys (ORACLE DB) does not get a table name, while the code that creates the map for  the cache gets this name from the query result, which is always null. When reading the cache, the table name is used which  results in the cache always returning an empty result.

## Steps To Reproduce
List the steps to reproduce the behavior.

* standard diff generation operation that creates a snaphot of the reference and target base 

Liquibase maven executions:

```java
<executions>
    <execution>
        <id>generate-schema</id>
        <phase>generate-test-resources</phase>
        <goals>
            <goal>dropAll</goal>
            <goal>update</goal>
            <goal>diff</goal>
        </goals>
    </execution>
    <execution>
        <id>generate-data</id>
        <phase>generate-test-resources</phase>
        <goals>
            <goal>diff</goal>
        </goals>
        <configuration>
            <diffTypes>data</diffTypes>
        </configuration>
    </execution>
</executions>
```

## Actual Behavior
Query result will preapre cache key like that:

```java
row.get("CONSTRAINT_CONTAINER") + "_" + row.get("TABLE_NAME") + "_" + row.get("CONSTRAINT_NAME"); // prepare cache Table name is always null
...
String lookupKey = schema.getName() + "_" + table + "_" + example.getName(); // read cache by key table name is not null
```

in above `row.get("TABLE_NAME")` is always NULL, as a result we have the effect as if no keys (Unique constraints) exist, which causes that they are added to the diff file and they should not because in fact they exist in DB. 

## Expected/Desired Behavior
Table name should be added to sql query. Then cache key will contain it and later when cache is used and table name will be given unique constraint will be read from cache. 

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: Stand alone PR
* Test Results: [https://github.com/liquibase/liquibase/pull/2139/checks](https://github.com/liquibase/liquibase/pull/2139/checks)

#### Testing
* Steps to Reproduce: Perform a snapshot against a database with unique constraints and see that it returns them
* Guidance:
  * Impact: Only impacts oracle. Constraints were returned before, but this change fixes some of the internal caching we do

#### Dev Verification
Reviewed code and saw automated tests pass

### **Test Requirements (Liquibase Internal QA)**
**Setup**

You will need two Oracle database instances.

On the first instance execute next sql script

```
CREATE TABLE test_table1
( id numeric(10) NOT NULL,
  first_name varchar2(50) NOT NULL,
  last_name varchar2(50),
  CONSTRAINT unique_id UNIQUE (id),
  CONSTRAINT unique_person UNIQUE (first_name, last_name)
);

INSERT ALL
  INTO test_table1 (id, first_name, last_name) VALUES (10, 'John', 'Doe')
  INTO test_table1 (id, first_name, last_name) VALUES (20, 'Jane', 'Dane')
SELECT * FROM dual;

CREATE TABLE test_table2
( id numeric(10) NOT NULL,
  first_name varchar2(50) NOT NULL,
  last_name varchar2(50),
  CONSTRAINT empty_id UNIQUE (id),
  CONSTRAINT empty_person UNIQUE (first_name, last_name)
);
```

Execute `liquibase generate-changelog --changelog-file lb2206-generated.xml --diff-types tables,columns,uniqueconstraints,data`

Execute `uptade` against second instance: `liquibase generate-changelog --changelog-file lb2206-generated.xml`

Make sure that second database instance was populated correctly.

**Manual Tests**

_Verify diff shows no difference in unique constraints._

* `liquibase diff`
* no missing or unexpected unique constraints are found

_Verify diff-changelog doesn’t ganerate any changes to unique constraints._

* `liquibase diff-changelog --changelog-file lb2206-diff.xml`
* generated changelog shows no difference between two instances

**Automated Tests**

No new functional tests required for this fix.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-2206) by [Unito](https://www.unito.io)
