### PR TITLE
Keep runInTransaction="false" from being included in generated changelogs

### DIFF
--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/DiffToChangeLog.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/DiffToChangeLog.java
@@ -772,7 +772,7 @@ public class DiffToChangeLog {
             if (useSeparateChangeSets(changes)) {
                 for (Change change : changes) {
                     ChangeSet changeSet = new ChangeSet(generateId(changes), getChangeSetAuthor(), false, false, this.changeSetPath, changeSetContext,
-                            null, false, quotingStrategy, null);
+                            null, true, quotingStrategy, null);
                     changeSet.setCreated(created);
                     if (diffOutputControl.getLabels() != null) {
                         changeSet.setLabels(diffOutputControl.getLabels());
@@ -782,7 +782,7 @@ public class DiffToChangeLog {
                 }
             } else {
                 ChangeSet changeSet = new ChangeSet(generateId(changes), getChangeSetAuthor(), false, false, this.changeSetPath, csContext,
-                        null, false, quotingStrategy, null);
+                        null, true, quotingStrategy, null);
                 changeSet.setCreated(created);
                 if (diffOutputControl.getLabels() != null) {
                     changeSet.setLabels(diffOutputControl.getLabels());


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

PR #2585 fixed our lack of serializing runInTransaction into changelogs, but the diff logic was incorrectly setting generated changesets as runInTransaction="false" which used to be ignored and therefore defaulted back to "true" but no longer is.

## Things to be aware of

- This is fixing an unreleased bug
- In the current build from master, all changesets in a generateChangeLog will have `runInTransaction="false"`. With this fix, there will be no runInTransaction flag included in the changesets, like it is in 4.12.0

## Things to worry about

- Nothing
