### PR TITLE
use PathHandlerFactory for outputFile parameter (DAT-11034)

### DIFF
--- a/liquibase-cli/src/main/java/liquibase/integration/commandline/CommandRunner.java
+++ b/liquibase-cli/src/main/java/liquibase/integration/commandline/CommandRunner.java
@@ -1,10 +1,12 @@
 package liquibase.integration.commandline;
 
+import liquibase.Scope;
 import liquibase.command.CommandResults;
 import liquibase.command.CommandScope;
 import liquibase.command.CommonArgumentNames;
 import liquibase.exception.CommandValidationException;
 import liquibase.exception.MissingRequiredArgumentException;
+import liquibase.resource.PathHandlerFactory;
 import liquibase.util.StringUtil;
 import picocli.CommandLine;
 
@@ -39,12 +41,13 @@ class CommandRunner implements Callable<CommandResults> {
         }
 
         final CommandScope commandScope = new CommandScope(commandName);
-        final File outputFile = LiquibaseCommandLineConfiguration.OUTPUT_FILE.getCurrentValue();
+        final String outputFile = LiquibaseCommandLineConfiguration.OUTPUT_FILE.getCurrentValue();
         OutputStream outputStream = null;
 
         try {
             if (outputFile != null) {
-                outputStream = new FileOutputStream(outputFile);
+                final PathHandlerFactory pathHandlerFactory = Scope.getCurrentScope().getSingleton(PathHandlerFactory.class);
+                outputStream = pathHandlerFactory.openResourceOutputStream(outputFile, true, true);
                 commandScope.setOutput(outputStream);
             }
 

--- a/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
+++ b/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
@@ -358,9 +358,9 @@ public class LiquibaseCommandLine {
                             Scope.getCurrentScope().getUI().sendMessage("Logs saved to " + logFile.getValue().getAbsolutePath());
                         }
 
-                        final ConfiguredValue<File> outputFile = LiquibaseCommandLineConfiguration.OUTPUT_FILE.getCurrentConfiguredValue();
+                        final ConfiguredValue<String> outputFile = LiquibaseCommandLineConfiguration.OUTPUT_FILE.getCurrentConfiguredValue();
                         if (outputFile.found()) {
-                            Scope.getCurrentScope().getUI().sendMessage("Output saved to " + outputFile.getValue().getAbsolutePath());
+                            Scope.getCurrentScope().getUI().sendMessage("Output saved to " + outputFile.getValue());
                         }
 
                         if (response == 0) {

--- a/liquibase-core/src/main/java/liquibase/integration/commandline/LiquibaseCommandLineConfiguration.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/LiquibaseCommandLineConfiguration.java
@@ -23,7 +23,7 @@ public class LiquibaseCommandLineConfiguration implements AutoloadedConfiguratio
     public static final ConfigurationDefinition<Level> LOG_LEVEL;
     public static final ConfigurationDefinition<String> LOG_CHANNELS;
     public static final ConfigurationDefinition<File> LOG_FILE;
-    public static final ConfigurationDefinition<File> OUTPUT_FILE;
+    public static final ConfigurationDefinition<String> OUTPUT_FILE;
     public static final ConfigurationDefinition<Boolean> SHOULD_RUN;
     public static final ConfigurationDefinition<ArgumentConverter> ARGUMENT_CONVERTER;
     public static final ConfigurationDefinition<String> MONITOR_PERFORMANCE;
@@ -67,7 +67,7 @@ public class LiquibaseCommandLineConfiguration implements AutoloadedConfiguratio
                 .build();
 
         LOG_FILE = builder.define("logFile", File.class).build();
-        OUTPUT_FILE = builder.define("outputFile", File.class).build();
+        OUTPUT_FILE = builder.define("outputFile", String.class).build();
 
         MONITOR_PERFORMANCE = builder.define("monitorPerformance", String.class)
                 .setDescription("Enable performance tracking. Set to 'false' to disable. If set to 'true', data is stored to a `liquibase-TIMESTAMP.jfr` file in your working directory. Any other value will enable tracking and be used as the name of the file to write the data to.")


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Use the PathHandlerFactory to write to files specified in the `outputFile` parameter.

## Things to be aware of


## Things to worry about

This should not be a breaking change.

## Additional Context

This is being done to support the S3 work.