### PR TITLE
Fixed local XSD lookup

### DIFF
--- a/liquibase-core/src/main/java/liquibase/parser/core/xml/LiquibaseEntityResolver.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/xml/LiquibaseEntityResolver.java
@@ -42,16 +42,20 @@ public class LiquibaseEntityResolver implements EntityResolver2 {
         if (streams.isEmpty()) {
             streams = getFallbackResourceAccessor().openStreams(null, path);
 
-            if (streams.isEmpty() && GlobalConfiguration.SECURE_PARSING.getCurrentValue()) {
-                String errorMessage = "Unable to resolve xml entity " + systemId + " locally: " +
-                        GlobalConfiguration.SECURE_PARSING.getKey() + " is set to 'true' which does not allow remote lookups. " +
-                        "Set it to 'false' to allow remote lookups of xsd files.";
-                throw new XSDLookUpException(errorMessage);
-            } else {
-                log.fine("Unable to resolve XML entity locally. Will load from network.");
-                return null;
+            if (streams.isEmpty()) {
+                if (GlobalConfiguration.SECURE_PARSING.getCurrentValue()) {
+                    String errorMessage = "Unable to resolve xml entity " + systemId + " locally: " +
+                            GlobalConfiguration.SECURE_PARSING.getKey() + " is set to 'true' which does not allow remote lookups. " +
+                            "Set it to 'false' to allow remote lookups of xsd files.";
+                    throw new XSDLookUpException(errorMessage);
+                } else {
+                    log.fine("Unable to resolve XML entity locally. Will load from network.");
+                    return null;
+                }
             }
-        } else if (streams.size() == 1) {
+        }
+
+        if (streams.size() == 1) {
             log.fine("Found XML entity at " + streams.getURIs().get(0));
         } else if (streams.size() > 1) {
             log.warning("Found " + streams.size() + " copies of " + systemId + ". Using " + streams.getURIs().get(0));
@@ -84,7 +88,7 @@ public class LiquibaseEntityResolver implements EntityResolver2 {
 
     @Override
     public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
-        Scope.getCurrentScope().getLog(getClass()).warning("Current XML parsers seems to not support EntityResolver2. External entities won't be correctly loaded");
+        Scope.getCurrentScope().getLog(getClass()).warning("The current XML parser does not seems to not support EntityResolver2. External entities may not be correctly loaded");
         return resolveEntity(null, publicId, null, systemId);
     }
 }

--- a/liquibase-core/src/test/groovy/liquibase/parser/core/xml/LiquibaseEntityResolverTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/parser/core/xml/LiquibaseEntityResolverTest.groovy
@@ -1,104 +1,77 @@
 package liquibase.parser.core.xml
 
-import org.junit.Test;
-
+import liquibase.GlobalConfiguration
+import liquibase.Scope
+import liquibase.resource.FileSystemResourceAccessor
 import spock.lang.Specification
+import spock.lang.Unroll
 
-//@RunWith(PowerMockRunner.class)
-//@PrepareForTest({ LiquibaseEntityResolver.class, StreamUtil.class })
-public class LiquibaseEntityResolverTest extends Specification {
-//
-//	private static final String SYSTEM_ID = "http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd";
-//
-//	private static final String SYSTEM_ID_WITH_MIGRATOR_PATH = "http://www.liquibase.org/xml/ns/migrator/dbchangelog-1.0.xsd";
-//	private static final String SYSTEM_ID_FROM_MIGRATOR_PATH = "http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.0.xsd";
-//
-//	private static final String PUBLIC_ID = "publicId";
-//	private static final String NAME = "name";
-//
-//	private static final String BASE_URI = "baseUri";
-//	private static final String BASE_PATH = "basePath";
-//	private static final String FILE_SYSTEM_ID = "fileSystemId";
-//	private static final String PATH_AND_SYSTEM_ID = FilenameUtils.concat(BASE_PATH, FILE_SYSTEM_ID);
-//
-//	private LiquibaseEntityResolver liquibaseEntityResolver;
-//
-//	@Mock
-//	private LiquibaseSchemaResolver liquibaseSchemaResolver;
-//
-//	@Mock
-//	private ResourceAccessor resourceAccessor;
-//
-//	@Mock
-//	private InputSource inputSource;
-//
-//	@Mock
-//	private XMLChangeLogSAXParser parser;
-//
-//	@Mock
-//	private InputStream inputStream;
-//
-//	@Mock
-//	private LiquibaseSerializer serializer;
-//
-//	@Before
-//	public void setUp() throws Exception {
-//		PowerMockito.mockStatic(StreamUtil.class);
-//
-//		PowerMockito.whenNew(LiquibaseSchemaResolver.class).withArguments(SYSTEM_ID, PUBLIC_ID, resourceAccessor).thenReturn(liquibaseSchemaResolver);
-//
-//		when(liquibaseSchemaResolver.resolve(parser)).thenReturn(inputSource);
-//		when(liquibaseSchemaResolver.resolve(serializer)).thenReturn(inputSource);
-//
-//		liquibaseEntityResolver = new LiquibaseEntityResolver(parser);
-//		liquibaseEntityResolver.useResoureAccessor(resourceAccessor, BASE_PATH);
-//	}
-//
-//	@Test
-//	public void shouldReturnNullSystemIdIsNull() throws Exception {
-//		InputSource result = liquibaseEntityResolver.resolveEntity(NAME, PUBLIC_ID, BASE_URI, null);
-//
-//		assertThat(result).isNull();
-//	}
-//
-//	@Test
-//	public void systemIdStartingWithMigratorShouldBeReplacedByDbChangelog() throws Exception {
-//		PowerMockito.whenNew(LiquibaseSchemaResolver.class).withArguments(SYSTEM_ID_FROM_MIGRATOR_PATH, PUBLIC_ID, resourceAccessor).thenReturn(liquibaseSchemaResolver);
-//
-//		InputSource result = liquibaseEntityResolver.resolveEntity(NAME, PUBLIC_ID, BASE_URI, SYSTEM_ID_WITH_MIGRATOR_PATH);
-//
-//		assertThat(result).isSameAs(inputSource);
-//	}
-//
-//	@Test
-//	public void shouldReturnSchemaResolverResultWhenSystemIdIsValidXsd() throws IOException, SAXException {
-//		InputSource result = liquibaseEntityResolver.resolveEntity(NAME, PUBLIC_ID, BASE_URI, SYSTEM_ID);
-//
-//		assertThat(result).isSameAs(inputSource);
-//	}
-//
-//	@Test
-//	public void shouldReturnSchemaResolverResultWhenSystemIdIsValidXsdAndSerializerIsNotNull() throws IOException, SAXException {
-//		liquibaseEntityResolver = new LiquibaseEntityResolver(serializer);
-//		liquibaseEntityResolver.useResoureAccessor(resourceAccessor, BASE_PATH);
-//
-//		InputSource result = liquibaseEntityResolver.resolveEntity(NAME, PUBLIC_ID, BASE_URI, SYSTEM_ID);
-//
-//		assertThat(result).isSameAs(inputSource);
-//	}
-//
-//
-//	@Test
-//	public void resolveEntityWithOnlyPublicIdAndSystemIdDelegatesToSchemResolver() throws IOException, SAXException {
-//		InputSource result = liquibaseEntityResolver.resolveEntity(PUBLIC_ID, SYSTEM_ID);
-//
-//		assertThat(result).isSameAs(inputSource);
-//	}
-//
-//	@Test
-//	public void getExternalSubsetShouldReturnNull() throws IOException, SAXException {
-//		InputSource externalSubset = liquibaseEntityResolver.getExternalSubset(NAME, BASE_URI);
-//
-//		assertThat(externalSubset).isNull();
-//	}
+class LiquibaseEntityResolverTest extends Specification {
+
+    @Unroll
+    def "resolveEntity finds packaged files correctly"() {
+        expect:
+        new LiquibaseEntityResolver().resolveEntity(null, null, null, systemId) != null
+
+        where:
+        systemId << [
+                "http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd",
+                "https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd",
+                "http://www.liquibase.org/xml/ns/migrator/dbchangelog-3.1.xsd",
+                "http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-next.xsd",
+                "http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd",
+                "/liquibase/banner.txt", //can find files without hostnames
+                "http://liquibase/banner.txt", //conversion of hostnames to files works for not just liquibase.org URLs
+        ]
+    }
+
+    @Unroll
+    def "resolveEntity finds packaged files correctly even if the configured resourceAccessor doesn't have it"() {
+        expect:
+        Scope.child([(Scope.Attr.resourceAccessor.name()): new FileSystemResourceAccessor(new File("."))], { ->
+            new LiquibaseEntityResolver().resolveEntity(null, null, null, systemId) != null
+        } as Scope.ScopedRunnerWithReturn) != null
+
+        where:
+        systemId << [
+                "http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd",
+                "https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd",
+        ]
+    }
+
+    @Unroll
+    def "resolveEntity returns null for non-packaged files"() {
+        expect:
+        Scope.child(GlobalConfiguration.SECURE_PARSING.key, false, { ->
+            new LiquibaseEntityResolver().resolveEntity(null, null, null, systemId) == null
+        }) == null
+
+        when:
+        Scope.child(GlobalConfiguration.SECURE_PARSING.key, true, { ->
+            new LiquibaseEntityResolver().resolveEntity(null, null, null, systemId) == null
+        })
+
+        then:
+        def e = thrown(XSDLookUpException)
+        e.message.startsWith("Unable to resolve xml entity")
+
+
+        where:
+        systemId << [
+                "http://www.liquibase.org/xml/ns/dbchangelog/invalid.xsd",
+                "http://www.example.com/xml/ns/dbchangelog/dbchangelog-3.1.xsd",
+                "http://www.example.com/random/file.txt",
+        ]
+    }
+
+    def "null systemId returns null"() {
+        expect:
+        new LiquibaseEntityResolver().resolveEntity("passed publicId", null) == null
+        new LiquibaseEntityResolver().resolveEntity("passed name", "passed publicId", "passed baseURI", null) == null
+    }
+
+    def "getExternalSubset returns null"() {
+        expect:
+        assert new LiquibaseEntityResolver().getExternalSubset("pased name", "passed baseURI") == null
+    }
 }


### PR DESCRIPTION
## Pull Request Type

<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->
- [X] Bug fix (non-breaking change which fixes an issue.)
- [ ] Enhancement/New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

There is an issue in the XSD lookup logic, where it always pulls the XSD file over the network if the primary ResourceAccessor fails to find it and the "fallback" one does.

When we'd get to the fallback code, the `&& SECURE_PARSING)` would be false and make the `if` block fail regardless of whether it found resources or not.

The standard Liquibase integrations (CLI, Maven, etc.) set up the primary resource accessor so we never hit the problem code path, but custom setups could. The integration tests, for example, did hit the problem code.