### PR TITLE
Fix tests search path DAT-10431

### DIFF
--- a/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/command/CommandTests.groovy
+++ b/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/command/CommandTests.groovy
@@ -300,7 +300,7 @@ Long Description: ${commandDefinition.getLongDescription() ?: "NOT SET"}
             }
 
             config.registerProvider(propertiesProvider)
-            resourceAccessor = new SearchPathResourceAccessor(Scope.getCurrentScope().getResourceAccessor())
+            resourceAccessor = new SearchPathResourceAccessor(testDef.searchPath, Scope.getCurrentScope().getResourceAccessor())
         }
 
         def scopeSettings = [


### PR DESCRIPTION
Need to use the `SearchPathResourceAccessor` constructor that takes the searchPath as the first parameter for tests.
