### PR TITLE
Fix code coverage metrics

### DIFF
--- a/.github/util/jacoco-aggregate.pom.xml
+++ b/.github/util/jacoco-aggregate.pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.liquibase</groupId>
+        <artifactId>liquibase</artifactId>
+        <version>0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>liquibase-aggregate</artifactId>
+
+</project>

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -306,8 +306,8 @@ jobs:
           rm -rf artifacts/*results-*macos-*
           rm -rf artifacts/*results-*windows-*
           
-          mkdir jacoco-aggregate
-          cp -r **/target/classes/* jacoco-aggregate/
+          mkdir -p jacoco-aggregate/target/classes
+          cp -r **/target/classes/* jacoco-aggregate/target/classes
           cp .github/util/jacoco-aggregate.pom.xml jacoco-aggregate/pom.xml
           
           (cd jacoco-aggregate && mvn jacoco:merge "-Djacoco.destFile=jacoco-aggregate.exec" "-Djacoco.fileSetDirectory=../artifacts" -Djacoco.fileSetInclude="**/target/jacoco/*.exec")

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,8 +173,8 @@ jobs:
       - name: Build & Test
         run: |
           mvn -B "-Dbuild.repository.owner=${{ needs.setup.outputs.thisRepositoryOwner }}" "-Dbuild.repository.name=${{ needs.setup.outputs.thisRepositoryName }}" "-Dbuild.branch=${{ needs.setup.outputs.thisBranchName }}" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=${{ needs.setup.outputs.thisSha }}" "-DtrimStackTrace=false" -pl '!liquibase-dist' jacoco:prepare-agent clean test package surefire-report:report
-          mvn -pl liquibase-core jacoco:merge -Djacoco.destFile="../target/jacoco/jacoco-aggregate.exec" -Djacoco.fileSetDirectory=".."
-          mvn -pl liquibase-core jacoco:report -Djacoco.dataFile="../target/jacoco/jacoco-aggregate.exec"  -Djacoco.outputDirectory="../target/jacoco"
+          mvn -pl liquibase-core jacoco:merge "-Djacoco.destFile=../target/jacoco/jacoco-aggregate.exec" "-Djacoco.fileSetDirectory=.."
+          mvn -pl liquibase-core jacoco:report "-Djacoco.dataFile=../target/jacoco/jacoco-aggregate.exec"  "-Djacoco.outputDirectory=../target/jacoco"
 
       - name: Remove Original Jars for *nix
         if: env.OS_TYPE != 'windows-2019'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -310,8 +310,8 @@ jobs:
           cp -r **/target/classes/* jacoco-aggregate/
           cp .github/util/jacoco-aggregate.pom.xml jacoco-aggregate/pom.xml
           
-          cd (jacoco-aggregate && mvn jacoco:merge "-Djacoco.destFile=jacoco-aggregate.exec" "-Djacoco.fileSetDirectory=../artifacts" -Djacoco.fileSetInclude="**/target/jacoco/*.exec")
-          cd (jacoco-aggregate && mvn jacoco:report "-Djacoco.dataFile=jacoco-aggregate.exec" "-Djacoco.formats=XML")
+          (cd jacoco-aggregate && mvn jacoco:merge "-Djacoco.destFile=jacoco-aggregate.exec" "-Djacoco.fileSetDirectory=../artifacts" -Djacoco.fileSetInclude="**/target/jacoco/*.exec")
+          (cd jacoco-aggregate && mvn jacoco:report "-Djacoco.dataFile=jacoco-aggregate.exec" "-Djacoco.formats=XML")
           
           # Run sonar
           mvn sonar:sonar -Dsonar.login=$SONAR_TOKEN -Dsonar.pullrequest.key=${{ github.event.pull_request.number }} -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }} -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }} -Dsonar.sonar.coverage.jacoco.xmlReportPaths=../jacoco-aggregate/jacoco-aggregate.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,7 +172,10 @@ jobs:
           cache: 'maven'
       - name: Build & Test
         run: |
-          mvn -B "-Dbuild.repository.owner=${{ needs.setup.outputs.thisRepositoryOwner }}" "-Dbuild.repository.name=${{ needs.setup.outputs.thisRepositoryName }}" "-Dbuild.branch=${{ needs.setup.outputs.thisBranchName }}" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=${{ needs.setup.outputs.thisSha }}" "-DtrimStackTrace=false" -pl '!liquibase-dist' clean test package surefire-report:report
+          mvn -B "-Dbuild.repository.owner=${{ needs.setup.outputs.thisRepositoryOwner }}" "-Dbuild.repository.name=${{ needs.setup.outputs.thisRepositoryName }}" "-Dbuild.branch=${{ needs.setup.outputs.thisBranchName }}" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=${{ needs.setup.outputs.thisSha }}" "-DtrimStackTrace=false" -pl '!liquibase-dist' jacoco:prepare-agent clean test package surefire-report:report
+          mvn -pl liquibase-core jacoco:merge -Djacoco.destFile=../target/jacoco/jacoco-aggregate.exec -Djacoco.fileSetDirectory=".."
+          mvn -pl liquibase-core jacoco:report -Djacoco.dataFile=../target/jacoco/jacoco-aggregate.exec  -Djacoco.outputDirectory=../target/jacoco
+
       - name: Remove Original Jars for *nix
         if: env.OS_TYPE != 'windows-2019'
         run: |
@@ -183,10 +186,11 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
-          name: liquibase-test-results-jdk${{ matrix.java }}
+          name: liquibase-test-results-jdk${{ matrix.java }}-${{ matrix.os }}
           path: |
             ./**/target/surefire-reports
             ./**/target/site
