### PR TITLE
Be explicit in using utf8mb4 for mysql/mariadb for NVARCHAR, NCHAR, and NCLOB

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/ClobType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/ClobType.java
@@ -113,7 +113,7 @@ public class ClobType extends LiquibaseDataType {
                 return new DatabaseDataType("MEDIUMTEXT");
             } else if (originalDefinition.toLowerCase(Locale.US).startsWith("nclob")) {
                 DatabaseDataType type = new DatabaseDataType("LONGTEXT");
-                type.addAdditionalInformation("CHARACTER SET utf8");
+                type.addAdditionalInformation("CHARACTER SET utf8mb4");
                 return type;
             } else {
                 return new DatabaseDataType("LONGTEXT");

--- a/liquibase-core/src/main/java/liquibase/datatype/core/NCharType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/NCharType.java
@@ -3,6 +3,7 @@ package liquibase.datatype.core;
 import liquibase.database.Database;
 import liquibase.database.core.HsqlDatabase;
 import liquibase.database.core.MSSQLDatabase;
+import liquibase.database.core.MySQLDatabase;
 import liquibase.database.core.OracleDatabase;
 import liquibase.datatype.DataTypeInfo;
 import liquibase.datatype.DatabaseDataType;
@@ -22,6 +23,13 @@ public class NCharType extends CharType {
         if (database instanceof OracleDatabase) {
             return new DatabaseDataType("NCHAR", getParameters());
         }
+
+        if (database instanceof MySQLDatabase) {
+            final DatabaseDataType type = new DatabaseDataType("CHAR", getParameters());
+            type.addAdditionalInformation("CHARACTER SET utf8mb4");
+            return type;
+        }
+
         if (database instanceof MSSQLDatabase) {
             Object[] parameters = getParameters();
             if (parameters.length > 0) {

--- a/liquibase-core/src/main/java/liquibase/datatype/core/NVarcharType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/NVarcharType.java
@@ -27,6 +27,13 @@ public class NVarcharType extends CharType {
         if (database instanceof OracleDatabase) {
             return new DatabaseDataType("NVARCHAR2", getParameters());
         }
+
+        if (database instanceof MySQLDatabase) {
+            final DatabaseDataType type = new DatabaseDataType("VARCHAR", getParameters());
+            type.addAdditionalInformation("CHARACTER SET utf8mb4");
+            return type;
+        }
+
         if (database instanceof MSSQLDatabase) {
             Object[] parameters = getParameters();
             if (parameters.length > 0) {

--- a/liquibase-core/src/test/groovy/liquibase/datatype/core/ClobTypeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/core/ClobTypeTest.groovy
@@ -33,7 +33,7 @@ class ClobTypeTest extends Specification {
         ["text"] | new MySQLDatabase()    | "TEXT"
         ["tinytext"] | new MySQLDatabase()    | "TINYTEXT"
         ["mediumtext"] | new MySQLDatabase()    | "MEDIUMTEXT"
-        ["nclob"] | new MySQLDatabase()    | "LONGTEXT CHARACTER SET utf8"
+        ["nclob"] | new MySQLDatabase()    | "LONGTEXT CHARACTER SET utf8mb4"
         [""] | new MySQLDatabase()    | "LONGTEXT"
         ["longvarchar"] | new H2Database()    | "LONGVARCHAR"
         ["java.sql.Types.LONGVARCHAR"] | new H2Database()    | "LONGVARCHAR"

--- a/liquibase-core/src/test/groovy/liquibase/datatype/core/NVarcharTypeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/core/NVarcharTypeTest.groovy
@@ -28,7 +28,7 @@ class NVarcharTypeTest extends Specification {
         []           | new MSSQLDatabase()    | "nvarchar(1)"
         [13]         | new MSSQLDatabase()    | "nvarchar(13)"
         [2147483647] | new MSSQLDatabase()    | "nvarchar(MAX)"
-        [13]         | new MySQLDatabase()    | "NVARCHAR(13)"
+        [13]         | new MySQLDatabase()    | "VARCHAR(13) CHARACTER SET utf8mb4"
     }
 
     def "too many parameters"() {


### PR DESCRIPTION
## Description
By default mysql and mariadb use "utf8" which they alias to "utf8mb3" which is not the utf8mb4 that most people would expect for similarity across the requested "NVARCHAR" standard type on other databases. utf8mb3 is also in the process of being deprecated so good to be explicit with utf8mb4 as they recommend. 

See:

* [https://dev.mysql.com/doc/refman/8.0/en/charset-unicode-utf8mb3.html](https://dev.mysql.com/doc/refman/8.0/en/charset-unicode-utf8mb3.html)
* [https://mariadb.com/kb/en/unicode/](https://mariadb.com/kb/en/unicode/)

Fixes #2045

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: [https://github.com/liquibase/liquibase/issues/2045](https://github.com/liquibase/liquibase/issues/2045)
* Test Results: [https://github.com/liquibase/liquibase/pull/2292/checks](https://github.com/liquibase/liquibase/pull/2292/checks)

#### Testing
* Steps to Reproduce: [https://github.com/liquibase/liquibase/issues/2045](https://github.com/liquibase/liquibase/issues/2045)
* Guidance:
  * Impact: only changes nclob/nvarchar/nchar datatype handling and only on mysql and mariadb

#### Dev Verification
Used this changeset:

```java
<changeSet author="myUser" id="myId1">
        <createTable tableName="UTF_TEST">
            <column name="ID" type="CHAR(36)">
                <constraints primaryKey="true" primaryKeyName="PK_NCLOB_TEXT_ID"/>
            </column>
            <column name="test_nclob" type="NCLOB"/>
            <column name="test_nvarchar" type="NVARCHAR(50)"/>
            <column name="test_varchar" type="VARCHAR(50)"/>
            <column name="test_nchar" type="NCHAR(50)"/>
            <column name="test_char" type="CHAR(50)"/>
        </createTable>
    </changeSet>
```

to ensure the columns were created successfully, and checked that the saved metadata was charset utf8b4 for the n* types but not the non-n* types

### **Test Requirements (Liquibase Internal QA)**
**Setup**

Execute update with `setup` label.

`liquibase update --changelog-file lb2196-changelog.xml --labels setup`

Make sure that table UTF-TEST was succsessfully created.

**Manual Tests**

All test cases should be verified against both MySQL and MAriaDB datbases

_Verify update-sql generates correct code for CLOB and NCLOB type columns._

* `liquibase update-sql --changelog-file lb2196-cangelog.xml --labels clob`
* `ALTER TABLE UTF_TEST ADD test_nclob LONGTEXT CHARACTER SET utf8mb4 NULL, ADD test_clob LONGTEXT NULL;`

_Verify  update is successful for CLOB and NCLOB type columns._

* `liquibase update --changelog-file lb2196-cangelog.xml --labels clob`
* update is successful
* verify that `test_nclob` column has correct charset

_Verify update-sql generates correct code for VARCHAR and NVARCHAR type columns._

* `liquibase update-sql --changelog-file lb2196-cangelog.xml --labels varchar`
* `ALTER TABLE UTF_TEST ADD test_nvarchar VARCHAR(50) CHARACTER SET utf8mb4 NULL, ADD test_varchar VARCHAR(50) NULL;`

_Verify  update is successful for VARCHAR and NVARCHAR type columns._

* `liquibase update --changelog-file lb2196-cangelog.xml --labels varchar`
* update is successful
* verify that `test_nvarchar` column has correct charset

_Verify update-sql generates correct code for CHAR and NCHAR type columns._

* `liquibase update-sql --changelog-file lb2196-cangelog.xml --labels char`
* `ALTER TABLE UTF_TEST ADD test_nchar CHAR(50) CHARACTER SET utf8mb4 NULL, ADD test_char CHAR(50) NULL;`

_Verify  update is successful for CHAR and NCHAR type columns._

* `liquibase update --changelog-file lb2196-cangelog.xml --labels char`
* update is successful
* verify that `test_nchar` column has correct charset



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-2196) by [Unito](https://www.unito.io)
