### PR TITLE
Add support for `AS <dataType>` clause for H2 since version 2.0

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateSequenceGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateSequenceGenerator.java
@@ -38,16 +38,21 @@ public class CreateSequenceGenerator extends AbstractSqlGenerator<CreateSequence
             validationErrors.checkDisallowedField("maxValue", statement.getMaxValue(), database, FirebirdDatabase.class, H2Database.class, HsqlDatabase.class);
         }
 
-        if (isPostgreWithoutAsDatatypeSupport(database)) {
-            validationErrors.checkDisallowedField("AS", statement.getDataType(), database, PostgresDatabase.class);
-        }
-
         validationErrors.checkDisallowedField("ordered", statement.getOrdered(), database, HsqlDatabase.class, PostgresDatabase.class, MSSQLDatabase.class);
-        validationErrors.checkDisallowedField("dataType", statement.getDataType(), database, DB2Database.class, HsqlDatabase.class, OracleDatabase.class, MySQLDatabase.class, MSSQLDatabase.class, CockroachDatabase.class);
 
-        if (isH2WithoutAsDatatypeSupport(database) && statement.getDataType() != null && !statement.getDataType().equalsIgnoreCase("bigint")) {
-            validationErrors.addWarning("This version of H2 only creates BIGINT sequences. Ignoring requested type " + statement.getDataType());
+        //check datatype
+        if (database instanceof PostgresDatabase) {
+            if (isPostgreWithoutAsDatatypeSupport(database)) {
+                validationErrors.checkDisallowedField("dataType", statement.getDataType(), database, PostgresDatabase.class);
+            }
+        } else if (database instanceof H2Database) {
+            if (isH2WithoutAsDatatypeSupport(database) && statement.getDataType() != null && !statement.getDataType().equalsIgnoreCase("bigint")) {
+                validationErrors.checkDisallowedField("dataType", statement.getDataType(), database, H2Database.class);
+            }
+        } else {
+            validationErrors.checkDisallowedField("dataType", statement.getDataType(), database, DB2Database.class, HsqlDatabase.class, OracleDatabase.class, MySQLDatabase.class, MSSQLDatabase.class, CockroachDatabase.class);
         }
+
 
         return validationErrors;
     }

--- a/liquibase-core/src/test/java/liquibase/sqlgenerator/core/CreateSequenceGeneratorTest.java
+++ b/liquibase-core/src/test/java/liquibase/sqlgenerator/core/CreateSequenceGeneratorTest.java
@@ -87,7 +87,7 @@ public class CreateSequenceGeneratorTest extends AbstractSqlGeneratorTest<Create
         createSequenceStatement.setDataType("int");
 
         errors = new CreateSequenceGenerator().validate(createSequenceStatement, postgresDatabase, new MockSqlGeneratorChain());
-        assertThat(errors.getErrorMessages()).contains("AS is not allowed on postgresql");
+        assertThat(errors.getErrorMessages()).contains("dataType is not allowed on postgresql");
 
 
         // verify that if no version is available the validate() method passes
@@ -107,7 +107,7 @@ public class CreateSequenceGeneratorTest extends AbstractSqlGeneratorTest<Create
     }
 
     @Test
-    public void oldH2IgnoresDataType() throws Exception {
+    public void oldH2FailsValidationWithDataType() throws Exception {
         DatabaseConnection dbConnection = mock(DatabaseConnection.class);
         H2Database h2Database = new H2Database();
         h2Database.setConnection(dbConnection);
@@ -125,8 +125,7 @@ public class CreateSequenceGeneratorTest extends AbstractSqlGeneratorTest<Create
 
         stmt.setDataType("INT");
         errors = generatorUnderTest.validate(stmt, h2Database, new MockSqlGeneratorChain());
-        assertThat(errors.getErrorMessages()).isEmpty();
-        assertThat(errors.getWarningMessages()).containsExactly("This version of H2 only creates BIGINT sequences. Ignoring requested type INT");
+        assertThat(errors.getErrorMessages()).containsExactly("dataType is not allowed on h2");
 
         String sql = generatorUnderTest.generateSql(stmt, h2Database, new MockSqlGeneratorChain())[0].toSql();
         assertThat(sql).isEqualTo("CREATE SEQUENCE SCHEMA_NAME.SEQUENCE_NAME");

--- a/liquibase-integration-tests/src/test/resources/changelogs/h2/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/h2/complete/root.changelog.xml
@@ -158,7 +158,7 @@
     </changeSet>
 
     <changeSet id="16a" author="nvoxland">
-        <createSequence sequenceName="seq_test" startValue="1000" incrementBy="2" />
+        <createSequence sequenceName="seq_test" startValue="1000" incrementBy="2" dataType="int" />
     </changeSet>
 
     <changeSet id="17" author="nvoxland">


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Currently Liquibase explicitly excludes H2 when emitting the `AS <dataType>` clause. However, H2 has support for this feature since version 2.0. This effect of this change is that the CreateSequenceGenerator will only omit the clause for versions before that.

## Things to be aware of

I also extended the existing unit test to verify the new behavior. In the process I also attempted to improve the code 
for better readability and consistency. For example, I used the generatorUnderTest field instead of creating a new CreateSequenceGenerator instance.

This also fixes the issue of an unsupported "dataType" on old h2 versions being ignored instead of failing validation like it should have. This will impact on old versions of h2 using dataType as an attribute.

## Things to worry about

n/a

## Additional Context

n/a
