### PR TITLE
Improved postgresql prepared statement performance

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -10,7 +10,6 @@ import liquibase.changelog.DatabaseChangeLog;
 import liquibase.changelog.RanChangeSet;
 import liquibase.changelog.StandardChangeLogHistoryService;
 import liquibase.GlobalConfiguration;
-import liquibase.configuration.ConfigurationDefinition;
 import liquibase.configuration.ConfiguredValue;
 import liquibase.database.core.OracleDatabase;
 import liquibase.database.core.PostgresDatabase;
@@ -88,10 +87,19 @@ import static liquibase.util.StringUtil.join;
  */
 public abstract class AbstractJdbcDatabase implements Database {
 
-    private static final Pattern startsWithNumberPattern = Pattern.compile("^[0-9].*");
     private static final int FETCH_SIZE = 1000;
     private static final int DEFAULT_MAX_TIMESTAMP_FRACTIONAL_DIGITS = 9;
-    private static Pattern CREATE_VIEW_AS_PATTERN = Pattern.compile("^CREATE\\s+.*?VIEW\\s+.*?AS\\s+", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+    private static final Pattern STARTS_WITH_NUMBER_PATTERN = Pattern.compile("^[0-9].*");
+    private static final Pattern NON_WORD_PATTERN = Pattern.compile(".*\\W.*");
+    private static final Pattern CREATE_VIEW_AS_PATTERN = Pattern.compile("^CREATE\\s+.*?VIEW\\s+.*?AS\\s+", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+    private static final Pattern DATE_ONLY_PATTERN = Pattern.compile("^\\d{4}\\-\\d{2}\\-\\d{2}$");
+    private static final Pattern DATE_TIME_PATTERN = Pattern.compile("^\\d{4}\\-\\d{2}\\-\\d{2}[T ]\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?$");
+    private static final Pattern TIMESTAMP_PATTERN = Pattern.compile("^\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+$");
+    private static final Pattern TIME_PATTERN = Pattern.compile("^\\d{2}:\\d{2}:\\d{2}$");
+    private static final Pattern NAME_WITH_DESC_PATTERN = Pattern.compile("(?i).*\\s+DESC");
+    private static final Pattern NAME_WITH_ASC_PATTERN = Pattern.compile("(?i).*\\s+ASC");
+
     private final Set<String> reservedWords = new HashSet<>();
     protected String defaultCatalogName;
     protected String defaultSchemaName;
@@ -495,7 +503,7 @@ public abstract class AbstractJdbcDatabase implements Database {
      * @param isoDate value to check.
      */
     protected boolean isDateOnly(final String isoDate) {
-        return isoDate.matches("^\\d{4}\\-\\d{2}\\-\\d{2}$")
+        return DATE_ONLY_PATTERN.matcher(isoDate).matches()
                 || NowAndTodayUtil.isNowOrTodayFormat(isoDate);
     }
 
@@ -508,7 +516,7 @@ public abstract class AbstractJdbcDatabase implements Database {
      * @param isoDate value to check.
      */
     protected boolean isDateTime(final String isoDate) {
-        return isoDate.matches("^\\d{4}\\-\\d{2}\\-\\d{2}[T ]\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?$")
+        return DATE_TIME_PATTERN.matcher(isoDate).matches()
                 || NowAndTodayUtil.isNowOrTodayFormat(isoDate);
     }
 
@@ -521,7 +529,7 @@ public abstract class AbstractJdbcDatabase implements Database {
      * @param isoDate value to check
      */
     protected boolean isTimestamp(final String isoDate) {
-        return isoDate.matches("^\\d{4}\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+$")
+        return TIMESTAMP_PATTERN.matcher(isoDate).matches()
                 || NowAndTodayUtil.isNowOrTodayFormat(isoDate);
     }
 
@@ -532,7 +540,7 @@ public abstract class AbstractJdbcDatabase implements Database {
      * @param isoDate value to check
      */
     protected boolean isTimeOnly(final String isoDate) {
-        return isoDate.matches("^\\d{2}:\\d{2}:\\d{2}$")
+        return TIME_PATTERN.matcher(isoDate).matches()
                 || NowAndTodayUtil.isNowOrTodayFormat(isoDate);
     }
 
@@ -739,7 +747,7 @@ public abstract class AbstractJdbcDatabase implements Database {
     * Check if given string starts with numeric values that may cause problems and should be escaped.
     */
     protected boolean startsWithNumeric(final String objectName) {
-        return startsWithNumberPattern.matcher(objectName).matches();
+        return STARTS_WITH_NUMBER_PATTERN.matcher(objectName).matches();
     }
 
     @Override
@@ -1002,7 +1010,7 @@ public abstract class AbstractJdbcDatabase implements Database {
     }
 
     protected boolean mustQuoteObjectName(String objectName, Class<? extends DatabaseObject> objectType) {
-        return objectName.contains("-") || startsWithNumeric(objectName) || isReservedWord(objectName) || objectName.matches(".*\\W.*");
+        return objectName.contains("-") || startsWithNumeric(objectName) || isReservedWord(objectName) || NON_WORD_PATTERN.matcher(objectName).matches();
     }
 
     protected String getQuotingStartCharacter() {
@@ -1068,10 +1076,10 @@ public abstract class AbstractJdbcDatabase implements Database {
                 sb.append(", ");
             }
             boolean descending = false;
-            if (columnName.matches("(?i).*\\s+DESC")) {
+            if (NAME_WITH_DESC_PATTERN.matcher(columnName).matches()) {
                 columnName = columnName.replaceFirst("(?i)\\s+DESC$", "");
                 descending = true;
-            } else if (columnName.matches("(?i).*\\s+ASC")) {
+            } else if (NAME_WITH_ASC_PATTERN.matcher(columnName).matches()) {
                 columnName = columnName.replaceFirst("(?i)\\s+ASC$", "");
             }
             sb.append(escapeObjectName(columnName, Column.class));

--- a/liquibase-core/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
+++ b/liquibase-core/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
@@ -133,7 +133,7 @@ public abstract class ExecutablePreparedStatementBase implements ExecutablePrepa
 
                 executeWithFlagsMethod.invoke(stmt, 1 ); //QueryExecutor.QUERY_ONESHOT
             } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-                throw new SQLException(e.getMessage(), e);
+                stmt.execute();
             }
         } else {
             stmt.execute();


### PR DESCRIPTION
## Description

Addresses two performance issues:
1. There are commonly used `matches()` calls made which rebuild the regexp pattern each time. It's not an excessive amount of time, but I was seeing perhaps 5% of our run time in that. 
  a. Converted them to compile and store the pattern once, then re-use those
2. Running prepared statements on postgresql is surprisingly slow (details below)
  a. Updated the code to reuse prepared statements
  b. Found a flag that can be passed to a postgesql-specific method that helped.

## Prepared Statement Performance Detailed Findings

In general, Liquibase does not use prepared statements. We generate the complete sql so that update vs. update-sql are doing exactly the same thing and just use the regular Statement class. But in loadData and loadUpdateData we sometimes need prepared statements for blobs etc. and so will auto-use them as needed and also allow the user to specify using them with the usePreparedStatements attribute.

For the regular insert statements we do, prepared statements SHOULD be as fast or faster. But postgresql is **_significantly_** slower. You can see it just by changing the usePreparedStatements value on a simple CSV with just strings/numbers.

The current code wasn't re-using the prepared statement objects like one normally should because of how our flow is structured. I added a vaguely ugly caching of those objects in hopes that re-using them correctly would meet what postgresql was expecting and help the performance. It helped, but didn't make a big difference. That is a better object use in general, though, so I left it in. It may help performance in some use cases and other databases even if my microbenchmark didn't see a big change.

What made the biggest difference was doing the execute with the `QUERY_ONESHOT` flag. Postgresql must be doing some expensive optimization in preparation for things being called a bunch of times and that is the cause of the slowness? 

That flag can only be set with a pg-specific `executeWithFlags()` call, though, so I had to call that via reflection since the driver classes aren't in the compile classpath. That change only applies to postgresql-related databases and we fall back to the regular execute if the reflection fails.

## Things to be aware of
- Only impacts postgresql, cockroach, edb, etc. 

## Things to worry about
- Does other versions of postgresql have different performance characteristics where QUERY_ONESHOT hurts more than helps? 
  - Does databases based on postgresql like edb have different performance characteristics too? Based on my understanding of what ONE_SHOT is saying (this statement will not be reparsed a bunch of times down the road) it is a valid hint for all the databases.


