### PR TITLE
do not allow individual commands to close the top-level OutputStream (System.out)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/command/CommandScope.java
+++ b/liquibase-core/src/main/java/liquibase/command/CommandScope.java
@@ -4,6 +4,7 @@ import liquibase.Scope;
 import liquibase.configuration.*;
 import liquibase.exception.CommandExecutionException;
 import liquibase.exception.CommandValidationException;
+import liquibase.io.UnclosableOutputStream;
 import liquibase.util.StringUtil;
 
 import java.io.OutputStream;
@@ -40,7 +41,12 @@ public class CommandScope {
      * Creates a new scope for the given command.
      */
     public CommandScope(String... commandName) throws CommandExecutionException {
-        setOutput(System.out);
+        /*
+        This is an UncloseableOutputStream because we do not want individual command steps to inadvertently (or
+        intentionally) close the System.out OutputStream. Closing System.out renders it unusable for other command
+        steps which expect it to still be open.
+         */
+        setOutput(new UnclosableOutputStream(System.out));
 
         final CommandFactory commandFactory = Scope.getCurrentScope().getSingleton(CommandFactory.class);
 

--- a/liquibase-core/src/main/java/liquibase/command/CommandScope.java
+++ b/liquibase-core/src/main/java/liquibase/command/CommandScope.java
@@ -41,12 +41,7 @@ public class CommandScope {
      * Creates a new scope for the given command.
      */
     public CommandScope(String... commandName) throws CommandExecutionException {
-        /*
-        This is an UncloseableOutputStream because we do not want individual command steps to inadvertently (or
-        intentionally) close the System.out OutputStream. Closing System.out renders it unusable for other command
-        steps which expect it to still be open.
-         */
-        setOutput(new UnclosableOutputStream(System.out));
+        setOutput(System.out);
 
         final CommandFactory commandFactory = Scope.getCurrentScope().getSingleton(CommandFactory.class);
 
@@ -133,7 +128,12 @@ public class CommandScope {
      * Think "what would be piped out", not "what the user is told about what is happening".
      */
     public CommandScope setOutput(OutputStream outputStream) {
-        this.outputStream = outputStream;
+        /*
+        This is an UncloseableOutputStream because we do not want individual command steps to inadvertently (or
+        intentionally) close the System.out OutputStream. Closing System.out renders it unusable for other command
+        steps which expect it to still be open.
+         */
+        this.outputStream = new UnclosableOutputStream(outputStream);
 
         return this;
     }

--- a/liquibase-core/src/main/java/liquibase/io/UnclosableOutputStream.java
+++ b/liquibase-core/src/main/java/liquibase/io/UnclosableOutputStream.java
@@ -1,0 +1,23 @@
+package liquibase.io;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * This class is a wrapper around OutputStreams, and makes them impossible for callers to close.
+ */
+public class UnclosableOutputStream extends FilterOutputStream {
+    public UnclosableOutputStream(OutputStream out) {
+        super(out);
+    }
+
+    /**
+     * This method does not actually close the underlying stream, but rather only flushes it. Callers should not be
+     * closing the stream they are given.
+     */
+    @Override
+    public void close() throws IOException {
+        out.flush();
+    }
+}


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

This change prevents individual commands from closing the output stream they are provided, which is actually `System.out`. It is bad practice for code to close `System.out` particularly because other command steps will still expect it to be open.

## Things to be aware of



## Things to worry about

In very unusual circumstances, we might get more output than we did initially, because commands called after the RegisterChangelogCommandStep previously had a closed output stream. This isn't really a worry, and more of a positive thing.

## Additional Context
