### PR TITLE
Fix getting ENUM column values from Mysql database having multiple schemas

### DIFF
--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
@@ -507,6 +507,7 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
                     // SET
                     boilerLength = "6";
                 }
+
                 List<String> enumValues = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database).queryForList(
                         new RawSqlStatement(
                                 "SELECT DISTINCT SUBSTRING_INDEX(SUBSTRING_INDEX(SUBSTRING(COLUMN_TYPE, " + boilerLength +
@@ -517,7 +518,8 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
                                         "UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) units\n" +
                                         "CROSS JOIN (SELECT 0 AS i UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 " +
                                         "UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) tens\n" +
-                                        "WHERE TABLE_NAME = '" + column.getRelation().getName() + "' \n" +
+                                        "WHERE TABLE_SCHEMA = '" + column.getSchema().getName() + "' \n" +
+                                        "AND TABLE_NAME = '" + column.getRelation().getName() + "' \n" +
                                         "AND COLUMN_NAME = '" + column.getName() + "'"), String.class);
                 String enumClause = "";
                 for (String enumValue : enumValues) {


### PR DESCRIPTION
Fix getting ENUM column values from Mysql database having multiple schemas with same table name and column name.

<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->
## Environment

**Liquibase Version**: 4.8.0 (PR is from Master branch)

**Liquibase Integration & Version**: Maven

**Liquibase Extension(s) & Version**: NA

**Database Vendor & Version**: MySQL

**Operating System Type & Version**: Mac

## Pull Request Type

<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->
- [x] Bug fix (non-breaking change which fixes an issue.)
- [ ] Enhancement/New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
In MySQL, if DB has 2 schemas say db1 and db2.  If both db1 and db2 have a table with the same name, stay example_table.  And if table in both schemas has a column with same name (say example_column) of type ENUM with different ENUM values, generate-changelog on db1 (or db2) returns a union of values from db1.example_table.example_column and db2.example_table.example_column.

This PR fixes it by adding a check on TABLE_SCHEMA in the where clause to retrieve ENUM values.

## Steps To Reproduce

1. In a MySQL instance, create 2 schemas - say db1 and db2. 
2. In both schemas, have a table with the same name (say example_table) with a column with the same name (say example_column).  Column should be of type 

```
CREATE TABLE db1.example_table (example_column ENUM('enum1', 'enum2') NOT NULL);
CREATE TABLE db2.example_table (example_column ENUM('enum3', 'enum4') NOT NULL);
```

Now if you run liquibase to generate the changelog for either of db1 or db2, it shows ENUM values for the column from both db1 and db2.

```
$ liquibase generate-changelog --username=*** --password=***  --url=jdbc:mysql://localhost:3306/db1 --changeLogFile=db1_changelog.mysql.sql 

# This generates changes as below.
-- changeset akatiyar:1646776634455-11
CREATE TABLE db1.example_table (example_column ENUM('enum1', 'enum2', 'enum3', 'enum4') NOT NULL);

```

## Actual Behavior
See Steps To Reproduce section above.

## Expected/Desired Behavior
See Steps To Reproduce section above.

## Screenshots (if appropriate)
If applicable, add screenshots to help explain your problem.

## Additional Context
Add any other context about the problem here.

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->
- [x] Build is successful and all new and existing tests pass
- [ ] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
- [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
- [ ] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls)
- [ ] Documentation Updated

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)
