### PR TITLE
Use PathHandler for writing log files, which allows using S3 and other extensions (DAT-11515)

### DIFF
--- a/liquibase-cli/src/main/java/liquibase/integration/commandline/CommandRunner.java
+++ b/liquibase-cli/src/main/java/liquibase/integration/commandline/CommandRunner.java
@@ -6,6 +6,7 @@ import liquibase.command.CommandScope;
 import liquibase.command.CommonArgumentNames;
 import liquibase.exception.CommandValidationException;
 import liquibase.exception.MissingRequiredArgumentException;
+import liquibase.resource.OpenOptions;
 import liquibase.resource.PathHandlerFactory;
 import liquibase.util.StringUtil;
 import picocli.CommandLine;
@@ -47,7 +48,7 @@ class CommandRunner implements Callable<CommandResults> {
         try {
             if (outputFile != null) {
                 final PathHandlerFactory pathHandlerFactory = Scope.getCurrentScope().getSingleton(PathHandlerFactory.class);
-                outputStream = pathHandlerFactory.openResourceOutputStream(outputFile, true);
+                outputStream = pathHandlerFactory.openResourceOutputStream(outputFile, new OpenOptions());
                 commandScope.setOutput(outputStream);
             }
 

--- a/liquibase-core/src/main/java/liquibase/changelog/ChangelogRewriter.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangelogRewriter.java
@@ -1,15 +1,16 @@
 package liquibase.changelog;
 
-import liquibase.Scope;
 import liquibase.GlobalConfiguration;
+import liquibase.Scope;
 import liquibase.parser.core.xml.XMLChangeLogSAXParser;
-import liquibase.resource.PathHandlerFactory;
+import liquibase.resource.OpenOptions;
 import liquibase.resource.Resource;
 import liquibase.resource.ResourceAccessor;
 import liquibase.util.StreamUtil;
 
-import java.io.*;
-import java.util.SortedSet;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -73,7 +74,7 @@ public class ChangelogRewriter {
                 }
             }
 
-            try (OutputStream outputStream = resource.openOutputStream(true)) {
+            try (OutputStream outputStream = resource.openOutputStream(new OpenOptions())) {
                 outputStream.write(changeLogString.getBytes(encoding));
             }
 
@@ -170,7 +171,7 @@ public class ChangelogRewriter {
             //
             // Write out the file again
             //
-            try (OutputStream outputStream = resource.openOutputStream(true)) {
+            try (OutputStream outputStream = resource.openOutputStream(new OpenOptions())) {
                 outputStream.write(changeLogString.getBytes(encoding));
             }
 

--- a/liquibase-core/src/main/java/liquibase/changelog/visitor/DBDocVisitor.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/visitor/DBDocVisitor.java
@@ -7,6 +7,7 @@ import liquibase.changelog.filter.ChangeSetFilterResult;
 import liquibase.database.Database;
 import liquibase.dbdoc.*;
 import liquibase.exception.LiquibaseException;
+import liquibase.resource.OpenOptions;
 import liquibase.resource.Resource;
 import liquibase.resource.ResourceAccessor;
 import liquibase.snapshot.DatabaseSnapshot;
@@ -176,7 +177,7 @@ public class DBDocVisitor implements ChangeSetVisitor {
             if (inputStream == null) {
                 throw new IOException("Can not find " + fileToCopy);
             }
-            outputStream = rootOutputDir.resolve(fileToCopy.replaceFirst(".*\\/", "")).openOutputStream(true);
+            outputStream = rootOutputDir.resolve(fileToCopy.replaceFirst(".*\\/", "")).openOutputStream(new OpenOptions());
             StreamUtil.copy(inputStream, outputStream);
         } finally {
             if (outputStream != null) {

--- a/liquibase-core/src/main/java/liquibase/dbdoc/ChangeLogWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/ChangeLogWriter.java
@@ -1,6 +1,7 @@
 package liquibase.dbdoc;
 
 import liquibase.GlobalConfiguration;
+import liquibase.resource.OpenOptions;
 import liquibase.resource.Resource;
 import liquibase.resource.ResourceAccessor;
 import liquibase.util.StreamUtil;
@@ -20,7 +21,7 @@ public class ChangeLogWriter {
         String changeLogOutFile = changeLog.replace(":", "_");
         Resource xmlFile = outputDir.resolve(changeLogOutFile.toLowerCase() + ".html");
 
-        try (BufferedWriter changeLogStream = new BufferedWriter(new OutputStreamWriter(xmlFile.openOutputStream(true),
+        try (BufferedWriter changeLogStream = new BufferedWriter(new OutputStreamWriter(xmlFile.openOutputStream(new OpenOptions()),
                 GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()))) {
             Resource stylesheet = resourceAccessor.get(physicalFilePath);
             if (stylesheet == null) {

--- a/liquibase-core/src/main/java/liquibase/dbdoc/HTMLListWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/HTMLListWriter.java
@@ -1,6 +1,7 @@
 package liquibase.dbdoc;
 
 import liquibase.GlobalConfiguration;
+import liquibase.resource.OpenOptions;
 import liquibase.resource.Resource;
 import liquibase.util.StringUtil;
 
@@ -21,7 +22,7 @@ public class HTMLListWriter {
     }
 
     public void writeHTML(SortedSet objects) throws IOException {
-        Writer fileWriter = new OutputStreamWriter(outputDir.resolve(filename).openOutputStream(true), GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue());
+        Writer fileWriter = new OutputStreamWriter(outputDir.resolve(filename).openOutputStream(new OpenOptions()), GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue());
 
         try {
             fileWriter.append("<HTML>\n" + "<HEAD><meta charset=\"utf-8\"/>\n" + "<TITLE>\n");

--- a/liquibase-core/src/main/java/liquibase/dbdoc/HTMLWriter.java
+++ b/liquibase-core/src/main/java/liquibase/dbdoc/HTMLWriter.java
@@ -2,15 +2,17 @@ package liquibase.dbdoc;
 
 import liquibase.change.Change;
 import liquibase.changelog.ChangeSet;
-import liquibase.GlobalConfiguration;
 import liquibase.database.Database;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.DatabaseHistoryException;
+import liquibase.resource.OpenOptions;
 import liquibase.resource.Resource;
 import liquibase.util.LiquibaseUtil;
 import liquibase.util.StringUtil;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.text.DateFormat;
 import java.util.Date;
 import java.util.List;
@@ -27,7 +29,7 @@ public abstract class HTMLWriter {
     protected abstract void writeCustomHTML(Writer fileWriter, Object object, List<Change> changes, Database database) throws IOException;
 
     private Writer createFileWriter(Object object) throws IOException {
-        return new OutputStreamWriter(outputDir.resolve(DBDocUtil.toFileName(object.toString().toLowerCase()) + ".html").openOutputStream(true));
+        return new OutputStreamWriter(outputDir.resolve(DBDocUtil.toFileName(object.toString().toLowerCase()) + ".html").openOutputStream(new OpenOptions()));
     }
 
     public void writeHTML(Object object, List<Change> ranChanges, List<Change> changesToRun, String changeLog) throws IOException, DatabaseHistoryException, DatabaseException {

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/DiffToChangeLog.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/DiffToChangeLog.java
@@ -16,6 +16,7 @@ import liquibase.exception.DatabaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.executor.Executor;
 import liquibase.executor.ExecutorService;
+import liquibase.resource.OpenOptions;
 import liquibase.resource.PathHandlerFactory;
 import liquibase.resource.Resource;
 import liquibase.serializer.ChangeLogSerializer;
@@ -157,7 +158,7 @@ public class DiffToChangeLog {
                                 String toInsert = "    " + innerXml + lineSeparator;
                                 fileContents.insert(endTagIndex, toInsert);
                             }
-                            try (OutputStream outputStream = file.openOutputStream(true)) {
+                            try (OutputStream outputStream = file.openOutputStream(new OpenOptions())) {
                                 outputStream.write(fileContents.toString().getBytes());
                             }
                         }
@@ -211,7 +212,7 @@ public class DiffToChangeLog {
             Scope.getCurrentScope().getLog(getClass()).info(file + " does not exist, creating and adding " + changeSets.size() + " changesets.");
         }
 
-        try (OutputStream stream = file.openOutputStream(true);
+        try (OutputStream stream = file.openOutputStream(new OpenOptions());
              PrintStream out = new PrintStream(stream, true, GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue())) {
             changeLogSerializer.write(changeSets, out);
         }

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingDataExternalFileChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingDataExternalFileChangeGenerator.java
@@ -10,6 +10,7 @@ import liquibase.database.jvm.JdbcConnection;
 import liquibase.diff.output.DiffOutputControl;
 import liquibase.diff.output.changelog.ChangeGeneratorChain;
 import liquibase.exception.UnexpectedLiquibaseException;
+import liquibase.resource.OpenOptions;
 import liquibase.resource.PathHandlerFactory;
 import liquibase.resource.Resource;
 import liquibase.servicelocator.LiquibaseService;
@@ -84,7 +85,7 @@ public class MissingDataExternalFileChangeGenerator extends MissingDataChangeGen
 
                 String[] dataTypes = new String[0];
                 try (
-                        OutputStream fileOutputStream = externalFileResource.openOutputStream(true);
+                        OutputStream fileOutputStream = externalFileResource.openOutputStream(new OpenOptions());
                         OutputStreamWriter outputStreamWriter = new OutputStreamWriter(
                                 fileOutputStream, GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue());
                         CSVWriter outputFile = new CSVWriter(new BufferedWriter(outputStreamWriter));

--- a/liquibase-core/src/main/java/liquibase/integration/commandline/LiquibaseCommandLineConfiguration.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/LiquibaseCommandLineConfiguration.java
@@ -22,7 +22,7 @@ public class LiquibaseCommandLineConfiguration implements AutoloadedConfiguratio
     public static final ConfigurationDefinition<String> DEFAULTS_FILE;
     public static final ConfigurationDefinition<Level> LOG_LEVEL;
     public static final ConfigurationDefinition<String> LOG_CHANNELS;
-    public static final ConfigurationDefinition<File> LOG_FILE;
+    public static final ConfigurationDefinition<String> LOG_FILE;
     public static final ConfigurationDefinition<String> OUTPUT_FILE;
     public static final ConfigurationDefinition<Boolean> SHOULD_RUN;
     public static final ConfigurationDefinition<ArgumentConverter> ARGUMENT_CONVERTER;
@@ -66,7 +66,7 @@ public class LiquibaseCommandLineConfiguration implements AutoloadedConfiguratio
                 .setDefaultValue("liquibase", "Controls which log channels have their level set by the liquibase.logLevel setting. Comma separate multiple values. To set the level of all channels, use 'all'. Example: liquibase,org.mariadb.jdbc")
                 .build();
 
-        LOG_FILE = builder.define("logFile", File.class).build();
+        LOG_FILE = builder.define("logFile", String.class).build();
         OUTPUT_FILE = builder.define("outputFile", String.class).build();
 
         MONITOR_PERFORMANCE = builder.define("monitorPerformance", String.class)

--- a/liquibase-core/src/main/java/liquibase/integration/spring/SpringResource.java
+++ b/liquibase-core/src/main/java/liquibase/integration/spring/SpringResource.java
@@ -1,6 +1,7 @@
 package liquibase.integration.spring;
 
 import liquibase.exception.UnexpectedLiquibaseException;
+import liquibase.resource.OpenOptions;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.WritableResource;
 
@@ -59,9 +60,12 @@ class SpringResource extends liquibase.resource.AbstractResource {
     }
 
     @Override
-    public OutputStream openOutputStream(boolean createIfNeeded) throws IOException {
-        if (!resource.exists() && !createIfNeeded) {
+    public OutputStream openOutputStream(OpenOptions openOptions) throws IOException {
+        if (!resource.exists() && !openOptions.isCreateIfNeeded()) {
             throw new IOException("Resource "+getUri()+" does not exist");
+        }
+        if (openOptions != null && openOptions.isAppend() && exists()) {
+            throw new IOException("Spring only supports truncating the existing resources.");
         }
         if (resource instanceof WritableResource) {
             return ((WritableResource) resource).getOutputStream();

--- a/liquibase-core/src/main/java/liquibase/resource/AbstractResource.java
+++ b/liquibase-core/src/main/java/liquibase/resource/AbstractResource.java
@@ -1,7 +1,5 @@
 package liquibase.resource;
 
-import liquibase.util.StringUtil;
-
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
@@ -40,7 +38,7 @@ public abstract class AbstractResource implements Resource {
     }
 
     @Override
-    public OutputStream openOutputStream(boolean createIfNeeded) throws IOException {
+    public OutputStream openOutputStream(OpenOptions openOptions) throws IOException {
         if (!isWritable()) {
             throw new IOException("Read only");
         }

--- a/liquibase-core/src/main/java/liquibase/resource/OpenOptions.java
+++ b/liquibase-core/src/main/java/liquibase/resource/OpenOptions.java
@@ -1,0 +1,55 @@
+package liquibase.resource;
+
+/**
+ * Defines the options for opening {@link Resource}s in Liquibase.
+ */
+public class OpenOptions {
+    private boolean truncate;
+    private boolean createIfNeeded;
+
+    /**
+     * Use default options of truncate = true, createIfNeeded = true;
+     */
+    public OpenOptions() {
+        this.truncate = true;
+        this.createIfNeeded = true;
+    }
+
+    /**
+     * Should an existing file be truncated when opened. Both this and {@link #isAppend()}
+     * are automatically kept in sync with each other.
+     */
+    public boolean isTruncate() {
+        return truncate;
+    }
+
+    public OpenOptions setTruncate(boolean truncate) {
+        this.truncate = truncate;
+        return this;
+    }
+
+    /**
+     * Should an existing file be appended to when opened. Both this and {@link #isTruncate()}
+     * are automatically kept in sync with each other.
+     */
+    public boolean isAppend() {
+        return !isTruncate();
+    }
+
+    public OpenOptions setAppend(boolean append) {
+        this.truncate = !append;
+        return this;
+    }
+
+    /**
+     * If true, create the resource if it does not exist. If false, do not create the resource.
+     */
+    public boolean isCreateIfNeeded() {
+        return createIfNeeded;
+    }
+
+    public OpenOptions setCreateIfNeeded(boolean createIfNeeded) {
+        this.createIfNeeded = createIfNeeded;
+        return this;
+    }
+}

--- a/liquibase-core/src/main/java/liquibase/resource/PathHandlerFactory.java
+++ b/liquibase-core/src/main/java/liquibase/resource/PathHandlerFactory.java
@@ -1,6 +1,5 @@
 package liquibase.resource;
 
-import liquibase.Scope;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.plugin.AbstractPluginFactory;
 
@@ -75,17 +74,30 @@ public class PathHandlerFactory extends AbstractPluginFactory<PathHandler> {
      *
      * @return null if resourcePath does not exist and createIfNotExists is false
      * @throws IOException if there is an error opening the stream
+     *
+     * @deprecated use {@link #openResourceOutputStream(String, OpenOptions)}
      */
+    @Deprecated
     public OutputStream openResourceOutputStream(String resourcePath, boolean createIfNotExists) throws IOException {
+        return openResourceOutputStream(resourcePath, new OpenOptions().setCreateIfNeeded(createIfNotExists));
+    }
+
+    /**
+     * Returns the outputStream from {@link #getResource(String)}, using settings from the passed {@link OpenOptions}.
+     *
+     * @return null if resourcePath does not exist and {@link OpenOptions#isCreateIfNeeded()} is false
+     * @throws IOException if there is an error opening the stream
+     */
+    public OutputStream openResourceOutputStream(String resourcePath, OpenOptions openOptions) throws IOException {
         Resource resource = getResource(resourcePath);
         if (!resource.exists()) {
-            if (createIfNotExists) {
+            if (openOptions.isCreateIfNeeded()) {
                 return createResource(resourcePath);
             } else {
                 return null;
             }
         }
-        return resource.openOutputStream(createIfNotExists);
+        return resource.openOutputStream(openOptions);
     }
 
     /**

--- a/liquibase-core/src/main/java/liquibase/resource/Resource.java
+++ b/liquibase-core/src/main/java/liquibase/resource/Resource.java
@@ -50,14 +50,21 @@ public interface Resource {
      */
     Resource resolveSibling(String other);
 
+    /**
+     * Opens an output stream given the passed {@link OpenOptions}.
+     * Cannot pass a null OpenOptions value
+     */
+    OutputStream openOutputStream(OpenOptions openOptions) throws IOException;
 
     /**
-     * Opens an output stream to write to this resource. Note that calling this method will truncate (erase) the existing file.
+     * Opens an output stream to write to this resource using the default {@link OpenOptions#OpenOptions()} settings plus the passed createIfNeeded value.
      *
-     * @param createIfNeeded if true, create the resource if it does not exist. If false, throw an exception if it does not exist
-     * @throws IOException if there is an error writing to the resource, including if the resource does not exist or permission don't allow writing.
+     * @deprecated use {@link #openOutputStream(OpenOptions)}
      */
-    OutputStream openOutputStream(boolean createIfNeeded) throws IOException;
+    @Deprecated
+    default OutputStream openOutputStream(boolean createIfNeeded) throws IOException {
+        return openOutputStream(new OpenOptions().setCreateIfNeeded(createIfNeeded));
+    }
 
     /**
      * Returns a unique and complete identifier for this resource.

--- a/liquibase-core/src/main/java/liquibase/resource/ResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/ResourceAccessor.java
@@ -253,8 +253,8 @@ public interface ResourceAccessor extends AutoCloseable {
         }
 
         @Override
-        public OutputStream openOutputStream(boolean createIfNeeded) throws IOException {
-            throw new UnexpectedLiquibaseException("Resource does not exist");
+        public OutputStream openOutputStream(OpenOptions openOptions) throws IOException {
+            return openOutputStream(new OpenOptions());
         }
     }
 }

--- a/liquibase-core/src/test/groovy/liquibase/resource/PathHandlerFactoryTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/resource/PathHandlerFactoryTest.groovy
@@ -52,10 +52,10 @@ class PathHandlerFactoryTest extends Specification {
         def pathHandlerFactory = Scope.currentScope.getSingleton(PathHandlerFactory)
 
         then:
-        pathHandlerFactory.openResourceOutputStream(path, false) == null //when createIfNotExists is false
+        pathHandlerFactory.openResourceOutputStream(path, new OpenOptions().setCreateIfNeeded(false)) == null //when createIfNotExists is false
 
         when:
-        def stream = pathHandlerFactory.openResourceOutputStream(path, true) //createIfNotExists is true
+        def stream = pathHandlerFactory.openResourceOutputStream(path, new OpenOptions().setCreateIfNeeded(true)) //createIfNotExists is true
         stream.withWriter {
             it.write("test")
         }
@@ -66,7 +66,7 @@ class PathHandlerFactoryTest extends Specification {
 
         when:
         //can update file
-        stream = pathHandlerFactory.openResourceOutputStream(path, true)
+        stream = pathHandlerFactory.openResourceOutputStream(path, new OpenOptions())
         stream.withWriter {
             it.write("test 2")
         }


### PR DESCRIPTION
This reverts commit 9949ca0bccd115411ad6cd45c8135d87be6d951e.

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Create log files using the `PathHandler` interfaces. Add support for different `OpenOptions` for resources, like appending and truncating existing files.

## Things to be aware of

- Liquibase erroneously closed the `Handler` in `LiquibaseCommandLine`. This is actually unnecessary as the Java log framework will handle closing it at the appropriate time. Additionally, Liquibase was closing the handler too early, which caused an exception to be thrown by the logging framework itself: `java.lang.IllegalStateException: Current state = FLUSHED, new state = CODING`
- Not all implementations of resource will support appending to existing files. Implementations which do not support appending will throw an exception if the file already exists and append is set to true.

## Things to worry about