### PR TITLE
DAT-11617: only check resource accessor if path is not absolute

### DIFF
--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/DiffToChangeLog.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/DiffToChangeLog.java
@@ -93,7 +93,7 @@ public class DiffToChangeLog {
     public void print(String changeLogFile, ChangeLogSerializer changeLogSerializer) throws ParserConfigurationException, IOException, DatabaseException {
         this.changeSetPath = changeLogFile;
         final PathHandlerFactory pathHandlerFactory = Scope.getCurrentScope().getSingleton(PathHandlerFactory.class);
-        Resource file = pathHandlerFactory.getResource(changeLogFile, true);
+        Resource file = pathHandlerFactory.getResource(changeLogFile, !pathHandlerFactory.isAbsolute(changeLogFile));
 
         final Map<String, Object> newScopeObjects = new HashMap<>();
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

When running generate changelog or diff changelog, only search the resource accessor if the output file argument is not an absolute path.

## Things to be aware of



## Things to worry about



## Additional Context

