### PR TITLE
Fix column capitalization for MS SQL Server metadata query

### DIFF
--- a/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -609,7 +609,7 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                         "WHEN 'varchar(max)' THEN " + java.sql.Types.VARCHAR + " " +
                         "WHEN 'xml' THEN " + java.sql.Types.LONGVARCHAR + " " +
                         "WHEN 'LONGNVARCHAR' THEN " + java.sql.Types.SQLXML + " " +
-                        "ELSE " + Types.OTHER + " END AS data_type, " +
+                        "ELSE " + Types.OTHER + " END AS DATA_TYPE, " +
                         "CASE WHEN c.is_nullable = 'true' THEN 1 ELSE 0 END AS NULLABLE, " +
                         "10 as NUM_PREC_RADIX, " +
                         "c.column_id as ORDINAL_POSITION, " +


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

The fixes the issue that was causing the `NullPointerException` in #3415 
The sql query used to look up metadata about a table was selecting `data_type`. Previously all of the column names were all being upper cased before using them, but a change was introduced to honor the databases case sensitivity. If an MS SQL Server instance is case sensitive the selected column was left as `data_type` (lower cased) but the Java code trying to use it was looking for it by String `DATA_TYPE`

## Things to be aware of

- Describe the technical choices you made
- Describe impacts on the codebase

## Things to worry about

- List any questions or concerns you have with the change
- List unknowns you have 

## Additional Context

Add any other context about the problem here.
