### PR TITLE
Return null if DATABASECHANGELOG not present  in StandardChangeLogHistoryService.java changeLogTable = SnapshotGeneratorFactory.getInstance().getDatabaseChangeLogTable

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
@@ -116,7 +116,7 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
 
         boolean changeLogCreateAttempted = false;
         Executor executor = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database);
-        if (changeLogTable != null) {
+        if (changeLogTable != null && hasDatabaseChangeLogTable) {
             boolean hasDescription = changeLogTable.getColumn("DESCRIPTION") != null;
             boolean hasComments = changeLogTable.getColumn("COMMENTS") != null;
             boolean hasTag = changeLogTable.getColumn("TAG") != null;

--- a/liquibase-core/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
@@ -116,7 +116,7 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
 
         boolean changeLogCreateAttempted = false;
         Executor executor = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database);
-        if (changeLogTable != null && hasDatabaseChangeLogTable) {
+        if (changeLogTable != null && hasDatabaseChangeLogTable()) {
             boolean hasDescription = changeLogTable.getColumn("DESCRIPTION") != null;
             boolean hasComments = changeLogTable.getColumn("COMMENTS") != null;
             boolean hasTag = changeLogTable.getColumn("TAG") != null;


### PR DESCRIPTION
## Environment

**Liquibase Version**:4.9.x

**Liquibase Integration & Version**: CLI

**Liquibase Extension(s) & Version**: 

**Database Vendor & Version**:

**Operating System Type & Version**:

## Pull Request Type

<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->
- [x] Bug fix (non-breaking change which fixes an issue.)
- [ ] Enhancement/New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
The bug was there for the first run of the update command, In the case of first run the DATABASECHANGELOG table was not present in case of empty database. To avoid exception in SELECT query on line 245 we need to add check if that DATABASECHANGELOG is present or not.

## Steps To Reproduce

-Create empty database on snowflake.
-Add sample change set
-run liquibase update from command line

## Actual Behavior
It throws error:
`SEVERE [liquibase.integration] Unexpected error running Liquibase: SQL compilation error: Object 'DB.PUBLIC.DATABASECHANGELOG' does not exist or not authorized. liquibase.exception.DatabaseException: Error executing SQL SELECT MD5SUM FROM "PUBLIC".DATABASECHANGELOG WHERE MD5SUM IS NOT NULL: SQL compilation error: Object 'LPM_DEV.PUBLIC.DATABASECHANGELOG' does not exist or not authorized. at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:95) at liquibase.executor.jvm.JdbcExecutor.query(JdbcExecutor.java:163) at liquibase.executor.jvm.JdbcExecutor.query(JdbcExecutor.java:171) at liquibase.executor.jvm.JdbcExecutor.queryForList(JdbcExecutor.java:236) at liquibase.executor.jvm.JdbcExecutor.queryForList(JdbcExecutor.java:231) at liquibase.changelog.StandardChangeLogHistoryService.init(StandardChangeLogHistoryService.java:245) at liquibase.Liquibase.checkLiquibaseTables(Liquibase.java:1913)
`

## Expected/Desired Behavior
Update should work properly

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->
- [X ] Build is successful and all new and existing tests pass
- [ ] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
- [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
- [ ] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls)
- [ ] Documentation Updated

## Need Help?
Come chat with us on our [discord channel](https://discord.com/channels/700506481111597066/700506481572839505)
