### PR TITLE
Fix handling of defaultSchemaName on Postgresql

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/PostgresDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/PostgresDatabase.java
@@ -388,4 +388,12 @@ public class PostgresDatabase extends AbstractJdbcDatabase {
     public CatalogAndSchema.CatalogAndSchemaCase getSchemaAndCatalogCase() {
         return CatalogAndSchema.CatalogAndSchemaCase.LOWER_CASE;
     }
+
+    @Override
+    public void rollback() throws DatabaseException {
+        super.rollback();
+
+        //Rollback in postgresql resets the search path. Need to put it back to the defaults
+        DatabaseUtils.initializeDatabase(getDefaultCatalogName(), getDefaultSchemaName(), this);
+    }
 }


### PR DESCRIPTION
## Description

When we first connect to postgresql, we call `SET SEARCH_PATH=...` to ensure the defaultSchemaName is first in the list.

However, when we roll back the connection (which we do throughout a liquibase run to ensure we have a clean connection) the search path on the connection gets rolled back to the initial value.

This PR restores the the reset of SEARCH_PATH in the rollback operation for postgreql

- Fixes #2234 
- Fixes #2640