### PR TITLE
Correctly set Bundle-Version in META-INF on release

### DIFF
--- a/.github/util/ManifestReversion.java
+++ b/.github/util/ManifestReversion.java
@@ -12,7 +12,9 @@ import java.util.jar.Manifest;
 public class ManifestReversion {
     public static void main(String[] args) throws Exception {
         String filename = args[0];
-        String version = args[1];
+        String version = args[1]
+                .replaceFirst("^v", "");
+
         Manifest manifest;
         try (InputStream input = new FileInputStream(filename)) {
             manifest = new Manifest(input);
@@ -21,7 +23,8 @@ public class ManifestReversion {
 
         attributes.putValue("Liquibase-Version", version);
 
-        if (attributes.containsKey("Bundle-Version")) {
+        final String bundleVersion = attributes.getValue("Bundle-Version");
+        if (bundleVersion != null) {
             attributes.putValue("Bundle-Version", version);
         }
 

--- a/.github/util/re-version.sh
+++ b/.github/util/re-version.sh
@@ -55,6 +55,22 @@ do
 
   cp $workdir/$jar $outdir
   rename.ul 0-SNAPSHOT $version $outdir/$jar
+
+  ## Make sure there are no left-over 0-SNAPSHOT versions
+  mkdir -p $workdir/test
+  unzip -q $outdir/*.jar -d $workdir/test
+
+  if grep -rl "0-SNAPSHOT" $workdir/test; then
+    echo "Found '0-SNAPSHOT' in re-versioned jars"
+    exit 1
+  fi
+
+  if grep -rl "0.0.0.SNAPSHOT" $workdir/test; then
+    echo "Found '0.0.0.SNAPSHOT' in re-versioned jars"
+    exit 1
+  fi
+
+  rm -rf $workdir/test
 done
 
 #### Update  javadoc jars


### PR DESCRIPTION
## Description

The in-development code always builds as version "0.0.0" and as part of the release process we replace the metadata that stores that placeholder version with the correct version. There are several places where that needs to be updated, including a Bundle-Version flag in META-INF/MANIFEST.MF, and that version was not updated correctly.

This fixes the logic for that, and also adds a check to the re-version.sh script to grep for 0-SNAPSHOT and 0.0.0.SNAPSHOT strings to catch any other problem spots that might get lost.

Fixes #2361 