### PR TITLE
Do not add default schema name to getSchemas method to avoid one sche…

### DIFF
--- a/liquibase-snowflake/src/main/java/liquibase/snapshot/jvm/SchemaSnapshotGeneratorSnowflake.java
+++ b/liquibase-snowflake/src/main/java/liquibase/snapshot/jvm/SchemaSnapshotGeneratorSnowflake.java
@@ -27,7 +27,7 @@ public class SchemaSnapshotGeneratorSnowflake extends SchemaSnapshotGenerator {
         List<String> returnList = new ArrayList<>();
 
         try (ResultSet schemas = ((JdbcConnection) database.getConnection()).getMetaData().getSchemas(database
-                .getDefaultCatalogName(), database.getDefaultSchemaName())) {
+                .getDefaultCatalogName(), null)) {
             while (schemas.next()) {
                 returnList.add(JdbcUtil.getValueForColumn(schemas, "TABLE_SCHEM", database));
             }


### PR DESCRIPTION
Do not add default schema name to getSchemas method to avoid one schema result name

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Hello!

We are thinking about migrating our product to the latest Liquibase library version. 
Now we are using the Snowflake extension fork library, but with the latest changes here, this extension moved into liqubase main library. So we can't use our fork workarounds and hacks no more. But we can try to fix it here.

Unfortunately, I can't come up with a ticket for this issue. I can just see the consequences of this issue while I'm using liqubase as a library in our product. (diffChangeLog command)

I can't see the result of comparing two schemas in Snowflake if I did "USE SCHEMA <schemaName>" for any schema in my catalog earlier. If 

`"SELECT CURRENT_SCHEMA()"`

return not null for the database.

Expected:

![2023-01-18 01_22_05-Schema Compare](https://user-images.githubusercontent.com/45152336/213026041-f48e15ad-7ac6-4ce4-8758-e56ae4828e2d.png)

Actual:

![2023-01-18 01_23_03-Schema Compare](https://user-images.githubusercontent.com/45152336/213026089-c6e6cd53-e0bf-4a39-af77-919de8391e8a.png)

So, the problem is in the method `getSchemas`.
In original SchemaSnapshotGenerator#getDatabaseSchemaNames simple `database.getConnection()).getMetaData().getSchemas()` is used. 
But for Snowflake, you have `ResultSet getSchemas(String catalog, String schemaPattern) throws SQLException;` implementation.
This method returns you only one schema in case                 
`getSchemas(database.getDefaultCatalogName(), database.getDefaultSchemaName())`

![2023-01-18 01_29_22-DBeaver Ultimate 22 3 2 - _TEST_DB 2_ Script-101](https://user-images.githubusercontent.com/45152336/213027678-e9816e36-cb50-425c-b344-ec38979aa006.png)

https://github.com/snowflakedb/snowflake-jdbc/blob/8c0a9ce074b6fea8befbe05727387924c53f9122/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java#L3001-L3033

So. If you want to specify the catalog name - it is ok. But the schema pattern name is not appropriate here.
