### PR TITLE
Better integrate CommandScope arguments into overall ValueProvider logic

### DIFF
--- a/liquibase-core/src/main/java/liquibase/command/CommandScope.java
+++ b/liquibase-core/src/main/java/liquibase/command/CommandScope.java
@@ -10,6 +10,7 @@ import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.*;
+import java.util.regex.Pattern;
 
 /**
  * The primary facade used for executing commands.
@@ -21,10 +22,10 @@ import java.util.*;
  */
 public class CommandScope {
 
+    public static final Pattern NO_PREFIX_PATTERN = Pattern.compile(".*\\.");
     private final CommandDefinition commandDefinition;
 
     private final SortedMap<String, Object> argumentValues = new TreeMap<>();
-    private final CommandScopeValueProvider commandScopeValueProvider = new CommandScopeValueProvider();
 
     /**
      * Config key including the command name. Example `liquibase.command.update`
@@ -98,7 +99,7 @@ public class CommandScope {
      */
     public <T> ConfiguredValue<T> getConfiguredValue(CommandArgumentDefinition<T> argument) {
         ConfigurationDefinition<T> configDef = createConfigurationDefinition(argument, true);
-        ConfiguredValue<T> providedValue = configDef.getCurrentConfiguredValue();
+        ConfiguredValue<T> providedValue = configDef.getCurrentConfiguredValue(new CommandScopeValueProvider());
 
         if (!providedValue.found() || providedValue.wasDefaultValueUsed()) {
             ConfigurationDefinition<T> noCommandConfigDef = createConfigurationDefinition(argument, false);
@@ -108,8 +109,6 @@ public class CommandScope {
                 providedValue = noCommandNameProvidedValue;
             }
         }
-
-        providedValue.override(commandScopeValueProvider.getProvidedValue(configDef.getKey(), argument.getName()));
 
         return providedValue;
     }
@@ -232,6 +231,9 @@ public class CommandScope {
         }
     }
 
+    /**
+     * Adapts the command-scoped arguments into the overall ValueProvider system
+     */
     private class CommandScopeValueProvider extends AbstractMapConfigurationValueProvider {
 
         @Override
@@ -247,6 +249,20 @@ public class CommandScope {
         @Override
         protected String getSourceDescription() {
             return "Command argument";
+        }
+
+        @Override
+        public ProvidedValue getProvidedValue(String... keyAndAliases) {
+            return super.getProvidedValue(keyAndAliases);
+        }
+
+        @Override
+        protected boolean keyMatches(String wantedKey, String storedKey) {
+            if (wantedKey.contains(".")) {
+                return super.keyMatches(NO_PREFIX_PATTERN.matcher(wantedKey).replaceFirst(""), storedKey);
+            } else {
+                return super.keyMatches(wantedKey, storedKey);
+            }
         }
     }
 }

--- a/liquibase-core/src/main/java/liquibase/configuration/ConfigurationDefinition.java
+++ b/liquibase-core/src/main/java/liquibase/configuration/ConfigurationDefinition.java
@@ -54,7 +54,7 @@ public class ConfigurationDefinition<DataType> implements Comparable<Configurati
     }
 
     /**
-     * Convenience method around {@link #getCurrentConfiguredValue()} to return the value.
+     * Convenience method around {@link #getCurrentConfiguredValue(ConfigurationValueProvider...)} to return the value.
      */
     public DataType getCurrentValue() {
         final Object value = getCurrentConfiguredValue().getProvidedValue().getValue();
@@ -70,7 +70,7 @@ public class ConfigurationDefinition<DataType> implements Comparable<Configurati
     }
 
     /**
-     * Convenience method around {@link #getCurrentConfiguredValue()} to return the obfuscated version of the value.
+     * Convenience method around {@link #getCurrentConfiguredValue(ConfigurationValueProvider...)} to return the obfuscated version of the value.
      *
      * @return the obfuscated value, or the plain-text value if no obfuscator is defined for this definition.
      */
