### PR TITLE
Upgraded maven dependency to 3.8.5

### DIFF
--- a/liquibase-extension-examples/pom.xml
+++ b/liquibase-extension-examples/pom.xml
@@ -12,10 +12,6 @@
 	<packaging>jar</packaging>
 	<description>Liquibase Examples</description>
 
-	<properties>
-		<targetMavenVersion>3.3.9</targetMavenVersion>
-	</properties>
-
 	<dependencies>
         <dependency>
             <groupId>org.liquibase</groupId>

--- a/liquibase-maven-plugin/pom.xml
+++ b/liquibase-maven-plugin/pom.xml
@@ -14,7 +14,7 @@
     <description>A Maven plugin wraps up some of the functionality of Liquibase</description>
 
     <properties>
-        <targetMavenVersion>3.3.9</targetMavenVersion>
+        <targetMavenVersion>3.8.5</targetMavenVersion>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
## Description

Updates the version of maven we compile against to 3.8.5 to avoid security scanners flagging the project.

Because we're not changing any code this does not impact versions of maven we support, but going forward we will have to be careful of new maven API method calls we make until we can update the test automation to test against older versions