### PR TITLE
generate-changelog does not capture same-name triggers defined on different tables (DAT-10112)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/DiffToChangeLog.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/DiffToChangeLog.java
@@ -280,7 +280,7 @@ public class DiffToChangeLog {
         types = getOrderedOutputTypes(MissingObjectChangeGenerator.class);
         List<DatabaseObject> missingObjects = new ArrayList<DatabaseObject>();
         for (Class<? extends DatabaseObject> type : types) {
-            for (DatabaseObject object : diffResult.getMissingObjects(type, getDbObjectComparator())) {
+            for (DatabaseObject object : diffResult.getMissingObjects(type)) {
                 if (object == null) {
                     continue;
                 }
@@ -322,28 +322,6 @@ public class DiffToChangeLog {
         changeSets.addAll(deleteChangeSets);
         changeSets.addAll(updateChangeSets);
         return changeSets;
-    }
-
-    private DatabaseObjectComparator getDbObjectComparator() {
-        return new DatabaseObjectComparator() {
-            @Override
-            public int compare(DatabaseObject o1, DatabaseObject o2) {
-                if (o1 instanceof Column && o1.getAttribute(ORDER_ATTRIBUTE, Integer.class) != null && o2.getAttribute(ORDER_ATTRIBUTE, Integer.class) != null) {
-                    int i = o1.getAttribute(ORDER_ATTRIBUTE, Integer.class).compareTo(o2.getAttribute(ORDER_ATTRIBUTE, Integer.class));
-                    if (i != 0) {
-                        return i;
-                    }
-                } else if (o1 instanceof StoredDatabaseLogic && o1.getAttribute(ORDER_ATTRIBUTE, Integer.class) != null
-                        && o2.getAttribute(ORDER_ATTRIBUTE, Integer.class) != null) {
-                    int order = o1.getAttribute(ORDER_ATTRIBUTE, Long.class).compareTo(o2.getAttribute(ORDER_ATTRIBUTE, Long.class));
-                    if (order != 0) {
-                        return order;
-                    }
-                }
-                return super.compare(o1, o2);
-
-            }
-        };
     }
 
     private List<DatabaseObject> sortUnexpectedObjects(Collection<? extends DatabaseObject> unexpectedObjects, Database database) {


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [?] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Removes use of getDbObjectComparator when finding missing objects.

## Things to be aware of

Removes what I believe is an unnecessary comparator and instead uses scoped comparators. 

## Things to worry about

This may cause other items that were previously "identical" to generate.

## Additional Context
N/A
