### PR TITLE
dynamically update copyright year in txt files; also update links in txt files (DAT-10261)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,4 +75,4 @@ LIQUIBASE is a registered trademark of [Liquibase Inc.](https://www.liquibase.co
 
 [Liquibase Blog](https://www.liquibase.org/blog)
 
-[Get Support & Advanced Features](https://www.liquibase.com/contact)
+[Get Support & Advanced Features](https://liquibase.com/pricing)

--- a/liquibase-dist/pom.xml
+++ b/liquibase-dist/pom.xml
@@ -283,6 +283,25 @@
 <!--                    </execution>-->
 <!--                </executions>-->
 <!--            </plugin>-->
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <id>timestamp-property</id>
+                        <goals>
+                            <goal>timestamp-property</goal>
+                        </goals>
+                        <phase>validate</phase>
+                        <configuration>
+                            <name>current.year</name>
+                            <pattern>yyyy</pattern>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/liquibase-dist/src/main/archive/GETTING_STARTED.txt
+++ b/liquibase-dist/src/main/archive/GETTING_STARTED.txt
@@ -243,15 +243,13 @@ For questions regarding Liquibase, you can submit an email to support@liquibase.
 or submit a post on stack overflow and use the #liquibase tag here: 
 https://stackoverflow.com/questions/tagged/liquibase
 
-You can also post questions to these Liquibase forums:
-Liquibase User Forum: https://forum.liquibase.org/#Forum/liquibase-users
-Liquibase Developer Forum: https://forum.liquibase.org/#Forum/liquibase-development.
+You can also post questions to the Liquibase forum: https://forum.liquibase.org
 
-Liquibase Documentation: www.liquibase.org/documentation/index.html
+Liquibase Documentation: https://docs.liquibase.com
 
 Need Liquibase Support? Get customer support by upgrading to Liquibase Pro here: 
-https://support.liquibase.org/
+https://liquibase.com/pricing
 
 
-Copyright 2021 Liquibase, Inc. All rights reserved. The program is subject to the
+Copyright ${current.year} Liquibase, Inc. All rights reserved. The program is subject to the
 license agreement, copyright, trademark, patent, and other laws.

--- a/liquibase-dist/src/main/archive/README.txt
+++ b/liquibase-dist/src/main/archive/README.txt
@@ -65,17 +65,15 @@ For questions regarding Liquibase, you can submit an email to support@liquibase.
 or submit a post on stack overflow and use the #liquibase tag: 
 https://stackoverflow.com/questions/tagged/liquibase
 
-You can also post questions to these Liquibase forums:
-Liquibase User Forum: https://forum.liquibase.org/#Forum/liquibase-users
-Liquibase Developer Forum: https://forum.liquibase.org/#Forum/liquibase-development
+You can also post questions to the Liquibase forum: https://forum.liquibase.org
 
-Liquibase Documentation: http://liquibase.org/documentation
+Liquibase Documentation: https://docs.liquibase.com
 
-Need Liquibase Support? Get customer support by upgrading to Liquibase Pro here: https://support.liquibase.org
+Need Liquibase Support? Get customer support by upgrading to Liquibase Pro here: https://liquibase.com/pricing
 
 
 ----------------------------------------
 The program is subject to the license agreement, copyright, trademark, patent, and other laws.
-Copyright 2021 Liquibase, Inc. All rights reserved.
+Copyright ${current.year} Liquibase, Inc. All rights reserved.
 
 

--- a/liquibase-dist/src/main/archive/UNINSTALL.txt
+++ b/liquibase-dist/src/main/archive/UNINSTALL.txt
@@ -8,10 +8,8 @@ Help & Support
 ----------------------------------------
 For questions regarding Liquibase, you can submit an email to answers@liquibase.org or submit a post on stack overflow and use the #liquibase tag: https://stackoverflow.com/questions/tagged/liquibase
 
-You can also post questions to these Liquibase forums:
-Liquibase User Forum: https://forum.liquibase.org/#Forum/liquibase-users
-Liquibase Developer Forum: https://forum.liquibase.org/#Forum/liquibase-development.
+You can also post questions to the Liquibase forum: https://forum.liquibase.org
 
-Liquibase Documentation: http://liquibase.org/documentation
+Liquibase Documentation: https://docs.liquibase.com
 
-Need Liquibase Support? Get customer support by upgrading to Liquibase Pro here: https://support.liquibase.org/
+Need Liquibase Support? Get customer support by upgrading to Liquibase Pro here: https://liquibase.com/pricing


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Update the year of the Liquibase copyright in the packaged .txt files to be dynamically generated at build time, and update the links in the files to point to new locations.

## Things to be aware of

I added a new maven plugin because I couldn't change the format of the `maven.build.timestamp.format` because that is already used elsewhere.

## Things to worry about

## Additional Context
