### PR TITLE
Avoid ClassCastException when loading LogService from Scope

### DIFF
--- a/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
+++ b/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
@@ -632,9 +632,11 @@ public class LiquibaseCommandLine {
     private void configureLogging(Level logLevel, String logFile) throws IOException {
         configuredLogLevel = logLevel;
 
-        final JavaLogService logService = (JavaLogService) Scope.getCurrentScope().get(Scope.Attr.logService, LogService.class);
+        final LogService logService = Scope.getCurrentScope().get(Scope.Attr.logService, LogService.class);
         java.util.logging.Logger liquibaseLogger = java.util.logging.Logger.getLogger("liquibase");
-        logService.setParent(liquibaseLogger);
+        if (logService instanceof JavaLogService) {
+            ((JavaLogService) logService).setParent(liquibaseLogger);
+        }
 
         System.setProperty("java.util.logging.SimpleFormatter.format", "[%1$tF %1$tT] %4$s [%2$s] %5$s%6$s%n");
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

This PR fixes a bug where a `ClassCastException` occurs when alternative logger implementations are on the classpath when the CLI is used. This was [previously fixed](https://github.com/liquibase/liquibase/blob/master/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java#L290-L293) on the older legacy `Main` class but the newer `LiquibaseCommandLine` still has the issue.

Motivation is to avoid issues like [this](https://github.com/mattbertolini/liquibase-slf4j/issues/16) from being created.

## Things to be aware of



## Things to worry about

None that I know of. This change is backwards compatible. 

## Additional Context


