### PR TITLE
Improved parsing of single-quoted strings

### DIFF
--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -125,9 +125,16 @@
 
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>org.javacc.plugin</groupId>
                 <artifactId>javacc-maven-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.0.3</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>net.java.dev.javacc</groupId>
+                        <artifactId>javacc</artifactId>
+                        <version>7.0.11</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <id>javacc</id>

--- a/liquibase-core/src/main/javacc/liquibase/util/grammar/SimpleSqlGrammar.jj
+++ b/liquibase-core/src/main/javacc/liquibase/util/grammar/SimpleSqlGrammar.jj
@@ -72,9 +72,10 @@ TOKEN:
 |	< S_IDENTIFIER: ( <LETTER> | <UNICODE_LETTERS> )+ ( <DIGIT> | <LETTER> | <UNICODE_LETTERS> | <SPECIAL_CHARS> )* >
 | 	< #LETTER: ["a"-"z", "A"-"Z", "_", "$"] >
 |   < #SPECIAL_CHARS: "$" | "_" | "#" | "@" >
-|   < S_CHAR_LITERAL: "'" (~["'"]|"\\'")* "'" ("'" (~["'"]|"\\'")* "'")*>
+|   < S_CHAR_LITERAL: (["U","E","N","R","B"]|"RB"|"_utf8")? (("'" ( <ESC> | ~["'", "\\", "\n", "\r"] )* "'") | ("'" ("''" | ~["'"])* "'")) >
 |   < S_QUOTED_IDENTIFIER: "\"" (~["\n","\r","\""])+ "\"" | ("`" (~["\n","\r","`"])+ "`") | ( "[" ~["0"-"9","]"] (~["\n","\r","]"])* "]" ) >
 |    <EMPTY_QUOTE: "\"" "\"">
+|   < #ESC: "\\" ["n","t","b","r","f","\\","'","\""] >
 
 /*
 Built list from http://stackoverflow.com/a/37668315/45756

--- a/liquibase-core/src/test/groovy/liquibase/util/SqlParserTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/util/SqlParserTest.groovy
@@ -46,6 +46,7 @@ class SqlParserTest extends Specification {
         "a ~ b"                                                                                            | ["a", "~", "b"]
         "a > b"                                                                                            | ["a", ">", "b"]
         "a <> b"                                                                                           | ["a", "<", ">", "b"]
+        "a != '\\\\' here"                                                                                      | ["a", "!", "=", "'\\\\'", "here"]
 
     }
 

--- a/liquibase-core/src/test/groovy/liquibase/util/StringUtilTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/util/StringUtilTest.groovy
@@ -15,7 +15,7 @@ class StringUtilTest extends Specification {
         that Arrays.asList(StringUtil.processMultiLineSQL(rawString, stripComments, splitStatements, endDelimiter)), Matchers.contains(expected.toArray())
 
         where:
-        stripComments | splitStatements | endDelimiter | rawString                                                                                                                                                                                           | expected
+        stripComments | splitStatements | endDelimiter | rawString                                                                                                                                                                                              | expected
         true          | true            | null         | "/**\nSome comments go here\n**/\ncreate table sqlfilerollback (id int);\n\n/**\nSome morecomments go here\n**/\ncreate table sqlfilerollback2 (id int);"                                           | ["create table sqlfilerollback (id int)", "create table sqlfilerollback2 (id int)"]
         true          | true            | null         | "/*\nThis is a test comment of MS-SQL script\n*/\n\nSelect * from Test;\nUpdate Test set field = 1"                                                                                                 | ["Select * from Test", "Update Test set field = 1"]
         true          | true            | null         | "some sql/*Some text\nmore text*/more sql"                                                                                                                                                          | ["some sqlmore sql"]

