### PR TITLE
Upgrade snakeyaml from 1.27 to 1.31 fixing CVE-2022-25857

### DIFF
--- a/liquibase-dist/src/main/maven/release.pom.xml
+++ b/liquibase-dist/src/main/maven/release.pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.27</version>
+            <version>1.31</version>
             <scope>compile</scope>
         </dependency>
 


### PR DESCRIPTION
## Description

Updates the snakeyaml dependency shipped in the liquibase-maven-plugin pom