### PR TITLE
enable 'includeAll' directive to work with liquibase resources provided in OSGi bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ original-pom.xml
 **/logback-test.xml
 **/*.swp
 **/dependency-reduced-pom.xml
+liquibase-core/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/
+.gradle/

--- a/liquibase-core/src/main/java/liquibase/resource/OSGiResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/OSGiResourceAccessor.java
@@ -1,11 +1,89 @@
 package liquibase.resource;
 
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.Enumeration;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import liquibase.Scope;
+import liquibase.resource.InputStreamList;
+import liquibase.resource.ResourceAccessor;
 import org.osgi.framework.Bundle;
-import org.osgi.framework.wiring.BundleWiring;
+import org.osgi.framework.FrameworkUtil;
 
-public class OSGiResourceAccessor extends ClassLoaderResourceAccessor {
+public class OSGiResourceAccessor implements ResourceAccessor {
 
-    public OSGiResourceAccessor(Bundle bundle) {
-        super(bundle.adapt(BundleWiring.class).getClassLoader());
+    private final Bundle bundle;
+    private static final String FORWARD_SLASH = "/";
+    private SortedSet<String> locations;
+
+    public OSGiResourceAccessor(Class resourcesBundle) {
+        bundle = FrameworkUtil.getBundle(resourcesBundle);
+    }
+
+    @Override
+    public InputStreamList openStreams(String relativeTo, String streamPath) throws IOException {
+        final Enumeration<URL> resources = bundle.getResources(getPath(relativeTo, streamPath));
+        InputStreamList inputStreamList = new InputStreamList();
+        while (resources != null && resources.hasMoreElements()) {
+            final URL url = resources.nextElement();
+            try {
+                inputStreamList.add(url.toURI(), url.openStream());
+            } catch (URISyntaxException e) {
+                Scope.getCurrentScope().getLog(getClass()).severe(String.format("Failed to convert URL %s to URI", url), e);
+            }
+        }
+        return inputStreamList;
+    }
+
+    @Override
+    public InputStream openStream(String relativeTo, String streamPath) throws IOException {
+        return bundle.getResource(getPath(relativeTo, streamPath)).openStream();
+    }
+
+    private String getPath(String relativeTo, String streamPath) {
+        StringBuilder path = new StringBuilder();
+
+        if (relativeTo != null) {
+            final URL resource = bundle.getResource(relativeTo);
+            if (resource != null) {
+                path.append(Paths.get(resource.getFile()).getParent());
+            }
+        }
+        path.append(streamPath);
+        return path.toString();
+    }
+
+    @Override
+    public SortedSet<String> list(String relativeTo, String path, boolean recursive, boolean includeFiles, boolean includeDirectories) throws IOException {
+        final Enumeration<URL> resources = bundle.findEntries(getPath(relativeTo, path), null, recursive);
+        SortedSet<String> list = new TreeSet<String>(){{add(FORWARD_SLASH);}};
+        while (resources != null && resources.hasMoreElements()) {
+            final URL url = resources.nextElement();
+            final String filePath = url.getFile();
+            if (includeFiles) {
+                list.add(filePath);
+            } else if (filePath.endsWith(FORWARD_SLASH)) {
+                list.add(filePath);
+            }
+        }
+        return list;
+    }
+
+    @Override
+    public SortedSet<String> describeLocations() {
+        try {
+            if (locations == null) {
+                locations = list(null, FORWARD_SLASH, true, false, true);
+            }
+            return locations;
+        } catch (IOException e) {
+            Scope.getCurrentScope().getLog(getClass()).severe("Failed to list all locations", e);
+            return new TreeSet<>();
+        }
     }
 }


### PR DESCRIPTION
<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->
## Environment

**Liquibase Version**: 4.4.0

**Liquibase Integration & Version**: liquibase-core 4.4.0 as a bundle in Apache Felix OSGi container, Liferay portal 7.4

**Liquibase Extension(s) & Version**: 

**Database Vendor & Version**: Postgresql 11.4

**Operating System Type & Version**: Linux

## Pull Request Type

<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->
- [ ] Bug fix (non-breaking change which fixes an issue.)
- [x] Enhancement/New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

I've succesfully used `liquibase-core` deployed as a bundle to Liferay Portal. Another sibling bundle provided `changelog.xml` together with BundleActivator code which executed the `changelog.xml` just fine.

I wanted to organize migration steps in separate files under a directory and used `includeAll` `changelog.xml` directive. The executor code however haven't found any of the migration files except for the entrypoint `changelog.xml` in which `includeAll` directive was declared.

`BundleActivator.java`:
```java
        ...
        ResourceAccessor resourceAccessor = new OSGIResourceAccessor(BundleActivator.class);
        try (Liquibase liquibase = new Liquibase("changelog.xml", resourceAccessor, database)) {
            LockServiceFactory.reset();
            liquibase.update(new Contexts());
        }
        ...
```

The pull requests contains modification of existing `OSGiResourceAccessor` class so that it supports traversing of an OSGi bundle directory structure which provides entrypoint `changelog.xml` and migration resources/paths declared in it.

## Steps To Reproduce

1. Prepare OSGi bundle with following `changelog.xml` resource:
```xml
<?xml version="1.0" encoding="UTF-8"?>

<databaseChangeLog
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">

    <includeAll path="steps/" relativeToChangelogFile="true"/>

</databaseChangeLog>
```
2. Add migration step `steps/0001-init.xml`:

```xml
<?xml version="1.0" encoding="UTF-8"?>

<databaseChangeLog
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">

    <changeSet id="1_add-initial-schema" author="ktor">
        <createTable tableName="test">
            <column name="id" type="uuid">
                <constraints primaryKey="true" nullable="false"/>
            </column>
        </createTable>
    </changeSet>
</databaseChangeLog>
```

## Actual Behavior
`changelog.xml` is read however no resources in `steps/` bundle directory are loaded. 

## Expected/Desired Behavior
`changelog.xml` is read and resources in `steps/` bundle directory are loaded. 

## Screenshots (if appropriate)
n/a

## Additional Context
n/a

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->
- [x] Build is successful and all new and existing tests pass
- [ ] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
- [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
- [ ] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls)
- [ ] Documentation Updated

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)
