### PR TITLE
Correctly handle indexes with descending columns in snapshot DAT-11447

### DIFF
--- a/liquibase-core/src/main/java/liquibase/serializer/core/yaml/YamlSnapshotSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/yaml/YamlSnapshotSerializer.java
@@ -12,7 +12,6 @@ import liquibase.structure.DatabaseObject;
 import liquibase.structure.DatabaseObjectCollection;
 import liquibase.structure.DatabaseObjectComparator;
 import liquibase.structure.core.Column;
-import liquibase.util.BooleanUtil;
 import liquibase.util.ISODateFormat;
 import liquibase.util.StringUtil;
 import org.yaml.snakeyaml.nodes.Node;
@@ -54,7 +53,7 @@ public class YamlSnapshotSerializer extends YamlSerializer implements SnapshotSe
     @Override
     protected Object toMap(final LiquibaseSerializable object) {
         if (object instanceof DatabaseObject) {
-            if (object instanceof Column && ((Column) object).isBelongsToIndex()) {
+            if (object instanceof Column && ((Column) object).isForIndex()) {
                 //not really a "real" column that has a snapshot to reference, just serialize the ColumnObject
                 return super.toMap(object);
             } else if (alreadySerializingObject) {

--- a/liquibase-core/src/main/java/liquibase/serializer/core/yaml/YamlSnapshotSerializer.java
+++ b/liquibase-core/src/main/java/liquibase/serializer/core/yaml/YamlSnapshotSerializer.java
@@ -54,8 +54,8 @@ public class YamlSnapshotSerializer extends YamlSerializer implements SnapshotSe
     @Override
     protected Object toMap(final LiquibaseSerializable object) {
         if (object instanceof DatabaseObject) {
-            if (object instanceof Column && (BooleanUtil.isTrue(((Column) object).getDescending()) || BooleanUtil.isTrue(((Column) object).getComputed()))) {
-                //not really a "real" column that has a snapshot to reference, just serialize it
+            if (object instanceof Column && ((Column) object).isBelongsToIndex()) {
+                //not really a "real" column that has a snapshot to reference, just serialize the ColumnObject
                 return super.toMap(object);
             } else if (alreadySerializingObject) {
                 String snapshotId = ((DatabaseObject) object).getSnapshotId();

--- a/liquibase-core/src/main/java/liquibase/snapshot/DatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/DatabaseSnapshot.java
@@ -609,7 +609,7 @@ public abstract class DatabaseSnapshot implements LiquibaseSerializable {
                     } else if ((value instanceof Collection) && !((Collection) value).isEmpty() && allObjects
                             .containsKey(((Collection) value).iterator().next())) {
                         List<DatabaseObject> newList = new ArrayList<DatabaseObject>();
-                        for (String element : (Collection<String>) value) {
+                        for (Object element : (Collection<Object>)value) {
                             newList.add(allObjects.get(element));
                         }
                         if (ObjectUtil.hasProperty(object, attr)) {

--- a/liquibase-core/src/main/java/liquibase/structure/core/Column.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/Column.java
@@ -21,6 +21,7 @@ public class Column extends AbstractDatabaseObject {
     private String name;
     private Boolean computed;
     private Boolean descending;
+    private boolean belongsToIndex;
 
     public Column() {
     }
@@ -58,6 +59,14 @@ public class Column extends AbstractDatabaseObject {
         }
 
         setRemarks(columnConfig.getRemarks());
+    }
+
+    public boolean isBelongsToIndex() {
+        return belongsToIndex;
+    }
+
+    public void setBelongsToIndex(boolean belongsToIndex) {
+        this.belongsToIndex = belongsToIndex;
     }
 
     public Relation getRelation() {
@@ -466,6 +475,7 @@ public class Column extends AbstractDatabaseObject {
         if (BooleanUtil.isTrue(getDescending()) || BooleanUtil.isTrue(getComputed())) {
             fields.remove("relation");
         }
+        fields.remove("belongsToIndex");
         return fields;
     }
 }

--- a/liquibase-core/src/main/java/liquibase/structure/core/Column.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/Column.java
@@ -21,7 +21,7 @@ public class Column extends AbstractDatabaseObject {
     private String name;
     private Boolean computed;
     private Boolean descending;
-    private boolean belongsToIndex;
+    private boolean forIndex;
 
     public Column() {
     }
@@ -61,12 +61,12 @@ public class Column extends AbstractDatabaseObject {
         setRemarks(columnConfig.getRemarks());
     }
 
-    public boolean isBelongsToIndex() {
-        return belongsToIndex;
+    public boolean isForIndex() {
+        return forIndex;
     }
 
-    public void setBelongsToIndex(boolean belongsToIndex) {
-        this.belongsToIndex = belongsToIndex;
+    public void setForIndex(boolean forIndex) {
+        this.forIndex = forIndex;
     }
 
     public Relation getRelation() {
@@ -475,7 +475,7 @@ public class Column extends AbstractDatabaseObject {
         if (BooleanUtil.isTrue(getDescending()) || BooleanUtil.isTrue(getComputed())) {
             fields.remove("relation");
         }
-        fields.remove("belongsToIndex");
+        fields.remove("forIndex");
         return fields;
     }
 }

--- a/liquibase-core/src/main/java/liquibase/structure/core/Index.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/Index.java
@@ -1,5 +1,8 @@
 package liquibase.structure.core;
 
+import liquibase.parser.core.ParsedNode;
+import liquibase.parser.core.ParsedNodeException;
+import liquibase.resource.ResourceAccessor;
 import liquibase.structure.AbstractDatabaseObject;
 import liquibase.structure.DatabaseObject;
 import liquibase.util.StringUtil;
@@ -155,6 +158,25 @@ public class Index extends AbstractDatabaseObject {
 		return getAssociatedWith().contains(keyword);
 	}
 
+    @Override
+    public void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException {
+        super.load(parsedNode, resourceAccessor);
+        ParsedNode columns = parsedNode.getChild(null, "columns");
+        List<ParsedNode> nodes = columns.getChildren(null, "column");
+        for (int i=0; i < nodes.size(); i++) {
+            ParsedNode node = nodes.get(i);
+            Column column = new Column();
+            // column.load(node, resourceAccessor);
+            column.setName((String) node.getChildren(null, "name").get(0).getValue());
+            column.setDescending(node.getChildValue(null, "descending", Boolean.class));
+            column.setComputed(node.getChildValue(null, "computed", Boolean.class));
+            if (getColumns().get(i) == null) {
+                getColumns().set(i, column);
+            } else {
+                getColumns().add(column);
+            }
+        }
+    }
 
     public Boolean getClustered() {
         return getAttribute("clustered", Boolean.class);

--- a/liquibase-core/src/main/java/liquibase/structure/core/Index.java
+++ b/liquibase-core/src/main/java/liquibase/structure/core/Index.java
@@ -159,7 +159,7 @@ public class Index extends AbstractDatabaseObject {
         //
         // For columns within an Index, we now represent
         // all the columns as actual Column objects with
-        // the belongsToIndex flag set
+        // the forIndex flag set
         //
         if (field != null && field.equals("columns")) {
             List<Object> returnList = new ArrayList<>();
@@ -168,7 +168,7 @@ public class Index extends AbstractDatabaseObject {
                 c.setName(column.getName());
                 c.setDescending(column.getDescending());
                 c.setComputed(column.getComputed());
-                c.setBelongsToIndex(true);
+                c.setForIndex(true);
                 returnList.add(c);
             }
             return returnList;

--- a/liquibase-integration-tests/src/test/groovy/liquibase/snapshot/IndexWithDescendingColumnSnapshotTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/snapshot/IndexWithDescendingColumnSnapshotTest.groovy
@@ -1,0 +1,190 @@
+package liquibase.snapshot
+
+import liquibase.Scope
+import liquibase.change.core.CreateIndexChange
+import liquibase.changelog.ChangeLogParameters
+import liquibase.changelog.ChangeSet
+import liquibase.changelog.DatabaseChangeLog
+import liquibase.command.CommandScope
+import liquibase.command.core.GenerateChangelogCommandStep
+import liquibase.command.core.InternalDiffCommandStep
+import liquibase.command.core.SnapshotCommandStep
+import liquibase.database.Database
+import liquibase.database.DatabaseFactory
+import liquibase.database.jvm.JdbcConnection
+import liquibase.diff.DiffResult
+import liquibase.diff.compare.CompareControl
+import liquibase.extension.testing.testsystem.DatabaseTestSystem
+import liquibase.extension.testing.testsystem.TestSystemFactory
+import liquibase.parser.core.json.JsonChangeLogParser
+import liquibase.resource.ResourceAccessor
+import liquibase.resource.SearchPathResourceAccessor
+import liquibase.statement.SqlStatement
+import liquibase.statement.core.RawSqlStatement
+import liquibase.structure.DatabaseObject
+import liquibase.structure.core.Index
+import liquibase.util.StringUtil
+import org.junit.Rule
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class IndexWithDescendingColumnSnapshotTest extends Specification {
+    @Rule
+    public DatabaseTestSystem mssqlDb = Scope.currentScope.getSingleton(TestSystemFactory).getTestSystem("mssql")
+
+    @Unroll
+    def "Index with a descending column is snapshot correctly"() {
+        when:
+        def connection = mssqlDb.getConnection()
+        def db = DatabaseFactory.instance.findCorrectDatabaseImplementation(new JdbcConnection(connection))
+        db.execute([
+                new RawSqlStatement(
+                        "CREATE TABLE tbl_Preferences (fld_EmployeeID INTEGER NOT NULL, " +
+                                "fld_JobClass CHAR(4) NOT NULL, " +
+                                "fld_Mon VARCHAR(25) NULL, " +
+                                "fld_Tue VARCHAR(25) NULL, " +
+                                "fld_Wed VARCHAR(25) NULL, " +
+                                "fld_Thu VARCHAR(25) NULL, " +
+                                "fld_Fri VARCHAR(25) NULL, " +
+                                "fld_Sat VARCHAR(25) NULL, " +
+                                "fld_Sun VARCHAR(25) NULL)"
+                ),
+                new RawSqlStatement(
+                        "CREATE INDEX IX_temp_tbl_Preferences_Plain " +
+                                "ON tbl_Preferences(" +
+                                "fld_Fri," +
+                                "fld_Thu," +
+                                "fld_Wed DESC)"
+                )
+        ] as SqlStatement[], null)
+        String snapshotFile = StringUtil.randomIdentifer(10) + "-snapshot.json"
+        String changelogFile = StringUtil.randomIdentifer(10) + "-changelog.json"
+
+        //
+        // Take a snapshot
+        //
+        final CommandScope snapshotScope = new CommandScope("snapshot")
+        snapshotScope.addArgumentValue(SnapshotCommandStep.URL_ARG.getName(), mssqlDb.getConnectionUrl())
+        snapshotScope.addArgumentValue(SnapshotCommandStep.DATABASE_ARG.getName(), db)
+        snapshotScope.addArgumentValue(SnapshotCommandStep.SNAPSHOT_FORMAT_ARG.getName(), "json")
+        OutputStream outputStream = new FileOutputStream(snapshotFile)
+        snapshotScope.setOutput(outputStream)
+        def results = snapshotScope.execute()
+        DatabaseSnapshot snapshot = results.getResult("snapshot") as DatabaseSnapshot
+
+        //
+        // Generate a changelog
+        //
+        String offlineUrl = "offline:mssql?snapshot=" + snapshotFile
+        final CommandScope generateChangelogScope = new CommandScope("generateChangelog")
+        generateChangelogScope.addArgumentValue(GenerateChangelogCommandStep.URL_ARG.getName(), offlineUrl)
+        generateChangelogScope.addArgumentValue(GenerateChangelogCommandStep.CHANGELOG_FILE_ARG.getName(), changelogFile)
+        generateChangelogScope.execute()
+
+        //
+        // Execute diff
+        //
+        ResourceAccessor resourceAccessor = new SearchPathResourceAccessor(".")
+        final Database targetDatabase =
+           DatabaseFactory.instance.openDatabase(offlineUrl, null, null, null, resourceAccessor)
+        final CommandScope diffScope = new CommandScope("internalDiff")
+        diffScope.addArgumentValue(InternalDiffCommandStep.REFERENCE_DATABASE_ARG.getName(), db)
+        diffScope.addArgumentValue(InternalDiffCommandStep.TARGET_DATABASE_ARG.getName(), targetDatabase)
+        diffScope.addArgumentValue(InternalDiffCommandStep.COMPARE_CONTROL_ARG, new CompareControl())
+        diffScope.addArgumentValue(InternalDiffCommandStep.SNAPSHOT_TYPES_ARG.getName(), new Class[0])
+        def diffResults = diffScope.execute()
+
+        then:
+        noExceptionThrown()
+
+        snapshot != null
+        DatabaseObject index = snapshot.get(new Index("IX_temp_tbl_preferences_Plain"))
+        index != null
+        index.getColumns().size() == 3
+        index.getColumns().get(2).getName() == "fld_Wed"
+        index.getColumns().get(2).getDescending()
+        index.getColumns().get(1).getName() == "fld_Thu"
+        ! index.getColumns().get(1).getDescending()
+
+        diffResults != null
+        DiffResult diffResult = diffResults.getResult("diffResult") as DiffResult
+        diffResult.getMissingObjects().size() == 0
+        diffResult.getUnexpectedObjects().size() == 0
+        diffResult.getChangedObjects().size() == 0
+
+        cleanup:
+        db.execute([
+                new RawSqlStatement(
+                        "DROP INDEX IX_temp_tbl_Preferences_Plain ON tbl_Preferences"
+                ),
+                new RawSqlStatement(
+                        "DROP TABLE tbl_Preferences"
+                )
+        ] as SqlStatement[], null)
+        if (outputStream != null) {
+            outputStream.close()
+        }
+        File f = new File(snapshotFile)
+        if (f.exists()) {
+            f.delete()
+        }
+        f = new File(changelogFile)
+        if (f.exists()) {
+            f.delete()
+        }
+    }
+
+    @Unroll
+    def "Index with a descending column in older format is handled correctly"() {
+        when:
+
+        String snapshotFile = "oldSnapshotWithDescendingIndex.json"
+        final CommandScope snapshotScope = new CommandScope("snapshot")
+        String offlineUrl = "offline:mssql?snapshot=" + snapshotFile
+        snapshotScope.addArgumentValue(SnapshotCommandStep.URL_ARG.getName(), offlineUrl)
+        snapshotScope.addArgumentValue(SnapshotCommandStep.SNAPSHOT_FORMAT_ARG.getName(), "json")
+        OutputStream outputStream = new ByteArrayOutputStream()
+        snapshotScope.setOutput(outputStream)
+        def results = snapshotScope.execute()
+        DatabaseSnapshot snapshot = results.getResult("snapshot") as DatabaseSnapshot
+        DatabaseObject index = snapshot.get(new Index("IX_temp_tbl_preferences_Plain"))
+
+        //
+        // Generate a changelog
+        //
+        String changelogFile = StringUtil.randomIdentifer(10) + "-changelog.json"
+        final CommandScope generateChangelogScope = new CommandScope("generateChangelog")
+        generateChangelogScope.addArgumentValue(GenerateChangelogCommandStep.URL_ARG.getName(), offlineUrl)
+        generateChangelogScope.addArgumentValue(GenerateChangelogCommandStep.CHANGELOG_FILE_ARG.getName(), changelogFile)
+        generateChangelogScope.execute()
+
+        ResourceAccessor resourceAccessor = new SearchPathResourceAccessor(".")
+        DatabaseChangeLog changelog = new JsonChangeLogParser().parse(changelogFile, new ChangeLogParameters(), resourceAccessor)
+        def changeSets = changelog.getChangeSets()
+        ChangeSet indexChangeSet = changeSets.get(1)
+        CreateIndexChange createIndexChange = indexChangeSet.getChanges().get(0)
+
+        then:
+        noExceptionThrown()
+
+        snapshot != null
+        index != null
+        index.getColumns().size() == 3
+        index.getColumns().get(2).getName() == "fld_Wed"
+        index.getColumns().get(2).getDescending()
+        index.getColumns().get(1).getName() == "fld_Thu"
+        ! index.getColumns().get(1).getDescending()
+
+        changelog != null
+        indexChangeSet.getChanges().size() == 1
+        createIndexChange != null
+        createIndexChange.getColumns().size() == 3
+        createIndexChange.getColumns().get(2).getDescending()
+
+        cleanup:
+        File f = new File(changelogFile)
+        if (f.exists()) {
+            f.delete()
+        }
+    }
+}

--- a/liquibase-integration-tests/src/test/resources/oldSnapshotWithDescendingIndex.json
+++ b/liquibase-integration-tests/src/test/resources/oldSnapshotWithDescendingIndex.json
@@ -1,0 +1,293 @@
+{
+  "snapshot": {
+    "created": "2022-12-03T18:07:43.163",
+    "database": {
+      "productVersion": "15.00.4261",
+      "shortName": "mssql",
+      "majorVersion": "15",
+      "minorVersion": "0",
+      "user": "PROSCHEMA",
+      "productName": "Microsoft SQL Server",
+      "url": "jdbc:sqlserver://localhost:1433;connectRetryInterval=10;connectRetryCount=1;maxResultBuffer=-1;sendTemporalDataTypesAsStringForBulkCopy=true;delayLoadingLobs=true;useFmtOnly=false;msiTokenCacheTtl=3600;useBulkCopyForBatchInsert=false;cancelQueryTimeout=-1;sslProtocol=TLS;jaasConfigurationName=SQLJDBCDriver;statementPoolingCacheSize=0;serverPreparedStatementDiscardThreshold=10;enablePrepareOnFirstPreparedStatementCall=false;fips=false;socketTimeout=0;authentication=NotSpecified;authenticationScheme=nativeAuthentication;xopenStates=false;sendTimeAsDatetime=true;replication=false;trustStoreType=JKS;trustServerCertificate=false;TransparentNetworkIPResolution=true;iPAddressPreference=IPv4First;serverNameAsACE=false;sendStringParametersAsUnicode=true;selectMethod=direct;responseBuffering=adaptive;queryTimeout=-1;packetSize=8000;multiSubnetFailover=false;loginTimeout=30;lockTimeout=-1;lastUpdateCount=true;prepareMethod=prepexec;encrypt=false;disableStatementPooling=true;databaseName=Catalog_A_PROSCHEMA;columnEncryptionSetting=Disabled;applicationName=Microsoft JDBC Driver for SQL Server;applicationIntent=readwrite;"
+    },
+    "objects": {
+      "liquibase.structure.core.Catalog": [
+        {
+          "catalog": {
+            "default": true,
+            "name": "Catalog_A_PROSCHEMA",
+            "snapshotId": "6a5c100"
+          }
+        }
+      ]
+      ,
+      "liquibase.structure.core.Column": [
+        {
+          "column": {
+            "computed": false,
+            "name": "fld_EmployeeID",
+            "nullable": false,
+            "order": "1!{java.lang.Integer}",
+            "relation": "liquibase.structure.core.Table#6a5c102",
+            "snapshotId": "6a5c107",
+            "type": {
+              "columnSize": "10!{java.lang.Integer}",
+              "columnSizeUnit": "BYTE!{liquibase.structure.core.DataType$ColumnSizeUnit}",
+              "dataTypeId": "4!{java.lang.Integer}",
+              "radix": "10!{java.lang.Integer}",
+              "typeName": "int"
+            }
+          }
+        },
+        {
+          "column": {
+            "computed": false,
+            "name": "fld_Fri",
+            "nullable": true,
+            "order": "7!{java.lang.Integer}",
+            "relation": "liquibase.structure.core.Table#6a5c102",
+            "snapshotId": "6a5c104",
+            "type": {
+              "columnSize": "25!{java.lang.Integer}",
+              "columnSizeUnit": "BYTE!{liquibase.structure.core.DataType$ColumnSizeUnit}",
+              "dataTypeId": "12!{java.lang.Integer}",
+              "radix": "10!{java.lang.Integer}",
+              "typeName": "varchar"
+            }
+          }
+        },
+        {
+          "column": {
+            "computed": false,
+            "name": "fld_JobClass",
+            "nullable": false,
+            "order": "2!{java.lang.Integer}",
+            "relation": "liquibase.structure.core.Table#6a5c102",
+            "snapshotId": "6a5c108",
+            "type": {
+              "columnSize": "4!{java.lang.Integer}",
+              "columnSizeUnit": "BYTE!{liquibase.structure.core.DataType$ColumnSizeUnit}",
+              "dataTypeId": "1!{java.lang.Integer}",
+              "radix": "10!{java.lang.Integer}",
+              "typeName": "char"
+            }
+          }
+        },
+        {
+          "column": {
+            "computed": false,
+            "name": "fld_Mon",
+            "nullable": true,
+            "order": "3!{java.lang.Integer}",
+            "relation": "liquibase.structure.core.Table#6a5c102",
+            "snapshotId": "6a5c109",
+            "type": {
+              "columnSize": "25!{java.lang.Integer}",
+              "columnSizeUnit": "BYTE!{liquibase.structure.core.DataType$ColumnSizeUnit}",
+              "dataTypeId": "12!{java.lang.Integer}",
+              "radix": "10!{java.lang.Integer}",
+              "typeName": "varchar"
+            }
+          }
+        },
+        {
+          "column": {
+            "computed": false,
+            "name": "fld_RowCounter",
+            "nullable": false,
+            "order": "10!{java.lang.Integer}",
+            "relation": "liquibase.structure.core.Table#6a5c102",
+            "snapshotId": "6a5c114",
+            "type": {
+              "columnSize": "10!{java.lang.Integer}",
+              "columnSizeUnit": "BYTE!{liquibase.structure.core.DataType$ColumnSizeUnit}",
+              "dataTypeId": "4!{java.lang.Integer}",
+              "radix": "10!{java.lang.Integer}",
+              "typeName": "int"
+            }
+          }
+        },
+        {
+          "column": {
+            "computed": false,
+            "name": "fld_Sat",
+            "nullable": true,
+            "order": "8!{java.lang.Integer}",
+            "relation": "liquibase.structure.core.Table#6a5c102",
+            "snapshotId": "6a5c112",
+            "type": {
+              "columnSize": "25!{java.lang.Integer}",
+              "columnSizeUnit": "BYTE!{liquibase.structure.core.DataType$ColumnSizeUnit}",
+              "dataTypeId": "12!{java.lang.Integer}",
+              "radix": "10!{java.lang.Integer}",
+              "typeName": "varchar"
+            }
+          }
+        },
+        {
+          "column": {
+            "computed": false,
+            "name": "fld_Sun",
+            "nullable": true,
+            "order": "9!{java.lang.Integer}",
+            "relation": "liquibase.structure.core.Table#6a5c102",
+            "snapshotId": "6a5c113",
+            "type": {
+              "columnSize": "25!{java.lang.Integer}",
+              "columnSizeUnit": "BYTE!{liquibase.structure.core.DataType$ColumnSizeUnit}",
+              "dataTypeId": "12!{java.lang.Integer}",
+              "radix": "10!{java.lang.Integer}",
+              "typeName": "varchar"
+            }
+          }
+        },
+        {
+          "column": {
+            "computed": false,
+            "name": "fld_Thu",
+            "nullable": true,
+            "order": "6!{java.lang.Integer}",
+            "relation": "liquibase.structure.core.Table#6a5c102",
+            "snapshotId": "6a5c105",
+            "type": {
+              "columnSize": "25!{java.lang.Integer}",
+              "columnSizeUnit": "BYTE!{liquibase.structure.core.DataType$ColumnSizeUnit}",
+              "dataTypeId": "12!{java.lang.Integer}",
+              "radix": "10!{java.lang.Integer}",
+              "typeName": "varchar"
+            }
+          }
+        },
+        {
+          "column": {
+            "computed": false,
+            "name": "fld_Tue",
+            "nullable": true,
+            "order": "4!{java.lang.Integer}",
+            "relation": "liquibase.structure.core.Table#6a5c102",
+            "snapshotId": "6a5c110",
+            "type": {
+              "columnSize": "25!{java.lang.Integer}",
+              "columnSizeUnit": "BYTE!{liquibase.structure.core.DataType$ColumnSizeUnit}",
+              "dataTypeId": "12!{java.lang.Integer}",
+              "radix": "10!{java.lang.Integer}",
+              "typeName": "varchar"
+            }
+          }
+        },
+        {
+          "column": {
+            "computed": false,
+            "name": "fld_Wed",
+            "nullable": true,
+            "order": "5!{java.lang.Integer}",
+            "relation": "liquibase.structure.core.Table#6a5c102",
+            "snapshotId": "6a5c111",
+            "type": {
+              "columnSize": "25!{java.lang.Integer}",
+              "columnSizeUnit": "BYTE!{liquibase.structure.core.DataType$ColumnSizeUnit}",
+              "dataTypeId": "12!{java.lang.Integer}",
+              "radix": "10!{java.lang.Integer}",
+              "typeName": "varchar"
+            }
+          }
+        },
+        {
+          "column": {
+            "descending": true,
+            "name": "fld_Wed",
+            "snapshotId": "6a5c106"
+          }
+        }
+      ]
+      ,
+      "liquibase.structure.core.Index": [
+        {
+          "index": {
+            "allowPageLocks": true,
+            "allowRowLocks": true,
+            "clustered": false,
+            "columns": [
+              "liquibase.structure.core.Column#6a5c104",
+              "liquibase.structure.core.Column#6a5c105",
+              {
+                "column": {
+                  "descending": true,
+                  "name": "fld_Wed",
+                  "snapshotId": "6a5c106"
+                }
+              }
+            ]
+            ,
+            "fillFactor": "0!{java.lang.Short}",
+            "ignoreDuplicateKeys": false,
+            "incrementalStatistics": false,
+            "name": "IX_temp_tbl_Preferences_Plain",
+            "padIndex": false,
+            "recomputeStatistics": true,
+            "snapshotId": "6a5c103",
+            "table": "liquibase.structure.core.Table#6a5c102",
+            "unique": false
+          }
+        }
+      ]
+      ,
+      "liquibase.structure.core.Schema": [
+        {
+          "schema": {
+            "catalog": "liquibase.structure.core.Catalog#6a5c100",
+            "default": true,
+            "name": "dbo",
+            "snapshotId": "6a5c101"
+          }
+        }
+      ]
+      ,
+      "liquibase.structure.core.Table": [
+        {
+          "table": {
+            "columns": [
+              "liquibase.structure.core.Column#6a5c107",
+              "liquibase.structure.core.Column#6a5c108",
+              "liquibase.structure.core.Column#6a5c109",
+              "liquibase.structure.core.Column#6a5c110",
+              "liquibase.structure.core.Column#6a5c111",
+              "liquibase.structure.core.Column#6a5c105",
+              "liquibase.structure.core.Column#6a5c104",
+              "liquibase.structure.core.Column#6a5c112",
+              "liquibase.structure.core.Column#6a5c113",
+              "liquibase.structure.core.Column#6a5c114"
+            ]
+            ,
+            "default_tablespace": false,
+            "indexes": [
+              "liquibase.structure.core.Index#6a5c103"
+            ]
+            ,
+            "name": "tbl_Preferences",
+            "schema": "liquibase.structure.core.Schema#6a5c101",
+            "snapshotId": "6a5c102"
+          }
+        }
+      ]
+      
+    },
+    "snapshotControl": {
+      "snapshotControl": {
+        "includedType": [
+          "liquibase.structure.core.Catalog",
+          "liquibase.structure.core.Column",
+          "liquibase.structure.core.ForeignKey",
+          "liquibase.structure.core.Index",
+          "liquibase.structure.core.PrimaryKey",
+          "liquibase.structure.core.Schema",
+          "liquibase.structure.core.Sequence",
+          "liquibase.structure.core.Table",
+          "liquibase.structure.core.UniqueConstraint",
+          "liquibase.structure.core.View"
+        ]
+        
+      }
+    }
+  }
+}


### PR DESCRIPTION
In the snapshot command, indexes with columns marked as descending were not getting serialized in a way that would allow a changelog to be successfully generated.  With this fix, columns are now explicitly serialized as objects, rather than as references to column objects.

