### PR TITLE
use lowercase sp_rename function in MSSQL (LB-1763)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/RenameSequenceGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/RenameSequenceGenerator.java
@@ -39,7 +39,7 @@ public class RenameSequenceGenerator extends AbstractSqlGenerator<RenameSequence
         } else if (database instanceof OracleDatabase) {
             sql = "RENAME " + database.escapeObjectName(statement.getOldSequenceName(), Sequence.class) + " TO " + database.escapeObjectName(statement.getNewSequenceName(), Sequence.class);
         } else if( database instanceof MSSQLDatabase){
-            sql = "SP_RENAME " + database.escapeObjectName(statement.getOldSequenceName(), Sequence.class) + " ," + database.escapeObjectName(statement.getNewSequenceName(),Sequence.class);
+            sql = "sp_rename " + database.escapeObjectName(statement.getOldSequenceName(), Sequence.class) + " ," + database.escapeObjectName(statement.getNewSequenceName(),Sequence.class);
         } else {
             sql = "ALTER SEQUENCE " + database.escapeSequenceName(statement.getCatalogName(), statement.getSchemaName(), statement.getOldSequenceName()) + " RENAME TO " + database.escapeObjectName(statement.getNewSequenceName(), Sequence.class);
         }

--- a/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/renameSequence/mssql.sql
+++ b/liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/renameSequence/mssql.sql
@@ -1,4 +1,4 @@
 -- Database: mssql
 -- Change Parameter: newSequenceName=seq_id
 -- Change Parameter: oldSequenceName=seq_id
-SP_RENAME seq_id ,seq_id;
+sp_rename seq_id ,seq_id;


### PR DESCRIPTION
Microsoft SQL Server uses the `sp_rename` function to rename sequences, and [it is spelled using lowercase letters](https://docs.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-rename-transact-sql?view=sql-server-ver15). SQL Server will permit it to be spelled with uppercase letters so long as the database collation is case-insensitive. For case sensitive collations, using uppercase letters will result in an error.