### PR TITLE
Added connector-api.jar to internal/lib

### DIFF
--- a/liquibase-dist/pom.xml
+++ b/liquibase-dist/pom.xml
@@ -114,6 +114,13 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- required for firebird driver -->
+        <dependency>
+            <groupId>javax.resource</groupId>
+            <artifactId>connector-api</artifactId>
+            <version>1.5</version>
+        </dependency>
+
         <!-- needed for inclusion in CLI when running in newer java versions -->
 
         <dependency>

--- a/liquibase-dist/src/main/archive/licenses/README.txt
+++ b/liquibase-dist/src/main/archive/licenses/README.txt
@@ -41,6 +41,7 @@ BSD 3 Clause License
 - org.firebirdsql.jdbc:jaybird (Dual License: LGPL, BSD-3 Clause)
 
 CDDL 1.1 License
+- javax.resource:connector-api
 - javax.xml.bind:jaxb-api
 
 Eclipse Distribution 1.0 License

--- a/liquibase-dist/src/main/assembly/assembly-bin.xml
+++ b/liquibase-dist/src/main/assembly/assembly-bin.xml
@@ -112,6 +112,7 @@
                 <include>org.xerial:sqlite-jdbc:jar:</include>
                 <include>com.ibm.db2:jcc:jar:</include>
                 <include>org.firebirdsql.jdbc:jaybird:</include>
+                <include>javax.resource:connector-api:</include>
 
                 <!-- CANNOT SHIP FOR LICENSE REASONS -->
                 <!-- <include>mysql:mysql-connector-java:jar</include>-->


### PR DESCRIPTION
## Description

The jaybird.jar we ship requires access to `javax.resources` which comes with the connector-api.jar.

This adds that required dependency and updates the licenses file accordingly.

## Current behavior

Running `liquibase update` against firebird with an out-of-the-box liquibase configuration fails with a "ClassNotFound" exception

## Updated Behavior

Running `liquibase update` against firebird with an out-of-the-box liquibase configuration runs successfully
