### PR TITLE
DAT-11591: use complete path of resource when generating load data statements

### DIFF
--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingDataExternalFileChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingDataExternalFileChangeGenerator.java
@@ -139,7 +139,7 @@ public class MissingDataExternalFileChangeGenerator extends MissingDataChangeGen
                 }
 
                 LoadDataChange change = new LoadDataChange();
-                change.setFile(fileName);
+                change.setFile(externalFileResource.getPath());
                 change.setEncoding(GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue());
                 if (outputControl.getIncludeCatalog()) {
                     change.setCatalogName(table.getSchema().getCatalogName());


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Use the complete path of the newly created resources which represent the data to be loaded.

## Things to be aware of



## Things to worry about

This could break some other integration I didn't think of.

## Additional Context


