### PR TITLE
Improve int/tinyint/smallint/bigint handling in H2

### DIFF
--- a/liquibase-core/src/main/java/liquibase/datatype/core/BigIntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/BigIntType.java
@@ -73,6 +73,9 @@ public class BigIntType extends LiquibaseDataType {
         if (database instanceof SybaseASADatabase) {
             return new DatabaseDataType("BIGINT");
         }
+        if (database instanceof H2Database) {
+            return new DatabaseDataType("BIGINT");
+        }
         return super.toDatabaseDataType(database);
     }
 

--- a/liquibase-core/src/main/java/liquibase/datatype/core/IntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/IntType.java
@@ -77,7 +77,9 @@ public class IntType extends LiquibaseDataType {
             int intParameter = Integer.valueOf(getParameters()[0].toString());
             if(intParameter >= 1 && intParameter <= 3) {
                 return new DatabaseDataType("TINYINT");
-            } else if (intParameter > 3 && intParameter <= 10) {
+            } else if (intParameter > 3 && intParameter <= 5) {
+                return new DatabaseDataType("SMALLINT");
+            } else if (intParameter > 5 && intParameter <= 10) {
                 return new DatabaseDataType("INTEGER");
             } else if (intParameter > 10) {
                 return new DatabaseDataType("BIGINT");

--- a/liquibase-core/src/main/java/liquibase/datatype/core/IntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/IntType.java
@@ -72,6 +72,17 @@ public class IntType extends LiquibaseDataType {
         if (database instanceof SybaseASADatabase) {
             return new DatabaseDataType("INTEGER");
         }
+        String rawDefinitionDataType = getRawDefinition().toLowerCase();
+        if (database instanceof H2Database && rawDefinitionDataType.matches("int\\([1-9]?[0-9]\\)")) {
+            int intParameter = Integer.valueOf(getParameters()[0].toString());
+            if(intParameter >= 1 && intParameter <= 3) {
+                return new DatabaseDataType("TINYINT");
+            } else if (intParameter > 3 && intParameter <= 10) {
+                return new DatabaseDataType("INTEGER");
+            } else if (intParameter > 10) {
+                return new DatabaseDataType("BIGINT");
+            }
+        }
         return super.toDatabaseDataType(database);
     }
 

--- a/liquibase-core/src/main/java/liquibase/datatype/core/SmallIntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/SmallIntType.java
@@ -62,6 +62,10 @@ public class SmallIntType extends LiquibaseDataType {
             return new DatabaseDataType("SMALLINT"); //always smallint regardless of parameters passed
         }
 
+        if (database instanceof H2Database) {
+            return new DatabaseDataType("SMALLINT");
+        }
+
         return super.toDatabaseDataType(database);
     }
 

--- a/liquibase-core/src/main/java/liquibase/datatype/core/TinyIntType.java
+++ b/liquibase-core/src/main/java/liquibase/datatype/core/TinyIntType.java
@@ -42,6 +42,9 @@ public class TinyIntType  extends LiquibaseDataType {
         if (database instanceof OracleDatabase) {
             return new DatabaseDataType("NUMBER",3);
         }
+        if (database instanceof H2Database) {
+            return new DatabaseDataType("TINYINT");
+        }
         return super.toDatabaseDataType(database);
     }
 

--- a/liquibase-core/src/test/groovy/liquibase/datatype/core/BigIntTypeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/core/BigIntTypeTest.groovy
@@ -1,0 +1,36 @@
+package liquibase.datatype.core;
+
+import liquibase.database.core.*;
+import liquibase.datatype.DataTypeFactory;
+import spock.lang.Specification;
+import spock.lang.Unroll;
+
+class BigIntTypeTest extends Specification {
+
+    @Unroll
+    def "toDatabaseType '#input' on #database.shortName"() {
+
+        when:
+        def type = DataTypeFactory.getInstance().fromDescription(input, database)
+
+        then:
+        type instanceof BigIntType
+        type.toDatabaseDataType(database).toString() == expected
+
+        where:
+        input         | database                   | expected
+        "bigint"      | new H2Database()           | "BIGINT"
+        "bigint(20)"  | new H2Database()           | "BIGINT"
+        "bigint"      | new MSSQLDatabase()        | "bigint"
+        "bigint"      | new PostgresDatabase()     | "BIGINT"
+        "bigint"      | new InformixDatabase()     | "INT8"
+        "bigint"      | new MySQLDatabase()        | "BIGINT"
+        "bigint"      | new DerbyDatabase()        | "BIGINT"
+        "bigint"      | new HsqlDatabase()         | "BIGINT"
+        "bigint"      | new FirebirdDatabase()     | "BIGINT"
+        "bigint"      | new SybaseASADatabase()    | "BIGINT"
+
+        //These are the some of the parsing combinations being tested for BigIntType for some of the supported DBs.
+        // Some of these scenarios are being also tested in DataTypeFactoryTest class.
+    }
+}

--- a/liquibase-core/src/test/groovy/liquibase/datatype/core/IntTypeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/core/IntTypeTest.groovy
@@ -1,0 +1,51 @@
+package liquibase.datatype.core
+
+import liquibase.database.core.DerbyDatabase
+import liquibase.database.core.FirebirdDatabase
+import liquibase.database.core.H2Database
+import liquibase.database.core.HsqlDatabase
+import liquibase.database.core.InformixDatabase
+import liquibase.database.core.MSSQLDatabase
+import liquibase.database.core.MySQLDatabase
+import liquibase.database.core.OracleDatabase
+import liquibase.database.core.PostgresDatabase
+import liquibase.database.core.SQLiteDatabase
+import liquibase.database.core.SybaseDatabase
+import liquibase.datatype.DataTypeFactory
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class IntTypeTest extends Specification{
+    @Unroll
+    def "toDatabaseType '#input' on #database.shortName"() {
+
+        when:
+        def type = DataTypeFactory.getInstance().fromDescription(input, database)
+
+        then:
+        type instanceof IntType
+        type.toDatabaseDataType(database).toString() == expected
+
+        where:
+        input           | database               | expected
+        "int"           | new H2Database()       | "INT"
+        "int(2)"        | new H2Database()       | "TINYINT"
+        "int(4)"        | new H2Database()       | "SMALLINT"
+        "int(7)"        | new H2Database()       | "INTEGER"
+        "int(20)"       | new H2Database()       | "BIGINT"
+        "int(20)"       | new H2Database()       | "BIGINT"
+        "int"           | new MSSQLDatabase()    | "int"
+        "int"           | new PostgresDatabase() | "INTEGER"
+        "int"           | new OracleDatabase()   | "INTEGER"
+        "int"           | new DerbyDatabase()    | "INTEGER"
+        "int"           | new MySQLDatabase()    | "INT"
+        "int"           | new FirebirdDatabase() | "INT"
+        "int"           | new HsqlDatabase()     | "INT"
+        "int"           | new InformixDatabase() | "INT"
+        "int"           | new SybaseDatabase()   | "INT"
+        "int"           | new SQLiteDatabase()   | "INTEGER"
+
+        //These are the some of the parsing combinations being tested for IntType for some of the supported DBs.
+        // Some of these scenarios are being also tested in DataTypeFactoryTest class.
+    }
+}

--- a/liquibase-core/src/test/groovy/liquibase/datatype/core/SmallIntTypeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/core/SmallIntTypeTest.groovy
@@ -1,0 +1,43 @@
+package liquibase.datatype.core
+
+import liquibase.database.core.AbstractDb2Database
+import liquibase.database.core.DerbyDatabase
+import liquibase.database.core.FirebirdDatabase
+import liquibase.database.core.H2Database
+import liquibase.database.core.InformixDatabase
+import liquibase.database.core.MSSQLDatabase
+import liquibase.database.core.MySQLDatabase
+import liquibase.database.core.OracleDatabase
+import liquibase.database.core.PostgresDatabase
+import liquibase.datatype.DataTypeFactory
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class SmallIntTypeTest extends Specification{
+
+        @Unroll
+        def "toDatabaseType '#input' on #database.shortName"() {
+
+            when:
+            def type = DataTypeFactory.getInstance().fromDescription(input, database)
+
+            then:
+            type instanceof SmallIntType
+            type.toDatabaseDataType(database).toString() == expected
+
+            where:
+            input           | database               | expected
+            "smallint"      | new H2Database()       | "SMALLINT"
+            "smallint(20)"  | new H2Database()       | "SMALLINT"
+            "smallint"      | new MSSQLDatabase()    | "smallint"
+            "smallint"      | new PostgresDatabase() | "SMALLINT"
+            "smallint"      | new OracleDatabase()   | "NUMBER(5)"
+            "smallint"      | new DerbyDatabase()    | "SMALLINT"
+            "smallint"      | new MySQLDatabase()    | "SMALLINT"
+            "smallint"      | new FirebirdDatabase() | "SMALLINT"
+            "smallint"      | new InformixDatabase() | "SMALLINT"
+
+            //These are the some of the parsing combinations being tested for SmallIntType for some of the supported DBs.
+            // Some of these scenarios are being also tested in DataTypeFactoryTest class.
+        }
+}

--- a/liquibase-core/src/test/groovy/liquibase/datatype/core/TinyIntTypeTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/datatype/core/TinyIntTypeTest.groovy
@@ -1,0 +1,41 @@
+package liquibase.datatype.core
+
+import liquibase.database.core.DerbyDatabase
+import liquibase.database.core.FirebirdDatabase
+import liquibase.database.core.H2Database
+import liquibase.database.core.InformixDatabase
+import liquibase.database.core.MSSQLDatabase
+import liquibase.database.core.MySQLDatabase
+import liquibase.database.core.OracleDatabase
+import liquibase.database.core.PostgresDatabase
+import liquibase.datatype.DataTypeFactory
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class TinyIntTypeTest extends Specification{
+    @Unroll
+    def "toDatabaseType '#input' on #database.shortName"() {
+
+        when:
+        def type = DataTypeFactory.getInstance().fromDescription(input, database)
+
+        then:
+        type instanceof TinyIntType
+        type.toDatabaseDataType(database).toString() == expected
+
+        where:
+        input           | database               | expected
+        "tinyint"      | new H2Database()       | "TINYINT"
+        "tinyint(20)"  | new H2Database()       | "TINYINT"
+        "tinyint"      | new MSSQLDatabase()    | "tinyint"
+        "tinyint"      | new PostgresDatabase() | "SMALLINT"
+        "tinyint"      | new OracleDatabase()   | "NUMBER(3)"
+        "tinyint"      | new DerbyDatabase()    | "SMALLINT"
+        "tinyint"      | new MySQLDatabase()    | "TINYINT"
+        "tinyint"      | new FirebirdDatabase() | "SMALLINT"
+        "tinyint"      | new InformixDatabase() | "TINYINT"
+
+        //These are the some of the parsing combinations being tested for TinyIntType for some of the supported DBs.
+        // Some of these scenarios are being also tested in DataTypeFactoryTest class.
+    }
+}

--- a/liquibase-integration-tests/src/test/resources/changelogs/h2/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/h2/complete/root.changelog.xml
@@ -374,5 +374,23 @@
             <column name="after_name" type="int" afterColumn="name"/>
         </addColumn>
     </changeSet>
+    <changeSet id="Test_DataType_Table" author="nvoxland">
+        <createTable tableName="Test_DataType">
+            <column name="id" type="int"/>
+            <column name="typeColumn" type="int"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="TestIntType" author="mallod">
+        <modifyDataType tableName="Test_DataType" columnName="typeColumn" newDataType="int(20)"/>
+    </changeSet>
+    <changeSet id="TestBigIntType" author="mallod">
+        <modifyDataType tableName="Test_DataType" columnName="typeColumn" newDataType="bigint(20)"/>
+    </changeSet>
+    <changeSet id="TestSmallIntType" author="mallod">
+        <modifyDataType tableName="Test_DataType" columnName="typeColumn" newDataType="smallint(20)"/>
+    </changeSet>
+    <changeSet id="TestTinyIntType" author="mallod">
+        <modifyDataType tableName="Test_DataType" columnName="typeColumn" newDataType="tinyint(20)"/>
+    </changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Implement support to consider integer precision by parsing to the specific integer type (tiny, integer or bigint) depending on the specified size.

Fixes #3250 
Fixes #3300 

## Things to be aware of

- This change only impacts integer data type for H2.

## Things to worry about

- Nothing.

## Additional Context

- Nothing.
