### PR TITLE
null pointer issue if change changelog object is null

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
@@ -897,9 +897,11 @@ public class ChangeSet implements Conditional, ChangeLogChild {
 
     public boolean isInheritableIgnore() {
        DatabaseChangeLog changeLog = getChangeLog();
-        if(null!=changeLog)
-        	return changeLog.isIncludeIgnore();
-        return false;
+        if (changeLog == null) {
+            return false;
+        }
+
+        return changeLog.isIncludeIgnore();
     }
 
     public Collection<ContextExpression> getInheritableContexts() {

--- a/liquibase-core/src/test/groovy/liquibase/changelog/ChangeSetTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/changelog/ChangeSetTest.groovy
@@ -561,4 +561,25 @@ public class ChangeSetTest extends Specification {
         null     | null
     }
 
+    def isInheritableIgnore() {
+        when:
+        def changeSet = new ChangeSet("id1", "author1", false, false, "/test.xml", null, null, null);
+
+        then:
+        !changeSet.isInheritableIgnore()
+
+        when:
+        def parent = new DatabaseChangeLog("com/example/test.xml")
+        changeSet = new ChangeSet("id1", "author1", false, false, "/test.xml", null, null, parent);
+
+        then:
+        !changeSet.isInheritableIgnore()
+
+        when:
+        parent.setIncludeIgnore(true)
+
+        then:
+        changeSet.isInheritableIgnore()
+    }
+
 }


### PR DESCRIPTION
This will throw null pointer if change changelog object is null. 
**Cannot invoke "liquibase.changelog.DatabaseChangeLog.isIncludeIgnore()" because "changeLog" is null.**
Environment Production
Liquibase Version: it started in 3.7.x onward.
 **public boolean isInheritableIgnore() {
        DatabaseChangeLog changeLog = this.getChangeLog();
        return changeLog.isIncludeIgnore();
    }
This method was added in 3.7.x** 

**Following is the change list 
commit 9ae2b572c79ff0273f1dfb2f867148e74dfebb98**

Liquibase Integration & Version: Spring boot

Liquibase Extension(s) & Version: it started in 3.7.x onward.

Database Vendor & Version: Oracle

Operating System Type & Version: Windows 10

## Pull Request Type
Bug fix (non-breaking change which fixes an issue.)
https://forum.liquibase.org/t/null-pointer-exception-in-liquibase-core/6838

## Description
when  changelog object remain null. this method through null pointer issue. 

**public boolean isInheritableIgnore() {
        DatabaseChangeLog changeLog = this.getChangeLog();
        return changeLog.isIncludeIgnore();
    }
This method was added in 3.7.x** 

**Cannot invoke "liquibase.changelog.DatabaseChangeLog.isIncludeIgnore()" because "changeLog" is null.**

## Steps To Reproduce
https://forum.liquibase.org/t/null-pointer-exception-in-liquibase-core/6838

## Actual Behavior
Code should no throw null pointer issue

## Expected/Desired Behavior
A clear and concise description of what happens in the software **after** this pull request.

## Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/1253703/167835693-19949d73-aece-45fc-a5b0-251f1cb511d4.png)

![image](https://user-images.githubusercontent.com/1253703/168072288-3c15e0df-3c59-4389-a9c1-da65dab7f7d6.png)


## Additional Context
Add any other context about the problem here.

## Fast Track PR Acceptance Checklist:

## Need Help?
[Come chat with us in the [Liquibase Forum](https://forum.liquibase.org/).](https://forum.liquibase.org/t/null-pointer-exception-in-liquibase-core/6838 Yes, to discuss this.)
