### PR TITLE
Fixed NullPointerException in SecureLogFilter.isLoggable

### DIFF
--- a/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
+++ b/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
@@ -1052,7 +1052,7 @@ public class LiquibaseCommandLine {
         public boolean isLoggable(LogRecord record) {
             final String filteredMessage = filter.filterMessage(record.getMessage());
 
-            final boolean equals = filteredMessage.equals(record.getMessage());
+            final boolean equals = filteredMessage != null && filteredMessage.equals(record.getMessage());
             return equals;
         }
     }

--- a/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineTest.groovy
+++ b/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineTest.groovy
@@ -3,9 +3,11 @@ package liquibase.integration.commandline
 
 import liquibase.command.CommandBuilder
 import liquibase.configuration.ConfigurationDefinition
-import picocli.CommandLine
+import liquibase.logging.LogMessageFilter
 import spock.lang.Specification
 import spock.lang.Unroll
+
+import java.util.logging.LogRecord
 
 class LiquibaseCommandLineTest extends Specification {
 
@@ -73,5 +75,21 @@ class LiquibaseCommandLineTest extends Specification {
         then:
         subcommands["update"].commandSpec.findOption("-D") != null
         subcommands["snapshot"].commandSpec.findOption("-D") == null
+    }
+
+    @Unroll
+    def "SecureLogFilter with null log message"() {
+        setup:
+        LogMessageFilter mockFilter = Mock()
+        LogRecord mockLogRecord = Mock()
+        LiquibaseCommandLine.SecureLogFilter secureLogFilter = new LiquibaseCommandLine.SecureLogFilter(mockFilter)
+
+        when:
+        mockFilter.filterMessage(null) >> null
+        mockLogRecord.getMessage() >> null
+        secureLogFilter.isLoggable(mockLogRecord)
+
+        then:
+        noExceptionThrown()
     }
 }

--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -2242,7 +2242,7 @@ public class Main {
         public boolean isLoggable(LogRecord record) {
             final String filteredMessage = filter.filterMessage(record.getMessage());
 
-            final boolean equals = filteredMessage.equals(record.getMessage());
+            final boolean equals = filteredMessage != null && filteredMessage.equals(record.getMessage());
             return equals;
         }
     }

--- a/liquibase-core/src/main/java/liquibase/logging/core/DefaultLogMessageFilter.java
+++ b/liquibase-core/src/main/java/liquibase/logging/core/DefaultLogMessageFilter.java
@@ -11,7 +11,7 @@ public class DefaultLogMessageFilter implements LogMessageFilter {
         if (HubConfiguration.LIQUIBASE_HUB_API_KEY != null) {
             liquibaseHubApiKey = HubConfiguration.LIQUIBASE_HUB_API_KEY.getCurrentValue();
         }
-        if (liquibaseHubApiKey != null) {
+        if (liquibaseHubApiKey != null && message != null) {
             message = message.replace(liquibaseHubApiKey, HubConfiguration.LIQUIBASE_HUB_API_KEY.getCurrentValueObfuscated());
         }
 

--- a/liquibase-core/src/test/java/liquibase/integration/commandline/MainTest.java
+++ b/liquibase-core/src/test/java/liquibase/integration/commandline/MainTest.java
@@ -1,8 +1,8 @@
 package liquibase.integration.commandline;
 
-import liquibase.GlobalConfiguration;
 import liquibase.Scope;
 import liquibase.exception.CommandLineParsingException;
+import liquibase.logging.LogMessageFilter;
 import liquibase.util.StringUtil;
 import org.junit.Assert;
 import org.junit.Test;
@@ -14,8 +14,11 @@ import java.util.List;
 import java.io.*;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.logging.LogRecord;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 
 /**
@@ -121,6 +124,17 @@ public class MainTest {
 //            ("local-context-for-liquibase-unit-tests")));
         assertTrue("Read context from liquibase.properties", ((cli.logFile != null) && ("target" +
             "/logfile_set_from_liquibase_properties.log").equals(cli.logFile)));
+    }
+
+    @Test
+    public void testSecureLogFilterForNullLogMessage() throws Exception {
+        LogMessageFilter mockFilter = mock(LogMessageFilter.class);
+        when(mockFilter.filterMessage(null)).thenReturn(null);
+        Main.SecureLogFilter secureLogFilter = new Main.SecureLogFilter(mockFilter);
+
+        LogRecord mockLogRecord = mock(LogRecord.class);
+        when(mockLogRecord.getMessage()).thenReturn(null);
+        assertFalse(secureLogFilter.isLoggable(mockLogRecord));
     }
 
     @Test


### PR DESCRIPTION
<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->
## Environment

**Liquibase Version**: 4.8.0

**Liquibase Integration & Version**: CLI

**Liquibase Extension(s) & Version**: none

**Database Vendor & Version**: I don't think it matters, but I tested with Postgres 12

**Operating System Type & Version**: all (I tested on Fedora35)

## Pull Request Type

<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->
- [x] Bug fix (non-breaking change which fixes an issue.)
- [ ] Enhancement/New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Fixes #1858

## Steps To Reproduce

List the steps to reproduce the behavior.
- Create a changelog.xml that uses a custom task (that implements `liquibase.change.custom.CustomTaskChange`).
- In the custom task, override the getConfirmationMessage method to return null:
```
    @Override
    public String getConfirmationMessage() {
        return null;
    }
```
- Run the 'update' command from the CLI, using either the `liquibase.integration.commandline.Main` or `liquibase.integration.commandline.LiquibaseCommandLine`, and setting the `--log-level=` argument (it's value doesn't matter, could be info/debug/whatever)

## Actual Behavior
The update fails. Here is the last part of the stacktrace:
```
Caused by: java.lang.NullPointerException
	at liquibase.integration.commandline.LiquibaseCommandLine$SecureLogFilter.isLoggable(LiquibaseCommandLine.java:1055)
	at java.logging/java.util.logging.Handler.isLoggable(Handler.java:346)
	at java.logging/java.util.logging.StreamHandler.isLoggable(StreamHandler.java:237)
	at java.logging/java.util.logging.StreamHandler.publish(StreamHandler.java:194)
	at java.logging/java.util.logging.ConsoleHandler.publish(ConsoleHandler.java:95)
	at java.logging/java.util.logging.Logger.log(Logger.java:979)
	at java.logging/java.util.logging.Logger.doLog(Logger.java:1006)
	at java.logging/java.util.logging.Logger.logp(Logger.java:1283)
	at liquibase.logging.core.JavaLogger.log(JavaLogger.java:30)
	at liquibase.logging.core.CompositeLogger.log(CompositeLogger.java:33)
	at liquibase.logging.core.CompositeLogger.log(CompositeLogger.java:33)
	at liquibase.logging.core.AbstractLogger.info(AbstractLogger.java:50)
	at liquibase.logging.core.AbstractLogger.info(AbstractLogger.java:45)
	at liquibase.changelog.ChangeSet.execute(ChangeSet.java:662)
	... 62 more
```

## Expected/Desired Behavior
The update should succeed.

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->
- [x] Build is successful and all new and existing tests pass
- [x] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
- [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
- [ ] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls)
- [ ] Documentation Updated

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)
