### PR TITLE
Update maven-bundle-plugin instructions to export package containing XSD files

### DIFF
--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -177,6 +177,10 @@
                             org.yaml.snakeyaml.*,
                             *;resolution:=optional
                         </Import-Package>
+                        <Export-Package>
+                            liquibase.*,
+                            www.liquibase.org.xml.ns.dbchangelog
+                        </Export-Package>
                         <Provide-Capability>
                           osgi.serviceloader; osgi.serviceloader=liquibase.serializer.ChangeLogSerializer,
                           osgi.serviceloader; osgi.serviceloader=liquibase.parser.NamespaceDetails,


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Currently XSD files can not be loaded from the liquibase-core.jar in an OSGI environment (using the `OSGiResourceAccessor`). The `LiquibaseEntityResolver` can not find the XSD resource. A workaround is to set secureParsing to false, so XSD can be looked up remotely.

The liquibase-core.jar contains two directories (packages). `liquibase` and `www.liquibase.org`. ONLY the `liquibase` package and it's sub-packages are being exported in the **MANIFEST.MF**. This means the XSD files, which are all under `www.liquibase.org.xml.ns.dbchangelog`, can not be accessed in an OSGI environment.

The reason why the XSD's are not exported in the MANIFEST.MF right now is because currently no _Export-Package_ tag is specified in the _maven-bundle-plugin_ instructions. This means the default behavior of the _maven-bundle-plugin_ is used:

> Export-Package> is now assumed to be the set of packages in your local Java sources, excluding the default package '.' and any packages containing 'impl' or 'internal'. (before version 2 of the bundleplugin it was based on the symbolic name)

See: https://felix.apache.org/documentation/subprojects/apache-felix-maven-bundle-plugin-bnd.html#_default_behavior

The XSD's have been moved to /src/main/recources, so they are not automatically included in the export.

I simply added an _Export-Package_ tag to the `maven-bundle-plugin` which includes all the packages under `liquibase` and the `www.liquibase.org.xml.ns.dbchangelog` package. This ensures that all packages are being exported in the MANIFEST.MF. 

With these in the OSGI headers, and using the`OSGiResourceAccessor`, XSD files could be found by `LiquibaseEntityResolver` again.

I think this fixes the issue #2817. 
Since the XSD files are a crucial part of Liquibase, I think this package should always be exported. This also allows OSGI environment to disable remote lookup, something we have been waiting for.
