### PR TITLE
Support default values in the format `(0)::real`

### DIFF
--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
@@ -37,7 +37,7 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
     protected static final String COLUMN_DEF_COL = "COLUMN_DEF";
 
     private Pattern postgresStringValuePattern = Pattern.compile("'(.*)'::[\\w .]+");
-    private Pattern postgresNumberValuePattern = Pattern.compile("(\\d*)::[\\w .]+");
+    private Pattern postgresNumberValuePattern = Pattern.compile("\\(?(\\d*)\\)?::[\\w .]+");
 
 
     public ColumnSnapshotGenerator() {


### PR DESCRIPTION
## Pull Request Type
- [X] Bug fix (non-breaking change which fixes an issue.)
- [ ] Enhancement/New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

The current code recognizes `0::real` in postgresql, but not `(0)::real`. Updated the regexp to handle both

Fixes #2833 

## Things to be aware of
- Only impacts handling of default values and only in postgresql

## Things to worry about
- Nothing
