### PR TITLE
Fix handling of relativeToChangelogFile with classpath: prefixed changelogs

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -569,6 +569,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
 
         String relativeBaseFileName = this.getPhysicalFilePath();
         if (isRelativePath) {
+            relativeBaseFileName = relativeBaseFileName.replaceFirst("classpath:", "");
             fileName =  FilenameUtil.concat(FilenameUtil.getDirectory(relativeBaseFileName), fileName);
         }
 


### PR DESCRIPTION
## Description
This is **Windows** specific issue.

In 4.6.0, a change broke the ability for spring boot projects that reference their changelog files with a `classpath:` prefix to `include` files with `relativeToChangelog=true`

## Replication Info
pom.xml file (liquibase dependency):

```
<dependency>
    <groupId>org.liquibase</groupId>
    <artifactId>liquibase-core</artifactId>
    <version>4.6.0</version>
</dependency>
```

application.yml file:

```java
spring:
  liquibase:
    change-log: classpath:/db/changelog/db-changelog.yml
  dataSource:
    driver-class-name: com.mysql.cj.jdbc.Driver
    url: "jdbc:mysql://localhost:3306/intuser_db?serverTimezone=UTC"
    username: root
    password: password
```

db-changelog.xml file:

```java
databaseChangeLog:
  - include:
      relativeToChangelogFile: true
      file: 001-users.yml
  - include:
      relativeToChangelogFile: true
      file: 002-chats.yml
```

##### These files come from [https://github.com/nsobadzhiev/liquibase-cascade-demo](https://github.com/nsobadzhiev/liquibase-cascade-demo) which also replicates the issue.
##### Error Message
```
Error starting ApplicationContext. To display the conditions report re-run your application with 'debug' enabled.
2021-11-11 09:55:43.425 ERROR 11908 --- [           main] o.s.boot.SpringApplication               : Application run failed

org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'liquibase' defined in class path resource [org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration$LiquibaseConfiguration.class]: Invocation of init method failed; nested exception is liquibase.exception.ChangeLogParseException: Error parsing classpath:/db/changelog/db-changelog.yml
```

## Work Around
Removing `classpath:` from your changelog file configuration will avoid the bug.

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: Stand-alone PR
* Local Branch: [https://github.com/liquibase/liquibase/tree/fix-classpath-prefix-include](https://github.com/liquibase/liquibase/tree/fix-classpath-prefix-include)
* Unit Tests: [https://github.com/liquibase/liquibase/pull/2189/checks](https://github.com/liquibase/liquibase/pull/2189/checks)
* Integration Tests: (shown in Unit Tests link above)
* Functional Tests: [https://jenkins.datical.net/job/liquibase-pro/job/fix-classpath-prefix-include/](https://jenkins.datical.net/job/liquibase-pro/job/fix-classpath-prefix-include/)

#### Testing
* Steps to Reproduce: "See above"
* Guidance:
  * Impact: Only fixes up times when people have classpath: as a prefix in their changelog setting for includes

#### Dev Verification
I found the bug when testing a different problem using the referenced repo. Running `mvn test` reproduced the problem. After the fix, `mvn test` worked.

I didn't include a unit test for the change because it's in a part of the code that would need a good amount of setup to be able to test. We need to get tests written around the spring integration better, and those tests will catch this at that point.

## Test Requirements (Liquibase Internal QA)
SpringBoot includes a built-in version of Liquibase which is quite old. Newer builds of Liquibase break handling of the Liquibase classpath. To reproduce this bug, specify an exact Liquibase version in the pom.xml. (See pom.xml example in repro steps for how to specify Liquibase 4.6.0).

Testing requires one MySQL database instance.

**Manual Tests**

**Setup:**

* Git clone the [https://github.com/nsobadzhiev/liquibase-cascade-demo](https://github.com/nsobadzhiev/liquibase-cascade-demo)  repository.
* Update the pom.xml file in liquibase-cascade-demo to specify the Liquibase fix branch as the version for the Liquibase dependency.
  * ```
		<dependency>
			<groupId>org.liquibase</groupId>
			<artifactId>liquibase-core</artifactId>
			<version>4.6.1-fix-classpath-prefix-include</version>
		</dependency>
```


* Update the application.yml file in liquibase-cascade-demo\main\resources to have the correct url, username and password for your local MySQL instance.
* In the liquibase-cascade-demo directory, execute a Maven compile.
  * This gets all the necessary dependencies to build the application jar.
  * `mvn compile`
* In the liquibase-cascade-demo directory, execute a Maven package without running tests.
  * This builds the application jar file (demo-0.0.1-SNAPSHOT.jar).
  * If the tests are not skipped, Liquibase will automatically run during packaging. We are going to test the fix by running the application itself instead of during mvn package.
  * The application jar is created in liquibase-cascade-demo/target
  * `mvn package -DskipTests`

_Verify the SpringBoot appliation does not fail due to an error loading the Liquibase classpath._

* CD to liquibase-cascade-demo/target
* Run the application: `java -jar demo-0.0.1-SNAPSHOT.jar`
  * There is no error message about failure to load the Liquibase classpath.
  * The output to console shows Liquibase create table account
  * The output to console shows Liquibase create table chat

_Verify the SpringBoot application successful created objects on the database._

* The table account exists.
* The table chat exists.

**Automated Tests**

* None required for this fix.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-2158) by [Unito](https://www.unito.io)
