### PR TITLE
Added Quality Checks commands and subcommands

### DIFF
--- a/liquibase-dist/src/main/archive/lib/liquibase_autocomplete.sh
+++ b/liquibase-dist/src/main/archive/lib/liquibase_autocomplete.sh
@@ -46,8 +46,17 @@ _liquibase()
   clearCheckSums
   changelogSync
   changelogSyncSQL
-changeLogSyncToTag
-changeLogSyncToTagSQL
+  changeLogSyncToTag
+  changeLogSyncToTagSQL
+  checks^show
+  checks^run
+  checks^bulk-set
+  checks^delete^--check-name=<check_short_name>
+  checks^customize^--check-name=<check_short_name>
+  checks^enable^--check-name=<check_short_name>
+  checks^disable^--check-name=<check_short_name>
+  checks^copy^--check-name=<check_short_name>
+  checks^reset^--check-name=<check_short_name>
   markNextChangeSetRan
   markNextChangeSetRanSQL
   listLocks
@@ -115,6 +124,7 @@ changeLogSyncToTagSQL
   --diffTypes=<catalog,tables,functions,views,columns,indexes,foreignkeys,primarykeys,uniqueconstraints,data,storedprocedure,triggers,sequences> -D<property.name>=<property.value>
   --verbose
   --liquibaseProLicenseKey"
+    
     # Handle --xxxxxx=
     if [[ ${prev} == "--"* && ${cur} == "=" ]] ; then
         COMPREPLY=(*)
@@ -138,6 +148,15 @@ changeLogSyncToTagSQL
         # If there's only one option, without =, then allow a space
         compopt +o nospace
     fi
+     
+    # Handle subcommands
+    for i in "${!COMPREPLY[@]}"; do 
+      temp="${COMPREPLY[$i]}"
+      COMPREPLY[$i]="${temp//\^/ }"
+    done
+    
     return 0
 }
+
+  
 complete -o nospace -F _liquibase liquibase


### PR DESCRIPTION
Liquibase Version: 4.6.1 and above.

Liquibase Integration & Version: CLI

Database Vendor & Version: Any

Operating System Type & Version: Unix/Linux (Bash)

## Pull Request Type
* [x] Enhancement/New feature (non-breaking change which adds functionality)

## Description
Added auto-complete "checks" commands to the liquibase-dist/src/main/archive/lib/liquibase_autocomplete.sh auto-complete scripts.

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: Stand alone PR
* Test Results: https://github.com/liquibase/liquibase/pull/2272/checks

#### Testing
* Steps to Reproduce: See above
* Guidance:
  * Impact: Only impacts linux, not macos (#2273)

#### Dev Verification
Reviewed code



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-2224) by [Unito](https://www.unito.io)
