### PR TITLE
Added whitelist for CLI log channels to include

### DIFF
--- a/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
+++ b/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
@@ -619,11 +619,22 @@ public class LiquibaseCommandLine {
             cliLogLevel = Level.OFF;
         }
 
-        final List<String> channels = StringUtil.splitAndTrim(LiquibaseCommandLineConfiguration.LOG_CHANNELS.getCurrentValue(), ",");
-        if (logLevel == Level.OFF) {
-            channels.add("");
+        final String configuredChannels = LiquibaseCommandLineConfiguration.LOG_CHANNELS.getCurrentValue();
+        List<String> channels;
+        if (configuredChannels.equalsIgnoreCase("all")) {
+            channels = new ArrayList<>(Arrays.asList("", "liquibase"));
+        } else {
+            channels = StringUtil.splitAndTrim(configuredChannels, ",");
+
+            if (logLevel == Level.OFF) {
+                channels.add("");
+            }
         }
+
         for (String channel : channels) {
+            if (channel.equalsIgnoreCase("all")) {
+                channel = "";
+            }
             java.util.logging.Logger.getLogger(channel).setLevel(logLevel);
         }
 

--- a/liquibase-core/src/main/java/liquibase/integration/commandline/LiquibaseCommandLineConfiguration.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/LiquibaseCommandLineConfiguration.java
@@ -21,6 +21,7 @@ public class LiquibaseCommandLineConfiguration implements AutoloadedConfiguratio
     public static final ConfigurationDefinition<Boolean> INCLUDE_SYSTEM_CLASSPATH;
     public static final ConfigurationDefinition<String> DEFAULTS_FILE;
     public static final ConfigurationDefinition<Level> LOG_LEVEL;
+    public static final ConfigurationDefinition<String> LOG_CHANNELS;
     public static final ConfigurationDefinition<File> LOG_FILE;
     public static final ConfigurationDefinition<File> OUTPUT_FILE;
     public static final ConfigurationDefinition<Boolean> SHOULD_RUN;
@@ -59,6 +60,10 @@ public class LiquibaseCommandLineConfiguration implements AutoloadedConfiguratio
         LOG_LEVEL = builder.define("logLevel", Level.class)
                 .setDefaultValue(Level.OFF,"Controls which logs get set to stderr AND to any log file. The CLI defaults, if log file set, to SEVERE. Others vary by integration. The official log levels are: OFF, SEVERE, WARNING, INFO, FINE")
                 .setValueHandler(ConfigurationValueConverter.LOG_LEVEL)
+                .build();
+
+        LOG_CHANNELS = builder.define("logChannels", String.class)
+                .setDefaultValue("liquibase", "Controls which log channels have their level set by the liquibase.logLevel setting. Comma separate multiple values. Example: liquibase,org.mariadb.jdbc")
                 .build();
 
         LOG_FILE = builder.define("logFile", File.class).build();

--- a/liquibase-core/src/main/java/liquibase/integration/commandline/LiquibaseCommandLineConfiguration.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/LiquibaseCommandLineConfiguration.java
@@ -63,7 +63,7 @@ public class LiquibaseCommandLineConfiguration implements AutoloadedConfiguratio
                 .build();
 
         LOG_CHANNELS = builder.define("logChannels", String.class)
-                .setDefaultValue("liquibase", "Controls which log channels have their level set by the liquibase.logLevel setting. Comma separate multiple values. Example: liquibase,org.mariadb.jdbc")
+                .setDefaultValue("liquibase", "Controls which log channels have their level set by the liquibase.logLevel setting. Comma separate multiple values. To set the level of all channels, use 'all'. Example: liquibase,org.mariadb.jdbc")
                 .build();
 
         LOG_FILE = builder.define("logFile", File.class).build();


### PR DESCRIPTION
## Impact

- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

Marked as a breaking change because 3rd party (non-liquibase) logging will no longer be logged without also specifying the --log-channels flag.

## Description

While we can't control the log configuration in most environments liquibase runs in, we do control the log setup in the CLI. 

Liquibase does not log any sensitive information, but we have no control over what other libraries will log and want to make sure nothing unexpected gets logged in user environments. 

Therefore, when applying the "logLevel" setting in the CLI, we are switching to a whitelisting of channels to include. The whitelist defaults to only "liquibase", but it can be controlled via a new `liquibase.logChannel` setting. For example, `--log-channels=liquibase,com.microsoft.sqlserver.jdbc`. We also support `--log-channels=all`

This replaces the previous reflection-based blacklisting of `net.sun.www.protocol.http.HttpURLConnection` which caused a warning in Java 11 and an ignored error in 17

## Things to be aware of
- Impacts the logging to both stdout and the log file
- Only impacts in the CLI

## Things to worry about
- Nothing

## Additional Context

I was not able to control the log level of `net.sun.www.protocol.http.HttpURLConnection` with the setting. I thing their use of the internal PlatformLogger is getting in the way. If anyone ever needs that, we can look at options for that. I was able to see it work with `org.mariadb` after adding `?log=true` to the mariadb url

## Testing

**Setup:** Configure liquibase to point to a mssql database

- Running `liquibase update` with no logLevel should print no logs
- Running `liquibase --log-level=FINE update` should log only messages with `[liquibase ...]` as the channel. No `[com.microsoft...]` channels
- Running `liquibase --log-level=FINE --log-channels=liquibase,com.microsoft update` should log messages with both the liquibase and com.microsoft channels 
- Running the above update calls with and without --log-channels works as expected in Java 8 and 17
- Running the update with and without --log-channels but with --log-file should have the same messages present/missing in the file as was in the console.