### PR TITLE
normalize path of SQL changelog file when parsing (DAT-11891)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
@@ -351,7 +351,6 @@ public class FormattedSqlChangeLogParser implements ChangeLogParser {
 
                     changeSet =
                        new ChangeSet(changeSetId, changeSetAuthor, runAlways, runOnChange, DatabaseChangeLog.normalizePath(logicalFilePath), context, dbms, runWith, runInTransaction, changeLog.getObjectQuotingStrategy(), changeLog);
-                    changeSet.setStoredFilePath(logicalFilePath);
                     changeSet.setLabels(new Labels(labels));
                     changeSet.setIgnore(Boolean.parseBoolean(ignore));
                     changeSet.setFailOnError(failOnError);

--- a/liquibase-core/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
@@ -350,7 +350,8 @@ public class FormattedSqlChangeLogParser implements ChangeLogParser {
                         changeLogParameters.expandExpressions(StringUtil.stripEnclosingQuotes(authorGroup), changeLog);
 
                     changeSet =
-                       new ChangeSet(changeSetId, changeSetAuthor, runAlways, runOnChange, logicalFilePath, context, dbms, runWith, runInTransaction, changeLog.getObjectQuotingStrategy(), changeLog);
+                       new ChangeSet(changeSetId, changeSetAuthor, runAlways, runOnChange, DatabaseChangeLog.normalizePath(logicalFilePath), context, dbms, runWith, runInTransaction, changeLog.getObjectQuotingStrategy(), changeLog);
+                    changeSet.setStoredFilePath(logicalFilePath);
                     changeSet.setLabels(new Labels(labels));
                     changeSet.setIgnore(Boolean.parseBoolean(ignore));
                     changeSet.setFailOnError(failOnError);

--- a/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/command/CommandTests.groovy
+++ b/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/command/CommandTests.groovy
@@ -401,7 +401,14 @@ Long Description: ${commandDefinition.getLongDescription() ?: "NOT SET"}
                     assert !testDef.expectFileToNotExist.exists(): "File '${testDef.expectFileToNotExist.getAbsolutePath()}' should not exist"
                 }
                 if (testDef.expectations != null) {
-                    testDef.expectations.call()
+                    Scope.child([
+                            "database": database,
+                    ], new Scope.ScopedRunner() {
+                        @Override
+                        void run() throws Exception {
+                            testDef.expectations.call()
+                        }
+                    })
                 }
             } finally {
                 if (testDef.setup != null) {


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Normalize the path of a SQL changelog file when parsing it.

## Things to be aware of

Tests are added in the pro repo.

## Things to worry about

This has the potential to break some other process which expects the path to be un-normalized.

## Additional Context
