### PR TITLE
[DAT-10093] added schema escaping to getColumns call to jdbc metadata classes

### DIFF
--- a/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -392,8 +392,8 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                        extract(
                             databaseMetaData.getColumns(
                                     ((AbstractJdbcDatabase) database).getJdbcCatalogName(catalogAndSchema),
-                                    ((AbstractJdbcDatabase) database).getJdbcSchemaName(catalogAndSchema),
-                                    tableName,
+                                    escapeForLike(((AbstractJdbcDatabase) database).getJdbcSchemaName(catalogAndSchema), database),
+                                    escapeForLike(tableName, database),
                                     SQL_FILTER_MATCH_ALL)
                     );
                     //
@@ -424,8 +424,9 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                 try {
                     List<CachedRow> returnList =
                         extract(databaseMetaData.getColumns(((AbstractJdbcDatabase) database)
-                            .getJdbcCatalogName(catalogAndSchema), ((AbstractJdbcDatabase) database)
-                            .getJdbcSchemaName(catalogAndSchema), SQL_FILTER_MATCH_ALL, SQL_FILTER_MATCH_ALL));
+                                    .getJdbcCatalogName(catalogAndSchema),
+                            escapeForLike(((AbstractJdbcDatabase) database).getJdbcSchemaName(catalogAndSchema), database),
+                            SQL_FILTER_MATCH_ALL, SQL_FILTER_MATCH_ALL));
                     //
                     // IF MARIADB
                     // Query to get actual data types and then map each column to its CachedRow

--- a/liquibase-integration-tests/src/test/groovy/liquibase/snapshot/JdbcDatabaseSnapshotTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/snapshot/JdbcDatabaseSnapshotTest.groovy
@@ -7,14 +7,12 @@ import liquibase.extension.testing.testsystem.DatabaseTestSystem
 import liquibase.extension.testing.testsystem.TestSystemFactory
 import liquibase.statement.SqlStatement
 import liquibase.statement.core.RawSqlStatement
+import liquibase.structure.core.Column
 import liquibase.structure.core.Table
 import liquibase.structure.core.View
 import org.junit.Rule
-import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
-
-import java.sql.Connection
 
 class JdbcDatabaseSnapshotTest extends Specification {
 
@@ -22,7 +20,7 @@ class JdbcDatabaseSnapshotTest extends Specification {
     public DatabaseTestSystem h2 = Scope.currentScope.getSingleton(TestSystemFactory).getTestSystem("h2")
 
     @Unroll
-    def "getTables and getViews works with underscores in schema names"() {
+    def "getTables, getColumns and getViews works with underscores in schema names"() {
         when:
         def connection = h2.getConnection()
         def db = DatabaseFactory.instance.findCorrectDatabaseImplementation(new JdbcConnection(connection))
@@ -36,6 +34,9 @@ class JdbcDatabaseSnapshotTest extends Specification {
         then:
         SnapshotGeneratorFactory.instance.has(new Table(null, "TEST-SCHEMA", "TEST_TABLE"), db)
         !SnapshotGeneratorFactory.instance.has(new Table(null, "TEST_SCHEMA", "TEST_TABLE"), db)
+
+        SnapshotGeneratorFactory.instance.has(new Column(Table.class,null, "TEST-SCHEMA", "TEST_TABLE", "ID"), db)
+        !SnapshotGeneratorFactory.instance.has(new Column(Table.class, null, "TEST_SCHEMA", "TEST_TABLE","ID"), db)
 
         SnapshotGeneratorFactory.instance.has(new View(null, "TEST-SCHEMA", "TEST_VIEW"), db)
         !SnapshotGeneratorFactory.instance.has(new View(null, "TEST_SCHEMA", "TEST_VIEW"), db)

--- a/liquibase-snowflake/src/main/java/liquibase/database/core/SnowflakeDatabase.java
+++ b/liquibase-snowflake/src/main/java/liquibase/database/core/SnowflakeDatabase.java
@@ -155,11 +155,6 @@ public class SnowflakeDatabase extends AbstractJdbcDatabase {
         return null;
     }
 
-    @Override
-    public boolean supportsSchemas() {
-        return true;
-    }
-
     private Set<String> getDefaultReservedWords() {
         /*
          * List taken from


### PR DESCRIPTION
## Environment

**Liquibase Version**: 4.11


**Database Vendor & Version**: all, fix needed for Snowflake

**Operating System Type & Version**: windows 10

## Pull Request Type

https://datical.atlassian.net/browse/DAT-10093
- [x] Bug fix (non-breaking change which fixes an issue.)
- [ ] Enhancement/New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

JdbcDatabaseSnapshot doesn't escape percent and underscore characters in schema names for getColumns() calls like it does for getTables (and actually getViews). For Snowflake jdbc classes this cause to dropping schema name from requests completely what causes slow performance.

## Steps To Reproduce

According to ticket description need to have Snowflake account with a number of schemas with number of tables and number of columns to clearly see Liquibase hangs for long time performing operations.

## Actual Behavior
liquibase slow performance on Snowflake DB.

## Expected/Desired Behavior
Performance increase.



## Fast Track PR Acceptance Checklist:

- [ ] Build is successful and all new and existing tests pass
- [ ] Added [Unit Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1274937609/How+to+Write+Liquibase+Core+Unit+Tests)
- [ ] Added [Integration Test(s)](https://liquibase.jira.com/wiki/spaces/LB/pages/1276608569/How+to+Write+Liquibase+Core+Integration+Tests)
- [ ] Added [Test Harness Test(s)](https://github.com/liquibase/liquibase-test-harness/pulls)
- [ ] Documentation Updated

## Need Help?
Come chat with us in the [Liquibase Forum](https://forum.liquibase.org/).
