### PR TITLE
match databases with numbers (like H2) in test filter

### DIFF
--- a/liquibase-extension-testing/src/main/java/liquibase/extension/testing/TestFilter.java
+++ b/liquibase-extension-testing/src/main/java/liquibase/extension/testing/TestFilter.java
@@ -77,7 +77,7 @@ public class TestFilter {
         }
         // This is the start of a string that comes from Intellij Idea if you copy the test definition from the run window.
         if (input.startsWith("java:test://")) {
-            Pattern p = Pattern.compile("(db:)(?<db>[a-z]*),(command:)(?<command>[a-zA-Z]*)} (?<def>.*)");
+            Pattern p = Pattern.compile("(db:)(?<db>[a-zA-Z0-9]*),(command:)(?<command>[a-zA-Z]*)} (?<def>.*)");
             Matcher matcher = p.matcher(input);
             if (!matcher.find()) {
                 Assert.fail("Cannot parse " + desc);


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

The test filtering logic needed to be expanded to match against databases that have numerics in their name, like H2.

## Things to be aware of


## Things to worry about

None - this is a test only change.

## Additional Context


