### PR TITLE
#1466 Add ignore:true changeset attribute to Formatted SQL changeLogs

### DIFF
--- a/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -1265,7 +1265,8 @@ public abstract class AbstractJdbcDatabase implements Database {
             if (statement.skipOnUnsupported() && !SqlGeneratorFactory.getInstance().supports(statement, this)) {
                 continue;
             }
-            Scope.getCurrentScope().getLog(getClass()).info("Executing Statement: " + statement);
+            Scope.getCurrentScope().getLog(getClass()).info("Executing Statement: " + statement.getClass());
+            Scope.getCurrentScope().getLog(getClass()).fine(statement.toString());
             try {
                 Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", this).execute(statement, sqlVisitors);
             } catch (DatabaseException e) {

--- a/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-core/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -1265,7 +1265,7 @@ public abstract class AbstractJdbcDatabase implements Database {
             if (statement.skipOnUnsupported() && !SqlGeneratorFactory.getInstance().supports(statement, this)) {
                 continue;
             }
-            Scope.getCurrentScope().getLog(getClass()).fine("Executing Statement: " + statement);
+            Scope.getCurrentScope().getLog(getClass()).info("Executing Statement: " + statement);
             try {
                 Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", this).execute(statement, sqlVisitors);
             } catch (DatabaseException e) {

--- a/liquibase-core/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
@@ -121,6 +121,7 @@ public class FormattedSqlChangeLogParser implements ChangeLogParser {
             Pattern labelsPattern = Pattern.compile(".*labels:(\\S*).*", Pattern.CASE_INSENSITIVE);
             Pattern runInTransactionPattern = Pattern.compile(".*runInTransaction:(\\w+).*", Pattern.CASE_INSENSITIVE);
             Pattern dbmsPattern = Pattern.compile(".*dbms:([^,][\\w!,]+).*", Pattern.CASE_INSENSITIVE);
+            Pattern ignorePattern = Pattern.compile(".*ignore:(\\w*).*", Pattern.CASE_INSENSITIVE);
             Pattern failOnErrorPattern = Pattern.compile(".*failOnError:(\\w+).*", Pattern.CASE_INSENSITIVE);
             Pattern onFailPattern = Pattern.compile(".*onFail:(\\w+).*", Pattern.CASE_INSENSITIVE);
             Pattern onErrorPattern = Pattern.compile(".*onError:(\\w+).*", Pattern.CASE_INSENSITIVE);
@@ -278,6 +279,7 @@ public class FormattedSqlChangeLogParser implements ChangeLogParser {
                     Matcher labelsPatternMatcher = labelsPattern.matcher(line);
                     Matcher runInTransactionPatternMatcher = runInTransactionPattern.matcher(line);
                     Matcher dbmsPatternMatcher = dbmsPattern.matcher(line);
+                    Matcher ignorePatternMatcher = ignorePattern.matcher(line);
                     Matcher failOnErrorPatternMatcher = failOnErrorPattern.matcher(line);
 
                     boolean stripComments = parseBoolean(stripCommentsPatternMatcher, changeSet, true);
@@ -322,6 +324,11 @@ public class FormattedSqlChangeLogParser implements ChangeLogParser {
                         dbms = changeLogParameters.expandExpressions(dbms, changeLog);
                     }
 
+                    String ignore = parseString(ignorePatternMatcher);
+                    if (ignore != null) {
+                        ignore = changeLogParameters.expandExpressions(ignore, changeLog);
+                    }
+
                     //
                     // Make sure that this line matches the --changeset <author>:<id> with no spaces before ID
                     //
@@ -349,6 +356,7 @@ public class FormattedSqlChangeLogParser implements ChangeLogParser {
                     changeSet =
                        new ChangeSet(changeSetId, changeSetAuthor, runAlways, runOnChange, logicalFilePath, context, dbms, runWith, runInTransaction, changeLog.getObjectQuotingStrategy(), changeLog);
                     changeSet.setLabels(new Labels(labels));
+                    changeSet.setIgnore(Boolean.parseBoolean(ignore));
                     changeSet.setFailOnError(failOnError);
                     changeLog.addChangeSet(changeSet);
 

--- a/liquibase-core/src/test/groovy/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.groovy
@@ -177,6 +177,16 @@ alter table test_table add column name2 varchar(20);
 
 """.trim()
 
+    private static final String VALID_CHANGELOG_WITH_IGNORE_PROP = """
+--liquibase formatted sql
+-- changeset sk:1 ignore:true
+create table changeSetToIgnore (
+    id int primary key
+);
+--rollback drop table changeSetToIgnore;
+
+""".trim()
+
     private static final String END_DELIMITER_CHANGELOG = """
 --liquibase formatted sql
 
@@ -403,6 +413,16 @@ CREATE TABLE ALL_CAPS_TABLE_2 (
 
         changeLog.getChangeSets().get(24).getRollback().getChanges().size() == 1
         ((RawSQLChange) changeLog.getChangeSets().get(24).getRollback().getChanges().get(0)).getSql().startsWith("create table test_table (")
+    }
+
+    def parseIgnoreProperty() throws Exception {
+        expect:
+        ChangeLogParameters params = new ChangeLogParameters()
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(VALID_CHANGELOG_WITH_IGNORE_PROP).parse("asdf.sql", params, new JUnitResourceAccessor())
+
+        changeLog.getChangeSets().get(0).getAuthor() == "sk"
+        changeLog.getChangeSets().get(0).getId() == "1"
+        assert changeLog.getChangeSets().get(0).isIgnore()
     }
 
     def "parse changeset with colon in ID"() throws Exception {


### PR DESCRIPTION
Added support for ignore property to changeset for formatted sql changelog. Added corresponding test as well.
Should I add it somewhere to documentation?

Tags: hacktoberfest, newbiescommit