### PR TITLE
Do not lower case the ProvidedValue description if the string is capitalized, i.e. it starts with 2 upper-case characters DAT-12614

### DIFF
--- a/liquibase-core/src/main/java/liquibase/configuration/LiquibaseConfiguration.java
+++ b/liquibase-core/src/main/java/liquibase/configuration/LiquibaseConfiguration.java
@@ -159,6 +159,11 @@ public class LiquibaseConfiguration implements SingletonObject {
                         logMessage.append("Overrides ");
                     }
 
+                    //
+                    // Only lower case the first character is
+                    // the first two characters are NOT uppercase.  This allows provider
+                    // strings like 'AWS' to be displayed correctly, i.e. as 'AWS', not 'aWS'
+                    //
                     String describe = providedValue.describe();
                     char[] chars = describe.toCharArray();
                     if (chars.length >= 2 && Character.isUpperCase(chars[0]) && Character.isUpperCase(chars[1])) {

--- a/liquibase-core/src/main/java/liquibase/configuration/LiquibaseConfiguration.java
+++ b/liquibase-core/src/main/java/liquibase/configuration/LiquibaseConfiguration.java
@@ -158,7 +158,14 @@ public class LiquibaseConfiguration implements SingletonObject {
                     if (foundFirstValue) {
                         logMessage.append("Overrides ");
                     }
-                    logMessage.append(StringUtil.lowerCaseFirst(providedValue.describe()));
+
+                    String describe = providedValue.describe();
+                    char[] chars = describe.toCharArray();
+                    if (chars.length >= 2 && Character.isUpperCase(chars[0]) && Character.isUpperCase(chars[1])) {
+                        logMessage.append(describe);
+                    } else {
+                        logMessage.append(StringUtil.lowerCaseFirst(describe));
+                    }
                     Object value = providedValue.getValue();
                     if (value != null) {
                         String finalValue = String.valueOf(value);


### PR DESCRIPTION
Previously, the description that comes with the ProvidedValue was always converted before display to have it's first character be lower-case.  In cases where the description is upper-case (like AWS, for instance) this doesn't make sense. So, if we detect that the description starts with at least 2 upper-case characters, we display it as-is.