### PR TITLE
Handle negative values when filtering out "!!int" lines DAT-9528

### DIFF
--- a/liquibase-core/src/main/java/liquibase/serializer/core/yaml/YamlSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/yaml/YamlSerializer.java
@@ -167,7 +167,8 @@ public abstract class YamlSerializer implements LiquibaseSerializer {
     }
 
     private String removeClassTypeMarksFromSerializedJson(String json) {
-        json = json.replaceAll("!!int \"(\\d+)\"", "$1");
+        // Handle both negative and positive numbers
+        json = json.replaceAll("!!int \"(-?\\d+)\"", "$1");
         json = json.replaceAll("!!bool \"(\\w+)\"", "$1");
         json = json.replaceAll("!!timestamp \"([^\"]*)\"", "$1");
         json = json.replaceAll("!!float \"([^\"]*)\"", "$1");


### PR DESCRIPTION
We filter out type information in our YAML serialization code, including "!!int <value>" lines.  We need to handle both negative and positive values.