### PR TITLE
Fix release-extensions.yml action to use github.rest, like the upgraded github-script v6 requires

### DIFF
--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -43,7 +43,7 @@ jobs:
           script: |
             console.log("Sending liquibase-release event to liquibase/${{ matrix.extension }}");
 
-            await github.repos.createDispatchEvent({
+            await github.rest.repos.createDispatchEvent({
                "owner": "liquibase",
                "repo": "${{ matrix.extension }}",
                "event_type": "liquibase-release",


### PR DESCRIPTION
<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->
## Environment

**Liquibase Version**:v.4.8.0

**Liquibase Integration & Version**: NA

**Liquibase Extension(s) & Version**: NA

**Database Vendor & Version**: All

**Operating System Type & Version**:NA

## Pull Request Type

<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->
- [x] Bug fix (non-breaking change which fixes an issue.)
- [ ] Enhancement/New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Changed gh-action for v6. 
Breaking change with rest api from v4 to v6 in github-script actions.
https://github.com/actions/github-script#breaking-changes-in-v5


## Steps To Reproduce

Run Release version action with out this change.
Error createDispatchEvent 
```
TypeError: Cannot read properties of undefined (reading 'createDispatchEvent')
Error: Unhandled error: TypeError: Cannot read properties of undefined (reading 'createDispatchEvent')
    at eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v6/dist/index.js:4797:16), <anonymous>:5:20)
    at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v6/dist/index.js:4798:12)
    at main (/home/runner/work/_actions/actions/github-script/v6/dist/index.js:4852:26)
    at Module.272 (/home/runner/work/_actions/actions/github-script/v6/dist/index.js:4836:1)
    at __webpack_require__ (/home/runner/work/_actions/actions/github-script/v6/dist/index.js:24:31)
    at startup (/home/runner/work/_actions/actions/github-script/v6/dist/index.js:43:19)
    at /home/runner/work/_actions/actions/github-script/v6/dist/index.js:49:18
    at Object.<anonymous> (/home/runner/work/_actions/actions/github-script/v6/dist/index.js:52:10)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
```
## Actual Behavior
Error shown above

## Expected/Desired Behavior
release-extensions works seemlessly.

## Screenshots (if appropriate)
If applicable, add screenshots to help explain your problem.

## Additional Context
Add any other context about the problem here.

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->
- [x] Build is successful and all new and existing tests pass
- [ ] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
- [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
- [ ] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls)
- [ ] Documentation Updated

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)
