### PR TITLE
Added duplicateFileMode setting for maven plugin

### DIFF
--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseChangeLogMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseChangeLogMojo.java
@@ -2,6 +2,7 @@
 // Copyright: Copyright(c) 2007 Trace Financial Limited
 package org.liquibase.maven.plugins;
 
+import liquibase.GlobalConfiguration;
 import liquibase.Liquibase;
 import liquibase.Scope;
 import liquibase.configuration.core.DeprecatedConfigurationValueProvider;
@@ -17,6 +18,7 @@ import org.liquibase.maven.property.PropertyElement;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * A Liquibase MOJO that requires the user to provide a DatabaseChangeLogFile to be able
@@ -92,6 +94,16 @@ public abstract class AbstractLiquibaseChangeLogMojo extends AbstractLiquibaseMo
     @PropertyElement(key = "liquibase.hub.mode")
     protected String hubMode;
 
+
+    /**
+     * How to handle multiple files being found in the search path that have duplicate paths.
+     * Options are WARN (log warning and choose one at random) or ERROR (fail current operation)
+     *
+     * @parameter property="liquibase.duplicateFileMode" default-value="ERROR"
+     */
+    @PropertyElement
+    protected String duplicateFileMode;
+
     @Override
     protected void checkRequiredParametersAreSpecified() throws MojoFailureException {
         super.checkRequiredParametersAreSpecified();
@@ -121,6 +133,9 @@ public abstract class AbstractLiquibaseChangeLogMojo extends AbstractLiquibaseMo
         }
         if (StringUtil.isNotEmpty(hubMode)) {
             DeprecatedConfigurationValueProvider.setData(HubConfiguration.LIQUIBASE_HUB_MODE.getKey(), hubMode);
+        }
+        if (StringUtil.isNotEmpty(duplicateFileMode)) {
+            DeprecatedConfigurationValueProvider.setData(GlobalConfiguration.DUPLICATE_FILE_MODE.getKey(), GlobalConfiguration.DuplicateFileMode.valueOf(duplicateFileMode.toUpperCase(Locale.ROOT)));
         }
     }
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Adds a maven-native flag for the liquibase.duplicateFileMode setting introduced in #3006

The config-level tag is `<duplicateFileMode>` and the global maven property to set is `liquibase.duplicateFileMode`

Fixes #3097

## Things to be aware of

- Parsing of the value is case insensitive
- Invalid values should throw a parse value
- Applies to all maven commands that use a changelog (extends AbstractLiquibaseChangeLogMojo)

## Things to worry about

- Nothing

