### PR TITLE
Do not fall back to resource accessor when trying to open OutputStream for file creation [DAT-11357] 

### DIFF
--- a/liquibase-cli/src/main/java/liquibase/integration/commandline/CommandRunner.java
+++ b/liquibase-cli/src/main/java/liquibase/integration/commandline/CommandRunner.java
@@ -47,7 +47,7 @@ class CommandRunner implements Callable<CommandResults> {
         try {
             if (outputFile != null) {
                 final PathHandlerFactory pathHandlerFactory = Scope.getCurrentScope().getSingleton(PathHandlerFactory.class);
-                outputStream = pathHandlerFactory.openResourceOutputStream(outputFile, true, true);
+                outputStream = pathHandlerFactory.openResourceOutputStream(outputFile, false, true);
                 commandScope.setOutput(outputStream);
             }
 


### PR DESCRIPTION
… .

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Do not fall back to resource accessor when trying to open OutputStream for file creation. File creation can either occur as a file in the current working directory, or somewhere else using an absolute path (like S3).

## Things to be aware of


## Things to worry about


## Additional Context
