### PR TITLE
Added new Quality Checks command and subcommands (Mac specifict)

### DIFF
--- a/liquibase-dist/src/main/archive/lib/liquibase_autocomplete_mac.bash
+++ b/liquibase-dist/src/main/archive/lib/liquibase_autocomplete_mac.bash
@@ -45,6 +45,15 @@ complete -W \
   listLocks \
   releaseLocks \
   dropAll \
+  'checks run' \
+  'checks delete --check-name=<check_short_name>' \
+  'checks bulk-set' \
+  'checks show' \
+  'checks customize --check-name=<check_short_name>' \
+  'checks reset --check-name=<check_short_name>' \
+  'checks enable --check-name=<check_short_name>' \
+  'checks disable --check-name=<check_short_name>' \
+  'checks copy --check-name=<check_short_name>' \
   --changeLogFile \
   --username \
   --password \


### PR DESCRIPTION
<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->
## Environment

**Liquibase Version**: 4.6.1 and above.

**Liquibase Integration & Version**: CLI

**Database Vendor & Version**: Any

**Operating System Type & Version**: MacOS (Bash)

## Pull Request Type
- [X] Enhancement/New feature (non-breaking change which adds functionality)

## Description

Added auto-complete "checks" commands to the liquibase-dist/src/main/archive/lib/liquibase_autocomplete_mac.bash auto-complete scripts.

---

## Dev Handoff Notes (Internal Use)

#### Links

- Fixed Issue: Stand alone PR
- Test Results: https://github.com/liquibase/liquibase/pull/2273/checks

#### Testing

- Steps to Reproduce: See above
- Guidance:
  - Impact: Only impacts mac autocomplete. Not linux (#2272 )

#### Dev Verification

Reviewed code

## Test Requirements (Liquibase Internal QA)
**Manual Tests**
* Verify auto-complete for the Quality Checks commands using a Mac terminal. 
  * 'checks run' 
  * 'checks delete --check-name=<check_short_name>' 
  * 'checks bulk-set' 
  * 'checks show' 
  * 'checks customize --check-name=<check_short_name>' 
  * 'checks reset --check-name=<check_short_name>' 
  * 'checks enable --check-name=<check_short_name>' 
  * 'checks disable --check-name=<check_short_name>' 
  * 'checks copy --check-name=<check_short_name>'

**Automated Tests**
* None required for this change.