--- a/liquibase-core/src/test/groovy/liquibase/util/grammar/SimpleSqlGrammarTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/util/grammar/SimpleSqlGrammarTest.groovy
@@ -8,7 +8,8 @@ class SimpleSqlGrammarTest extends Specification {
     @Unroll
     def test() {
         when:
-        def grammar = new SimpleSqlGrammar(new ByteArrayInputStream(input.getBytes()))
+        def tokenManager = new SimpleSqlGrammarTokenManager(new SimpleCharStream(new StringReader(input)));
+        def grammar = new SimpleSqlGrammar(tokenManager)
 
         def tokens = new ArrayList<String>()
         Token token
@@ -20,17 +21,27 @@ class SimpleSqlGrammarTest extends Specification {
         tokens == expected
 
         where:
-        input                                  | expected
-        ""                                     | []
-        "sql goes here"                        | ["sql", " ", "goes", " ", "here"]
-        "  odd    spacing  stuff  "            | ["  ", "odd", "    ", "spacing", "  ", "stuff", "  "]
-        "create table test"                    | ["create", " ", "table", " ", "test"]
-        "create table catalog.schema.test"     | ["create", " ", "table", " ", "catalog.schema.test"]
-        "create table [test]"                  | ["create", " ", "table", " ", "[test]"]
-        "create table \"test\""                | ["create", " ", "table", " ", "\"test\""]
-        "create table /* comment here */ test" | ["create", " ", "table", " ", "/* comment here */", " ", "test"]
-        "insert 'a string'"                    | ["insert", " ", "'a string'"]
-        "invalid ' sql"                        | ["invalid", " ", "'", " ", "sql"]
-        "utf8-〠＠chars works"                   | ["utf8", "-", "〠＠chars", " ", "works"]
+        input                                                  | expected
+        ""                                                     | []
+        "sql goes here"                                        | ["sql", " ", "goes", " ", "here"]
+        "  odd    spacing  stuff  "                            | ["  ", "odd", "    ", "spacing", "  ", "stuff", "  "]
+        "create table test"                                    | ["create", " ", "table", " ", "test"]
+        "create table catalog.schema.test"                     | ["create", " ", "table", " ", "catalog.schema.test"]
+        "create table [test]"                                  | ["create", " ", "table", " ", "[test]"]
+        "create table \"test\""                                | ["create", " ", "table", " ", "\"test\""]
+        "create table /* comment here */ test"                 | ["create", " ", "table", " ", "/* comment here */", " ", "test"]
+        "insert 'a string'"                                    | ["insert", " ", "'a string'"]
+        "escaped quotes ' '' '"                                | ["escaped", " ", "quotes", " ", "' '' '"]
+        "escaped quotes ''''"                                  | ["escaped", " ", "quotes", " ", "''''"]
+        "mysql escaped quotes ' \\' '"                         | ["mysql", " ", "escaped", " ", "quotes", " ", "' \\' '"]
+        "mysql escaped quotes '\\''"                           | ["mysql", " ", "escaped", " ", "quotes", " ", "'\\''"]
+        "invalid ' sql"                                        | ["invalid", " ", "'", " ", "sql"]
+        "'invalid' ' sql"                                      | ["'invalid'", " ", "'", " ", "sql"]
+        "utf8-〠＠chars works"                                   | ["utf8", "-", "〠＠chars", " ", "works"]
+        "single '\\' works"                                    | ["single", " ", "'\\'", " ", "works"]
+        "double '\\\\' works"                                  | ["double", " ", "'\\\\'", " ", "works"]
+        "unquoted \\\\ works"                                  | ["unquoted", " ", "\\", "\\", " ", "works"]
+        "'one quote' then 'two quote' then 'three quote' more" | ["'one quote'", " ", "then", " ", "'two quote'", " ", "then", " ", "'three quote'", " ", "more"]
+        "'\\\\' then quotes '')"                               | ["'\\\\'", " ", "then", " ", "quotes", " ", "''", ")"]
     }
 }

--- a/liquibase-extension-examples/pom.xml
+++ b/liquibase-extension-examples/pom.xml
@@ -30,25 +30,6 @@
 
       <plugins>
           <plugin>
-              <groupId>org.codehaus.mojo</groupId>
-              <artifactId>javacc-maven-plugin</artifactId>
-              <version>2.6</version>
-              <executions>
-                  <execution>
-                      <id>javacc</id>
-                      <goals>
-                          <goal>javacc</goal>
-                      </goals>
-                      <configuration>
-                          <javaUnicodeEscape>false</javaUnicodeEscape>
-                          <unicodeInput>true</unicodeInput>
-                      </configuration>
-                  </execution>
-              </executions>
-          </plugin>
-
-
-          <plugin>
               <groupId>org.apache.felix</groupId>
               <artifactId>maven-bundle-plugin</artifactId>
               <version>5.1.6</version>


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

The sql parser did not correctly handle a string with `\`s before a closing `'` when there were more `'`s in the line.

For example, this SQL failed to split on the `#`:

```
/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
#
/*!40101 SET NAMES utf8 */;
#
/*!50503 SET NAMES utf8mb4 */;
#
/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
#
/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
#

CREATE PROCEDURE test_procedure (
    in      p1      text
)
begin
    if p1 != '\\' then
select current_timestamp;
end if;
end
#

/*!40101 SET SQL_MODE=IFNULL(@OLD_SQL_MODE, '') */;
#
/*!40014 SET FOREIGN_KEY_CHECKS=IF(@OLD_FOREIGN_KEY_CHECKS IS NULL, 1, @OLD_FOREIGN_KEY_CHECKS) */;
#
/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
#
```

called from 

```
   <sqlFile
                path="some_procedure_name.sql"
                relativeToChangelogFile="true"
                endDelimiter="#"
        />
```

## Things to be aware of

- Replaces the quoted string handling with example from https://github.com/JSQLParser/JSqlParser/blob/c1c38fe26b1fe90a3dd770aff99150c9783081d9/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt#L483

## Things to worry about

- Changes all the single-quoted string handling, but should be a general improvement. Existing tests cover the main odd cases
