### PR TITLE
Remove duplicate databasechangeloglock SQL when running update-sql against a new database

### DIFF
--- a/liquibase-core/src/main/java/liquibase/lockservice/StandardLockService.java
+++ b/liquibase-core/src/main/java/liquibase/lockservice/StandardLockService.java
@@ -17,6 +17,7 @@ import liquibase.exception.LockException;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.executor.Executor;
 import liquibase.executor.ExecutorService;
+import liquibase.executor.LoggingExecutor;
 import liquibase.snapshot.InvalidExampleException;
 import liquibase.snapshot.SnapshotGeneratorFactory;
 import liquibase.sql.Sql;
@@ -99,6 +100,14 @@ public class StandardLockService implements LockService {
         Executor executor = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc",  database);
 
         int maxIterations = 10;
+        if (executor instanceof LoggingExecutor) {
+            //can't / don't have to re-check
+            if (hasDatabaseChangeLogLockTable()) {
+                maxIterations = 0;
+            } else {
+                maxIterations = 1;
+            }
+        }
         for (int i = 0; i < maxIterations; i++) {
             try {
                 if (!hasDatabaseChangeLogLockTable(true)) {

--- a/liquibase-core/src/main/java/liquibase/ui/ConsoleUIService.java
+++ b/liquibase-core/src/main/java/liquibase/ui/ConsoleUIService.java
@@ -64,7 +64,7 @@ public class ConsoleUIService extends AbstractExtensibleObject implements UIServ
 
     @Override
     public boolean getAllowPrompt() {
-        return allowPrompt;
+        return getConsole().supportsInput() && allowPrompt;
     }
 
     @Override


### PR DESCRIPTION
## Description
Fixes #2309

Caused by the "are we locked?" loop we added to catch race conditions in clusters, since in "update sql" mode the table doesn't get created like it normally would.

When looking at the output SQL, I also saw that the lock table got unlocked and re-locked due to the HubService.register() logic thinking it can prompt when it really can't and so unnecessarily unlocking.

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: [https://github.com/liquibase/liquibase/issues/2309](https://github.com/liquibase/liquibase/issues/2309)
* Test Results: [https://github.com/liquibase/liquibase/pull/2335/checks](https://github.com/liquibase/liquibase/pull/2335/checks)

#### Testing
* Steps to Reproduce: [https://github.com/liquibase/liquibase/issues/2309](https://github.com/liquibase/liquibase/issues/2309)
* Guidance:
  * Impact: 
    * Only changes behavior when in "*-sql" mode
    * Updated the generic "can we prompt" logic to take into account whether the console supports input, not just what the passed configuration is.

#### Dev Verification
Ran update-sql against a new h2 database, and made sure the create and lock logic happens only once

**Test Requirements (Liquibase Internal QA)**

**Setup**

Make sure DATABASECHANGELOGLOCK table is not present in database.

**Manual Tests**

_Verify update-sql outputs correct number of statements related to DATABASECHANGELOGLOCK table._

* `liquibase update-sql --changelog-file lb2208-changelog.xml`
* there is only one CREATE TABLE DATABASECHANGELOGLOCK statement
* there is only one INSERT INTO DATABASECHANGELOGLOCK statement
* there is only one DELETE FROM DATABASECHANGELOGLOCK statement
* there are only two UPDATE DATABASECHANGELOGLOCK statements (one before changesets and one after)

Execute update with `setup` label: `liquibase update --changelog-file lb2208-changelog --labels setup`

_Verify update-sql outputs correct number of statements_ when _DATABASECHANGELOGLOCK table already exists._

* `liquibase update-sql --changelog-file lb2208-changelog --labels test`
* there are no CREATE TABLE DATABASECHANGELOGLOCK statements
* there  are no INSERT INTO DATABASECHANGELOGLOCK statements
* there are no DELETE FROM DATABASECHANGELOGLOCK statements
* there are only two UPDATE DATABASECHANGELOGLOCK statements (one before changesets and one after)

**Automated Tests**

No new functional tests required for this fix.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-2208) by [Unito](https://www.unito.io)
