### PR TITLE
DAT-10260: add outputFile argument in maven plugin for checks.run target

### DIFF
--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseChecksRunMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseChecksRunMojo.java
@@ -7,6 +7,10 @@ import liquibase.exception.CommandExecutionException;
 import liquibase.util.StringUtil;
 import org.liquibase.maven.property.PropertyElement;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+
 /**
  * Check the changelog for issues
  *
@@ -119,6 +123,12 @@ public class LiquibaseChecksRunMojo extends AbstractLiquibaseChecksMojo {
     @PropertyElement
     protected String driverPropertiesFile;
 
+    /**
+     * @parameter property="liquibase.outputFile"
+     */
+    @PropertyElement
+    protected File outputFile;
+
     @Override
     protected void performLiquibaseTask(Liquibase liquibase) throws CommandExecutionException {
         CommandScope liquibaseCommand = new CommandScope("checks", "run");
@@ -136,6 +146,13 @@ public class LiquibaseChecksRunMojo extends AbstractLiquibaseChecksMojo {
         addArgumentIfNotEmpty(liquibaseCommand, defaultCatalogName, "defaultCatalogName");
         addArgumentIfNotEmpty(liquibaseCommand, driver, "driver");
         addArgumentIfNotEmpty(liquibaseCommand, driverPropertiesFile, "driverPropertiesFile");
+        if (outputFile != null) {
+            try {
+                liquibaseCommand.setOutput(new FileOutputStream(outputFile));
+            } catch (FileNotFoundException e) {
+                throw new CommandExecutionException(e);
+            }
+        }
         liquibaseCommand.addArgumentValue("checksIntegration", "maven");
         liquibaseCommand.execute();
     }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Add the `outputFile` argument to the `checks.run` maven plugin target.

## Things to be aware of

## Things to worry about

## Additional Context


