### PR TITLE
Adds ChangeExecListener properties to maven plugin (DAT-12219)

### DIFF
--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
@@ -3,6 +3,8 @@ package org.liquibase.maven.plugins;
 import liquibase.GlobalConfiguration;
 import liquibase.Liquibase;
 import liquibase.Scope;
+import liquibase.changelog.visitor.ChangeExecListener;
+import liquibase.changelog.visitor.DefaultChangeExecListener;
 import liquibase.configuration.LiquibaseConfiguration;
 import liquibase.configuration.core.DefaultsFileValueProvider;
 import liquibase.database.Database;
@@ -10,6 +12,7 @@ import liquibase.exception.DatabaseException;
 import liquibase.exception.LiquibaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.integration.IntegrationDetails;
+import liquibase.integration.commandline.ChangeExecListenerUtils;
 import liquibase.integration.commandline.CommandLineUtils;
 import liquibase.integration.commandline.LiquibaseCommandLineConfiguration;
 import liquibase.resource.DirectoryResourceAccessor;
@@ -576,7 +579,24 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
     @PropertyElement
     protected String sqlcmdCatalogName;
 
+    /**
+     * Specifies the fully qualified class name of the custom ChangeExecListener
+     *
+     * @parameter property="liquibase.changeExecListenerClass"
+     */
+    @PropertyElement
+    protected String changeExecListenerClass;
+
+    /**
+     * Specifies the property file for controlling the custom ChangeExecListener
+     *
+     * @parameter property="liquibase.changeExecListenerPropertiesFile"
+     */
+    @PropertyElement
+    protected String changeExecListenerPropertiesFile;
+
     protected String commandName;
+    protected DefaultChangeExecListener defaultChangeExecListener;
 
     /**
      * Get the specified license key. This first checks liquibaseLicenseKey and if no key is found, then returns
@@ -714,6 +734,12 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
                             liquibase = createLiquibase(database);
 
                             configureChangeLogProperties();
+
+                            ChangeExecListener listener = ChangeExecListenerUtils.getChangeExecListener(
+                                    liquibase.getDatabase(), liquibase.getResourceAccessor(),
+                                    changeExecListenerClass, changeExecListenerPropertiesFile);
+                            defaultChangeExecListener = new DefaultChangeExecListener(listener);
+                            liquibase.setChangeExecListener(defaultChangeExecListener);
 
                             getLog().debug("expressionVars = " + String.valueOf(expressionVars));
 

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseUpdate.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseUpdate.java
@@ -3,13 +3,16 @@ package org.liquibase.maven.plugins;
 import liquibase.Contexts;
 import liquibase.LabelExpression;
 import liquibase.Liquibase;
+import liquibase.changelog.visitor.DefaultChangeExecListener;
+import liquibase.command.CommandScope;
 import liquibase.exception.LiquibaseException;
+import liquibase.integration.commandline.ChangeExecListenerUtils;
 import org.liquibase.maven.property.PropertyElement;
 
 /**
  * <p>Applies the DatabaseChangeLogs to the database. Useful as part of the build
  * process.</p>
- * 
+ *
  * @author Peter Murray
  * @description Liquibase Update Maven plugin
  * @goal update
@@ -18,28 +21,49 @@ public class LiquibaseUpdate extends AbstractLiquibaseUpdateMojo {
 
     /**
      * Whether or not to perform a drop on the database before executing the change.
+     *
      * @parameter property="liquibase.dropFirst" default-value="false"
      */
     @PropertyElement
     protected boolean dropFirst;
 
-  @Override
-  protected void doUpdate(Liquibase liquibase) throws LiquibaseException {
-      if (dropFirst) {
-        liquibase.dropAll();
-      }
+    /**
+     * If set to true and any changeset in a deployment fails, then the update operation stops, and liquibase attempts to rollback all changesets just deployed. A changeset marked "fail-on-error=false" does not trigger as an error, therefore rollback-on-error will not occur. Additionally, if a changeset is not auto-rollback compliant or does not have a rollback script, then no rollback-on-error will occur for any changeset.
+     *
+     * @parameter property="liquibase.rollbackOnError" default-value="false"
+     */
+    @PropertyElement
+    protected boolean rollbackOnError;
 
-    if (changesToApply > 0) {
-      liquibase.update(changesToApply, new Contexts(contexts), new LabelExpression(getLabelFilter()));
-    } else {
-      liquibase.update(toTag, new Contexts(contexts), new LabelExpression(getLabelFilter()));
+    @Override
+    protected void doUpdate(Liquibase liquibase) throws LiquibaseException {
+        if (dropFirst) {
+            liquibase.dropAll();
+        }
+        try {
+            if (changesToApply > 0) {
+                liquibase.update(changesToApply, new Contexts(contexts), new LabelExpression(getLabelFilter()));
+            } else {
+                liquibase.update(toTag, new Contexts(contexts), new LabelExpression(getLabelFilter()));
+            }
+        } catch (LiquibaseException exception) {
+            if (rollbackOnError) {
+                CommandScope liquibaseCommand = new CommandScope("internalRollbackOnError");
+                liquibaseCommand.addArgumentValue("database", liquibase.getDatabase());
+                liquibaseCommand.addArgumentValue("exception", exception);
+                liquibaseCommand.addArgumentValue("listener", defaultChangeExecListener);
+                liquibaseCommand.addArgumentValue("rollbackOnError", rollbackOnError);
+                liquibaseCommand.execute();
+            } else {
+                throw exception;
+            }
+        }
     }
-  }
+
 
     @Override
     protected void printSettings(String indent) {
         super.printSettings(indent);
         getLog().info(indent + "drop first? " + dropFirst);
-
     }
 }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description
Adds change exec listener and rollback on error property elements. Sets up change exec listener for mojos. Handles migration errors on updates.

## Things to be aware of
N/A

## Things to worry about
N/A

## Additional Context
N/A
