### PR TITLE
Fix for working with Firebird 2 and newer versions. Fixes nullables and boolean type.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/Firebird3Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/Firebird3Database.java
@@ -1,5 +1,0 @@
-package liquibase.database.core;
-
-public class Firebird3Database extends FirebirdDatabase {
-
-}

--- a/liquibase-core/src/main/java/liquibase/database/core/FirebirdDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/FirebirdDatabase.java
@@ -19,22 +19,6 @@ public class FirebirdDatabase extends AbstractJdbcDatabase {
         super.sequenceNextValueFunction="NEXT VALUE FOR %s";
     }
 
-    private boolean version2 = false;
-
-    public boolean isVersion2() {
-        return version2;
-    }
-
-    @Override
-    public void setConnection(final DatabaseConnection conn) {
-        super.setConnection(conn);
-        try {
-            version2 = conn.getDatabaseProductName().startsWith("Firebird 2");
-        } catch (DatabaseException e) {
-            // Do nothing
-        }
-    }
-
     @Override
     public boolean isCorrectDatabaseImplementation(DatabaseConnection conn) throws DatabaseException {
         return conn.getDatabaseProductName().startsWith("Firebird");

--- a/liquibase-core/src/main/java/liquibase/database/core/FirebirdDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/FirebirdDatabase.java
@@ -19,6 +19,22 @@ public class FirebirdDatabase extends AbstractJdbcDatabase {
         super.sequenceNextValueFunction="NEXT VALUE FOR %s";
     }
 
+    private boolean version2 = false;
+
+    public boolean isVersion2() {
+        return version2;
+    }
+
+    @Override
+    public void setConnection(final DatabaseConnection conn) {
+        super.setConnection(conn);
+        try {
+            version2 = conn.getDatabaseProductName().startsWith("Firebird 2");
+        } catch (DatabaseException e) {
+            // Do nothing
+        }
+    }
+
     @Override
     public boolean isCorrectDatabaseImplementation(DatabaseConnection conn) throws DatabaseException {
         return conn.getDatabaseProductName().startsWith("Firebird");

--- a/liquibase-core/src/main/java/liquibase/datatype/core/BooleanType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/BooleanType.java
@@ -1,5 +1,6 @@
 package liquibase.datatype.core;
 
+import liquibase.Scope;
 import liquibase.change.core.LoadDataChange;
 import liquibase.database.Database;
 import liquibase.database.core.*;
@@ -26,7 +27,7 @@ public class BooleanType extends LiquibaseDataType {
                     return new DatabaseDataType("SMALLINT");
                 }
             } catch (DatabaseException e) {
-                //assume it's version 3+
+                Scope.getCurrentScope().getLog(getClass()).fine("Error checking database major version, assuming version 3+: "+e.getMessage(), e);
             }
             return new DatabaseDataType("BOOLEAN");
         }
@@ -123,8 +124,8 @@ public class BooleanType extends LiquibaseDataType {
                 if (database.getDatabaseMajorVersion() <= 2) {
                     return true;
                 }
-            } catch (DatabaseException ignored) {
-                //assume it's version 3
+            } catch (DatabaseException e) {
+                Scope.getCurrentScope().getLog(getClass()).fine("Error checking database major version, assuming version 3+: "+e.getMessage(), e);
             }
             return false;
         }

