### PR TITLE
Bump hsqldb from 2.4.0 to 2.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
         <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
-            <version>2.4.0</version>
+            <version>2.5.2</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
## Description

Upgrade hsqldb to the latest Java 8 compatible version