### PR TITLE
Set max fractional timestamp digits to 12 for all DB2 editions (fix #2880)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/AbstractDb2Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/AbstractDb2Database.java
@@ -24,7 +24,9 @@ import java.util.Locale;
 
 public abstract class AbstractDb2Database extends AbstractJdbcDatabase {
 
-    public AbstractDb2Database() {
+    private static final int MAX_DB2_TIMESTAMP_FRACTIONAL_DIGITS = 12;
+
+	public AbstractDb2Database() {
         super.setCurrentDateTimeFunction("CURRENT TIMESTAMP");
         super.sequenceNextValueFunction = "NEXT VALUE FOR %s";
         super.sequenceCurrentValueFunction = "PREVIOUS VALUE FOR %s";
@@ -235,4 +237,19 @@ public abstract class AbstractDb2Database extends AbstractJdbcDatabase {
     public CatalogAndSchema.CatalogAndSchemaCase getSchemaAndCatalogCase() {
         return CatalogAndSchema.CatalogAndSchemaCase.ORIGINAL_CASE;
     }
+
+	@Override
+	public int getMaxFractionalDigitsForTimestamp() {
+		try {
+			// See https://www.ibm.com/docs/en/db2/9.7?topic=enhancements-timestamp-data-type-allows-parameterized-precision
+			// Max precision for timestamp is 12 digits in all editions of DB from version 9.7 onwards
+			if (getDatabaseMajorVersion() > 9 || getDatabaseMajorVersion() == 9 && getDatabaseMinorVersion() >= 7) {
+				return MAX_DB2_TIMESTAMP_FRACTIONAL_DIGITS;
+			} else {
+				return super.getMaxFractionalDigitsForTimestamp();
+			} 
+		} catch (Exception e) {
+			return super.getMaxFractionalDigitsForTimestamp();
+		}
+	}
 }

--- a/liquibase-core/src/main/java/liquibase/database/core/Db2zDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/Db2zDatabase.java
@@ -9,11 +9,7 @@ import liquibase.util.StringUtil;
 
 public class Db2zDatabase extends AbstractDb2Database {
 	
-	// See https://www.ibm.com/support/knowledgecenter/en/SSEPEK_11.0.0/sqlref/src/tpc/db2z_limits.html#db2z_limits__limdt, 
-	// may not apply to older versions, caveat emptor 
-	private static final int MAX_DB2Z_TIMESTAMP_FRACTIONAL_DIGITS = 12;
-	
-    public Db2zDatabase() {
+	public Db2zDatabase() {
         super.setCurrentDateTimeFunction("CURRENT TIMESTAMP");
         super.sequenceNextValueFunction = "NEXT VALUE FOR %s";
         super.sequenceCurrentValueFunction = "PREVIOUS VALUE FOR %s";
@@ -50,10 +46,5 @@ public class Db2zDatabase extends AbstractDb2Database {
     @Override
     protected String getDefaultDatabaseProductName() {
         return "DB2/z";
-    }
-
-    @Override
-    public int getMaxFractionalDigitsForTimestamp() {
-    	return MAX_DB2Z_TIMESTAMP_FRACTIONAL_DIGITS;
     }
 }

--- a/liquibase-core/src/test/java/liquibase/database/core/DB2DatabaseTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/core/DB2DatabaseTest.java
@@ -16,4 +16,10 @@ public class DB2DatabaseTest extends TestCase {
         }
     }
 
+    public void testMaxFractionDigits() {
+        Database database = new DB2Database();
+        assertEquals(12, database.getMaxFractionalDigitsForTimestamp());
+    }
+
+
 }

--- a/liquibase-core/src/test/java/liquibase/database/core/DB2zDatabaseTest.java
+++ b/liquibase-core/src/test/java/liquibase/database/core/DB2zDatabaseTest.java
@@ -16,4 +16,9 @@ public class DB2zDatabaseTest extends TestCase {
         }
     }
 
+    public void testMaxFractionDigits() {
+        Database database = new Db2zDatabase();
+        assertEquals(12, database.getMaxFractionalDigitsForTimestamp());
+    }
+
 }


### PR DESCRIPTION
<!--- This environment context section helps us quickly review your PR. 
      Please take a minute to fill-out this information. -->
## Environment

**Liquibase Version**:
4.11.0
**Liquibase Integration & Version**: <Pick one: CLI, maven, gradle, spring boot, servlet, etc.>
Maven
**Liquibase Extension(s) & Version**: 

**Database Vendor & Version**:
DB2 11
**Operating System Type & Version**:
Linux/Unix/Windows
## Pull Request Type

<!--- What types of changes does your code introduce?
      Put an `x` in all the boxes that apply: 
      If this PR fixes an existing GH issue, edit the next line to add "closes #XXXX" to auto-link.
      If this PR fixes an existing CORE Jira issue, note that as well, although there will be no auto-linking. -->
- [x] Bug fix (non-breaking change which fixes an issue.)
- [ ] Enhancement/New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

A clear and concise description of the issue being addressed.  Additional guidance [here](https://liquibase.jira.com/wiki/spaces/LB/pages/1274904896/How+to+Contribute+Code+to+Liquibase+Core).
- Describe the actual problematic behavior.
- Ensure private information is redacted.


## Steps To Reproduce
1. In an existing DB2 database, create a table with a TIMESTAMP(12) column
2. Run generate-changelog

List the steps to reproduce the behavior.
- Please be precise and ensure private information is redacted
- Include things like
  - Files used - sql scripts, changelog file(s), property file(s), config files, POM Files
  - Exact commands used - CLI, maven, gradle, spring boot, servlet, etc.

## Actual Behavior
A clear and concise description of what happens in the software **before** this pull request.
- Include console output if relevant
- Include log files if available.

The generate-changelog job fails with error saying that 12 digits is not supported by DB2:
[2022-05-30 16:07:50] SEVERE [liquibase.integration] Using a TIMESTAMP data type with a fractional precision of 12 is not supported on db2: A timestamp datatype with 12 fractional digits was requested, but DB2/LINUX X8664 only supports 9 digits.

## Expected/Desired Behavior
A clear and concise description of what happens in the software **after** this pull request.

The generate-changelog job successfully creates the change log, because DB2 does support 12 digit precision in timestamps.

## Screenshots (if appropriate)
If applicable, add screenshots to help explain your problem.

## Additional Context
Add any other context about the problem here.

## Fast Track PR Acceptance Checklist:
<!--- Completing these speeds up the acceptance of your pull request -->
<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, just ask us in a comment. We're here to help! -->
- [x] Build is successful and all new and existing tests pass
- [x] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
- [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
- [ ] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls)
- [ ] Documentation Updated

## Need Help?
Come chat with us in the [Liquibase Forum](https://forum.liquibase.org/).
