### PR TITLE
Fix XML parsing test on Windows

### DIFF
--- a/liquibase-core/src/main/java/liquibase/parser/ChangeLogParser.java
+++ b/liquibase-core/src/main/java/liquibase/parser/ChangeLogParser.java
@@ -13,7 +13,7 @@ public interface ChangeLogParser extends LiquibaseParser {
     
     /**
      * Parses a Liquibase database changelog and returns the parsed form as an object.
-     * @param physicalChangeLogLocation the physical location of the changelog. The exakt file formats and locations
+     * @param physicalChangeLogLocation the physical location of the changelog. The exact file formats and locations
      * where can load changelog files from depend on the implementations and capabilities of the implementing parsers.
      * @param changeLogParameters parameters given by the end user that should be applied while parsing the changelog
      *  (i.e. replacement of ${placeholders} inside the changelogs with user-defined content)

--- a/liquibase-core/src/test/groovy/liquibase/parser/core/xml/XMLChangeLogSAXParserTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/parser/core/xml/XMLChangeLogSAXParserTest.groovy
@@ -23,7 +23,7 @@ class XMLChangeLogSAXParserTest extends Specification {
 
     def INSECURE_XML = """
 <!DOCTYPE databaseChangeLog [
-        <!ENTITY insecure SYSTEM "file://invalid.txt">
+        <!ENTITY insecure SYSTEM "file:///invalid.txt">
         ]>
 
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
@@ -97,7 +97,7 @@ class XMLChangeLogSAXParserTest extends Specification {
 
         then:
         def e = thrown(ChangeLogParseException)
-        e.message.contains("Error Reading Changelog File: invalid.txt")
+        e.message.contains("Error Reading Changelog File: " + File.separator + "invalid.txt")
     }
 
 }


### PR DESCRIPTION
It is not valid to have a file:// URL with only two forward slashes. It is valid to have either 1 or 3 forward slashes. See https://en.wikipedia.org/wiki/File_URI_scheme