### PR TITLE
Fix double with precision type error for H2 

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/DoubleType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/DoubleType.java
@@ -39,7 +39,8 @@ public class DoubleType  extends LiquibaseDataType {
         if ((database instanceof AbstractDb2Database) || (database instanceof DerbyDatabase) || (database instanceof HsqlDatabase)) {
             return new DatabaseDataType("DOUBLE");
         }
-        if (database instanceof H2Database && getRawDefinition().toLowerCase().contains("precision")) {
+        String rawDefinitionDataType = getRawDefinition().toLowerCase();
+        if (database instanceof H2Database && (rawDefinitionDataType.contains("precision")) || rawDefinitionDataType.matches("double\\([1-9]?[0-9]\\)")) {
             return new DatabaseDataType("DOUBLE PRECISION");
         }
 

--- a/liquibase-core/src/main/java/liquibase/datatype/core/DoubleType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/DoubleType.java
@@ -39,8 +39,7 @@ public class DoubleType  extends LiquibaseDataType {
         if ((database instanceof AbstractDb2Database) || (database instanceof DerbyDatabase) || (database instanceof HsqlDatabase)) {
             return new DatabaseDataType("DOUBLE");
         }
-        String rawDefinitionDataType = getRawDefinition().toLowerCase();
-        if (database instanceof H2Database && (rawDefinitionDataType.contains("precision")) || rawDefinitionDataType.matches("double\\([1-9]?[0-9]\\)")) {
+        if (database instanceof H2Database) {
             return new DatabaseDataType("DOUBLE PRECISION");
         }
 

--- a/liquibase-core/src/test/groovy/liquibase/datatype/core/DoubleTypeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/core/DoubleTypeTest.groovy
@@ -29,6 +29,7 @@ class DoubleTypeTest extends Specification {
         "double"                         | new HsqlDatabase()     | "DOUBLE"
         "double"                         | new H2Database()       | "DOUBLE"
         "double precision"               | new H2Database()       | "DOUBLE PRECISION"
+        "double(20)"                     | new H2Database()       | "DOUBLE PRECISION"
         "double"                         | new MSSQLDatabase()    | "float(53)"
         "double"                         | new PostgresDatabase() | "DOUBLE PRECISION"
         "double"                         | new InformixDatabase() | "DOUBLE PRECISION"

--- a/liquibase-core/src/test/groovy/liquibase/datatype/core/DoubleTypeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/core/DoubleTypeTest.groovy
@@ -27,7 +27,7 @@ class DoubleTypeTest extends Specification {
         "double"                         | new DB2Database()      | "DOUBLE"
         "double"                         | new DerbyDatabase()    | "DOUBLE"
         "double"                         | new HsqlDatabase()     | "DOUBLE"
-        "double"                         | new H2Database()       | "DOUBLE"
+        "double"                         | new H2Database()       | "DOUBLE PRECISION"
         "double precision"               | new H2Database()       | "DOUBLE PRECISION"
         "double(20)"                     | new H2Database()       | "DOUBLE PRECISION"
         "double"                         | new MSSQLDatabase()    | "float(53)"


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Fix double type column parsing when double type is specified with precision (i.e. double(25)). 

Fixes #3099 

## Things to be aware of

- Added logic to parse double(xy) as a "Double Precision" for H2 database.
- Only impact on H2 database.

## Things to worry about

- Nothing.

## Additional Context

- Nothing.
