### PR TITLE
Fixes md5 generation of SQLVisitors that was changed on 4.16.0

### DIFF
--- a/liquibase-core/src/main/java/liquibase/sql/visitor/AbstractSqlVisitor.java
+++ b/liquibase-core/src/main/java/liquibase/sql/visitor/AbstractSqlVisitor.java
@@ -76,7 +76,12 @@ public abstract class AbstractSqlVisitor implements SqlVisitor {
 
     @Override
     public CheckSum generateCheckSum() {
-        return CheckSum.compute(new StringChangeLogSerializer().serialize(this, false));
+        String stringToMd5 = new StringChangeLogSerializer().serialize(this, false);
+        if (this.getContextFilter() != null) {
+            stringToMd5 = stringToMd5.replace("contextFilter=\"" + this.getContextFilter().toString(),
+                    "contexts=\"" + this.getContextFilter().toString());
+        }
+        return CheckSum.compute(stringToMd5);
     }
 
     @Override


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

On Liquibase 4.16, PR #2971 introduced "contextFilter" replacement field. As it is used to generate the md5sum, the md5sums changed. 
This PR 'fixes' those fields names when calculating the md5 to keep compatibility with Liquibase < 4.16 . 

## Things to be aware of

- MD5Sums generated using Liquibase 4.16.0 -> 4.18.0 with changeset containing SqlVisitors using  "context", "contexts" 
or "contextFilter" are different from the other versions.

## Things to worry about

- None.

## Additional Context

- Reported on issue #3269, but it is not same problem.

