### PR TITLE
Not possible to provide changelogs from outside classpath 

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/spring/SpringResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/integration/spring/SpringResourceAccessor.java
@@ -185,12 +185,14 @@ public class SpringResourceAccessor extends AbstractResourceAccessor {
      * Default implementation adds "classpath:" and removes duplicated /'s and classpath:'s
      */
     protected String finalizeSearchPath(String searchPath) {
+        if(searchPath.matches("^classpath\\*?:.*")) {
+            searchPath = searchPath.replace("classpath:","").replace("classpath*:","");
+            searchPath = "classpath*:/" +searchPath;
+        } else if(!searchPath.matches("^\\w+:.*")) {
+            searchPath = "classpath*:/" +searchPath;
+        }
         searchPath = searchPath.replace("\\", "/");
-        searchPath = searchPath.replaceAll("classpath\\*?:", "");
-        searchPath = "/" + searchPath;
         searchPath = searchPath.replaceAll("//+", "/");
-
-        searchPath = "classpath*:" + searchPath;
 
         return searchPath;
     }

--- a/liquibase-core/src/test/groovy/liquibase/integration/spring/SpringResourceAccessorTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/integration/spring/SpringResourceAccessorTest.groovy
@@ -91,7 +91,7 @@ class SpringResourceAccessorTest extends Specification {
         "classpath:classpath:/path/to/file" | "classpath*:/path/to/file"
         "classpath*:/path/to/file" | "classpath*:/path/to/file"
         "classpath*:path/to/file" | "classpath*:/path/to/file"
-
+        "file:/path/to/file" | "file:/path/to/file"
     }
 
 


### PR DESCRIPTION
Ensure that SpringResourceAccessor uses classpath* protocol for loading resources if no other protocol is given.
- no protocol -> classpath*:
- classpath:  -> classpath*:
- classpath*: -> classpath*:
- file:       -> file:

<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->
## Environment

**Liquibase Version**:

4.2.0

**Liquibase Integration & Version**: <Pick one: CLI, maven, gradle, spring boot, servlet, etc.>

maven

**Liquibase Extension(s) & Version**: 

none

**Database Vendor & Version**:

none

**Operating System Type & Version**:

Windows 11

## Pull Request Type

<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->
- [ x] Bug fix (non-breaking change which fixes an issue.)
- [ ] Enhancement/New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

A clear and concise description of the issue being addressed.  Additional guidance [here](https://liquibase.jira.com/wiki/spaces/LB/pages/1274904896/How+to+Contribute+Code+to+Liquibase+Core).

As described in #1540 it is not possible to provide changelogs from outside classpath. All locations will be searched on classpath only, even if a file protocol is provided. File protocol is used when database changelogs are handled outside the running applications as installation procedure is separated from deployment. So providing file protocol should be possible.

## Steps To Reproduce

List the steps to reproduce the behavior.

Just specify changelog location with file protocol.

## Actual Behavior

Location is changed to point to classpath.

## Expected/Desired Behavior

When file protocol is given, this should remain unchanged.

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->
- [x ] Build is successful and all new and existing tests pass
- [ x] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
- [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
- [ ] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls)
- [ ] Documentation Updated

## Need Help?

