### PR TITLE
Make FormattedSqlChangeLogParser reusable

### DIFF
--- a/liquibase-core/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
@@ -31,7 +31,7 @@ public class FormattedSqlChangeLogParser implements ChangeLogParser {
     public boolean supports(String changeLogFile, ResourceAccessor resourceAccessor) {
         BufferedReader reader = null;
         try {
-            if (supportExtension(changeLogFile)) {
+            if (supportsExtension(changeLogFile)) {
                 InputStream fileStream = openChangeLogFile(changeLogFile, resourceAccessor);
                 if (fileStream == null) {
                     return false;


### PR DESCRIPTION
## Description

Currently the FormattedSqlChangeLogParser's `supports()` method is hard-coded to only support files that end in `.sql`. This makes it difficult for extensions to subclass to leverage the logic in FormattedSqlChangeLogParser but use a different extension. In this case, to have use formatted *.cypher files for neo4j