### PR TITLE
Allow renameColumn on newer SQLite versions

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/RenameColumnGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/RenameColumnGenerator.java
@@ -3,6 +3,7 @@ package liquibase.sqlgenerator.core;
 import liquibase.database.Database;
 import liquibase.database.core.*;
 import liquibase.datatype.DataTypeFactory;
+import liquibase.exception.DatabaseException;
 import liquibase.exception.ValidationErrors;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
@@ -16,7 +17,17 @@ public class RenameColumnGenerator extends AbstractSqlGenerator<RenameColumnStat
 
     @Override
     public boolean supports(RenameColumnStatement statement, Database database) {
-        return !(database instanceof SQLiteDatabase);
+        if(database instanceof  SQLiteDatabase) {
+            try {
+                if(database.getDatabaseMajorVersion() <= 3 && database.getDatabaseMinorVersion() < 25) {
+                    return false;
+                }
+            }
+            catch (DatabaseException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return true;
     }
 
     @Override

--- a/liquibase-integration-tests/src/test/resources/changelogs/sqlite/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/sqlite/complete/root.changelog.xml
@@ -352,6 +352,27 @@
         </customChange>
 
     </changeSet>
+    <changeSet id="59" author="mallod">
+        <comment>
+            Test table to be used Rename Column testing - GitHub issue 2925
+        </comment>
+        <createTable tableName="test_person">
+            <column name="id" type="int" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="firstname" type="varchar(50)"/>
+            <column name="lastname" type="varchar(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="city" type="varchar(30)"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="60" author="mallod">
+        <comment>
+            Test to make sure Rename Column testing fix for GitHub issue 2925 works as expected
+        </comment>
+        <renameColumn tableName="test_person" oldColumnName="city" newColumnName="cityName" />
+    </changeSet>
 
     <!--<changeSet id="60" author="nvoxland">-->
         <!--<executeCommand executable="getmac" os="Windows XP">-->


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Updated `supports()` method logic from `RenameColumnGenerator` class to return `true` for SQLite database from version 3.25 or higher, or any other supported database.

Fixes #2925 


## Things to be aware of

- Change method logic to consider SQLite DB version.
- This change only has impact on SQLite, for any other database it will keep behaving as of now.

## Things to worry about

- This method might need to be revisited once again in a future if for a newer version this change is not again supported. 

## Additional Context

- Nothing.
