### PR TITLE
Make ClassLoaderResourceAccessor implement Closable

### DIFF
--- a/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
@@ -270,7 +270,7 @@ public class ClassLoaderResourceAccessor extends AbstractResourceAccessor implem
                     try (JarFile jar = new JarFile(URLDecoder.decode(jarPath, StandardCharsets.UTF_8.name()))) {
                         String comparePath = path;
                         if (comparePath.startsWith("/")) {
-                            comparePath = "/"+comparePath;
+                            comparePath = "/" + comparePath;
                         }
                         Enumeration<JarEntry> entries = jar.entries();
                         while (entries.hasMoreElements()) {
@@ -355,16 +355,17 @@ public class ClassLoaderResourceAccessor extends AbstractResourceAccessor implem
 
         return description;
     }
+
     @Override
     public void close() throws Exception {
         if (rootPaths != null) {
-          for (final FileSystem rootPath : rootPaths) {
-            try {
-              rootPath.close();
+            for (final FileSystem rootPath : rootPaths) {
+                try {
+                    rootPath.close();
+                } catch (final Exception e) {
+                    Scope.getCurrentScope().getLog(getClass()).fine("Cannot close path " + e.getMessage(), e);
+                }
             }
-            catch(final Exception ignored){
-            }
-          }
         }
-     }
+    }
 }

--- a/liquibase-core/src/test/groovy/liquibase/resource/ClassLoaderResourceAccessorTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/resource/ClassLoaderResourceAccessorTest.groovy
@@ -5,6 +5,8 @@ import liquibase.util.StreamUtil
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import java.nio.file.FileSystem
+
 class ClassLoaderResourceAccessorTest extends Specification {
 
     def testResourceAccessor = new ClassLoaderResourceAccessor(new URLClassLoader(
@@ -152,5 +154,24 @@ class ClassLoaderResourceAccessorTest extends Specification {
                         ]
                 ],
         ]
+    }
+
+    def close() {
+        setup:
+        FileSystem path1 = Mock()
+        FileSystem path2 = Mock()
+
+        when:
+        def testAccessor = new ClassLoaderResourceAccessor(this.getClass().getClassLoader())
+
+        testAccessor.rootPaths = null;
+        testAccessor.close() //no errors thrown from close() when rootPaths is null
+
+        testAccessor.rootPaths = [path1, path2]
+        testAccessor.close()
+
+        then:
+        2 * path1.close()
+        1 * path2.close()
     }
 }


### PR DESCRIPTION
## Description
The ClassLoaderResourceAccessor opens resources but has no method for closing them. Add a close() method to clean it up as part of the AutoClosabable interface

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: Stand alone PR
* Test Results: https://github.com/liquibase/liquibase/pull/2308/checks

#### Testing
* Steps to Reproduce: None
* Guidance:
  * Impact: This adds a close method which our code does not use. 3rd party integrations would be able to take advantage of it, however.

#### Dev Verification
Reviewed code



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-2205) by [Unito](https://www.unito.io)
