### PR TITLE
Changed what sequence attributes are included in diff/generate changelog for Snowflake

### DIFF
--- a/liquibase-snowflake/src/main/java/liquibase/diff/output/changelog/core/ChangedSequenceChangeGeneratorSnowflake.java
+++ b/liquibase-snowflake/src/main/java/liquibase/diff/output/changelog/core/ChangedSequenceChangeGeneratorSnowflake.java
@@ -1,0 +1,47 @@
+package liquibase.diff.output.changelog.core;
+
+import liquibase.change.Change;
+import liquibase.change.core.AlterSequenceChange;
+import liquibase.database.Database;
+import liquibase.database.core.SnowflakeDatabase;
+import liquibase.diff.ObjectDifferences;
+import liquibase.diff.output.DiffOutputControl;
+import liquibase.diff.output.changelog.ChangeGeneratorChain;
+import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.Sequence;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ChangedSequenceChangeGeneratorSnowflake extends ChangedSequenceChangeGenerator{
+
+    @Override
+    public int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
+        int priority = super.getPriority(objectType, database);
+        if ((Sequence.class.isAssignableFrom(objectType)) && (database instanceof SnowflakeDatabase)) {
+            priority += PRIORITY_DATABASE;
+        }
+        return priority;
+    }
+
+    @Override
+    public Change[] fixChanged(DatabaseObject changedObject, ObjectDifferences differences, DiffOutputControl control, Database referenceDatabase, Database comparisonDatabase, ChangeGeneratorChain chain) {
+        Sequence sequence = (Sequence) changedObject;
+
+        List<Change> changes = new ArrayList<>();
+        AlterSequenceChange accumulatedChange = createAlterSequenceChange(sequence, control);
+
+        if (differences.isDifferent("incrementBy")) {
+            AlterSequenceChange change = createAlterSequenceChange(sequence, control);
+            change.setIncrementBy(sequence.getIncrementBy());
+            accumulatedChange.setIncrementBy(sequence.getIncrementBy());
+            changes.add(change);
+        }
+
+        if (changes.isEmpty()) {
+            return null;
+        } else {
+            return changes.toArray(new Change[changes.size()]);
+        }
+    }
+}

--- a/liquibase-snowflake/src/main/java/liquibase/diff/output/changelog/core/MissingSequenceChangeGeneratorSnowflake.java
+++ b/liquibase-snowflake/src/main/java/liquibase/diff/output/changelog/core/MissingSequenceChangeGeneratorSnowflake.java
@@ -26,6 +26,9 @@ public class MissingSequenceChangeGeneratorSnowflake extends MissingSequenceChan
 
         CreateSequenceChange change = new CreateSequenceChange();
         change.setSequenceName(sequence.getName());
+        if (control.getIncludeCatalog()) {
+            change.setCatalogName(sequence.getSchema().getCatalogName());
+        }
         if (control.getIncludeSchema()) {
             change.setSchemaName(sequence.getSchema().getName());
         }

--- a/liquibase-snowflake/src/main/java/liquibase/diff/output/changelog/core/MissingSequenceChangeGeneratorSnowflake.java
+++ b/liquibase-snowflake/src/main/java/liquibase/diff/output/changelog/core/MissingSequenceChangeGeneratorSnowflake.java
@@ -1,0 +1,38 @@
+package liquibase.diff.output.changelog.core;
+
+import liquibase.change.Change;
+import liquibase.change.core.CreateSequenceChange;
+import liquibase.database.Database;
+import liquibase.database.core.SnowflakeDatabase;
+import liquibase.diff.output.DiffOutputControl;
+import liquibase.diff.output.changelog.ChangeGeneratorChain;
+import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.Sequence;
+
+public class MissingSequenceChangeGeneratorSnowflake extends MissingSequenceChangeGenerator{
+
+    @Override
+    public int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
+        int priority = super.getPriority(objectType, database);
+        if ((Sequence.class.isAssignableFrom(objectType)) && (database instanceof SnowflakeDatabase)) {
+            priority += PRIORITY_DATABASE;
+        }
+        return priority;
+    }
+
+    @Override
+    public Change[] fixMissing(DatabaseObject missingObject, DiffOutputControl control, Database referenceDatabase, Database comparisonDatabase, ChangeGeneratorChain chain) {
+        Sequence sequence = (Sequence) missingObject;
+
+        CreateSequenceChange change = new CreateSequenceChange();
+        change.setSequenceName(sequence.getName());
+        if (control.getIncludeSchema()) {
+            change.setSchemaName(sequence.getSchema().getName());
+        }
+        change.setStartValue(sequence.getStartValue());
+        change.setIncrementBy(sequence.getIncrementBy());
+
+        return new Change[] { change };
+
+    }
+}

