### PR TITLE
Fixed input string handling in CompareControl constructor

### DIFF
--- a/liquibase-core/src/main/java/liquibase/diff/compare/CompareControl.java
+++ b/liquibase-core/src/main/java/liquibase/diff/compare/CompareControl.java
@@ -48,15 +48,15 @@ public class CompareControl {
             String referenceCatalogName = null;
             String referenceSchemaName = splitReferenceSchemas[i];
             if (referenceSchemaName.contains(".")) {
-                referenceCatalogName = referenceSchemaName.split(".", 2)[0];
-                referenceSchemaName = referenceSchemaName.split(".", 2)[1];
+                referenceCatalogName = referenceSchemaName.split("\\.", 2)[0];
+                referenceSchemaName = referenceSchemaName.split("\\.", 2)[1];
             }
 
             String comparisonCatalogName = null;
             String comparisonSchemaName = splitComparisonSchemas[i];
             if (comparisonSchemaName.contains(".")) {
-                comparisonCatalogName = comparisonSchemaName.split(".", 2)[0];
-                comparisonSchemaName = comparisonSchemaName.split(".", 2)[1];
+                comparisonCatalogName = comparisonSchemaName.split("\\.", 2)[0];
+                comparisonSchemaName = comparisonSchemaName.split("\\.", 2)[1];
             }
 
             CatalogAndSchema referenceSchema = new CatalogAndSchema(referenceCatalogName, referenceSchemaName);

--- a/liquibase-core/src/test/groovy/liquibase/diff/compare/CompareControlTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/diff/compare/CompareControlTest.groovy
@@ -1,0 +1,20 @@
+package liquibase.diff.compare
+
+
+import spock.lang.Specification
+
+class CompareControlTest extends Specification {
+
+    def "CompareControl correctly splits schemas"() {
+        given:
+        String[] schemas = ["aaa.bbb", "ccc.ddd"]
+        def result = new CompareControl(schemas, null)
+
+        expect:
+        result.getSchemaComparisons()[0].getReferenceSchema().getCatalogName() == "aaa"
+        result.getSchemaComparisons()[0].getReferenceSchema().getSchemaName() == "bbb"
+        result.getSchemaComparisons()[0].getComparisonSchema().getCatalogName() == "ccc"
+        result.getSchemaComparisons()[0].getComparisonSchema().getSchemaName() == "ddd"
+
+    }
+}


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Incorrect regex expression "." in call to 'split()'  at CompareControl constructor was causing the strings to being wrongly slit.

As this code is not used within liquibase-core, an unit test was created.
Fixes #3204 

## Things to be aware of

- Code fixed

## Things to worry about

- None

## Additional Context

- None
