### PR TITLE
DAT-11505: use proper file not found message for execute-sql

### DIFF
--- a/liquibase-core/src/main/java/liquibase/command/core/InternalExecuteSqlCommandStep.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/InternalExecuteSqlCommandStep.java
@@ -9,6 +9,7 @@ import liquibase.executor.ExecutorService;
 import liquibase.resource.PathHandlerFactory;
 import liquibase.resource.Resource;
 import liquibase.statement.core.RawSqlStatement;
+import liquibase.util.FileUtil;
 import liquibase.util.StreamUtil;
 import liquibase.util.StringUtil;
 
@@ -61,7 +62,7 @@ public class InternalExecuteSqlCommandStep extends AbstractCommandStep {
             final PathHandlerFactory pathHandlerFactory = Scope.getCurrentScope().getSingleton(PathHandlerFactory.class);
             Resource resource = pathHandlerFactory.getResource(sqlFile, true);
             if (!resource.exists()){
-              throw new LiquibaseException(String.format("The file '%s' does not exist", sqlFile));
+                throw new LiquibaseException(FileUtil.getFileNotFoundMessage(sqlFile));
             }
             sqlText = StreamUtil.readStreamAsString(resource.openInputStream());
         }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Use the proper message for files not found when running execute-sql command.

## Things to be aware of


## Things to worry about

## Additional Context
