### PR TITLE
Do not throw a confusing error if a datatype specified as a changelog parameter is not expanded

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/DataTypeFactory.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/DataTypeFactory.java
@@ -112,6 +112,10 @@ public class DataTypeFactory {
         if (dataTypeDefinition == null) {
             return null;
         }
+        if (dataTypeDefinition.matches("^\\$\\{.*}$")) {
+            return new UnknownType(dataTypeDefinition);
+        }
+
         String dataTypeName = dataTypeDefinition;
 
         // Remove the first occurrence of (anything within parentheses). This will remove the size information from
@@ -238,6 +242,7 @@ public class DataTypeFactory {
                 param = StringUtil.trimToNull(param);
                 if (param != null) {
                     String[] paramAndValue = param.split(":", 2);
+
                     // TODO: A run-time exception will occur here if the user writes a property name into the
                     // data type which does not exist - but what else could we do in this case, except aborting?
                     ObjectUtil.setProperty(liquibaseDataType, paramAndValue[0], paramAndValue[1]);

--- a/liquibase-core/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
@@ -2,7 +2,6 @@ package liquibase.datatype
 
 import liquibase.database.core.*
 import liquibase.datatype.core.*
-import liquibase.database.core.MockDatabase
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -242,8 +241,8 @@ class DataTypeFactoryTest extends Specification {
         "BINARY(16)"                                   | new H2Database()       | "BINARY(16)"                                   | BlobType      | false
         "timestamp"                                    | new H2Database()       | "TIMESTAMP"                                    | TimestampType | false
         "timestamp(6)"                                 | new H2Database()       | "TIMESTAMP(6)"                                 | TimestampType | false
-        "TIMESTAMP WITH TIMEZONE"                      | new H2Database()       | "TIMESTAMP WITH TIME ZONE"                      | TimestampType | false
-        "TIMESTAMP(6) WITH TIMEZONE"                   | new H2Database()       | "TIMESTAMP(6) WITH TIME ZONE"                   | TimestampType | false
+        "TIMESTAMP WITH TIMEZONE"                      | new H2Database()       | "TIMESTAMP WITH TIME ZONE"                     | TimestampType | false
+        "TIMESTAMP(6) WITH TIMEZONE"                   | new H2Database()       | "TIMESTAMP(6) WITH TIME ZONE"                  | TimestampType | false
         "timestamp without timezone"                   | new H2Database()       | "TIMESTAMP"                                    | TimestampType | false
         "timestamp(6) without timezone"                | new H2Database()       | "TIMESTAMP(6)"                                 | TimestampType | false
         "timestamptz"                                  | new H2Database()       | "TIMESTAMP"                                    | TimestampType | false
@@ -252,8 +251,9 @@ class DataTypeFactoryTest extends Specification {
         "java.sql.Timestamp(6)"                        | new H2Database()       | "TIMESTAMP(6)"                                 | TimestampType | false
         "java.sql.Types.TIMESTAMP"                     | new H2Database()       | "TIMESTAMP"                                    | TimestampType | false
         "java.sql.Types.TIMESTAMP(6)"                  | new H2Database()       | "TIMESTAMP(6)"                                 | TimestampType | false
-        "java.sql.Types.TIMESTAMP_WITH_TIMEZONE"       | new H2Database()       | "TIMESTAMP WITH TIME ZONE"                      | TimestampType | false
-        "java.sql.Types.TIMESTAMP_WITH_TIMEZONE(6)"    | new H2Database()       | "TIMESTAMP(6) WITH TIME ZONE"                   | TimestampType | false
+        "java.sql.Types.TIMESTAMP_WITH_TIMEZONE"       | new H2Database()       | "TIMESTAMP WITH TIME ZONE"                     | TimestampType | false
+        "java.sql.Types.TIMESTAMP_WITH_TIMEZONE(6)"    | new H2Database()       | "TIMESTAMP(6) WITH TIME ZONE"                  | TimestampType | false
+        "\${invalidParam}"                             | new H2Database()       | "\${INVALIDPARAM}"                             | UnknownType   | false
     }
 
     @Unroll("#featureName: #object for #database")


### PR DESCRIPTION
## Description

If a user specifies something that looks like a changelog parameter but doesn't match a specified parameter, liquibase simply users it as-is. 

However, the DataType.fromDescription function that is used to determine the actual datatype to return cannot correctly handle a datatype that is formatted like a changelog parameter.

This fixes the datatype handling so it handles a datatype that looks like `${ ... }` as just a datatype it doesn't understand.

## Example Problem Changeset

```
<createTable tableName="test_table">
    <column name="id" type="${invalid}"/>
</createTable>
```

## Current behavior

Throws an `ArrayIndexOutOfBoundsException` exception

## Fixed behavior

Fails with an error like `Syntax error in SQL statement "CREATE TABLE test_table (id ${INVALID }` which allows the user to recognize that they did not correctly set the changelog parameter