### PR TITLE
Default charset to UTF-8 and introduce GlobalConfiguration.FILE_ENCODING

### DIFF
--- a/liquibase-core/src/main/java/liquibase/GlobalConfiguration.java
+++ b/liquibase-core/src/main/java/liquibase/GlobalConfiguration.java
@@ -1,9 +1,10 @@
 package liquibase;
 
-import liquibase.configuration.ConfigurationDefinition;
 import liquibase.configuration.AutoloadedConfigurations;
+import liquibase.configuration.ConfigurationDefinition;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Configuration container for global properties.
@@ -17,6 +18,7 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
     public static final ConfigurationDefinition<String> LIQUIBASE_SCHEMA_NAME;
     public static final ConfigurationDefinition<String> OUTPUT_LINE_SEPARATOR;
     public static final ConfigurationDefinition<String> OUTPUT_FILE_ENCODING;
+    public static final ConfigurationDefinition<Charset> FILE_ENCODING;
     public static final ConfigurationDefinition<Long> CHANGELOGLOCK_WAIT_TIME;
     public static final ConfigurationDefinition<Long> CHANGELOGLOCK_POLL_RATE;
     public static final ConfigurationDefinition<Boolean> CONVERT_DATA_TYPES;
@@ -76,6 +78,26 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
         OUTPUT_LINE_SEPARATOR = builder.define("outputLineSeparator", String.class)
                 .setDescription("Line separator for output")
                 .setDefaultValue(System.getProperty("line.separator"),"Line separator(LF or CRLF) for output. Defaults to OS default")
+                .build();
+
+        FILE_ENCODING = builder.define("fileEncoding", Charset.class)
+                .setDescription("Encoding to use when reading files. Valid values include: UTF-8, UTF-16, UTF-16BE, UTF-16LE, US-ASCII, or OS to use the system configured encoding.")
+                .setDefaultValue(StandardCharsets.UTF_8)
+                .setValueHandler(value -> {
+                    if (value == null) {
+                        return StandardCharsets.UTF_8;
+                    }
+                    if (value instanceof Charset) {
+                        return (Charset) value;
+                    }
+                    final String valueString = String.valueOf(value);
+                    if (valueString.equalsIgnoreCase("os")) {
+                        return Charset.defaultCharset();
+                    } else {
+                        return Charset.forName(valueString);
+                    }
+                })
+                .setCommonlyUsed(true)
                 .build();
 
         OUTPUT_FILE_ENCODING = builder.define("outputFileEncoding", String.class)

--- a/liquibase-core/src/main/java/liquibase/Scope.java
+++ b/liquibase-core/src/main/java/liquibase/Scope.java
@@ -20,13 +20,9 @@ import liquibase.ui.UIService;
 import liquibase.util.SmartMap;
 import liquibase.util.StringUtil;
 
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.nio.charset.Charset;
 import java.util.*;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * This scope object is used to hold configuration and other parameters within a call without needing complex method signatures.
