### PR TITLE
create parent directories only if the parent exists (DAT-11485)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/resource/PathResource.java
+++ b/liquibase-core/src/main/java/liquibase/resource/PathResource.java
@@ -1,9 +1,8 @@
 package liquibase.resource;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import liquibase.Scope;
+
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.zip.GZIPInputStream;
@@ -59,7 +58,13 @@ public class PathResource extends AbstractResource {
     public OutputStream openOutputStream(boolean createIfNeeded) throws IOException {
         if (!exists()) {
             if (createIfNeeded) {
-                path.getParent().toFile().mkdirs();
+                Path parent = path.getParent();
+                if (parent != null) {
+                    boolean mkdirs = parent.toFile().mkdirs();
+                    if (!mkdirs) {
+                        Scope.getCurrentScope().getLog(getClass()).warning("Failed to create parent directories for file " + path);
+                    }
+                }
             } else {
                 throw new IOException("File " + this.getUri() + " does not exist");
             }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Only `mkdirs` of the parent if the parent is not null.

## Things to be aware of


## Things to worry about

## Additional Context

