### PR TITLE
Added new liquibase.duplicateFileMode setting

### DIFF
--- a/liquibase-core/src/main/java/liquibase/GlobalConfiguration.java
+++ b/liquibase-core/src/main/java/liquibase/GlobalConfiguration.java
@@ -203,7 +203,7 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
 
         DUPLICATE_FILE_MODE = builder.define("duplicateFileMode", DuplicateFileMode.class)
                 .setDescription("How to handle multiple files being found in the search path that have duplicate paths. Options are WARN (log warning and choose one at random) or ERROR (fail current operation)")
-                .setDefaultValue(DuplicateFileMode.WARN)
+                .setDefaultValue(DuplicateFileMode.ERROR)
                 .build();
     }
 

--- a/liquibase-core/src/main/java/liquibase/GlobalConfiguration.java
+++ b/liquibase-core/src/main/java/liquibase/GlobalConfiguration.java
@@ -32,6 +32,8 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
     public static final ConfigurationDefinition<Boolean> PRESERVE_SCHEMA_CASE;
     public static final ConfigurationDefinition<Boolean> SHOW_BANNER;
 
+    public static final ConfigurationDefinition<DuplicateFileMode> DUPLICATE_FILE_MODE;
+
     /**
      * @deprecated No longer used
      */
@@ -198,5 +200,15 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
                 .setDescription("If true, show a Liquibase banner on startup.")
                 .setDefaultValue(true)
                 .build();
+
+        DUPLICATE_FILE_MODE = builder.define("duplicateFileMode", DuplicateFileMode.class)
+                .setDescription("How to handle multiple files being found in the search path that have duplicate paths. Options are WARN (log warning and choose one at random) or ERROR (fail current operation)")
+                .setDefaultValue(DuplicateFileMode.WARN)
+                .build();
+    }
+
+    public enum DuplicateFileMode {
+        WARN,
+        ERROR,
     }
 }

--- a/liquibase-core/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-core/src/main/java/liquibase/Liquibase.java
@@ -49,10 +49,7 @@ import liquibase.util.StreamUtil;
 import liquibase.util.StringUtil;
 
 import javax.xml.parsers.ParserConfigurationException;
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintStream;
-import java.io.Writer;
+import java.io.*;
 import java.text.DateFormat;
 import java.util.*;
 import java.util.function.Supplier;
