### PR TITLE
Fix pull request reporting information collected by Sonar

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,7 +218,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn clean verify sonar:sonar -P sonar -Dsonar.login=$SONAR_TOKEN
+        run: mvn clean verify sonar:sonar -P sonar -Dsonar.login=$SONAR_TOKEN -Dsonar.pullrequest.key=${{ github.event.pull_request.number }} -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }} -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }}
 
   integration-test:
     name: Integration Test


### PR DESCRIPTION
## Description

The sonar integration does not support pull_request_target and considers them as being ran against master, which is not right.

This explicitly sets the needed settings for sonar