### PR TITLE
Correctly handle old "liquibase tagExists myTag" style CLI structure

### DIFF
--- a/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
+++ b/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
@@ -98,7 +98,7 @@ public class LiquibaseCommandLine {
         this.legacyPositionalArguments.put("futurerollbackcountsql", FutureRollbackCountSqlCommandStep.COUNT_ARG.getName());
         this.legacyPositionalArguments.put("futurerollbackfromtagsql", FutureRollbackFromTagSqlCommandStep.TAG_ARG.getName());
         this.legacyPositionalArguments.put("tag", TagCommandStep.TAG_ARG.getName());
-        this.legacyPositionalArguments.put("tagExists", TagExistsCommandStep.TAG_ARG.getName());
+        this.legacyPositionalArguments.put("tagexists", TagExistsCommandStep.TAG_ARG.getName());
         this.legacyPositionalArguments.put("rollback", RollbackCommandStep.TAG_ARG.getName());
         this.legacyPositionalArguments.put("rollbacksql", RollbackSqlCommandStep.TAG_ARG.getName());
         this.legacyPositionalArguments.put("rollbacktodate", RollbackToDateCommandStep.DATE_ARG.getName());


### PR DESCRIPTION
## Description
fixes #2109 

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: [https://github.com/liquibase/liquibase/issues/2109](https://github.com/liquibase/liquibase/issues/2109)
* Test Results: [https://github.com/liquibase/liquibase/pull/2269/checks](https://github.com/liquibase/liquibase/pull/2269/checks)

#### Testing
* Steps to Reproduce: [https://github.com/liquibase/liquibase/issues/2109](https://github.com/liquibase/liquibase/issues/2109)
* Guidance:
  * Impact: correctly converts the old style pattern into the new version before passing it along to the normal CLI logic. The rest of the code sees it as `liquibase tag-exists --tag mytag`

#### Dev Verification
Ran `liquibase tagExists myTag` against an h2 database and got "The tag 'myTag' does NOT exist in '@jdbc:h2:mem:liquibase'" as expected.

### **Test Requirements (Liquibase Internal QA)**
**Setup**

Execute an update command with attached changelog file

* `liquibase update --changelog-file lb2192-changelog.xml`
* Verify that update was executed successfully

Execute tag command

* `liquibase tag create`
* Verify that tag `create` was successfully assigned to last row in DATABASECHANGELOG table

**Manual Tests**

_Verify that new CLI command_ `tag-exists --tag` _works correctly when specified tag is present._

* `liquibase tag-exists --tag create`
* `The tag 'create' already exists in <your database>` message is shown

_Verify that new CLI command_ `tag-exists --tag` _works correctly when specified tag is not present._

* `liquibase tag-exists --tag mytag`
* `The tag 'mytag' does NOT exist in <your database>` message is shown

_Verify that new CLI command_ `tag-exists` _works correctly when specified tag is present._

* `liquibase tag-exists create`
* `The tag 'create' already exists in <your database>` message is shown

_Verify that new CLI command_ `tag-exists` _works correctly when specified tag is not present._

* `liquibase tag-exists mytag`
* `The tag 'mytag' does NOT exist in <your database>` message is shown

_Verify that old CLI command_ `tagExists` _works correctly when specified tag is present._

* `liquibase tagExists create`
* `The tag 'create' already exists in <your database>` message is shown

_Verify that old CLI command_ `tagExists` _works correctly when specified tag is not present._

* `liquibase tagExists mytag`
* `The tag 'mytag' does NOT exist in <your database>` message is shown

**Automated Tests**

No new functional tests required for this fix.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-2192) by [Unito](https://www.unito.io)
