### PR TITLE
Upgrade installer to ship with jdk 17.0.4+8

### DIFF
--- a/liquibase-dist/src/main/install4j/liquibase.install4j
+++ b/liquibase-dist/src/main/install4j/liquibase.install4j
@@ -16,7 +16,7 @@
         <entry>sqlite-*</entry>
       </macSearchedJars>
     </codeSigning>
-    <jreBundles jdkProviderId="AdoptOpenJDK" release="openjdk17/jdk-17.0.3+7" />
+    <jreBundles jdkProviderId="AdoptOpenJDK" release="openjdk17/jdk-17.0.4+8" />
   </application>
   <files>
     <mountPoints>


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Upgrades the jdk installed with the windows/mac installers to 17.0.4 vs. 17.0.3

## Things to be aware of

- Only impacts the installers
- Builds always use "latest" 17.x so already upgraded

## Things to worry about

- Nothing

## Additional Context

No security issues with 17.0.3, just upgrades and bugfixes in 17.0.4
