### PR TITLE
improve console output of failing CommandTests (DAT-9038)

### DIFF
--- a/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/command/CommandTests.groovy
+++ b/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/command/CommandTests.groovy
@@ -361,6 +361,11 @@ Long Description: ${commandDefinition.getLongDescription() ?: "NOT SET"}
                 substring = (caseInsensitive && substring != null ? substring.toLowerCase() : substring)
                 assert !actual.contains(StringUtil.standardizeLineEndings(StringUtil.trimToEmpty(substring))): "$actual does not contain: '$substring'"
             }
+
+            @Override
+            String getExpected() {
+                return substring
+            }
         }
     }
 
@@ -380,6 +385,11 @@ Long Description: ${commandDefinition.getLongDescription() ?: "NOT SET"}
                     int count = (actual.split(Pattern.quote(edited), -1).length) - 1
                     assert count == occurrences: "$actual does not contain '$substring' $occurrences times.  It appears $count times"
                 }
+            }
+
+            @Override
+            String getExpected() {
+                return substring
             }
         }
     }
@@ -457,7 +467,7 @@ Long Description: ${commandDefinition.getLongDescription() ?: "NOT SET"}
                     try {
                         ((OutputCheck) expectedOutputCheck).check(fullOutput)
                     } catch (AssertionError e) {
-                        Assert.fail("$fullOutput : ${e.getMessage()}")
+                        throw new ComparisonFailure(e.getMessage(), expectedOutputCheck.expected, fullOutput)
                     }
                 } else {
                     Assert.fail "Unknown $outputDescription check type: ${expectedOutputCheck.class.name}"
@@ -962,6 +972,10 @@ Long Description: ${commandDefinition.getLongDescription() ?: "NOT SET"}
 
     interface OutputCheck {
         def check(String actual) throws AssertionError
+        /**
+         * @return the expected value from this output check
+         */
+        String getExpected()
     }
 
     interface FileContentCheck {


### PR DESCRIPTION
Throwing a `ComparisonFailure` exception is treated differently by Intellij Idea. Idea will include a button to show the diff between the expected and actual in the console output for the failed test, which is very convenient.