--- a/liquibase-core/src/main/java/liquibase/datatype/core/BooleanType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/BooleanType.java
@@ -19,7 +19,7 @@ public class BooleanType extends LiquibaseDataType {
     @Override
     public DatabaseDataType toDatabaseDataType(Database database) {
         String originalDefinition = StringUtil.trimToEmpty(getRawDefinition());
-        if ((database instanceof Firebird3Database)) {
+        if ((database instanceof FirebirdDatabase) && ! ((FirebirdDatabase)database).isVersion2()) {
             return new DatabaseDataType("BOOLEAN");
         }
 
@@ -110,7 +110,7 @@ public class BooleanType extends LiquibaseDataType {
     }
 
     protected boolean isNumericBoolean(Database database) {
-        if (database instanceof Firebird3Database) {
+        if ((database instanceof FirebirdDatabase) && ! ((FirebirdDatabase)database).isVersion2()) {
             return false;
         }
         if (database instanceof DerbyDatabase) {

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/SetNullableGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/SetNullableGenerator.java
@@ -89,7 +89,7 @@ public class SetNullableGenerator extends AbstractSqlGenerator<SetNullableStatem
                 nullableString = "";
             }
             sql = "ALTER TABLE " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + " MODIFY (" + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " " + DataTypeFactory.getInstance().fromDescription(statement.getColumnDataType(), database).toDatabaseDataType(database) + nullableString + ")";
-        } else if (database instanceof FirebirdDatabase && !(database instanceof Firebird3Database)) {
+        } else if (database instanceof FirebirdDatabase && (((FirebirdDatabase)database).isVersion2())) {
             // For Firebird database prior to Firebird 3 the ALTER TABLE syntax is not working
             // As a workaround we can modify the system table entry directly (see http://www.firebirdfaq.org/faq103/)
             sql = "UPDATE RDB$RELATION_FIELDS SET RDB$NULL_FLAG = " + (statement.isNullable() ? "NULL" : "1") + " WHERE RDB$RELATION_NAME = '" + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + "' AND RDB$FIELD_NAME = '" + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + "'";

--- a/liquibase-core/src/main/resources/META-INF/services/liquibase.database.Database
+++ b/liquibase-core/src/main/resources/META-INF/services/liquibase.database.Database
@@ -3,7 +3,6 @@ liquibase.database.core.DB2Database
 liquibase.database.core.Db2zDatabase
 liquibase.database.core.DerbyDatabase
 liquibase.database.core.EnterpriseDBDatabase
-liquibase.database.core.Firebird3Database
 liquibase.database.core.FirebirdDatabase
 liquibase.database.core.H2Database
 liquibase.database.core.HsqlDatabase

--- a/liquibase-integration-tests/src/test/java/liquibase/statementexecute/AddUniqueConstraintExecutorTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/statementexecute/AddUniqueConstraintExecutorTest.java
@@ -153,7 +153,7 @@ public class AddUniqueConstraintExecutorTest extends AbstractExecuteTest {
                 SybaseASADatabase.class, SybaseDatabase.class);
         assertCorrect("alter table [lbcat2].[lbschem2].[adduqtest] add constraint [uq_test] unique " +
                 "([coltomakeuq])", MSSQLDatabase.class);
-        assertCorrect("alter table [adduqtest] add constraint [uq_test] unique ([coltomakeuq])", FirebirdDatabase.class, Firebird3Database.class);
+        assertCorrect("alter table [adduqtest] add constraint [uq_test] unique ([coltomakeuq])", FirebirdDatabase.class);
 
         assertCorrect("alter table [lbschem2].[adduqtest] add constraint [uq_test] unique ([coltomakeuq])", HsqlDatabase.class);
         assertCorrect("alter table \"lbcat2\".[adduqtest] add constraint [uq_test] unique ([coltomakeuq])", DB2Database.class, Db2zDatabase.class);

--- a/liquibase-integration-tests/src/test/java/liquibase/statementexecute/MarkChangeSetRanExecuteTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/statementexecute/MarkChangeSetRanExecuteTest.java
@@ -67,7 +67,7 @@ public class MarkChangeSetRanExecuteTest extends AbstractExecuteTest {
                         "('a', 'b', 'c', current_timestamp, 1, " +
                         "'8:d41d8cd98f00b204e9800998ecf8427e', 'empty', '', 'executed', 'e', null, '" + version + "'," +
                         " null)",
-                FirebirdDatabase.class, Firebird3Database.class, DerbyDatabase.class);
+                FirebirdDatabase.class, DerbyDatabase.class);
         assertCorrect("insert into databasechangelog (id, author, filename, dateexecuted, orderexecuted, " +
                         "md5sum, description, comments, exectype, contexts, labels, liquibase, deployment_id) values " +
                         "('a', 'b', 'c', now, 1, " +

--- a/liquibase-integration-tests/src/test/java/liquibase/statementexecute/RenameColumnExecuteTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/statementexecute/RenameColumnExecuteTest.java
@@ -48,7 +48,7 @@ public class RenameColumnExecuteTest extends AbstractExecuteTest {
 
         assertCorrect("rename column table_name.column_name to new_name", DerbyDatabase.class, InformixDatabase.class);
         assertCorrect("alter table table_name alter column column_name rename to new_name", H2Database.class, HsqlDatabase.class);
-        assertCorrect("alter table table_name alter column column_name to new_name", FirebirdDatabase.class, Firebird3Database.class);
+        assertCorrect("alter table table_name alter column column_name to new_name", FirebirdDatabase.class);
         assertCorrect("alter table table_name change column_name new_name int", MySQLDatabase.class, MariaDBDatabase.class);
         assertCorrect("exec sp_rename '[table_name].[column_name]', 'new_name'", MSSQLDatabase.class);
         assertCorrect("exec sp_rename 'table_name.column_name', 'new_name'", SybaseDatabase.class);


### PR DESCRIPTION
Fix for working with Firebird 2 and newer versions. Fixes nullables and boolean type.

Current implementation does not handle correctly working on Firebird 2.5 and Firebird 3 databases. It always assumes a Firebird 3 database, which incurs in invalid SQL statements.

The proposed fix eliminates the Firebird3Database class and instead includes a "version2" attribute in the FirebirdDatabase class. This attribute is populated when the connection is set.

I've fixed the tests and impacted classes (BooleanType and SetNullableGenerator) for this implementation.
