### PR TITLE
when generating SelectFromDatabaseChangeLogLock statement, cast LOCKED column to integer for MariaDB (DAT-10798)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/SelectFromDatabaseChangeLogLockGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/SelectFromDatabaseChangeLogLockGenerator.java
@@ -3,6 +3,7 @@ package liquibase.sqlgenerator.core;
 import liquibase.change.ColumnConfig;
 import liquibase.database.Database;
 import liquibase.database.ObjectQuotingStrategy;
+import liquibase.database.core.MariaDBDatabase;
 import liquibase.database.core.OracleDatabase;
 import liquibase.exception.ValidationErrors;
 import liquibase.sql.Sql;
@@ -38,7 +39,12 @@ public class SelectFromDatabaseChangeLogLockGenerator extends AbstractSqlGenerat
                     if ((col.getComputed() != null) && col.getComputed()) {
                         return col.getName();
                     } else {
-                        return database.escapeColumnName(null, null, null, col.getName());
+                        String escapedColumnName = database.escapeColumnName(null, null, null, col.getName());
+                        if (database instanceof MariaDBDatabase && col.getName().equalsIgnoreCase("locked")) {
+                            return "CAST(" + escapedColumnName + " AS INTEGER) AS " + escapedColumnName;
+                        } else {
+                            return escapedColumnName;
+                        }
                     }
                 }
             }) + " FROM " +


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

The newer versions of the MariaDB driver, which have been shipped with recent versions of Liquibase, return the `LOCKED` column as a `BitSet` by default. This adds casting to the select statement, so that the column is returned as an integer.

## Things to be aware of

I tested this with the driver that is shipped with older versions of Liquibase (which did not exhibit the `BitSet` issue) and this change is backwards compatible with those drivers.

## Things to worry about

Perhaps there was a better way to solve this problem that I'm not aware of.

I was unable to write an integration test for this. For some reason, the integration tests returned the `LOCKED` column as an integer, even before I added the casting.

## Additional Context


