### PR TITLE
hide CommandFailedException stacktrace when thrown to set exit code (DAT-9608)

### DIFF
--- a/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
+++ b/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
@@ -233,7 +233,11 @@ public class LiquibaseCommandLine {
             bestMessage = bestMessage.replace("Unexpected error running Liquibase: ", "");
         }
 
-        Scope.getCurrentScope().getLog(getClass()).severe(bestMessage, exception);
+        if (cause instanceof CommandFailedException && ((CommandFailedException) cause).isHidden()) {
+            Scope.getCurrentScope().getLog(getClass()).severe(bestMessage);
+        } else {
+            Scope.getCurrentScope().getLog(getClass()).severe(bestMessage, exception);
+        }
 
         boolean printUsage = false;
         try (final StringWriter suggestionWriter = new StringWriter();

--- a/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
+++ b/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
@@ -13,7 +13,6 @@ import liquibase.configuration.LiquibaseConfiguration;
 import liquibase.configuration.core.DefaultsFileValueProvider;
 import liquibase.exception.CommandLineParsingException;
 import liquibase.exception.CommandValidationException;
-import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.hub.HubConfiguration;
 import liquibase.license.LicenseService;
 import liquibase.license.LicenseServiceFactory;
@@ -30,7 +29,6 @@ import liquibase.util.StringUtil;
 import picocli.CommandLine;
 
 import java.io.*;
-import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -233,7 +231,7 @@ public class LiquibaseCommandLine {
             bestMessage = bestMessage.replace("Unexpected error running Liquibase: ", "");
         }
 
-        if (cause instanceof CommandFailedException && ((CommandFailedException) cause).isHidden()) {
+        if (cause instanceof CommandFailedException && ((CommandFailedException) cause).isExpected()) {
             Scope.getCurrentScope().getLog(getClass()).severe(bestMessage);
         } else {
             Scope.getCurrentScope().getLog(getClass()).severe(bestMessage, exception);

--- a/liquibase-core/src/main/java/liquibase/command/CommandFailedException.java
+++ b/liquibase-core/src/main/java/liquibase/command/CommandFailedException.java
@@ -3,11 +3,13 @@ package liquibase.command;
 public class CommandFailedException extends Exception {
     private final CommandResults results;
     private final int exitCode;
+    private final boolean hidden;
 
-    public CommandFailedException(CommandResults results, int exitCode, String message) {
+    public CommandFailedException(CommandResults results, int exitCode, String message, boolean hidden) {
         super(message);
         this.results = results;
         this.exitCode = exitCode;
+        this.hidden = hidden;
     }
 
     public CommandResults getResults() {
@@ -16,5 +18,13 @@ public class CommandFailedException extends Exception {
 
     public int getExitCode() {
         return exitCode;
+    }
+
+    /**
+     * In certain circumstances, this exception is thrown solely to set the exit code of a command's execution. In these
+     * cases, Liquibase does not print the stacktrace of the exception to the logs, and isHidden returns true.
+     */
+    public boolean isHidden() {
+        return hidden;
     }
 }

--- a/liquibase-core/src/main/java/liquibase/command/CommandFailedException.java
+++ b/liquibase-core/src/main/java/liquibase/command/CommandFailedException.java
@@ -1,15 +1,20 @@
 package liquibase.command;
 
+/**
+ * CommandFailedException is thrown any time a command did not succeed. If it did not succeed due to normal and expected
+ * reasons, mark it as expected=true. If the CommandFailedException is marked as expected=false, the code calling the
+ * command may want to do additional logging or handling of the exception because it knows the command was surprised by the result.
+ */
 public class CommandFailedException extends Exception {
     private final CommandResults results;
     private final int exitCode;
-    private final boolean hidden;
+    private final boolean expected;
 
-    public CommandFailedException(CommandResults results, int exitCode, String message, boolean hidden) {
+    public CommandFailedException(CommandResults results, int exitCode, String message, boolean expected) {
         super(message);
         this.results = results;
         this.exitCode = exitCode;
-        this.hidden = hidden;
+        this.expected = expected;
     }
 
     public CommandResults getResults() {
@@ -21,10 +26,11 @@ public class CommandFailedException extends Exception {
     }
 
     /**
-     * In certain circumstances, this exception is thrown solely to set the exit code of a command's execution. In these
-     * cases, Liquibase does not print the stacktrace of the exception to the logs, and isHidden returns true.
+     * In certain circumstances, this exception is thrown solely to set the exit code of a command's execution, in which
+     * case, the exception is expected. In these cases, Liquibase does not print the stacktrace of the exception to the
+     * logs, and isExpected returns true.
      */
-    public boolean isHidden() {
-        return hidden;
+    public boolean isExpected() {
+        return expected;
     }
 }

--- a/liquibase-core/src/main/java/liquibase/command/CommandResultsBuilder.java
+++ b/liquibase-core/src/main/java/liquibase/command/CommandResultsBuilder.java
@@ -1,6 +1,7 @@
 package liquibase.command;
 
 import liquibase.Scope;
+import liquibase.precondition.FailedPrecondition;
 import liquibase.util.StringUtil;
 
 import java.io.OutputStream;
@@ -56,7 +57,11 @@ public class CommandResultsBuilder {
     }
 
     public CommandFailedException commandFailed(String message, int exitCode) {
-        return new CommandFailedException(this.build(), exitCode, message);
+        return commandFailed(message, exitCode, false);
+    }
+
+    public CommandFailedException commandFailed(String message, int exitCode, boolean hidden) {
+        return new CommandFailedException(this.build(), exitCode, message, hidden);
     }
 
     /**

--- a/liquibase-core/src/main/java/liquibase/command/CommandResultsBuilder.java
+++ b/liquibase-core/src/main/java/liquibase/command/CommandResultsBuilder.java
@@ -60,8 +60,8 @@ public class CommandResultsBuilder {
         return commandFailed(message, exitCode, false);
     }
 
-    public CommandFailedException commandFailed(String message, int exitCode, boolean hidden) {
-        return new CommandFailedException(this.build(), exitCode, message, hidden);
+    public CommandFailedException commandFailed(String message, int exitCode, boolean expected) {
+        return new CommandFailedException(this.build(), exitCode, message, expected);
     }
 
     /**


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Stacktraces will not be printed to the logs when a CommandFailedException is set to "hidden".

## Things to be aware of

## Things to worry about

`isHidden` is perhaps not the best name we can come up with.

## Additional Context
