### PR TITLE
Add logic to Derby.getDefaultDriver() to check for availability of different driver classes

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/DerbyDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/DerbyDatabase.java
@@ -43,27 +43,28 @@ public class DerbyDatabase extends AbstractJdbcDatabase {
         if (url == null) {
             return null;
         } else if (url.toLowerCase().startsWith("jdbc:derby://")) {
-                //Derby client driver class name for versions 10.15.X.X and above.
-                String derbyNewDriverClassName = "org.apache.derby.client.ClientAutoloadedDriver";
-                //Derby client driver class name for versions below 10.15.X.X.
-                String derbyOldDriverClassName = "org.apache.derby.jdbc.ClientDriver";
+            //Derby client driver class name for versions 10.15.X.X and above.
+            String derbyNewDriverClassName = "org.apache.derby.client.ClientAutoloadedDriver";
+            //Derby client driver class name for versions below 10.15.X.X.
+            String derbyOldDriverClassName = "org.apache.derby.jdbc.ClientDriver";
+            try {
+                // Check if we have a driver for versions 10.15.X.X and above. Load and return it if we do.
+                Class.forName(derbyNewDriverClassName);
+                return derbyNewDriverClassName;
+            } catch (ClassNotFoundException exception) {
+                // Check if we have a driver for versions below 10.15.X.X. Load and return it if we do.
                 try {
-                    // Check if we have a driver for versions 10.15.X.X and above. Load and return it if we do.
-                    Class.forName(derbyNewDriverClassName);
+                    Class.forName(derbyOldDriverClassName);
+                    return derbyOldDriverClassName;
+                } catch (ClassNotFoundException classNotFoundException) {
+                    // Return class for newer versions anyway
                     return derbyNewDriverClassName;
-                } catch (ClassNotFoundException exception) {
-                    // Check if we have a driver for versions below 10.15.X.X. Load and return it if we do.
-                    try {
-                        Class.forName(derbyOldDriverClassName);
-                        return derbyOldDriverClassName;
-                    } catch (ClassNotFoundException classNotFoundException) {
-                        // Return class for newer versions anyway
-                        return derbyNewDriverClassName;
-                    }
                 }
-            } else if (url.startsWith("jdbc:derby") || url.startsWith("java:derby")) {
-                return "org.apache.derby.jdbc.EmbeddedDriver";
             }
+        } else if (url.startsWith("jdbc:derby") || url.startsWith("java:derby")) {
+            //Use EmbeddedDriver if using a derby URL but without the `://` in it
+            return "org.apache.derby.jdbc.EmbeddedDriver";
+        }
         return null;
     }
 
@@ -133,10 +134,10 @@ public class DerbyDatabase extends AbstractJdbcDatabase {
             String dateString = super.getDateLiteral(isoDate);
             int decimalDigits = dateString.length() - dateString.indexOf('.') - 2;
             String padding = "";
-            for (int i=6; i> decimalDigits; i--) {
+            for (int i = 6; i > decimalDigits; i--) {
                 padding += "0";
             }
-            return "TIMESTAMP(" + dateString.replaceFirst("'$", padding+"'") + ")";
+            return "TIMESTAMP(" + dateString.replaceFirst("'$", padding + "'") + ")";
         }
     }
 
@@ -167,7 +168,7 @@ public class DerbyDatabase extends AbstractJdbcDatabase {
             } else {
                 url += ";shutdown=true";
             }
-                Scope.getCurrentScope().getLog(getClass()).info("Shutting down derby connection: " + url);
+            Scope.getCurrentScope().getLog(getClass()).info("Shutting down derby connection: " + url);
             // this cleans up the lock files in the embedded derby database folder
             JdbcConnection connection = (JdbcConnection) getConnection();
             ClassLoader classLoader = connection.getWrappedConnection().getClass().getClassLoader();
@@ -193,7 +194,7 @@ public class DerbyDatabase extends AbstractJdbcDatabase {
     /**
      * Determine Apache Derby driver major/minor version.
      */
-    @SuppressWarnings({ "static-access", "unchecked" })
+    @SuppressWarnings({"static-access", "unchecked"})
     protected void determineDriverVersion() {
         try {
 // Locate the Derby sysinfo class and query its version info
@@ -241,7 +242,7 @@ public class DerbyDatabase extends AbstractJdbcDatabase {
         }
         try {
             return (this.getDatabaseMajorVersion() > 10) || ((this.getDatabaseMajorVersion() == 10) && (this
-                .getDatabaseMinorVersion() > 7));
+                    .getDatabaseMinorVersion() > 7));
         } catch (DatabaseException e) {
             return false; //assume not
         }


### PR DESCRIPTION
## Description

Newer versions of derby use a new driver name, and the old driver is no longer available.

Fix for Derby getDefaultDriver() method to load appropriate driver classes based on db version. 


Fixes #1835