### PR TITLE
Added liquibase.changelogParseMode setting

### DIFF
--- a/liquibase-core/src/main/java/liquibase/GlobalConfiguration.java
+++ b/liquibase-core/src/main/java/liquibase/GlobalConfiguration.java
@@ -34,6 +34,8 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
 
     public static final ConfigurationDefinition<DuplicateFileMode> DUPLICATE_FILE_MODE;
 
+    public static final ConfigurationDefinition<ChangelogParseMode> CHANGELOG_PARSE_MODE;
+
     /**
      * @deprecated No longer used
      */
@@ -210,10 +212,20 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
         SEARCH_PATH = builder.define("searchPath", String.class)
                 .setDescription("Complete list of Location(s) to search for files such as changelog files in. Multiple paths can be specified by separating them with commas.")
                 .build();
+
+        CHANGELOG_PARSE_MODE = builder.define("changelogParseMode", ChangelogParseMode.class)
+                .setDescription("Configures how to handle unknown fields in changelog files. Possible values: STRICT which causes parsing to fail, and LAX which continues with the parsing.")
+                .setDefaultValue(ChangelogParseMode.STRICT)
+                .build();
     }
 
     public enum DuplicateFileMode {
         WARN,
         ERROR,
+    }
+
+    public enum ChangelogParseMode {
+        STRICT,
+        LAX,
     }
 }

--- a/liquibase-core/src/main/java/liquibase/GlobalConfiguration.java
+++ b/liquibase-core/src/main/java/liquibase/GlobalConfiguration.java
@@ -34,8 +34,6 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
 
     public static final ConfigurationDefinition<DuplicateFileMode> DUPLICATE_FILE_MODE;
 
-    public static final ConfigurationDefinition<ChangelogParseMode> CHANGELOG_PARSE_MODE;
-
     /**
      * @deprecated No longer used
      */
@@ -212,20 +210,10 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
         SEARCH_PATH = builder.define("searchPath", String.class)
                 .setDescription("Complete list of Location(s) to search for files such as changelog files in. Multiple paths can be specified by separating them with commas.")
                 .build();
-
-        CHANGELOG_PARSE_MODE = builder.define("changelogParseMode", ChangelogParseMode.class)
-                .setDescription("Configures how to handle unknown fields in changelog files. Possible values: STRICT which causes parsing to fail, and LAX which continues with the parsing.")
-                .setDefaultValue(ChangelogParseMode.STRICT)
-                .build();
     }
 
     public enum DuplicateFileMode {
         WARN,
         ERROR,
-    }
-
-    public enum ChangelogParseMode {
-        STRICT,
-        LAX,
     }
 }

