### PR TITLE
Restore FileSystemResourceAccessor and add tests.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/resource/FileSystemResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/FileSystemResourceAccessor.java
@@ -1,0 +1,63 @@
+package liquibase.resource;
+
+import liquibase.Scope;
+import liquibase.exception.UnexpectedLiquibaseException;
+import liquibase.util.CollectionUtil;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.nio.file.Path;
+
+/**
+ * A @{link ResourceAccessor} implementation for files on the file system.
+ * Will look for files in zip and jar files if they are added as root paths.
+ *
+ * @deprecated Use {@link DirectoryResourceAccessor} or {@link ZipResourceAccessor}
+ */
+@Deprecated
+public class FileSystemResourceAccessor extends CompositeResourceAccessor {
+
+    /**
+     * Creates a FileSystemResourceAccessor with the given directories/files as the roots.
+     */
+    public FileSystemResourceAccessor(File... baseDirsAndFiles) {
+        for (File base : CollectionUtil.createIfNull(baseDirsAndFiles)) {
+            addRootPath(base);
+        }
+    }
+
+    /**
+     * @deprecated use {@link FileSystemResourceAccessor#FileSystemResourceAccessor(File...)}
+     */
+    public FileSystemResourceAccessor(String file) {
+        this(new File(file));
+
+    }
+
+    protected void addRootPath(Path path) {
+        if (path == null) {
+            return;
+        }
+        addRootPath(path.toFile());
+    }
+
+    protected void addRootPath(File base) {
+        if (base == null) {
+            return;
+        }
+
+        try {
+            if (!base.exists()) {
+                Scope.getCurrentScope().getLog(getClass()).warning("Non-existent path: " + base.getAbsolutePath());
+            } else if (base.isDirectory()) {
+                addResourceAccessor(new DirectoryResourceAccessor(base));
+            } else if (base.getName().endsWith(".jar") || base.getName().toLowerCase().endsWith("zip")) {
+                addResourceAccessor(new ZipResourceAccessor(base));
+            } else {
+                throw new IllegalArgumentException(base.getAbsolutePath() + " must be a directory, jar or zip");
+            }
+        } catch (FileNotFoundException e) {
+            throw new UnexpectedLiquibaseException(e);
+        }
+    }
+}

