### PR TITLE
Reset the ranChangesets cache if we know there were changes to the da…

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
@@ -286,6 +286,11 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
                     " " + getDatabase().getShortName() + " when checking databasechangelog table");
             }
         }
+
+        if (statementsToExecute.size() > 0) {
+            //reset the cache if there was a change to the table. Especially catches things like md5 changes which might have been updated but would still be wrong in the cache
+            this.ranChangeSetList = null;
+        }
         serviceInitialized = true;
     }
 


### PR DESCRIPTION
## Description

Fixes #2580 by resetting the ranChangesets cache if we know there were changes to the databasechangelog table (including checksum clearing) in the init() logic.