### PR TITLE
Ensure Postgresql search_path entries are quoted correctly

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/DatabaseUtils.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/DatabaseUtils.java
@@ -1,5 +1,6 @@
 package liquibase.database.core;
 
+import liquibase.GlobalConfiguration;
 import liquibase.Scope;
 import liquibase.database.Database;
 import liquibase.database.OfflineConnection;
@@ -8,6 +9,7 @@ import liquibase.executor.Executor;
 import liquibase.executor.ExecutorService;
 import liquibase.statement.core.RawSqlStatement;
 import liquibase.structure.core.Schema;
+import liquibase.util.StringUtil;
 
 public class DatabaseUtils {
     /**
@@ -39,11 +41,22 @@ public class DatabaseUtils {
                 String searchPath = executor.queryForObject(new RawSqlStatement("SHOW SEARCH_PATH"), String.class);
 
                 if (!searchPath.equals(defaultCatalogName) && !searchPath.startsWith(defaultSchemaName + ",") && !searchPath.startsWith("\"" + defaultSchemaName + "\",")) {
-                    if (database instanceof CockroachDatabase) {
-                        // CockroachDB doesn't support unquoted `$user` type values
-                        searchPath = searchPath.replaceAll("(\\$\\w+)", "'$1'");
+                    String finalSearchPath;
+                    if (GlobalConfiguration.PRESERVE_SCHEMA_CASE.getCurrentValue()) {
+                        finalSearchPath = ((PostgresDatabase) database).quoteObject(defaultSchemaName, Schema.class);
+                    } else {
+                        finalSearchPath = defaultSchemaName;
                     }
-                    executor.execute(new RawSqlStatement("SET SEARCH_PATH TO " + database.escapeObjectName(defaultSchemaName, Schema.class) + ", " + searchPath));
+
+                    //If existing search path entries are not quoted, quote them. Some databases do not show them as quoted even though they need to be (like $user or case sensitive schemas)
+                    finalSearchPath += ", " + StringUtil.join(StringUtil.splitAndTrim(searchPath, ","), ",", (StringUtil.StringUtilFormatter<String>) obj -> {
+                        if (obj.startsWith("\"")) {
+                            return obj;
+                        }
+                        return ((PostgresDatabase) database).quoteObject(obj, Schema.class);
+                    });
+
+                    executor.execute(new RawSqlStatement("SET SEARCH_PATH TO " + finalSearchPath));
                 }
 
             } else if (database instanceof AbstractDb2Database) {


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

In postgresql and it's varients (redshift, cockroachdb, etc), the search_path that gets set based on the defaultSchemaName uses the value returned from `show search_path`. Sometimes, objects such as `$user` in that shown search path are note quoted like is needed to re-set them. 

This PR updates the logic from handling only values that start with a `$` and only on cockroachdb to handling all non-quoted values on all postgresql versions. 

The change handles cases where a value comes back already quoted from `show search_path`. 

For example, if defaultSchemaName is being set to `test`,  it will `set search_path=test, "$user", "public"` whether the original `show seach_path` returned `"$user", public` or `$user, public`.

By quoting `"public"` like that, it will enforce the case on public, but in my testing the value in search_path was already correctly cased. If I called `set search_path=$user, PUBLIC"` then show search_path still returned `$user, public`. And if I called `set search_path=$user, "TEST", public` it showed as `"$user", "TEST", public`. So the change seems correct still.

Fixes #2928

## Things to be aware of
- Nothing beyond what is in description


## Things to worry about

- Nothing

