### PR TITLE
warn if XSD version does not match build version in validate command (DAT-9874)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-core/src/main/java/liquibase/Liquibase.java
@@ -33,6 +33,7 @@ import liquibase.logging.core.BufferedLogService;
 import liquibase.logging.core.CompositeLogService;
 import liquibase.parser.ChangeLogParser;
 import liquibase.parser.ChangeLogParserFactory;
+import liquibase.parser.core.xml.XMLChangeLogSAXParser;
 import liquibase.resource.InputStreamList;
 import liquibase.resource.ResourceAccessor;
 import liquibase.serializer.ChangeLogSerializer;
@@ -364,8 +365,21 @@ public class Liquibase implements AutoCloseable {
 
 
     public DatabaseChangeLog getDatabaseChangeLog() throws LiquibaseException {
+        return getDatabaseChangeLog(false);
+    }
+
+    /**
+     * @param shouldWarnOnMismatchedXsdVersion When set to true, a warning will be printed to the console if the XSD
+     *                                         version used does not match the version of Liquibase. If "latest" is used
+     *                                         as the XSD version, no warning is printed. If the changelog is not xml
+     *                                         format, no warning is printed.
+     */
+    public DatabaseChangeLog getDatabaseChangeLog(boolean shouldWarnOnMismatchedXsdVersion) throws LiquibaseException {
         if (databaseChangeLog == null && changeLogFile != null) {
             ChangeLogParser parser = ChangeLogParserFactory.getInstance().getParser(changeLogFile, resourceAccessor);
+            if (parser instanceof XMLChangeLogSAXParser) {
+                ((XMLChangeLogSAXParser) parser).setShouldWarnOnMismatchedXsdVersion(shouldWarnOnMismatchedXsdVersion);
+            }
             databaseChangeLog = parser.parse(changeLogFile, changeLogParameters, resourceAccessor);
         }
 
@@ -2278,7 +2292,7 @@ public class Liquibase implements AutoCloseable {
      */
     public void validate() throws LiquibaseException {
 
-        DatabaseChangeLog changeLog = getDatabaseChangeLog();
+        DatabaseChangeLog changeLog = getDatabaseChangeLog(true);
         changeLog.validate(database);
     }
 

--- a/liquibase-core/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-core/src/main/java/liquibase/Liquibase.java
@@ -374,7 +374,7 @@ public class Liquibase implements AutoCloseable {
      *                                         as the XSD version, no warning is printed. If the changelog is not xml
      *                                         format, no warning is printed.
      */
-    public DatabaseChangeLog getDatabaseChangeLog(boolean shouldWarnOnMismatchedXsdVersion) throws LiquibaseException {
+    private DatabaseChangeLog getDatabaseChangeLog(boolean shouldWarnOnMismatchedXsdVersion) throws LiquibaseException {
         if (databaseChangeLog == null && changeLogFile != null) {
             ChangeLogParser parser = ChangeLogParserFactory.getInstance().getParser(changeLogFile, resourceAccessor);
             if (parser instanceof XMLChangeLogSAXParser) {

--- a/liquibase-core/src/main/java/liquibase/parser/core/xml/LiquibaseEntityResolver.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/xml/LiquibaseEntityResolver.java
@@ -97,7 +97,7 @@ public class LiquibaseEntityResolver implements EntityResolver2 {
                     String xsdVersion = versionMatcher.group("version");
                     if (!buildVersion.startsWith(xsdVersion)) {
                         hasWarnedAboutMismatchedXsdVersion = true;
-                        String msg = "INFO: An older version of the XSD is specified in the changelog's <databaseChangeLog> header. This can lead to unexpected outcomes. Please update it to '" + buildVersion + "'. Learn more at https://docs.liquibase.com";
+                        String msg = "INFO: An older version of the XSD is specified in one or more changelog's <databaseChangeLog> header. This can lead to unexpected outcomes. If a specific XSD is not required, please replace all XSD version references with \"-latest\". Learn more at https://docs.liquibase.com";
                         Scope.getCurrentScope().getLog(getClass()).info(msg);
                         Scope.getCurrentScope().getUI().sendMessage(msg);
                     }

--- a/liquibase-core/src/main/java/liquibase/parser/core/xml/XMLChangeLogSAXParser.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/xml/XMLChangeLogSAXParser.java
@@ -59,6 +59,14 @@ public class XMLChangeLogSAXParser extends AbstractChangeLogParser {
         return saxParserFactory;
     }
 
+    /**
+     * When set to true, a warning will be printed to the console if the XSD version used does not match the version
+     * of Liquibase. If "latest" is used as the XSD version, no warning is printed.
+     */
+    public void setShouldWarnOnMismatchedXsdVersion(boolean shouldWarnOnMismatchedXsdVersion) {
+        resolver.setShouldWarnOnMismatchedXsdVersion(shouldWarnOnMismatchedXsdVersion);
+    }
+
     @Override
     protected ParsedNode parseToNode(String physicalChangeLogLocation, ChangeLogParameters changeLogParameters, ResourceAccessor resourceAccessor) throws ChangeLogParseException {
         try (InputStream inputStream = resourceAccessor.openStream(null, physicalChangeLogLocation)) {

--- a/liquibase-core/src/test/groovy/liquibase/parser/core/xml/LiquibaseEntityResolverTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/parser/core/xml/LiquibaseEntityResolverTest.groovy
@@ -36,17 +36,19 @@ class LiquibaseEntityResolverTest extends Specification {
         def originalProperties = LiquibaseUtil.liquibaseBuildProperties
         LiquibaseUtil.liquibaseBuildProperties = new Properties()
         LiquibaseUtil.liquibaseBuildProperties.put("build.version", buildVersion)
+        def er = new LiquibaseEntityResolver()
+        er.setShouldWarnOnMismatchedXsdVersion(true)
 
         expect:
         Scope.child([
                 (Scope.Attr.ui.name())        : uiService
         ], {
-            new LiquibaseEntityResolver().resolveEntity(null, null, null, systemId)
+            er.resolveEntity(null, null, null, systemId)
         } as Scope.ScopedRunnerWithReturn<InputSource>) != null
 
         // This is an ugly assertion line, it is essentially saying, either we expect the message, so make sure it's there
         // or we expect no message, so make sure there are no messages.
-        ((expectedWarningMessage && uiService.getMessages().contains("WARNING: An older version of the XSD is specified in the changelog's <databaseChangeLog> header. This can lead to unexpected outcomes. Please update it to '" + buildVersion + "'. Learn more at https://docs.liquibase.com"))
+        ((expectedWarningMessage && uiService.getMessages().contains("INFO: An older version of the XSD is specified in the changelog's <databaseChangeLog> header. This can lead to unexpected outcomes. Please update it to '" + buildVersion + "'. Learn more at https://docs.liquibase.com"))
         || (!expectedWarningMessage && uiService.getMessages().isEmpty()))
 
         cleanup:

--- a/liquibase-core/src/test/groovy/liquibase/parser/core/xml/LiquibaseEntityResolverTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/parser/core/xml/LiquibaseEntityResolverTest.groovy
@@ -49,7 +49,7 @@ class LiquibaseEntityResolverTest extends Specification {
 
         // This is an ugly assertion line, it is essentially saying, either we expect the message, so make sure it's there
         // or we expect no message, so make sure there are no messages.
-        ((expectedWarningMessage && uiService.getMessages().contains("INFO: An older version of the XSD is specified in the changelog's <databaseChangeLog> header. This can lead to unexpected outcomes. Please update it to '" + buildVersion + "'. Learn more at https://docs.liquibase.com"))
+        ((expectedWarningMessage && uiService.getMessages().contains("INFO: An older version of the XSD is specified in one or more changelog's <databaseChangeLog> header. This can lead to unexpected outcomes. If a specific XSD is not required, please replace all XSD version references with \"-latest\". Learn more at https://docs.liquibase.com"))
         || (!expectedWarningMessage && uiService.getMessages().isEmpty()))
 
         cleanup:

--- a/liquibase-core/src/test/groovy/liquibase/parser/core/xml/LiquibaseEntityResolverTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/parser/core/xml/LiquibaseEntityResolverTest.groovy
@@ -1,8 +1,11 @@
 package liquibase.parser.core.xml
 
 import liquibase.GlobalConfiguration
+import liquibase.LiquibaseTest
 import liquibase.Scope
 import liquibase.resource.FileSystemResourceAccessor
+import liquibase.util.LiquibaseUtil
+import org.xml.sax.InputSource
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -23,6 +26,45 @@ class LiquibaseEntityResolverTest extends Specification {
                 "/liquibase/banner.txt", //can find files without hostnames
                 "http://liquibase/banner.txt", //conversion of hostnames to files works for not just liquibase.org URLs
         ]
+    }
+
+    @Unroll
+    def "warning message for mismatched xsd and build versions #systemId /// #buildVersion"() {
+        given:
+        def uiService = new LiquibaseTest.TestConsoleUIService()
+        // Save these props for later
+        def originalProperties = LiquibaseUtil.liquibaseBuildProperties
+        LiquibaseUtil.liquibaseBuildProperties = new Properties()
+        LiquibaseUtil.liquibaseBuildProperties.put("build.version", buildVersion)
+
+        expect:
+        Scope.child([
+                (Scope.Attr.ui.name())        : uiService
+        ], {
+            new LiquibaseEntityResolver().resolveEntity(null, null, null, systemId)
+        } as Scope.ScopedRunnerWithReturn<InputSource>) != null
+
+        // This is an ugly assertion line, it is essentially saying, either we expect the message, so make sure it's there
+        // or we expect no message, so make sure there are no messages.
+        ((expectedWarningMessage && uiService.getMessages().contains("WARNING: An older version of the XSD is specified in the changelog's <databaseChangeLog> header. This can lead to unexpected outcomes. Please update it to '" + buildVersion + "'. Learn more at https://docs.liquibase.com"))
+        || (!expectedWarningMessage && uiService.getMessages().isEmpty()))
+
+        cleanup:
+        // Set the build properties back to what they were before the test.
+        LiquibaseUtil.liquibaseBuildProperties = originalProperties
+
+        where:
+        buildVersion | systemId | expectedWarningMessage
+        "3.1.0" | "http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd" | false
+        "3.1.1" | "http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd" | false
+        "4.12.0" | "http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd" | true
+        "4.12.0" | "https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd" | true
+        "4.12.0" | "http://www.liquibase.org/xml/ns/migrator/dbchangelog-3.1.xsd" | true
+        "4.12.0" | "http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-next.xsd" | false
+        "4.12.0" | "http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd" | false
+        "4.12.0" | "http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd" | false
+        "4.12.0" | "/liquibase/banner.txt" | false
+        "4.12.0" | "http://liquibase/banner.txt" | false
     }
 
     @Unroll

--- a/liquibase-core/src/test/groovy/liquibase/parser/core/xml/LiquibaseEntityResolverTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/parser/core/xml/LiquibaseEntityResolverTest.groovy
@@ -38,6 +38,7 @@ class LiquibaseEntityResolverTest extends Specification {
         LiquibaseUtil.liquibaseBuildProperties.put("build.version", buildVersion)
         def er = new LiquibaseEntityResolver()
         er.setShouldWarnOnMismatchedXsdVersion(true)
+        er.hasWarnedAboutMismatchedXsdVersion = false
 
         expect:
         Scope.child([


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Warn if specified XSD version is different than the version of the build when running the `validate` command.

## Things to be aware of

I made this change in a way that this check is "best effort". It should not ever cause a user to experience an uncaught exception.

## Things to worry about

It is possible that the regex I'm using is not robust enough to properly get the version out of the XSD URL. It is also possible that there is a better way to do this than using a regex.

## Additional Context


