### PR TITLE
Postgresql: Fix for case when current search_path is an empty string

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/core/DatabaseUtils.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/DatabaseUtils.java
@@ -10,6 +10,7 @@ import liquibase.executor.ExecutorService;
 import liquibase.statement.core.RawSqlStatement;
 import liquibase.structure.core.Schema;
 import liquibase.util.StringUtil;
+import org.apache.commons.lang3.StringUtils;
 
 public class DatabaseUtils {
     /**
@@ -48,13 +49,15 @@ public class DatabaseUtils {
                         finalSearchPath = defaultSchemaName;
                     }
 
-                    //If existing search path entries are not quoted, quote them. Some databases do not show them as quoted even though they need to be (like $user or case sensitive schemas)
-                    finalSearchPath += ", " + StringUtil.join(StringUtil.splitAndTrim(searchPath, ","), ",", (StringUtil.StringUtilFormatter<String>) obj -> {
-                        if (obj.startsWith("\"")) {
-                            return obj;
-                        }
-                        return ((PostgresDatabase) database).quoteObject(obj, Schema.class);
-                    });
+                    if (StringUtils.isNotBlank(searchPath)) {
+                        //If existing search path entries are not quoted, quote them. Some databases do not show them as quoted even though they need to be (like $user or case sensitive schemas)
+                        finalSearchPath += ", " + StringUtil.join(StringUtil.splitAndTrim(searchPath, ","), ",", (StringUtil.StringUtilFormatter<String>) obj -> {
+                            if (obj.startsWith("\"")) {
+                                return obj;
+                            }
+                            return ((PostgresDatabase) database).quoteObject(obj, Schema.class);
+                        });
+                    }
 
                     executor.execute(new RawSqlStatement("SET SEARCH_PATH TO " + finalSearchPath));
                 }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

In certain cases the search path in a postgres database can be empty (not null, but an empty string). For us it happens when running postgres with testcontainers for IT tests, probably on rollbacks (as you call initializeDatabase for every rollback to reset default schema). In case searchPath is empty we should not try and process it, just re-set the default schema.