### PR TITLE
Fix MSSQL generated xml changelogs for view column comments (DAT-12835)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/SetColumnRemarksChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/SetColumnRemarksChange.java
@@ -18,7 +18,7 @@ public class SetColumnRemarksChange extends AbstractChange {
     private String columnName;
     private String remarks;
     private String columnDataType;
-    private ColumnParentType columnParentType;
+    private String columnParentType;
 
     @Override
     public ValidationErrors validate(Database database) {
@@ -31,7 +31,7 @@ public class SetColumnRemarksChange extends AbstractChange {
     @Override
     public SqlStatement[] generateStatements(Database database) {
         return new SqlStatement[]{
-                new SetColumnRemarksStatement(catalogName, schemaName, tableName, columnName, remarks, columnDataType, columnParentType)
+                new SetColumnRemarksStatement(catalogName, schemaName, tableName, columnName, remarks, columnDataType, ColumnParentType.valueOf(columnParentType.toUpperCase()))
         };
     }
 
@@ -93,11 +93,11 @@ public class SetColumnRemarksChange extends AbstractChange {
         this.columnDataType = columnDataType;
     }
 
-    public void setColumnParentType(ColumnParentType columnParentType) {
+    public void setColumnParentType(String columnParentType) {
         this.columnParentType = columnParentType;
     }
 
-    public ColumnParentType getColumnParentType() {
+    public String getColumnParentType() {
         return columnParentType;
     }
 }

--- a/liquibase-core/src/main/java/liquibase/change/core/SetColumnRemarksChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/SetColumnRemarksChange.java
@@ -7,11 +7,7 @@ import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.SetColumnRemarksStatement;
-import liquibase.util.ColumnOwnerType;
-
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
+import liquibase.util.ColumnParentType;
 
 @DatabaseChange(name = "setColumnRemarks", description = "Set remarks on a column", priority = ChangeMetaData.PRIORITY_DEFAULT)
 public class SetColumnRemarksChange extends AbstractChange {
@@ -22,7 +18,7 @@ public class SetColumnRemarksChange extends AbstractChange {
     private String columnName;
     private String remarks;
     private String columnDataType;
-    private ColumnOwnerType ownerType;
+    private ColumnParentType columnParentType;
 
     @Override
     public ValidationErrors validate(Database database) {
@@ -35,7 +31,7 @@ public class SetColumnRemarksChange extends AbstractChange {
     @Override
     public SqlStatement[] generateStatements(Database database) {
         return new SqlStatement[]{
-                new SetColumnRemarksStatement(catalogName, schemaName, tableName, columnName, remarks, columnDataType, ownerType)
+                new SetColumnRemarksStatement(catalogName, schemaName, tableName, columnName, remarks, columnDataType, columnParentType)
         };
     }
 
@@ -97,11 +93,11 @@ public class SetColumnRemarksChange extends AbstractChange {
         this.columnDataType = columnDataType;
     }
 
-    public void setOwnerType(ColumnOwnerType ownerType) {
-        this.ownerType = ownerType;
+    public void setColumnParentType(ColumnParentType columnParentType) {
+        this.columnParentType = columnParentType;
     }
 
-    public ColumnOwnerType getOwnerType() {
-        return ownerType;
+    public ColumnParentType getColumnParentType() {
+        return columnParentType;
     }
 }

--- a/liquibase-core/src/main/java/liquibase/change/core/SetColumnRemarksChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/SetColumnRemarksChange.java
@@ -101,8 +101,7 @@ public class SetColumnRemarksChange extends AbstractChange {
         this.ownerType = ownerType;
     }
 
-    @Override
-    public Set<String> getSerializableFields() {
-        return new HashSet<>(Arrays.asList("catalogName", "schemaName", "tableName", "columnName", "remarks", "columnDataType"));
+    public ColumnOwnerType getOwnerType() {
+        return ownerType;
     }
 }

--- a/liquibase-core/src/main/java/liquibase/change/core/SetColumnRemarksChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/SetColumnRemarksChange.java
@@ -31,7 +31,7 @@ public class SetColumnRemarksChange extends AbstractChange {
     @Override
     public SqlStatement[] generateStatements(Database database) {
         return new SqlStatement[]{
-                new SetColumnRemarksStatement(catalogName, schemaName, tableName, columnName, remarks, columnDataType, ColumnParentType.valueOf(columnParentType.toUpperCase()))
+                new SetColumnRemarksStatement(catalogName, schemaName, tableName, columnName, remarks, columnDataType, columnParentType)
         };
     }
 

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingViewChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingViewChangeGenerator.java
@@ -13,7 +13,7 @@ import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.Column;
 import liquibase.structure.core.Table;
 import liquibase.structure.core.View;
-import liquibase.util.ColumnOwnerType;
+import liquibase.util.ColumnParentType;
 import liquibase.util.StringUtil;
 
 import java.util.ArrayList;
@@ -102,7 +102,7 @@ public class MissingViewChangeGenerator extends AbstractChangeGenerator implemen
                             columnRemarks.setCatalogName(control.getIncludeCatalog() ? view.getSchema().getCatalogName() : null);
                             columnRemarks.setSchemaName(control.getIncludeSchema() ? view.getSchema().getName() : null);
                             columnRemarks.setTableName(column.getRelation().getName());
-                            columnRemarks.setOwnerType(ColumnOwnerType.VIEW);
+                            columnRemarks.setColumnParentType(ColumnParentType.VIEW);
                             columnRemarksList.add(columnRemarks);
                         }
                 );

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingViewChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingViewChangeGenerator.java
@@ -102,7 +102,7 @@ public class MissingViewChangeGenerator extends AbstractChangeGenerator implemen
                             columnRemarks.setCatalogName(control.getIncludeCatalog() ? view.getSchema().getCatalogName() : null);
                             columnRemarks.setSchemaName(control.getIncludeSchema() ? view.getSchema().getName() : null);
                             columnRemarks.setTableName(column.getRelation().getName());
-                            columnRemarks.setColumnParentType(ColumnParentType.VIEW);
+                            columnRemarks.setColumnParentType(ColumnParentType.VIEW.name());
                             columnRemarksList.add(columnRemarks);
                         }
                 );

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/SetColumnRemarksGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/SetColumnRemarksGenerator.java
@@ -11,10 +11,8 @@ import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.statement.core.SetColumnRemarksStatement;
 import liquibase.structure.core.Column;
 import liquibase.structure.core.Table;
-import liquibase.util.ColumnOwnerType;
+import liquibase.util.ColumnParentType;
 import liquibase.util.StringUtil;
-
-import java.util.Optional;
 
 public class SetColumnRemarksGenerator extends AbstractSqlGenerator<SetColumnRemarksStatement> {
     @Override
@@ -72,7 +70,7 @@ public class SetColumnRemarksGenerator extends AbstractSqlGenerator<SetColumnRem
             String qualifiedTableName = String.format("%s.%s", schemaName, statement.getTableName());
             String columnName = statement.getColumnName();
             String targetObject = "TABLE";
-            if (statement.getOwnerType() != null && statement.getOwnerType() == ColumnOwnerType.VIEW) {
+            if (statement.getColumnParentType() != null && statement.getColumnParentType() == ColumnParentType.VIEW) {
                 targetObject = "VIEW";
             }
 

--- a/liquibase-core/src/main/java/liquibase/statement/core/SetColumnRemarksStatement.java
+++ b/liquibase-core/src/main/java/liquibase/statement/core/SetColumnRemarksStatement.java
@@ -11,7 +11,7 @@ public class SetColumnRemarksStatement extends AbstractSqlStatement {
     private String columnName;
     private String remarks;
     private String columnDataType;
-    private ColumnParentType columnParentType;
+    private String columnParentType;
 
     public SetColumnRemarksStatement(String catalogName, String schemaName, String tableName, String columnName, String remarks) {
         this(catalogName, schemaName, tableName, columnName, remarks, null);
@@ -37,7 +37,7 @@ public class SetColumnRemarksStatement extends AbstractSqlStatement {
                                      String columnName,
                                      String remarks,
                                      String columnDataType,
-                                     ColumnParentType columnParentType) {
+                                     String columnParentType) {
         this.catalogName = catalogName;
         this.schemaName = schemaName;
         this.tableName = tableName;
@@ -72,6 +72,6 @@ public class SetColumnRemarksStatement extends AbstractSqlStatement {
     }
 
     public ColumnParentType getColumnParentType() {
-        return columnParentType;
+        return columnParentType != null ? ColumnParentType.valueOf(columnParentType) : null;
     }
 }

--- a/liquibase-core/src/main/java/liquibase/statement/core/SetColumnRemarksStatement.java
+++ b/liquibase-core/src/main/java/liquibase/statement/core/SetColumnRemarksStatement.java
@@ -1,7 +1,7 @@
 package liquibase.statement.core;
 
 import liquibase.statement.AbstractSqlStatement;
-import liquibase.util.ColumnOwnerType;
+import liquibase.util.ColumnParentType;
 
 public class SetColumnRemarksStatement extends AbstractSqlStatement {
 
@@ -11,7 +11,7 @@ public class SetColumnRemarksStatement extends AbstractSqlStatement {
     private String columnName;
     private String remarks;
     private String columnDataType;
-    private ColumnOwnerType ownerType;
+    private ColumnParentType columnParentType;
 
     public SetColumnRemarksStatement(String catalogName, String schemaName, String tableName, String columnName, String remarks) {
         this(catalogName, schemaName, tableName, columnName, remarks, null);
@@ -37,14 +37,14 @@ public class SetColumnRemarksStatement extends AbstractSqlStatement {
                                      String columnName,
                                      String remarks,
                                      String columnDataType,
-                                     ColumnOwnerType ownerType) {
+                                     ColumnParentType columnParentType) {
         this.catalogName = catalogName;
         this.schemaName = schemaName;
         this.tableName = tableName;
         this.columnName = columnName;
         this.remarks = remarks;
         this.columnDataType = columnDataType;
-        this.ownerType = ownerType;
+        this.columnParentType = columnParentType;
     }
 
     public String getColumnDataType() {
@@ -71,7 +71,7 @@ public class SetColumnRemarksStatement extends AbstractSqlStatement {
         return remarks;
     }
 
-    public ColumnOwnerType getOwnerType() {
-        return ownerType;
+    public ColumnParentType getColumnParentType() {
+        return columnParentType;
     }
 }

--- a/liquibase-core/src/main/java/liquibase/util/ColumnParentType.java
+++ b/liquibase-core/src/main/java/liquibase/util/ColumnParentType.java
@@ -3,7 +3,7 @@ package liquibase.util;
 /**
  * Used to indicate what type of relation owns a column.
  */
-public enum ColumnOwnerType {
+public enum ColumnParentType {
     TABLE,
     VIEW
 }

--- a/liquibase-core/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
+++ b/liquibase-core/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
@@ -955,7 +955,7 @@
             <xsd:attribute name="columnName" type="xsd:string" use="required"/>
             <xsd:attribute name="columnDataType" type="xsd:string"/>
             <xsd:attribute name="remarks" type="xsd:string"/>
-            <xsd:attribute name="ownerType" type="xsd:string"/>
+            <xsd:attribute name="columnParentType" type="xsd:string"/>
         </xsd:complexType>
     </xsd:element>
 

--- a/liquibase-core/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
+++ b/liquibase-core/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
@@ -955,6 +955,7 @@
             <xsd:attribute name="columnName" type="xsd:string" use="required"/>
             <xsd:attribute name="columnDataType" type="xsd:string"/>
             <xsd:attribute name="remarks" type="xsd:string"/>
+            <xsd:attribute name="ownerType" type="xsd:string"/>
         </xsd:complexType>
     </xsd:element>
 

--- a/liquibase-core/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
+++ b/liquibase-core/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
@@ -947,6 +947,13 @@
         </xsd:complexType>
     </xsd:element>
 
+    <xsd:simpleType name="columnParentTypeEnum">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="TABLE"/>
+            <xsd:enumeration value="VIEW"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
     <xsd:element name="setColumnRemarks">
         <xsd:complexType>
             <xsd:attribute name="catalogName" type="xsd:string"/>
@@ -955,7 +962,7 @@
             <xsd:attribute name="columnName" type="xsd:string" use="required"/>
             <xsd:attribute name="columnDataType" type="xsd:string"/>
             <xsd:attribute name="remarks" type="xsd:string"/>
-            <xsd:attribute name="columnParentType" type="xsd:string"/>
+            <xsd:attribute name="columnParentType" type="columnParentTypeEnum"/>
         </xsd:complexType>
     </xsd:element>
 

--- a/liquibase-core/src/test/groovy/liquibase/serializer/core/string/StringChangeLogSerializerTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/serializer/core/string/StringChangeLogSerializerTest.groovy
@@ -293,8 +293,6 @@ public class StringChangeLogSerializerTest extends Specification {
                 //nothing
             } else if (field.getType().equals(LoadDataChange.LOAD_DATA_TYPE.class)) {
                 //nothing
-            } else if (field.getType().equals(ColumnParentType.class)) {
-                field.set(object, ColumnParentType.TABLE)
             } else if (field.getType().equals(long.class)) {
                 field.set(object, createInteger().longValue());
             } else if (field.getType().equals(String.class)) {

--- a/liquibase-core/src/test/groovy/liquibase/serializer/core/string/StringChangeLogSerializerTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/serializer/core/string/StringChangeLogSerializerTest.groovy
@@ -2,46 +2,29 @@ package liquibase.serializer.core.string
 
 import liquibase.Scope
 import liquibase.changelog.ChangeSet
-import liquibase.test.JUnitResourceAccessor
-import liquibase.util.ColumnOwnerType
+import liquibase.util.ColumnParentType
 import spock.lang.Specification
-import spock.lang.Unroll;
+import spock.lang.Unroll
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.fail
 
-import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.SortedSet;
-import java.util.TreeSet;
+import java.lang.reflect.Type
 
-import liquibase.change.*;
-import liquibase.change.DatabaseChangeProperty;
+import liquibase.change.*
 import liquibase.change.core.*;
 import liquibase.change.custom.CustomChangeWrapper;
 import liquibase.change.custom.CustomSqlChange;
 import liquibase.change.custom.ExampleCustomSqlChange;
 import liquibase.changelog.ChangeLogParameters;
-import liquibase.logging.Logger;
-import liquibase.resource.ClassLoaderResourceAccessor;
+import liquibase.logging.Logger
 import liquibase.resource.ResourceAccessor;
 import liquibase.statement.DatabaseFunction;
 
 import liquibase.statement.SequenceCurrentValueFunction;
-import liquibase.statement.SequenceNextValueFunction;
-import org.junit.Test;
+import liquibase.statement.SequenceNextValueFunction
 
 public class StringChangeLogSerializerTest extends Specification {
 
@@ -310,8 +293,8 @@ public class StringChangeLogSerializerTest extends Specification {
                 //nothing
             } else if (field.getType().equals(LoadDataChange.LOAD_DATA_TYPE.class)) {
                 //nothing
-            } else if (field.getType().equals(ColumnOwnerType.class)) {
-                field.set(object, ColumnOwnerType.TABLE)
+            } else if (field.getType().equals(ColumnParentType.class)) {
+                field.set(object, ColumnParentType.TABLE)
             } else if (field.getType().equals(long.class)) {
                 field.set(object, createInteger().longValue());
             } else if (field.getType().equals(String.class)) {

--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/core/GenerateChangeLogMSSQLCommandTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/core/GenerateChangeLogMSSQLCommandTest.groovy
@@ -44,21 +44,21 @@ class GenerateChangeLogMSSQLCommandTest extends Specification {
         outputFile.delete()
     }
 
-    def "Should generate table comments, view comments, table column comments, view column comments and be able to use the generated xml changelog"() {
+    def "Should generate table comments, view comments, table column comments, view column comments and be able to use the generated xml/json/yml changelog"(String fileType) {
         given:
         runUpdate('changelogs/mssql/issues/generate.changelog.table.view.comments.sql')
 
         when:
-        runGenerateChangelog('output.mssql.xml')
+        runGenerateChangelog("output.mssql.$fileType")
 
         then:
-        def outputFile = new File('output.mssql.xml')
+        def outputFile = new File("output.mssql.$fileType")
         def contents = FileUtil.getContents(outputFile)
-        contents.count("columnParentType=\"VIEW\"") == 2 //Should appear for the two view column comments.
+        contents.count('columnParentType') == 2 //Should appear for the two view column comments.
 
         when:
         runDropAll()
-        runUpdate('output.mssql.xml')
+        runUpdate("output.mssql.$fileType")
 
         then:
         noExceptionThrown()
@@ -66,6 +66,9 @@ class GenerateChangeLogMSSQLCommandTest extends Specification {
         cleanup:
         runDropAll()
         outputFile.delete()
+
+        where:
+        fileType << ['xml', 'json', 'yml']
     }
 
     private void runGenerateChangelog(String outputFile) {

--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/core/GenerateChangeLogMSSQLCommandTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/core/GenerateChangeLogMSSQLCommandTest.groovy
@@ -20,7 +20,7 @@ class GenerateChangeLogMSSQLCommandTest extends Specification {
         runUpdate('changelogs/mssql/issues/generate.changelog.table.view.comments.sql')
 
         when:
-        runGenerateChangelog()
+        runGenerateChangelog('output.mssql.sql')
 
         then:
         def outputFile = new File('output.mssql.sql')
@@ -44,13 +44,37 @@ class GenerateChangeLogMSSQLCommandTest extends Specification {
         outputFile.delete()
     }
 
-    private void runGenerateChangelog() {
+    def "Should generate table comments, view comments, table column comments, view column comments and be able to use the generated xml changelog"() {
+        given:
+        runUpdate('changelogs/mssql/issues/generate.changelog.table.view.comments.sql')
+
+        when:
+        runGenerateChangelog('output.mssql.xml')
+
+        then:
+        def outputFile = new File('output.mssql.xml')
+        def contents = FileUtil.getContents(outputFile)
+        contents.count("columnParentType=\"VIEW\"") == 2 //Should appear for the two view column comments.
+
+        when:
+        runDropAll()
+        runUpdate('output.mssql.xml')
+
+        then:
+        noExceptionThrown()
+
+        cleanup:
+        runDropAll()
+        outputFile.delete()
+    }
+
+    private void runGenerateChangelog(String outputFile) {
         GenerateChangelogCommandStep step = new GenerateChangelogCommandStep()
         CommandScope commandScope = new CommandScope(GenerateChangelogCommandStep.COMMAND_NAME)
         commandScope.addArgumentValue(GenerateChangelogCommandStep.URL_ARG, mssql.getConnectionUrl())
         commandScope.addArgumentValue(GenerateChangelogCommandStep.USERNAME_ARG, mssql.getUsername())
         commandScope.addArgumentValue(GenerateChangelogCommandStep.PASSWORD_ARG, mssql.getPassword())
-        commandScope.addArgumentValue(GenerateChangelogCommandStep.CHANGELOG_FILE_ARG, 'output.mssql.sql')
+        commandScope.addArgumentValue(GenerateChangelogCommandStep.CHANGELOG_FILE_ARG, outputFile)
         OutputStream outputStream = new ByteArrayOutputStream()
         CommandResultsBuilder commandResultsBuilder = new CommandResultsBuilder(commandScope, outputStream)
         step.run(commandResultsBuilder)


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description
Adds new attribute `columnParentType` to `SetColumnRemarksChange`. This is an string that contains two valid values `TABLE, VIEW`. This is required to enable any `setColumnRemarks` change type to know whether the owner of the column is a view or a table. The syntax for sql server (and currently _only_ SQL Server) is different between the two cases. 

## Things to be aware of
For backwards compatibility it feels like an enum will be a easier solution to maintain than just an `isView` boolean attribute. Another solution could be to create a new change type `SetViewColumnRemarks` however this is ONLY currently necessary for SQL Server, so that feels a bit heavy handed and would potentially lead to some confusion as now there would be two valid ways to set column remarks for view column comments in say, postgresql.

## Things to worry about
Adds new attribute `columnParentType` to `SetColumnRemarksChange`. This updates our xsd.

## Additional Context
N/A
