### PR TITLE
Add missing generator for parameterized SQL statements

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/RawParameterizedSqlGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/RawParameterizedSqlGenerator.java
@@ -1,0 +1,24 @@
+package liquibase.sqlgenerator.core;
+
+import liquibase.database.Database;
+import liquibase.exception.ValidationErrors;
+import liquibase.sql.Sql;
+import liquibase.sql.UnparsedSql;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.statement.core.RawParameterizedSqlStatement;
+
+public class RawParameterizedSqlGenerator extends AbstractSqlGenerator<RawParameterizedSqlStatement> {
+
+    @Override
+    public ValidationErrors validate(RawParameterizedSqlStatement statement, Database database, SqlGeneratorChain<RawParameterizedSqlStatement> sqlGeneratorChain) {
+        ValidationErrors validationErrors = new ValidationErrors();
+        validationErrors.checkRequiredField("sql", statement.getSql());
+        validationErrors.checkRequiredField("parameters", statement.getParameters(), false);
+        return validationErrors;
+    }
+
+    @Override
+    public Sql[] generateSql(RawParameterizedSqlStatement statement, Database database, SqlGeneratorChain<RawParameterizedSqlStatement> sqlGeneratorChain) {
+        return new Sql[] {new UnparsedSql(statement.getSql())};
+    }
+}

--- a/liquibase-core/src/main/resources/META-INF/services/liquibase.sqlgenerator.SqlGenerator
+++ b/liquibase-core/src/main/resources/META-INF/services/liquibase.sqlgenerator.SqlGenerator
@@ -80,6 +80,7 @@ liquibase.sqlgenerator.core.InsertSetGenerator
 liquibase.sqlgenerator.core.LockDatabaseChangeLogGenerator
 liquibase.sqlgenerator.core.MarkChangeSetRanGenerator
 liquibase.sqlgenerator.core.ModifyDataTypeGenerator
+liquibase.sqlgenerator.core.RawParameterizedSqlGenerator
 liquibase.sqlgenerator.core.RawSqlGenerator
 liquibase.sqlgenerator.core.ReindexGeneratorSQLite
 liquibase.sqlgenerator.core.RemoveChangeSetRanStatusGenerator


### PR DESCRIPTION
This prevents RawParameterizedSqlStatement to be processed during
dry-run

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

I started replacing most string-interpolated raw SQL statements with proper `liquibase.statement.core.RawParameterizedSqlStatement` instances in the Neo4j extension (see [PR](https://github.com/liquibase/liquibase-neo4j/pull/226)).

However, the dry-run (`updateSQL`) failed executing because there was no generator for these.

This should have no impact at all, since I believe only the Neo4j extension is currently using `RawParameterizedSqlStatement`.

There is no urgency as I already implemented the missing generator in the extension itself.
I'll remove it from the extension whenever that pull request is merged and its changes are released.