### PR TITLE
DAT-10314 - Reverts removal of `interceptCleanupSpecMethod`

### DIFF
--- a/liquibase-extension-testing/src/main/java/liquibase/extension/testing/testsystem/spock/LiquibaseIntegrationMethodInterceptor.java
+++ b/liquibase-extension-testing/src/main/java/liquibase/extension/testing/testsystem/spock/LiquibaseIntegrationMethodInterceptor.java
@@ -88,4 +88,14 @@ public class LiquibaseIntegrationMethodInterceptor extends AbstractMethodInterce
     private static TestSystem readContainerFromField(FieldInfo f, IMethodInvocation invocation) {
         return (TestSystem) f.readValue(invocation.getInstance());
     }
+
+    /**
+     * Required for executing Spock cleanupSpec fixture method.
+     *
+     * @param invocation the cleanup method invocation
+     */
+    @Override
+    public void interceptCleanupSpecMethod(IMethodInvocation invocation) throws Throwable {
+        invocation.proceed();
+    }
 }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description
Reverts removal of `interceptCleanupSpecMethod` in `LiquibaseIntegrationMethodInterceptor`. Adds comment explaining use case. 

Without this change `def cleanupSpec(){}` is completely ignored in Spock tests.

This was removed in [this commit](https://github.com/liquibase/liquibase/commit/d2bea1a72c921e343fc9ea376e70bb6f0ac5d0aa). 

## Things to be aware of
N/A

## Things to worry about
Tests should still pass.

## Additional Context
