### PR TITLE
MSSQL: Throw validation error if "ordered" is specified in createSequence/alterSequence

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AlterSequenceGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/AlterSequenceGenerator.java
@@ -33,7 +33,7 @@ public class AlterSequenceGenerator extends AbstractSqlGenerator<AlterSequenceSt
             validationErrors.checkDisallowedField("minValue", alterSequenceStatement.getMinValue(), database, H2Database.class);
         }
 
-        validationErrors.checkDisallowedField("ordered", alterSequenceStatement.getOrdered(), database, HsqlDatabase.class, DB2Database.class);
+        validationErrors.checkDisallowedField("ordered", alterSequenceStatement.getOrdered(), database, HsqlDatabase.class, DB2Database.class, MSSQLDatabase.class);
         validationErrors.checkDisallowedField("dataType", alterSequenceStatement.getDataType(), database, DB2Database.class, HsqlDatabase.class, OracleDatabase.class, MySQLDatabase.class, MSSQLDatabase.class);
         validationErrors.checkRequiredField("sequenceName", alterSequenceStatement.getSequenceName());
 

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateSequenceGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateSequenceGenerator.java
@@ -42,7 +42,7 @@ public class CreateSequenceGenerator extends AbstractSqlGenerator<CreateSequence
             validationErrors.checkDisallowedField("AS", statement.getDataType(), database, PostgresDatabase.class);
         }
 
-        validationErrors.checkDisallowedField("ordered", statement.getOrdered(), database, HsqlDatabase.class, PostgresDatabase.class);
+        validationErrors.checkDisallowedField("ordered", statement.getOrdered(), database, HsqlDatabase.class, PostgresDatabase.class, MSSQLDatabase.class);
         validationErrors.checkDisallowedField("dataType", statement.getDataType(), database, DB2Database.class, HsqlDatabase.class, OracleDatabase.class, MySQLDatabase.class, MSSQLDatabase.class, CockroachDatabase.class);
 
         if (database instanceof H2Database && statement.getDataType() != null && !statement.getDataType().equalsIgnoreCase("bigint")) {


### PR DESCRIPTION
## Description

SqlServer does not support an ordered/unordered clause in sequences and so Liquibase should throw a validation error if the user attempts to specify it in either createSequence or alterSequence.

https://docs.microsoft.com/en-us/sql/t-sql/statements/create-sequence-transact-sql?view=sql-server-ver15

Fixes #2528