@@ -81,15 +81,17 @@ public class ConfigurationDefinition<DataType> implements Comparable<Configurati
     /**
      * @return Full details on the current value for this definition.
      * Will always return a {@link ConfiguredValue},
+     *
+     * @param additionalValueProviders additional {@link ConfigurationValueProvider}s to use with higher priority than the ones registered in {@link LiquibaseConfiguration}. The higher the array index, the higher the priority.
      */
-    public ConfiguredValue<DataType> getCurrentConfiguredValue() {
+    public ConfiguredValue<DataType> getCurrentConfiguredValue(ConfigurationValueProvider... additionalValueProviders) {
         final LiquibaseConfiguration liquibaseConfiguration = Scope.getCurrentScope().getSingleton(LiquibaseConfiguration.class);
 
         List<String> keyList = new ArrayList<>();
         keyList.add(this.getKey());
         keyList.addAll(this.getAliasKeys());
 
-        ConfiguredValue<?> configurationValue = liquibaseConfiguration.getCurrentConfiguredValue(valueConverter, valueObfuscator, keyList.toArray(new String[0]));
+        ConfiguredValue<?> configurationValue = liquibaseConfiguration.getCurrentConfiguredValue(valueConverter, valueObfuscator, additionalValueProviders, keyList.toArray(new String[0]));
 
         if (!configurationValue.found()) {
             defaultValue = this.getDefaultValue();

--- a/liquibase-core/src/main/java/liquibase/configuration/ConfiguredValue.java
+++ b/liquibase-core/src/main/java/liquibase/configuration/ConfiguredValue.java
@@ -79,6 +79,15 @@ public class ConfiguredValue<DataType> {
     }
 
     /**
+     * Modifies the current configured value. If a new provider is overriding the old value, use {@link #override(ProvidedValue)}.
+     * This is for changing the value outside the "provider" infrastructure.
+     */
+    public void override(Object newValue, String sourceDescription) {
+        ProvidedValue thisValue = this.getProvidedValue();
+        this.providedValues.add(0, new ProvidedValue(thisValue.getRequestedKey(), thisValue.getActualKey(), newValue, sourceDescription, thisValue.getProvider()));
+    }
+
+    /**
      * @return a full list of where the configuration value was set and/or overridden.
      */
     public List<ProvidedValue> getProvidedValues() {

--- a/liquibase-core/src/test/java/liquibase/command/core/MockCommandStep.java
+++ b/liquibase-core/src/test/java/liquibase/command/core/MockCommandStep.java
@@ -1,7 +1,6 @@
 package liquibase.command.core;
 
-import liquibase.command.AbstractCommandStep;
-import liquibase.command.CommandResultsBuilder;
+import liquibase.command.*;
 
 /**
  * A command step for use in unit tests
@@ -10,9 +9,18 @@ public class MockCommandStep extends AbstractCommandStep {
 
     public static MockCommandStep logic;
 
-    /**
-     * Resets any internal state, including removing defined arguments or defintions
-     */
+    public static final CommandArgumentDefinition<String> VALUE_1_ARG;
+
+    static {
+        CommandBuilder builder = new CommandBuilder(new String[]{"mock"});
+
+        VALUE_1_ARG = builder.argument("value1", String.class)
+                .description("Value 1").build();
+    }
+
+        /**
+         * Resets any internal state, including removing defined arguments or defintions
+         */
     public static void reset() {
         logic = null;
     }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Settings from CommandScope would override values from other ValueProviders, but it did it outside the normal pipeline so things like ValueModifier wasn't correctly applied.

This modifies the `ConfigurationDefinition.getCurrentConfiguredValue()` to be able to use non-global ValueProviders such as CommandScopeValueProvider and fixes CommandScope to use that.

It also adds a new ConfiguredValue.override() function for modifications of configured values that aren't coming from new providers, such as from ConfiguredValueModifier

## Things to be aware of

- Preserves exiting API while adding new methods

## Things to worry about

- Nothing

## Additional Context

Nothing
