### PR TITLE
#1259: Logging start of change set file

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -1265,7 +1265,8 @@ public abstract class AbstractJdbcDatabase implements Database {
             if (statement.skipOnUnsupported() && !SqlGeneratorFactory.getInstance().supports(statement, this)) {
                 continue;
             }
-            Scope.getCurrentScope().getLog(getClass()).info("Executing Statement: " + statement);
+            Scope.getCurrentScope().getLog(getClass()).info("Executing Statement: " + statement.getClass());
+            Scope.getCurrentScope().getLog(getClass()).fine(statement.toString());
             try {
                 Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", this).execute(statement, sqlVisitors);
             } catch (DatabaseException e) {

--- a/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -1265,7 +1265,7 @@ public abstract class AbstractJdbcDatabase implements Database {
             if (statement.skipOnUnsupported() && !SqlGeneratorFactory.getInstance().supports(statement, this)) {
                 continue;
             }
-            Scope.getCurrentScope().getLog(getClass()).fine("Executing Statement: " + statement);
+            Scope.getCurrentScope().getLog(getClass()).info("Executing Statement: " + statement);
             try {
                 Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", this).execute(statement, sqlVisitors);
             } catch (DatabaseException e) {


### PR DESCRIPTION
Changed log message from fine to info for the following text: "[INFO] Executing Statement: insert into person (name) values ('John')". Then it will show the start date of executing statement for custom sql.

Tags: hacktoberfest, firstPR

Examples:

Running Changeset: example-changelog.xml::8::your.name
[INFO] Executing Statement: insert into person (name) values ('John')
[INFO] Custom SQL executed
[INFO] ChangeSet example-changelog.xml::8::your.name ran successfully in 17ms
....
Running Changeset: example-changelog.xml::9::your.name
[INFO] Executing Statement: liquibase.statement.core.AddColumnStatement@52a7928a
[INFO] Columns middleName(varchar(20)) added to person
[INFO] ChangeSet example-changelog.xml::9::your.name ran successfully in 17ms