### PR TITLE
error when JAVA_HOME is set to invalid value (DAT-10545)

### DIFF
--- a/liquibase-dist/src/main/archive/liquibase
+++ b/liquibase-dist/src/main/archive/liquibase
@@ -32,7 +32,7 @@ if [ -z "${JAVA_HOME}" ]; then
   fi
 else
   if [ ! -x "$JAVA_HOME" ] ; then
-    echo "ERROR: Liquibase cannot determine a valid JAVA_PATH or JAVA_HOME. Please inspect your configurations and try again." >&2
+    echo "ERROR: The JAVA_HOME environment variable is not defined correctly, so Liquibase cannot be started. JAVA_HOME is set to \"$JAVA_HOME\" and it does not exist." >&2
     exit 1
   fi
 fi

--- a/liquibase-dist/src/main/archive/liquibase
+++ b/liquibase-dist/src/main/archive/liquibase
@@ -30,6 +30,11 @@ if [ -z "${JAVA_HOME}" ]; then
   elif [ -d "${LIQUIBASE_HOME}/.install4j/jre.bundle/Contents/Home" ]; then
     JAVA_HOME="${LIQUIBASE_HOME}/.install4j/jre.bundle/Contents/Home"
   fi
+else
+  if [[ $JAVA_HOME == *";"* ]]; then
+    #JAVA_HOME is set, use only the first JAVA_HOME in the semicolon separated list
+    JAVA_HOME=$(echo "$JAVA_HOME" | cut -d ";" -f 1)
+  fi
 fi
 
 if [ -z "${JAVA_HOME}" ]; then

--- a/liquibase-dist/src/main/archive/liquibase
+++ b/liquibase-dist/src/main/archive/liquibase
@@ -31,9 +31,9 @@ if [ -z "${JAVA_HOME}" ]; then
     JAVA_HOME="${LIQUIBASE_HOME}/.install4j/jre.bundle/Contents/Home"
   fi
 else
-  if [[ $JAVA_HOME == *";"* ]]; then
-    #JAVA_HOME is set, use only the first JAVA_HOME in the semicolon separated list
-    JAVA_HOME=$(echo "$JAVA_HOME" | cut -d ";" -f 1)
+  if [ ! -x "$JAVA_HOME" ] ; then
+    echo "ERROR: Liquibase cannot determine a valid JAVA_PATH or JAVA_HOME. Please inspect your configurations and try again." >&2
+    exit 1
   fi
 fi
 

--- a/liquibase-dist/src/main/archive/liquibase.bat
+++ b/liquibase-dist/src/main/archive/liquibase.bat
@@ -17,6 +17,11 @@ if exist "%LIQUIBASE_HOME%\jre" if "%JAVA_HOME%"=="" (
     set JAVA_HOME=%LIQUIBASE_HOME%\jre
 )
 
+rem use only the first JAVA_HOME in the semicolon separated list
+for /f "tokens=1 delims=;" %%a in ("%JAVA_HOME%") do (
+    set JAVA_HOME=%%a
+)
+
 rem special characters may be lost
 setlocal DISABLEDELAYEDEXPANSION
 

--- a/liquibase-dist/src/main/archive/liquibase.bat
+++ b/liquibase-dist/src/main/archive/liquibase.bat
@@ -19,7 +19,7 @@ if exist "%LIQUIBASE_HOME%\jre" if "%JAVA_HOME%"=="" (
 
 if NOT "%JAVA_HOME%" == "" if not exist "%JAVA_HOME%" (
   echo ERROR: The JAVA_HOME environment variable is not defined correctly, so Liquibase cannot be started. JAVA_HOME is set to "%JAVA_HOME%" and it does not exist. >&2
-  exit 1
+  exit /B 1
 )
 
 rem special characters may be lost

--- a/liquibase-dist/src/main/archive/liquibase.bat
+++ b/liquibase-dist/src/main/archive/liquibase.bat
@@ -17,9 +17,9 @@ if exist "%LIQUIBASE_HOME%\jre" if "%JAVA_HOME%"=="" (
     set JAVA_HOME=%LIQUIBASE_HOME%\jre
 )
 
-rem use only the first JAVA_HOME in the semicolon separated list
-for /f "tokens=1 delims=;" %%a in ("%JAVA_HOME%") do (
-    set JAVA_HOME=%%a
+if not exist "%JAVA_HOME%" (
+  echo ERROR: Liquibase cannot determine a valid JAVA_PATH or JAVA_HOME. Please inspect your configurations and try again. >&2
+  exit 1
 )
 
 rem special characters may be lost

--- a/liquibase-dist/src/main/archive/liquibase.bat
+++ b/liquibase-dist/src/main/archive/liquibase.bat
@@ -17,7 +17,7 @@ if exist "%LIQUIBASE_HOME%\jre" if "%JAVA_HOME%"=="" (
     set JAVA_HOME=%LIQUIBASE_HOME%\jre
 )
 
-if not exist "%JAVA_HOME%" (
+if NOT "%JAVA_HOME%" == "" if not exist "%JAVA_HOME%" (
   echo ERROR: Liquibase cannot determine a valid JAVA_PATH or JAVA_HOME. Please inspect your configurations and try again. >&2
   exit 1
 )

--- a/liquibase-dist/src/main/archive/liquibase.bat
+++ b/liquibase-dist/src/main/archive/liquibase.bat
@@ -18,7 +18,7 @@ if exist "%LIQUIBASE_HOME%\jre" if "%JAVA_HOME%"=="" (
 )
 
 if NOT "%JAVA_HOME%" == "" if not exist "%JAVA_HOME%" (
-  echo ERROR: Liquibase cannot determine a valid JAVA_PATH or JAVA_HOME. Please inspect your configurations and try again. >&2
+  echo ERROR: The JAVA_HOME environment variable is not defined correctly, so Liquibase cannot be started. JAVA_HOME is set to "%JAVA_HOME%" and it does not exist. >&2
   exit 1
 )
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Throw an error and fail to start Liquibase if the JAVA_HOME environment variable is set and the path it points to does not exist.

## Things to be aware of



## Things to worry about

If there is an edge case we didn't think about or test for, this will prevent Liquibase from starting in those scenarios.

## Additional Context
