### PR TITLE
Added a new conversion from NUMBER(1, 0) to BOOLEAN for Postgres when convert-data-types is set to true

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/NumberType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/NumberType.java
@@ -6,6 +6,7 @@ import liquibase.database.core.*;
 import liquibase.datatype.DataTypeInfo;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.LiquibaseDataType;
+import liquibase.GlobalConfiguration;
 
 import java.util.Arrays;
 
@@ -47,7 +48,11 @@ public class NumberType extends LiquibaseDataType {
                 return new DatabaseDataType("NUMBER", getParameters());
             }
         } else if (database instanceof PostgresDatabase) {
-            if ((getParameters().length > 0) && (Integer.parseInt(getParameters()[0].toString()) > 1000)) {
+            if (GlobalConfiguration.CONVERT_DATA_TYPES.getCurrentValue()){
+                if ((getParameters().length > 1) && "1".equals(getParameters()[0]) && "0".equals(getParameters()[1])) {
+                    return new DatabaseDataType("BOOLEAN");
+                }
+            } else if ((getParameters().length > 0) && (Integer.parseInt(getParameters()[0].toString()) > 1000)) {
                 return new DatabaseDataType("numeric");
             }
             return new DatabaseDataType("numeric", getParameters());


### PR DESCRIPTION
Added new conversion from NUMBER(1, 0) to BOOLEAN for Postgres when convert-data-types is true running against Postgres

## Environment
**Liquibase Version**: >3.9.0
**Liquibase Integration & Version**: CLI
**Database Vendor & Version**: PostgreSQL

**Operating System Type & Version**: Any

## Pull Request Type
- [ ] Bug fix (non-breaking change which fixes an issue.)
- [x] Enhancement/New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
This is a feature request to add the functionality to convert a data type NUMBER(1,0) to a BOOLEAN when deployed to a PostgreSQL database when the convert-data-types is set to true.
Here is the doc for convert-data-types for reference https://docs.liquibase.com/commands/config-ref/convert-data-types-parameter.html

This use-case introduced by the customer is that they previously ran the NUMBER(1,0) data type columns due to the lack of having a boolean data type in Oracle.  Now that they are transitioning away from Oracle to Postgres, they would like to use the same modeled changes and have Liquibase convert those NUMBER(1,0) Oracle data types to BOOLEAN Postgres data types.

## Steps To Reproduce
Run the following changeset against an Postgres database with convert-data-types=true
```xml
    <changeSet author="author" id="my_id">
        <createTable tableName="EMP">
            <column name="JOB_ID" type="VARCHAR2(10 BYTE)">
                <constraints nullable="false" primaryKey="true" primaryKeyName="JOB_ID_PK"/>
            </column>
            <column name="MIN_SALARY" type="NUMBER(6, 0)"/>
            <column name="MAX_SALARY" type="NUMBER(6, 0)"/>
            <column name="IS_EMPLOYED" type="NUMBER(1, 0)"/>
        </createTable>
    </changeSet>
```

## Actual Behavior
Currently the data types will remain the same since we do not have the functionality to convert NUMBER(1, 0) to BOOLEAN against PostgreSQL database. 

## Desired Behavior
The desired behavior is that the changeset should generate the following conversion from NUMBER(1, 0) to BOOLEAN against PostgreSQL database. 
```sql
-- Changeset mychangelog.xml::my_id::author
CREATE TABLE public.EMP (JOB_ID VARCHAR(10) NOT NULL, MIN_SALARY numeric(6, 0), MAX_SALARY numeric(6, 0), IS_EMPLOYED BOOLEAN, CONSTRAINT JOB_ID_PK PRIMARY KEY (JOB_ID));
```

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->
- [x] Build is successful and all new and existing tests pass
- [x] Documentation Updated to reflect the changes

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)
