### PR TITLE
Spring Boot: better support relativeToChangelogfile when ResourceLoaders return FilteredReactiveWebContextResources

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/spring/SpringResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/integration/spring/SpringResourceAccessor.java
@@ -24,7 +24,11 @@ public class SpringResourceAccessor extends AbstractResourceAccessor {
 
     public SpringResourceAccessor(ResourceLoader resourceLoader) {
         this.resourceLoader = resourceLoader;
-        this.fallbackResourceLoader = new DefaultResourceLoader(resourceLoader.getClassLoader());
+        if (resourceLoader == null) {
+            this.fallbackResourceLoader = new DefaultResourceLoader(Thread.currentThread().getContextClassLoader());
+        } else {
+            this.fallbackResourceLoader = new DefaultResourceLoader(resourceLoader.getClassLoader());
+        }
     }
 
     @Override


### PR DESCRIPTION
## Pull Request Type

<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->
- [X] Bug fix (non-breaking change which fixes an issue.)
- [ ] Enhancement/New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Subclasses of [FilteredReactiveWebContextResource ](https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/web/reactive/context/FilteredReactiveWebContextResource.java) and potentially others, make `exists() always returns false in order to avoid exposing the whole classpath in a non-servlet environment.` which impacts Liquibase's logic in figuring out relative paths.

The change to SpringResourceAccessor to rely on exists() was introduced in Liquibase 4.0, so this will fix some changelogs that worked in 3.x but not any versions.

Improves spring support as mentioned in #2281 for at least some configurations. 

## Example Fixed Scenario

file:/...../target/classes/liquibase/init/test.xml
```
<?xml version="1.0" encoding="UTF-8"?>
<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
    <changeSet>
        <sqlFile path="test.sql" relativeToChangelogFile="true" splitStatements="false"/>
    </changeSet>
</databaseChangeLog>
```
file:/...../target/classes/liquibase/init/test.sql

Liquibase 4.9.1 fails to find test.sql relative to test.xml which contains the changelog

## Actual Behavior
```
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'liquibase' defined in class path resource [org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration$LiquibaseConfiguration.class]: Invocation of init method failed; nested exception is liquibase.exception.LiquibaseException: liquibase.exception.UnexpectedLiquibaseException: java.io.IOException: The file test.sql was not found in
    - file:/...../target/classes/
    - file:/...../target/classes/
Specifying files by absolute path was removed in Liquibase 4.0. Please use a relative path or add '/' to the classpath parameter.
```

## Expected/Desired Behavior
```
2022-04-14 16:06:45.705  INFO 36588 --- [  restartedMain] liquibase.database                       : Set default schema name to public
2022-04-14 16:06:45.910  INFO 36588 --- [  restartedMain] liquibase.lockservice                    : Successfully acquired change log lock
2022-04-14 16:06:46.688  INFO 36588 --- [  restartedMain] liquibase.changelog                      : Reading from public.databasechangelog
Running Changeset: liquibase/init/test.xml::test-003::tester
2022-04-14 16:06:46.930  INFO 36588 --- [  restartedMain] liquibase.changelog                      : SQL in file test.sql executed
2022-04-14 16:06:46.938  INFO 36588 --- [  restartedMain] liquibase.changelog                      : ChangeSet liquibase/init/test.xml::test-003::tester ran successfully in 80ms
2022-04-14 16:06:46.966  INFO 36588 --- [  restartedMain] liquibase.lockservice                    : Successfully released change log lock
```

