### PR TITLE
Fix EnterpriseDB database recognition

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/EnterpriseDBDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/EnterpriseDBDatabase.java
@@ -23,7 +23,7 @@ public class EnterpriseDBDatabase extends PostgresDatabase {
                     if (stmt != null) {
                         try (ResultSet rs = stmt.executeQuery("select version()")) {
                             if (rs.next()) {
-                                return ((String) JdbcUtil.getResultSetValue(rs, 1)).startsWith("EnterpriseDB");
+                                return ((String) JdbcUtil.getResultSetValue(rs, 1)).contains("EnterpriseDB");
                             }
                         }
                     }

--- a/liquibase-core/src/test/groovy/liquibase/database/core/EnterpriseDBDatabaseTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/database/core/EnterpriseDBDatabaseTest.groovy
@@ -1,0 +1,34 @@
+package liquibase.database.core
+
+import liquibase.database.jvm.JdbcConnection
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.sql.ResultSet
+import java.sql.Statement
+
+class EnterpriseDBDatabaseTest extends Specification {
+
+    @Unroll
+    def "isCorrectDatabaseImplementation"() {
+        when:
+        def conn = Mock(JdbcConnection)
+        def stmt = Mock(Statement)
+        def rs = Mock(ResultSet)
+
+        conn.getURL() >> url
+        conn.createStatement() >> stmt
+        stmt.executeQuery("select version()") >> rs
+        rs.next() >> true
+        rs.getObject(1) >> version
+
+        then:
+        new EnterpriseDBDatabase().isCorrectDatabaseImplementation(conn) == expected
+
+        where:
+        url                                   | version                                                                                                                                         | expected
+        "jdbc:edb://localhost:50000/db"       | "PostgreSQL 11.0 (EnterpriseDB Advanced Server 11.0.0) on x86_64-pc-linux-gnu, compiled by gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-11), 64-bit" | true
+        "jdbc:postgresql://localhost:5432/db" | "PostgreSQL 11.0 (EnterpriseDB Advanced Server 11.0.0) on x86_64-pc-linux-gnu, compiled by gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-11), 64-bit" | true
+        "jdbc:edb://localhost:50000/db"       | "PostgreSQL 9.3.10 on x86_64-unknown-linux-gnu, compiled by gcc (Ubuntu 4.8.2-19ubuntu1) 4.8.2, 64-bit"                                         | false
+    }
+}


### PR DESCRIPTION
## Description

The result of `version()` for EDB doesn't have "EnterpriseDB" at the beginning of the string, but can by anywhere in it.

This fixes the check to better handle different cases.

Fixes DAT-9954

Test Harness tests: https://github.com/liquibase/liquibase-test-harness/pull/209/