### PR TITLE
Move interactive prompting logic into core module (DAT-8642)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/ui/interactive/AbstractCommandLineValueGetter.java
+++ b/liquibase-core/src/main/java/liquibase/ui/interactive/AbstractCommandLineValueGetter.java
@@ -118,7 +118,7 @@ public abstract class AbstractCommandLineValueGetter<T> {
      * @return the message
      */
     private String getMessage(InteractivePromptableCustomizationWrapper<?> parameter) {
-        return parameter.getParameter().getUiMessage() + " (options: " + parameter.getParameter().getOptions() + ") ";
+        return parameter.getParameter().getUiMessage() + " (options: " + parameter.getParameter().getOptions() + ")";
     }
 
     /**

--- a/liquibase-core/src/main/java/liquibase/ui/interactive/AbstractCommandLineValueGetter.java
+++ b/liquibase-core/src/main/java/liquibase/ui/interactive/AbstractCommandLineValueGetter.java
@@ -1,0 +1,136 @@
+package liquibase.ui.interactive;
+
+import liquibase.Scope;
+import liquibase.ui.InputHandler;
+
+import java.util.List;
+
+/**
+ * This class represents the basis for prompts to the user to input values, and should be used as part of the process
+ * of obtaining user input for quality checks.
+ * @param <T> the type the user is expected to enter
+ */
+public abstract class AbstractCommandLineValueGetter<T> {
+
+    /**
+     * The type of the value that will be obtained.
+     */
+    private final Class<T> clazz;
+
+    /**
+     * Create a new value getter.
+     * @param clazz the type of the value that will be obtained
+     */
+    public AbstractCommandLineValueGetter(Class<T> clazz) {
+        this.clazz = clazz;
+    }
+
+    /**
+     * Prompt the user to enter a value for a parameter, and include the existing value in the prompt.
+     * @param parameter the parameter to obtain a value for
+     * @param newParameterValues a list of the values that have already been entered by the user during this interactive CLI parameter prompting situation
+     * @return the value entered by the user
+     */
+    public final T prompt(InteractivePromptableCustomizationWrapper<T> parameter, List<DynamicRuleParameter> newParameterValues, Object currentValue) {
+        // determine which value should be displayed in square brackets as the value that will be selected if user presses enter
+        Object valueToPromptAsDefault;
+        if (currentValue != null) {
+            /*
+             * The value is being converted here, because enum types get read from the check settings file as strings.
+             * As a result, the default value and current value (which should be the same type), are not; the default
+             * value would be an enum and the current value would be a string.
+             */
+            try {
+                valueToPromptAsDefault = convert((String) currentValue);
+            } catch (Exception e) {
+                valueToPromptAsDefault = currentValue;
+            }
+        } else {
+            valueToPromptAsDefault = parameter.getDefaultValue();
+        }
+
+        // assume the user just hit enter to accept the default and revalidate it, since hitting enter to accept the
+        // default skips the validation logic in ConsoleUIService. Reprompt endlessly until a valid value is entered.
+        T prompt = null;
+        boolean valid = false;
+        while (!valid && (prompt == null || prompt.equals(valueToPromptAsDefault))) {
+            prompt = doPrompt(parameter, newParameterValues, valueToPromptAsDefault, (currentValue != null || parameter.getDefaultValue() != null));
+
+            try {
+                valid = doValidate(parameter, newParameterValues, prompt);
+            } catch (IllegalArgumentException e) {
+                Scope.getCurrentScope().getUI().sendErrorMessage("Invalid value: '" + prompt + "': " + e.getMessage());
+            }
+        }
+        return prompt;
+    }
+
+    private T doPrompt(InteractivePromptableCustomizationWrapper<T> parameter, List<DynamicRuleParameter> newParameterValues, Object valueToPromptAsDefault, boolean shouldAllowEmptyValues) {
+        return Scope.getCurrentScope().getUI().prompt(getMessage(parameter), (T) valueToPromptAsDefault, new InputHandler<T>() {
+            @Override
+            public T parseInput(String input, Class<T> type) throws IllegalArgumentException {
+                T convert;
+                try {
+                    convert = AbstractCommandLineValueGetter.this.convert(input);
+                } catch (Exception e) {
+                    if (e.getMessage() != null) {
+                        throw new IllegalArgumentException(
+                                String.format("Invalid value: '%s': %s", input, e.getMessage()), e);
+                    }
+                    throw new IllegalArgumentException(e);
+                }
+
+                try {
+                    if (!doValidate(parameter, newParameterValues, convert)) {
+                        throw new IllegalArgumentException("The supplied value is not valid.");
+                    }
+                } catch (Exception e) {
+                    if (e.getMessage() != null) {
+                        throw new IllegalArgumentException(
+                                String.format("Invalid value: '%s': %s", input, e.getMessage()), e);
+                    }
+                    throw new IllegalArgumentException(
+                            String.format("Invalid value: '%s': The supplied value is not valid.", input), e);
+                }
+                return convert;
+            }
+
+            @Override
+            public boolean shouldAllowEmptyInput() {
+                // We do not allow empty input, because as of right now, all parameters require values. In the future,
+                // there may be parameters which permit empty values, which would need to tie in here.
+                return shouldAllowEmptyValues;
+            }
+        }, clazz);
+    }
+
+    private boolean doValidate(InteractivePromptableCustomizationWrapper<T> parameter, List<DynamicRuleParameter> newParameterValues, T convert) throws IllegalArgumentException {
+        if (parameter.getValidationCallbackOverride() != null) {
+            return parameter.getValidationCallbackOverride().apply(convert, newParameterValues);
+        } else {
+            return AbstractCommandLineValueGetter.this.validate(convert);
+        }
+    }
+
+    /**
+     * Generate the prompt message.
+     * @param parameter the parameter to prompt for
+     * @return the message
+     */
+    private String getMessage(InteractivePromptableCustomizationWrapper<?> parameter) {
+        return parameter.getParameter().getUiMessage() + " (options: " + parameter.getParameter().getOptions() + ") ";
+    }
+
+    /**
+     * Given the input from the user, after being converted, validate it.
+     * @return true if it is valid
+     */
+    public abstract boolean validate(T input);
+
+    /**
+     * Given the raw input string from the user, convert it to the right type.
+     * @param input the raw input string from the prompt
+     * @return the converted input
+     */
+    public abstract T convert(String input);
+}

--- a/liquibase-core/src/main/java/liquibase/ui/interactive/DynamicRuleParameter.java
+++ b/liquibase-core/src/main/java/liquibase/ui/interactive/DynamicRuleParameter.java
@@ -1,0 +1,65 @@
+package liquibase.ui.interactive;
+
+
+import java.util.Objects;
+
+
+public class DynamicRuleParameter {
+
+    /**
+     * The actual underlying DynamicRuleParameterEnum that corresponds to this value. We store the parameter as a string,
+     * because different versions of Liquibase might not contain the enum that the rule requires. We want to be able to
+     * parse newer conf files with older versions of Liquibase, without a SnakeYaml error that it cannot find the enum
+     * value.
+     */
+    private String parameter;
+    private Object value;
+
+    /**
+     * Constructor for SnakeYaml
+     */
+    public DynamicRuleParameter() {
+    }
+
+    public DynamicRuleParameter(IInteractivelyPromptableEnum parameter, Object value) {
+        Objects.requireNonNull(parameter);
+        this.parameter = parameter.toString();
+        this.value = value;
+    }
+
+    public DynamicRuleParameter(String parameter, Object value) {
+        Objects.requireNonNull(parameter);
+        this.parameter = parameter;
+        this.value = value;
+    }
+
+    public String getParameter() {
+        return parameter;
+    }
+
+    public void setParameter(String parameter) {
+        this.parameter = parameter;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public void setValue(Object value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DynamicRuleParameter that = (DynamicRuleParameter) o;
+        return Objects.equals(parameter, that.parameter) && value.equals(that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parameter, value);
+    }
+}
+

--- a/liquibase-core/src/main/java/liquibase/ui/interactive/IInteractivelyPromptableEnum.java
+++ b/liquibase-core/src/main/java/liquibase/ui/interactive/IInteractivelyPromptableEnum.java
@@ -1,0 +1,29 @@
+package liquibase.ui.interactive;
+
+
+public interface IInteractivelyPromptableEnum {
+    /**
+     * Description of the parameter to be used in the UI output.
+     */
+    String getDescription();
+
+    /**
+     * The default value of the parameter if the parameter has not been customized.
+     */
+    Object getDefaultValue();
+
+    /**
+     * The implementation of the value getter that will be used to prompt the user to input a value.
+     */
+    AbstractCommandLineValueGetter<?> getInteractiveCommandLineValueGetter();
+
+    /**
+     * Parameter message to be used in the UI output.
+     */
+    String getUiMessage();
+
+    /*
+     * Possible options for this parameter
+     */
+    String getOptions();
+}

--- a/liquibase-core/src/main/java/liquibase/ui/interactive/InteractivePromptableCustomizationWrapper.java
+++ b/liquibase-core/src/main/java/liquibase/ui/interactive/InteractivePromptableCustomizationWrapper.java
@@ -1,0 +1,69 @@
+package liquibase.ui.interactive;
+
+
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * This class exists to wrap the parameter enum so that individual usages can provide specific
+ * overrides of the logic defined in the enum class. You should access the underlying parameter as little as possible
+ * and instead, access it using getter wrapper methods in this class. That will allow future developers to specify
+ * custom overrides for each rule (for example, overriding the default value for a specific usage without
+ * affecting all others).
+ */
+public class InteractivePromptableCustomizationWrapper<T> {
+    private final IInteractivelyPromptableEnum parameter;
+    private final BiFunction<T, List<DynamicRuleParameter>, Boolean> validationCallbackOverride;
+    private final Function<List<DynamicRuleParameter>, Boolean> shouldPrompt;
+
+    public InteractivePromptableCustomizationWrapper(IInteractivelyPromptableEnum parameter) {
+        this.parameter = parameter;
+        this.validationCallbackOverride = null;
+        this.shouldPrompt = null;
+    }
+
+    public InteractivePromptableCustomizationWrapper(IInteractivelyPromptableEnum parameter, BiFunction<T, List<DynamicRuleParameter>, Boolean> validationCallbackOverride, Function<List<DynamicRuleParameter>, Boolean> shouldPrompt) {
+        this.parameter = parameter;
+        this.validationCallbackOverride = validationCallbackOverride;
+        this.shouldPrompt = shouldPrompt;
+    }
+
+    public Object getDefaultValue() {
+        return parameter.getDefaultValue();
+    }
+
+    public IInteractivelyPromptableEnum getParameter() {
+        return parameter;
+    }
+
+    public AbstractCommandLineValueGetter<?> getInteractiveCommandLineValueGetter() {
+        return parameter.getInteractiveCommandLineValueGetter();
+    }
+
+    public BiFunction<T, List<DynamicRuleParameter>, Boolean> getValidationCallbackOverride() {
+        return validationCallbackOverride;
+    }
+
+    public Function<List<DynamicRuleParameter>, Boolean> getShouldPrompt() {
+        return shouldPrompt;
+    }
+
+    @Override
+    public String toString() {
+        return getParameter().toString();
+    }
+
+    /**
+     * Determine if the rule parameter should be prompted for in a checks customize scenario.
+     * @param existingNewValues the values already provided in the checks customize session
+     * @return true if the prompt should occur for this parameter, false if not
+     */
+    public boolean shouldPrompt(List<DynamicRuleParameter> existingNewValues) {
+        boolean resp = true;
+        if (shouldPrompt != null) {
+            resp = shouldPrompt.apply(existingNewValues);
+        }
+        return resp;
+    }
+}


### PR DESCRIPTION
This PR (in combination with the Pro PR) does a few small things:

- Move the interactive CLI prompting logic into the core modules so they can be used outside of pro
- Add an interface for the enum which dictates the prompting logic. This is so that we can have separate promptable enums in the core and pro code and use the same abstract prompting logic for both.