### PR TITLE
Prevent NPE in FileUtil if parent file does not exist (DAT-8275)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/util/FileUtil.java
+++ b/liquibase-core/src/main/java/liquibase/util/FileUtil.java
@@ -30,7 +30,9 @@ public class FileUtil {
     }
 
     public static void write(String contents, File file, boolean append) throws IOException {
-        file.getParentFile().mkdirs();
+        if (file.getParentFile() != null) {
+            file.getParentFile().mkdirs();
+        }
 
         try (
                 FileOutputStream output = new FileOutputStream(file, append)


### PR DESCRIPTION
In the event that a particular file's parent file does not exist, this change prevents a `NullPointerException`.