+            ./target/jacoco
 
       - name: Archive Modules
         if: ${{ matrix.java == 8 && matrix.os == 'ubuntu-latest'}}
@@ -195,33 +199,6 @@ jobs:
           name: liquibase-modules
           path: |
             */target/*-0-SNAPSHOT.jar
-
-  sonar:
-    name: Sonar Scan
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-          ref: ${{ github.event.pull_request.head.sha || github.event.after}}
-      - name: Set up JDK
-        uses: actions/setup-java@v2
-        with:
-          java-version: 11
-          distribution: 'adopt'
-          cache: 'maven'
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-      - name: Build and analyze
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn clean verify sonar:sonar -P sonar -Dsonar.login=$SONAR_TOKEN -Dsonar.pullrequest.key=${{ github.event.pull_request.number }} -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }} -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }}
 
   integration-test:
     name: Integration Test
@@ -273,7 +250,7 @@ jobs:
           password: ${{ secrets.ARTIFACTORY_TOKEN }}
 
       - name: Run Tests
-        run: mvn -B jar:jar jar:test-jar surefire:test -DtrimStackTrace=false -Dliquibase.sdk.testSystem.test=${{ matrix.testSystem }} -Dliquibase.sdk.testSystem.acceptLicenses=${{ matrix.testSystem }} -Dtest=*IntegrationTest,*ExecutorTest -DfailIfNoTests=false
+        run: mvn -B jacoco:prepare-agent jar:jar jar:test-jar surefire:test -DtrimStackTrace=false -Dliquibase.sdk.testSystem.test=${{ matrix.testSystem }} -Dliquibase.sdk.testSystem.acceptLicenses=${{ matrix.testSystem }} -Dtest=*IntegrationTest,*ExecutorTest -DfailIfNoTests=false
 
       - name: Archive Test Results
         if: ${{ always() }}
@@ -282,6 +259,46 @@ jobs:
           name: ${{ steps.prepare.outputs.testResultsArtifact }}
           path: |
             ./**/target/surefire-reports
