### PR TITLE
Fix getResourceAccessor logic to avoid setting changeLogDirectory when searchPath has already set

### DIFF
--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseChangeLogMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseChangeLogMojo.java
@@ -30,7 +30,7 @@ import java.util.Locale;
 public abstract class AbstractLiquibaseChangeLogMojo extends AbstractLiquibaseMojo {
 
     /**
-   * Specifies the directory where Liquibase can find your <i>changelog</i> file.
+   * Specifies the directory where Liquibase can find your <i>changelog</i> file. This is an aliases for searchPath
      *
    * @parameter property="liquibase.changeLogDirectory"
      */
@@ -159,18 +159,23 @@ public abstract class AbstractLiquibaseChangeLogMojo extends AbstractLiquibaseMo
     }
 
     @Override
-    protected ResourceAccessor getResourceAccessor(ClassLoader cl) throws IOException {
+    protected ResourceAccessor getResourceAccessor(ClassLoader cl) throws IOException, MojoFailureException {
         List<ResourceAccessor> resourceAccessors = new ArrayList<ResourceAccessor>();
         resourceAccessors.add(new MavenResourceAccessor(cl));
         resourceAccessors.add(new DirectoryResourceAccessor(project.getBasedir()));
         resourceAccessors.add(new ClassLoaderResourceAccessor(getClass().getClassLoader()));
 
+        String finalSearchPath = searchPath;
+
         if (changeLogDirectory != null) {
+            if (searchPath != null) {
+                throw new MojoFailureException("Cannot specify searchPath and changeLogDirectory");
+            }
             calculateChangeLogDirectoryAbsolutePath();
-            resourceAccessors.add(new DirectoryResourceAccessor(new File(changeLogDirectory)));
+            finalSearchPath = changeLogDirectory;
         }
 
-        return new SearchPathResourceAccessor(searchPath, resourceAccessors.toArray(new ResourceAccessor[0]));
+        return new SearchPathResourceAccessor(finalSearchPath, resourceAccessors.toArray(new ResourceAccessor[0]));
     }
 
     @Override

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseChangeLogMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseChangeLogMojo.java
@@ -169,7 +169,7 @@ public abstract class AbstractLiquibaseChangeLogMojo extends AbstractLiquibaseMo
 
         if (changeLogDirectory != null) {
             if (searchPath != null) {
-                throw new MojoFailureException("Cannot specify searchPath and changeLogDirectory");
+                throw new MojoFailureException("Cannot specify searchPath and changeLogDirectory at the same time");
             }
             calculateChangeLogDirectoryAbsolutePath();
             finalSearchPath = changeLogDirectory;

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
@@ -923,7 +923,7 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
     }
 
     @SuppressWarnings("java:S2095")
-    protected ResourceAccessor getResourceAccessor(ClassLoader cl) throws IOException {
+    protected ResourceAccessor getResourceAccessor(ClassLoader cl) throws IOException, MojoFailureException {
         ResourceAccessor mFO = new MavenResourceAccessor(cl);
         ResourceAccessor fsFO = new DirectoryResourceAccessor(project.getBasedir());
         return new SearchPathResourceAccessor(searchPath, mFO, fsFO);

--- a/liquibase-maven-plugin/src/test/java/org/liquibase/maven/plugins/AbstractLiquibaseChangeLogMojoTest.java
+++ b/liquibase-maven-plugin/src/test/java/org/liquibase/maven/plugins/AbstractLiquibaseChangeLogMojoTest.java
@@ -1,0 +1,59 @@
+package org.liquibase.maven.plugins;
+
+import liquibase.resource.ResourceAccessor;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+public class AbstractLiquibaseChangeLogMojoTest {
+
+
+    @Test
+    public void validateGetResourceAccessorDoesNotGeneratedTwoFileAccessorsWhenChangeLogDirectoryIsSet() throws MojoFailureException, IOException {
+        //GIVEN
+        AbstractLiquibaseChangeLogMojo mojo = new LiquibaseChangeLogMojoTest();
+        mojo.project = mock(MavenProject.class);
+        when(mojo.project.getBasedir()).thenReturn(new File(System.getProperty("user.dir")));
+        mojo.changeLogDirectory = System.getProperty("user.dir");
+        mojo.searchPath = null;
+        //WHEN
+        ResourceAccessor changeLogAccessor = mojo.getResourceAccessor(mock(ClassLoader.class));
+        //THEN
+        List<String> locations = changeLogAccessor.describeLocations();
+        Assert.assertTrue(locations.size() == 1);
+        Assert.assertEquals(mojo.changeLogDirectory, locations.get(0));
+    }
+
+    @Test
+    public void validateGetResourceAccessorDoesNotGenerateFileAccessorsWhenChangeLogDirectoryAndSearchPathAreSet() throws IOException {
+
+        try {
+            //GIVEN
+            AbstractLiquibaseChangeLogMojo mojo = new LiquibaseChangeLogMojoTest();
+            mojo.project = mock(MavenProject.class);
+            when(mojo.project.getBasedir()).thenReturn(new File(System.getProperty("user.dir")));
+            mojo.changeLogDirectory = System.getProperty("user.dir");
+            mojo.searchPath = System.getProperty("user.dir");
+            //WHEN
+            mojo.getResourceAccessor(mock(ClassLoader.class));
+            //THEN
+            Assert.fail("exception thrown");
+        } catch (MojoFailureException  e) {
+            Assert.assertEquals("Cannot specify searchPath and changeLogDirectory at the same time", e.getMessage());
+        }
+    }
+
+    private static class LiquibaseChangeLogMojoTest extends AbstractLiquibaseChangeLogMojo {
+        // For testing purposes have chose the strategy of creating an empty class as we are trying to test an abstract class
+        // which otherwise we cannot instantiate
+    }
+
+
+}

--- a/liquibase-maven-plugin/src/test/java/org/liquibase/maven/plugins/AbstractLiquibaseChangeLogMojoTest.java
+++ b/liquibase-maven-plugin/src/test/java/org/liquibase/maven/plugins/AbstractLiquibaseChangeLogMojoTest.java
@@ -1,5 +1,6 @@
 package org.liquibase.maven.plugins;
 
+import liquibase.resource.PathResource;
 import liquibase.resource.ResourceAccessor;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
@@ -8,6 +9,8 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 
 import static org.mockito.Mockito.*;
@@ -20,7 +23,7 @@ public class AbstractLiquibaseChangeLogMojoTest {
         //GIVEN
         AbstractLiquibaseChangeLogMojo mojo = new LiquibaseChangeLogMojoTest();
         mojo.project = mock(MavenProject.class);
-        String userDir = System.getProperty("user.dir");
+        String userDir = Paths.get(System.getProperty("user.dir")).toString();
         when(mojo.project.getBasedir()).thenReturn(new File(userDir));
         mojo.changeLogDirectory = userDir;
         mojo.searchPath = null;
@@ -29,7 +32,7 @@ public class AbstractLiquibaseChangeLogMojoTest {
         //THEN
         List<String> locations = changeLogAccessor.describeLocations();
         Assert.assertTrue(locations.size() == 1);
-        Assert.assertEquals(mojo.changeLogDirectory, locations.get(0));
+        Assert.assertEquals(mojo.changeLogDirectory, Paths.get(locations.get(0)).toString());
     }
 
     @Test
@@ -39,7 +42,7 @@ public class AbstractLiquibaseChangeLogMojoTest {
             //GIVEN
             AbstractLiquibaseChangeLogMojo mojo = new LiquibaseChangeLogMojoTest();
             mojo.project = mock(MavenProject.class);
-            String userDir = System.getProperty("user.dir");
+            String userDir = Paths.get(System.getProperty("user.dir")).toString();
             when(mojo.project.getBasedir()).thenReturn(new File(userDir));
             mojo.changeLogDirectory = userDir;
             mojo.searchPath = userDir;

--- a/liquibase-maven-plugin/src/test/java/org/liquibase/maven/plugins/AbstractLiquibaseChangeLogMojoTest.java
+++ b/liquibase-maven-plugin/src/test/java/org/liquibase/maven/plugins/AbstractLiquibaseChangeLogMojoTest.java
@@ -20,8 +20,9 @@ public class AbstractLiquibaseChangeLogMojoTest {
         //GIVEN
         AbstractLiquibaseChangeLogMojo mojo = new LiquibaseChangeLogMojoTest();
         mojo.project = mock(MavenProject.class);
-        when(mojo.project.getBasedir()).thenReturn(new File(System.getProperty("user.dir")));
-        mojo.changeLogDirectory = System.getProperty("user.dir");
+        String userDir = System.getProperty("user.dir");
+        when(mojo.project.getBasedir()).thenReturn(new File(userDir));
+        mojo.changeLogDirectory = userDir;
         mojo.searchPath = null;
         //WHEN
         ResourceAccessor changeLogAccessor = mojo.getResourceAccessor(mock(ClassLoader.class));
@@ -38,9 +39,10 @@ public class AbstractLiquibaseChangeLogMojoTest {
             //GIVEN
             AbstractLiquibaseChangeLogMojo mojo = new LiquibaseChangeLogMojoTest();
             mojo.project = mock(MavenProject.class);
-            when(mojo.project.getBasedir()).thenReturn(new File(System.getProperty("user.dir")));
-            mojo.changeLogDirectory = System.getProperty("user.dir");
-            mojo.searchPath = System.getProperty("user.dir");
+            String userDir = System.getProperty("user.dir");
+            when(mojo.project.getBasedir()).thenReturn(new File(userDir));
+            mojo.changeLogDirectory = userDir;
+            mojo.searchPath = userDir;
             //WHEN
             mojo.getResourceAccessor(mock(ClassLoader.class));
             //THEN

--- a/liquibase-maven-plugin/src/test/java/org/liquibase/maven/plugins/AbstractLiquibaseChangeLogMojoTest.java
+++ b/liquibase-maven-plugin/src/test/java/org/liquibase/maven/plugins/AbstractLiquibaseChangeLogMojoTest.java
@@ -31,8 +31,9 @@ public class AbstractLiquibaseChangeLogMojoTest {
         ResourceAccessor changeLogAccessor = mojo.getResourceAccessor(mock(ClassLoader.class));
         //THEN
         List<String> locations = changeLogAccessor.describeLocations();
+        String dirLocation = locations.get(0).replace("git ", "/");
         Assert.assertTrue(locations.size() == 1);
-        Assert.assertEquals(mojo.changeLogDirectory, Paths.get(locations.get(0)).toString());
+        Assert.assertEquals(mojo.changeLogDirectory, dirLocation);
     }
 
     @Test

--- a/liquibase-maven-plugin/src/test/java/org/liquibase/maven/plugins/AbstractLiquibaseChangeLogMojoTest.java
+++ b/liquibase-maven-plugin/src/test/java/org/liquibase/maven/plugins/AbstractLiquibaseChangeLogMojoTest.java
@@ -31,7 +31,7 @@ public class AbstractLiquibaseChangeLogMojoTest {
         ResourceAccessor changeLogAccessor = mojo.getResourceAccessor(mock(ClassLoader.class));
         //THEN
         List<String> locations = changeLogAccessor.describeLocations();
-        String dirLocation = locations.get(0).replace("git ", "/");
+        String dirLocation = locations.get(0).replace("\\", "/");
         Assert.assertTrue(locations.size() == 1);
         Assert.assertEquals(mojo.changeLogDirectory, dirLocation);
     }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Fixes #3282 

## Things to be aware of

- Maven was conflicting to find changelog file in two different paths, so this fix avoid setting a new location if there is one already defined.
- Only impacts Maven.

## Things to worry about

- Nothing

## Additional Context

- Nothing
