### PR TITLE
Formatted SQL files with uppercase in the liquibase attributes (DAT-10531)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
@@ -43,8 +43,8 @@ public class FormattedSqlChangeLogParser implements ChangeLogParser {
                 while (firstLine.trim().isEmpty() && reader.ready()) {
                     firstLine = reader.readLine();
                 }
-
-                return (firstLine != null) && firstLine.matches("\\-\\-\\s*liquibase formatted.*");
+                Pattern firstLinePattern = Pattern.compile("\\-\\-\\s*liquibase formatted.*", Pattern.CASE_INSENSITIVE);
+                return (firstLine != null) && firstLinePattern.matcher(firstLine).matches();
             } else {
                 return false;
             }

--- a/liquibase-core/src/test/groovy/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.groovy
@@ -186,11 +186,34 @@ grant execute on any_procedure_name to ANY_USER3/
                     "-precondition 123\n" +
                     "select 1;"
 
+    private static final String VALID_ALL_CAPS_CHANGELOG = """
+--LIQUIBASE FORMATTED SQL
+
+--CHANGESET SOME_USER:ALL_CAPS_SCRIPT_1
+CREATE TABLE ALL_CAPS_TABLE_1 (
+    ID INT PRIMARY KEY AUTO_INCREMENT NOT NULL,
+    NAME VARCHAR(50) NOT NULL,
+    ADDRESS1 VARCHAR(50),
+    ADDRESS2 VARCHAR(50),
+    CITY VARCHAR(30)
+)
+
+--CHANGESET SOME_USER:ALL_CAPS_SCRIPT_2
+CREATE TABLE ALL_CAPS_TABLE_2 (
+    ID INT PRIMARY KEY AUTO_INCREMENT NOT NULL,
+    NAME VARCHAR(50) NOT NULL,
+    ADDRESS1 VARCHAR(50),
+    ADDRESS2 VARCHAR(50),
+    CITY VARCHAR(30)
+)
+"""
+
     def supports() throws Exception {
         expect:
         assert new MockFormattedSqlChangeLogParser(VALID_CHANGELOG).supports("asdf.sql", new JUnitResourceAccessor())
         assert !new MockFormattedSqlChangeLogParser(INVALID_CHANGELOG).supports("asdf.sql", new JUnitResourceAccessor())
         assert new MockFormattedSqlChangeLogParser(VALID_CHANGELOG).supports("asdf.SQL", new JUnitResourceAccessor())
+        assert new MockFormattedSqlChangeLogParser(VALID_ALL_CAPS_CHANGELOG).supports("BLAH.SQL", new JUnitResourceAccessor())
     }
 
     def invalidPrecondition() throws Exception {
@@ -639,6 +662,14 @@ grant execute on any_procedure_name to ANY_USER3/
         where:
         example                                                                                                       | expected
         "--liquibase formatted sql\n--changeset John Doe:12345\nCREATE PROC TEST\nAnother Line\nEND MY PROC;\n/"      | "CREATE PROC TEST\nAnother Line\nEND MY PROC;\n/"
+    }
+
+    def parse_withAllCaps() {
+        when:
+        def changeLog = new MockFormattedSqlChangeLogParser(VALID_ALL_CAPS_CHANGELOG).parse("ALL_CAPS.SQL", new ChangeLogParameters(), new JUnitResourceAccessor())
+
+        then:
+        changeLog.getChangeSets().size() == 2
     }
 
     @LiquibaseService(skip = true)


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [x] Breaking change (fix or feature that would cause existing functionality to change) 
 
## Description

Updates first line check on FormattedSqlChangeLogParser to check for the string `--liquibase formatted` without checking case. Previously files with `--LIQUIBASE FORMATTED SQL` as the first line would be read as raw sql not formatted sql. 

## Things to be aware of

Added a new pattern in the `supports` method of `FormattedSqlChangeLogParser` instead of just using `String#matches`. 

## Things to worry about

If someone did not notice an `ALL CAPS` file like in the test case was executed as raw sql (not formatted sql) this update will cause the file to be parsed differently which could lead to unexpected behavior.

## Additional Context

N/A
