### PR TITLE
Ensures that Postgresql works with blob types bytea and oid (large objects)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
+++ b/liquibase-core/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
@@ -15,8 +15,10 @@ import liquibase.exception.LiquibaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.listener.SqlListener;
 import liquibase.logging.Logger;
-import liquibase.resource.InputStreamList;
 import liquibase.resource.ResourceAccessor;
+import liquibase.snapshot.SnapshotGeneratorFactory;
+import liquibase.structure.core.Column;
+import liquibase.structure.core.Table;
 import liquibase.util.FilenameUtil;
 import liquibase.util.JdbcUtil;
 import liquibase.util.StreamUtil;
@@ -56,6 +58,8 @@ public abstract class ExecutablePreparedStatementBase implements ExecutablePrepa
 
     //Cache the executeWithFlags method to avoid reflection overhead
     private static Method executeWithFlagsMethod;
+
+    private Map<String, Object> snapshotScratchPad = new HashMap<>();
 
     protected ExecutablePreparedStatementBase(Database database, String catalogName, String schemaName, String
             tableName, List<? extends ColumnConfig> columns, ChangeSet changeSet, ResourceAccessor resourceAccessor) {
@@ -272,6 +276,25 @@ public abstract class ExecutablePreparedStatementBase implements ExecutablePrepa
             LOG.fine("value is blob = " + col.getValueBlobFile());
             try {
                 LOBContent<InputStream> lob = toBinaryStream(col.getValueBlobFile());
+
+                if (database instanceof PostgresDatabase) {
+                    String snapshotKeyName = String.format("%s-%s-%s-%s", getCatalogName(), getSchemaName(), getTableName(), col.getName());
+                    Column snapshot = (Column) this.getScratchData(snapshotKeyName);
+                    if (snapshot == null) {
+                        snapshot = SnapshotGeneratorFactory.getInstance().createSnapshot(
+                                new Column(Table.class, getCatalogName(), getSchemaName(), getTableName(), col.getName()), database);
+                        this.setScratchData(snapshotKeyName, snapshot);
+                    }
+
+                    if (snapshot.getType().getTypeName().equalsIgnoreCase("bytea")) {
+                        if (lob.length <= Integer.MAX_VALUE) {
+                            stmt.setBinaryStream(i, lob.content, (int) lob.length);
+                        } else {
+                            stmt.setBinaryStream(i, lob.content, lob.length);
+                        }
+                        return;
+                    }
+                }
                 if (lob.length <= Integer.MAX_VALUE) {
                     stmt.setBlob(i, lob.content, (int) lob.length);
                 } else {
@@ -460,6 +483,14 @@ public abstract class ExecutablePreparedStatementBase implements ExecutablePrepa
 
     public ResourceAccessor getResourceAccessor() {
         return resourceAccessor;
+    }
+
+    private Object getScratchData(String key) {
+        return snapshotScratchPad.get(key);
+    }
+
+    private Object setScratchData(String key, Object data) {
+        return snapshotScratchPad.put(key, data);
     }
 
     protected long getContentLength(InputStream in) throws IOException {

--- a/liquibase-integration-tests/src/test/resources/changelogs/pgsql/complete/testBlob.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/pgsql/complete/testBlob.changelog.xml
@@ -1,0 +1,22 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.1.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="di-1" author="someauthor">
+        <createTable tableName="blobtest">
+            <column name="id" type="int8">
+                <constraints nullable="false"/>
+            </column>
+            <column name="content_bytea" type="bytea"/>
+            <column name="content_oid" type="oid"/>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="di-2" author="someauthor">
+        <insert tableName="blobtest">
+            <column name="id" valueNumeric="1"/>
+            <column name="content_bytea" valueBlobFile="datafiles/enum-data.csv" />
+            <column name="content_oid" valueBlobFile="datafiles/enum-data.csv"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Postgresql defines 2 column types to handle blob types: bytea and large objects that must be declared as "oid". According to postgresql documentation, both must use different jdbc methods (https://jdbc.postgresql.org/documentation/binary-data/) . 

Until Liquibase 4.13, bytea was supported.  But https://github.com/liquibase/liquibase/pull/605 changed the methods to support large objects instead of bytea. 

This fix validates the column type and uses the appropriated jdbc method depending on it.

## Things to be aware of

- A column cache has been created to make sure that snapshot data for a column is requested only once
- After this patch, both oid and bytea column types should work.

## Things to worry about
 - NA

## Additional Context

- Fixes #3165 