### PR TITLE
Fixed issue with parameter expression parsing

### DIFF
--- a/liquibase-core/src/test/groovy/liquibase/changelog/ExpressionExpanderTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/changelog/ExpressionExpanderTest.groovy
@@ -69,6 +69,7 @@ class ExpressionExpanderTest extends Specification {
         PRESERVE | "valid '\${double.nested.value.valid}' double nested"                                             | "valid 'double a param with param1=value1' double nested"
         PRESERVE | "invalid '\${double.nested.value.invalid}' double nested"                                         | "invalid 'double \${nested.value.invalid}' double nested"
         EMPTY    | "invalid '\${double.nested.value.invalid}' double nested"                                         | "invalid 'double ' double nested"
+        PRESERVE | "INSERT INTO script (id, script) VALUES (5, '{test} \${test} {test} \${test} {test} ');"                                  | "INSERT INTO script (id, script) VALUES (5, '{test} \${test} {test} \${test} {test} ');"
     }
 
 

--- a/liquibase-core/src/test/groovy/liquibase/changelog/ExpressionExpanderTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/changelog/ExpressionExpanderTest.groovy
@@ -44,6 +44,7 @@ class ExpressionExpanderTest extends Specification {
         PRESERVE | ""                                                                                                | ""
         PRESERVE | "A Simple String"                                                                                 | "A Simple String"
         PRESERVE | "With { brackets } in it"                                                                         | "With { brackets } in it"
+        PRESERVE | "With \${ unmatched"                                                                              | "With \${ unmatched"
         PRESERVE | "A string with one expression \${param1} set"                                                     | "A string with one expression value1 set"
         PRESERVE | "A string with two expressions \${param1} and \${param2} set"                                     | "A string with two expressions value1 and value2 set"
         EMPTY    | "A string with two expressions \${param1} and \${param2} set"                                     | "A string with two expressions value1 and value2 set"
@@ -69,7 +70,12 @@ class ExpressionExpanderTest extends Specification {
         PRESERVE | "valid '\${double.nested.value.valid}' double nested"                                             | "valid 'double a param with param1=value1' double nested"
         PRESERVE | "invalid '\${double.nested.value.invalid}' double nested"                                         | "invalid 'double \${nested.value.invalid}' double nested"
         EMPTY    | "invalid '\${double.nested.value.invalid}' double nested"                                         | "invalid 'double ' double nested"
-        PRESERVE | "INSERT INTO script (id, script) VALUES (5, '{test} \${test} {test} \${test} {test} ');"                                  | "INSERT INTO script (id, script) VALUES (5, '{test} \${test} {test} \${test} {test} ');"
+        PRESERVE | "INSERT INTO script (id, script) VALUES (5, '{test} \${test} {test} \${test} {test} ');"          | "INSERT INTO script (id, script) VALUES (5, '{test} \${test} {test} \${test} {test} ');"
+        PRESERVE | "test \$\$ here"                                                                                  | "test \$\$ here"
+        PRESERVE | "test \$1.30 here"                                                                                | "test \$1.30 here"
+        PRESERVE | "test \$1.30 here \$"                                                                             | "test \$1.30 here \$"
+        PRESERVE | "ending \${"                                                                                      | "ending \${"
+        PRESERVE | "ending \$"                                                                                       | "ending \$"
     }
 
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Changes in the 4.11.0 release around changelog parameter parsing made it so we weren't correctly handling a `}` characters that appear after a changelog expression.

So just having `{test}` worked. And `{test} ${test}` worked. But `${test} {test}` did not.

This updates the parser logic to correctly handle the failing case.

Fixes #2980

## Things to be aware of

- Existing tests ensure the refactoring doesn't cause other regressions
- Added test case for this new example

## Things to worry about

- Any other character combinations that were broken in 4.11.0? I don't think so, the closing bracket is the one special case we handle.

