### PR TITLE
Upgraded jaxb libraries to the newest 2.3.x versions

### DIFF
--- a/liquibase-dist/pom.xml
+++ b/liquibase-dist/pom.xml
@@ -119,21 +119,20 @@
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <version>2.3.0</version>
+            <version>2.3.1</version>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
+            <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-core</artifactId>
-            <version>2.3.0</version>
+            <version>2.3.0.1</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>2.3.0</version>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.6</version>
             <optional>true</optional>
         </dependency>
-
 
     </dependencies>
 

--- a/liquibase-dist/src/main/assembly/assembly-bin.xml
+++ b/liquibase-dist/src/main/assembly/assembly-bin.xml
@@ -79,8 +79,8 @@
             <includes>
                 <include>org.yaml:snakeyaml:jar:</include>
                 <include>javax.xml.bind:jaxb-api:jar:</include>
-                <include>com.sun.xml.bind:jaxb-impl:jar:</include>
-                <include>com.sun.xml.bind:jaxb-core:jar:</include>
+                <include>org.glassfish.jaxb:jaxb-runtime:jar:</include>
+                <include>org.glassfish.jaxb:jaxb-core:jar:</include>
                 <include>info.picocli:picocli:jar:</include>
 
                 <include>com.h2database:h2:jar:</include>

--- a/liquibase-dist/src/main/maven/release.pom.xml
+++ b/liquibase-dist/src/main/maven/release.pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <version>2.3.0</version>
+            <version>2.3.1</version>
             <scope>compile</scope>
         </dependency>
 

--- a/liquibase-maven-plugin/pom.xml
+++ b/liquibase-maven-plugin/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <version>2.3.0</version>
+            <version>2.3.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -228,22 +228,21 @@
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <version>2.3.0</version>
+            <version>2.3.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
+            <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-core</artifactId>
-            <version>2.3.0</version>
+            <version>2.3.0.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>2.3.0</version>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.6</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Description

Updated shipped jaxb libraries. To continue to support libraries we use which expect `javax.xml` vs. `jakarta.xml` packages we had to stay on 2.3.x vs. upgrading to 3.x

## Things to be aware of

The new `jaxb-runtime-2.3.6.jar` file replaces the old `jaxb-impl-2.3.0.jar` file. 

The `jaxb-api` and `jaxb-core` jar files have the same base names, just different versions now.