### PR TITLE
Fix minor typos in ColumnConfig.java documentation

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/ColumnConfig.java
+++ b/liquibase-core/src/main/java/liquibase/change/ColumnConfig.java
@@ -311,7 +311,7 @@ public class ColumnConfig extends AbstractLiquibaseSerializable {
 
     /**
      * Set the valueBoolean based on a given string.
-     * If the passed value cannot be parsed as a date, it is assumed to be a function that returns a boolean.
+     * If the passed value cannot be parsed as a boolean, it is assumed to be a function that returns a boolean.
      * If the string "null" or an empty string is passed, it will set a null value.
      * If "1" is passed, defaultValueBoolean is set to true. If 0 is passed, defaultValueBoolean is set to false
      */
@@ -584,7 +584,7 @@ public class ColumnConfig extends AbstractLiquibaseSerializable {
 
     /**
      * Set the defaultValueBoolean based on a given string.
-     * If the passed value cannot be parsed as a date, it is assumed to be a function that returns a boolean.
+     * If the passed value cannot be parsed as a boolean, it is assumed to be a function that returns a boolean.
      * If the string "null" or an empty string is passed, it will set a null value.
      * If "1" is passed, defaultValueBoolean is set to true. If 0 is passed, defaultValueBoolean is set to false
      */


### PR DESCRIPTION
The JDocs for two boolean methods contain an incorrect reference to `date` (likely a copy/pasted value that was not updated as were several other references) in the descriptions of `setValueBoolean(String valueBoolean)` and `setDefaultValueBoolean(String defaultValueBoolean)`.

This commit corrects both to the proper term, `boolean`.

<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->
## Environment

**Liquibase Version**: 4.5.0

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->
- [ ] Build is successful and all new and existing tests pass
- [ ] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
- [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
- [ ] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls)
- [x] Documentation Updated

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)