+            ./**/target/site
+            ./target/jacoco
+
+  sonar:
+    name: Sonar Scan
+    runs-on: ubuntu-latest
+    needs: [ setup, build, integration-test ]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          ref: ${{ github.event.pull_request.head.sha || github.event.after}}
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: 'adopt'
+          cache: 'maven'
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Download coverage information
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+
+      - name: Aggregate Coverage Info
+        run: |
+          mvn -pl liquibase-core jacoco:merge -Djacoco.destFile=../jacoco-overall/jacoco.exec -Djacoco.fileSetDirectory=artifacts -Djacoco.fileSetInclude="**/target/jacoco/*.exec"
+          mvn -pl liquibase-core jacoco:report -Djacoco.dataFile=../jacoco-overall/jacoco.exec  -Djacoco.outputDirectory=../jacoco-overall/jacoco
+
+      - name: Sonar Analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: mvn sonar:sonar -Dsonar.login=$SONAR_TOKEN -Dsonar.pullrequest.key=${{ github.event.pull_request.number }} -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }} -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }} -Dsonar.sonar.coverage.jacoco.xmlReportPaths=../jacoco-overall/jacoco/jacoco.xml
 
   package:
     name: Package Artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,6 @@ jobs:
         run: |
           mvn -B "-Dbuild.repository.owner=${{ needs.setup.outputs.thisRepositoryOwner }}" "-Dbuild.repository.name=${{ needs.setup.outputs.thisRepositoryName }}" "-Dbuild.branch=${{ needs.setup.outputs.thisBranchName }}" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=${{ needs.setup.outputs.thisSha }}" "-DtrimStackTrace=false" -pl '!liquibase-dist' jacoco:prepare-agent clean test package surefire-report:report
           mvn -pl liquibase-core jacoco:merge "-Djacoco.destFile=../target/jacoco/jacoco-aggregate.exec" "-Djacoco.fileSetDirectory=.."
-          mvn -pl liquibase-core jacoco:report "-Djacoco.dataFile=../target/jacoco/jacoco-aggregate.exec"  "-Djacoco.outputDirectory=../target/jacoco" "-Djacoco.formats=XML"
 
       - name: Remove Original Jars for *nix
         if: env.OS_TYPE != 'windows-2019'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,8 +173,8 @@ jobs:
       - name: Build & Test
         run: |
           mvn -B "-Dbuild.repository.owner=${{ needs.setup.outputs.thisRepositoryOwner }}" "-Dbuild.repository.name=${{ needs.setup.outputs.thisRepositoryName }}" "-Dbuild.branch=${{ needs.setup.outputs.thisBranchName }}" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=${{ needs.setup.outputs.thisSha }}" "-DtrimStackTrace=false" -pl '!liquibase-dist' jacoco:prepare-agent clean test package surefire-report:report
-          mvn -pl liquibase-core jacoco:merge -Djacoco.destFile=../target/jacoco/jacoco-aggregate.exec -Djacoco.fileSetDirectory=".."
-          mvn -pl liquibase-core jacoco:report -Djacoco.dataFile=../target/jacoco/jacoco-aggregate.exec  -Djacoco.outputDirectory=../target/jacoco
+          mvn -pl liquibase-core jacoco:merge -Djacoco.destFile="../target/jacoco/jacoco-aggregate.exec" -Djacoco.fileSetDirectory=".."
+          mvn -pl liquibase-core jacoco:report -Djacoco.dataFile="../target/jacoco/jacoco-aggregate.exec"  -Djacoco.outputDirectory="../target/jacoco"
 
       - name: Remove Original Jars for *nix
         if: env.OS_TYPE != 'windows-2019'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -289,16 +289,20 @@ jobs:
         with:
           path: artifacts
 
-      - name: Aggregate Coverage Info
-        run: |
-          mvn -pl liquibase-core jacoco:merge "-Djacoco.destFile=../jacoco-overall/jacoco.exec" "-Djacoco.fileSetDirectory=artifacts" "-Djacoco.fileSetInclude=**/target/jacoco/*.exec"
-          mvn -pl liquibase-core jacoco:report "-Djacoco.dataFile=../jacoco-overall/jacoco.exec"  "-Djacoco.outputDirectory=../jacoco-overall/jacoco"  "-Djacoco.formats=XML"
-
       - name: Sonar Analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn compile sonar:sonar -Dsonar.login=$SONAR_TOKEN -Dsonar.pullrequest.key=${{ github.event.pull_request.number }} -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }} -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }} -Dsonar.sonar.coverage.jacoco.xmlReportPaths=../jacoco-overall/jacoco/jacoco.xml
