### PR TITLE
Fix "No inverse to CreateProcedureChange" error when using rollbackOneChangeSetSQL (DAT-6361)

### DIFF
--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseRollbackOneChangeSetSQL.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseRollbackOneChangeSetSQL.java
@@ -166,6 +166,7 @@ public class LiquibaseRollbackOneChangeSetSQL extends AbstractLiquibaseChangeLog
         argsMap.put("changeSetId", this.changeSetId);
         argsMap.put("changeSetAuthor", this.changeSetAuthor);
         argsMap.put("changeSetPath", this.changeSetPath);
+        argsMap.put("rollbackScript", this.rollbackScript);
         return argsMap;
     }
 }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description
Adds rollback script to args map when using rollbackOneChangeSet via maven to ensure the inverse changeset is found if it is provided. 

## Things to be aware of
N/A

## Things to worry about
N/A

## Additional Context
