### PR TITLE
Correctly catch potentially null value

### DIFF
--- a/liquibase-core/src/main/java/liquibase/diff/DiffGeneratorFactory.java
+++ b/liquibase-core/src/main/java/liquibase/diff/DiffGeneratorFactory.java
@@ -84,7 +84,7 @@ public class DiffGeneratorFactory {
 
     public DiffResult compare(DatabaseSnapshot referenceSnapshot, DatabaseSnapshot comparisonSnapshot, CompareControl compareControl) throws DatabaseException {
         Database referenceDatabase = referenceSnapshot.getDatabase();
-        if (comparisonSnapshot !=null && referenceSnapshot!=null) {
+        if (comparisonSnapshot !=null && referenceDatabase!=null) {
             if (referenceDatabase.getDefaultCatalogName() == null || referenceDatabase.getDefaultCatalogName().isEmpty()) {
                 referenceDatabase.setDefaultCatalogName(comparisonSnapshot.getDatabase().getDefaultCatalogName());
             }


### PR DESCRIPTION
check if referenceDatabase not null instead of referenceSnapshot.

---

## Dev Handoff Notes (Internal Use)

#### Links

- Stand alone PR
- Test Results: https://github.com/liquibase/liquibase/pull/2330/checks

#### Testing

- Steps to Reproduce: Not sure. The fix obviously avoids a nulls a null pointer which could happen, but I'm not sure how to set up something naturally happening in liquibase to trigger it. Not sure what could lead to a null value, but if anything does it will handle it better now. Probably needs no additional manual testing?
- Guidance:
  - Impact: Stops potential null pointer
  
#### Dev Verification

Reviewed code. 
