### PR TITLE
Add liquibase.showBanner global configuration setting

### DIFF
--- a/liquibase-core/src/main/java/liquibase/GlobalConfiguration.java
+++ b/liquibase-core/src/main/java/liquibase/GlobalConfiguration.java
@@ -29,6 +29,7 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
     public static final ConfigurationDefinition<Boolean> GENERATED_CHANGESET_IDS_INCLUDE_DESCRIPTION;
     public static final ConfigurationDefinition<Boolean> INCLUDE_CATALOG_IN_SPECIFICATION;
     public static final ConfigurationDefinition<Boolean> SHOULD_SNAPSHOT_DATA;
+    public static final ConfigurationDefinition<Boolean> SHOW_BANNER;
 
     /**
      * @deprecated No longer used
@@ -184,6 +185,11 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
 
         SECURE_PARSING = builder.define("secureParsing", Boolean.class)
                 .setDescription("If true, remove functionality from file parsers which could be used insecurely. Examples include (but not limited to) disabling remote XML entity support.")
+                .setDefaultValue(true)
+                .build();
+
+        SHOW_BANNER = builder.define("showBanner", Boolean.class)
+                .setDescription("If true, show a Liquibase banner on startup.")
                 .setDefaultValue(true)
                 .build();
     }

--- a/liquibase-core/src/main/java/liquibase/integration/commandline/CommandLineUtils.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/CommandLineUtils.java
@@ -271,14 +271,16 @@ public class CommandLineUtils {
         buildTimeString = LiquibaseUtil.getBuildTime();
 
         StringBuilder banner = new StringBuilder();
+        if (GlobalConfiguration.SHOW_BANNER.getCurrentValue()) {
 
-        // Banner is stored in liquibase/banner.txt in resources.
-        Class commandLinUtilsClass = CommandLineUtils.class;
-        InputStream inputStream = commandLinUtilsClass.getResourceAsStream("/liquibase/banner.txt");
-        try {
-            banner.append(readFromInputStream(inputStream));
-        } catch (IOException e) {
-            Scope.getCurrentScope().getLog(commandLinUtilsClass).fine("Unable to locate banner file.");
+            // Banner is stored in liquibase/banner.txt in resources.
+            Class commandLinUtilsClass = CommandLineUtils.class;
+            InputStream inputStream = commandLinUtilsClass.getResourceAsStream("/liquibase/banner.txt");
+            try {
+                banner.append(readFromInputStream(inputStream));
+            } catch (IOException e) {
+                Scope.getCurrentScope().getLog(commandLinUtilsClass).fine("Unable to locate banner file.");
+            }
         }
 
         banner.append(String.format(

--- a/liquibase-core/src/test/groovy/liquibase/integration/commandline/CommandLineUtilsTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/integration/commandline/CommandLineUtilsTest.groovy
@@ -1,0 +1,27 @@
+package liquibase.integration.commandline
+
+import liquibase.GlobalConfiguration
+import liquibase.Scope
+import spock.lang.Specification
+
+class CommandLineUtilsTest extends Specification {
+
+    def getBanner() {
+        expect:
+        CommandLineUtils.getBanner().contains("Get documentation at docs.liquibase.com")
+        CommandLineUtils.getBanner().contains("Starting Liquibase at");
+        CommandLineUtils.getBanner().contains("version ")
+    }
+
+    def "getBanner with banner disabled"() {
+        when:
+        String banner = Scope.child([(GlobalConfiguration.SHOW_BANNER.key): false], { ->
+            return CommandLineUtils.getBanner()
+        } as Scope.ScopedRunnerWithReturn<String>)
+
+        then:
+        !banner.contains("Get documentation at docs.liquibase.com")
+        banner.contains("Starting Liquibase at");
+        banner.contains("version ")
+    }
+}


### PR DESCRIPTION
## Description

Adds a new `liquibase.showBanner` setting that disables the Liquibase startup banner. The start time and version information are preserved because they are informational and small.

The default value for the setting is "true".

Fixes #2681 