### PR TITLE
Add schemas and includeSchema parameters to maven generateChangeLog

### DIFF
--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseGenerateChangeLogMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseGenerateChangeLogMojo.java
@@ -16,11 +16,6 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.liquibase.maven.property.PropertyElement;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-
 /**
  * <p>Generates a changelog based on the current database schema. Typically used when
  * beginning to use Liquibase on an existing project and database schema.</p>


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

`schemas` and `includeSchema` parameters have been added to `LiquibaseGenerateChangeLogMojo` class to let liquibase know which schemas needs to consider at the time of generating a change log, as well as whether to include schema names on it. 

Fixes #3174

## Things to be aware of

- Nothing

## Things to worry about

- Nothing

## Additional Context

N/A
