### PR TITLE
Remove disruptive and superfluous Exception declaration from ClassLoaderResourceAccessor.close()

### DIFF
--- a/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
@@ -357,7 +357,7 @@ public class ClassLoaderResourceAccessor extends AbstractResourceAccessor implem
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() {
         if (rootPaths != null) {
             for (final FileSystem rootPath : rootPaths) {
                 try {


### PR DESCRIPTION
## Environment

**Liquibase Version**: 4.8.0

**Liquibase Integration & Version**: Maven, Quarkus

## Pull Request Type

- [x] Bug fix (non-breaking change which fixes an issue.)
- [ ] Enhancement/New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

The method handles IOException internally and there is no other checked exception, so `throws Exception` really shouldn't be there, as it forces callers to add bogus exception handling.

## Steps To Reproduce

not relevant

## Actual Behavior

n/a

## Expected/Desired Behavior

n/a

## Screenshots (if appropriate)

n/a

## Additional Context

I'm currently adding calls to this new method to the Quarkus extensions, which is when I found this issue.