@@ -52,6 +48,10 @@ public class Scope {
         executeMode,
         lineSeparator,
         serviceLocator,
+
+        /**
+         * @deprecated use {@link GlobalConfiguration#FILE_ENCODING}
+         */
         fileEncoding,
         databaseChangeLog,
         changeSet,
@@ -99,7 +99,7 @@ public class Scope {
         return scopeManager.getCurrentScope();
     }
 
-    public static void setScopeManager(ScopeManager scopeManager)  {
+    public static void setScopeManager(ScopeManager scopeManager) {
         Scope currentScope = getCurrentScope();
         if (currentScope == null) {
             currentScope = new Scope();
@@ -126,7 +126,7 @@ public class Scope {
     }
 
     /**
-     * @param parent The new Scopes parent in the hierarchy of Scopes, not null. 
+     * @param parent      The new Scopes parent in the hierarchy of Scopes, not null.
      * @param scopeValues The values for the new Scope.
      */
     protected Scope(Scope parent, Map<String, Object> scopeValues) {
@@ -172,14 +172,14 @@ public class Scope {
         child(listener, null, runner);
     }
 
-    public static void child(LiquibaseListener listener, Map<String, Object> scopeValues, ScopedRunner runner) throws Exception{
+    public static void child(LiquibaseListener listener, Map<String, Object> scopeValues, ScopedRunner runner) throws Exception {
         child(listener, scopeValues, () -> {
             runner.run();
             return null;
         });
     }
 
-    public static <T> T child(LiquibaseListener listener, Map<String, Object> scopeValues, ScopedRunnerWithReturn<T> runner) throws Exception{
+    public static <T> T child(LiquibaseListener listener, Map<String, Object> scopeValues, ScopedRunnerWithReturn<T> runner) throws Exception {
         String scopeId = enter(listener, scopeValues);
 
         try {
@@ -218,12 +218,13 @@ public class Scope {
 
     /**
      * Exits the scope started with {@link #enter(LiquibaseListener, Map)}
+     *
      * @param scopeId The id of the scope to exit. Throws an exception if the name does not match the current scope.
      */
     public static void exit(String scopeId) throws Exception {
         Scope currentScope = getCurrentScope();
         if (!currentScope.scopeId.equals(scopeId)) {
-            throw new RuntimeException("Cannot end scope "+scopeId+" when currently at scope "+currentScope.scopeId);
+            throw new RuntimeException("Cannot end scope " + scopeId + " when currently at scope " + currentScope.scopeId);
         }
 
         scopeManager.setCurrentScope(currentScope.getParent());
@@ -366,6 +367,9 @@ public class Scope {
         return get(Attr.lineSeparator, System.lineSeparator());
     }
 
+    /**
+     * @deprecated use {@link GlobalConfiguration#FILE_ENCODING}
+     */
     public Charset getFileEncoding() {
         return get(Attr.fileEncoding, Charset.defaultCharset());
     }
@@ -413,6 +417,7 @@ public class Scope {
     public interface ScopedRunner<T> {
         void run() throws Exception;
     }
+
     public interface ScopedRunnerWithReturn<T> {
         T run() throws Exception;
     }

--- a/liquibase-core/src/main/java/liquibase/database/core/PostgresDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/PostgresDatabase.java
@@ -1,6 +1,7 @@
 package liquibase.database.core;
 
 import liquibase.CatalogAndSchema;
+import liquibase.GlobalConfiguration;
 import liquibase.Scope;
 import liquibase.changelog.column.LiquibaseColumn;
 import liquibase.database.AbstractJdbcDatabase;
@@ -40,7 +41,6 @@ public class PostgresDatabase extends AbstractJdbcDatabase {
      */
     static final int PGSQL_PK_BYTES_LIMIT = 63;
     static final String PGSQL_PK_SUFFIX = "_pkey";
-    static final Charset CHARSET = Scope.getCurrentScope().getFileEncoding();
 
     private static final int PGSQL_DEFAULT_TCP_PORT_NUMBER = 5432;
     private static final Logger LOG = Scope.getCurrentScope().getLog(PostgresDatabase.class);
@@ -350,8 +350,10 @@ public class PostgresDatabase extends AbstractJdbcDatabase {
      */
     @Override
     public String generatePrimaryKeyName(final String tableName) {
-        final byte[] tableNameBytes = tableName.getBytes(CHARSET);
-        final int pkNameBaseAllowedBytesCount = PGSQL_PK_BYTES_LIMIT - PGSQL_PK_SUFFIX.getBytes(CHARSET).length;
+        final Charset charset = GlobalConfiguration.FILE_ENCODING.getCurrentValue();
+
+        final byte[] tableNameBytes = tableName.getBytes(charset);
+        final int pkNameBaseAllowedBytesCount = PGSQL_PK_BYTES_LIMIT - PGSQL_PK_SUFFIX.getBytes(charset).length;
 
         if (tableNameBytes.length <= pkNameBaseAllowedBytesCount) {
             return tableName + PGSQL_PK_SUFFIX;
@@ -359,7 +361,7 @@ public class PostgresDatabase extends AbstractJdbcDatabase {
 
         // As symbols could be encoded with more than 1 byte, the last symbol bytes couldn't be identified precisely.
         // To avoid the last symbol being the invalid one, just truncate it.
-        final String baseName = new String(tableNameBytes, 0, pkNameBaseAllowedBytesCount, CHARSET);
+        final String baseName = new String(tableNameBytes, 0, pkNameBaseAllowedBytesCount, charset);
         return baseName.substring(0, baseName.length() - 1) + PGSQL_PK_SUFFIX;
     }
 

--- a/liquibase-core/src/main/java/liquibase/util/StreamUtil.java
+++ b/liquibase-core/src/main/java/liquibase/util/StreamUtil.java
@@ -38,7 +38,7 @@ public abstract class StreamUtil {
     }
 
     /**
-     * Calls {@link #readStreamAsString(InputStream, String)} with {@link Scope#getFileEncoding()} as the encoding
+     * Calls {@link #readStreamAsString(InputStream, String)} with {@link GlobalConfiguration#FILE_ENCODING} as the encoding
      */
     public static String readStreamAsString(InputStream stream) throws IOException {
         return readStreamAsString(stream, null);
@@ -46,7 +46,7 @@ public abstract class StreamUtil {
 
     /**
      * Returns the given stream as a string using the given encoding.
-     * If encoding is null, use {@link Scope#getFileEncoding()}
+     * If encoding is null, use {@link GlobalConfiguration#FILE_ENCODING}
      */
     public static String readStreamAsString(InputStream stream, String encoding) throws IOException {
         StringBuilder result = new StringBuilder();
@@ -80,7 +80,7 @@ public abstract class StreamUtil {
             }
         }
 
-        return new InputStreamReader(encodingAwareStream, ObjectUtil.defaultIfNull(encoding, Scope.getCurrentScope().getFileEncoding().toString()));
+        return new InputStreamReader(encodingAwareStream, ObjectUtil.defaultIfNull(encoding == null ? null : Charset.forName(encoding), GlobalConfiguration.FILE_ENCODING.getCurrentValue()));
     }
 
     /**

--- a/liquibase-core/src/test/groovy/liquibase/GlobalConfigurationTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/GlobalConfigurationTest.groovy
@@ -1,0 +1,28 @@
+package liquibase
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
+
+class GlobalConfigurationTest extends Specification {
+
+    @Unroll
+    def "file_encoding"() {
+        expect:
+        GlobalConfiguration.FILE_ENCODING.valueConverter.convert(input) == expected
+
+        where:
+        input      | expected
+        "UTF-8"    | StandardCharsets.UTF_8
+        "utf-8"    | StandardCharsets.UTF_8
+        "utf-16"   | StandardCharsets.UTF_16
+        "UTF-16BE" | StandardCharsets.UTF_16BE
+        "UTF-16lE" | StandardCharsets.UTF_16LE
+        "ascii"    | StandardCharsets.US_ASCII
+        "us-ASCII" | StandardCharsets.US_ASCII
+        "os"       | Charset.defaultCharset()
+        null       | StandardCharsets.UTF_8
+    }
+}

--- a/liquibase-core/src/test/java/liquibase/database/core/PostgresDatabaseTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/core/PostgresDatabaseTest.java
@@ -1,5 +1,6 @@
 package liquibase.database.core;
 
+import liquibase.GlobalConfiguration;
 import liquibase.changelog.column.LiquibaseColumn;
 import liquibase.database.AbstractJdbcDatabaseTest;
 import liquibase.database.Database;
@@ -158,7 +159,7 @@ public class PostgresDatabaseTest extends AbstractJdbcDatabaseTest {
 //    }
 
     private void assertPrimaryKeyName(String expected, String actual) {
-        assertTrue(expected.getBytes(PostgresDatabase.CHARSET).length <= PostgresDatabase.PGSQL_PK_BYTES_LIMIT);
+        assertTrue(expected.getBytes(GlobalConfiguration.FILE_ENCODING.getCurrentValue()).length <= PostgresDatabase.PGSQL_PK_BYTES_LIMIT);
         assert expected.equals(actual) : "Invalid " + actual + " vs expected " + expected;
     }
 


### PR DESCRIPTION
# Overview

Changes the default encoding to **_read_** files in from "OS default" to UTF-8 (marking as ReleaseMajor for this reason).

Introduces a new global `liquibase.fileEncoding` setting that can be set in the CLI as `--file-encoding=ASCII` or as `liquibase.fileEncoding: ASCII` in the liquibase.properties file etc.

Within the code, reading the new setting replaces the now-deprecated Scope.getFileEncoding() function.

# Impact

Fixes #1445 along with any other other issues where users are attempting to read UTF-8 files but their os default language is not UTF-8 compatible.

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: [https://github.com/liquibase/liquibase/issues/1445](https://github.com/liquibase/liquibase/issues/1445)
* Local Branch: [https://github.com/liquibase/liquibase/tree/default-to-utf8](https://github.com/liquibase/liquibase/tree/default-to-utf8)
* Unit Tests: [https://github.com/liquibase/liquibase/pull/2144/checks](https://github.com/liquibase/liquibase/pull/2144/checks)
* Integration Tests: (shown in Unit Tests link above)
* Functional Tests: [https://jenkins.datical.net/job/liquibase-pro/job/default-to-utf8/](https://jenkins.datical.net/job/liquibase-pro/job/default-to-utf8/)

#### Testing
* Steps to Reproduce: [https://github.com/liquibase/liquibase/issues/1445](https://github.com/liquibase/liquibase/issues/1445)
* Guidance:
  * Introduced a new liquibase.fileEncoding global setting and updated code to use it
  * Change is not database-specific, it changes how we read changelog files off the disk
  * Code that reads files is well-isolated to just a couple methods
  * I'd suggest testing: running update and update-sql commands using a file with UTF-8 values in them with and without the new --file-encoding CLI argument

#### Dev Verification
Added unit tests for value parsing. Ensured existing unit tests that deal with charsets still work

Fixes #1445

## Test Requirements (Internal Liquibase QA)
This bug is reported against MariaDB but the fix is database-agnostic. Additional changes were made to improve handling of encoding on Postgres. Testing will be performed against MariaDB and Postgres.

The bug manifests during Liquibase reads of files. I’ve selected two Liquibase commands that read from files (update-sql and update). The fix is _only_ for reads, not for writes.

**Automated Test Requirements**

* None. The developer tests are sufficient coverage for the level of code where the fix occurs.

**Manual Test Requirements**

Use the attached changelogs to execute tests against MariaDB and Postgres. An example of “incorrect characters” is:

`  ("1", "<p>assets├óΓé¼Γäó market capitalisation.</p>");`

_Verify liquibase help includes the new -~~file~~encoding CLI argument as a GLOBAL argument._

* `liquibase --help`

_Verify update~~sql does not produce incorrect characters for an insert containing a back~~tick ( ` )._

* `liquibase --file-encoding utf-8 update-sql --changelog-file lb2107-changelog.sql`
* MariaDB
* Postgres

_Verify update is successful for an insert containing a back-tick ( ` )._

* `liquibase update --file-encoding utf-8 --changelog-file lb2107-changelog.sql`
* MariaDB
* Postgres

_Verify the TBL_LB2107 row has the correct representation of the back-tick ( ` )._

* `SELECT * FROM TBL_LB2701`
* MariaDB
* Postgres



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-2107) by [Unito](https://www.unito.io)
