### PR TITLE
ignore contents of multiline comments when parsing formatted SQL files (DAT-10296)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/util/StringUtil.java
+++ b/liquibase-core/src/main/java/liquibase/util/StringUtil.java
@@ -283,6 +283,9 @@ public class StringUtil {
      * @return The String without the comments in
      */
     public static String stripComments(String multiLineSQL) {
+        if (StringUtil.isEmpty(multiLineSQL)) {
+            return multiLineSQL;
+        }
         return SqlParser.parse(multiLineSQL, true, false).toString().trim();
     }
 

--- a/liquibase-core/src/test/groovy/liquibase/util/SqlParserTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/util/SqlParserTest.groovy
@@ -28,6 +28,10 @@ class SqlParserTest extends Specification {
         "a\nstring\n\nwith\nnewlines"                                                                      | ["a", "string", "with", "newlines"]
         "a string /* with a comment */ here"                                                               | ["a", "string", "here"]
         "a string /* with a 'quoted' comment */ here"                                                      | ["a", "string", "here"]
+        "a string /* with a \n'quoted' comment */ here"                                                    | ["a", "string", "here"]
+        "a string /* with a \r\n'quoted' comment */ here"                                                  | ["a", "string", "here"]
+        """a string /* with a
+'quoted' comment */ here"""                                                                                | ["a", "string", "here"]
         "one string; and another"                                                                          | ["one", "string", ";", "and", "another"]
         "'a quoted semicolon; here' and /* a commented semicolon; here */"                                 | ["'a quoted semicolon; here'", "and"]
         "--here is a comment\nand a statement;\nand another --followed by a comment"                       | ["and", "a", "statement", ";", "and", "another"]


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description



## Things to be aware of



## Things to worry about

This is a bit overzealous, and removes contents of multiline comments everywhere, including in places it might not be appropriate to do so (like inside of the SQL part of the changeset, where the comments should be handled based on the stripComments setting)

## Additional Context


