### PR TITLE
readd noarg method for CommandScope arguments for backwards compatibility

### DIFF
--- a/liquibase-core/src/main/java/liquibase/configuration/ConfigurationDefinition.java
+++ b/liquibase-core/src/main/java/liquibase/configuration/ConfigurationDefinition.java
@@ -81,6 +81,14 @@ public class ConfigurationDefinition<DataType> implements Comparable<Configurati
     /**
      * @return Full details on the current value for this definition.
      * Will always return a {@link ConfiguredValue},
+     */
+    public ConfiguredValue<DataType> getCurrentConfiguredValue() {
+        return getCurrentConfiguredValue(new ConfigurationValueProvider[]{});
+    }
+
+    /**
+     * @return Full details on the current value for this definition.
+     * Will always return a {@link ConfiguredValue},
      *
      * @param additionalValueProviders additional {@link ConfigurationValueProvider}s to use with higher priority than the ones registered in {@link LiquibaseConfiguration}. The higher the array index, the higher the priority.
      */


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Readds the noarg method that was removed in #3448.

## Things to be aware of

This shouldn't technically be necessary, but we're readding it anyway to try to maintain some semblance of backwards compatibility.

## Things to worry about


## Additional Context


