### PR TITLE
Allow to drop and create a view for a Postgres database if replacing the view would fail. Fixes #1042

### DIFF
--- a/liquibase-core/src/main/java/liquibase/GlobalConfiguration.java
+++ b/liquibase-core/src/main/java/liquibase/GlobalConfiguration.java
@@ -31,6 +31,7 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
     public static final ConfigurationDefinition<Boolean> SHOULD_SNAPSHOT_DATA;
     public static final ConfigurationDefinition<Boolean> PRESERVE_SCHEMA_CASE;
     public static final ConfigurationDefinition<Boolean> SHOW_BANNER;
+    public static final ConfigurationDefinition<Boolean> DROP_IF_CANNOT_REPLACE;
 
     public static final ConfigurationDefinition<DuplicateFileMode> DUPLICATE_FILE_MODE;
 
@@ -209,6 +210,10 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
 
         SEARCH_PATH = builder.define("searchPath", String.class)
                 .setDescription("Complete list of Location(s) to search for files such as changelog files in. Multiple paths can be specified by separating them with commas.")
+                .build();
+
+        DROP_IF_CANNOT_REPLACE = builder.define("dropIfCannotReplace", Boolean.class)
+                .setDescription("If true, drop and recreate a view when replacing it is going to fail.")
                 .build();
     }
 

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateViewGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/CreateViewGenerator.java
@@ -1,6 +1,7 @@
 package liquibase.sqlgenerator.core;
 
 import liquibase.CatalogAndSchema;
+import liquibase.GlobalConfiguration;
 import liquibase.database.Database;
 import liquibase.database.core.*;
 import liquibase.exception.DatabaseException;
@@ -91,10 +92,10 @@ public class CreateViewGenerator extends AbstractSqlGenerator<CreateViewStatemen
                         + "] AS SELECT " +
                         "''This is a code stub which will be replaced by an Alter Statement'' as [code_stub]'"));
                 viewDefinition.replace("CREATE", "ALTER");
-            } else if (database instanceof HsqlDatabase) {
+            } else if (shouldPrependDropViewStatement(database, statement)) {
                 sql.add(new UnparsedSql(
                     "DROP VIEW IF EXISTS " + database.escapeViewName(statement.getCatalogName(),
-                        statement.getSchemaName(), statement.getViewName())));
+                    statement.getSchemaName(), statement.getViewName())));
             } else {
                 //
                 // Do not generate CREATE OR REPLACE if:
@@ -108,6 +109,17 @@ public class CreateViewGenerator extends AbstractSqlGenerator<CreateViewStatemen
         }
         sql.add(new UnparsedSql(viewDefinition.toString(), getAffectedView(statement)));
         return sql.toArray(new Sql[sql.size()]);
+    }
+
+    private boolean shouldPrependDropViewStatement(Database database, CreateViewStatement statement) {
+        // allow overriding the value of the dropIfCannotReplace attribute
+        // from liquibase.properties or command line
+        boolean dropIfCannotReplace = statement.isDropIfCannotReplace();
+        if (GlobalConfiguration.DROP_IF_CANNOT_REPLACE.getCurrentValue() != null) {
+            dropIfCannotReplace = GlobalConfiguration.DROP_IF_CANNOT_REPLACE.getCurrentValue();
+        } 
+        return database instanceof HsqlDatabase ||
+              (database instanceof PostgresDatabase && dropIfCannotReplace);
     }
 
     //

