### PR TITLE
Correctly handle null class package names in the logging system

### DIFF
--- a/liquibase-core/src/main/java/liquibase/logging/core/JavaLogService.java
+++ b/liquibase-core/src/main/java/liquibase/logging/core/JavaLogService.java
@@ -42,8 +42,12 @@ public class JavaLogService extends AbstractLogService {
      * For example, all {@link liquibase.change.Change} classes will return a log name of "liquibase.change" no matter what class name or package name they have.
      */
     protected String getLogName(Class clazz) {
-        if (clazz == null || clazz.getPackage() == null) {
+        if (clazz == null) {
             return "unknown";
+        }
+
+        if (clazz.getPackage() == null) {
+            return clazz.getName();
         }
 
         final String classPackageName = clazz.getPackage().getName();

--- a/liquibase-core/src/main/java/liquibase/logging/core/JavaLogService.java
+++ b/liquibase-core/src/main/java/liquibase/logging/core/JavaLogService.java
@@ -42,6 +42,10 @@ public class JavaLogService extends AbstractLogService {
      * For example, all {@link liquibase.change.Change} classes will return a log name of "liquibase.change" no matter what class name or package name they have.
      */
     protected String getLogName(Class clazz) {
+        if (clazz == null || clazz.getPackage() == null) {
+            return "unknown";
+        }
+
         final String classPackageName = clazz.getPackage().getName();
         if (classPackageName.equals("liquibase")) {
             return "liquibase";

--- a/liquibase-core/src/test/groovy/liquibase/logging/core/JavaLogServiceTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/logging/core/JavaLogServiceTest.groovy
@@ -5,6 +5,7 @@ import liquibase.Scope
 import liquibase.change.Change
 import liquibase.change.core.CreateTableChange
 import liquibase.util.StringUtil
+import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -16,12 +17,27 @@ class JavaLogServiceTest extends Specification {
         new JavaLogService().getLogName(clazz) == expected
 
         where:
-        clazz                    | expected
-        Scope.class              | "liquibase"
-        Change.class             | "liquibase.change"
-        CreateTableChange.class  | "liquibase.change"
-        StringUtil.class         | "liquibase.util"
-        String.class             | "liquibase"
-        CreateTableExampleChange | "liquibase.change"
+        clazz                             | expected
+        Scope.class                       | "liquibase"
+        Change.class                      | "liquibase.change"
+        CreateTableChange.class           | "liquibase.change"
+        StringUtil.class                  | "liquibase.util"
+        String.class                      | "liquibase"
+        CreateTableExampleChange          | "liquibase.change"
+        null                              | "unknown"
+    }
+
+    def "getLogName with a null package"() {
+        when:
+        def noPackageClass = { -> }.getClass()
+
+        def nameField = Class.class.getDeclaredField("name")
+        nameField.setAccessible(true)
+        nameField.set(noPackageClass, "NoPackageClass")
+
+        then:
+        noPackageClass.getPackage() == null
+        new JavaLogService().getLogName(noPackageClass) == "unknown"
+
     }
 }

--- a/liquibase-core/src/test/groovy/liquibase/logging/core/JavaLogServiceTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/logging/core/JavaLogServiceTest.groovy
@@ -5,7 +5,6 @@ import liquibase.Scope
 import liquibase.change.Change
 import liquibase.change.core.CreateTableChange
 import liquibase.util.StringUtil
-import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -17,27 +16,14 @@ class JavaLogServiceTest extends Specification {
         new JavaLogService().getLogName(clazz) == expected
 
         where:
-        clazz                             | expected
-        Scope.class                       | "liquibase"
-        Change.class                      | "liquibase.change"
-        CreateTableChange.class           | "liquibase.change"
-        StringUtil.class                  | "liquibase.util"
-        String.class                      | "liquibase"
-        CreateTableExampleChange          | "liquibase.change"
-        null                              | "unknown"
-    }
-
-    def "getLogName with a null package"() {
-        when:
-        def noPackageClass = { -> }.getClass()
-
-        def nameField = Class.class.getDeclaredField("name")
-        nameField.setAccessible(true)
-        nameField.set(noPackageClass, "NoPackageClass")
-
-        then:
-        noPackageClass.getPackage() == null
-        new JavaLogService().getLogName(noPackageClass) == "NoPackageClass"
-
+        clazz                    | expected
+        Scope.class              | "liquibase"
+        Change.class             | "liquibase.change"
+        CreateTableChange.class  | "liquibase.change"
+        StringUtil.class         | "liquibase.util"
+        String.class             | "liquibase"
+        CreateTableExampleChange | "liquibase.change"
+        null                     | "unknown"
+        int.class                | "int"
     }
 }

--- a/liquibase-core/src/test/groovy/liquibase/logging/core/JavaLogServiceTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/logging/core/JavaLogServiceTest.groovy
@@ -37,7 +37,7 @@ class JavaLogServiceTest extends Specification {
 
         then:
         noPackageClass.getPackage() == null
-        new JavaLogService().getLogName(noPackageClass) == "unknown"
+        new JavaLogService().getLogName(noPackageClass) == "NoPackageClass"
 
     }
 }


### PR DESCRIPTION
## Description

The Class.getPackage() method can return null, especially in non-java JVM languages like clojure.

Updates the JavaLogService to use the class name as the log name if the passed class object returns a null package.

Fixes #2633