+        run: |
+          # Jacoco and sonar need class files
+          mvn compile
+          
+          # Aggregate converage information 
+          mvn -pl liquibase-core jacoco:merge "-Djacoco.destFile=../jacoco-overall/jacoco.exec" "-Djacoco.fileSetDirectory=artifacts" "-Djacoco.fileSetInclude=**/target/jacoco/*.exec"
+          mvn -pl liquibase-core jacoco:report "-Djacoco.dataFile=../jacoco-overall/jacoco.exec"  "-Djacoco.outputDirectory=../jacoco-overall/jacoco"  "-Djacoco.formats=XML"
+          
+          # Run sonar
+          mvn sonar:sonar -Dsonar.login=$SONAR_TOKEN -Dsonar.pullrequest.key=${{ github.event.pull_request.number }} -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }} -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }} -Dsonar.sonar.coverage.jacoco.xmlReportPaths=../jacoco-overall/jacoco/jacoco.xml
 
   package:
     name: Package Artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -289,20 +289,33 @@ jobs:
         with:
           path: artifacts
 
+      - name: Restore Built Code Cache
+        uses: actions/cache@v2
+        with:
+          key: built-code-${{ github.run_number }}-${{ github.run_attempt }}
+          path: ./**/target
+
       - name: Sonar Analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          # Jacoco and sonar need class files
