### PR TITLE
Include columnDataType in generated setColumnRemarks changesets

### DIFF
--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/ChangedColumnChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/ChangedColumnChangeGenerator.java
@@ -81,6 +81,11 @@ public class ChangedColumnChangeGenerator extends AbstractChangeGenerator implem
             change.setColumnName(column.getName());
             change.setRemarks(column.getRemarks());
 
+            LiquibaseDataType columnDataType = DataTypeFactory.getInstance().from(column.getType(), comparisonDatabase);
+            if (columnDataType != null) {
+            change.setColumnDataType(columnDataType.toString());
+            }
+
             changes.add(change);
         }
 

--- a/liquibase-core/src/main/java/liquibase/parser/core/xml/XMLChangeLogSAXParser.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/xml/XMLChangeLogSAXParser.java
@@ -16,7 +16,7 @@ import java.io.InputStream;
 
 public class XMLChangeLogSAXParser extends AbstractChangeLogParser {
 
-    public static final String LIQUIBASE_SCHEMA_VERSION = "4.1";
+    public static final String LIQUIBASE_SCHEMA_VERSION = "4.6";
     private SAXParserFactory saxParserFactory;
 
     private final LiquibaseEntityResolver resolver = new LiquibaseEntityResolver();


### PR DESCRIPTION
## Description
In 4.6.2, changesets generated due to differences in column remarks would not include the columnDataType attribute which is needed for some databases (mysql for sure).

This change adds the datatype to the generated Change if it is available.

## Repo Steps
If you create two tables on different databases with different comments like this:

```java
create table intuser_db.test_table (id int, name int COMMENT 'table 1');
create table intuser_db2.test_table (id int, name int  COMMENT 'table 2');
```

then run `liquibase diff-changelog` between the intuser_db and intuser_db2 databases, the generated changeset used to look like this:

```java
<changeSet author="nathan (generated)" id="1640195447990-1">
        <setColumnRemarks columnName="name" remarks="table 2" tableName="test_table"/>
    </changeSet>
```

without the columnDataType attribute. If you tried to run this changeset against a mysql database, it would fail with a "columnDataType is required" error.

With this change, the generated changest looks like this:

```java
<changeSet author="nathan (generated)" id="1640195447990-1">
        <setColumnRemarks columnDataType="int" columnName="name" remarks="table 2" tableName="test_table"/>
    </changeSet>
```

which cleanly applies to mysql and other database types.

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: Stand alone PR
* Test Results: [https://github.com/liquibase/liquibase/pull/2188/checks](https://github.com/liquibase/liquibase/pull/2188/checks)

#### Testing
* Steps to Reproduce: See above
* Guidance:
  * Impact: Changes how the setColumnRemarks change is generated for all databases, so it always includes the columnDataType. That attribute is ignored on databases that don't need it

#### Dev Verification
Ensured the steps listed above work locally.

### **Test Requirements (Liquibase Internal QA)**
You will require 2 MySQL database instances.

**Setup**

On first database instance execute `create table test_table (id int, int_col int COMMENT 'database 1', char_col char(50) COMMENT 'first test');`

On second database instance execute `create table test_table (id int, int_col int COMMENT 'database 2', char_col char(50) COMMENT 'second test');`

**Manual Tests**

_Verify diff-changelog generates columnDataType parameter._

* `liquibase diff-changelog --changelog-file lb2199-changelog.xml`
* generated changelog should contain 2 changesets with <setColumnRemarks> tag
  * first changeset should contain `columnName="int_col" columnDataType="int(10)"` arguments
  * second changeset should contain `columnName="char_col" columnDataType="char(50)"` arguments

_Verify update is successful with generated changelog._

* `liquibase update --changelog-file lb2199-changelog.xml`
* int_col in first database instance now has `database 2` remark
* char_col in first database instance now has `second test` remark

_Repeat all tests for json, yaml and sql changelog formats._

**Automated Tests**

No new functional tests required for this fix.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-2199) by [Unito](https://www.unito.io)
