### PR TITLE
Move opencsv to be non-shaded

### DIFF
--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -113,8 +113,6 @@
             <artifactId>opencsv</artifactId>
             <version>5.6</version>
         </dependency>
-
-
     </dependencies>
 
     <build>
@@ -230,48 +228,6 @@
                         <goals>
                             <goal>manifest</goal>
                         </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.3.0</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <artifactSet>
-                                <includes>
-                                    <include>com.opencsv:*</include>
-                                    <include>org.apache.commons:commons-lang3</include>
-                                    <include>org.apache.commons:commons-text</include>
-                                    <include>org.apache.commons:commons-collections4</include>
-                                </includes>
-                            </artifactSet>
-                            <relocations>
-                                <relocation>
-                                    <pattern>org.apache.commons.collections4</pattern>
-                                    <shadedPattern>liquibase.repackaged.org.apache.commons.collections4</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.apache.commons.lang3</pattern>
-                                    <shadedPattern>liquibase.repackaged.org.apache.commons.lang3</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.apache.commons.text</pattern>
-                                    <shadedPattern>liquibase.repackaged.org.apache.commons.text</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.opencsv</pattern>
-                                    <shadedPattern>liquibase.repackaged.com.opencsv</shadedPattern>
-                                </relocation>
-                            </relocations>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/liquibase-dist/pom.xml
+++ b/liquibase-dist/pom.xml
@@ -114,13 +114,6 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- required for firebird driver -->
-        <dependency>
-            <groupId>javax.resource</groupId>
-            <artifactId>connector-api</artifactId>
-            <version>1.5</version>
-        </dependency>
-
         <!-- needed for inclusion in CLI when running in newer java versions -->
 
         <dependency>

--- a/liquibase-dist/src/main/assembly/assembly-bin.xml
+++ b/liquibase-dist/src/main/assembly/assembly-bin.xml
@@ -125,7 +125,6 @@
                 <exclude>org.antlr:antlr4-runtime:jar:</exclude>  <!-- from connector-api -->
                 <exclude>org.checkerframework:checker-qual:jar:</exclude> <!-- from postgresql -->
                 <exclude>commons-beanutils:commons-beanutils:jar:</exclude> <!-- from opencsv -->
-                <exclude>commons-beanutils:commons-beanutils:jar:</exclude> <!-- from opencsv -->
                 <exclude>org.glassfish.jaxb:txw2:jar:</exclude> <!-- from jaxb-core -->
                 <exclude>com.sun.istack:istack-commons-runtime:jar:</exclude> <!-- from jaxb-core -->
                 <exclude>jakarta.xml.bind:jakarta.xml.bind-api:jar:</exclude> <!-- from jaxb-runtime -->

--- a/liquibase-dist/src/main/assembly/assembly-bin.xml
+++ b/liquibase-dist/src/main/assembly/assembly-bin.xml
@@ -96,7 +96,10 @@
         <dependencySet>
             <outputFileNameMapping> ${artifact.artifactId}${dashClassifier?}.${artifact.extension}</outputFileNameMapping>
             <outputDirectory>internal/lib</outputDirectory>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <scope>runtime</scope>
             <includes>
+                <include>com.opencsv:opencsv:</include>
                 <include>org.yaml:snakeyaml:jar:</include>
                 <include>javax.xml.bind:jaxb-api:jar:</include>
                 <include>org.glassfish.jaxb:jaxb-runtime:jar:</include>
@@ -112,12 +115,23 @@
                 <include>org.xerial:sqlite-jdbc:jar:</include>
                 <include>com.ibm.db2:jcc:jar:</include>
                 <include>org.firebirdsql.jdbc:jaybird:</include>
-                <include>javax.resource:connector-api:</include>
 
                 <!-- CANNOT SHIP FOR LICENSE REASONS -->
                 <!-- <include>mysql:mysql-connector-java:jar</include>-->
-
             </includes>
+
+            <!-- some libraries lie about compile vs. runtime dependencies. Or we don't hit code that uses these. So exclude them manually. -->
+            <excludes>
+                <exclude>org.antlr:antlr4-runtime:jar:</exclude>  <!-- from connector-api -->
+                <exclude>org.checkerframework:checker-qual:jar:</exclude> <!-- from postgresql -->
+                <exclude>commons-beanutils:commons-beanutils:jar:</exclude> <!-- from opencsv -->
+                <exclude>commons-beanutils:commons-beanutils:jar:</exclude> <!-- from opencsv -->
+                <exclude>org.glassfish.jaxb:txw2:jar:</exclude> <!-- from jaxb-core -->
+                <exclude>com.sun.istack:istack-commons-runtime:jar:</exclude> <!-- from jaxb-core -->
+                <exclude>jakarta.xml.bind:jakarta.xml.bind-api:jar:</exclude> <!-- from jaxb-runtime -->
+                <exclude>com.sun.activation:jakarta.activation:jar:</exclude> <!-- from jaxb-runtime -->
+                <exclude>javax.activation:javax.activation-api:jar:</exclude> <!-- from jaxb-api -->
+            </excludes>
         </dependencySet>
     </dependencySets>
 

--- a/liquibase-dist/src/main/maven/release.pom.xml
+++ b/liquibase-dist/src/main/maven/release.pom.xml
@@ -41,7 +41,12 @@
             <artifactId>snakeyaml</artifactId>
             <version>1.27</version>
             <scope>compile</scope>
-            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.opencsv</groupId>
+            <artifactId>opencsv</artifactId>
+            <version>5.6</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
## Description

Rather than shading opencsv into the liquibase-core.jar, define it as a dependency in the shipped pom.xml and include it as a separate jar in the internal/lib directory. 

Opencsv has dependencies on commons-collections4, commons-lang3, and commons-text so they are will be in the internal/lib directory as well.

Partly addresses #2852 but not fully so not marking it as "fixes"

## Expected changes
- No liquibase/repackaged directory in liquibase-core.jar anymore
- commons-collections4.jar added to to internal/lib
- commons-lang3.jar added to to internal/lib
- commons-text.jar added to to internal/lib
- opencsv.jar added to internal/lib
- Nothing else new added to internal/lib

## Testing

The CLI and maven plugin should continue to handle changelogs with loadData pointing to CSV files with no issues.