### PR TITLE
#3035 add Double data type class to avoid incorrect double(0) databas…

### DIFF
--- a/liquibase-snowflake/src/main/java/liquibase/datatype/core/DoubleDataTypeSnowflake.java
+++ b/liquibase-snowflake/src/main/java/liquibase/datatype/core/DoubleDataTypeSnowflake.java
@@ -1,0 +1,36 @@
+package liquibase.datatype.core;
+
+import liquibase.database.Database;
+import liquibase.database.core.SnowflakeDatabase;
+import liquibase.datatype.DataTypeInfo;
+import liquibase.datatype.DatabaseDataType;
+import liquibase.datatype.LiquibaseDataType;
+
+@DataTypeInfo(
+    name = "double",
+    aliases = {"java.sql.Types.DOUBLE", "java.lang.Double"},
+    minParameters = 0,
+    maxParameters = 2,
+    priority = LiquibaseDataType.PRIORITY_DATABASE
+)
+public class DoubleDataTypeSnowflake extends DoubleType {
+
+    public DoubleDataTypeSnowflake() {
+
+    }
+
+    public int getPriority() {
+        return LiquibaseDataType.PRIORITY_DATABASE;
+    }
+
+    @Override
+    public boolean supports(Database database) {
+        return database instanceof SnowflakeDatabase;
+    }
+
+    @Override
+    public DatabaseDataType toDatabaseDataType(Database database) {
+        // Double is an alias for the FLOAT data type in Snowflake.
+        return new DatabaseDataType("FLOAT");
+    }
+}

--- a/liquibase-snowflake/src/main/resources/META-INF/services/liquibase.datatype.LiquibaseDataType
+++ b/liquibase-snowflake/src/main/resources/META-INF/services/liquibase.datatype.LiquibaseDataType
@@ -1,2 +1,3 @@
 liquibase.datatype.core.TextDataTypeSnowflake
 liquibase.datatype.core.TimestampNTZTypeSnowflake
+liquibase.datatype.core.DoubleDataTypeSnowflake


### PR DESCRIPTION
add Double data type class to avoid incorrect double(0) database data type result

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

A clear and concise description of the change being made.  

As I can see, I can add a new condition to the DoubleType class, so I made these changes in the snowflake package.
Basically, this is a copy of HanaDoubleType and such kind of extension data type classes.
We fixed this problem that way in our snowflake extension fork and have used it since December. Works fine for us.

More about numeric types: https://docs.snowflake.com/en/sql-reference/data-types-numeric.html#double-double-precision-real

I can do "DOUBLE" instead of "FLOAT", but, I think, it will be not correct.
