### PR TITLE
deprecate DefaultLoggerConfiguration (DAT-11970)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/logging/core/DefaultLoggerConfiguration.java
+++ b/liquibase-core/src/main/java/liquibase/logging/core/DefaultLoggerConfiguration.java
@@ -6,8 +6,10 @@ import liquibase.configuration.AutoloadedConfigurations;
 /**
  * Configuration container for {@link liquibase.logging.LogService} properties
  */
+@Deprecated
 public class DefaultLoggerConfiguration implements AutoloadedConfigurations {
 
+    @Deprecated
     public static ConfigurationDefinition<String> LOG_LEVEL;
 
     static {
@@ -15,6 +17,7 @@ public class DefaultLoggerConfiguration implements AutoloadedConfigurations {
         LOG_LEVEL = builder.define("level", String.class)
                 .setDescription("Logging level")
                 .setDefaultValue("INFO")
+                .setInternal(true)
                 .build();
     }
 }

--- a/liquibase-core/src/main/java/liquibase/logging/core/DefaultLoggerConfiguration.java
+++ b/liquibase-core/src/main/java/liquibase/logging/core/DefaultLoggerConfiguration.java
@@ -5,6 +5,8 @@ import liquibase.configuration.AutoloadedConfigurations;
 
 /**
  * Configuration container for {@link liquibase.logging.LogService} properties
+ * @deprecated not in use anywhere in Liquibase code and has been superseded by log-level and its associated command
+ * line parameters
  */
 @Deprecated
 public class DefaultLoggerConfiguration implements AutoloadedConfigurations {


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

DefaultLoggerConfiguration is not used anywhere. It is now deprecated and hidden from the help output.

## Things to be aware of

DefaultLoggerConfiguration is not being removed yet because other extensions may use it.

## Things to worry about



## Additional Context


