### PR TITLE
Support "double precision" type in mysql

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/DoubleType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/DoubleType.java
@@ -6,6 +6,9 @@ import liquibase.database.core.*;
 import liquibase.datatype.DataTypeInfo;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.LiquibaseDataType;
+import liquibase.util.StringUtil;
+
+import java.util.Locale;
 
 @DataTypeInfo(name="double", aliases = {"java.sql.Types.DOUBLE", "java.lang.Double"}, minParameters = 0, maxParameters = 2, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class DoubleType  extends LiquibaseDataType {
@@ -16,13 +19,21 @@ public class DoubleType  extends LiquibaseDataType {
         }
         if (database instanceof MySQLDatabase) {
             DatabaseDataType datatype;
-            if ((getParameters() != null) && (getParameters().length > 1)) {
-                datatype = new DatabaseDataType("DOUBLE", getParameters());
-            } else {
-                datatype = new DatabaseDataType("DOUBLE");
+            String additionalInfo = StringUtil.trimToEmpty(getAdditionalInformation()).toUpperCase(Locale.US);
+            String name = "DOUBLE";
+            if (additionalInfo.contains("PRECISION")) {
+                name += " PRECISION";
+                additionalInfo = additionalInfo.replace("PRECISION", "");
             }
 
-            datatype.addAdditionalInformation(getAdditionalInformation());
+            if ((getParameters() != null) && (getParameters().length > 1)) {
+                datatype = new DatabaseDataType(name, getParameters());
+            } else {
+                datatype = new DatabaseDataType(name);
+            }
+
+            additionalInfo = additionalInfo.replaceAll("\\s+", " ");
+            datatype.addAdditionalInformation(StringUtil.trimToNull(additionalInfo));
             return datatype;
         }
         if ((database instanceof AbstractDb2Database) || (database instanceof DerbyDatabase) || (database instanceof HsqlDatabase)) {

--- a/liquibase-core/src/test/groovy/liquibase/datatype/core/DoubleTypeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/core/DoubleTypeTest.groovy
@@ -1,35 +1,39 @@
 package liquibase.datatype.core
 
 import liquibase.database.core.*
+import liquibase.datatype.DataTypeFactory
 import liquibase.exception.UnexpectedLiquibaseException
-import liquibase.database.core.MockDatabase
 import spock.lang.Specification
 import spock.lang.Unroll
 
 class DoubleTypeTest extends Specification {
 
     @Unroll
-    def "toDatabaseType"() {
+    def "toDatabaseType '#input' on #database.shortName"() {
         when:
-        def type = new DoubleType()
-        for (param in params) {
-            type.addParameter(param)
-        }
+        def type = DataTypeFactory.getInstance().fromDescription(input, database)
 
         then:
+        type instanceof DoubleType
         type.toDatabaseDataType(database).toString() == expected
 
         where:
-        params | database               | expected
-        [22]   | new MySQLDatabase()    | "DOUBLE"
-        [7, 3] | new MySQLDatabase()    | "DOUBLE(7, 3)"
-        [22]   | new DB2Database()      | "DOUBLE"
-        [22]   | new DerbyDatabase()    | "DOUBLE"
-        [22]   | new HsqlDatabase()     | "DOUBLE"
-        [22]   | new MSSQLDatabase()    | "float(53)"
-        [22]   | new PostgresDatabase() | "DOUBLE PRECISION"
-        [22]   | new InformixDatabase() | "DOUBLE PRECISION"
-        []     | new OracleDatabase()   | "FLOAT(24)"
+        input                            | database               | expected
+        "double(22)"                     | new MySQLDatabase()    | "DOUBLE"
+        "double(7,3)"                    | new MySQLDatabase()    | "DOUBLE(7, 3)"
+        "double precision(7,3)"          | new MySQLDatabase()    | "DOUBLE PRECISION(7, 3)"
+        "double(7,3) unsigned"           | new MySQLDatabase()    | "DOUBLE(7, 3) UNSIGNED"
+        "double precision(7,3) unsigned" | new MySQLDatabase()    | "DOUBLE PRECISION(7, 3) UNSIGNED"
+        "double"                         | new DB2Database()      | "DOUBLE"
+        "double"                         | new DerbyDatabase()    | "DOUBLE"
+        "double"                         | new HsqlDatabase()     | "DOUBLE"
+        "double"                         | new H2Database()       | "DOUBLE"
+        "double precision"               | new H2Database()       | "DOUBLE PRECISION"
+        "double"                         | new MSSQLDatabase()    | "float(53)"
+        "double"                         | new PostgresDatabase() | "DOUBLE PRECISION"
+        "double"                         | new InformixDatabase() | "DOUBLE PRECISION"
+        "double"                         | new FirebirdDatabase() | "DOUBLE PRECISION"
+        "double"                         | new OracleDatabase()   | "FLOAT(24)"
     }
 
     def "too many parameters"() {


### PR DESCRIPTION
## Description

Added handling for "double precision" which is a distinct type in mysql vs. just "double" https://dev.mysql.com/doc/refman/8.0/en/numeric-type-syntax.html

Fixes #2337 