### PR TITLE
[CORE-3202] Fix NUMBER not compatible with H2

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/NumberType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/NumberType.java
@@ -38,7 +38,7 @@ public class NumberType extends LiquibaseDataType {
         } else if ((database instanceof MySQLDatabase) || (database instanceof AbstractDb2Database) || (database instanceof
             HsqlDatabase) || (database instanceof DerbyDatabase) || (database instanceof FirebirdDatabase) ||
             (database instanceof InformixDatabase) || (database instanceof SybaseASADatabase) || (database instanceof
-            SybaseDatabase)) {
+            SybaseDatabase) || (database instanceof H2Database)) {
             return new DatabaseDataType("numeric", getParameters());
         } else if (database instanceof OracleDatabase) {
             if ((getParameters().length > 1) && "0".equals(getParameters()[0]) && "-127".equals(getParameters()[1])) {

--- a/liquibase-core/src/test/groovy/liquibase/datatype/core/NumberTypeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/core/NumberTypeTest.groovy
@@ -1,5 +1,6 @@
 package liquibase.datatype.core
 
+import liquibase.database.core.H2Database
 import liquibase.database.core.PostgresDatabase
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -24,5 +25,8 @@ class NumberTypeTest extends Specification {
         [2000]     | new PostgresDatabase() | "numeric"
         ["1", "2"] | new PostgresDatabase() | "numeric(1, 2)"
         ["*", "0"] | new PostgresDatabase() | "numeric(*, 0)"
+        []         | new H2Database()       | "numeric"
+        [1]        | new H2Database()       | "numeric(1)"
+        ["1", "2"] | new H2Database()       | "numeric(1, 2)"
     }
 }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Fixes NUMBER not compatible with H2 in PostreSql compatibility mode (or suggested for h2 in general).
Full description is here - https://liquibase.jira.com/browse/CORE-3202

As H2 supports numeric, we can use it as a default type as for others DBs
