### PR TITLE
Removed invalid warning in Maven

### DIFF
--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
@@ -592,12 +592,14 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
     }
 
     protected Writer getOutputWriter(final File outputFile) throws IOException {
-        if (outputFileEncoding == null) {
-            getLog().info("Char encoding not set! The created file will be system dependent!");
-            return new OutputStreamWriter(new FileOutputStream(outputFile), GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue());
+        String encoding = this.outputFileEncoding;
+
+        if (encoding == null) {
+            encoding = GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue();
         }
-        getLog().debug("Writing output file with [" + outputFileEncoding + "] file encoding.");
-        return new BufferedWriter(new OutputStreamWriter(new FileOutputStream(outputFile), outputFileEncoding));
+        getLog().debug("Writing output file with '" + encoding + "' file encoding.");
+
+        return new BufferedWriter(new OutputStreamWriter(new FileOutputStream(outputFile), encoding));
     }
 
     @Override


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

When using maven, if you did not specify an outputFileEncoding setting, it gave a warning about the encoding being system dependent. That is not the case, it defaults to UTF-8 so I removed the warning. We used to fall back to the system encoding instead of UTF-8, but changed that quite a while ago (maybe 4.6?)

I also cleaned up the code slightly so that there is consistent creation of the stream regardless of how the encoding was determined.

## Things to be aware of

- Only impacts maven

## Things to worry about

- Nothing 
