### PR TITLE
Make extension matching for SQL parsers case-insensitve DAT-10265

### DIFF
--- a/liquibase-core/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
@@ -481,7 +481,7 @@ public class FormattedSqlChangeLogParser implements ChangeLogParser {
     }
 
     protected boolean supportsExtension(String changelogFile){
-        return changelogFile.endsWith(".sql");
+        return changelogFile.toLowerCase().endsWith(".sql");
     }
 
     private SqlPrecondition parseSqlCheckCondition(String body) throws ChangeLogParseException{

--- a/liquibase-core/src/main/java/liquibase/parser/core/sql/SqlChangeLogParser.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/sql/SqlChangeLogParser.java
@@ -19,7 +19,7 @@ public class SqlChangeLogParser implements ChangeLogParser {
 
     @Override
     public boolean supports(String changeLogFile, ResourceAccessor resourceAccessor) {
-        return changeLogFile.endsWith(".sql");
+        return changeLogFile.toLowerCase().endsWith(".sql");
     }
 
     @Override

--- a/liquibase-core/src/test/groovy/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.groovy
@@ -190,6 +190,7 @@ grant execute on any_procedure_name to ANY_USER3/
         expect:
         assert new MockFormattedSqlChangeLogParser(VALID_CHANGELOG).supports("asdf.sql", new JUnitResourceAccessor())
         assert !new MockFormattedSqlChangeLogParser(INVALID_CHANGELOG).supports("asdf.sql", new JUnitResourceAccessor())
+        assert new MockFormattedSqlChangeLogParser(VALID_CHANGELOG).supports("asdf.SQL", new JUnitResourceAccessor())
     }
 
     def invalidPrecondition() throws Exception {


### PR DESCRIPTION
## Description

Currently Liquibase only considers files that end in a lowercase .sql as parse-able by either the raw or formatted parsers. 

This makes those parsers recognize sql files regardless of the case of the extension.