### PR TITLE
Use correct message in console output of register changelog command - DAT-7757

### DIFF
--- a/liquibase-core/src/main/java/liquibase/command/core/RegisterChangelogCommandStep.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/RegisterChangelogCommandStep.java
@@ -109,7 +109,7 @@ public class RegisterChangelogCommandStep extends AbstractCommandStep {
                 }
             } else if (hubProjectName != null) {
                 if (hubProjectName.length() > 255) {
-                    throw new CommandExecutionException("\nThe project COMMAND_NAME you gave is longer than 255 characters\n\n");
+                    throw new CommandExecutionException("\nThe project name you gave is longer than 255 characters\n\n");
                 }
                 project = service.createProject(new Project().setName(hubProjectName));
                 if (project == null) {
@@ -168,7 +168,7 @@ public class RegisterChangelogCommandStep extends AbstractCommandStep {
                         ui.sendMessage("\nNo project created\n");
                         continue;
                     } else if (projectName.length() > 255) {
-                        ui.sendMessage("\nThe project COMMAND_NAME you entered is longer than 255 characters\n");
+                        ui.sendMessage("\nThe project name you entered is longer than 255 characters\n");
                         continue;
                     }
                     project = service.createProject(new Project().setName(projectName));
@@ -219,7 +219,7 @@ public class RegisterChangelogCommandStep extends AbstractCommandStep {
         final UIService ui = Scope.getCurrentScope().getUI();
 
         String hubUrl = HubConfiguration.LIQUIBASE_HUB_URL.getCurrentValue();
-        String input = ui.prompt("Please enter your Project COMMAND_NAME and press [enter].  This is editable in your Liquibase Hub account at " + hubUrl, null, null, String.class);
+        String input = ui.prompt("Please enter your Project name and press [enter].  This is editable in your Liquibase Hub account at " + hubUrl, null, null, String.class);
         return StringUtil.trimToEmpty(input);
     }
 

--- a/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/registerChangelog.test.groovy
+++ b/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/registerChangelog.test.groovy
@@ -34,6 +34,33 @@ Optional Args:
         ]
     }
 
+    run "Happy path, supply hub project name when prompted interactively", {
+        arguments = [
+                changelogFile: "changelogs/hsqldb/complete/registered-changelog-test.xml",
+        ]
+        setup {
+            createTempResource "changelogs/hsqldb/complete/rollback.changelog.xml", "changelogs/hsqldb/complete/registered-changelog-test.xml"
+        }
+        testUI = new CommandTests.TestUIWithAnswers(["c", "project name here"] as String[])
+        expectedUI = "Please enter your Project name and press [enter]"
+        expectedResults = [
+                statusCode   : 0,
+                registeredChangeLogId  : { MockHubService.randomUUID.toString() }
+        ]
+    }
+
+    run "Name is too long", {
+        arguments = [
+                hubProjectName   : "String longer than 255 characters qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq",
+                changelogFile: "changelogs/hsqldb/complete/registered-changelog-test.xml",
+        ]
+        setup {
+            createTempResource "changelogs/hsqldb/complete/rollback.changelog.xml", "changelogs/hsqldb/complete/registered-changelog-test.xml"
+        }
+        expectedException = CommandExecutionException.class
+        expectedExceptionMessage = "The project name you gave is longer than 255 characters"
+    }
+
     run "Run with already-registered changelog throws an exception", {
         arguments = [
                 changelogFile: "simple.changelog.with.id.xml"


### PR DESCRIPTION
Use correct phrasing in the the register changelog command console outputs.