### PR TITLE
Fix start failure with Nullpointed exception when Environment contains empty string Key (fix Issue 2631)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,8 @@ If the `MANIFEST.MF` file is not the first entry, `java.util.jar.JarInputStream#
 
 [[PR#2643](https://github.com/liquibase/liquibase/pull/2643)] Fixed an issue in snapshot on PostgreSQL where non-integer datatypes that used a default value with a sequence would not be handled correctly [DAT-8670]
 
+[[PR#2691](https://github.com/liquibase/liquibase/pull/2691)] Fixed invalid JSON in the example-changelog.json file [DAT-9893]
+
 Changes in version 4.9.0 (2022.03.17)
 
 # Notable Changes

--- a/liquibase-core/src/test/groovy/liquibase/configuration/core/MapConfigurationValueProviderTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/configuration/core/MapConfigurationValueProviderTest.groovy
@@ -19,6 +19,15 @@ class MapConfigurationValueProviderTest extends Specification {
         provider.getProvidedValue("empty-property") == null
     }
 
+    def "null values count as not set"() {
+        when:
+        def provider = new MapConfigurationValueProvider(["null.property": null])
+
+        then:
+        provider.getProvidedValue("null.property") == null
+        provider.getProvidedValue("null-property") == null
+    }
+
     @Unroll
     def "keyMatches"() {
         expect:
@@ -42,6 +51,7 @@ class MapConfigurationValueProviderTest extends Specification {
         "parent.child"        | "parent"               | false
         "upper.kabob"         | "UPPER-KABOB"          | true
         "one.two.three"       | "one-two-three"        | true
+        "null-name"           | null                   | false
     }
 
     def "changing map values get picked up dispite caching"() {


### PR DESCRIPTION
Updated ordering of storedKey and wantedKey so String.equalsIgnoreCase won't be called on a null value if passed to AbstractMapConfigurationValueProvider

Updated keyMatches in CommandLineArgumentValueProvider to ensure that the store key is a string value before calling .replace won't be called on a null value

<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->
## Environment

**Liquibase Version**: 4.8.0

**Liquibase Integration & Version**: Maven

**Liquibase Extension(s) & Version**: 

**Database Vendor & Version**:hsqldb

**Operating System Type & Version**:macOS Monterey 12.2.1

## Pull Request Type

<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->
- [x] Bug fix (non-breaking change which fixes an issue.)
- [ ] Enhancement/New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

A clear and concise description of the issue being addressed.  Additional guidance [here](https://liquibase.jira.com/wiki/spaces/LB/pages/1274904896/How+to+Contribute+Code+to+Liquibase+Core).
When a system has a null or empty string key for an env var it causes liquibase fail the start of the application 

## Steps To Reproduce

List the steps to reproduce the behavior.
You can add an empty string key to your Env map at runtime 


## Actual Behavior
A clear and concise description of what happens in the software **before** this pull request.
Application fails with nullpointer

## Expected/Desired Behavior
Null or empty string values are handled correctly at start up 

## Screenshots (if appropriate)
To recreate 
<img width="1184" alt="Screen Shot 2022-03-11 at 5 56 32 PM" src="https://user-images.githubusercontent.com/43050244/157986182-986db631-065f-496e-8137-e9b0a9bc6c63.png">

Without my change
<img width="1884" alt="Screen Shot 2022-03-11 at 5 57 46 PM" src="https://user-images.githubusercontent.com/43050244/157986195-ad870b85-5353-4f5c-9bec-5153bf0edb36.png">

With my changes 
<img width="1898" alt="Screen Shot 2022-03-11 at 6 05 49 PM" src="https://user-images.githubusercontent.com/43050244/157986257-61a7fee9-39cb-4e90-9103-13a45c3a3ab3.png">


## Additional Context
Add any other context about the problem here.

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->
- [x] Build is successful and all new and existing tests pass
- [ ] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
- [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
- [ ] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls)
- [ ] Documentation Updated

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)
