### PR TITLE
#1290: Forbid empty changeSet id and author

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
@@ -106,7 +106,7 @@ public class ValidatingVisitor implements ChangeSetVisitor {
         boolean shouldValidate = !ran || changeSet.shouldRunOnChange() || changeSet.shouldAlwaysRun();
 
         if (!areChangeSetAttributesValid(changeSet)) {
-            changeSet.setValidationFailed(false);
+            changeSet.setValidationFailed(true);
             shouldValidate = false;
         };
 
@@ -168,7 +168,7 @@ public class ValidatingVisitor implements ChangeSetVisitor {
 
         boolean valid = false;
         if (authorEmpty && idEmpty) {
-            validationErrors.addError("ChangeSet Id and Author is empty", changeSet);
+            validationErrors.addError("ChangeSet Id and Author are empty", changeSet);
         } else if (authorEmpty) {
             validationErrors.addError("ChangeSet Author is empty", changeSet);
         } else if (idEmpty) {

--- a/liquibase-core/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
@@ -104,6 +104,12 @@ public class ValidatingVisitor implements ChangeSetVisitor {
         }
         changeSet.setStoredCheckSum(ran?ranChangeSet.getLastCheckSum():null);
         boolean shouldValidate = !ran || changeSet.shouldRunOnChange() || changeSet.shouldAlwaysRun();
+
+        if (!areChangeSetAttributesValid(changeSet)) {
+            changeSet.setValidationFailed(false);
+            shouldValidate = false;
+        };
+
         for (Change change : changeSet.getChanges()) {
             try {
                 change.finishInitialization();
@@ -155,6 +161,23 @@ public class ValidatingVisitor implements ChangeSetVisitor {
             seenChangeSets.add(changeSetString);
         }
     } // public void visit(...)
+
+    private boolean areChangeSetAttributesValid(ChangeSet changeSet) {
+        boolean authorEmpty = StringUtil.isEmpty(changeSet.getAuthor());
+        boolean idEmpty = StringUtil.isEmpty(changeSet.getId());
+
+        boolean valid = false;
+        if (authorEmpty && idEmpty) {
+            validationErrors.addError("ChangeSet Id and Author is empty", changeSet);
+        } else if (authorEmpty) {
+            validationErrors.addError("ChangeSet Author is empty", changeSet);
+        } else if (idEmpty) {
+            validationErrors.addError("ChangeSet Id is empty", changeSet);
+        } else {
+            valid = true;
+        }
+        return valid;
+    }
 
     public List<String> getInvalidMD5Sums() {
         return invalidMD5Sums;

--- a/liquibase-core/src/main/java/liquibase/exception/ValidationErrors.java
+++ b/liquibase-core/src/main/java/liquibase/exception/ValidationErrors.java
@@ -128,6 +128,12 @@ public class ValidationErrors {
         return this;
     }
 
+
+    public ValidationErrors addError(String message, ChangeSet changeSet) {
+        this.errorMessages.add(message + ", " + changeSet);
+        return this;
+    }
+
     public List<String> getErrorMessages() {
         return errorMessages;
     }
@@ -151,7 +157,7 @@ public class ValidationErrors {
 
     public void addAll(ValidationErrors validationErrors, ChangeSet changeSet) {
         for (String message : validationErrors.getErrorMessages()) {
-            this.errorMessages.add(message + ", " + changeSet);
+            this.addError(message, changeSet);
         }
         for (String message : validationErrors.getWarningMessages()) {
             this.warningMessages.add(message + ", " + changeSet);

--- a/liquibase-core/src/test/groovy/liquibase/changelog/ChangeSetTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/changelog/ChangeSetTest.groovy
@@ -4,6 +4,7 @@ package liquibase.changelog
 import liquibase.Scope
 import liquibase.change.CheckSum
 import liquibase.change.core.*
+import liquibase.database.core.MockDatabase
 import liquibase.parser.ChangeLogParserConfiguration
 import liquibase.parser.core.ParsedNode
 import liquibase.parser.core.ParsedNodeException
@@ -622,6 +623,28 @@ public class ChangeSetTest extends Specification {
 
         then:
         changeSet.isInheritableIgnore()
+    }
+
+    def "execute returns a MARK_RAN state when changeSet is set with validation failed as true"() {
+        when:
+        DatabaseChangeLog databaseChangeLog = new DatabaseChangeLog("com/example/test.xml")
+        def changeSet = new ChangeSet(databaseChangeLog)
+        def node = new ParsedNode(null, "changeSet").addChildren([id: "1", author: "mallod"])
+        changeSet.setValidationFailed(true)
+
+        then:
+        changeSet.execute(databaseChangeLog, new MockDatabase()) == ChangeSet.ExecType.MARK_RAN
+    }
+
+    def "execute returns a EXECUTED state when changeSet is set with validation failed as false"() {
+        when:
+        DatabaseChangeLog databaseChangeLog = new DatabaseChangeLog("com/example/test.xml")
+        def changeSet = new ChangeSet(databaseChangeLog)
+        def node = new ParsedNode(null, "changeSet").addChildren([id: "2", author: "mallod"])
+        changeSet.setValidationFailed(false)
+
+        then:
+        changeSet.execute(databaseChangeLog, new MockDatabase()) == ChangeSet.ExecType.EXECUTED
     }
 
 }

--- a/liquibase-core/src/test/java/liquibase/changelog/visitor/ValidatingVisitorTest.java
+++ b/liquibase-core/src/test/java/liquibase/changelog/visitor/ValidatingVisitorTest.java
@@ -110,6 +110,46 @@ public class ValidatingVisitorTest {
     }
 
     @Test
+    public void visit_validateErrorOnEmptyAuthor() throws Exception {
+
+        ChangeSet changeSet = new ChangeSet("emptyAuthor", "", false, false, "path/changelog", null, null, null);
+
+        ValidatingVisitor handler = new ValidatingVisitor(new ArrayList<>());
+        handler.visit(changeSet, new DatabaseChangeLog(), null, null);
+
+        assertEquals(1, handler.getValidationErrors().getErrorMessages().size());
+        assertTrue(handler.getValidationErrors().getErrorMessages().get(0).contains("Author"));
+        assertFalse(handler.validationPassed());
+    }
+
+    @Test
+    public void visit_validateErrorOnEmptyId() throws Exception {
+
+        ChangeSet changeSet = new ChangeSet("", "emptyId", false, false, "path/changelog", null, null, null);
+
+        ValidatingVisitor handler = new ValidatingVisitor(new ArrayList<>());
+        handler.visit(changeSet, new DatabaseChangeLog(), null, null);
+
+        assertEquals(1, handler.getValidationErrors().getErrorMessages().size());
+        assertTrue(handler.getValidationErrors().getErrorMessages().get(0).contains("Id"));
+        assertFalse(handler.validationPassed());
+    }
+
+    @Test
+    public void visit_validateErrorOnEmptyAuthorAndId() throws Exception {
+
+        ChangeSet changeSet = new ChangeSet("", "", false, false, "path/changelog", null, null, null);
+
+        ValidatingVisitor handler = new ValidatingVisitor(new ArrayList<>());
+        handler.visit(changeSet, new DatabaseChangeLog(), null, null);
+
+        assertEquals(1, handler.getValidationErrors().getErrorMessages().size());
+        assertTrue(handler.getValidationErrors().getErrorMessages().get(0).contains("Author"));
+        assertTrue(handler.getValidationErrors().getErrorMessages().get(0).contains("Id"));
+        assertFalse(handler.validationPassed());
+    }
+
+    @Test
     public void visit_torunOnly() throws Exception {
 
         changeSet1.addChange(new CreateTableChange() {


### PR DESCRIPTION
Added validation for these attributes to ValidatingVisitor.
Tests are also added for the cases when author or id or both attributes are empty.

Tags: hacktoberfest, newbiePR