### PR TITLE
Upgraded mssql driver to 10.2.0

### DIFF
--- a/liquibase-dist/pom.xml
+++ b/liquibase-dist/pom.xml
@@ -22,7 +22,7 @@
         <h2.version>2.1.210</h2.version>
         <hsqldb.version>2.5.2</hsqldb.version>
         <postgresql.version>42.3.2</postgresql.version>
-        <mssql.version>8.4.0.jre8</mssql.version>
+        <mssql.version>10.2.0.jre8</mssql.version>
         <mysql.version>8.0.21</mysql.version>
         <mariadb.version>2.7.0</mariadb.version>
         <oracle.version>18.3.0.0</oracle.version>

--- a/liquibase-extension-testing/src/main/java/liquibase/extension/testing/testsystem/core/MSSQLTestSystem.java
+++ b/liquibase-extension-testing/src/main/java/liquibase/extension/testing/testsystem/core/MSSQLTestSystem.java
@@ -35,7 +35,7 @@ public class MSSQLTestSystem extends DatabaseTestSystem {
     public String getConnectionUrl() {
         final JdbcDatabaseContainer container = ((DockerDatabaseWrapper) wrapper).getContainer();
 
-        return "jdbc:sqlserver://" + container.getHost() + ":" + container.getMappedPort(MSSQLServerContainer.MS_SQL_SERVER_PORT)+";databaseName="+getCatalog();
+        return "jdbc:sqlserver://" + container.getHost() + ":" + container.getMappedPort(MSSQLServerContainer.MS_SQL_SERVER_PORT)+";databaseName="+getCatalog()+";encrypt=false";
     }
     @Override
     protected String[] getSetupSql() {

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
-            <version>8.2.2.jre8</version>
+            <version>10.2.0.jre8</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
## Description

Upgraded SqlServer jdbc driver to the newest major version

## End User Impact

The driver changed the encryption default from "false" to "true" between the old 8.x and the new 10.x driver. That means that anyone who has a self-signed certificate in their database will need to add either `encrypt=false` OR `trustServerCertificate=true` OR add the server certificate to their java trusted certificate list.