### PR TITLE
allow use of pro DatabaseObject's for filtering with generateChangeLog (DAT-9542)

### DIFF
--- a/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/generateChangelog.test.groovy
+++ b/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/generateChangelog.test.groovy
@@ -89,6 +89,51 @@ Optional Args:
         ]
     }
 
+    run "Filtering with includeObjects", {
+        arguments = [
+            url     : { it.url },
+            username: { it.username },
+            password: { it.password },
+            changelogFile: "target/test-classes/changelog-test.xml",
+            includeObjects: "table:FIRSTTABLE"
+        ]
+        setup {
+            cleanResources(SetupCleanResources.CleanupMode.CLEAN_ON_SETUP, "changelog-test.xml")
+            database = [
+                    new CreateTableChange(
+                            tableName: "FirstTable",
+                            columns: [
+                                    ColumnConfig.fromName("FirstColumn")
+                                            .setType("VARCHAR(255)")
+                            ]
+                    ),
+                    new CreateTableChange(
+                            tableName: "SecondTable",
+                            columns: [
+                                    ColumnConfig.fromName("SecondColumn")
+                                            .setType("VARCHAR(255)")
+                            ]
+                    ),
+                    new TagDatabaseChange(
+                            tag: "version_2.0"
+                    ),
+                    new CreateTableChange(
+                            tableName: "liquibaseRunInfo",
+                            columns: [
+                                    ColumnConfig.fromName("timesRan")
+                                            .setType("INT")
+                            ]
+                    ),
+            ]
+        }
+        expectedFileContent = [
+                "target/test-classes/changelog-test.xml" : [CommandTests.assertContains("<changeSet ", 1)]
+        ]
+        expectedResults = [
+                statusCode   : 0
+        ]
+    }
+
     run "Run without changelogFile throws exception", {
         arguments = [
                 changelogFile: ""


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Allow usage of pro `DatabaseObject` classes in the `includeObject` and `excludeObject` filter for the generateChangeLog command.

## Things to be aware of

Tests for this are in the pro repo.

## Things to worry about



## Additional Context

