### PR TITLE
Added test-reporter action

### DIFF
--- a/.github/workflows/build-test-report.yml
+++ b/.github/workflows/build-test-report.yml
@@ -1,0 +1,18 @@
+name: 'Test Report'
+on:
+  workflow_run:
+    workflows: ['Build and Test'] # runs after build.yml workflow
+    types:
+      - completed
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dorny/test-reporter@v1
+        with:
+          artifact: /liquibase-test-results-(.*)/
+          name: "Test Results: "
+          path: '**/*.xml'
+          reporter: java-junit
+          only-summary: 'false'
+


### PR DESCRIPTION
## Description

Added https://github.com/dorny/test-reporter as an extra step in the build process. 

We are wanting to more easily see:
- All tests that ran
- Any tests that failed
- Output from failed tests

which this seems to provide. 

I also looked at:
- https://github.com/marketplace/actions/publish-unit-test-results
- https://github.com/marketplace/actions/junit-report-action
But they didn't seem to meet our needs as well.
