### PR TITLE
Issue 3619 - Allow control of recursion for includeAll via minDepth and maxDepth attributes

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeLogIncludeAll.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeLogIncludeAll.java
@@ -14,9 +14,13 @@ public class ChangeLogIncludeAll extends AbstractLiquibaseSerializable implement
     private String resourceFilter;
     private ContextExpression context;
 
+    private Integer minDepth;
+
+    private Integer maxDepth;
+
     @Override
     public Set<String> getSerializableFields() {
-        return new LinkedHashSet<>(Arrays.asList("path", "errorIfMissingOrEmpty", "relativeToChangelogFile", "resourceFilter", "context"));
+        return new LinkedHashSet<>(Arrays.asList("path", "errorIfMissingOrEmpty", "relativeToChangelogFile", "resourceFilter", "context", "minDepth", "maxDepth"));
     }
 
     @Override
@@ -68,4 +72,12 @@ public class ChangeLogIncludeAll extends AbstractLiquibaseSerializable implement
     public void setContext(ContextExpression context) {
         this.context = context;
     }
+
+    public Integer getMinDepth() { return minDepth; }
+
+    public void setMinDepth (Integer minDepth) { this.minDepth = minDepth; }
+
+    public Integer getMaxDepth() { return maxDepth; }
+
+    public void setMaxDepth (Integer maxDepth) { this.maxDepth = maxDepth; }
 }

--- a/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -494,6 +494,8 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                         includeContextFilter,
                         labels,
                         ignore,
+                        node.getChildValue(null, "minDepth", Integer.valueOf(1)),
+                        node.getChildValue(null, "maxDepth", Integer.MAX_VALUE),
                         (ModifyChangeSets)nodeScratch.get("modifyChangeSets"));
                 break;
             }
@@ -604,7 +606,9 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                 resourceAccessor,
                 includeContextFilter,
                 labels,
