### PR TITLE
Fixes behaviour of includeAll by keeping the trailing slash on the path

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -652,10 +652,10 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                             .replace("\\", "/");
                 }
 
+                path = path.replace("\\", "/");
                 if (StringUtil.isNotEmpty(path) && !(path.endsWith("/"))) {
                     path = path + '/';
                 }
-                path = path.replace("\\", "/");
                 LOG.fine("includeAll for " + pathName);
                 LOG.fine("Using file opener for includeAll: " + resourceAccessor.toString());
 

--- a/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -635,11 +635,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
             if (pathName == null) {
                 throw new SetupException("No path attribute for includeAll");
             }
-            pathName = pathName.replace('\\', '/');
 
-            if (StringUtil.isNotEmpty(pathName) && !(pathName.endsWith("/"))) {
-                pathName = pathName + '/';
-            }
             String relativeTo = null;
             if (isRelativeToChangelogFile) {
                 relativeTo = this.getPhysicalFilePath();
@@ -656,6 +652,9 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                             .replace("\\", "/");
                 }
 
+                if (StringUtil.isNotEmpty(path) && !(path.endsWith("/"))) {
+                    path = path + '/';
+                }
                 path = path.replace("\\", "/");
                 LOG.fine("includeAll for " + pathName);
                 LOG.fine("Using file opener for includeAll: " + resourceAccessor.toString());

--- a/liquibase-core/src/test/groovy/liquibase/changelog/DatabaseChangeLogTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/changelog/DatabaseChangeLogTest.groovy
@@ -370,7 +370,7 @@ create view sql_view as select * from sql_table;'''
         changeLogFile.includeAll("", true, { r -> r != changeLogFile.physicalFilePath}, true, changeLogFile.getStandardChangeLogComparator(), resourceAccessor, new ContextExpression(), new Labels(), false)
 
         then:
-        resourceAccessor.callingPath == "com/example/children"
+        resourceAccessor.callingPath == "com/example/children/"
     }
 
     @Unroll("#featureName: #changeSets")


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

PR #3355 aimed to fix issues related to "./" and "../" , but by using Paths.get it is also removing trailing slashs. The changed method has logic to append the trailing slash, but it is located above the new code - so it baceme useless. This PR moves the code that fixes the path to be executed after Paths.get.

## Things to be aware of

- Fixes includeAll on S3 extension.
- Tests restored as they were before #3355 

## Things to worry about

- None

## Additional Context

- Issue raised by S3 extension tests.