--- a/liquibase-core/src/main/java/liquibase/statement/core/CreateViewStatement.java
+++ b/liquibase-core/src/main/java/liquibase/statement/core/CreateViewStatement.java
@@ -9,14 +9,16 @@ public class CreateViewStatement extends AbstractSqlStatement {
     private String viewName;
     private String selectQuery;
     private boolean replaceIfExists;
+    private boolean dropIfCannotReplace;
     private boolean fullDefinition;
 
-    public CreateViewStatement(String catalogName, String schemaName, String viewName, String selectQuery, boolean replaceIfExists) {
+    public CreateViewStatement(String catalogName, String schemaName, String viewName, String selectQuery, boolean replaceIfExists, boolean dropIfCannotReplace) {
         this.catalogName = catalogName;
         this.schemaName = schemaName;
         this.viewName = viewName;
         this.selectQuery = selectQuery;
         this.replaceIfExists = replaceIfExists;
+        this.dropIfCannotReplace = dropIfCannotReplace;
     }
 
     public String getCatalogName() {
@@ -37,6 +39,10 @@ public class CreateViewStatement extends AbstractSqlStatement {
 
     public boolean isReplaceIfExists() {
         return replaceIfExists;
+    }
+
+    public boolean isDropIfCannotReplace() {
+        return dropIfCannotReplace;
     }
 
     /**

--- a/liquibase-core/src/test/groovy/liquibase/sqlgenerator/core/CreateViewGeneratorTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/sqlgenerator/core/CreateViewGeneratorTest.groovy
@@ -1,9 +1,11 @@
 package liquibase.sqlgenerator.core
 
-
+import liquibase.database.core.HsqlDatabase
 import liquibase.database.core.OracleDatabase
+import liquibase.database.core.PostgresDatabase
 import liquibase.sqlgenerator.SqlGeneratorFactory
 import liquibase.statement.core.CreateViewStatement
+import liquibase.Scope
 import spock.lang.Specification
 
 class CreateViewGeneratorTest extends Specification {
@@ -11,7 +13,7 @@ class CreateViewGeneratorTest extends Specification {
     def "creates a view from a sql"() {
         when:
         def selectQuery = "SELECT SYSDATE FROM DUAL"
-        def statement = new CreateViewStatement("PUBLIC", "schema", "my_view", selectQuery, false)
+        def statement = new CreateViewStatement("PUBLIC", "schema", "my_view", selectQuery, false, false)
         def generators = SqlGeneratorFactory.instance.getGenerators(statement, new OracleDatabase())
 
         then:
@@ -29,7 +31,7 @@ class CreateViewGeneratorTest extends Specification {
     def "creates a replace view from a sql"() {
         when:
         def selectQuery = "SELECT SYSDATE FROM DUAL"
-        def statement = new CreateViewStatement("PUBLIC", "schema", "my_view", selectQuery, true)
+        def statement = new CreateViewStatement("PUBLIC", "schema", "my_view", selectQuery, true, false)
         def generators = SqlGeneratorFactory.instance.getGenerators(statement, new OracleDatabase())
 
         then:
@@ -47,7 +49,7 @@ class CreateViewGeneratorTest extends Specification {
     def "replace is added even when a select replace is used"() {
         when:
         def selectQuery = "SELECT REPLACE('The quick brown dog', 'dog', 'fox') FROM DUAL"
-        def statement = new CreateViewStatement("PUBLIC", "schem", "my_view", selectQuery, true)
+        def statement = new CreateViewStatement("PUBLIC", "schem", "my_view", selectQuery, true, false)
         def generators = SqlGeneratorFactory.instance.getGenerators(statement, new OracleDatabase())
 
         then:
@@ -62,5 +64,40 @@ class CreateViewGeneratorTest extends Specification {
         sql[0].toString() == "CREATE OR REPLACE VIEW PUBLIC.my_view AS " + selectQuery + ";"
     }
 
+    def "creates drop view statement for Postgres when replace is true and dropIfCannotReplace propery is set"() {
+        given:
+        System.setProperty("liquibase.dropIfCannotReplace", dropIfCannotReplacePropValue)
+
+        when:
+        def selectQuery = "SELECT SYSDATE FROM DUAL"
+        def statement = new CreateViewStatement("PUBLIC", "schema", "my_view", selectQuery, true, false)
+        def generators = SqlGeneratorFactory.instance.getGenerators(statement, database)
+
+        then:
+        generators.size() > 0
+        generators[0] instanceof CreateViewGenerator
+
+        when:
+        def sql = SqlGeneratorFactory.instance.generateSql(statement, database)
+
+        then:
+        sql.length == expectedNumOfSqlStatements
+        if (sql.length == 1) {
+            sql[0].toString() == "CREATE OR REPLACE VIEW PUBLIC.my_view AS " + selectQuery + ";"
+        }
+        else {
+            sql[0].toString() == "DROP VIEW IF EXISTS PUBLIC.my_view;"
+            sql[1].toString() == "CREATE OR REPLACE VIEW PUBLIC.my_view AS " + selectQuery + ";"
+        }
+
+        where:
+        database | dropIfCannotReplacePropValue | expectedNumOfSqlStatements
+        new HsqlDatabase() | "false" | 2
+        new HsqlDatabase() | "true" | 2
+        new OracleDatabase() | "false" | 1
+        new OracleDatabase() | "true" | 1
+        new PostgresDatabase() | "false" | 1
+        new PostgresDatabase() | "true" | 2
+    }
 
 }

--- a/liquibase-core/src/test/java/liquibase/statement/core/CreateViewStatementTest.java
+++ b/liquibase-core/src/test/java/liquibase/statement/core/CreateViewStatementTest.java
@@ -4,7 +4,7 @@ public class CreateViewStatementTest extends AbstractSqStatementTest<CreateViewS
 
     @Override
     protected CreateViewStatement createStatementUnderTest() {
-        return new CreateViewStatement(null, null, null, null, false);
+        return new CreateViewStatement(null, null, null, null, false, false);
     }
 
 }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

- Added new dropIfCannotReplace property to the createView functionality with the ability to override the value specified in a changelog via specifying the liquibase.dropIfCannotReplace property value in the liquibase.properties file or on the liquibase command line, or via a system property.
- The functionality applies only if replaceIfExists attribute of createView is set to true.

## Things to be aware of

- The code change is constrained to affect the createView functionality for the Postgres database only.
- I verified the functionality by setting the liquibase.dropIfCannotReplace system property in the unit test.  I did not know how to verify the functionality when the liquibase.dropIfCannotReplace propery is set in the liquibase.properties file.

## Things to worry about

None at this time.

## Additional Context

None at this time.
