### PR TITLE
instruct surefire to read files with UTF-8 encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -308,6 +308,7 @@
                 </dependencies>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
This fixes test failures when running through maven on Windows.

See:
- https://stackoverflow.com/questions/17656475/maven-source-encoding-in-utf-8-not-working
- https://issues.apache.org/jira/browse/SUREFIRE-951