### PR TITLE
Fix createTable on Mysql not preserving primary key information when remarks also defined on the column

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/CreateTableChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/CreateTableChange.java
@@ -78,7 +78,8 @@ public class CreateTableChange extends AbstractChange implements ChangeWithColum
                 statement.addPrimaryKeyColumn(column.getName(), columnType, defaultValue, constraints.getValidatePrimaryKey(),
                         constraints.isDeferrable() != null && constraints.isDeferrable(),
                         constraints.isInitiallyDeferred() != null && constraints.isInitiallyDeferred(),
-                    constraints.getPrimaryKeyName(),constraints.getPrimaryKeyTablespace());
+                    constraints.getPrimaryKeyName(),constraints.getPrimaryKeyTablespace(),
+                        column.getRemarks());
 
             } else {
                 statement.addColumn(column.getName(),
@@ -136,7 +137,7 @@ public class CreateTableChange extends AbstractChange implements ChangeWithColum
         List<SqlStatement> statements = new ArrayList<>();
         statements.add(statement);
 
-        if (StringUtil.trimToNull(remarks) != null) {
+        if (StringUtil.trimToNull(remarks) != null && !(database instanceof MySQLDatabase)) {
             SetTableRemarksStatement remarksStatement = new SetTableRemarksStatement(catalogName, schemaName, tableName, remarks);
             if (SqlGeneratorFactory.getInstance().supports(remarksStatement, database)) {
                 statements.add(remarksStatement);
@@ -145,7 +146,7 @@ public class CreateTableChange extends AbstractChange implements ChangeWithColum
 
         for (ColumnConfig column : getColumns()) {
             String columnRemarks = StringUtil.trimToNull(column.getRemarks());
-            if (columnRemarks != null) {
+            if (columnRemarks != null && !(database instanceof MySQLDatabase)) {
                 SetColumnRemarksStatement remarksStatement = new SetColumnRemarksStatement(catalogName, schemaName, tableName, column.getName(), columnRemarks, column.getType());
                 if (SqlGeneratorFactory.getInstance().supports(remarksStatement, database)) {
                     statements.add(remarksStatement);

--- a/liquibase-core/src/main/java/liquibase/statement/core/CreateTableStatement.java
+++ b/liquibase-core/src/main/java/liquibase/statement/core/CreateTableStatement.java
@@ -115,8 +115,14 @@ public class CreateTableStatement extends AbstractSqlStatement implements Compou
         return addPrimaryKeyColumn(columnName, columnType, defaultValue, validate, false, false, keyName, tablespace, constraints);
     }
 
+
     public CreateTableStatement addPrimaryKeyColumn(String columnName, LiquibaseDataType columnType, Object defaultValue,
                                                     Boolean validate, boolean deferrable, boolean initiallyDeferred, String keyName, String tablespace, ColumnConstraint... constraints) {
+        return addPrimaryKeyColumn(columnName, columnType, defaultValue, validate, deferrable, initiallyDeferred, keyName, tablespace, null, constraints);
+    }
+
+    public CreateTableStatement addPrimaryKeyColumn(String columnName, LiquibaseDataType columnType, Object defaultValue,
+                                                    Boolean validate, boolean deferrable, boolean initiallyDeferred, String keyName, String tablespace, String remarks, ColumnConstraint... constraints) {
         PrimaryKeyConstraint pkConstraint = new PrimaryKeyConstraint(keyName);
         if (validate != null) {
             pkConstraint.setValidatePrimaryKey(validate);
@@ -131,7 +137,7 @@ public class CreateTableStatement extends AbstractSqlStatement implements Compou
         allConstraints.add(pkConstraint);
 
 
-        addColumn(columnName, columnType, defaultValue, allConstraints.toArray(new ColumnConstraint[allConstraints.size()]));
+        addColumn(columnName, columnType, defaultValue, remarks, allConstraints.toArray(new ColumnConstraint[allConstraints.size()]));
 
         return this;
     }


### PR DESCRIPTION
## Pull Request Type

- [X] Bug fix (non-breaking change which fixes an issue.)
- [ ] Enhancement/New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Mysql losses primary key and other information if we do a `alter column modify .... remarks` statement. 

So ensure that the initial "create" includes all the remarks and do not attempt to modify them after the fact.

Fixes #2301
Fixes #2634
Fixes #1793
Fixes #1214
Fixes #1210

Test-harness PR: https://github.com/liquibase/liquibase-test-harness/pull/211

## Things to be aware of

- Impacts SQL for mysql and mariadb only

## Things to worry about

- Nothing