### PR TITLE
make BufferedLogService thread safe

### DIFF
--- a/liquibase-core/src/main/java/liquibase/logging/core/BufferedLogService.java
+++ b/liquibase-core/src/main/java/liquibase/logging/core/BufferedLogService.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.logging.Level;
@@ -16,7 +17,7 @@ public class BufferedLogService extends AbstractLogService {
     // Truncate the return value at 10MB = 10,000,000 bytes
     //
     public static final int MAX_LOG_LENGTH = 10000000;
-    private List<BufferedLogMessage> log = new ArrayList<>();
+    private final List<BufferedLogMessage> log = Collections.synchronizedList(new ArrayList<>());
 
 
     @Override


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Makes the underlying log store for the `BufferedLogService` thread safe.

## Things to be aware of

We occasionally get errors like:

```
java.util.ConcurrentModificationException
	at java.base/java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1043)
	at java.base/java.util.ArrayList$Itr.next(ArrayList.java:997)
	at liquibase.logging.core.BufferedLogService.getLogAsString(BufferedLogService.java:39)
	at ...
```

in the pro integration tests, this should resolve them.

## Things to worry about

Performance impacts from the synchronized list? This is unlikely because Liquibase is not a terribly thread-heavy application.

## Additional Context


