### PR TITLE
Change value modifier to make StandardLockService extendable for future extension

### DIFF
--- a/liquibase-core/src/main/java/liquibase/lockservice/StandardLockService.java
+++ b/liquibase-core/src/main/java/liquibase/lockservice/StandardLockService.java
@@ -37,7 +37,7 @@ import java.util.*;
 import static java.util.ResourceBundle.getBundle;
 
 public class StandardLockService implements LockService {
-    private static final ResourceBundle coreBundle = getBundle("liquibase/i18n/liquibase-core");
+    protected static final ResourceBundle coreBundle = getBundle("liquibase/i18n/liquibase-core");
 
     protected Database database;
 
@@ -70,7 +70,7 @@ public class StandardLockService implements LockService {
         this.database = database;
     }
 
-    public Long getChangeLogLockWaitTime() {
+    protected Long getChangeLogLockWaitTime() {
         if (changeLogLockPollRate != null) {
             return changeLogLockPollRate;
         }
@@ -82,7 +82,7 @@ public class StandardLockService implements LockService {
         this.changeLogLockPollRate = changeLogLockWaitTime;
     }
 
-    public Long getChangeLogLockRecheckTime() {
+    protected Long getChangeLogLockRecheckTime() {
         if (changeLogLockRecheckTime != null) {
             return changeLogLockRecheckTime;
         }
@@ -187,7 +187,7 @@ public class StandardLockService implements LockService {
      * Determine whether the databasechangeloglock table has been initialized.
      * @param forceRecheck if true, do not use any cached information, and recheck the actual database
      */
-    private boolean isDatabaseChangeLogLockTableInitialized(final boolean tableJustCreated, final boolean forceRecheck) {
+    protected boolean isDatabaseChangeLogLockTableInitialized(final boolean tableJustCreated, final boolean forceRecheck) {
         if (!isDatabaseChangeLogLockTableInitialized || forceRecheck) {
             Executor executor = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database);
 
@@ -222,7 +222,7 @@ public class StandardLockService implements LockService {
      * Check whether the databasechangeloglock table exists in the database.
      * @param forceRecheck if true, do not use any cached information and check the actual database
      */
-    private boolean hasDatabaseChangeLogLockTable(boolean forceRecheck) {
+    protected boolean hasDatabaseChangeLogLockTable(boolean forceRecheck) {
         if (forceRecheck || hasDatabaseChangeLogLockTable == null) {
             try {
                 hasDatabaseChangeLogLockTable = SnapshotGeneratorFactory.getInstance()
@@ -234,7 +234,7 @@ public class StandardLockService implements LockService {
         return hasDatabaseChangeLogLockTable;
     }
 
-    public boolean hasDatabaseChangeLogLockTable() throws DatabaseException {
+    protected boolean hasDatabaseChangeLogLockTable() throws DatabaseException {
         return hasDatabaseChangeLogLockTable(false);
     }
 
@@ -331,6 +331,7 @@ public class StandardLockService implements LockService {
             try {
                 database.rollback();
             } catch (DatabaseException e) {
+
             }
         }
 


### PR DESCRIPTION
This pull request changes the modifiers of standard lock service to protected for the case where only certain parts of the lock service need to be rewritten. 

An example is this pr in the Keyspace extension.
https://github.com/liquibase/liquibase-amazon-keyspaces/pull/8