### PR TITLE
Escape schema/tablenames in metadata.getTables()

### DIFF
--- a/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -1029,8 +1029,8 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
 
                     String catalog = ((AbstractJdbcDatabase) database).getJdbcCatalogName(catalogAndSchema);
                     String schema = ((AbstractJdbcDatabase) database).getJdbcSchemaName(catalogAndSchema);
-                    return extract(databaseMetaData.getTables(catalog, schema, ((table == null) ?
-                            SQL_FILTER_MATCH_ALL : table), new String[]{"TABLE"}));
+                    return extract(databaseMetaData.getTables(catalog, escapeForLike(schema), ((table == null) ?
+                            SQL_FILTER_MATCH_ALL : escapeForLike(table)), new String[]{"TABLE"}));
                 }
 
                 @Override
@@ -1049,7 +1049,7 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
 
                     String catalog = ((AbstractJdbcDatabase) database).getJdbcCatalogName(catalogAndSchema);
                     String schema = ((AbstractJdbcDatabase) database).getJdbcSchemaName(catalogAndSchema);
-                    return extract(databaseMetaData.getTables(catalog, schema, SQL_FILTER_MATCH_ALL, new String[]{"TABLE"}));
+                    return extract(databaseMetaData.getTables(catalog, escapeForLike(schema), SQL_FILTER_MATCH_ALL, new String[]{"TABLE"}));
                 }
 
                 private List<CachedRow> queryMssql(CatalogAndSchema catalogAndSchema, String tableName) throws DatabaseException, SQLException {
@@ -1133,8 +1133,8 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                 private List<CachedRow> queryPostgres(CatalogAndSchema catalogAndSchema, String tableName) throws SQLException {
                     String catalog = ((AbstractJdbcDatabase) database).getJdbcCatalogName(catalogAndSchema);
                     String schema = ((AbstractJdbcDatabase) database).getJdbcSchemaName(catalogAndSchema);
-                    return extract(databaseMetaData.getTables(catalog, schema, ((tableName == null) ?
-                            SQL_FILTER_MATCH_ALL : tableName), new String[]{"TABLE", "PARTITIONED TABLE"}));
+                    return extract(databaseMetaData.getTables(catalog, escapeForLike(schema), ((tableName == null) ?
+                            SQL_FILTER_MATCH_ALL : escapeForLike(tableName)), new String[]{"TABLE", "PARTITIONED TABLE"}));
 
                 }
             });
@@ -1186,8 +1186,8 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
 
                     String catalog = ((AbstractJdbcDatabase) database).getJdbcCatalogName(catalogAndSchema);
                     String schema = ((AbstractJdbcDatabase) database).getJdbcSchemaName(catalogAndSchema);
-                    return extract(databaseMetaData.getTables(catalog, schema, ((view == null) ? SQL_FILTER_MATCH_ALL
-                            : view), new String[]{"VIEW"}));
+                    return extract(databaseMetaData.getTables(catalog, escapeForLike(schema), ((view == null) ? SQL_FILTER_MATCH_ALL
+                            : escapeForLike(view)), new String[]{"VIEW"}));
                 }
 
                 @Override
@@ -1200,7 +1200,7 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
 
                     String catalog = ((AbstractJdbcDatabase) database).getJdbcCatalogName(catalogAndSchema);
                     String schema = ((AbstractJdbcDatabase) database).getJdbcSchemaName(catalogAndSchema);
-                    return extract(databaseMetaData.getTables(catalog, schema, SQL_FILTER_MATCH_ALL, new String[]{"VIEW"}));
+                    return extract(databaseMetaData.getTables(catalog, escapeForLike(schema), SQL_FILTER_MATCH_ALL, new String[]{"VIEW"}));
                 }
 
 
@@ -1696,6 +1696,12 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
 
     private String getAllCatalogsStringScratchData() {
         return (String) JdbcDatabaseSnapshot.this.getScratchData(ALL_CATALOGS_STRING_SCRATCH_KEY);
+    }
+
+    private String escapeForLike(String string) {
+        return string
+                .replace("%", "\\%")
+                .replace("_", "\\_");
     }
 
 }


### PR DESCRIPTION
## Description

Escape _'s and %s in schema/table names used in getTables() because so that searches for a table with an _ in them won't also match tablese without them, since the jdbc method uses those in LIKE operations