### PR TITLE
Support both javax.servlet and jakarta.servlet

### DIFF
--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -31,6 +31,13 @@
         </dependency>
 
         <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>5.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derby</artifactId>
             <version>10.14.2.0</version>

--- a/liquibase-core/src/main/java/liquibase/integration/servlet/GenericServletListener.java
+++ b/liquibase-core/src/main/java/liquibase/integration/servlet/GenericServletListener.java
@@ -1,0 +1,256 @@
+package liquibase.integration.servlet;
+
+import liquibase.Contexts;
+import liquibase.LabelExpression;
+import liquibase.Liquibase;
+import liquibase.Scope;
+import liquibase.configuration.ConfiguredValue;
+import liquibase.configuration.LiquibaseConfiguration;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.core.DerbyDatabase;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.LiquibaseException;
+import liquibase.integration.commandline.LiquibaseCommandLineConfiguration;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import liquibase.resource.CompositeResourceAccessor;
+import liquibase.resource.FileSystemResourceAccessor;
+import liquibase.resource.ResourceAccessor;
+import liquibase.util.NetUtil;
+import liquibase.util.StringUtil;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Enumeration;
+
+/**
+ * Servlet listener than can be added to web.xml to allow Liquibase to run on every application server startup.
+ * Using this listener allows users to know that they always have the most up to date database, although it will
+ * slow down application server startup slightly.
+ * See the <a href="http://www.liquibase.org/documentation/servlet_listener.html">Liquibase documentation</a> for
+ * more information.
+ *
+ * @see LiquibaseJakartaServletListener
+ * @see LiquibaseServletListener
+ */
+abstract class GenericServletListener {
+
+    private static final String LIQUIBASE_CHANGELOG = "liquibase.changelog";
+    private static final String LIQUIBASE_CONTEXTS = "liquibase.contexts";
+    private static final String LIQUIBASE_LABELS = "liquibase.labels";
+    private static final String LIQUIBASE_DATASOURCE = "liquibase.datasource";
+    private static final String LIQUIBASE_HOST_EXCLUDES = "liquibase.host.excludes";
+    private static final String LIQUIBASE_HOST_INCLUDES = "liquibase.host.includes";
+    private static final String LIQUIBASE_ONERROR_FAIL = "liquibase.onerror.fail";
+    private static final String LIQUIBASE_PARAMETER = "liquibase.parameter";
+    private static final String LIQUIBASE_SCHEMA_DEFAULT = "liquibase.schema.default";
+
+    private String changeLogFile;
+    private String dataSourceName;
+    private String contexts;
+    private String labels;
+    private String defaultSchema;
+    private String hostName;
+
+    public String getChangeLogFile() {
+        return changeLogFile;
+    }
+
+    public void setChangeLogFile(String changeLogFile) {
+        this.changeLogFile = changeLogFile;
+    }
+
+    public String getContexts() {
+        return contexts;
+    }
+
+    public void setContexts(String ctxt) {
+        contexts = ctxt;
+    }
+
+    public String getLabels() {
+        return labels;
+    }
+
+    public void setLabels(String labels) {
+        this.labels = labels;
+    }
+
+    public String getDataSource() {
+        return dataSourceName;
+    }
+
+    /**
+     * Sets the name of the data source.
+     */
+    public void setDataSource(String dataSource) {
+        this.dataSourceName = dataSource;
+    }
+
+    public String getDefaultSchema() {
+        return defaultSchema;
+    }
+
+    public void contextInitialized(GenericServletWrapper.ServletContext servletContext) {
+        final LiquibaseConfiguration liquibaseConfiguration = Scope.getCurrentScope().getSingleton(LiquibaseConfiguration.class);
+
+        try {
+            this.hostName = NetUtil.getLocalHostName();
+        } catch (Exception e) {
+            servletContext.log("Cannot find hostname: " + e.getMessage());
+            return;
+        }
+
+        InitialContext ic = null;
+        String failOnError = null;
+        final ServletConfigurationValueProvider servletConfigurationValueProvider = new ServletConfigurationValueProvider(servletContext, ic);
+        try {
+            ic = new InitialContext();
+
+            liquibaseConfiguration.registerProvider(servletConfigurationValueProvider);
+
+            failOnError = (String) liquibaseConfiguration.getCurrentConfiguredValue(null, null, LIQUIBASE_ONERROR_FAIL).getValue();
+            if (checkPreconditions(servletContext, ic)) {
+                executeUpdate(servletContext, ic);
+            }
+
+        } catch (Exception e) {
+            if (!"false".equals(failOnError)) {
+                throw new RuntimeException(e);
+            }
+        } finally {
+            if (ic != null) {
+                try {
+                    ic.close();
+                } catch (NamingException e) {
+                    // ignore
+                }
+            }
+            liquibaseConfiguration.removeProvider(servletConfigurationValueProvider);
+
+
+        }
+    }
+
+    /**
+     * Checks if the update is supposed to be executed. That depends on several conditions:
+     * <ol>
+     * <li>if liquibase.shouldRun is <code>false</code> the update will not be executed.</li>
+     * <li>if {@value LiquibaseServletListener#LIQUIBASE_HOST_INCLUDES} contains the current hostname, the the update will be executed.</li>
+     * <li>if {@value LiquibaseServletListener#LIQUIBASE_HOST_EXCLUDES} contains the current hostname, the the update will not be executed.</li>
+     * </ol>
+     */
+    private boolean checkPreconditions(GenericServletWrapper.ServletContext servletContext, InitialContext ic) {
+        if (!LiquibaseCommandLineConfiguration.SHOULD_RUN.getCurrentValue()) {
+            Scope.getCurrentScope().getLog(getClass()).info("Liquibase did not run on " + hostName
+                    + " because " + LiquibaseCommandLineConfiguration.SHOULD_RUN.getKey()
+                    + " was set to false");
+            return false;
+        }
+
+        final LiquibaseConfiguration liquibaseConfiguration = Scope.getCurrentScope().getSingleton(LiquibaseConfiguration.class);
+
+        String machineIncludes = (String) liquibaseConfiguration.getCurrentConfiguredValue(null, null, LIQUIBASE_HOST_INCLUDES).getValue();
+        String machineExcludes = (String) liquibaseConfiguration.getCurrentConfiguredValue(null, null, LIQUIBASE_HOST_EXCLUDES).getValue();
+
+        boolean shouldRun = false;
+        if ((machineIncludes == null) && (machineExcludes == null)) {
+            shouldRun = true;
+        } else if (machineIncludes != null) {
+            for (String machine : machineIncludes.split(",")) {
+                machine = machine.trim();
+                if (hostName.equalsIgnoreCase(machine)) {
+                    shouldRun = true;
+                }
+            }
+        } else if (machineExcludes != null) {
+            shouldRun = true;
+            for (String machine : machineExcludes.split(",")) {
+                machine = machine.trim();
+                if (hostName.equalsIgnoreCase(machine)) {
+                    shouldRun = false;
+                }
+            }
+        }
+
+        final ConfiguredValue<Boolean> shouldRunValue = LiquibaseCommandLineConfiguration.SHOULD_RUN.getCurrentConfiguredValue();
+        if (LiquibaseCommandLineConfiguration.SHOULD_RUN.getCurrentValue() && !shouldRunValue.wasDefaultValueUsed()) {
+            shouldRun = true;
+            servletContext.log("ignoring " + LIQUIBASE_HOST_INCLUDES + " and "
+                    + LIQUIBASE_HOST_EXCLUDES + ", since " + shouldRunValue.getProvidedValue().describe()
+                    + "=true");
+        }
+        if (!shouldRun) {
+            servletContext.log("LiquibaseServletListener did not run due to "
+                    + LIQUIBASE_HOST_INCLUDES + " and/or " + LIQUIBASE_HOST_EXCLUDES + "");
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Executes the Liquibase update.
+     */
+    @java.lang.SuppressWarnings("squid:S2095")
+    private void executeUpdate(GenericServletWrapper.ServletContext servletContext, InitialContext ic) throws NamingException, SQLException, LiquibaseException {
+        final LiquibaseConfiguration liquibaseConfiguration = Scope.getCurrentScope().getSingleton(LiquibaseConfiguration.class);
+
+        setDataSource((String) liquibaseConfiguration.getCurrentConfiguredValue(null, null, LIQUIBASE_DATASOURCE).getValue());
+        if (getDataSource() == null) {
+            throw new RuntimeException("Cannot run Liquibase, " + LIQUIBASE_DATASOURCE + " is not set");
+        }
+
+        setChangeLogFile((String) liquibaseConfiguration.getCurrentConfiguredValue(null, null, LIQUIBASE_CHANGELOG).getValue());
+        if (getChangeLogFile() == null) {
+            throw new RuntimeException("Cannot run Liquibase, " + LIQUIBASE_CHANGELOG + " is not set");
+        }
+
+        setContexts((String) liquibaseConfiguration.getCurrentConfiguredValue(null, null, LIQUIBASE_CONTEXTS).getValue());
+        setLabels((String) liquibaseConfiguration.getCurrentConfiguredValue(null, null, LIQUIBASE_LABELS).getValue());
+        this.defaultSchema = StringUtil.trimToNull((String) liquibaseConfiguration.getCurrentConfiguredValue(null, null, LIQUIBASE_SCHEMA_DEFAULT).getValue());
+
+        Connection connection = null;
+        Database database = null;
+        Liquibase liquibase = null;
+        try {
+            DataSource dataSource = (DataSource) ic.lookup(this.dataSourceName);
+
+            connection = dataSource.getConnection();
+
+            Thread currentThread = Thread.currentThread();
+            ClassLoader contextClassLoader = currentThread.getContextClassLoader();
+            ResourceAccessor threadClFO = new ClassLoaderResourceAccessor(contextClassLoader);
+
+            ResourceAccessor clFO = new ClassLoaderResourceAccessor();
+            ResourceAccessor fsFO = new FileSystemResourceAccessor();
+
+
+            database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(connection));
+            database.setDefaultSchemaName(getDefaultSchema());
+            liquibase = new Liquibase(getChangeLogFile(), new CompositeResourceAccessor(clFO, fsFO, threadClFO), database);
+
+            @SuppressWarnings("unchecked")
+            Enumeration<String> initParameters = servletContext.getInitParameterNames();
+            while (initParameters.hasMoreElements()) {
+                String name = initParameters.nextElement().trim();
+                if (name.startsWith(LIQUIBASE_PARAMETER + ".")) {
+                    liquibase.setChangeLogParameter(name.substring(LIQUIBASE_PARAMETER.length() + 1), liquibaseConfiguration.getCurrentConfiguredValue(null, null, name));
+                }
+            }
+
+            liquibase.update(new Contexts(getContexts()), new LabelExpression(getLabels()));
+            if (database instanceof DerbyDatabase) {
+                ((DerbyDatabase) database).setShutdownEmbeddedDerby(false);
+            }
+        } finally {
+            if (liquibase != null) {
+                liquibase.close();
+            } else if (connection != null) {
+                connection.close();
+            }
+        }
+    }
+}

--- a/liquibase-core/src/main/java/liquibase/integration/servlet/GenericServletWrapper.java
+++ b/liquibase-core/src/main/java/liquibase/integration/servlet/GenericServletWrapper.java
@@ -1,0 +1,38 @@
+package liquibase.integration.servlet;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Enumeration;
+
+/**
+ * To support both javax.servlet and jakarta.servlet implementations, this class wraps the classes we use so that the shared code does not have to depend
+ * on a particular implementation.
+ *
+ * NOTE: Only methods which Liquibase currently uses are exposed, which may cause breaking changes if/when new abstract methods are added to the wrappers.
+ */
+class GenericServletWrapper {
+
+    public abstract static class ServletContext {
+
+        public abstract void log(String message);
+
+        public abstract String getInitParameter(String key);
+
+        public abstract Enumeration<String> getInitParameterNames();
+    }
+
+    public abstract static class HttpServletRequest {
+
+        public abstract String getParameter(String key);
+
+        public abstract String getRequestURI();
+    }
+
+    public abstract static class HttpServletResponse {
+
+        public abstract void setContentType(String type);
+
+        public abstract PrintWriter getWriter() throws IOException;
+    }
+
+}

--- a/liquibase-core/src/main/java/liquibase/integration/servlet/GenericStatusServlet.java
+++ b/liquibase-core/src/main/java/liquibase/integration/servlet/GenericStatusServlet.java
@@ -1,0 +1,89 @@
+package liquibase.integration.servlet;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.text.DateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+/**
+ * Servlet that can be registered via web.xml to view the log of the Liquibase run from the LiquibaseServletListener.
+ *
+ * @see LiquibaseStatusServlet
+ * @see LiquibaseJakartaStatusServlet
+ */
+class GenericStatusServlet {
+
+    private static final long serialVersionUID = 1092565349351848089L;
+    private static final List<LogRecord> liquibaseRunLog = new ArrayList<>();
+
+    public static synchronized void logMessage(LogRecord message) {
+        liquibaseRunLog.add(message);
+    }
+
+    protected void doGet(GenericServletWrapper.HttpServletRequest httpServletRequest, GenericServletWrapper.HttpServletResponse httpServletResponse) throws IOException {
+        httpServletResponse.setContentType("text/html");
+
+        String logLevelToDisplay = httpServletRequest.getParameter("logLevel");
+        Level currentLevel = Level.INFO;
+        if (logLevelToDisplay != null) {
+            try {
+                currentLevel = Level.parse(logLevelToDisplay);
+            } catch (IllegalArgumentException illegalArgumentException) {
+                throw new IOException(illegalArgumentException);
+            }
+
+        }
+
+        PrintWriter writer = httpServletResponse.getWriter();
+        writer.println("<html>");
+        writer.println("<head><title>Liquibase Status</title></head>");
+        writer.println("<body>");
+        if (liquibaseRunLog.isEmpty()) {
+            writer.println("<b>Liquibase did not run</b>");
+        } else {
+            writer.println("<b>View level: " + getLevelLink(Level.SEVERE, currentLevel, httpServletRequest)
+                    + " " + getLevelLink(Level.WARNING, currentLevel, httpServletRequest)
+                    + " " + getLevelLink(Level.INFO, currentLevel, httpServletRequest)
+                    + " " + getLevelLink(Level.CONFIG, currentLevel, httpServletRequest)
+                    + " " + getLevelLink(Level.FINE, currentLevel, httpServletRequest)
+                    + " " + getLevelLink(Level.FINER, currentLevel, httpServletRequest)
+                    + " " + getLevelLink(Level.FINEST, currentLevel, httpServletRequest)
+                    + "</b>");
+
+            writer.println("<hr>");
+            writer.println("<b>Liquibase started at " + DateFormat.getDateTimeInstance().format(new Date
+                    (liquibaseRunLog.get(0).getMillis())));
+            writer.println("<hr>");
+            writer.println("<pre>");
+            for (LogRecord record : liquibaseRunLog) {
+                if (record.getLevel().intValue() >= currentLevel.intValue()) {
+                    writer.println(record.getLevel() + ": " + record.getMessage());
+                    if (record.getThrown() != null) {
+                        record.getThrown().printStackTrace(writer);
+                    }
+                }
+            }
+            writer.println("");
+            writer.println("");
+
+            writer.println("</pre>");
+            writer.println("<hr>");
+            writer.println("<b>Liquibase finished at " + DateFormat.getDateTimeInstance().format(new Date
+                    (liquibaseRunLog.get(liquibaseRunLog.size() - 1).getMillis())));
+        }
+        writer.println("</body>");
+        writer.println("</html>");
+    }
+
+    private String getLevelLink(Level level, Level currentLevel, GenericServletWrapper.HttpServletRequest request) {
+        if (currentLevel.equals(level)) {
+            return level.getName();
+        } else {
+            return "<a href=" + request.getRequestURI() + "?logLevel=" + level.getName() + ">" + level.getName() + "</a>";
+        }
+    }
+}

--- a/liquibase-core/src/main/java/liquibase/integration/servlet/LiquibaseJakartaServletListener.java
+++ b/liquibase-core/src/main/java/liquibase/integration/servlet/LiquibaseJakartaServletListener.java
@@ -1,17 +1,15 @@
 package liquibase.integration.servlet;
 
-import javax.servlet.ServletContextEvent;
-import javax.servlet.ServletContextListener;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+
 import java.util.Enumeration;
 
-/**
- * Version of {@link GenericServletListener} that uses javax.servlet and NOT jakarta.servlet
- */
-public class LiquibaseServletListener extends GenericServletListener implements ServletContextListener {
+public class LiquibaseJakartaServletListener extends GenericServletListener implements ServletContextListener {
 
     @Override
     public void contextInitialized(ServletContextEvent sce) {
-        super.contextInitialized(new JavaxServletContext(sce.getServletContext()));
+        super.contextInitialized(new JakartaServletContext(sce.getServletContext()));
     }
 
     @Override
@@ -19,11 +17,11 @@ public class LiquibaseServletListener extends GenericServletListener implements 
 
     }
 
-    private static class JavaxServletContext extends GenericServletWrapper.ServletContext {
+    private static class JakartaServletContext extends GenericServletWrapper.ServletContext {
 
-        private final javax.servlet.ServletContext servletContext;
+        private final jakarta.servlet.ServletContext servletContext;
 
-        private JavaxServletContext(javax.servlet.ServletContext servletContext) {
+        private JakartaServletContext(jakarta.servlet.ServletContext servletContext) {
             this.servletContext = servletContext;
         }
 
@@ -42,6 +40,4 @@ public class LiquibaseServletListener extends GenericServletListener implements 
             return servletContext.getInitParameterNames();
         }
     }
-
-
 }

--- a/liquibase-core/src/main/java/liquibase/integration/servlet/LiquibaseJakartaStatusServlet.java
+++ b/liquibase-core/src/main/java/liquibase/integration/servlet/LiquibaseJakartaStatusServlet.java
@@ -1,0 +1,58 @@
+package liquibase.integration.servlet;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+public class LiquibaseJakartaStatusServlet extends HttpServlet {
+
+    private final GenericStatusServlet delegate;
+
+    public LiquibaseJakartaStatusServlet() {
+        this.delegate = new GenericStatusServlet();
+    }
+
+    @Override
+    protected void doGet(jakarta.servlet.http.HttpServletRequest req, jakarta.servlet.http.HttpServletResponse resp) throws ServletException, IOException {
+        delegate.doGet(new JakartaHttpServletRequest(req), new JakartaHttpServletResponse(resp));
+    }
+
+    private static class JakartaHttpServletRequest extends GenericServletWrapper.HttpServletRequest {
+        private final jakarta.servlet.http.HttpServletRequest request;
+
+        public JakartaHttpServletRequest(jakarta.servlet.http.HttpServletRequest req) {
+            this.request = req;
+        }
+
+        @Override
+        public String getParameter(String key) {
+            return request.getParameter(key);
+        }
+
+        @Override
+        public String getRequestURI() {
+            return request.getRequestURI();
+        }
+    }
+
+    private static class JakartaHttpServletResponse extends GenericServletWrapper.HttpServletResponse {
+
+        private final jakarta.servlet.http.HttpServletResponse response;
+
+        public JakartaHttpServletResponse(jakarta.servlet.http.HttpServletResponse resp) {
+            this.response = resp;
+        }
+
+        @Override
+        public void setContentType(String type) {
+            this.response.setContentType(type);
+        }
+
+        @Override
+        public PrintWriter getWriter() throws IOException {
+            return response.getWriter();
+        }
+    }
+}

--- a/liquibase-core/src/main/java/liquibase/integration/servlet/LiquibaseStatusServlet.java
+++ b/liquibase-core/src/main/java/liquibase/integration/servlet/LiquibaseStatusServlet.java
@@ -1,92 +1,60 @@
 package liquibase.integration.servlet;
 
 import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.text.DateFormat;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.LogRecord;
 
 /**
- * Servlet that can be registered via web.xml to view the log of the Liquibase run from the LiquibaseServletListener.
+ * Version of {@link GenericStatusServlet} that uses javax.servlet and NOT jakarta.servlet
  */
-@SuppressWarnings("java:S1989")
 public class LiquibaseStatusServlet extends HttpServlet {
 
-    private static final long serialVersionUID = 1092565349351848089L;
-    private static final List<LogRecord> liquibaseRunLog = new ArrayList<>();
+    private final GenericStatusServlet delegate;
 
-    public static synchronized void logMessage(LogRecord message) {
-        liquibaseRunLog.add(message);
-
+    public LiquibaseStatusServlet() {
+        this.delegate = new GenericStatusServlet();
     }
 
     @Override
-    protected void doGet(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws IOException {
-        httpServletResponse.setContentType("text/html");
-
-        String logLevelToDisplay = httpServletRequest.getParameter("logLevel");
-        Level currentLevel = Level.INFO;
-        if (logLevelToDisplay != null) {
-            try {
-                currentLevel = Level.parse(logLevelToDisplay);
-            } catch (IllegalArgumentException illegalArgumentException) {
-                throw new IOException(illegalArgumentException);
-            }
-
-        }
-
-        PrintWriter writer = httpServletResponse.getWriter();
-        writer.println("<html>");
-        writer.println("<head><title>Liquibase Status</title></head>");
-        writer.println("<body>");
-        if (liquibaseRunLog.isEmpty()) {
-            writer.println("<b>Liquibase did not run</b>");
-        } else {
-            writer.println("<b>View level: " + getLevelLink(Level.SEVERE, currentLevel, httpServletRequest)
-                    + " " + getLevelLink(Level.WARNING, currentLevel, httpServletRequest)
-                    + " " + getLevelLink(Level.INFO, currentLevel, httpServletRequest)
-                    + " " + getLevelLink(Level.CONFIG, currentLevel, httpServletRequest)
-                    + " " + getLevelLink(Level.FINE, currentLevel, httpServletRequest)
-                    + " " + getLevelLink(Level.FINER, currentLevel, httpServletRequest)
-                    + " " + getLevelLink(Level.FINEST, currentLevel, httpServletRequest)
-                    + "</b>");
-
-            writer.println("<hr>");
-            writer.println("<b>Liquibase started at " + DateFormat.getDateTimeInstance().format(new Date
-                    (liquibaseRunLog.get(0).getMillis())));
-            writer.println("<hr>");
-            writer.println("<pre>");
-            for (LogRecord record : liquibaseRunLog) {
-                if (record.getLevel().intValue() >= currentLevel.intValue()) {
-                    writer.println(record.getLevel() + ": " + record.getMessage());
-                    if (record.getThrown() != null) {
-                        record.getThrown().printStackTrace(writer);
-                    }
-                }
-            }
-            writer.println("");
-            writer.println("");
-
-            writer.println("</pre>");
-            writer.println("<hr>");
-            writer.println("<b>Liquibase finished at " + DateFormat.getDateTimeInstance().format(new Date
-                    (liquibaseRunLog.get(liquibaseRunLog.size() - 1).getMillis())));
-        }
-        writer.println("</body>");
-        writer.println("</html>");
+    protected void doGet(javax.servlet.http.HttpServletRequest req, javax.servlet.http.HttpServletResponse resp) throws javax.servlet.ServletException, IOException {
+        delegate.doGet(new JavaxHttpServletRequest(req), new JavaxHttpServletResponse(resp));
     }
 
-    private String getLevelLink(Level level, Level currentLevel, HttpServletRequest request) {
-        if (currentLevel.equals(level)) {
-            return level.getName();
-        } else {
-            return "<a href=" + request.getRequestURI() + "?logLevel=" + level.getName() + ">" + level.getName() + "</a>";
+    private static class JavaxHttpServletRequest extends GenericServletWrapper.HttpServletRequest {
+        private final javax.servlet.http.HttpServletRequest request;
+
+        public JavaxHttpServletRequest(javax.servlet.http.HttpServletRequest req) {
+            this.request = req;
+        }
+
+        @Override
+        public String getParameter(String key) {
+            return request.getParameter(key);
+        }
+
+        @Override
+        public String getRequestURI() {
+            return request.getRequestURI();
         }
     }
+
+    private static class JavaxHttpServletResponse extends GenericServletWrapper.HttpServletResponse {
+
+        private final javax.servlet.http.HttpServletResponse response;
+
+        public JavaxHttpServletResponse(javax.servlet.http.HttpServletResponse resp) {
+            this.response = resp;
+        }
+
+        @Override
+        public void setContentType(String type) {
+            this.response.setContentType(type);
+        }
+
+        @Override
+        public PrintWriter getWriter() throws IOException {
+            return response.getWriter();
+        }
+    }
+
 }

--- a/liquibase-core/src/main/java/liquibase/integration/servlet/ServletConfigurationValueProvider.java
+++ b/liquibase-core/src/main/java/liquibase/integration/servlet/ServletConfigurationValueProvider.java
@@ -1,13 +1,11 @@
 package liquibase.integration.servlet;
 
 import liquibase.configuration.AbstractConfigurationValueProvider;
-import liquibase.configuration.ConfigurationValueProvider;
 import liquibase.configuration.ProvidedValue;
 
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
-import javax.servlet.ServletContext;
 
 public class ServletConfigurationValueProvider extends AbstractConfigurationValueProvider {
 
@@ -18,10 +16,10 @@ public class ServletConfigurationValueProvider extends AbstractConfigurationValu
         return 30;
     }
 
-    private final ServletContext servletContext;
+    private final GenericServletWrapper.ServletContext servletContext;
     private final InitialContext initialContext;
 
-    public ServletConfigurationValueProvider(ServletContext servletContext, InitialContext initialContext) {
+    public ServletConfigurationValueProvider(GenericServletWrapper.ServletContext servletContext, InitialContext initialContext) {
         this.servletContext = servletContext;
         this.initialContext = initialContext;
     }

--- a/liquibase-core/src/test/java/liquibase/integration/servlet/LiquibaseServletListenerTest.java
+++ b/liquibase-core/src/test/java/liquibase/integration/servlet/LiquibaseServletListenerTest.java
@@ -10,8 +10,6 @@ import java.util.Collections;
 
 import javax.naming.Context;
 import javax.naming.NamingException;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletContextEvent;
 import javax.sql.DataSource;
 
 import org.apache.derby.jdbc.BasicEmbeddedDataSource40;
@@ -29,7 +27,7 @@ public class LiquibaseServletListenerTest extends TestCase {
     static DataSource dataSource;
 
     private LiquibaseServletListener servletListener;
-    private ServletContext servletContext;
+    private GenericServletWrapper.ServletContext servletContext;
     private Context namingContext;
 
     public static Test suite() {
@@ -52,7 +50,7 @@ public class LiquibaseServletListenerTest extends TestCase {
     public void setUp() throws Exception {
         servletListener = new LiquibaseServletListener();
 
-        servletContext = mock(ServletContext.class);
+        servletContext = mock(GenericServletWrapper.ServletContext.class);
         when(servletContext.getInitParameter(LIQUIBASE_DATASOURCE)).thenReturn("myDS");
         when(servletContext.getInitParameter(LIQUIBASE_CHANGELOG))
                 .thenReturn("liquibase/integration/servlet/simple-changelog.xml");
@@ -73,7 +71,7 @@ public class LiquibaseServletListenerTest extends TestCase {
             return;
         }
         try (Connection pooled = dataSource.getConnection()) {
-            servletListener.contextInitialized(new ServletContextEvent(servletContext));
+            servletListener.contextInitialized(servletContext);
             assertEquals("connection.closed", false, pooled.isClosed());
         }
     }


### PR DESCRIPTION
## Description

Fixes #2298 by extracting the servlet code into a generic version that supports either package, then wrapping the javax/jakarta-specific classes