### PR TITLE
Include should fail if a parser cannot be found for the specified file

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -375,7 +375,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                             includeContexts,
                             labels,
                             ignore,
-                            true);
+                            OnUnknownFileFormat.FAIL);
                 } catch (LiquibaseException e) {
                     throw new SetupException(e);
                 }
@@ -585,7 +585,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
 
             for (String path : resources) {
                 Scope.getCurrentScope().getLog(getClass()).info("Reading resource: " + path);
-                include(path, false, resourceAccessor, includeContexts, labels, ignore, false);
+                include(path, false, resourceAccessor, includeContexts, labels, ignore, OnUnknownFileFormat.WARN);
             }
         } catch (Exception e) {
             throw new SetupException(e);
@@ -618,13 +618,27 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                 logEveryUnknownFileFormat);
     }
 
-        public boolean include(String fileName,
+    /**
+     * @deprecated
+     */
+    public boolean include(String fileName,
                            boolean isRelativePath,
                            ResourceAccessor resourceAccessor,
                            ContextExpression includeContexts,
                            Labels labels,
                            Boolean ignore,
                            boolean logEveryUnknownFileFormat)
+            throws LiquibaseException {
+        return include(fileName, isRelativePath, resourceAccessor, includeContexts, labels, ignore, logEveryUnknownFileFormat ? OnUnknownFileFormat.WARN : OnUnknownFileFormat.SKIP);
+    }
+
+    public boolean include(String fileName,
+                           boolean isRelativePath,
+                           ResourceAccessor resourceAccessor,
+                           ContextExpression includeContexts,
+                           Labels labels,
+                           Boolean ignore,
+                           OnUnknownFileFormat onUnknownFileFormat)
             throws LiquibaseException {
 
         if (".svn".equalsIgnoreCase(fileName) || "cvs".equalsIgnoreCase(fileName)) {
@@ -663,9 +677,12 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                 }
             }
         } catch (UnknownChangelogFormatException e) {
+            if (onUnknownFileFormat == OnUnknownFileFormat.FAIL) {
+                throw e;
+            }
             // This matches only an extension, but filename can be a full path, too. Is it right?
             boolean matchesFileExtension = StringUtil.trimToEmpty(fileName).matches("\\.\\w+$");
-            if (matchesFileExtension || logEveryUnknownFileFormat) {
+            if (matchesFileExtension || onUnknownFileFormat == OnUnknownFileFormat.WARN) {
                 Scope.getCurrentScope().getLog(getClass()).warning(
                         "included file " + relativeBaseFileName + "/" + fileName + " is not a recognized file type"
                 );
@@ -742,6 +759,12 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
         public void addNestedPrecondition(Precondition precondition) {
             super.addNestedPrecondition(precondition);
         }
+    }
+
+    public enum OnUnknownFileFormat {
+        SKIP,
+        WARN,
+        FAIL
     }
 
 }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Currently, include fails for files that cannot be found, but files which cannot be parsed as a changelog are silently ignored.
This makes Liquibase fail saying the file cannot be parsed (regardless of whether the file exists or not)

## Things to be aware of

- Error was introduced from re-use of the logic in includeAll where we skip files in an includeAll'ed directory which can't be parsed
- IncludeAll continues to fail if the given directory does not exist, but only warns on files within that directory that cannot be parsed

## Things to worry about

- Nothing

## Additional Context

DAT-10591
