### PR TITLE
Mysql: Support additional information "double" datatypes

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/DoubleType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/DoubleType.java
@@ -15,11 +15,15 @@ public class DoubleType  extends LiquibaseDataType {
             return new DatabaseDataType(database.escapeDataTypeName("float"), 53);
         }
         if (database instanceof MySQLDatabase) {
+            DatabaseDataType datatype;
             if ((getParameters() != null) && (getParameters().length > 1)) {
-                return new DatabaseDataType("DOUBLE", getParameters());
+                datatype = new DatabaseDataType("DOUBLE", getParameters());
             } else {
-                return new DatabaseDataType("DOUBLE");
+                datatype = new DatabaseDataType("DOUBLE");
             }
+
+            datatype.addAdditionalInformation(getAdditionalInformation());
+            return datatype;
         }
         if ((database instanceof AbstractDb2Database) || (database instanceof DerbyDatabase) || (database instanceof
             HsqlDatabase)) {


### PR DESCRIPTION
## Description
Pass along parsed "additional information" information to the final datatype for doubles in mysql/mariadb.

Fixes #2169 which hit the problem with "unsigned"

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: [https://github.com/liquibase/liquibase/issues/2169](https://github.com/liquibase/liquibase/issues/2169)
* Test Results: [https://github.com/liquibase/liquibase/pull/2293/checks](https://github.com/liquibase/liquibase/pull/2293/checks)

#### Testing
* Steps to Reproduce: [{LINK TO ISSUE OR "See above"}](https://github.com/liquibase/liquibase/issues/2169)
* Guidance:
  * Impact: only impacts parsing of double type for mysql/mariadb in existing changelogs

#### Dev Verification
Tested that changeset

```java
<changeSet author="myUser" id="myId1">
        <createTable tableName="double_test">
            <column name="ID" type="CHAR(36)">
                <constraints primaryKey="true"/>
            </column>
            <column name="double_column" type="double(38,2) unsigned"/>
        </createTable>
    </changeSet>
```

correctly included the "unsigned" and the (38,2) when ran against mysql

### **Test Requirements (Liquibase Internal QA)**
**Manual Tests**

_Verify update-sql generates correct sql code for createTable on MySQL5 database_

* `liquibase update-sql --changelog-file lb2195-changelog.xml --labels create`
* CREATE TABLE double_test (unsigned_column DOUBLE(5, 2) unsigned NULL, signed_column DOUBLE(5, 2) signed NULL, zerofill_column DOUBLE(5, 2) zerofill NULL);

_Verify update is successful for createTable on MySQL5 database_

* `liquibase update --changelog-file lb2195-changelog.xml --labels create`
* update is successful
* table `double_test` exists and contains `unsigned_column`, `signed_column` and `zerofill_column` columns
* mentioned above columns have correct additional information in their data types

_Verify update is successful for insert correct data on MySQL5 database_

* `liquibase update --changelog-file lb2195-changelog.xml --labels correct,special`
* update is successful
* data was successfully and correctly inserted into `double_test` table

_Verify update throws an error for insert incorrect data on MySQL5 database_

* `liquibase update --changelog-file lb2195-changelog.xml --labels wrong`
* `Out of range value` is thrown

Repeat all test cases for MySQL8 and MariaDB

**Automated Tests**

No new functional tests required for this fix.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-2195) by [Unito](https://www.unito.io)
