### PR TITLE
Fix incorrect error message when rollback is not supported for for json,yml and ,xml changelogs

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
@@ -831,7 +831,7 @@ public class ChangeSet implements Conditional, ChangeLogChild {
                 List<Change> changes = getChanges();
                 for (int i = changes.size() - 1; i >= 0; i--) {
                     Change change = changes.get(i);
-                    if (change instanceof RawSQLChange) {
+                    if (change instanceof RawSQLChange && this.getFilePath().toLowerCase().endsWith(".sql")) {
                         throw new RollbackFailedException("Liquibase does not support automatic rollback generation for raw " +
                             "sql changes (did you mean to specify keyword \"empty\" to ignore rolling back this change?)");
                     }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Incorrect response for json,yml,xml changelogs when rollback is not supported for for json,yml and ,xml changelogs. 

The response "Liquibase does not support automatic rollback generation for raw sql changes (did you mean to specify keyword "empty" to ignore rolling back this change?)" is only for sql changelogs, but is showing for all of them. This fix narrows it to sql files.

## Things to be aware of

- Used the same logic that FormattedSqlChangeLogParser.supportsExtension applies to find out if it supports the changelog file.
- Fixes #3469 

## Things to worry about

- None

## Additional Context


