### PR TITLE
Fixed URIResource.resolveSibling

### DIFF
--- a/liquibase-core/src/main/java/liquibase/resource/URIResource.java
+++ b/liquibase-core/src/main/java/liquibase/resource/URIResource.java
@@ -25,7 +25,7 @@ public class URIResource extends AbstractResource {
 
     @Override
     public Resource resolveSibling(String other) {
-        return new URIResource(resolveSiblingPath(other), URI.create(getUri().toString().replaceFirst("/.*?$", "") + "/" + other));
+        return new URIResource(resolveSiblingPath(other), URI.create(getUri().toString().replaceFirst("/[^/]*$", "") + "/" + other));
     }
 
     @Override

--- a/liquibase-core/src/test/groovy/liquibase/resource/URIResourceAccessorTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/resource/URIResourceAccessorTest.groovy
@@ -1,10 +1,23 @@
 package liquibase.resource
 
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class URIResourceAccessorTest extends Specification {
 
-//    "file:/c:/"                        | "file:/c:/"
-//    "http://example.local/nowhere.txt" | "http://example.local/nowhere.txt"
+    @Unroll
+    def resolveSibling() {
+        when:
+        def newResource = new URIResource(path, URI.create(uri)).resolveSibling(input)
 
+        then:
+        newResource.uri.toString() == expectedUri
+        newResource.path == expectedPath
+
+        where:
+        path                                             | uri                                                                                                           | input       | expectedUri                                                                                               | expectedPath
+        "my/file.xml"                                    | "file:/local/my/file.xml"                                                                                     | "other.csv" | "file:/local/my/other.csv"                                                                                | "my/other.csv"
+        "liquibase/harness/data/changelogs/loadData.xml" | "jar:file:/C:/Users/example/liquibase-test-harness-1.0.6.jar!/liquibase/harness/data/changelogs/loadData.xml" | "load.csv"  | "jar:file:/C:/Users/example/liquibase-test-harness-1.0.6.jar!/liquibase/harness/data/changelogs/load.csv" | "liquibase/harness/data/changelogs/load.csv"
+        "my/file.xml"                                    | "http:/local/my/file.xml"                                                                                     | "other.csv" | "http:/local/my/other.csv"                                                                                | "my/other.csv"
+    }
 }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Fixes the creation of "relative" resources based on being relative to other files.

For example, using `<include path="newFile.xml" relativeToChangelogFile="true">`.

The issue is only with files looked up via URLs, such as files within a jar from the classloader. It doesn't impact all ResourceAccessor implementations

## Things to be aware of

- Regular expression we were using for "strip everything after the last /" was not always working

## Things to worry about

- Nothing
