### PR TITLE
Add catalog null check to fix initializing a MSSQL db issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ original-pom.xml
 **/logback-test.xml
 **/*.swp
 **/dependency-reduced-pom.xml
+compareGeneratedSqlWithExpectedSqlForMinimalChangesets/

--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,3 @@ original-pom.xml
 **/logback-test.xml
 **/*.swp
 **/dependency-reduced-pom.xml
-compareGeneratedSqlWithExpectedSqlForMinimalChangesets/

--- a/liquibase-core/src/main/java/liquibase/database/core/DatabaseUtils.java
+++ b/liquibase-core/src/main/java/liquibase/database/core/DatabaseUtils.java
@@ -73,9 +73,11 @@ public class DatabaseUtils {
                 }
                 executor.execute(new RawSqlStatement("USE " + schema));
             } else if (database instanceof MSSQLDatabase) {
-                executor.execute(new RawSqlStatement("USE " + defaultCatalogName));
+                    defaultCatalogName = StringUtil.trimToNull(defaultCatalogName);
+                    if (defaultCatalogName != null) {
+                        executor.execute(new RawSqlStatement(String.format("USE %s", defaultCatalogName)));
+                    }
             }
-
         }
     }
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

A null check has been added in order to avoid having issues when trying to run a Liquibase command like "generateChangeLog" proving only the `defaultSchemaName`. 

Fixes #3181 

## Things to be aware of

- nothing

## Things to worry about

- nothing

## Additional Context

- nothing
