### PR TITLE
Log exceptions in CDILiquibase before rethrowing them

### DIFF
--- a/liquibase-cdi/src/main/java/liquibase/integration/cdi/CDILiquibase.java
+++ b/liquibase-cdi/src/main/java/liquibase/integration/cdi/CDILiquibase.java
@@ -79,7 +79,8 @@ public class CDILiquibase implements Extension {
 
     @Inject
     @LiquibaseType
-    private CDILiquibaseConfig config;
+    protected CDILiquibaseConfig config;
+
     @Inject
     @LiquibaseType
     private DataSource dataSource;
@@ -132,7 +133,7 @@ public class CDILiquibase implements Extension {
         }
     }
 
-    private void performUpdate() throws LiquibaseException {
+    protected void performUpdate() throws LiquibaseException {
         Connection c = null;
         Liquibase liquibase = null;
         try {

--- a/liquibase-cdi/src/main/java/liquibase/integration/cdi/CDILiquibase.java
+++ b/liquibase-cdi/src/main/java/liquibase/integration/cdi/CDILiquibase.java
@@ -10,8 +10,8 @@ import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.LiquibaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
-import liquibase.integration.commandline.LiquibaseCommandLineConfiguration;
 import liquibase.integration.cdi.annotations.LiquibaseType;
+import liquibase.integration.commandline.LiquibaseCommandLineConfiguration;
 import liquibase.logging.Logger;
 import liquibase.resource.ResourceAccessor;
 import liquibase.util.LiquibaseUtil;
@@ -77,9 +77,11 @@ public class CDILiquibase implements Extension {
     @LiquibaseType
     ResourceAccessor resourceAccessor;
 
-    @Inject @LiquibaseType
+    @Inject
+    @LiquibaseType
     private CDILiquibaseConfig config;
-    @Inject @LiquibaseType
+    @Inject
+    @LiquibaseType
     private DataSource dataSource;
     private boolean initialized;
     private boolean updateSuccessful;
@@ -94,33 +96,38 @@ public class CDILiquibase implements Extension {
 
     @PostConstruct
     public void onStartup() {
-        Logger log = Scope.getCurrentScope().getLog(getClass());
-
-        log.info("Booting Liquibase " + LiquibaseUtil.getBuildVersionInfo());
-        String hostName;
         try {
-            hostName = NetUtil.getLocalHostName();
-        } catch (Exception e) {
-            log.warning("Cannot find hostname: " + e.getMessage());
-            log.fine("", e);
-            return;
-        }
+            Logger log = Scope.getCurrentScope().getLog(getClass());
 
-        if (!LiquibaseCommandLineConfiguration.SHOULD_RUN.getCurrentValue()) {
-            log.info(String.format("Liquibase did not run on %s because %s was set to false.",
-                    hostName,
-                LiquibaseCommandLineConfiguration.SHOULD_RUN.getKey()
-            ));
-            return;
-        }
-        if (!config.getShouldRun()) {
-            log.info(String.format("Liquibase did not run on %s because CDILiquibaseConfig.shouldRun was set to false.", hostName));
-            return;
-        }
-        initialized = true;
-        try {
+            log.info("Booting Liquibase " + LiquibaseUtil.getBuildVersionInfo());
+            String hostName;
+            try {
+                hostName = NetUtil.getLocalHostName();
+            } catch (Exception e) {
+                log.warning("Cannot find hostname: " + e.getMessage());
+                log.fine("", e);
+                return;
+            }
+
+            if (!LiquibaseCommandLineConfiguration.SHOULD_RUN.getCurrentValue()) {
+                log.info(String.format("Liquibase did not run on %s because %s was set to false.",
+                        hostName,
+                        LiquibaseCommandLineConfiguration.SHOULD_RUN.getKey()
+                ));
+                return;
+            }
+            if (!config.getShouldRun()) {
+                log.info(String.format("Liquibase did not run on %s because CDILiquibaseConfig.shouldRun was set to false.", hostName));
+                return;
+            }
+            initialized = true;
             performUpdate();
-        } catch (LiquibaseException e) {
+        } catch (Throwable e) {
+            Scope.getCurrentScope().getLog(getClass()).severe(e.getMessage(), e);
+            if (e instanceof RuntimeException) {
+                throw (RuntimeException) e;
+            }
+
             throw new UnexpectedLiquibaseException(e);
         }
     }
@@ -158,7 +165,7 @@ public class CDILiquibase implements Extension {
     protected Liquibase createLiquibase(Connection c) throws LiquibaseException {
         Liquibase liquibase = new Liquibase(config.getChangeLog(), resourceAccessor, createDatabase(c));
         if (config.getParameters() != null) {
-            for(Map.Entry<String, String> entry: config.getParameters().entrySet()) {
+            for (Map.Entry<String, String> entry : config.getParameters().entrySet()) {
                 liquibase.setChangeLogParameter(entry.getKey(), entry.getValue());
             }
         }
@@ -173,6 +180,7 @@ public class CDILiquibase implements Extension {
     /**
      * Subclasses may override this method add change some database settings such as
      * default schema before returning the database object.
+     *
      * @param c
      * @return a Database implementation retrieved from the {@link liquibase.database.DatabaseFactory}.
      * @throws DatabaseException


### PR DESCRIPTION
## Description
Alternative to #2355 that fixes #2354

Rather than logging the exceptions only within changeset iterator, better catch all exceptions and log them withing CDILiquibase.

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: https://github.com/liquibase/liquibase/issues/2354
* Test Results: https://github.com/liquibase/liquibase/pull/2397/checks

#### Testing
* Steps to Reproduce: Have failing changelog in an CDI environment
* Guidance:
  * Impact: Only impacts CDI

#### Dev Verification
Don't have a CDI environment to test in, but code is straightforward and issue author closed #2355 in favor of this fix.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-2223) by [Unito](https://www.unito.io)
