### PR TITLE
'Validate' exit code should be 1 on error

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -4,6 +4,7 @@ import liquibase.*;
 import liquibase.change.CheckSum;
 import liquibase.changelog.ChangeLogParameters;
 import liquibase.changelog.visitor.ChangeExecListener;
+import liquibase.command.CommandFailedException;
 import liquibase.command.CommandResults;
 import liquibase.command.CommandScope;
 import liquibase.command.core.*;
@@ -1043,7 +1044,7 @@ public class Main {
      * Reads various execution parameters from an InputStream and sets our internal state according to the values
      * found.
      *
-     * @param  propertiesInputStream       an InputStream from a Java properties file
+     * @param propertiesInputStream an InputStream from a Java properties file
      * @throws IOException                 if there is a problem reading the InputStream
      * @throws CommandLineParsingException if an invalid property is encountered
      */
@@ -1709,18 +1710,18 @@ public class Main {
                 LockService lockService = LockServiceFactory.getInstance().getLockService(database);
                 lockService.forceReleaseLock();
                 Scope.getCurrentScope().getUI().sendMessage(String.format(
-                        coreBundle.getString("successfully.released.database.change.log.locks"),
-                        liquibase.getDatabase().getConnection().getConnectionUserName() +
-                                "@" + liquibase.getDatabase().getConnection().getURL()
+                                coreBundle.getString("successfully.released.database.change.log.locks"),
+                                liquibase.getDatabase().getConnection().getConnectionUserName() +
+                                        "@" + liquibase.getDatabase().getConnection().getURL()
                         )
                 );
                 return;
             } else if (COMMANDS.TAG.equalsIgnoreCase(command)) {
                 liquibase.tag(getCommandArgument());
                 Scope.getCurrentScope().getUI().sendMessage(String.format(
-                        coreBundle.getString("successfully.tagged"), liquibase.getDatabase()
-                                .getConnection().getConnectionUserName() + "@" +
-                                liquibase.getDatabase().getConnection().getURL()
+                                coreBundle.getString("successfully.tagged"), liquibase.getDatabase()
+                                        .getConnection().getConnectionUserName() + "@" +
+                                        liquibase.getDatabase().getConnection().getURL()
                         )
                 );
                 return;
@@ -1729,14 +1730,14 @@ public class Main {
                 boolean exists = liquibase.tagExists(tag);
                 if (exists) {
                     Scope.getCurrentScope().getUI().sendMessage(String.format(coreBundle.getString("tag.exists"), tag,
-                            liquibase.getDatabase().getConnection().getConnectionUserName() + "@" +
-                                    liquibase.getDatabase().getConnection().getURL()
+                                    liquibase.getDatabase().getConnection().getConnectionUserName() + "@" +
+                                            liquibase.getDatabase().getConnection().getURL()
                             )
                     );
                 } else {
                     Scope.getCurrentScope().getUI().sendMessage(String.format(coreBundle.getString("tag.does.not.exist"), tag,
-                            liquibase.getDatabase().getConnection().getConnectionUserName() + "@" +
-                                    liquibase.getDatabase().getConnection().getURL()
+                                    liquibase.getDatabase().getConnection().getConnectionUserName() + "@" +
+                                            liquibase.getDatabase().getConnection().getURL()
                             )
                     );
                 }
@@ -1843,12 +1844,7 @@ public class Main {
                 liquibase.reportUnexpectedChangeSets(runVerbose, contexts, getOutputWriter());
                 return;
             } else if (COMMANDS.VALIDATE.equalsIgnoreCase(command)) {
-                try {
-                    liquibase.validate();
-                } catch (ValidationFailedException e) {
-                    e.printDescriptiveError(System.err);
-                    return;
-                }
+                liquibase.validate();
                 Scope.getCurrentScope().getUI().sendMessage(coreBundle.getString("no.validation.errors.found"));
                 return;
             } else if (COMMANDS.CLEAR_CHECKSUMS.equalsIgnoreCase(command)) {


### PR DESCRIPTION
## Description
If 'liquibase validate' finds any errors, it should throw the exception and therefore exit with a non-zero error code. 

Fixes #1006

This changes the behavior of the 'validate' command in automation, so marked it as "ReleaseMajor" so it doesn't end up in a patch release.

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: [https://github.com/liquibase/liquibase/issues/1006](https://github.com/liquibase/liquibase/issues/1006)
* Local Branch: [https://github.com/liquibase/liquibase/tree/validation-errors-set-error-code](https://github.com/liquibase/liquibase/tree/validation-errors-set-error-code)
* Unit Tests: [https://github.com/liquibase/liquibase/pull/2185/checks](https://github.com/liquibase/liquibase/pull/2185/checks)
* Integration Tests: (shown in Unit Tests link above)
* Functional Tests: [https://jenkins.datical.net/job/liquibase-pro/job/validation-errors-set-error-code/](https://jenkins.datical.net/job/liquibase-pro/job/validation-errors-set-error-code/)

#### Testing
* Steps to Reproduce: [https://github.com/liquibase/liquibase/issues/1006](https://github.com/liquibase/liquibase/issues/1006)
* Guidance:
  * Impact: only impacts the validate command in the CLI specifically

#### Dev Verification
Ensured that validate command returns exit code 0 if no validation errors, 1 if there are errors.

## QA Research Findings
* Validations related to changed checksums and duplicate identifiers exit with code 0. (This is the bug).
* Validations related to missing changeset attributes, referenced files that cannot be located and incorrect formatting for structured changelogs exit with code 1.
* The validations that exit with code 1 do not have the same user friendly messaging concerning the errors that the validations with exit code 0 have. For comparison:
  * ```
DUPLICATE IDENTIFIERS
Validation Error:
     2 change sets had duplicate identifiers
          LB2159-changelog.xml::1::createSequenceWithNoCycle::Liquibase User
          LB2159-changelog.xml::2::createSequenceWithNoCycle::Liquibase User
Liquibase command 'validate' was executed successfull
```



  * ```
MISSING FILE
Unexpected error running Liquibase: java.io.IOException: The file thereIsNoFileHere.sql was not found in
    - C:\
    - C:\Users\erz\work\DaticalDB-testing\liquibase-pro-cli-project\postgres_lbpro_master\.
    - C:\Users\erz\work\DaticalDB-testing\liquibase-pro-cli-project\postgres_lbpro_master\postgresql-42.2.18.jar
Specifying files by absolute path was removed in Liquibase 4.0. Please use a relative path or add '/' to the classpath parameter
```



  * ```
INVALID CHANGELOG STRUCTURE
Unexpected error running Liquibase: Syntax error in file LB2159-changelog.yml: while scanning for the next token
found character '\t(TAB)' that cannot start any token. (Do not use \t(TAB) for indentation)
 in 'reader', line 3, column 1:
        id: 1-TabInYMLIsNoNo
```



Given that the bug is related to validate errors that do not return a failure exit code (1), testing will focus on the two cases that exibit the bug.

## Test Requirements (Internal Liquibase QA)
This fix is database-agnostic and any database can be used for the tests. The attached XML changelog has changesets that will replicate two cases where the `validate` command returns exit code 0. On the fix branch, the exit code for both cases should be 1.

To validate the exit code at the end of each test case, run the following commands:

* On Windows, `echo %ErrorLevel%`
* On Linux/Mac, `echo $?`

**Manual Tests**

_Verify validate returns exit code 1 for a changelog with duplicate identifiers._

**Setup:** 

* Uncomment the changesets for Test Case 1 in LB2159-changelog.xml.

`liquibase validate --changelog-file LB2159-changelog.xml`

* Exit code is 1
* Console output includes the changesets that were duplicated.

_Verify validate returns exit code 1 for changelog with a changed checksum._

**Setup:** 

* Comment out the changesets for Test Case 1 in LB2159-changelog.xml.
* Execute an update to deploy the changeset for Test Case 2. 
* Delete one of the columns from the table in Test Case 2.

`liquibase validate --changelog-file LB2159-changelog.xml`

* Exit code is 1
* Console output includes the changesets with a changed checksum.

**Automated Tests**

* A functional test to liquibase-pro-tests is required for this ticket.
  * Add a new ValidateTestClass to src/test/java/tests/functional 
  * The test can execute against any DB platform but only needs to run against one of the faster databases (postgres, mysql or mariadb).

_Verify that validate returns non-zero when there is a duplicated changeset identifier._

* GIVEN a changelog with duplicate changeset identifiers
* WHEN I run `liquibase validate --changelog-file <changelog.xml>`
* THEN I expect Liquibase to exit with code 1
* AND I expect the console to inform me that a changeset has a duplicate identifier.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-2159) by [Unito](https://www.unito.io)
