### PR TITLE
Force "json" resultset formats in Snowflake when running Java 17+

### DIFF
--- a/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
+++ b/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
@@ -22,10 +22,7 @@ import liquibase.resource.CompositeResourceAccessor;
 import liquibase.resource.FileSystemResourceAccessor;
 import liquibase.ui.ConsoleUIService;
 import liquibase.ui.UIService;
-import liquibase.util.ISODateFormat;
-import liquibase.util.LiquibaseUtil;
-import liquibase.util.ObjectUtil;
-import liquibase.util.StringUtil;
+import liquibase.util.*;
 import picocli.CommandLine;
 
 import java.io.*;
@@ -383,10 +380,8 @@ public class LiquibaseCommandLine {
                 return;
             }
 
-            final String version = System.getProperty("java.version");
-            final String[] splitVersion = version.split("\\.", 2);
-            if (Integer.parseInt(splitVersion[0]) < 11) {
-                Scope.getCurrentScope().getUI().sendMessage("Performance monitoring requires Java 11 or greater. Version " + version + " is not supported.");
+            if (SystemUtil.getJavaMajorVersion() < 11) {
+                Scope.getCurrentScope().getUI().sendMessage("Performance monitoring requires Java 11 or greater. Version " + SystemUtil.getJavaVersion() + " is not supported.");
                 return;
             }
 

--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -31,10 +31,7 @@ import liquibase.resource.CompositeResourceAccessor;
 import liquibase.resource.FileSystemResourceAccessor;
 import liquibase.resource.ResourceAccessor;
 import liquibase.ui.ConsoleUIService;
-import liquibase.util.BooleanUtil;
-import liquibase.util.ISODateFormat;
-import liquibase.util.LiquibaseUtil;
-import liquibase.util.StringUtil;
+import liquibase.util.*;
 
 import java.io.*;
 import java.lang.reflect.Field;
@@ -250,7 +247,7 @@ public class Main {
 
                         Scope.getCurrentScope().getUI().sendMessage(String.format("Running Java under %s (Version %s)",
                                 System.getProperties().getProperty("java.home"),
-                                System.getProperty("java.version")
+                                SystemUtil.getJavaVersion()
                         ));
                         return Integer.valueOf(0);
                     }

--- a/liquibase-core/src/main/java/liquibase/util/SystemUtil.java
+++ b/liquibase-core/src/main/java/liquibase/util/SystemUtil.java
@@ -5,4 +5,26 @@ public class SystemUtil {
     public static boolean isWindows() {
         return StringUtil.trimToEmpty(System.getProperties().getProperty("os.name")).toLowerCase().startsWith("windows");
     }
+
+    /**
+     * Returns java.version system property
+     */
+    public static String getJavaVersion() {
+        return System.getProperty("java.version");
+    }
+
+
+    /**
+     * Returns the "major" version of java, including returning "8" for java "1.8"
+     */
+    public static int getJavaMajorVersion() {
+        final String version = getJavaVersion();
+        String[] splitVersion = version.split("\\.", 2);
+        int majorVersion = Integer.parseInt(splitVersion[0]);
+        if (majorVersion == 1) {
+            splitVersion = splitVersion[1].split("\\.", 2);
+            return Integer.parseInt(splitVersion[0]);
+        }
+        return majorVersion;
+    }
 }

--- a/liquibase-core/src/test/groovy/liquibase/util/SystemUtilTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/util/SystemUtilTest.groovy
@@ -8,4 +8,14 @@ class SystemUtilTest extends Specification {
         expect:
         SystemUtil.isWindows() == new File("c:\\").exists()
     }
+
+    def getJavaMajorVersion() {
+        expect:
+        SystemUtil.getJavaMajorVersion() >= 8
+    }
+
+    def getJavaVersion() {
+        expect:
+        SystemUtil.getJavaVersion().contains(".")
+    }
 }

--- a/liquibase-snowflake/src/main/java/liquibase/database/core/SnowflakeDatabase.java
+++ b/liquibase-snowflake/src/main/java/liquibase/database/core/SnowflakeDatabase.java
@@ -1,13 +1,14 @@
 package liquibase.database.core;
 
-import liquibase.CatalogAndSchema;
-import liquibase.GlobalConfiguration;
 import liquibase.Scope;
 import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.DatabaseConnection;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
+import liquibase.executor.ExecutorService;
+import liquibase.statement.core.RawSqlStatement;
 import liquibase.structure.DatabaseObject;
+import liquibase.util.SystemUtil;
 
 import java.math.BigInteger;
 import java.sql.ResultSet;
@@ -153,6 +154,32 @@ public class SnowflakeDatabase extends AbstractJdbcDatabase {
             Scope.getCurrentScope().getLog(getClass()).info("Error getting default schema", e);
         }
         return null;
+    }
+
+    @Override
+    public void setConnection(DatabaseConnection conn) {
+        super.setConnection(conn);
+
+        configureSession();
+    }
+
+    @Override
+    public void rollback() throws DatabaseException {
+        super.rollback();
+        configureSession();
+    }
+
+    protected void configureSession() {
+        //Due to the snowflake driver's use of reflection on java.nio within the arrow support, queries fail with a "can't load class" error if the default arrow result format is returned
+        //This ensures we use the json format which does work with 17+
+        //We don't force it if we are running under java 17 since arrow does work for those versions
+        if (SystemUtil.getJavaMajorVersion() >= 17) {
+            try {
+                Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", this).execute(new RawSqlStatement("alter session set jdbc_query_result_format = 'JSON'"));
+            } catch (DatabaseException e) {
+                Scope.getCurrentScope().getLog(getClass()).warning(e.getMessage(), e);
+            }
+        }
     }
 
     private Set<String> getDefaultReservedWords() {


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

The snowflake jdbc driver 3.10+ uses reflection in their arrow support which doesn't work with JDK 17 due to the java.nio module not being marked as used by the snowflake driver.

Perhaps there is a better way of solving this through Liquibase getting configured with java module definitions? Or running under a "--add-opens=java.base/java.nio=ALL-UNNAMED" type setup, but I think that is going to have to be a longer investigation than I'd like to do right now.

So, this PR makes it so if the user is running under Java 17+, when we connect to the database we set the result set format to be JSON which avoids all the problem code in the jdbc driver. If that statement throws any errors, we log it and continue on in case it's not needed.  If they are under java 17, we let them continue to use whatever format they asked for since those versions work correctly.

Fixes #3000

## Things to be aware of

- Applies to everyone running snowflake under 17+, not just the CLI

## Things to worry about

- Nothing
