### PR TITLE
fix order of enum values on MySQL 8

### DIFF
--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
@@ -521,7 +521,8 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
                                         "UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) tens\n" +
                                         "WHERE TABLE_SCHEMA = '" + column.getSchema().getName() + "' \n" +
                                         "AND TABLE_NAME = '" + column.getRelation().getName() + "' \n" +
-                                        "AND COLUMN_NAME = '" + column.getName() + "'"), String.class);
+                                        "AND COLUMN_NAME = '" + column.getName() + "'\n" +
+                                        "ORDER BY tens.i, units.i"), String.class);
                 String enumClause = "";
                 for (String enumValue : enumValues) {
                     enumClause += "'" + enumValue + "', ";


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Fixes #3147.

On MySQL 5.7.12 enums values are retrieved in the correct order.
On MySQL 8.0.28 enums values are retrieved in this order: 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 20, 19, 18, 17...

This fix adds an `order by` so enums are explicitly retrieved in the correct order.