### PR TITLE
Reworks DirectoryPathHandler to allow colons in file names. (DAT-12363)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/resource/DirectoryPathHandler.java
+++ b/liquibase-core/src/main/java/liquibase/resource/DirectoryPathHandler.java
@@ -20,7 +20,7 @@ public class DirectoryPathHandler extends AbstractPathHandler {
             return PRIORITY_DEFAULT;
         }
 
-        if (root.startsWith("file:") || root.matches("^[A-Za-z]:.*")) {
+        if (root.startsWith("file:") || root.matches("^[A-Za-z,:].*")) {
             return PRIORITY_DEFAULT;
         } else {
             return PRIORITY_NOT_APPLICABLE;

--- a/liquibase-core/src/main/java/liquibase/resource/DirectoryPathHandler.java
+++ b/liquibase-core/src/main/java/liquibase/resource/DirectoryPathHandler.java
@@ -20,6 +20,10 @@ public class DirectoryPathHandler extends AbstractPathHandler {
             return PRIORITY_DEFAULT;
         }
 
+        if (root.matches("^https?://.*")) {
+            return PRIORITY_NOT_APPLICABLE;
+        }
+
         if (root.startsWith("file:") || root.matches("^[A-Za-z,:].*")) {
             return PRIORITY_DEFAULT;
         } else {

--- a/liquibase-core/src/main/java/liquibase/resource/DirectoryPathHandler.java
+++ b/liquibase-core/src/main/java/liquibase/resource/DirectoryPathHandler.java
@@ -20,7 +20,11 @@ public class DirectoryPathHandler extends AbstractPathHandler {
             return PRIORITY_DEFAULT;
         }
 
-        if (root.matches("^https?://.*")) {
+        if (root.matches("^https?://.*")) { // Do not support http files
+            return PRIORITY_NOT_APPLICABLE;
+        }
+
+        if (root.matches("^proto:.*")) { // Do not support protobuf files
             return PRIORITY_NOT_APPLICABLE;
         }
 

--- a/liquibase-core/src/test/groovy/liquibase/resource/DirectoryPathHandlerTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/resource/DirectoryPathHandlerTest.groovy
@@ -29,6 +29,7 @@ class DirectoryPathHandlerTest extends Specification {
         "file:/tmp/liquibase.xml"       | PRIORITY_DEFAULT
         "file:///tmp/liquibase.xml"     | PRIORITY_DEFAULT
         "http://localhost"              | PRIORITY_NOT_APPLICABLE
+        "https://localhost"             | PRIORITY_NOT_APPLICABLE
         "some-path:including-colon.yml" | PRIORITY_DEFAULT
     }
 

--- a/liquibase-core/src/test/groovy/liquibase/resource/DirectoryPathHandlerTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/resource/DirectoryPathHandlerTest.groovy
@@ -17,18 +17,19 @@ class DirectoryPathHandlerTest extends Specification {
         new DirectoryPathHandler().getPriority(input) == expected
 
         where:
-        input                       | expected
-        null                        | PRIORITY_NOT_APPLICABLE
-        "simple"                    | PRIORITY_DEFAULT
-        "with/path"                 | PRIORITY_DEFAULT
-        "with\\path"                | PRIORITY_DEFAULT
-        "c:\\windows\\path"         | PRIORITY_DEFAULT
-        "c:/windows/path"           | PRIORITY_DEFAULT
-        "/c:/windows/path"          | PRIORITY_DEFAULT
-        "D:\\windows\\path"         | PRIORITY_DEFAULT
-        "file:/tmp/liquibase.xml"   | PRIORITY_DEFAULT
-        "file:///tmp/liquibase.xml" | PRIORITY_DEFAULT
-        "http://localhost"          | PRIORITY_NOT_APPLICABLE
+        input                           | expected
+        null                            | PRIORITY_NOT_APPLICABLE
+        "simple"                        | PRIORITY_DEFAULT
+        "with/path"                     | PRIORITY_DEFAULT
+        "with\\path"                    | PRIORITY_DEFAULT
+        "c:\\windows\\path"             | PRIORITY_DEFAULT
+        "c:/windows/path"               | PRIORITY_DEFAULT
+        "/c:/windows/path"              | PRIORITY_DEFAULT
+        "D:\\windows\\path"             | PRIORITY_DEFAULT
+        "file:/tmp/liquibase.xml"       | PRIORITY_DEFAULT
+        "file:///tmp/liquibase.xml"     | PRIORITY_DEFAULT
+        "http://localhost"              | PRIORITY_NOT_APPLICABLE
+        "some-path:including-colon.yml" | PRIORITY_DEFAULT
     }
 
     def "open reads existing file"() {


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description
Moves ":" into regex validating DirectoryPathHandler's priority. With this change, you are now able to generate changelogs with filenames such as `example:something-else.yml`. 

## Things to be aware of
Changes priorty check of DirectoryPathHandler.

## Things to worry about
Explicitly disallow files starting with `http://`, `https://` and `proto:` rather than just falling back on excluding `:`. Unsure if there is additional impact of this change. 

## Additional Context
N/A
