### PR TITLE
Added showBanner configuration to maven

### DIFF
--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
@@ -272,6 +272,7 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
      */
     @PropertyElement
     protected String databaseChangeLogTableName;
+
     /**
      * Specifies the table name to use for the DATABASECHANGELOGLOCK table.
      *
@@ -279,6 +280,14 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
      */
     @PropertyElement
     protected String databaseChangeLogLockTableName;
+
+    /**
+     * Show the liquibase banner in output.
+     *
+     * @parameter property="liquibase.showBanner"
+     */
+    @PropertyElement
+    protected boolean showBanner = true;
 
     /**
      * Specifies the server ID in the Maven <i>settings.xml</i> to use when authenticating.
@@ -430,7 +439,9 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
 
                     configureFieldsAndValues();
 
-                    getLog().info(CommandLineUtils.getBanner());
+                    if (showBanner) {
+                        getLog().info(CommandLineUtils.getBanner());
+                    }
 
                     // Displays the settings for the Mojo depending of verbosity mode.
                     displayMojoSettings();


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Adds a maven-native setting for the new liquibase.showBanner flag. 

With the change, running `mvn -Dliquibase.showBanner=false ...` will hide the banner. 

## Things to be aware of

- Only impacts maven
- Applies to all maven commands
- Can also be set with a `<showBanner>` configuration within the maven plugin.

## Things to worry about

-Nothing