### PR TITLE
Added call to modifyChangeSet during execute method to allow the changeSet to be correctly set on the executor DAT-12388

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
@@ -584,6 +584,8 @@ public class ChangeSet implements Conditional, ChangeLogChild {
                 database.setAutoCommit(!runInTransaction);
             }
 
+            executor.modifyChangeSet(this);
+
             executor.comment("Changeset " + toString(false));
             if (StringUtil.trimToNull(getComments()) != null) {
                 String comments = getComments();


### PR DESCRIPTION
Added call to modifyChangeSet during execute method to allow thechangeSet to be correctly set on the executor