--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
@@ -443,11 +443,7 @@ public class ChangeSet implements Conditional, ChangeLogChild {
                 break;
             case "preConditions":
                 this.preconditions = new PreconditionContainer();
-                try {
-                    this.preconditions.load(child, resourceAccessor);
-                } catch (ParsedNodeException e) {
-                    e.printStackTrace();
-                }
+                this.preconditions.load(child, resourceAccessor);
                 break;
             case "changes":
                 for (ParsedNode changeNode : child.getChildren()) {

--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
@@ -17,6 +17,7 @@ import liquibase.executor.Executor;
 import liquibase.executor.ExecutorService;
 import liquibase.executor.LoggingExecutor;
 import liquibase.logging.Logger;
+import liquibase.parser.ChangeLogParserConfiguration;
 import liquibase.parser.core.ParsedNode;
 import liquibase.parser.core.ParsedNodeException;
 import liquibase.precondition.Conditional;
@@ -519,7 +520,7 @@ public class ChangeSet implements Conditional, ChangeLogChild {
     protected Change toChange(ParsedNode value, ResourceAccessor resourceAccessor) throws ParsedNodeException {
         Change change = Scope.getCurrentScope().getSingleton(ChangeFactory.class).create(value.getName());
         if (change == null) {
-            if (value.getChildren().size() > 0 && GlobalConfiguration.CHANGELOG_PARSE_MODE.getCurrentValue().equals(GlobalConfiguration.ChangelogParseMode.STRICT)) {
+            if (value.getChildren().size() > 0 && ChangeLogParserConfiguration.CHANGELOG_PARSE_MODE.getCurrentValue().equals(ChangeLogParserConfiguration.ChangelogParseMode.STRICT)) {
                 String message = "";
                 if (this.getChangeLog() != null && this.getChangeLog().getPhysicalFilePath() != null) {
                     message = "Error parsing " + this.getChangeLog().getPhysicalFilePath() + ": ";

--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
@@ -524,7 +524,7 @@ public class ChangeSet implements Conditional, ChangeLogChild {
                 if (this.getChangeLog() != null && this.getChangeLog().getPhysicalFilePath() != null) {
                     message = "Error parsing " + this.getChangeLog().getPhysicalFilePath() + ": ";
                 }
-                message += "Unknown change type '" + value.getName() + "'. Check the spelling/capitalization and/or whether any required Liquibase extensions are missing.";
+                message += "Unknown change type '" + value.getName() + "'. Check for spelling or capitalization errors and missing extensions such as liquibase-commercial.";
                 throw new ParsedNodeException(message);
             }
             return null;

--- a/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -426,13 +426,9 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
             }
             case "preConditions": {
                 PreconditionContainer parsedContainer = new PreconditionContainer();
-                try {
-                    parsedContainer.load(node, resourceAccessor);
-                    this.preconditionContainer.addNestedPrecondition(parsedContainer);
+                parsedContainer.load(node, resourceAccessor);
+                this.preconditionContainer.addNestedPrecondition(parsedContainer);
 
-                } catch (ParsedNodeException e) {
-                    e.printStackTrace();
-                }
                 break;
             }
             case "property": {

--- a/liquibase-core/src/main/java/liquibase/parser/ChangeLogParserConfiguration.java
+++ b/liquibase-core/src/main/java/liquibase/parser/ChangeLogParserConfiguration.java
@@ -1,5 +1,6 @@
 package liquibase.parser;
 
+import liquibase.GlobalConfiguration;
 import liquibase.configuration.AutoloadedConfigurations;
 import liquibase.configuration.ConfigurationDefinition;
 
@@ -11,6 +12,9 @@ public class ChangeLogParserConfiguration implements AutoloadedConfigurations {
     public static final ConfigurationDefinition<Boolean> SUPPORT_PROPERTY_ESCAPING;
     public static final ConfigurationDefinition<Boolean> USE_PROCEDURE_SCHEMA;
     public static final ConfigurationDefinition<MissingPropertyMode> MISSING_PROPERTY_MODE;
+
+    public static final ConfigurationDefinition<ChangelogParseMode> CHANGELOG_PARSE_MODE;
+
 
     static {
         ConfigurationDefinition.Builder builder = new ConfigurationDefinition.Builder("liquibase");
@@ -30,11 +34,23 @@ public class ChangeLogParserConfiguration implements AutoloadedConfigurations {
                 .setDescription("How to handle changelog property expressions where a value is not set. For example, a string '${address}' when no 'address' property was defined. Values can be: 'preserve' which leaves the string as-is, 'empty' which replaces it with an empty string, or 'error' which stops processing with an error.")
                 .setDefaultValue(MissingPropertyMode.PRESERVE)
                 .build();
+
+
+        CHANGELOG_PARSE_MODE = builder.define("changelogParseMode", ChangelogParseMode.class)
+                .setDescription("Configures how to handle unknown fields in changelog files. Possible values: STRICT which causes parsing to fail, and LAX which continues with the parsing.")
+                .setDefaultValue(ChangelogParseMode.STRICT)
+                .build();
+
     }
 
     public enum MissingPropertyMode {
         PRESERVE,
         EMPTY,
         ERROR,
+    }
+
+    public enum ChangelogParseMode {
+        STRICT,
+        LAX,
     }
 }

--- a/liquibase-core/src/main/java/liquibase/precondition/PreconditionLogic.java
+++ b/liquibase-core/src/main/java/liquibase/precondition/PreconditionLogic.java
@@ -49,7 +49,7 @@ public abstract class PreconditionLogic extends AbstractPrecondition {
         Precondition precondition = PreconditionFactory.getInstance().create(node.getName());
         if (precondition == null) {
             if (node.getChildren() != null && node.getChildren().size() > 0 && GlobalConfiguration.CHANGELOG_PARSE_MODE.getCurrentValue().equals(GlobalConfiguration.ChangelogParseMode.STRICT)) {
-                throw new ParsedNodeException("Unknown precondition '" + node.getName() + "'. Check the spelling/capitalization and/or whether any required Liquibase extensions are missing.");
+                throw new ParsedNodeException("Unknown precondition '" + node.getName() + "'. Check for spelling or capitalization errors and missing extensions such as liquibase-commercial.");
             }
 
             return null;

--- a/liquibase-core/src/main/java/liquibase/precondition/PreconditionLogic.java
+++ b/liquibase-core/src/main/java/liquibase/precondition/PreconditionLogic.java
@@ -3,6 +3,7 @@ package liquibase.precondition;
 import liquibase.GlobalConfiguration;
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
+import liquibase.parser.ChangeLogParserConfiguration;
 import liquibase.parser.core.ParsedNode;
 import liquibase.parser.core.ParsedNodeException;
 import liquibase.resource.ResourceAccessor;
@@ -48,7 +49,7 @@ public abstract class PreconditionLogic extends AbstractPrecondition {
     protected Precondition toPrecondition(ParsedNode node, ResourceAccessor resourceAccessor) throws ParsedNodeException {
         Precondition precondition = PreconditionFactory.getInstance().create(node.getName());
         if (precondition == null) {
-            if (node.getChildren() != null && node.getChildren().size() > 0 && GlobalConfiguration.CHANGELOG_PARSE_MODE.getCurrentValue().equals(GlobalConfiguration.ChangelogParseMode.STRICT)) {
+            if (node.getChildren() != null && node.getChildren().size() > 0 && ChangeLogParserConfiguration.CHANGELOG_PARSE_MODE.getCurrentValue().equals(ChangeLogParserConfiguration.ChangelogParseMode.STRICT)) {
                 throw new ParsedNodeException("Unknown precondition '" + node.getName() + "'. Check for spelling or capitalization errors and missing extensions such as liquibase-commercial.");
             }
 

--- a/liquibase-core/src/main/java/liquibase/precondition/PreconditionLogic.java
+++ b/liquibase-core/src/main/java/liquibase/precondition/PreconditionLogic.java
@@ -1,5 +1,6 @@
 package liquibase.precondition;
 
+import liquibase.GlobalConfiguration;
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
 import liquibase.parser.core.ParsedNode;
@@ -47,6 +48,10 @@ public abstract class PreconditionLogic extends AbstractPrecondition {
     protected Precondition toPrecondition(ParsedNode node, ResourceAccessor resourceAccessor) throws ParsedNodeException {
         Precondition precondition = PreconditionFactory.getInstance().create(node.getName());
         if (precondition == null) {
+            if (node.getChildren() != null && node.getChildren().size() > 0 && GlobalConfiguration.CHANGELOG_PARSE_MODE.getCurrentValue().equals(GlobalConfiguration.ChangelogParseMode.STRICT)) {
+                throw new ParsedNodeException("Unknown precondition '" + node.getName() + "'. Check the spelling/capitalization and/or whether any required Liquibase extensions are missing.");
+            }
+
             return null;
         }
 

--- a/liquibase-core/src/test/groovy/liquibase/changelog/ChangeSetTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/changelog/ChangeSetTest.groovy
@@ -1,7 +1,10 @@
 package liquibase.changelog
 
+import liquibase.GlobalConfiguration
+import liquibase.Scope
 import liquibase.change.CheckSum
 import liquibase.change.core.*
+import liquibase.exception.ChangeLogParseException
 import liquibase.parser.core.ParsedNode
 import liquibase.parser.core.ParsedNodeException
 import liquibase.precondition.core.RunningAsPrecondition
@@ -185,6 +188,39 @@ public class ChangeSetTest extends Specification {
         changeSet.changes[0].tableName == "table_1"
         changeSet.changes[0].changeSet == changeSet
         changeSet.changes[1].tableName == "table_2"
+    }
+
+    def "load node with unknown change types and strict parsing"() {
+        when:
+        def changeSet = new ChangeSet(new DatabaseChangeLog("com/example/test.xml"))
+        def node = new ParsedNode(null, "changeSet")
+                .addChildren([id: "1", author: "nvoxland"])
+                .addChild(new ParsedNode(null, "createTable").addChild(null, "tableName", "table_1"))
+                .addChild(new ParsedNode(null, "invalid").addChild(null, "tableName", "table_2"))
+        changeSet.load(node, resourceSupplier.simpleResourceAccessor)
+
+        then:
+        def e = thrown(ParsedNodeException)
+        e.message == "Error parsing com/example/test.xml: Unknown change type 'invalid'. Check the spelling/capitalization and/or whether any required Liquibase extensions are missing."
+    }
+
+    def "load node with unknown change types and lax parsing"() {
+        when:
+        def changeSet = new ChangeSet(new DatabaseChangeLog("com/example/test.xml"))
+        def node = new ParsedNode(null, "changeSet")
+                .addChildren([id: "1", author: "nvoxland"])
+                .addChild(new ParsedNode(null, "createTable").addChild(null, "tableName", "table_1"))
+                .addChild(new ParsedNode(null, "invalid").addChild(null, "tableName", "table_2"))
+
+        Scope.child([(GlobalConfiguration.CHANGELOG_PARSE_MODE.getKey()) : GlobalConfiguration.ChangelogParseMode.LAX], {
+            ->
+            changeSet.load(node, resourceSupplier.simpleResourceAccessor)
+        } as Scope.ScopedRunner)
+
+
+        then:
+        notThrown(ParsedNodeException)
+        changeSet.getChanges().size() == 1
     }
 
     def "load node with rollback containing sql as value"() {

--- a/liquibase-core/src/test/groovy/liquibase/changelog/ChangeSetTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/changelog/ChangeSetTest.groovy
@@ -201,7 +201,7 @@ public class ChangeSetTest extends Specification {
 
         then:
         def e = thrown(ParsedNodeException)
-        e.message == "Error parsing com/example/test.xml: Unknown change type 'invalid'. Check the spelling/capitalization and/or whether any required Liquibase extensions are missing."
+        e.message == "Error parsing com/example/test.xml: Unknown change type 'invalid'. Check for spelling or capitalization errors and missing extensions such as liquibase-commercial."
     }
 
     def "load node with unknown change types and lax parsing"() {

--- a/liquibase-core/src/test/groovy/liquibase/changelog/ChangeSetTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/changelog/ChangeSetTest.groovy
@@ -1,10 +1,10 @@
 package liquibase.changelog
 
-import liquibase.GlobalConfiguration
+
 import liquibase.Scope
 import liquibase.change.CheckSum
 import liquibase.change.core.*
-import liquibase.exception.ChangeLogParseException
+import liquibase.parser.ChangeLogParserConfiguration
 import liquibase.parser.core.ParsedNode
 import liquibase.parser.core.ParsedNodeException
 import liquibase.precondition.core.RunningAsPrecondition
@@ -212,7 +212,7 @@ public class ChangeSetTest extends Specification {
                 .addChild(new ParsedNode(null, "createTable").addChild(null, "tableName", "table_1"))
                 .addChild(new ParsedNode(null, "invalid").addChild(null, "tableName", "table_2"))
 
-        Scope.child([(GlobalConfiguration.CHANGELOG_PARSE_MODE.getKey()) : GlobalConfiguration.ChangelogParseMode.LAX], {
+        Scope.child([(ChangeLogParserConfiguration.CHANGELOG_PARSE_MODE.getKey()): ChangeLogParserConfiguration.ChangelogParseMode.LAX], {
             ->
             changeSet.load(node, resourceSupplier.simpleResourceAccessor)
         } as Scope.ScopedRunner)

--- a/liquibase-core/src/test/groovy/liquibase/parser/core/yaml/YamlChangeLogParser_RealFile_Test.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/parser/core/yaml/YamlChangeLogParser_RealFile_Test.groovy
@@ -300,29 +300,6 @@ public class YamlChangeLogParser_RealFile_Test extends Specification {
         assert e.message.startsWith("Syntax error in file liquibase/parser/core/yaml/malformedChangeLog.yaml")
     }
 
-    def "elements that don't correspond to anything in liquibase are ignored"() throws Exception {
-        def path = "liquibase/parser/core/yaml/unusedTagsChangeLog.yaml"
-        expect:
-        DatabaseChangeLog changeLog = new YamlChangeLogParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor());
-
-        changeLog.getLogicalFilePath() == path
-        changeLog.getPhysicalFilePath() == path
-
-        changeLog.getPreconditions().getNestedPreconditions().size() == 0
-        changeLog.getChangeSets().size() == 1
-
-        ChangeSet changeSet = changeLog.getChangeSets().get(0);
-        changeSet.getAuthor() == "nvoxland"
-        changeSet.getId() == "1"
-        changeSet.getChanges().size() == 1
-        changeSet.getFilePath() == path
-        changeSet.getComments() == "Some comments go here"
-
-        Change change = changeSet.getChanges().get(0);
-        Scope.getCurrentScope().getSingleton(ChangeFactory.class).getChangeMetaData(change).getName() == "createTable"
-        assert change instanceof CreateTableChange
-    }
-
     def "changeLog parameters are correctly expanded"() throws Exception {
         when:
         def params = new ChangeLogParameters(new MockDatabase());

--- a/liquibase-core/src/test/groovy/liquibase/precondition/core/PreconditionContainerTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/precondition/core/PreconditionContainerTest.groovy
@@ -142,7 +142,7 @@ class PreconditionContainerTest extends Specification {
 
         then:
         def e = thrown(ParsedNodeException)
-        e.message == "Unknown precondition 'invalid'. Check the spelling/capitalization and/or whether any required Liquibase extensions are missing."
+        e.message == "Unknown precondition 'invalid'. Check for spelling or capitalization errors and missing extensions such as liquibase-commercial."
     }
 
     def "load handles node with unknown preconditions in lax mode"() {

--- a/liquibase-core/src/test/groovy/liquibase/precondition/core/PreconditionContainerTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/precondition/core/PreconditionContainerTest.groovy
@@ -1,5 +1,7 @@
 package liquibase.precondition.core
 
+import liquibase.GlobalConfiguration
+import liquibase.Scope
 import liquibase.exception.SetupException
 import liquibase.parser.core.ParsedNode
 import liquibase.parser.core.ParsedNodeException
@@ -9,7 +11,8 @@ import spock.lang.Specification
 
 class PreconditionContainerTest extends Specification {
 
-    @Shared resourceSupplier = new ResourceSupplier()
+    @Shared
+            resourceSupplier = new ResourceSupplier()
 
     def "load handles empty node with params"() {
         when:
@@ -101,8 +104,8 @@ class PreconditionContainerTest extends Specification {
         def node = new ParsedNode(null, "preConditions").addChildren([onFail: "MARK_RAN"])
                 .addChild(new ParsedNode(null, "runningAs").addChildren([username: "my_user"]))
                 .addChild(new ParsedNode(null, "or")
-                    .addChildren([runningAs: [username: "other_user"]])
-                    .addChildren([runningAs: [username: "yet_other_user"]])
+                        .addChildren([runningAs: [username: "other_user"]])
+                        .addChildren([runningAs: [username: "yet_other_user"]])
                 )
                 .addChild(new ParsedNode(null, "tableExists").addChildren([tableName: "my_table"]))
 
@@ -128,4 +131,35 @@ class PreconditionContainerTest extends Specification {
 
     }
 
+    def "load handles node with unknown preconditions in strict mode"() {
+        when:
+        def node = new ParsedNode(null, "preConditions").addChildren([onFail: "MARK_RAN"])
+                .addChild(new ParsedNode(null, "invalid").addChildren([tableName: "my_table"]))
+                .addChild(new ParsedNode(null, "tableExists").addChildren([tableName: "my_table"]))
+
+        def container = new PreconditionContainer()
+        container.load(node, resourceSupplier.simpleResourceAccessor)
+
+        then:
+        def e = thrown(ParsedNodeException)
+        e.message == "Unknown precondition 'invalid'. Check the spelling/capitalization and/or whether any required Liquibase extensions are missing."
+    }
+
+    def "load handles node with unknown preconditions in lax mode"() {
+        when:
+        def node = new ParsedNode(null, "preConditions").addChildren([onFail: "MARK_RAN"])
+                .addChild(new ParsedNode(null, "invalid").addChildren([tableName: "my_table"]))
+                .addChild(new ParsedNode(null, "tableExists").addChildren([tableName: "my_table"]))
+
+        def container = new PreconditionContainer()
+        Scope.currentScope.child([(GlobalConfiguration.CHANGELOG_PARSE_MODE.key): GlobalConfiguration.ChangelogParseMode.LAX], {
+            ->
+            container.load(node, resourceSupplier.simpleResourceAccessor)
+        } as Scope.ScopedRunner)
+
+
+        then:
+        notThrown(ParsedNodeException)
+        container.getNestedPreconditions().size() == 1
+    }
 }

--- a/liquibase-core/src/test/groovy/liquibase/precondition/core/PreconditionContainerTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/precondition/core/PreconditionContainerTest.groovy
@@ -3,6 +3,7 @@ package liquibase.precondition.core
 import liquibase.GlobalConfiguration
 import liquibase.Scope
 import liquibase.exception.SetupException
+import liquibase.parser.ChangeLogParserConfiguration
 import liquibase.parser.core.ParsedNode
 import liquibase.parser.core.ParsedNodeException
 import liquibase.sdk.supplier.resource.ResourceSupplier
@@ -152,7 +153,7 @@ class PreconditionContainerTest extends Specification {
                 .addChild(new ParsedNode(null, "tableExists").addChildren([tableName: "my_table"]))
 
         def container = new PreconditionContainer()
-        Scope.currentScope.child([(GlobalConfiguration.CHANGELOG_PARSE_MODE.key): GlobalConfiguration.ChangelogParseMode.LAX], {
+        Scope.currentScope.child([(ChangeLogParserConfiguration.CHANGELOG_PARSE_MODE.key): ChangeLogParserConfiguration.ChangelogParseMode.LAX], {
             ->
             container.load(node, resourceSupplier.simpleResourceAccessor)
         } as Scope.ScopedRunner)

--- a/liquibase-core/src/test/resources/liquibase/registered-changelog.json
+++ b/liquibase-core/src/test/resources/liquibase/registered-changelog.json
@@ -48,24 +48,6 @@
   
   {
     "changeSet": {
-      "id": "1604958377003-3",
-      "author": "wesley (generated)",
-      "changes": [
-        {
-          "createTrigger": {
-            "disabled": false,
-            "path": "objects/trigger/TRIGGER1.sql",
-            "relativeToChangelogFile": true,
-            "tableName": "ACCOUNT",
-            "triggerName": "TRIGGER1"
-          }
-        }]
-      
-    }
-  },
-  
-  {
-    "changeSet": {
       "id": "1604958377003-4",
       "author": "wesley (generated)",
       "changes": [
@@ -414,39 +396,5 @@
         }]
       
     }
-  },
-  
-  {
-    "changeSet": {
-      "id": "1604958377003-14",
-      "author": "wesley (generated)",
-      "changes": [
-        {
-          "addCheckConstraint": {
-            "constraintBody": "supplier_id BETWEEN 100 and 9999",
-            "constraintName": "CHECK_SUPPLIER_ID",
-            "disabled": false,
-            "tableName": "SUPPLIERS"
-          }
-        }]
-      
-    }
-  },
-  
-  {
-    "changeSet": {
-      "id": "1604958377003-15",
-      "author": "wesley (generated)",
-      "changes": [
-        {
-          "createFunction": {
-            "functionName": "FUNC_COMPUTE_TAX",
-            "path": "objects/function/FUNC_COMPUTE_TAX.sql",
-            "relativeToChangelogFile": true
-          }
-        }]
-      
-    }
   }
-  
 ]}

--- a/liquibase-core/src/test/resources/liquibase/registered-changelog.yml
+++ b/liquibase-core/src/test/resources/liquibase/registered-changelog.yml
@@ -23,16 +23,6 @@ databaseChangeLog:
         procedureName: PROC_HELLO_WORLD
         relativeToChangelogFile: true
 - changeSet:
-    id: 1604960286751-3
-    author: wesley (generated)
-    changes:
-    - createTrigger:
-        disabled: false
-        path: objects/trigger/TRIGGER1.sql
-        relativeToChangelogFile: true
-        tableName: ACCOUNT
-        triggerName: TRIGGER1
-- changeSet:
     id: 1604960286751-4
     author: wesley (generated)
     changes:
@@ -208,21 +198,3 @@ databaseChangeLog:
             type: VARCHAR2(50 BYTE)
         tableName: SUPPLIERS1
         tablespace: USERS
-- changeSet:
-    id: 1604960286751-14
-    author: wesley (generated)
-    changes:
-    - addCheckConstraint:
-        constraintBody: supplier_id BETWEEN 100 and 9999
-        constraintName: CHECK_SUPPLIER_ID
-        disabled: false
-        tableName: SUPPLIERS
-- changeSet:
-    id: 1604960286751-15
-    author: wesley (generated)
-    changes:
-    - createFunction:
-        functionName: FUNC_COMPUTE_TAX
-        path: objects/function/FUNC_COMPUTE_TAX.sql
-        relativeToChangelogFile: true
-

--- a/liquibase-core/src/test/resources/liquibase/simple.json
+++ b/liquibase-core/src/test/resources/liquibase/simple.json
@@ -46,24 +46,6 @@
   
   {
     "changeSet": {
-      "id": "1604958377003-3",
-      "author": "wesley (generated)",
-      "changes": [
-        {
-          "createTrigger": {
-            "disabled": false,
-            "path": "objects/trigger/TRIGGER1.sql",
-            "relativeToChangelogFile": true,
-            "tableName": "ACCOUNT",
-            "triggerName": "TRIGGER1"
-          }
-        }]
-      
-    }
-  },
-  
-  {
-    "changeSet": {
       "id": "1604958377003-4",
       "author": "wesley (generated)",
       "changes": [
@@ -412,39 +394,5 @@
         }]
       
     }
-  },
-  
-  {
-    "changeSet": {
-      "id": "1604958377003-14",
-      "author": "wesley (generated)",
-      "changes": [
-        {
-          "addCheckConstraint": {
-            "constraintBody": "supplier_id BETWEEN 100 and 9999",
-            "constraintName": "CHECK_SUPPLIER_ID",
-            "disabled": false,
-            "tableName": "SUPPLIERS"
-          }
-        }]
-      
-    }
-  },
-  
-  {
-    "changeSet": {
-      "id": "1604958377003-15",
-      "author": "wesley (generated)",
-      "changes": [
-        {
-          "createFunction": {
-            "functionName": "FUNC_COMPUTE_TAX",
-            "path": "objects/function/FUNC_COMPUTE_TAX.sql",
-            "relativeToChangelogFile": true
-          }
-        }]
-      
-    }
   }
-  
 ]}

--- a/liquibase-core/src/test/resources/liquibase/test-changelog.json
+++ b/liquibase-core/src/test/resources/liquibase/test-changelog.json
@@ -46,24 +46,6 @@
   
   {
     "changeSet": {
-      "id": "1604958377003-3",
-      "author": "wesley (generated)",
-      "changes": [
-        {
-          "createTrigger": {
-            "disabled": false,
-            "path": "objects/trigger/TRIGGER1.sql",
-            "relativeToChangelogFile": true,
-            "tableName": "ACCOUNT",
-            "triggerName": "TRIGGER1"
-          }
-        }]
-      
-    }
-  },
-  
-  {
-    "changeSet": {
       "id": "1604958377003-4",
       "author": "wesley (generated)",
       "changes": [
@@ -412,39 +394,5 @@
         }]
       
     }
-  },
-  
-  {
-    "changeSet": {
-      "id": "1604958377003-14",
-      "author": "wesley (generated)",
-      "changes": [
-        {
-          "addCheckConstraint": {
-            "constraintBody": "supplier_id BETWEEN 100 and 9999",
-            "constraintName": "CHECK_SUPPLIER_ID",
-            "disabled": false,
-            "tableName": "SUPPLIERS"
-          }
-        }]
-      
-    }
-  },
-  
-  {
-    "changeSet": {
-      "id": "1604958377003-15",
-      "author": "wesley (generated)",
-      "changes": [
-        {
-          "createFunction": {
-            "functionName": "FUNC_COMPUTE_TAX",
-            "path": "objects/function/FUNC_COMPUTE_TAX.sql",
-            "relativeToChangelogFile": true
-          }
-        }]
-      
-    }
   }
-  
 ]}

--- a/liquibase-core/src/test/resources/liquibase/test-changelog.yml
+++ b/liquibase-core/src/test/resources/liquibase/test-changelog.yml
@@ -22,16 +22,6 @@ databaseChangeLog:
         procedureName: PROC_HELLO_WORLD
         relativeToChangelogFile: true
 - changeSet:
-    id: 1604960286751-3
-    author: wesley (generated)
-    changes:
-    - createTrigger:
-        disabled: false
-        path: objects/trigger/TRIGGER1.sql
-        relativeToChangelogFile: true
-        tableName: ACCOUNT
-        triggerName: TRIGGER1
-- changeSet:
     id: 1604960286751-4
     author: wesley (generated)
     changes:
@@ -207,21 +197,3 @@ databaseChangeLog:
             type: VARCHAR2(50 BYTE)
         tableName: SUPPLIERS1
         tablespace: USERS
-- changeSet:
-    id: 1604960286751-14
-    author: wesley (generated)
-    changes:
-    - addCheckConstraint:
-        constraintBody: supplier_id BETWEEN 100 and 9999
-        constraintName: CHECK_SUPPLIER_ID
-        disabled: false
-        tableName: SUPPLIERS
-- changeSet:
-    id: 1604960286751-15
-    author: wesley (generated)
-    changes:
-    - createFunction:
-        functionName: FUNC_COMPUTE_TAX
-        path: objects/function/FUNC_COMPUTE_TAX.sql
-        relativeToChangelogFile: true
-


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Currently, if you have a changelog with an unknown change type or precondition, liquibase just silently skips it. 

For example, in
```
databaseChangeLog:
  - changeSet:
      id: 1
      author: example
      changes:
        - randomInvalid:
            tableName: person
```
            
we have no `randomInvalid` type defined and so we just silently skip it and treat it as an empty changeset.

If you're using an XML format which has xsd validation and you aren't using extensions, you can't have invalid changes since the XSD will catch that. But if you're using yaml/json (or dbchangelog-ext.xsd) and misspell something or are in any format and referencing an extension change and don't have that extension available you can have it skip it.

The new `liquibase.changelogParseMode` setting can be either "STRICT" or "LAX" where "STRICT" is the new default and "LAX" is the old behavior. 

In working through the code, the reason for the old "lax"-ness is that at the part of the parsing where we create Change objects, we don't **_really_** know what is a change and what is an attribute on the changeset, and the possible attributes are extendable so we don't know the possible attributes. So what is happening is we try to parse it as a change object and if it doesn't correspond to a defined change we set it as an attribute.

Longer term we are planning on larger changes to the parsing logic and will eventually be able to be more strict in "strict" parsing mode than we can right now and check attributes, preconditions, etc. as well. For now we can check for things that look like they are meant to be change types that don't correspond to them.

## Things to be aware of

- Changes the default behavior from "LAX" to "STRICT"
- Checks both preconditions and change
- Applies to xml, yaml, and json. Formatted SQL can't specify changes or preconditions

## Things to worry about

- Nothing

