### PR TITLE
Upgrade snakeyaml maven reference from 1.32 to 1.33

### DIFF
--- a/liquibase-dist/src/main/maven/release.pom.xml
+++ b/liquibase-dist/src/main/maven/release.pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.32</version>
+            <version>1.33</version>
             <scope>compile</scope>
         </dependency>
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

The CLI and overall project uses snakeyaml 1.33 but there is a separate pom.xml used for what we publish which still uses 1.32.

This upgrades that dependency to macch.

## Things to be aware of

- Impacts people using liquibase as a maven dependency

## Things to worry about

- Nothing
