### PR TITLE
CockroachDatabase: Limit calls to version()

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/CockroachDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/CockroachDatabase.java
@@ -32,17 +32,20 @@ public class CockroachDatabase extends PostgresDatabase {
 
     @Override
     public boolean isCorrectDatabaseImplementation(DatabaseConnection conn) throws DatabaseException {
-        if (conn instanceof JdbcConnection) {
-            try (Statement stmt = ((JdbcConnection) conn).createStatement()) {
-                if (stmt != null) {
-                    try (ResultSet rs = stmt.executeQuery("select version()")) {
-                        if (rs.next()) {
-                            return ((String) JdbcUtil.getResultSetValue(rs, 1)).startsWith("CockroachDB");
+        final String url = conn.getURL();
+        if (url.startsWith("jdbc:postgres") || url.startsWith("postgres")) {
+            if (conn instanceof JdbcConnection) {
+                try (Statement stmt = ((JdbcConnection) conn).createStatement()) {
+                    if (stmt != null) {
+                        try (ResultSet rs = stmt.executeQuery("select version()")) {
+                            if (rs.next()) {
+                                return ((String) JdbcUtil.getResultSetValue(rs, 1)).startsWith("CockroachDB");
+                            }
                         }
                     }
+                } catch (SQLException throwables) {
+                    return false;
                 }
-            } catch (SQLException throwables) {
-                return false;
             }
         }
 

--- a/liquibase-core/src/main/java/liquibase/database/core/PostgresDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/PostgresDatabase.java
@@ -388,22 +388,4 @@ public class PostgresDatabase extends AbstractJdbcDatabase {
     public CatalogAndSchema.CatalogAndSchemaCase getSchemaAndCatalogCase() {
         return CatalogAndSchema.CatalogAndSchemaCase.LOWER_CASE;
     }
-
-    public String getDatabaseFullVersion() throws DatabaseException {
-        if (getConnection() == null) {
-            throw new DatabaseException("Connection not set. Can not get database version. " +
-                    "Postgres Database wasn't initialized in proper way !");
-        }
-        if (dbFullVersion != null){
-            return dbFullVersion;
-        }
-        final String sqlToGetVersion = "SELECT version()";
-        List<?> result = Scope.getCurrentScope().getSingleton(ExecutorService.class).
-                getExecutor("jdbc", this).queryForList(new RawSqlStatement(sqlToGetVersion), String.class);
-        if (result != null && !result.isEmpty()){
-            return dbFullVersion = result.get(0).toString();
-        }
-
-        throw new DatabaseException("Connection set to Postgres type we don't support !");
-    }
 }


### PR DESCRIPTION
## Description

Rather than making a likely invalid SQL call to `select version()` regardless of the connection to determine if it's a cockroachdb database, first check that the URL looks like a cockroachdb database before checking whether it is or not.

Checking for both `jdbc:postgres:` and `postgres:` without the `:` to also support `jdbc:postgresql:` and `postgresql:` based on https://www.cockroachlabs.com/docs/stable/connection-parameters.html#connect-using-a-url

Fixes #2483 