--- a/liquibase-core/src/test/groovy/liquibase/resource/FileSystemResourceAccessorTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/resource/FileSystemResourceAccessorTest.groovy
@@ -1,0 +1,123 @@
+package liquibase.resource
+
+import liquibase.util.StreamUtil
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * @deprecated Remove this test when removing {@link liquibase.resource.FileSystemResourceAccessor}
+ */
+@Deprecated
+class FileSystemResourceAccessorTest extends Specification {
+
+    FileSystemResourceAccessor simpleTestAccessor
+
+    def setup() {
+        def testClasspathRoot = new File(this.getClass().getClassLoader().getResource("liquibase/resource/FileSystemResourceAccessorTest.class").toURI())
+                .getParentFile()
+                .getParentFile()
+                .getParentFile()
+        simpleTestAccessor = new FileSystemResourceAccessor(testClasspathRoot);
+
+    }
+
+    @Unroll
+    def "openStreams and openStream"() {
+        when:
+        def accessor = new FileSystemResourceAccessor("src/main" as File)
+
+        def streams = accessor.openStreams(relativeTo, path)
+        def stream = accessor.openStream(relativeTo, path)
+
+        then:
+        streams.size() == 1
+        StreamUtil.readStreamAsString(streams.iterator().next()).contains(expected)
+        StreamUtil.readStreamAsString(stream).contains(expected)
+
+        where:
+        relativeTo                      | path                            | expected
+        null                            | "java/liquibase/Liquibase.java" | "class Liquibase"
+        "java/liquibase/Liquibase.java" | "Scope.java"                    | "class Scope"
+        "java/liquibase/Liquibase.java" | "util/StringUtil.java"          | "class StringUtil"
+    }
+
+    @Unroll
+    def "list non-recursive"() {
+        when:
+        def accessor = new FileSystemResourceAccessor("src/main" as File)
+
+        def results = accessor.list(relativeTo, path, false, true, false)
+
+        then:
+        results.contains("java/liquibase/AbstractExtensibleObject.java")
+        !results.contains("java/liquibase/util/StringUtil.java")
+
+        where:
+        relativeTo      | path
+        null            | "java/liquibase"
+        "java/file.txt" | "liquibase"
+    }
+
+    @Unroll("#featureName: #path")
+    def "getAll"() {
+        expect:
+        simpleTestAccessor.getAll(path)*.getPath() == expected
+
+        where:
+        path                                                           | expected
+        "liquibase/resource/FileSystemResourceAccessorTest.class"       | ["liquibase/resource/FileSystemResourceAccessorTest.class"]
+        "/liquibase/resource/FileSystemResourceAccessorTest.class"      | ["liquibase/resource/FileSystemResourceAccessorTest.class"]
+        "liquibase\\resource\\FileSystemResourceAccessorTest.class"     | ["liquibase/resource/FileSystemResourceAccessorTest.class"]
+        "\\liquibase\\resource\\FileSystemResourceAccessorTest.class"   | ["liquibase/resource/FileSystemResourceAccessorTest.class"]
+        "com/example/file with space.txt"                              | ["com/example/file with space.txt"]
+        "com\\example\\file with space.txt"                            | ["com/example/file with space.txt"]
+        "com/example/file with space.txt"                              | ["com/example/file with space.txt"]
+        "c:\\liquibase\\resource\\FileSystemResourceAccessorTest.class" | ["liquibase/resource/FileSystemResourceAccessorTest.class"]
+    }
+
+    def "getAll returns empty if nothing matches"() {
+        expect:
+        simpleTestAccessor.getAll("com/example/invalid.txt").size() == 0
+    }
+
+    @Unroll
+    def "search fails with invalid values: #path"() {
+        when:
+        simpleTestAccessor.search(path, true)
+
+        then:
+        def e = thrown(Exception)
+        e.message == expected
+
+        where:
+        path                                                     | expected
+        null                                                     | "Path must not be null"
+        "liquibase/resource/FileSystemResourceAccessorTest.class" | "'liquibase/resource/FileSystemResourceAccessorTest.class' is a file, not a directory"
+    }
+
+    @Unroll
+    def "list"() {
+        expect:
+        simpleTestAccessor.search(path, recursive)*.getPath() as SortedSet == expected as SortedSet
+
+        where:
+        path          | recursive | expected
+        "com/example" | false     | ["com/example/changelog.xml", "com/example/file with space.txt", "com/example/my-logic.sql", "com/example/users.csv"]
+        "com/example" | true      | ["com/example/changelog.xml",
+                                     "com/example/directory/file-in-directory.txt",
+                                     "com/example/everywhere/file-everywhere.txt",
+                                     "com/example/everywhere/other-file-everywhere.txt",
+                                     "com/example/file with space.txt",
+                                     "com/example/liquibase/change/ColumnConfig.class",
+                                     "com/example/liquibase/change/ComputedConfig.class",
+                                     "com/example/liquibase/change/CreateTableExampleChange.class",
+                                     "com/example/liquibase/change/DefaultConstraintConfig.class",
+                                     "com/example/liquibase/change/IdentityConfig.class",
+                                     "com/example/liquibase/change/KeyColumnConfig.class",
+                                     "com/example/liquibase/change/PrimaryKeyConfig.class",
+                                     "com/example/liquibase/change/UniqueConstraintConfig.class",
+                                     "com/example/my-logic.sql",
+                                     "com/example/users.csv"]
+    }
+
+}


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description
The class liquibase.resource.FileSystemResourceAccessor is absent from the 4.17.0 release, but it was still present in 4.16.0  and was dropped without deprecation. This PR restores the class as deprecated and add tests.

- Fixes #3478 