### PR TITLE
fixed includeAll when loaded from embedded jar files (fix for #2352)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
@@ -5,6 +5,7 @@ import liquibase.changelog.DatabaseChangeLog;
 import liquibase.util.StreamUtil;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
@@ -17,6 +18,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.jar.JarInputStream;
 
 /**
  * An implementation of {@link FileSystemResourceAccessor} that builds up the file roots based on the passed {@link ClassLoader}.
@@ -264,32 +266,39 @@ public class ClassLoaderResourceAccessor extends AbstractResourceAccessor implem
 
             try {
                 if (urlExternalForm.startsWith("jar:file:") && urlExternalForm.contains("!")) {
-                    //We can search the jar directly
-                    String jarPath = url.getPath();
-                    jarPath = jarPath.substring(5, jarPath.indexOf("!"));
-                    try (JarFile jar = new JarFile(URLDecoder.decode(jarPath, StandardCharsets.UTF_8.name()))) {
-                        String comparePath = path;
-                        if (comparePath.startsWith("/")) {
-                            comparePath = "/" + comparePath;
-                        }
-                        Enumeration<JarEntry> entries = jar.entries();
-                        while (entries.hasMoreElements()) {
-                            JarEntry entry = entries.nextElement();
-                            String name = entry.getName();
-                            if (name.startsWith(comparePath) && !comparePath.equals(name)) {
-                                if (entry.isDirectory()) {
-                                    if (!includeDirectories) {
-                                        continue;
-                                    }
+                    // load the jar file from the URL input stream
+                    final int splitIndex = urlExternalForm.lastIndexOf('!');
+                    String comparePath = urlExternalForm.substring(splitIndex+1);
+                    String jarPath = urlExternalForm.substring(0, splitIndex);
 
+                    final JarInputStream jarStream;
+                    final URL jarUrl = classLoader.getResource(jarPath);
+                    if (jarUrl != null) {
+                        jarStream = new JarInputStream(jarUrl.openStream());
+                    }
+                    else {
+                        jarStream = new JarInputStream(new FileInputStream(URLDecoder.decode(jarPath.substring(9), StandardCharsets.UTF_8.name())));
+                    }
+
+                    if (comparePath.startsWith("/")) {
+                        comparePath = comparePath.substring(1);
+                    }
+
+                    for (JarEntry entry = jarStream.getNextJarEntry(); entry != null; entry = jarStream.getNextJarEntry()) {
+                        String name = entry.getName();
+                        if (name.startsWith(comparePath) && !comparePath.equals(name)) {
+                            if (entry.isDirectory()) {
+                                if (!includeDirectories) {
+                                    continue;
+                                }
+
+                                if (recursive || !name.substring(comparePath.length()).contains("/")) {
+                                    returnSet.add(name);
+                                }
+                            } else {
+                                if (includeFiles) {
                                     if (recursive || !name.substring(comparePath.length()).contains("/")) {
                                         returnSet.add(name);
-                                    }
-                                } else {
-                                    if (includeFiles) {
-                                        if (recursive || !name.substring(comparePath.length()).contains("/")) {
-                                            returnSet.add(name);
-                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->
## Environment
Grails 5.0.3

**Liquibase Version**:
4.6.2

**Liquibase Integration & Version**: <Pick one: CLI, maven, gradle, spring boot, servlet, etc.>
Core

**Liquibase Extension(s) & Version**: 

**Database Vendor & Version**:

**Operating System Type & Version**:
Mac Monterey 12.1

## Description

A clear and concise description of the issue being addressed.
When running the application as a jar file the migrations are not found.  The following error is returned:

liquibase.exception.SetupException: Could not find directory or directory was empty for includeAll 'current/'
        at liquibase.changelog.DatabaseChangeLog.includeAll(DatabaseChangeLog.java:553)
        at liquibase.changelog.DatabaseChangeLog.handleChildNode(DatabaseChangeLog.java:409)
        at liquibase.changelog.DatabaseChangeLog.load(DatabaseChangeLog.java:318)
        at liquibase.parser.core.xml.AbstractChangeLogParser.parse(AbstractChangeLogParser.java:23)
        ... 96 more
Caused by: liquibase.exception.SetupException: Could not find directory or directory was empty for includeAll 'current/'
        at liquibase.changelog.DatabaseChangeLog.includeAll(DatabaseChangeLog.java:544)
        ... 99 more

## Steps To Reproduce

Package migrations into jar file relative to changeLogFile
Build a spring bootable jar for application and include the jar with migrations
run the spring bootable jar

## Actual Behavior
The above exception is thrown because ClassLoaderResourceAccessor cannot parse the resource path:
jar:file:/Users/khayes/griffin.git/trifleet/build/libs/trifleet-12.0.0.jar!/BOOT-INF/lib/common-12.0.0-plain.jar!/current/

## Expected/Desired Behavior
Migrations should be loaded from the embedded jar file

## Screenshots (if appropriate)
If applicable, add screenshots to help explain your problem.

## Additional Context
Add any other context about the problem here.