-          mvn compile
+          # Aggregate converage information
+          ## sonar requires all the class files to be from the same jvm. Remove any non-java-8 ones
+          rm -rf artifacts/*results-jdk11*
+          rm -rf artifacts/*results-jdk17*
+          rm -rf artifacts/*results-*macos-*
+          rm -rf artifacts/*results-*windows-*
           
-          # Aggregate converage information 
-          mvn -pl liquibase-core jacoco:merge "-Djacoco.destFile=../jacoco-overall/jacoco.exec" "-Djacoco.fileSetDirectory=artifacts" "-Djacoco.fileSetInclude=**/target/jacoco/*.exec"
-          mvn -pl liquibase-core jacoco:report "-Djacoco.dataFile=../jacoco-overall/jacoco.exec"  "-Djacoco.outputDirectory=../jacoco-overall/jacoco"  "-Djacoco.formats=XML"
+          mkdir jacoco-aggregate
+          cp -r **/target/classes/* jacoco-aggregate/
+          cp .github/util/jacoco-aggregate.pom.xml jacoco-aggregate/pom.xml
+          
+          cd (jacoco-aggregate && mvn jacoco:merge "-Djacoco.destFile=jacoco-aggregate.exec" "-Djacoco.fileSetDirectory=../artifacts" -Djacoco.fileSetInclude="**/target/jacoco/*.exec")
+          cd (jacoco-aggregate && mvn jacoco:report "-Djacoco.dataFile=jacoco-aggregate.exec" "-Djacoco.formats=XML")
           
           # Run sonar
-          mvn sonar:sonar -Dsonar.login=$SONAR_TOKEN -Dsonar.pullrequest.key=${{ github.event.pull_request.number }} -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }} -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }} -Dsonar.sonar.coverage.jacoco.xmlReportPaths=../jacoco-overall/jacoco/jacoco.xml
+          mvn sonar:sonar -Dsonar.login=$SONAR_TOKEN -Dsonar.pullrequest.key=${{ github.event.pull_request.number }} -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }} -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }} -Dsonar.sonar.coverage.jacoco.xmlReportPaths=../jacoco-aggregate/jacoco-aggregate.xml
 
   package:
     name: Package Artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,7 @@ jobs:
         run: |
           mvn -B "-Dbuild.repository.owner=${{ needs.setup.outputs.thisRepositoryOwner }}" "-Dbuild.repository.name=${{ needs.setup.outputs.thisRepositoryName }}" "-Dbuild.branch=${{ needs.setup.outputs.thisBranchName }}" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=${{ needs.setup.outputs.thisSha }}" "-DtrimStackTrace=false" -pl '!liquibase-dist' jacoco:prepare-agent clean test package surefire-report:report
           mvn -pl liquibase-core jacoco:merge "-Djacoco.destFile=../target/jacoco/jacoco-aggregate.exec" "-Djacoco.fileSetDirectory=.."
-          mvn -pl liquibase-core jacoco:report "-Djacoco.dataFile=../target/jacoco/jacoco-aggregate.exec"  "-Djacoco.outputDirectory=../target/jacoco"
+          mvn -pl liquibase-core jacoco:report "-Djacoco.dataFile=../target/jacoco/jacoco-aggregate.exec"  "-Djacoco.outputDirectory=../target/jacoco" "-Djacoco.formats=xml"
 
       - name: Remove Original Jars for *nix
         if: env.OS_TYPE != 'windows-2019'
@@ -291,14 +291,14 @@ jobs:
 
       - name: Aggregate Coverage Info
         run: |
-          mvn -pl liquibase-core jacoco:merge -Djacoco.destFile=../jacoco-overall/jacoco.exec -Djacoco.fileSetDirectory=artifacts -Djacoco.fileSetInclude="**/target/jacoco/*.exec"
-          mvn -pl liquibase-core jacoco:report -Djacoco.dataFile=../jacoco-overall/jacoco.exec  -Djacoco.outputDirectory=../jacoco-overall/jacoco
+          mvn -pl liquibase-core jacoco:merge "-Djacoco.destFile=../jacoco-overall/jacoco.exec" "-Djacoco.fileSetDirectory=artifacts" "-Djacoco.fileSetInclude=**/target/jacoco/*.exec"
+          mvn -pl liquibase-core jacoco:report "-Djacoco.dataFile=../jacoco-overall/jacoco.exec"  "-Djacoco.outputDirectory=../jacoco-overall/jacoco"  "-Djacoco.formats=xml"
 
       - name: Sonar Analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn sonar:sonar -Dsonar.login=$SONAR_TOKEN -Dsonar.pullrequest.key=${{ github.event.pull_request.number }} -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }} -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }} -Dsonar.sonar.coverage.jacoco.xmlReportPaths=../jacoco-overall/jacoco/jacoco.xml
+        run: mvn compile sonar:sonar -Dsonar.login=$SONAR_TOKEN -Dsonar.pullrequest.key=${{ github.event.pull_request.number }} -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }} -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }} -Dsonar.sonar.coverage.jacoco.xmlReportPaths=../jacoco-overall/jacoco/jacoco.xml
 
   package:
     name: Package Artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,7 @@ jobs:
         run: |
           mvn -B "-Dbuild.repository.owner=${{ needs.setup.outputs.thisRepositoryOwner }}" "-Dbuild.repository.name=${{ needs.setup.outputs.thisRepositoryName }}" "-Dbuild.branch=${{ needs.setup.outputs.thisBranchName }}" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=${{ needs.setup.outputs.thisSha }}" "-DtrimStackTrace=false" -pl '!liquibase-dist' jacoco:prepare-agent clean test package surefire-report:report
           mvn -pl liquibase-core jacoco:merge "-Djacoco.destFile=../target/jacoco/jacoco-aggregate.exec" "-Djacoco.fileSetDirectory=.."
-          mvn -pl liquibase-core jacoco:report "-Djacoco.dataFile=../target/jacoco/jacoco-aggregate.exec"  "-Djacoco.outputDirectory=../target/jacoco" "-Djacoco.formats=xml"
+          mvn -pl liquibase-core jacoco:report "-Djacoco.dataFile=../target/jacoco/jacoco-aggregate.exec"  "-Djacoco.outputDirectory=../target/jacoco" "-Djacoco.formats=XML"
 
       - name: Remove Original Jars for *nix
         if: env.OS_TYPE != 'windows-2019'
@@ -292,7 +292,7 @@ jobs:
       - name: Aggregate Coverage Info
         run: |
           mvn -pl liquibase-core jacoco:merge "-Djacoco.destFile=../jacoco-overall/jacoco.exec" "-Djacoco.fileSetDirectory=artifacts" "-Djacoco.fileSetInclude=**/target/jacoco/*.exec"
-          mvn -pl liquibase-core jacoco:report "-Djacoco.dataFile=../jacoco-overall/jacoco.exec"  "-Djacoco.outputDirectory=../jacoco-overall/jacoco"  "-Djacoco.formats=xml"
+          mvn -pl liquibase-core jacoco:report "-Djacoco.dataFile=../jacoco-overall/jacoco.exec"  "-Djacoco.outputDirectory=../jacoco-overall/jacoco"  "-Djacoco.formats=XML"
 
       - name: Sonar Analyze
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,7 +173,7 @@ jobs:
       - name: Build & Test
         run: |
           mvn -B "-Dbuild.repository.owner=${{ needs.setup.outputs.thisRepositoryOwner }}" "-Dbuild.repository.name=${{ needs.setup.outputs.thisRepositoryName }}" "-Dbuild.branch=${{ needs.setup.outputs.thisBranchName }}" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=${{ needs.setup.outputs.thisSha }}" "-DtrimStackTrace=false" -pl '!liquibase-dist' jacoco:prepare-agent clean test package surefire-report:report
-          mvn -pl liquibase-core jacoco:merge "-Djacoco.destFile=../target/jacoco/jacoco-aggregate.exec" "-Djacoco.fileSetDirectory=.."
+          mvn -pl liquibase-core jacoco:merge "-Djacoco.destFile=../target/jacoco/jacoco-aggregate.exec" "-Djacoco.fileSetDirectory=.." "-Djacoco.fileSetInclude=**/target/*.exec"
 
       - name: Remove Original Jars for *nix
         if: env.OS_TYPE != 'windows-2019'

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         <jacoco.fileSetDirectory></jacoco.fileSetDirectory>
         <jacoco.fileSetInclude>**/target/*.exec</jacoco.fileSetInclude>
         <jacoco.outputDirectory></jacoco.outputDirectory>
+        <jacoco.formats></jacoco.formats>
 
         <sonar.organization>liquibase</sonar.organization>
         <sonar.projectKey>liquibase</sonar.projectKey>
@@ -431,6 +432,7 @@
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.7</version>
                 <configuration>
+                    <formats>${jacoco.formats}</formats>
                     <outputDirectory>${jacoco.outputDirectory}</outputDirectory>
                     <fileSets>
                         <fileSet>

--- a/pom.xml
+++ b/pom.xml
@@ -72,9 +72,11 @@
         <argLine></argLine>
 
         <jacoco.fileSetDirectory></jacoco.fileSetDirectory>
-        <jacoco.fileSetInclude>**/target/*.exec</jacoco.fileSetInclude>
         <jacoco.outputDirectory></jacoco.outputDirectory>
         <jacoco.formats></jacoco.formats>
+        <jacoco.destFile></jacoco.destFile>
+        <jacoco.dataFile></jacoco.dataFile>
+        <jacoco.fileSetInclude></jacoco.fileSetInclude>
 
         <sonar.organization>liquibase</sonar.organization>
         <sonar.projectKey>liquibase</sonar.projectKey>
@@ -433,7 +435,9 @@
                 <version>0.8.7</version>
                 <configuration>
                     <formats>${jacoco.formats}</formats>
+                    <destFile>${jacoco.destFile}</destFile>
                     <outputDirectory>${jacoco.outputDirectory}</outputDirectory>
+                    <dataFile>${jacoco.dataFile}</dataFile>
                     <fileSets>
                         <fileSet>
                             <directory>${jacoco.fileSetDirectory}</directory>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,6 @@
         <jacoco.fileSetDirectory></jacoco.fileSetDirectory>
         <jacoco.outputDirectory></jacoco.outputDirectory>
         <jacoco.formats></jacoco.formats>
-        <jacoco.destFile></jacoco.destFile>
         <jacoco.dataFile></jacoco.dataFile>
         <jacoco.fileSetInclude></jacoco.fileSetInclude>
 
@@ -329,7 +328,6 @@
                 </dependencies>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                    <forkCount>0</forkCount>
                     <argLine>@{argLine} -Dfile.encoding=${project.build.sourceEncoding} -Xmx1024m</argLine>
                 </configuration>
             </plugin>
@@ -436,7 +434,6 @@
                 <version>0.8.7</version>
                 <configuration>
                     <formats>${jacoco.formats}</formats>
-                    <destFile>${jacoco.destFile}</destFile>
                     <outputDirectory>${jacoco.outputDirectory}</outputDirectory>
                     <dataFile>${jacoco.dataFile}</dataFile>
                     <fileSets>

--- a/pom.xml
+++ b/pom.xml
@@ -329,7 +329,8 @@
                 </dependencies>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                    <argLine>@{argLine} -Dfile.encoding=${project.build.sourceEncoding}</argLine>
+                    <forkCount>0</forkCount>
+                    <argLine>@{argLine} -Dfile.encoding=${project.build.sourceEncoding} -Xmx1024m</argLine>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,19 @@
         <junit.version>4.13.2</junit.version>
         <trimStackTrace>false</trimStackTrace>
         <argLine></argLine>
+
+        <jacoco.fileSetDirectory></jacoco.fileSetDirectory>
+        <jacoco.fileSetInclude>**/target/*.exec</jacoco.fileSetInclude>
+        <jacoco.outputDirectory></jacoco.outputDirectory>
+
+        <sonar.organization>liquibase</sonar.organization>
+        <sonar.projectKey>liquibase</sonar.projectKey>
+        <sonar.projectName>Liquibase</sonar.projectName>
+        <sonar.projectDescription>Liquibase</sonar.projectDescription>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <sonar.scm.provider>git</sonar.scm.provider>
+        <sonar.qualitygate.wait>true</sonar.qualitygate.wait>
+
     </properties>
 
 
@@ -313,7 +326,7 @@
                 </dependencies>
                 <configuration>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                    <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
+                    <argLine>@{argLine} -Dfile.encoding=${project.build.sourceEncoding}</argLine>
                 </configuration>
             </plugin>
 
@@ -413,6 +426,29 @@
                 </executions>
             </plugin>
 
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.7</version>
+                <configuration>
+                    <outputDirectory>${jacoco.outputDirectory}</outputDirectory>
+                    <fileSets>
+                        <fileSet>
+                            <directory>${jacoco.fileSetDirectory}</directory>
+                            <includes>
+                                <include>${jacoco.fileSetInclude}</include>
+                            </includes>
+                        </fileSet>
+                    </fileSets>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>3.9.1.2184</version>
+            </plugin>
+
             <!--        <plugin>-->
             <!--            <artifactId>maven-install-plugin</artifactId>-->
             <!--            <version>2.5.2</version>-->
@@ -463,57 +499,6 @@
                                 --add-opens java.base/java.lang=ALL-UNNAMED
                             </argLine>
                         </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>sonar</id>
-            <properties>
-                <sonar.organization>liquibase</sonar.organization>
-                <sonar.projectKey>liquibase</sonar.projectKey>
-                <sonar.projectName>Liquibase</sonar.projectName>
-                <sonar.projectDescription>Liquibase</sonar.projectDescription>
-                <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-                <sonar.scm.provider>git</sonar.scm.provider>
-                <sonar.qualitygate.wait>true</sonar.qualitygate.wait>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.sonarsource.scanner.maven</groupId>
-                        <artifactId>sonar-maven-plugin</artifactId>
-                        <version>3.9.1.2184</version>
-                        <executions>
-                            <execution>
-                                <id>sonar</id>
-                                <goals>
-                                    <goal>sonar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-
-                    <plugin>
-                        <groupId>org.jacoco</groupId>
-                        <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.8.7</version>
-                        <executions>
-                            <execution>
-                                <id>prepare-agent</id>
-                                <goals>
-                                    <goal>prepare-agent</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>report</id>
-                                <phase>test</phase>
-                                <goals>
-                                    <goal>report</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
## Description

Currently our code coverage metrics are incomplete because they are only capturing what gets covered in the "Sonar Scan" job, not in the matrix of runs across the different database types or OS or JVM versions. 

As a result, there is a lot of code which does get exercised by our tests, but will always show as "not covered".

This PR is trying to solve that by running with coverage info across all our different test runs, then in the Sonar job it aggregates that data together and reports on that. 