### PR TITLE
Quote liquibase.jar path in bash launcher

### DIFF
--- a/liquibase-dist/src/main/archive/liquibase
+++ b/liquibase-dist/src/main/archive/liquibase
@@ -47,4 +47,4 @@ fi
 JAVA_OPTS="${JAVA_OPTS-}"
 
 export LIQUIBASE_HOME
-"${JAVA_PATH}" $JAVA_OPTS -jar $LIQUIBASE_HOME/liquibase.jar ${1+"$@"}
+"${JAVA_PATH}" $JAVA_OPTS -jar "$LIQUIBASE_HOME/liquibase.jar" ${1+"$@"}


### PR DESCRIPTION
## Description

The current `liquibase` bash script does not quote the liquibase.jar path, so it will not run if there is a space in the path to LIQUIBASE_HOME. It fails with a `Error: Unable to access jarfile` error.

This quotes the path so it works correctly

## Repo Steps

1. Untar liquibase.tar.gz to a path containing a space in the filename
2. Run `./liquibase --version` 