-                ignore);
+                ignore,
+                1,
+                Integer.MAX_VALUE);
     }
     public void includeAll(String pathName,
                            boolean isRelativeToChangelogFile,
@@ -614,10 +618,12 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                            ResourceAccessor resourceAccessor,
                            ContextExpression includeContextFilter,
                            Labels labels,
-                           boolean ignore)
+                           boolean ignore,
+                           Integer minDepth,
+                           Integer maxDepth)
             throws SetupException {
         includeAll(pathName, isRelativeToChangelogFile, resourceFilter, errorIfMissingOrEmpty, resourceComparator,
-                   resourceAccessor, includeContextFilter, labels, ignore, new ModifyChangeSets(null));
+                   resourceAccessor, includeContextFilter, labels, ignore, minDepth, maxDepth, new ModifyChangeSets(null));
     }
 
     public void includeAll(String pathName,
@@ -629,6 +635,8 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                            ContextExpression includeContextFilter,
                            Labels labels,
                            boolean ignore,
+                           Integer minDepth,
+                           Integer maxDepth,
                            ModifyChangeSets modifyChangeSets)
             throws SetupException {
         try {
@@ -659,8 +667,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                 LOG.fine("includeAll for " + pathName);
                 LOG.fine("Using file opener for includeAll: " + resourceAccessor.toString());
 
-                //TODO: JML update to have minDepth and maxDepth attributes
-                unsortedResources = resourceAccessor.search(path, 1, Integer.MAX_VALUE);
+                unsortedResources = resourceAccessor.search(path, minDepth, maxDepth);
             } catch (IOException e) {
                 if (errorIfMissingOrEmpty) {
                     throw e;

--- a/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -659,7 +659,8 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                 LOG.fine("includeAll for " + pathName);
                 LOG.fine("Using file opener for includeAll: " + resourceAccessor.toString());
 
-                unsortedResources = resourceAccessor.search(path, true);
+                //TODO: JML update to have minDepth and maxDepth attributes
+                unsortedResources = resourceAccessor.search(path, 1, Integer.MAX_VALUE);
             } catch (IOException e) {
                 if (errorIfMissingOrEmpty) {
                     throw e;

--- a/liquibase-core/src/main/java/liquibase/integration/spring/SpringResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/integration/spring/SpringResourceAccessor.java
@@ -48,6 +48,11 @@ public class SpringResourceAccessor extends AbstractResourceAccessor {
     }
 
     @Override
+    public List<liquibase.resource.Resource> search(String searchPath, Integer minDepth, Integer maxDepth) throws IOException {
+        throw new UnexpectedLiquibaseException("Method not implemented");
+    }
+
+    @Override
     public List<liquibase.resource.Resource> search(String searchPath, boolean recursive) throws IOException {
         if (recursive) {
             searchPath += "/**";

--- a/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/ClassLoaderResourceAccessor.java
@@ -1,7 +1,6 @@
 package liquibase.resource;
 
 import liquibase.Scope;
-import liquibase.exception.UnexpectedLiquibaseException;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;

--- a/liquibase-core/src/main/java/liquibase/resource/CompositeResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/CompositeResourceAccessor.java
@@ -45,6 +45,16 @@ public class CompositeResourceAccessor extends AbstractResourceAccessor {
     }
 
     @Override
+    public List<Resource> search(String path, Integer minDepth, Integer maxDepth) throws IOException {
+        LinkedHashSet<Resource> returnList = new LinkedHashSet<>();
+        for (ResourceAccessor accessor : resourceAccessors) {
+            returnList.addAll(CollectionUtil.createIfNull(accessor.search(path, minDepth, maxDepth)));
+        }
+
+        return new ArrayList<>(returnList);
+    }
+
+    @Override
     public List<Resource> search(String path, boolean recursive) throws IOException {
         LinkedHashSet<Resource> returnList = new LinkedHashSet<>();
         for (ResourceAccessor accessor : resourceAccessors) {

--- a/liquibase-core/src/main/java/liquibase/resource/PathHandlerFactory.java
+++ b/liquibase-core/src/main/java/liquibase/resource/PathHandlerFactory.java
@@ -116,6 +116,11 @@ public class PathHandlerFactory extends AbstractPluginFactory<PathHandler> {
         }
 
         @Override
+        public List<Resource> search(String path, Integer minDepth, Integer maxDepth) throws IOException {
+            throw new UnexpectedLiquibaseException("Method not implemented");
+        }
+
+        @Override
         public List<Resource> search(String path, boolean recursive) throws IOException {
             throw new UnexpectedLiquibaseException("Method not implemented");
         }

--- a/liquibase-core/src/main/java/liquibase/resource/ResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/resource/ResourceAccessor.java
@@ -129,6 +129,30 @@ public interface ResourceAccessor extends AutoCloseable {
      * </ul>
      *
      * @param path      The path to lookup resources in.
+     * @param minDepth  Minimum folder depth from path to start searching (default: 0)
+     * @param maxDepth  Maximum folder depth from path to stop searching (default: null)
+     * @return empty set if nothing was found
+     * @throws IOException if there is an error searching the system.
+     */
+    List<Resource> search(String path, Integer minDepth, Integer maxDepth) throws IOException;
+
+    /**
+     * Returns the path to all resources contained in the given path.
+     * Multiple resources may be returned with the same path, but only if they are actually unique files.
+     * Order is important to pay attention to, they should be returned in a user-expected manner based on this resource accessor.
+     * <br><br>
+     * Should return an empty list if:
+     * <ul>
+     *     <li>Path does not exist</li>
+     * </ul>
+     * Should throw an exception if:
+     * <ul>
+     *     <li>Path is null</li>
+     *     <li>Path is not a "directory"</li>
+     *     <li>Path exists but cannot be read from</li>
+     * </ul>
+     *
+     * @param path      The path to lookup resources in.
      * @param recursive Set to true and will return paths to contents in subdirectories as well.
      * @return empty set if nothing was found
      * @throws IOException if there is an error searching the system.

--- a/liquibase-core/src/main/java/liquibase/sdk/resource/MockResourceAccessor.java
+++ b/liquibase-core/src/main/java/liquibase/sdk/resource/MockResourceAccessor.java
@@ -1,5 +1,6 @@
 package liquibase.sdk.resource;
 
+import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.resource.AbstractResourceAccessor;
 import liquibase.resource.Resource;
 
@@ -36,6 +37,11 @@ public class MockResourceAccessor extends AbstractResourceAccessor {
             return null;
         }
         return returnSet;
+    }
+
+    @Override
+    public List<Resource> search(String path, Integer minDepth, Integer maxDepth) throws IOException {
+        throw new UnexpectedLiquibaseException("Method not implemented");
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/sdk/supplier/resource/ResourceSupplier.java
+++ b/liquibase-core/src/main/java/liquibase/sdk/supplier/resource/ResourceSupplier.java
@@ -53,6 +53,11 @@ public class ResourceSupplier {
         }
 
         @Override
+        public List<Resource> search(String path, Integer minDepth, Integer maxDepth) throws IOException {
+            return null;
+        }
+
+        @Override
         public List<Resource> search(String path, boolean recursive) throws IOException {
             return null;
         }

--- a/liquibase-core/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
+++ b/liquibase-core/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
@@ -108,6 +108,8 @@
             <xsd:attribute name="context" type="xsd:string"/>
             <xsd:attribute name="labels" type="xsd:string"/>
             <xsd:attribute name="contextFilter" type="xsd:string"/>
+            <xsd:attribute name="minDepth" type="xsd:positiveInteger" default="1"/>
+            <xsd:attribute name="maxDepth" type="xsd:positiveInteger" default="null"/>
             <xsd:anyAttribute namespace="##other" processContents="lax"/>
         </xsd:complexType>
     </xsd:element>


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Adds two new attributes to the changelog `includeAll` attribute: `minDepth` (inclusive, default `1`) and `maxDepth` (inclusive, default `Integer.MAX_VALUE`). These defaults allow `includeAll` to behave as it did before these provided changes.

For `minDepth`, `0` and `1` are treated the same way and denote the directory specified in the `includeAll`'s `path` attribute. Having a `minDepth` of 2 would skip any files specified in the `includeAll`'s `path` attribute and only start searching for files to include in immediate subdirectories of the `includeAll`'s `path` attribute.

For `maxDepth`, `1` is the minimum value. A value less than `minDepth` will result in no files being included. The `maxDepth` attribute is computed off of the `includeAll`'s `path` attribute, not based on the `minDepth` attribute.

Examples:

`minDepth`=`1`,`maxDepth`=`1`: Include all the files in the specified `path` attribute directory and do not look in any subdirectories (identical to recursive: false).

`minDepth`=`1`,`maxDepth`=`2`: Include all the files in the specified `path` attribute directory and look in immediate subdirectories and those subdirectories' immediate subdirectories.

... So on and so forth for maxDepth

`minDepth`=`2`,`maxDepth`=`null`: Do not include any files in the specified `path` attribute directory and look in all subdirectories for files.

## Things to be aware of

Not only did this require the change of the `includeAll` attribute, but also the `ResourceAccessor` interface.

As this change occurred on the base interface, all `ResourceAccessors` changed to support this model.

## Things to worry about

1. I've never worked with the Spring framework before. Because of this, I as unsure how/if I should handle the depth bounded search function for the `SpringResourceAccessor` class. For now, I created the method and just immediately throw an error saying it is not implemented. Not sure if this is acceptable or if this should be fully implemented.
2. I wasn't sure how/if I should implemented the depth bounded search function for the `MockResourceAccessor` class. For now, I created the method and just immediately throw an error saying it is not implemented. Not sure if this is acceptable or if this should be fully implemented.
3. I am unsure how to properly write tests for this when it is based on a filesystem configuration.
