### PR TITLE
fix TableOutput spaces when using long words (DAT-10069)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/util/TableOutput.java
+++ b/liquibase-core/src/main/java/liquibase/util/TableOutput.java
@@ -213,6 +213,11 @@ public class TableOutput {
      * @return the new current running width
      */
     private static int doAppend(int runningWidth, String part, int maxWidth, StringBuilder result) {
+        // If a word that is longer than the maxWidth is appended before this method is called, it will spill onto
+        // multiple lines, and we only care about the runningWidth of the last line.
+        if (runningWidth > maxWidth) {
+            runningWidth = runningWidth % maxWidth;
+        }
         int spaceWidth = runningWidth > 0 ? 1 : 0;
         if (runningWidth + (part.length() + spaceWidth) > maxWidth) {
             runningWidth = fillLineWithSpaces(runningWidth, maxWidth, result);


### PR DESCRIPTION
## Environment

**Liquibase Version**: N/A

**Liquibase Integration & Version**: N/A

**Liquibase Extension(s) & Version**: N/A

**Database Vendor & Version**: N/A

**Operating System Type & Version**: N/A

## Pull Request Type

<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->
- [X] Bug fix (non-breaking change which fixes an issue.)
- [ ] Enhancement/New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Outputting long lines with a single word that spans over multiple lines caused the next word to be appended directly without a space:

```
+-----+--------------------------------+-----------------------------+--------------------------------+---------+--------------------------------+----------+
| 127 | Disallow postgres non reserved | PostgresNonReservedKeywords | Disallow Postgres non-reserved | false   | OBJECT_TYPES = null            | 0        |
|     | keywords                       |                             | keywords from being used in    |         | ALLOWED_LIST = null            |          |
|     |                                |                             | database object names. See     |         | CASE_SENSITIVE = true          |          |
|     |                                |                             | https://www.postgresql.org/doc |         |                                |          |
|     |                                |                             | s/14/sql-keywords-appendix.htm |         |                                |          |
|     |                                |                             | lfor complete list of keywords |         |                                |          |
|     |                                |                             | .                              |         |                                |          |
+-----+--------------------------------+-----------------------------+--------------------------------+---------+--------------------------------+----------+
```

## Steps To Reproduce

Use the TableOutput class to print out a cell with a single word that stretches over multiple lines.

## Actual Behavior

Word after the long word is appended without a space.

## Expected/Desired Behavior

Space exists between long word and next word.

## Screenshots (if appropriate)


## Additional Context


## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->
- [ ] Build is successful and all new and existing tests pass
- [ ] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
- [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
- [ ] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls)
- [ ] Documentation Updated

## Need Help?
Come chat with us in the [Liquibase Forum](https://forum.liquibase.org/).
