### PR TITLE
Update Liquibase.java

### DIFF
--- a/liquibase-core/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-core/src/main/java/liquibase/Liquibase.java
@@ -691,7 +691,7 @@ public class Liquibase implements AutoCloseable {
                 /* We have no other choice than to save the current Executer here. */
                 @SuppressWarnings("squid:S1941")
                 Executor oldTemplate = getAndReplaceJdbcExecutor(output);
-                outputHeader("Update " + changesToApply + " Change Sets Database Script");
+                outputHeader("Update " + changesToApply + " Changesets Database Script");
 
                 update(changesToApply, contexts, labelExpression);
 
@@ -2056,7 +2056,7 @@ public class Liquibase implements AutoCloseable {
                 out.append(StreamUtil.getLineSeparator());
             } else {
                 out.append(String.valueOf(unrunChangeSets.size()));
-                out.append(" change sets have not been applied to ");
+                out.append(" changesets have not been applied to ");
                 out.append(getDatabase().getConnection().getConnectionUserName());
                 out.append("@");
                 out.append(getDatabase().getConnection().getURL());


### PR DESCRIPTION
Changeset Consistency Naming conventions #3041

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

A clear and concise description of the change being made.  

Steps To Reproduce

Run
liquibase history
against a database that has been updated by at least one changeset

Run
liquibase status
against a database that has at least one changeset needed to be updated.
Actual Behavior

The history command uses the name changesets
Database updated at 1/28/22, 4:53 PM. Applied 97 changeset(s) in 82.304s, DeploymentId: 3410389992

The status command calls uses the name change sets
2 change sets have not been applied to

Expected/Desired Behavior

Both commands use the same terminology
updated to changesets.

NOTE: I found one other case of Change sets that I also updated to Changesets


