### PR TITLE
YAMLChangelogParser: Fix parsing logic around changeLogId in a Map

### DIFF
--- a/liquibase-core/src/main/java/liquibase/parser/core/yaml/YamlChangeLogParser.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/yaml/YamlChangeLogParser.java
@@ -65,10 +65,11 @@ public class YamlChangeLogParser extends YamlParser implements ChangeLogParser {
                                     context, labels, global);
                         }
                     }
-                }
-                else if (((Map) obj).containsKey("changeLogId")) {
-                    String changeLogId = (String)((Map)obj).get("changeLogId");
-                    changeLog.setChangeLogId(changeLogId);
+
+                    if (((Map) obj).containsKey("changeLogId")) {
+                        String changeLogId = (String)((Map)obj).get("changeLogId");
+                        changeLog.setChangeLogId(changeLogId);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Description
Fixes #1988 

Problem code was caused by an incorrect merge in the changeLogId handling, so I fixed the `if` statement nesting to be correct.

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: [https://github.com/liquibase/liquibase/issues/1988](https://github.com/liquibase/liquibase/issues/1988)
* Local Branch: [https://github.com/liquibase/liquibase/tree/yaml-changelog-id](https://github.com/liquibase/liquibase/tree/yaml-changelog-id)
* Unit Tests: [https://github.com/liquibase/liquibase/pull/2168/checks](https://github.com/liquibase/liquibase/pull/2168/checks)
* Integration Tests: (shown in Unit Tests link above)
* Functional Tests: [https://jenkins.datical.net/job/liquibase-pro/job/yaml-changelog-id/](https://jenkins.datical.net/job/liquibase-pro/job/yaml-changelog-id/)

#### Testing
* Steps to Reproduce: [https://github.com/liquibase/liquibase/issues/1988](https://github.com/liquibase/liquibase/issues/1988)
* Guidance:
  * Impact: database independent
  * Moves a setting of changeLogId into a more logical spot in the code. The code got triggered in an invalid yaml like in the reported bug, I'm not sure what valid ways hit that spot. Maybe there are none and it's just invalid code? The valid yaml files I tried ended up setting changeLogId via a different part of the code than the part that changed.
  * The code was obviously merged wrong, and a straightforward move
  * Fix is purely in the yaml parsing code, so just testing an `update` command is all that is needed

#### Dev Verification
Ran `update` with various valid and invalid yaml files to see what sort of errors we get. We no longer can get the ClassCastException that the issue reported. Validation of  invalid yaml files in general can be improved, but that would be a much larger project

##### Error Message
```
liquibase.exception.CommandExecutionException: 
liquibase.exception.LiquibaseException: 
Unexpected error running Liquibase: 
class java.util.ArrayList cannot be cast to class java.util.Map 
```

## Test Requirements (Liquibase Internal QA)
The bug being addressed in this fix impacted only YAML changelogs with an invalid changelog format. Any database platform can be used for testing. However, repro validation was done against a MySQL database.

**Manual Tests**

_Verify update-sql with an invalid YAML changelog does not throw a class cast exception._

`liquibase --log-level INFO update-sql --changelog-file lb2123-invalid-changelog.yml`

* The update-sql is successful.
* There is no class cast exception.
* The update-sql output shows Lock Database and Release Database Lock messages.
  * There are no changesets to deploy in lb2123-invalid-changelog.yml.

_Verify update with an invalid YAML changelog does not throw a cast cast exception._

`liquibase --log-level INFO update --changelog-file lb2123-invalid-changelog.yml`

* The update is successful.
* There is no class cast exception.
* The console output shows successfully acquired change log lock
* The console output shows successfully released change log lock
  * No changes are deployed as there are no change sets in the invalid changelog.

_Verify update-sql with a valid YAML changelog does not throw a class cast exception._

`liquibase --log-level INFO update-sql --changelog-file lb2123-valid-changelog.yml`

* The update-sql is successful.
* There is no class cast exception.
* The update-sql output shows SQL to create the table `account`

_Verify update with a valid YAML changelog does not throw a class cast exception._

`liquibase --log-level INFO update --changelog-file lb2123-valid-changelog.yml`

* The update is successful.
* There is no class cast exception.
* The console output shows that changeset `myfilepath::1603997898589-1::gemfire (generated)` ran successfully.
* The table `account` exists on the database.

**Automated Tests**

* None required for this ticket.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-2123) by [Unito](https://www.unito.io)
