### PR TITLE
add support for default-catalog-name in SQL Server (DAT-10484)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/DatabaseUtils.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/DatabaseUtils.java
@@ -59,6 +59,8 @@ public class DatabaseUtils {
                     schema = defaultSchemaName;
                 }
                 executor.execute(new RawSqlStatement("USE " + schema));
+            } else if (database instanceof MSSQLDatabase) {
+                executor.execute(new RawSqlStatement("USE " + defaultCatalogName));
             }
 
         }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Adds support for `--default-catalog-name` when using SQL Server.

## Things to be aware of

## Things to worry about

- This breaks the existing trend of treating schemas identically to catalogs. I believe this to be correct for SQL Server, but will that be confusing for users?

## Additional Context