### PR TITLE
Fix: Add "LOCKED" as keyword for EDB

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/EnterpriseDBDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/EnterpriseDBDatabase.java
@@ -18,7 +18,7 @@ public class EnterpriseDBDatabase extends PostgresDatabase {
     public EnterpriseDBDatabase() {
         super();
         
-        reservedWords.addAll(Arrays.asList("Locked"));
+        reservedWords.addAll(Arrays.asList("LOCKED"));
     }
     
     @Override

--- a/liquibase-core/src/main/java/liquibase/database/core/EnterpriseDBDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/EnterpriseDBDatabase.java
@@ -11,9 +11,16 @@ import liquibase.util.JdbcUtil;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Arrays;
 
 public class EnterpriseDBDatabase extends PostgresDatabase {
 
+    public EnterpriseDBDatabase() {
+        super();
+        
+        reservedWords.addAll(Arrays.asList("Locked"));
+    }
+    
     @Override
     public boolean isCorrectDatabaseImplementation(DatabaseConnection conn) throws DatabaseException {
         final String url = conn.getURL();

--- a/liquibase-core/src/main/java/liquibase/database/core/PostgresDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/PostgresDatabase.java
@@ -50,7 +50,7 @@ public class PostgresDatabase extends AbstractJdbcDatabase {
 
     private Set<String> systemTablesAndViews = new HashSet<>();
 
-    private Set<String> reservedWords = new HashSet<>();
+    protected Set<String> reservedWords = new HashSet<>();
 
     public PostgresDatabase() {
         super.setCurrentDateTimeFunction("NOW()");


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

During testing of the latest 4.15.0 version with an EDB database, i got the following exception:
`Caused by: liquibase.exception.DatabaseException: Error executing SQL SELECT LOCKED FROM XMAPSYSTEM.databasechangeloglock WHERE ID=1: FEHLER: Column »locked« doesn't exists.
Note: Perhaps the intention was to refer to the "databasechangeloglock.lockedby" column.
  Position: 8
	at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:90) ~[liquibase-core-4.15.0.jar:?]
	at liquibase.executor.jvm.JdbcExecutor.query(JdbcExecutor.java:202) ~[liquibase-core-4.15.0.jar:?]
	at liquibase.executor.jvm.JdbcExecutor.query(JdbcExecutor.java:210) ~[liquibase-core-4.15.0.jar:?]
	at liquibase.executor.jvm.JdbcExecutor.queryForObject(JdbcExecutor.java:218) ~[liquibase-core-4.15.0.jar:?]
	at liquibase.executor.jvm.JdbcExecutor.queryForObject(JdbcExecutor.java:233) ~[liquibase-core-4.15.0.jar:?]
	at liquibase.executor.jvm.JdbcExecutor.queryForObject(JdbcExecutor.java:228) ~[liquibase-core-4.15.0.jar:?]
	at liquibase.lockservice.StandardLockService.acquireLock(StandardLockService.java:288) ~[liquibase-core-4.15.0.jar:?]
	at liquibase.lockservice.StandardLockService.waitForLock(StandardLockService.java:247) ~[liquibase-core-4.15.0.jar:?]
	at liquibase.Liquibase.lambda$update$1(Liquibase.java:212) ~[liquibase-core-4.15.0.jar:?]
	at liquibase.Scope.lambda$child$0(Scope.java:180) ~[liquibase-core-4.15.0.jar:?]
	at liquibase.Scope.child(Scope.java:189) ~[liquibase-core-4.15.0.jar:?]
	at liquibase.Scope.child(Scope.java:179) ~[liquibase-core-4.15.0.jar:?]
	at liquibase.Scope.child(Scope.java:158) ~[liquibase-core-4.15.0.jar:?]
	at liquibase.Liquibase.runInScope(Liquibase.java:2414) ~[liquibase-core-4.15.0.jar:?]
	at liquibase.Liquibase.update(Liquibase.java:209) ~[liquibase-core-4.15.0.jar:?]
	at liquibase.Liquibase.update(Liquibase.java:195) ~[liquibase-core-4.15.0.jar:?]
	at liquibase.Liquibase.update(Liquibase.java:191) ~[liquibase-core-4.15.0.jar:?]`

That's why I added the keyword "LOCKED" to the list for EDB so that it would be escaped.

