### PR TITLE
Restored outputDefaultSchema and outputDefaultCatalog command arguments

### DIFF
--- a/liquibase-core/src/main/java/liquibase/command/core/ChangelogSyncSqlCommandStep.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/ChangelogSyncSqlCommandStep.java
@@ -18,6 +18,8 @@ public class ChangelogSyncSqlCommandStep extends AbstractCliWrapperCommandStep {
     public static final CommandArgumentDefinition<String> CONTEXTS_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_PROPERTIES_FILE_ARG;
+    public static final CommandArgumentDefinition<Boolean> OUTPUT_DEFAULT_SCHEMA_ARG;
+    public static final CommandArgumentDefinition<Boolean> OUTPUT_DEFAULT_CATALOG_ARG;
 
     static {
         CommandBuilder builder = new CommandBuilder(COMMAND_NAME);
@@ -42,6 +44,14 @@ public class ChangelogSyncSqlCommandStep extends AbstractCliWrapperCommandStep {
                 .description("Label expression to use for filtering which changes to mark as executed").build();
         CONTEXTS_ARG = builder.argument("contexts", String.class)
                 .description("Context string to use for filtering which changes to mark as executed").build();
+        OUTPUT_DEFAULT_SCHEMA_ARG = builder.argument("outputDefaultSchema", Boolean.class)
+                .description("Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified")
+                .defaultValue(true)
+                .build();
+        OUTPUT_DEFAULT_CATALOG_ARG = builder.argument("outputDefaultCatalog", Boolean.class)
+                .description("Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified")
+                .defaultValue(true)
+                .build();
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/command/core/ChangelogSyncToTagSqlCommandStep.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/ChangelogSyncToTagSqlCommandStep.java
@@ -19,6 +19,8 @@ public class ChangelogSyncToTagSqlCommandStep extends AbstractCliWrapperCommandS
     public static final CommandArgumentDefinition<String> TAG_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_PROPERTIES_FILE_ARG;
+    public static final CommandArgumentDefinition<Boolean> OUTPUT_DEFAULT_SCHEMA_ARG;
+    public static final CommandArgumentDefinition<Boolean> OUTPUT_DEFAULT_CATALOG_ARG;
 
     static {
         CommandBuilder builder = new CommandBuilder(COMMAND_NAME);
@@ -45,6 +47,14 @@ public class ChangelogSyncToTagSqlCommandStep extends AbstractCliWrapperCommandS
                 .description("Changeset contexts to match").build();
         TAG_ARG = builder.argument("tag", String.class).required()
                 .description("Tag ID to execute changelogSync to").build();
+        OUTPUT_DEFAULT_SCHEMA_ARG = builder.argument("outputDefaultSchema", Boolean.class)
+                .description("Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified")
+                .defaultValue(true)
+                .build();
+        OUTPUT_DEFAULT_CATALOG_ARG = builder.argument("outputDefaultCatalog", Boolean.class)
+                .description("Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified")
+                .defaultValue(true)
+                .build();
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/command/core/FutureRollbackCountSqlCommandStep.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/FutureRollbackCountSqlCommandStep.java
@@ -19,6 +19,8 @@ public class FutureRollbackCountSqlCommandStep extends AbstractCliWrapperCommand
     public static final CommandArgumentDefinition<Integer> COUNT_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_PROPERTIES_FILE_ARG;
+    public static final CommandArgumentDefinition<Boolean> OUTPUT_DEFAULT_SCHEMA_ARG;
+    public static final CommandArgumentDefinition<Boolean> OUTPUT_DEFAULT_CATALOG_ARG;
 
     static {
         CommandBuilder builder = new CommandBuilder(COMMAND_NAME);
@@ -46,6 +48,14 @@ public class FutureRollbackCountSqlCommandStep extends AbstractCliWrapperCommand
                 .description("Changeset contexts to match").build();
         COUNT_ARG = builder.argument("count", Integer.class).required()
                 .description("Number of change sets to generate rollback SQL for").build();
+        OUTPUT_DEFAULT_SCHEMA_ARG = builder.argument("outputDefaultSchema", Boolean.class)
+                .description("Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified")
+                .defaultValue(true)
+                .build();
+        OUTPUT_DEFAULT_CATALOG_ARG = builder.argument("outputDefaultCatalog", Boolean.class)
+                .description("Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified")
+                .defaultValue(true)
+                .build();
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/command/core/FutureRollbackFromTagSqlCommandStep.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/FutureRollbackFromTagSqlCommandStep.java
@@ -19,6 +19,8 @@ public class FutureRollbackFromTagSqlCommandStep extends AbstractCliWrapperComma
     public static final CommandArgumentDefinition<String> TAG_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_PROPERTIES_FILE_ARG;
+    public static final CommandArgumentDefinition<Boolean> OUTPUT_DEFAULT_SCHEMA_ARG;
+    public static final CommandArgumentDefinition<Boolean> OUTPUT_DEFAULT_CATALOG_ARG;
 
     static {
         CommandBuilder builder = new CommandBuilder(COMMAND_NAME);
@@ -46,6 +48,14 @@ public class FutureRollbackFromTagSqlCommandStep extends AbstractCliWrapperComma
                 .description("Changeset contexts to match").build();
         TAG_ARG = builder.argument("tag", String.class).required()
                 .description("Tag ID to rollback from").build();
+        OUTPUT_DEFAULT_SCHEMA_ARG = builder.argument("outputDefaultSchema", Boolean.class)
+                .description("Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified")
+                .defaultValue(true)
+                .build();
+        OUTPUT_DEFAULT_CATALOG_ARG = builder.argument("outputDefaultCatalog", Boolean.class)
+                .description("Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified")
+                .defaultValue(true)
+                .build();
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/command/core/FutureRollbackSqlCommandStep.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/FutureRollbackSqlCommandStep.java
@@ -18,6 +18,8 @@ public class FutureRollbackSqlCommandStep extends AbstractCliWrapperCommandStep 
     public static final CommandArgumentDefinition<String> CONTEXTS_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_PROPERTIES_FILE_ARG;
+    public static final CommandArgumentDefinition<Boolean> OUTPUT_DEFAULT_SCHEMA_ARG;
+    public static final CommandArgumentDefinition<Boolean> OUTPUT_DEFAULT_CATALOG_ARG;
 
     static {
         CommandBuilder builder = new CommandBuilder(COMMAND_NAME);
@@ -43,6 +45,14 @@ public class FutureRollbackSqlCommandStep extends AbstractCliWrapperCommandStep 
                 .description("Changeset labels to match").build();
         CONTEXTS_ARG = builder.argument("contexts", String.class)
                 .description("Changeset contexts to match").build();
+        OUTPUT_DEFAULT_SCHEMA_ARG = builder.argument("outputDefaultSchema", Boolean.class)
+                .description("Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified")
+                .defaultValue(true)
+                .build();
+        OUTPUT_DEFAULT_CATALOG_ARG = builder.argument("outputDefaultCatalog", Boolean.class)
+                .description("Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified")
+                .defaultValue(true)
+                .build();
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/command/core/RollbackCountSqlCommandStep.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/RollbackCountSqlCommandStep.java
@@ -22,6 +22,8 @@ public class RollbackCountSqlCommandStep extends AbstractCliWrapperCommandStep {
     public static final CommandArgumentDefinition<String> CHANGE_EXEC_LISTENER_PROPERTIES_FILE_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_PROPERTIES_FILE_ARG;
+    public static final CommandArgumentDefinition<Boolean> OUTPUT_DEFAULT_SCHEMA_ARG;
+    public static final CommandArgumentDefinition<Boolean> OUTPUT_DEFAULT_CATALOG_ARG;
 
     static {
         CommandBuilder builder = new CommandBuilder(COMMAND_NAME);
@@ -55,6 +57,14 @@ public class RollbackCountSqlCommandStep extends AbstractCliWrapperCommandStep {
             .description("Fully-qualified class which specifies a ChangeExecListener").build();
         CHANGE_EXEC_LISTENER_PROPERTIES_FILE_ARG = builder.argument("changeExecListenerPropertiesFile", String.class)
             .description("Path to a properties file for the ChangeExecListenerClass").build();
+        OUTPUT_DEFAULT_SCHEMA_ARG = builder.argument("outputDefaultSchema", Boolean.class)
+                .description("Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified")
+                .defaultValue(true)
+                .build();
+        OUTPUT_DEFAULT_CATALOG_ARG = builder.argument("outputDefaultCatalog", Boolean.class)
+                .description("Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified")
+                .defaultValue(true)
+                .build();
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/command/core/RollbackSqlCommandStep.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/RollbackSqlCommandStep.java
@@ -22,6 +22,8 @@ public class RollbackSqlCommandStep extends AbstractCliWrapperCommandStep {
     public static final CommandArgumentDefinition<String> CHANGE_EXEC_LISTENER_PROPERTIES_FILE_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_PROPERTIES_FILE_ARG;
+    public static final CommandArgumentDefinition<Boolean> OUTPUT_DEFAULT_SCHEMA_ARG;
+    public static final CommandArgumentDefinition<Boolean> OUTPUT_DEFAULT_CATALOG_ARG;
 
     static {
         CommandBuilder builder = new CommandBuilder(COMMAND_NAME);
@@ -55,6 +57,14 @@ public class RollbackSqlCommandStep extends AbstractCliWrapperCommandStep {
             .description("Fully-qualified class which specifies a ChangeExecListener").build();
         CHANGE_EXEC_LISTENER_PROPERTIES_FILE_ARG = builder.argument("changeExecListenerPropertiesFile", String.class)
             .description("Path to a properties file for the ChangeExecListenerClass").build();
+        OUTPUT_DEFAULT_SCHEMA_ARG = builder.argument("outputDefaultSchema", Boolean.class)
+                .description("Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified")
+                .defaultValue(true)
+                .build();
+        OUTPUT_DEFAULT_CATALOG_ARG = builder.argument("outputDefaultCatalog", Boolean.class)
+                .description("Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified")
+                .defaultValue(true)
+                .build();
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/command/core/RollbackToDateSqlCommandStep.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/RollbackToDateSqlCommandStep.java
@@ -24,6 +24,8 @@ public class RollbackToDateSqlCommandStep extends AbstractCliWrapperCommandStep 
     public static final CommandArgumentDefinition<String> CHANGE_EXEC_LISTENER_PROPERTIES_FILE_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_PROPERTIES_FILE_ARG;
+    public static final CommandArgumentDefinition<Boolean> OUTPUT_DEFAULT_SCHEMA_ARG;
+    public static final CommandArgumentDefinition<Boolean> OUTPUT_DEFAULT_CATALOG_ARG;
 
     static {
         CommandBuilder builder = new CommandBuilder(COMMAND_NAME);
@@ -57,6 +59,14 @@ public class RollbackToDateSqlCommandStep extends AbstractCliWrapperCommandStep 
             .description("Fully-qualified class which specifies a ChangeExecListener").build();
         CHANGE_EXEC_LISTENER_PROPERTIES_FILE_ARG = builder.argument("changeExecListenerPropertiesFile", String.class)
             .description("Path to a properties file for the ChangeExecListenerClass").build();
+        OUTPUT_DEFAULT_SCHEMA_ARG = builder.argument("outputDefaultSchema", Boolean.class)
+                .description("Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified")
+                .defaultValue(true)
+                .build();
+        OUTPUT_DEFAULT_CATALOG_ARG = builder.argument("outputDefaultCatalog", Boolean.class)
+                .description("Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified")
+                .defaultValue(true)
+                .build();
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/command/core/UpdateCountSqlCommandStep.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/UpdateCountSqlCommandStep.java
@@ -21,6 +21,8 @@ public class UpdateCountSqlCommandStep extends AbstractCliWrapperCommandStep {
     public static final CommandArgumentDefinition<String> CHANGE_EXEC_LISTENER_PROPERTIES_FILE_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_PROPERTIES_FILE_ARG;
+    public static final CommandArgumentDefinition<Boolean> OUTPUT_DEFAULT_SCHEMA_ARG;
+    public static final CommandArgumentDefinition<Boolean> OUTPUT_DEFAULT_CATALOG_ARG;
 
     static {
         CommandBuilder builder = new CommandBuilder(COMMAND_NAME);
@@ -52,6 +54,14 @@ public class UpdateCountSqlCommandStep extends AbstractCliWrapperCommandStep {
             .description("Fully-qualified class which specifies a ChangeExecListener").build();
         CHANGE_EXEC_LISTENER_PROPERTIES_FILE_ARG = builder.argument("changeExecListenerPropertiesFile", String.class)
             .description("Path to a properties file for the ChangeExecListenerClass").build();
+        OUTPUT_DEFAULT_SCHEMA_ARG = builder.argument("outputDefaultSchema", Boolean.class)
+                .description("Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified")
+                .defaultValue(true)
+                .build();
+        OUTPUT_DEFAULT_CATALOG_ARG = builder.argument("outputDefaultCatalog", Boolean.class)
+                .description("Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified")
+                .defaultValue(true)
+                .build();
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/command/core/UpdateSqlCommandStep.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/UpdateSqlCommandStep.java
@@ -21,6 +21,8 @@ public class UpdateSqlCommandStep extends AbstractCliWrapperCommandStep {
     public static final CommandArgumentDefinition<String> CHANGE_EXEC_LISTENER_PROPERTIES_FILE_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_PROPERTIES_FILE_ARG;
+    public static final CommandArgumentDefinition<Boolean> OUTPUT_DEFAULT_SCHEMA_ARG;
+    public static final CommandArgumentDefinition<Boolean> OUTPUT_DEFAULT_CATALOG_ARG;
 
     static {
         CommandBuilder builder = new CommandBuilder(COMMAND_NAME, LEGACY_COMMAND_NAME);
@@ -50,6 +52,14 @@ public class UpdateSqlCommandStep extends AbstractCliWrapperCommandStep {
                 .description("Fully-qualified class which specifies a ChangeExecListener").build();
         CHANGE_EXEC_LISTENER_PROPERTIES_FILE_ARG = builder.argument("changeExecListenerPropertiesFile", String.class)
                 .description("Path to a properties file for the ChangeExecListenerClass").build();
+        OUTPUT_DEFAULT_SCHEMA_ARG = builder.argument("outputDefaultSchema", Boolean.class)
+                .description("Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified")
+                .defaultValue(true)
+                .build();
+        OUTPUT_DEFAULT_CATALOG_ARG = builder.argument("outputDefaultCatalog", Boolean.class)
+                .description("Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified")
+                .defaultValue(true)
+                .build();
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/command/core/UpdateToTagSqlCommandStep.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/UpdateToTagSqlCommandStep.java
@@ -21,6 +21,8 @@ public class UpdateToTagSqlCommandStep extends AbstractCliWrapperCommandStep {
     public static final CommandArgumentDefinition<String> CHANGE_EXEC_LISTENER_PROPERTIES_FILE_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_PROPERTIES_FILE_ARG;
+    public static final CommandArgumentDefinition<Boolean> OUTPUT_DEFAULT_SCHEMA_ARG;
+    public static final CommandArgumentDefinition<Boolean> OUTPUT_DEFAULT_CATALOG_ARG;
 
     static {
         CommandBuilder builder = new CommandBuilder(COMMAND_NAME);
@@ -52,6 +54,14 @@ public class UpdateToTagSqlCommandStep extends AbstractCliWrapperCommandStep {
             .description("Fully-qualified class which specifies a ChangeExecListener").build();
         CHANGE_EXEC_LISTENER_PROPERTIES_FILE_ARG = builder.argument("changeExecListenerPropertiesFile", String.class)
             .description("Path to a properties file for the ChangeExecListenerClass").build();
+        OUTPUT_DEFAULT_SCHEMA_ARG = builder.argument("outputDefaultSchema", Boolean.class)
+                .description("Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified")
+                .defaultValue(true)
+                .build();
+        OUTPUT_DEFAULT_CATALOG_ARG = builder.argument("outputDefaultCatalog", Boolean.class)
+                .description("Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified")
+                .defaultValue(true)
+                .build();
     }
 
     @Override

--- a/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/changelogSyncSql.test.groovy
+++ b/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/changelogSyncSql.test.groovy
@@ -27,6 +27,10 @@ Optional Args:
     Default: null
   labels (String) Label expression to use for filtering which changes to mark as executed
     Default: null
+  outputDefaultCatalog (Boolean) Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified
+    Default: true
+  outputDefaultSchema (Boolean) Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified
+    Default: true
   password (String) The database password
     Default: null
     OBFUSCATED

--- a/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/changelogSyncToTagSql.test.groovy
+++ b/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/changelogSyncToTagSql.test.groovy
@@ -28,6 +28,10 @@ Optional Args:
     Default: null
   labels (String) Changeset labels to match
     Default: null
+  outputDefaultCatalog (Boolean) Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified
+    Default: true
+  outputDefaultSchema (Boolean) Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified
+    Default: true
   password (String) The database password
     Default: null
     OBFUSCATED

--- a/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/futureRollbackCountSql.test.groovy
+++ b/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/futureRollbackCountSql.test.groovy
@@ -25,6 +25,10 @@ Optional Args:
     Default: null
   labels (String) Changeset labels to match
     Default: null
+  outputDefaultCatalog (Boolean) Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified
+    Default: true
+  outputDefaultSchema (Boolean) Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified
+    Default: true
   password (String) The database password
     Default: null
     OBFUSCATED

--- a/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/futureRollbackFromTagSql.test.groovy
+++ b/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/futureRollbackFromTagSql.test.groovy
@@ -25,6 +25,10 @@ Optional Args:
     Default: null
   labels (String) Changeset labels to match
     Default: null
+  outputDefaultCatalog (Boolean) Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified
+    Default: true
+  outputDefaultSchema (Boolean) Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified
+    Default: true
   password (String) Password to use to connect to the database
     Default: null
     OBFUSCATED

--- a/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/futureRollbackSql.test.groovy
+++ b/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/futureRollbackSql.test.groovy
@@ -24,6 +24,10 @@ Optional Args:
     Default: null
   labels (String) Changeset labels to match
     Default: null
+  outputDefaultCatalog (Boolean) Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified
+    Default: true
+  outputDefaultSchema (Boolean) Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified
+    Default: true
   password (String) Password to use to connect to the database
     Default: null
     OBFUSCATED

--- a/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/rollbackCountSql.test.groovy
+++ b/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/rollbackCountSql.test.groovy
@@ -29,6 +29,10 @@ Optional Args:
     Default: null
   labels (String) Changeset labels to match
     Default: null
+  outputDefaultCatalog (Boolean) Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified
+    Default: true
+  outputDefaultSchema (Boolean) Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified
+    Default: true
   password (String) Password to use to connect to the database
     Default: null
     OBFUSCATED

--- a/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/rollbackSql.test.groovy
+++ b/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/rollbackSql.test.groovy
@@ -29,6 +29,10 @@ Optional Args:
     Default: null
   labels (String) Changeset labels to match
     Default: null
+  outputDefaultCatalog (Boolean) Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified
+    Default: true
+  outputDefaultSchema (Boolean) Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified
+    Default: true
   password (String) Password to use to connect to the database
     Default: null
     OBFUSCATED

--- a/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/rollbackToDateSql.test.groovy
+++ b/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/rollbackToDateSql.test.groovy
@@ -29,6 +29,10 @@ Optional Args:
     Default: null
   labels (String) Changeset labels to match
     Default: null
+  outputDefaultCatalog (Boolean) Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified
+    Default: true
+  outputDefaultSchema (Boolean) Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified
+    Default: true
   password (String) Password to use to connect to the database
     Default: null
     OBFUSCATED

--- a/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/updateCountSql.test.groovy
+++ b/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/updateCountSql.test.groovy
@@ -29,6 +29,10 @@ Optional Args:
     Default: null
   labels (String) Changeset labels to match
     Default: null
+  outputDefaultCatalog (Boolean) Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified
+    Default: true
+  outputDefaultSchema (Boolean) Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified
+    Default: true
   password (String) Password to use to connect to the database
     Default: null
     OBFUSCATED

--- a/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/updateSql.test.groovy
+++ b/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/updateSql.test.groovy
@@ -30,6 +30,10 @@ Optional Args:
     Default: null
   labels (String) Changeset labels to match
     Default: null
+  outputDefaultCatalog (Boolean) Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified
+    Default: true
+  outputDefaultSchema (Boolean) Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified
+    Default: true
   password (String) Password to use to connect to the database
     Default: null
     OBFUSCATED

--- a/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/updateToTagSql.test.groovy
+++ b/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/updateToTagSql.test.groovy
@@ -29,6 +29,10 @@ Optional Args:
     Default: null
   labels (String) Changeset labels to match
     Default: null
+  outputDefaultCatalog (Boolean) Control whether names of objects in the default catalog are fully qualified or not. If true they are. If false, only objects outside the default catalog are fully qualified
+    Default: true
+  outputDefaultSchema (Boolean) Control whether names of objects in the default schema are fully qualified or not. If true they are. If false, only objects outside the default schema are fully qualified
+    Default: true
   password (String) Password to use to connect to the database
     Default: null
     OBFUSCATED


### PR DESCRIPTION
## Description

With the command framework refactoring in 4.4.0, the outputDefaultSchema and outputDefaultCatalog arguments were missed. Because of that, there is no way to change the behavior away from the default value (true).

The flag is re-added as a command-level argument, since it only really applies to *Sql commands and is therefore not a global argument.

- If true, any generated SQL will have objects in the default schema fully qualified with the default schema and/or default catalog as possible. 
- If false, any generated SQL will have objects in the default schema and/or default catalog left unqualified. Objects in non-default schema/catalog are always fully qualified.

This change ensures the flag is exposed and passed along, but does not attempt to change or test the behavior as it was in 4.3 and before.

## Additional Context

Fixes #2547

## Things to be aware of
- The existing command test setup lets us catch the commands which had the flags added and if they get lost again down the road. But we don't have a good automated test option for ensuring they are correctly respected and so need to be manually checked for now.


## Things to worry about
- Nothing