### PR TITLE
Reduce unnecessary calls to getArgumentValue (DAT-11785)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/command/AbstractCliWrapperCommandStep.java
+++ b/liquibase-core/src/main/java/liquibase/command/AbstractCliWrapperCommandStep.java
@@ -78,11 +78,11 @@ public abstract class AbstractCliWrapperCommandStep extends AbstractCommandStep 
             if (positionalArgumentName != null && positionalArgumentName.equalsIgnoreCase(key)) {
                 return;
             }
-
-            String argValue = (commandScope.getArgumentValue(value) != null ? commandScope.getArgumentValue(value).toString() : null);
+            Object argumentValue = commandScope.getArgumentValue(value);
+            String argValue = (argumentValue != null ? argumentValue.toString() : null);
             if (argValue != null) {
                 argsList.add("--" + key);
-                argsList.add(commandScope.getArgumentValue(value).toString());
+                argsList.add(argumentValue.toString());
             }
         });
 
@@ -90,7 +90,8 @@ public abstract class AbstractCliWrapperCommandStep extends AbstractCommandStep 
 
         arguments.forEach((key, value) -> {
             if (key.equalsIgnoreCase(positionalArgumentName)) {
-                String argValue = (commandScope.getArgumentValue(value) != null ? commandScope.getArgumentValue(value).toString() : null);
+                Object argumentValue = commandScope.getArgumentValue(value);
+                String argValue = (argumentValue != null ? argumentValue.toString() : null);
                 if (argValue != null) {
                     argsList.add(argValue);
                 }
@@ -100,10 +101,11 @@ public abstract class AbstractCliWrapperCommandStep extends AbstractCommandStep 
             if (!finalLegacyCommandArguments.contains(key)) {
                 return;
             }
-            String argValue = (commandScope.getArgumentValue(value) != null ? commandScope.getArgumentValue(value).toString() : null);
+            Object argumentValue = commandScope.getArgumentValue(value);
+            String argValue = (argumentValue != null ? argumentValue.toString() : null);
             if (argValue != null) {
                 argsList.add("--" + key);
-                argsList.add(commandScope.getArgumentValue(value).toString());
+                argsList.add(argumentValue.toString());
             }
         });
         String[] args = new String[argsList.size()];

--- a/liquibase-core/src/main/java/liquibase/configuration/ConfiguredValueModifier.java
+++ b/liquibase-core/src/main/java/liquibase/configuration/ConfiguredValueModifier.java
@@ -1,5 +1,6 @@
 package liquibase.configuration;
 
+import liquibase.command.CommandArgumentDefinition;
 import liquibase.plugin.Plugin;
 
 /**
@@ -16,7 +17,7 @@ public interface ConfiguredValueModifier<DataType> extends Plugin {
     int getOrder();
 
     /**
-     * Called to potentially override the given {@link ConfiguredValue}.
+     * Called to potentially override the given {@link ConfiguredValue}. This method will be called twice, once during the validation phase of a command step from {@link CommandArgumentDefinition#validate(liquibase.command.CommandScope)}, and once during the execution phase of a command step.
      * Implementations can use any information from the passed {@link ConfiguredValue}, including calling getProvidedValue() to determine keys used, format of the value, etc.
      * If an implementation wants to modify the value, it should call {@link ConfiguredValue#override(ProvidedValue)}
      */

--- a/liquibase-core/src/main/java/liquibase/configuration/ConfiguredValueModifier.java
+++ b/liquibase-core/src/main/java/liquibase/configuration/ConfiguredValueModifier.java
@@ -1,6 +1,5 @@
 package liquibase.configuration;
 
-import liquibase.command.CommandArgumentDefinition;
 import liquibase.plugin.Plugin;
 
 /**
@@ -17,7 +16,7 @@ public interface ConfiguredValueModifier<DataType> extends Plugin {
     int getOrder();
 
     /**
-     * Called to potentially override the given {@link ConfiguredValue}. This method will be called twice, once during the validation phase of a command step from {@link CommandArgumentDefinition#validate(liquibase.command.CommandScope)}, and once during the execution phase of a command step.
+     * Called to potentially override the given {@link ConfiguredValue}.
      * Implementations can use any information from the passed {@link ConfiguredValue}, including calling getProvidedValue() to determine keys used, format of the value, etc.
      * If an implementation wants to modify the value, it should call {@link ConfiguredValue#override(ProvidedValue)}
      */


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Reduce unnecessary calls to `getArgumentValue` so that `ConfiguredValueModifier`'s aren't called more than necessary.

Resolves #3144 

## Things to be aware of

This reduces the number of calls to the `ConfiguredValueModifier` from four to two. I don't think it's reasonably possible to reduce from two to one. The two calls occur in different phases of a command running: validation and execution. It seems reasonable to me that these two calls occur.

## Things to worry about



## Additional Context