@@ -972,13 +969,11 @@ public class Liquibase implements AutoCloseable {
     protected void executeRollbackScript(String rollbackScript, List<ChangeSet> changeSets, Contexts contexts, LabelExpression labelExpression) throws LiquibaseException {
         final Executor executor = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database);
         String rollbackScriptContents;
-        try (InputStreamList streams = resourceAccessor.openStreams(null, rollbackScript)) {
-            if ((streams == null) || streams.isEmpty()) {
+        try (InputStream stream = resourceAccessor.openStream(null, rollbackScript)) {
+            if (stream == null) {
                 throw new LiquibaseException("WARNING: The rollback script '" + rollbackScript + "' was not located.  Please check your parameters. No rollback was performed");
-            } else if (streams.size() > 1) {
-                throw new LiquibaseException("Found multiple rollbackScripts named " + rollbackScript);
             }
-            rollbackScriptContents = StreamUtil.readStreamAsString(streams.iterator().next());
+            rollbackScriptContents = StreamUtil.readStreamAsString(stream);
         } catch (IOException e) {
             throw new LiquibaseException("Error reading rollbackScript " + executor + ": " + e.getMessage());
         }

--- a/liquibase-core/src/main/java/liquibase/resource/AbstractResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/AbstractResourceAccessor.java
@@ -1,11 +1,16 @@
 package liquibase.resource;
 
 import liquibase.AbstractExtensibleObject;
+import liquibase.GlobalConfiguration;
 import liquibase.Scope;
+import liquibase.exception.UnexpectedLiquibaseException;
+import liquibase.logging.Logger;
 import liquibase.util.StringUtil;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.util.Iterator;
 
 /**
  * Convenience base class for {@link ResourceAccessor} implementations.
@@ -20,9 +25,36 @@ public abstract class AbstractResourceAccessor extends AbstractExtensibleObject 
         if (streamList == null || streamList.size() == 0) {
             return null;
         } else if (streamList.size() > 1) {
-            streamList.close();
-            Scope.getCurrentScope().getLog(getClass()).warning("ResourceAccessor roots: "+Scope.getCurrentScope().getResourceAccessor().getClass().getName());
-            throw new IOException("Found " + streamList.size() + " files that match " + streamPath+": "+ StringUtil.join(streamList.getURIs(), ", ", new StringUtil.ToStringFormatter()));
+            String message = "Found " + streamList.size() + " files matching '" + streamPath + "':" + System.lineSeparator();
+            for (URI uri : streamList.getURIs()) {
+                message += "    - " + uri.toString() + System.lineSeparator();
+            }
+            message += "  Search Path: " + System.lineSeparator();
+            for (String location : Scope.getCurrentScope().getResourceAccessor().describeLocations()) {
+                message += "    - " + location + System.lineSeparator();
+            }
+
+            final GlobalConfiguration.DuplicateFileMode mode = GlobalConfiguration.DUPLICATE_FILE_MODE.getCurrentValue();
+            final Logger log = Scope.getCurrentScope().getLog(getClass());
+
+            if (mode == GlobalConfiguration.DuplicateFileMode.ERROR) {
+                throw new IOException(message);
+            } else if (mode == GlobalConfiguration.DuplicateFileMode.WARN) {
+                log.warning(message + "  Using " + streamList.getURIs().get(0));
+
+                InputStream returnStream = null;
+                final Iterator<InputStream> iterator = streamList.iterator();
+                while (iterator.hasNext()) {
+                    if (returnStream == null) {
+                        returnStream = iterator.next();
+                    } else {
+                        iterator.next().close();
+                    }
+                }
+                return returnStream;
+            } else {
+                throw new UnexpectedLiquibaseException("Unexpected DuplicateFileMode: " + mode);
+            }
         } else {
             return streamList.iterator().next();
         }

--- a/liquibase-core/src/main/java/liquibase/resource/AbstractResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/AbstractResourceAccessor.java
@@ -40,7 +40,7 @@ public abstract class AbstractResourceAccessor extends AbstractExtensibleObject 
             if (mode == GlobalConfiguration.DuplicateFileMode.ERROR) {
                 throw new IOException(message);
             } else if (mode == GlobalConfiguration.DuplicateFileMode.WARN) {
-                log.warning(message + "  Using " + streamList.getURIs().get(0));
+                log.warning(message + "  Using " + streamList.getURIs().get(0)+". To fail when duplicates are found, set liquibase.duplicateFileMode=ERROR");
 
                 InputStream returnStream = null;
                 final Iterator<InputStream> iterator = streamList.iterator();

--- a/liquibase-core/src/main/java/liquibase/resource/ResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/ResourceAccessor.java
@@ -27,6 +27,7 @@ public interface ResourceAccessor {
 
     /**
      * Returns a single stream matching the given path. See {@link #openStreams(String, String)} for details about path options.
+     * Implementations should respect {@link liquibase.GlobalConfiguration#DUPLICATE_FILE_MODE}
      *
      * @param relativeTo Location that streamPath should be found relative to. If null, streamPath is an absolute path
      * @return null if the resource does not exist

--- a/liquibase-core/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
+++ b/liquibase-core/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
@@ -422,18 +422,7 @@ public abstract class ExecutablePreparedStatementBase implements ExecutablePrepa
     @java.lang.SuppressWarnings("squid:S2095")
     private InputStream getResourceAsStream(String valueLobFile) throws IOException, LiquibaseException {
         String fileName = getFileName(valueLobFile);
-        InputStreamList streams = this.resourceAccessor.openStreams(null, fileName);
-        if ((streams == null) || streams.isEmpty()) {
-            return null;
-        }
-        if (streams.size() > 1) {
-            for (InputStream stream : streams) {
-                stream.close();
-            }
-
-            throw new IOException(streams.size() + " matched " + valueLobFile);
-        }
-        return streams.iterator().next();
+        return this.resourceAccessor.openStream(null, fileName);
     }
 
     private String getFileName(String fileName) {

--- a/liquibase-core/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
+++ b/liquibase-core/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
@@ -333,6 +333,7 @@ public abstract class ExecutablePreparedStatementBase implements ExecutablePrepa
         }
     }
 
+    @SuppressWarnings("java:S2583")
     private LOBContent<InputStream> toBinaryStream(String valueLobFile) throws LiquibaseException, IOException {
         InputStream in = getResourceAsStream(valueLobFile);
 
@@ -376,6 +377,7 @@ public abstract class ExecutablePreparedStatementBase implements ExecutablePrepa
         }
     }
 
+    @SuppressWarnings("java:S2583")
     private LOBContent<Reader> toCharacterStream(String valueLobFile, String encoding)
             throws IOException, LiquibaseException {
         InputStream in = getResourceAsStream(valueLobFile);
@@ -419,7 +421,7 @@ public abstract class ExecutablePreparedStatementBase implements ExecutablePrepa
         }
     }
 
-    @java.lang.SuppressWarnings("squid:S2095")
+    @SuppressWarnings("squid:S2095")
     private InputStream getResourceAsStream(String valueLobFile) throws IOException, LiquibaseException {
         String fileName = getFileName(valueLobFile);
         return this.resourceAccessor.openStream(null, fileName);

--- a/liquibase-core/src/test/groovy/liquibase/resource/FileSystemResourceAccessorTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/resource/FileSystemResourceAccessorTest.groovy
@@ -112,7 +112,7 @@ class FileSystemResourceAccessorTest extends Specification {
 
         then:
         def e = thrown(IOException)
-        e.message.startsWith("Found 3 files matching 'com/example/everywhere/file-everywhere.txt':")
+        e.message.startsWith("Found 3 files with the path 'com/example/everywhere/file-everywhere.txt':")
         e.message.contains("file-everywhere.txt")
         e.message.contains("test-classes")
         e.message.contains("simple-files.jar")

--- a/liquibase-core/src/test/groovy/liquibase/resource/FileSystemResourceAccessorTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/resource/FileSystemResourceAccessorTest.groovy
@@ -1,5 +1,7 @@
 package liquibase.resource
 
+import liquibase.GlobalConfiguration
+import liquibase.Scope
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -102,17 +104,29 @@ class FileSystemResourceAccessorTest extends Specification {
         ]
     }
 
-    def "openStream throws an error if multiple files match"() {
+    def "openStream throws an error if multiple files match and duplicateFileMode == error"() {
         when:
-        simpleTestAccessor.openStream(null, "com/example/everywhere/file-everywhere.txt",)
+        Scope.child(GlobalConfiguration.DUPLICATE_FILE_MODE.getKey(), GlobalConfiguration.DuplicateFileMode.ERROR, { ->
+            simpleTestAccessor.openStream(null, "com/example/everywhere/file-everywhere.txt",)
+        } as Scope.ScopedRunner)
 
         then:
         def e = thrown(IOException)
-        e.message.startsWith("Found 3 files that match com/example/everywhere/file-everywhere.txt: file:")
+        e.message.startsWith("Found 3 files matching 'com/example/everywhere/file-everywhere.txt':")
         e.message.contains("file-everywhere.txt")
         e.message.contains("test-classes")
         e.message.contains("simple-files.jar")
         e.message.contains("simple-files.zip")
+    }
+
+    def "openStream does not throw an error if multiple files match and duplicateFileMode == warn"() {
+        when:
+        Scope.child(GlobalConfiguration.DUPLICATE_FILE_MODE.getKey(), GlobalConfiguration.DuplicateFileMode.WARN, { ->
+            simpleTestAccessor.openStream(null, "com/example/everywhere/file-everywhere.txt",)
+        } as Scope.ScopedRunner)
+
+        then:
+        noExceptionThrown()
     }
 
     def "openStream returns null if nothing matches"() {


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Currently, when the same path is found in multiple locations liquibase fails with an error.

This PR adds a new `liquibase.duplicateFileMode` global setting which defaults to "ERROR" but can also be set to "WARN".

## Things to be aware of

- Existing behavior of "ERROR" logic is still the default.
- Refactored some usages of openStreams that duplicated the logic in openStream to just use openStream in order to take advantage of this new behavior.
- Searched the code for usages of openStream vs. openStreams and addressed all I found that should be updated

## Things to worry about

- Nothing

