### PR TITLE
Fix columnNames snapshot attribute of uniqueConstraints for Snowflake

### DIFF
--- a/liquibase-snowflake/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGeneratorSnowflake.java
+++ b/liquibase-snowflake/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGeneratorSnowflake.java
@@ -2,7 +2,6 @@ package liquibase.snapshot.jvm;
 
 import liquibase.Scope;
 import liquibase.database.Database;
-import liquibase.database.core.H2Database;
 import liquibase.database.core.SnowflakeDatabase;
 import liquibase.exception.DatabaseException;
 import liquibase.executor.ExecutorService;
@@ -12,7 +11,6 @@ import liquibase.snapshot.SnapshotGenerator;
 import liquibase.statement.core.RawSqlStatement;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.*;
-import liquibase.util.StringUtil;
 
 import java.sql.SQLException;
 import java.util.List;
@@ -28,32 +26,6 @@ public class UniqueConstraintSnapshotGeneratorSnowflake extends UniqueConstraint
         } else {
             return PRIORITY_NONE;
         }
-    }
-
-    @Override
-    protected DatabaseObject snapshotObject(DatabaseObject example, DatabaseSnapshot snapshot) throws DatabaseException {
-        Database database = snapshot.getDatabase();
-        UniqueConstraint exampleConstraint = (UniqueConstraint) example;
-        Relation table = exampleConstraint.getRelation();
-
-        List<Map<String, ?>> metadata = listColumns(exampleConstraint, database, snapshot);
-
-        if (metadata.isEmpty()) {
-            return null;
-        }
-        UniqueConstraint constraint = new UniqueConstraint();
-        constraint.setRelation(table);
-        constraint.setName(example.getName());
-        constraint.setBackingIndex(exampleConstraint.getBackingIndex());
-        constraint.setInitiallyDeferred(((UniqueConstraint) example).isInitiallyDeferred());
-        constraint.setDeferrable(((UniqueConstraint) example).isDeferrable());
-        constraint.setClustered(((UniqueConstraint) example).isClustered());
-
-        for (Map<String, ?> col : metadata) {
-            constraint.getColumns().add(new Column((String) col.get("COLUMN_NAME")).setRelation(table));
-        }
-
-        return constraint;
     }
 
     @Override


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

INFORMATION_SCHEMA in Snowflake doesn’t track ‘column_name’ attribute for constraints. As result, uniqueConstraints snapshot and changesets produced from diff/generate-changelog commands contain columnNames=”” attribute which results in Error during following update command. Currently the best workaround to get column_name for constraint is to use SHOW UNIQUE KEYS command followed by result_scan(last_query_id()) function.
