### PR TITLE
Don't repackage all org.apache.* classes.

### DIFF
--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -262,8 +262,16 @@
                             </artifactSet>
                             <relocations>
                                 <relocation>
-                                    <pattern>org.apache</pattern>
-                                    <shadedPattern>liquibase.repackaged.org.apache</shadedPattern>
+                                    <pattern>org.apache.commons.collections4</pattern>
+                                    <shadedPattern>liquibase.repackaged.org.apache.commons.collections4</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons.lang3</pattern>
+                                    <shadedPattern>liquibase.repackaged.org.apache.commons.lang3</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons.text</pattern>
+                                    <shadedPattern>liquibase.repackaged.org.apache.commons.text</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>com.opencsv</pattern>


### PR DESCRIPTION
## Description
Previously, we were renaming all org.apache.* packages, which broke any org.apache.* classes we reference but DON'T package, like Ant and Derby support.

Instead, just relocate the ones we shade into the artifact as internal dependencies.

Fixes #2391
Fixes #2388

- - -
## Dev Handoff Notes (Internal Use)
#### Links
* Fixed Issue: 
  * https://github.com/liquibase/liquibase/issues/2391
  * https://github.com/liquibase/liquibase/issues/2388
* Test Results: https://github.com/liquibase/liquibase/pull/2429/checks

#### Testing
* Steps to Reproduce: https://github.com/liquibase/liquibase/issues/2391
* Guidance:
  * Impact: limits what class names get replaced with a "repackaged" package

#### Dev Verification
Ran test from #2391 after limiting change
Ensured there are no unshaded non-liquibase package names in the final jar file



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-2222) by [Unito](https://www.unito.io)