--- a/liquibase-snowflake/src/main/java/liquibase/sqlgenerator/core/CreateSequenceGeneratorSnowflake.java
+++ b/liquibase-snowflake/src/main/java/liquibase/sqlgenerator/core/CreateSequenceGeneratorSnowflake.java
@@ -1,0 +1,54 @@
+package liquibase.sqlgenerator.core;
+
+import liquibase.database.Database;
+import liquibase.database.core.*;
+import liquibase.exception.ValidationErrors;
+import liquibase.sql.Sql;
+import liquibase.sql.UnparsedSql;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.statement.core.CreateSequenceStatement;
+
+public class CreateSequenceGeneratorSnowflake extends CreateSequenceGenerator{
+
+    @Override
+    public int getPriority() {
+        return PRIORITY_DATABASE;
+    }
+
+    @Override
+    public boolean supports(CreateSequenceStatement statement, Database database) {
+        return database instanceof SnowflakeDatabase;
+    }
+
+    @Override
+    public ValidationErrors validate(CreateSequenceStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+        ValidationErrors validationErrors = new ValidationErrors();
+
+        validationErrors.checkRequiredField("sequenceName", statement.getSequenceName());
+
+        validationErrors.checkDisallowedField("minValue", statement.getMinValue(), database, SnowflakeDatabase.class);
+        validationErrors.checkDisallowedField("maxValue", statement.getMaxValue(), database, SnowflakeDatabase.class);
+        validationErrors.checkDisallowedField("cacheSize", statement.getCacheSize(), database, SnowflakeDatabase.class);
+        validationErrors.checkDisallowedField("cycle", statement.getCycle(), database, SnowflakeDatabase.class);
+        validationErrors.checkDisallowedField("datatype", statement.getDataType(), database, SnowflakeDatabase.class);
+        validationErrors.checkDisallowedField("ordered", statement.getOrdered(), database, SnowflakeDatabase.class);
+
+        return validationErrors;
+    }
+
+    @Override
+    public Sql[] generateSql(CreateSequenceStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+        StringBuilder queryStringBuilder = new StringBuilder();
+        queryStringBuilder.append("CREATE SEQUENCE ");
+        queryStringBuilder.append(database.escapeSequenceName(statement.getCatalogName(), statement.getSchemaName(), statement.getSequenceName()));
+        if (database instanceof SnowflakeDatabase) {
+            if (statement.getStartValue() != null) {
+                queryStringBuilder.append(" START WITH ").append(statement.getStartValue());
+            }
+            if (statement.getIncrementBy() != null) {
+                queryStringBuilder.append(" INCREMENT BY ").append(statement.getIncrementBy());
+            }
+        }
+        return new Sql[]{new UnparsedSql(queryStringBuilder.toString(), getAffectedSequence(statement))};
+    }
+}

--- a/liquibase-snowflake/src/main/resources/META-INF/services/liquibase.diff.output.changelog.ChangeGenerator
+++ b/liquibase-snowflake/src/main/resources/META-INF/services/liquibase.diff.output.changelog.ChangeGenerator
@@ -1,0 +1,2 @@
+liquibase.diff.output.changelog.core.ChangedSequenceChangeGeneratorSnowflake
+liquibase.diff.output.changelog.core.MissingSequenceChangeGeneratorSnowflake

--- a/liquibase-snowflake/src/main/resources/META-INF/services/liquibase.sqlgenerator.SqlGenerator
+++ b/liquibase-snowflake/src/main/resources/META-INF/services/liquibase.sqlgenerator.SqlGenerator
@@ -1,3 +1,4 @@
+liquibase.sqlgenerator.core.CreateSequenceGeneratorSnowflake
 liquibase.sqlgenerator.core.DropDefaultValueGeneratorSnowflake
 liquibase.sqlgenerator.core.DropProcedureGeneratorSnowflake
 liquibase.sqlgenerator.core.InsertOrUpdateGeneratorSnowflake


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Snowflake only supports operating 'startWith' and 'incrementBy' sequence attributes. The rests are set by default and are not allowed to be set or changed. In order for Liquibase to correctly work with those 'fixed' attributes we need to:

- Throw a validation error when the 'fixed' attributes are present in changesets that are being applied to Snowflake
- Include the values in JSON snapshots so the database is accurately and completely represented BUT
- Exclude the 'fixed' attributes from any changesets generated by diffChangelog or generateChangelog so that we don't generate invalid changesets
