### PR TITLE
Improve mysql loadData performance

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
@@ -266,7 +266,10 @@ public class LoadDataChange extends AbstractTableChange implements ChangeWithCol
     public SqlStatement[] generateStatements(Database database) {
         boolean databaseSupportsBatchUpdates = false;
         try {
-            databaseSupportsBatchUpdates = database.supportsBatchUpdates();
+            if (!(database instanceof MySQLDatabase)) {
+                //mysql supports batch updates, but the performance vs. the big insert is worse
+                databaseSupportsBatchUpdates = database.supportsBatchUpdates();
+            }
         } catch (DatabaseException e) {
             throw new UnexpectedLiquibaseException(e);
         }


### PR DESCRIPTION
## Description
Fixes #1984

On mysql, the jdbc batch performance we switched to seems much worse than a large insert statement on mysql.

The general preparedStatement/batch logic could use a good refactoring, but this improves performance on mysql without impacting anything else at this point.

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: [https://github.com/liquibase/liquibase/issues/1984](https://github.com/liquibase/liquibase/issues/1984)
* Local Branch: [https://github.com/liquibase/liquibase/tree/improve-loaddata-mysql-performance](https://github.com/liquibase/liquibase/tree/improve-loaddata-mysql-performance)
* Tests Results: [https://github.com/liquibase/liquibase/pull/](https://github.com/liquibase/liquibase/pull/){PR ID}/checks

#### Testing
* Steps to Reproduce: [{LINK TO ISSUE OR "See above"}](https://github.com/liquibase/liquibase/issues/1984)
* Guidance:
  * Impact: Changes the SQL used by mysql only in loadData only

#### Dev Verification
Running the test dataset listed in the issue, with table3_seed_data.xml's file changed to table3_seed_data_16000.csv ran in 10 seconds vs. 80 seconds in 4.6.1

## Test Requirements (Liquibase Internal QA)
A MySQL 8.0 instance is required for this test. The bug replicates using both Liquibase Maven and Liquibase CLI. Use the attached files to run tests with the CLI. Use the Maven project provided by the Community reporter to test Liquibase Maven.

* liquibase_upgrade_test.zip:  [https://github.com/liquibase/liquibase/issues/1984](https://github.com/liquibase/liquibase/issues/1984)

As a part of conditioning this ticket for test, I ran update using Liquibase Maven with 4.0.0, Liquibase CLI with 4.0.0, and Liquibase CLI with 4.4.0. Although many factors impact how fast any given machine runs on any given network, the degradation in performance between Liquibase 4.0.0 and Liquibase 4.4.0 is evident.

##### Output of Update for The Three LoadData Changesets
|**Data Load Tables**|**LB CLI 4.4.0**|**LB CLI 4.0.0**|**LB MVN 4.0.0**|
|----|----|----|----|
|TABLE1|379 ms|15 ms|17 ms|
|TABLE2|3048 ms|34 ms|24 ms|
|TABLE3|6284 ms|55 ms|31 ms|

##### Reminder
When replicating this issue using Liquibase 4.0.0 you need to use the legacy format of CLI commands and remove any Hub properties from the liquibase.properties file.

**Manual Tests**

**Test Steps (CLI)**

To validate this fix, start with an empty MySQL database. Run update with log-level INFO. In the console output, look for the following lines to get the time spent loading data:

* ChangeSet data/seed_data/table1_seed_data.xml::table1_seed_data::me
* ChangeSet data/seed_data/table2_seed_data.xml::table2_seed_data::me
* ChangeSet data/seed_data/table3_seed_data.xml::table3_seed_data::me
* Note the time spent for each of the loadData changesets.

Drop all objects from the database and repeat the previous steps 4 more times (for a total of 5 update operations).

Average the times spent executing the loadData changesets.

_Verify update of loadData changesets to a MySQL database is performant using the CLI._

`liquibase --log-level INFO update --changelog-file db.changelog-master.xml`

* Average the values for the five loadData changeset executions.
* If the average time to update MySQL with a loadData changeset is closer to the time taken in Liquibase 4.0.0, we will consider this fix “passing.” (There are no specific thresholds defined by product). 

- - -
**Test Steps (Maven)**

Use the Maven project provided by the Community reporter to test Liquibase Maven.

* liquibase_upgrade_test.zip:  [https://github.com/liquibase/liquibase/issues/1984](https://github.com/liquibase/liquibase/issues/1984) 

Configure the Maven pom to use the Liquibase jar for the fix build. Unfortunately, the new build system does not upload to Artifactory, so `mvn compile` will not automatically get the liquibase dependency for you. You must manually install the jar using the following command:
`mvn -B org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file -Dfile=Path/to/your/liquibaseJar/liquibase.jar`

Then run:

* mvn clean
* mvn compile
  * If you get an error about test-classes, manually create the directory in the target directory created during compile.

As with the CLI, start with an empty MySQL database.

Execute `mvn liquibase:update` to run the Liquibase update command. In the console output, look for the following lines to get the time spent loading data:

* ChangeSet data/seed_data/table1_seed_data.xml::table1_seed_data::me
* ChangeSet data/seed_data/table2_seed_data.xml::table2_seed_data::me
* ChangeSet data/seed_data/table3_seed_data.xml::table3_seed_data::me
* Note the time spent for each of the loadData changesets.

Drop all objects from the database and repeat the previous steps 4 more times (for a total of 5 liquibase:update operations).

_Verify update of loadData changesets to a MySQL database is performant using Liquibase Maven._

`mvn liquibase:update`

* Average the values for the five loadData changeset executions.
* If the average time to update MySQL with a loadData changeset is closer to the time taken in Liquibase 4.0.0, we will consider this fix “passing.” (There are no specific thresholds defined by product). 

**Automated Tests**

* No automated tests required.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-2173) by [Unito](https://www.unito.io)
