### PR TITLE
Consistent ARG-suffix for 'defaultSchemaName'-Parameter

### DIFF
--- a/liquibase-core/src/main/java/liquibase/command/core/UpdateCommandStep.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/UpdateCommandStep.java
@@ -11,7 +11,7 @@ public class UpdateCommandStep extends AbstractCliWrapperCommandStep {
 
     public static final CommandArgumentDefinition<String> CHANGELOG_FILE_ARG;
     public static final CommandArgumentDefinition<String> URL_ARG;
-    public static final CommandArgumentDefinition<String> DEFAULT_SCHEMA_NAME;
+    public static final CommandArgumentDefinition<String> DEFAULT_SCHEMA_NAME_ARG;
     public static final CommandArgumentDefinition<String> DEFAULT_CATALOG_NAME_ARG;
     public static final CommandArgumentDefinition<String> USERNAME_ARG;
     public static final CommandArgumentDefinition<String> PASSWORD_ARG;
@@ -27,7 +27,7 @@ public class UpdateCommandStep extends AbstractCliWrapperCommandStep {
 
         URL_ARG = builder.argument(CommonArgumentNames.URL, String.class).required()
             .description("The JDBC database connection URL").build();
-        DEFAULT_SCHEMA_NAME = builder.argument("defaultSchemaName", String.class)
+        DEFAULT_SCHEMA_NAME_ARG = builder.argument("defaultSchemaName", String.class)
                 .description("The default schema name to use for the database connection").build();
         DEFAULT_CATALOG_NAME_ARG = builder.argument("defaultCatalogName", String.class)
                 .description("The default catalog name to use for the database connection").build();

--- a/liquibase-core/src/main/java/liquibase/command/core/UpdateCommandStep.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/UpdateCommandStep.java
@@ -11,6 +11,7 @@ public class UpdateCommandStep extends AbstractCliWrapperCommandStep {
 
     public static final CommandArgumentDefinition<String> CHANGELOG_FILE_ARG;
     public static final CommandArgumentDefinition<String> URL_ARG;
+
     public static final CommandArgumentDefinition<String> DEFAULT_SCHEMA_NAME_ARG;
     public static final CommandArgumentDefinition<String> DEFAULT_CATALOG_NAME_ARG;
     public static final CommandArgumentDefinition<String> USERNAME_ARG;
@@ -21,6 +22,10 @@ public class UpdateCommandStep extends AbstractCliWrapperCommandStep {
     public static final CommandArgumentDefinition<String> CHANGE_EXEC_LISTENER_PROPERTIES_FILE_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_PROPERTIES_FILE_ARG;
+
+    /** Outdated field. Use {@link UpdateCommandStep#DEFAULT_SCHEMA_NAME_ARG} instead, which is of the same value. */
+    @Deprecated()
+    public static final CommandArgumentDefinition<String> DEFAULT_SCHEMA_NAME;
 
     static {
         CommandBuilder builder = new CommandBuilder(COMMAND_NAME, LEGACY_COMMAND_NAME);
@@ -52,6 +57,9 @@ public class UpdateCommandStep extends AbstractCliWrapperCommandStep {
                 .description("Fully-qualified class which specifies a ChangeExecListener").build();
         CHANGE_EXEC_LISTENER_PROPERTIES_FILE_ARG = builder.argument("changeExecListenerPropertiesFile", String.class)
                 .description("Path to a properties file for the ChangeExecListenerClass").build();
+
+        //remove the following line once the deprecated field in this class has been eliminated:
+        DEFAULT_SCHEMA_NAME = DEFAULT_SCHEMA_NAME_ARG;
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/command/core/UpdateTestingRollbackCommandStep.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/UpdateTestingRollbackCommandStep.java
@@ -10,7 +10,7 @@ public class UpdateTestingRollbackCommandStep extends AbstractCliWrapperCommandS
 
     public static final CommandArgumentDefinition<String> CHANGELOG_FILE_ARG;
     public static final CommandArgumentDefinition<String> URL_ARG;
-    public static final CommandArgumentDefinition<String> DEFAULT_SCHEMA_NAME;
+    public static final CommandArgumentDefinition<String> DEFAULT_SCHEMA_NAME_ARG;
     public static final CommandArgumentDefinition<String> DEFAULT_CATALOG_NAME_ARG;
     public static final CommandArgumentDefinition<String> USERNAME_ARG;
     public static final CommandArgumentDefinition<String> PASSWORD_ARG;
@@ -26,7 +26,7 @@ public class UpdateTestingRollbackCommandStep extends AbstractCliWrapperCommandS
 
         URL_ARG = builder.argument(CommonArgumentNames.URL, String.class).required()
                 .description("The JDBC database connection URL").build();
-        DEFAULT_SCHEMA_NAME = builder.argument("defaultSchemaName", String.class)
+        DEFAULT_SCHEMA_NAME_ARG = builder.argument("defaultSchemaName", String.class)
                 .description("The default schema name to use for the database connection").build();
         DEFAULT_CATALOG_NAME_ARG = builder.argument("defaultCatalogName", String.class)
                 .description("The default catalog name to use for the database connection").build();

--- a/liquibase-core/src/main/java/liquibase/command/core/UpdateTestingRollbackCommandStep.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/UpdateTestingRollbackCommandStep.java
@@ -21,6 +21,10 @@ public class UpdateTestingRollbackCommandStep extends AbstractCliWrapperCommandS
     public static final CommandArgumentDefinition<String> DRIVER_ARG;
     public static final CommandArgumentDefinition<String> DRIVER_PROPERTIES_FILE_ARG;
 
+    /** Outdated field. Use {@link UpdateTestingRollbackCommandStep#DEFAULT_SCHEMA_NAME_ARG} instead, which is of the same value. */
+    @Deprecated()
+    public static final CommandArgumentDefinition<String> DEFAULT_SCHEMA_NAME;
+
     static {
         CommandBuilder builder = new CommandBuilder(COMMAND_NAME);
 
@@ -51,6 +55,9 @@ public class UpdateTestingRollbackCommandStep extends AbstractCliWrapperCommandS
                 .description("Fully-qualified class which specifies a ChangeExecListener").build();
         CHANGE_EXEC_LISTENER_PROPERTIES_FILE_ARG = builder.argument("changeExecListenerPropertiesFile", String.class)
                 .description("Path to a properties file for the ChangeExecListenerClass").build();
+
+        //remove the following line once the deprecated field in this class has been eliminated:
+        DEFAULT_SCHEMA_NAME = DEFAULT_SCHEMA_NAME_ARG;
     }
 
     @Override


### PR DESCRIPTION
## Impact
Minimal, ensures consistent code in all CLI-Command classes.
 
## Description

All **but two** _CommandStep_-classes employ the following naming scheme for the  'defaultSchemaName'-Parameter:

`public static final CommandArgumentDefinition<String> DEFAULT_SCHEMA_NAME_ARG;`

Except two classes, which used:

`public static final CommandArgumentDefinition<String> DEFAULT_SCHEMA_NAME;`

This PR fixes this.

## Things to worry about

None 😉 

## Additional Context

I started to investigate what the root cause of #3587 could be and noticed this while code-reading 😉 
