### PR TITLE
Feature to allow checksum upgrade to support either new normalized filepaths or legacy stored file paths

### DIFF
--- a/liquibase-core/src/main/java/liquibase/GlobalConfiguration.java
+++ b/liquibase-core/src/main/java/liquibase/GlobalConfiguration.java
@@ -33,6 +33,7 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
     public static final ConfigurationDefinition<Boolean> SHOW_BANNER;
 
     public static final ConfigurationDefinition<DuplicateFileMode> DUPLICATE_FILE_MODE;
+    public static final ConfigurationDefinition<Boolean> STORE_NORMALIZED_FILE_NAME_IN_DATABASECHANGELOG_TABLE;
 
     /**
      * @deprecated No longer used
@@ -209,6 +210,11 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
 
         SEARCH_PATH = builder.define("searchPath", String.class)
                 .setDescription("Complete list of Location(s) to search for files such as changelog files in. Multiple paths can be specified by separating them with commas.")
+                .build();
+
+        STORE_NORMALIZED_FILE_NAME_IN_DATABASECHANGELOG_TABLE = builder.define("storeNormalizedFileNameInDatabaseChangelogTable", Boolean.class)
+                .setDescription("Should liquibase save a normalized File Name in the Database ChangeLog Table. Use to select between pre3.x and 4.x behaviour. Default true.")
+                .setDefaultValue(true)
                 .build();
     }
 

--- a/liquibase-core/src/main/java/liquibase/changelog/AbstractChangeLogHistoryService.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/AbstractChangeLogHistoryService.java
@@ -72,6 +72,8 @@ public abstract class AbstractChangeLogHistoryService implements ChangeLogHistor
                         Scope.getCurrentScope().getLog(getClass()).fine(
                                 "Updating null or out of date checksum on changeSet " + changeSet + " to correct value"
                         );
+                        // to allow switching between saving normalized or configured path
+                        changeSet.setStoredFilePath(ranChangeSet.getStoredChangeLog());
                         replaceChecksum(changeSet);
                     }
                 }

--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeLogIterator.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeLogIterator.java
@@ -41,6 +41,8 @@ public class ChangeLogIterator {
 	        for (ChangeSet changeSet : changeSetsForRanChangeSet) {
                 if (changeSet != null) {
                     changeSet.setFilePath(DatabaseChangeLog.normalizePath(ranChangeSet.getChangeLog()));
+                    // to allow switching between saving normalized or configured path
+                    changeSet.setStoredFilePath(ranChangeSet.getStoredChangeLog());
                     changeSets.add(changeSet);
                 }
 	        }

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/UpdateChangeSetChecksumGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/UpdateChangeSetChecksumGenerator.java
@@ -13,6 +13,7 @@ import liquibase.statement.SqlStatement;
 import liquibase.statement.core.UpdateChangeSetChecksumStatement;
 import liquibase.statement.core.UpdateStatement;
 import liquibase.structure.core.Column;
+import liquibase.util.StringUtil;
 
 public class UpdateChangeSetChecksumGenerator extends AbstractSqlGenerator<UpdateChangeSetChecksumStatement> {
     @Override
@@ -45,7 +46,8 @@ public class UpdateChangeSetChecksumGenerator extends AbstractSqlGenerator<Updat
 
     private String getFilePathToUseInWhereClause(ChangeSet changeSet) {
         String changeSetFilePath = changeSet.getFilePath();
-        if (!GlobalConfiguration.STORE_NORMALIZED_FILE_NAME_IN_DATABASECHANGELOG_TABLE.getCurrentValue()) {
+        if (!GlobalConfiguration.STORE_NORMALIZED_FILE_NAME_IN_DATABASECHANGELOG_TABLE.getCurrentValue()
+                && StringUtil.isNotEmpty(changeSet.getStoredFilePath())) {
             changeSetFilePath = changeSet.getStoredFilePath();
         }
         return changeSetFilePath;

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/UpdateChangeSetChecksumGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/UpdateChangeSetChecksumGenerator.java
@@ -1,5 +1,6 @@
 package liquibase.sqlgenerator.core;
 
+import liquibase.GlobalConfiguration;
 import liquibase.changelog.ChangeSet;
 import liquibase.changelog.column.LiquibaseColumn;
 import liquibase.database.Database;
@@ -34,11 +35,19 @@ public class UpdateChangeSetChecksumGenerator extends AbstractSqlGenerator<Updat
                     .setWhereClause(database.escapeObjectName("ID", LiquibaseColumn.class) + " = ? " +
                             "AND " + database.escapeObjectName("AUTHOR", LiquibaseColumn.class) + " = ? " +
                             "AND " + database.escapeObjectName("FILENAME", LiquibaseColumn.class) + " = ?")
-                    .addWhereParameters(changeSet.getId(), changeSet.getAuthor(), changeSet.getFilePath());
+                    .addWhereParameters(changeSet.getId(), changeSet.getAuthor(), getFilePathToUseInWhereClause(changeSet));
 
             return SqlGeneratorFactory.getInstance().generateSql(runStatement, database);
         } finally {
             database.setObjectQuotingStrategy(currentStrategy);
         }
+    }
+
+    private String getFilePathToUseInWhereClause(ChangeSet changeSet) {
+        String changeSetFilePath = changeSet.getFilePath();
+        if (!GlobalConfiguration.STORE_NORMALIZED_FILE_NAME_IN_DATABASECHANGELOG_TABLE.getCurrentValue()) {
+            changeSetFilePath = changeSet.getStoredFilePath();
+        }
+        return changeSetFilePath;
     }
 }

--- a/liquibase-core/src/test/java/liquibase/sqlgenerator/core/UpdateChangeSetChecksumGeneratorTest.java
+++ b/liquibase-core/src/test/java/liquibase/sqlgenerator/core/UpdateChangeSetChecksumGeneratorTest.java
@@ -1,0 +1,115 @@
+package liquibase.sqlgenerator.core;
+
+import liquibase.change.CheckSum;
+import liquibase.changelog.ChangeSet;
+import liquibase.database.Database;
+import liquibase.sqlgenerator.SqlGeneratorFactory;
+import liquibase.statement.SqlStatement;
+import liquibase.statement.core.UpdateChangeSetChecksumStatement;
+import liquibase.statement.core.UpdateStatement;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UpdateChangeSetChecksumGeneratorTest {
+
+    public static final String SOME_UPDATED_CHECK_SUM = "SomeUpdatedCheckSum";
+    public static final String CHANGESET_SOME_ID = "SomeId";
+    public static final String CHANGESET_SOME_AUTHOR = "SomeAuthor";
+    public static final String CHANGESET_NORMALIZED_FILE_PATH = "SomeNormalizedFilePath";
+    public static final String CHANGESET_STORED_FILE_PATH = "SomeStoredFilePath";
+    public static final String ENVKEY_USE_NORMALIZED_FILENAME = "liquibase.storeNormalizedFileNameInDatabaseChangelogTable";
+
+    UpdateChangeSetChecksumGenerator sqlGenerator = new UpdateChangeSetChecksumGenerator();
+
+    @Mock
+    Database mockedDatabase;
+
+    @Mock
+    ChangeSet mockedChangeSet;
+
+    @Mock
+    CheckSum mockedUpdatedCheckSum;
+
+    @Mock
+    SqlGeneratorFactory sqlGeneratorFactory;
+
+    @Before
+    public void setUp() throws Exception {
+        doReturn("SomeCatalogName").when(mockedDatabase).getLiquibaseCatalogName();
+        doReturn("SomeSchemaName").when(mockedDatabase).getLiquibaseSchemaName();
+        doReturn("SomeChangeLogTableName").when(mockedDatabase).getDatabaseChangeLogTableName();
+        doReturn(SOME_UPDATED_CHECK_SUM).when(mockedUpdatedCheckSum).toString();
+        doReturn(mockedUpdatedCheckSum).when(mockedChangeSet).generateCheckSum();
+        doReturn(CHANGESET_SOME_ID).when(mockedChangeSet).getId();
+        doReturn(CHANGESET_SOME_AUTHOR).when(mockedChangeSet).getAuthor();
+        doReturn(CHANGESET_NORMALIZED_FILE_PATH).when(mockedChangeSet).getFilePath();
+        doReturn(CHANGESET_STORED_FILE_PATH).when(mockedChangeSet).getStoredFilePath();
+        doAnswer((invocation) -> invocation.getArgument(0)).when(mockedDatabase).escapeObjectName(anyString(),any());
+    }
+
+    @Test
+    public void generateSqlUsesChangesetsNormalizedFilePathByDefault() {
+        List<String> expectedWhereParams = Arrays.asList(CHANGESET_SOME_ID, CHANGESET_SOME_AUTHOR, CHANGESET_NORMALIZED_FILE_PATH);
+        verifyWhereParamsListInTheGeneratedStatement(expectedWhereParams, null);
+    }
+
+    @Test
+    public void generateSqlUsesChangesetsNormalizedFilePathWhenUseNormalizedFilePathFlagIsTrue() {
+        List<String> expectedWhereParams = Arrays.asList(CHANGESET_SOME_ID, CHANGESET_SOME_AUTHOR, CHANGESET_NORMALIZED_FILE_PATH);
+        verifyWhereParamsListInTheGeneratedStatement(expectedWhereParams, Boolean.TRUE);
+    }
+
+    @Test
+    public void generateSqlUsesChangesetsStoredFilePathWhenUseNormalizedFilePathFlagIsFalse() {
+        List<String> expectedWhereParams = Arrays.asList(CHANGESET_SOME_ID, CHANGESET_SOME_AUTHOR, CHANGESET_STORED_FILE_PATH);
+        verifyWhereParamsListInTheGeneratedStatement(expectedWhereParams, Boolean.FALSE);
+    }
+
+
+    private void verifyWhereParamsListInTheGeneratedStatement(List<String> expectedWhereParams, Boolean useNormalizedEnvVar) {
+
+        String originalVal = System.getProperty(ENVKEY_USE_NORMALIZED_FILENAME);
+        initializeSystemPropertyTo(useNormalizedEnvVar ==null? null: String.valueOf(useNormalizedEnvVar));
+
+        try (MockedStatic<SqlGeneratorFactory> staticSqlGeneratorFactory = mockStatic(SqlGeneratorFactory.class)) {
+
+            staticSqlGeneratorFactory.when(SqlGeneratorFactory::getInstance).thenReturn(sqlGeneratorFactory);
+            UpdateChangeSetChecksumStatement statement = new UpdateChangeSetChecksumStatement(mockedChangeSet);
+            sqlGenerator.generateSql(statement, mockedDatabase, null);
+            ArgumentCaptor<SqlStatement> statementCaptor = ArgumentCaptor.forClass(SqlStatement.class);
+            verify(sqlGeneratorFactory,times(1))
+                    .generateSql(
+                            statementCaptor.capture(), eq(mockedDatabase));
+            SqlStatement suppliedSqlStatement = statementCaptor.getValue();
+            assertTrue("Expect the supplied Statement to be a UpdateStatmeent Instance",
+                    UpdateStatement.class.isInstance(suppliedSqlStatement));
+            UpdateStatement suppliedUpdateStmt = (UpdateStatement) suppliedSqlStatement;
+            List<Object> suppliedParams = suppliedUpdateStmt.getWhereParameters();
+            assertEquals(expectedWhereParams, suppliedParams);
+
+        } finally {
+            initializeSystemPropertyTo(originalVal);
+        }
+    }
+
+    private void initializeSystemPropertyTo(String originalVal) {
+        System.clearProperty(ENVKEY_USE_NORMALIZED_FILENAME);
+        if (originalVal != null) {
+            System.setProperty(ENVKEY_USE_NORMALIZED_FILENAME, originalVal);
+        }
+    }
+
+}

--- a/liquibase-core/src/test/java/liquibase/sqlgenerator/core/UpdateChangeSetChecksumGeneratorTest.java
+++ b/liquibase-core/src/test/java/liquibase/sqlgenerator/core/UpdateChangeSetChecksumGeneratorTest.java
@@ -78,6 +78,19 @@ public class UpdateChangeSetChecksumGeneratorTest {
         verifyWhereParamsListInTheGeneratedStatement(expectedWhereParams, Boolean.FALSE);
     }
 
+    @Test
+    public void generateSqlUsesChangesetsNormalizedFilePathWhenUseNormalizedFilePathFlagIsFalseAndChangeSetStoredFilePathIsNull() {
+        List<String> expectedWhereParams = Arrays.asList(CHANGESET_SOME_ID, CHANGESET_SOME_AUTHOR, CHANGESET_NORMALIZED_FILE_PATH);
+        doReturn(null).when(mockedChangeSet).getStoredFilePath();
+        verifyWhereParamsListInTheGeneratedStatement(expectedWhereParams, Boolean.FALSE);
+    }
+
+    @Test
+    public void generateSqlUsesChangesetsNormalizedFilePathWhenUseNormalizedFilePathFlagIsFalseAndChangeSetStoredFilePathIsEmpty() {
+        List<String> expectedWhereParams = Arrays.asList(CHANGESET_SOME_ID, CHANGESET_SOME_AUTHOR, CHANGESET_NORMALIZED_FILE_PATH);
+        doReturn("").when(mockedChangeSet).getStoredFilePath();
+        verifyWhereParamsListInTheGeneratedStatement(expectedWhereParams, Boolean.FALSE);
+    }
 
     private void verifyWhereParamsListInTheGeneratedStatement(List<String> expectedWhereParams, Boolean useNormalizedEnvVar) {
 
@@ -85,9 +98,9 @@ public class UpdateChangeSetChecksumGeneratorTest {
         initializeSystemPropertyTo(useNormalizedEnvVar ==null? null: String.valueOf(useNormalizedEnvVar));
 
         try (MockedStatic<SqlGeneratorFactory> staticSqlGeneratorFactory = mockStatic(SqlGeneratorFactory.class)) {
-
             staticSqlGeneratorFactory.when(SqlGeneratorFactory::getInstance).thenReturn(sqlGeneratorFactory);
             UpdateChangeSetChecksumStatement statement = new UpdateChangeSetChecksumStatement(mockedChangeSet);
+
             sqlGenerator.generateSql(statement, mockedDatabase, null);
             ArgumentCaptor<SqlStatement> statementCaptor = ArgumentCaptor.forClass(SqlStatement.class);
             verify(sqlGeneratorFactory,times(1))


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes expected existing functionality)
- [x ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description
When attempting to upgrade checksums in the databasechangelog table, Liquibase generates an `UPDATE` statement whose `WHERE` clause uses the normalized file path. This will cause `RanChangeSets` that used the older non-normalized paths, for eg with a `classpath:<some/file/path>`, in them to ignore the update and the checksum is never saved.

- Change being submitted
  - Adding a new `GlobalConfiguration` definition flag `liquibase.storeNormalizedFileNameInDatabaseChangelogTable`
  - Default value is `True`
  - Configuring this to `False` will allow fallback to the older Update Checksum behaviour but keep the new normalized file check everywhere else
  - Added tests to verify this behaviour
  - Added a fix to recent upstream code changes that cause the generated changesets to forget the stored filepaths


- Steps to Reproduce
  - Create a project that uses Liquibase 3.x (for eg. 3.5.3)
  - Configure the changelog file location using a classpath: specification
  - Verify the checksum generated in the databasechangelog table contains the file name with classpath: in it
  - Verify that the MD5Sum column begins with 7 and not 8 as in the latest versions
  - Now update the project to use latest liquibase versions
  - Rerun the project and the Checksum will not be updated
  - Debug logging will indicate 0 records updated
  - This happens since the where clause uses the normalized file specification which doesnt have classpath: in it.

## Things to be aware of

- The changes in the upstream classes `ChangeLogIterator` and `AbstractChangeLogHistoryService`  can be avoided with a simple change in `DatabaseChangeLog.getChangeSets(RanChangeSets ...)` but the functionality is not clear to me so left unchanged there. 
- Since this is an extra field that is being updated in the `ChangeSet` other functionality that is not using it should be unaffected 
  
## Things to worry about

- No tests for the `ChangeLogIterator` and `AbstractChangeLogHistoryService` 


