### PR TITLE
do not support setting column comments on a view in Snowflake (DAT-12530)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/AbstractChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/AbstractChange.java
@@ -380,7 +380,7 @@ public abstract class AbstractChange extends AbstractPlugin implements Change {
                 warnings.addAll(SqlGeneratorFactory.getInstance().warn(statement, database));
             } else if (statement.skipOnUnsupported()) {
                 warnings.addWarning(
-                    statement.getClass().getName() + " is not supported on " + database.getShortName() +
+                    statement.getClass().getName() + " is not supported on " + database.getDisplayName() +
                         ", but " + Scope.getCurrentScope().getSingleton(ChangeFactory.class).getChangeMetaData(this).getName() +
                         " will still execute");
             }
@@ -420,7 +420,7 @@ public abstract class AbstractChange extends AbstractPlugin implements Change {
         // Record warnings if statements are unsupported on database
         if (!generateStatementsVolatile(database)) {
             String unsupportedWarning = Scope.getCurrentScope().getSingleton(ChangeFactory.class).getChangeMetaData(this).getName()
-                    + " is not supported on " + database.getShortName();
+                    + " is not supported on " + database.getDisplayName();
             boolean sawUnsupportedError = false;
 
             SqlStatement[] statements = generateStatements(database);
@@ -489,7 +489,7 @@ public abstract class AbstractChange extends AbstractPlugin implements Change {
                 if (!inverse.supports(database)) {
                     throw new RollbackImpossibleException(
                         Scope.getCurrentScope().getSingleton(ChangeFactory.class).getChangeMetaData(inverse).getName() + " is not supported on " +
-                            database.getShortName()
+                            database.getDisplayName()
                     );
                 }
                 statements.addAll(Arrays.asList(inverse.generateStatements(database)));

--- a/liquibase-core/src/main/java/liquibase/database/Database.java
+++ b/liquibase-core/src/main/java/liquibase/database/Database.java
@@ -84,6 +84,14 @@ public interface Database extends PrioritizedService, AutoCloseable {
      */
     String getShortName();
 
+    /**
+     * @return a properly formatted name of the product. Used for situations where the database is printed to the
+     * console. Example: "Snowflake" (note the capitalization)
+     */
+    default String getDisplayName() {
+        return getShortName();
+    }
+
     String getDefaultCatalogName();
 
     void setDefaultCatalogName(String catalogName) throws DatabaseException;

--- a/liquibase-core/src/main/java/liquibase/exception/DatabaseIncapableOfOperation.java
+++ b/liquibase-core/src/main/java/liquibase/exception/DatabaseIncapableOfOperation.java
@@ -8,7 +8,7 @@ public class DatabaseIncapableOfOperation extends RuntimeException {
     private String reason;
 
     public DatabaseIncapableOfOperation(String operation, String reason, Database database) {
-        super(operation + " is not supported on " + database.getShortName() + ": " + reason);
+        super(operation + " is not supported on " + database.getDisplayName() + ": " + reason);
         this.reason = reason;
     }
 

--- a/liquibase-core/src/main/java/liquibase/exception/StatementNotSupportedOnDatabaseException.java
+++ b/liquibase-core/src/main/java/liquibase/exception/StatementNotSupportedOnDatabaseException.java
@@ -8,11 +8,11 @@ public class StatementNotSupportedOnDatabaseException extends DatabaseException 
     private String reason;
 
     public StatementNotSupportedOnDatabaseException(SqlStatement statement, Database database) {
-        super(statement.getClass().getName()+" is not supported on "+database.getShortName());
+        super(statement.getClass().getName()+" is not supported on "+database.getDisplayName());
     }
 
     public StatementNotSupportedOnDatabaseException(String reason, SqlStatement statement, Database database) {
-        super(statement.getClass().getName()+" is not supported on "+database.getShortName()+": "+reason);
+        super(statement.getClass().getName()+" is not supported on "+database.getDisplayName()+": "+reason);
         this.reason = reason;
     }
 

--- a/liquibase-core/src/main/java/liquibase/exception/ValidationErrors.java
+++ b/liquibase-core/src/main/java/liquibase/exception/ValidationErrors.java
@@ -64,7 +64,7 @@ public class ValidationErrors {
     }
 
     /**
-     * Checks that the the given value is set.
+     * Checks that the given value is set.
      * @param allowEmptyValue  If true, empty string and empty arrays are allowed. If false, they are not.
      */
     public ValidationErrors checkRequiredField(String requiredFieldName, Object value, String postfix, boolean allowEmptyValue) {

--- a/liquibase-snowflake/src/main/java/liquibase/database/core/SnowflakeDatabase.java
+++ b/liquibase-snowflake/src/main/java/liquibase/database/core/SnowflakeDatabase.java
@@ -37,6 +37,11 @@ public class SnowflakeDatabase extends AbstractJdbcDatabase {
     }
 
     @Override
+    public String getDisplayName() {
+        return "Snowflake";
+    }
+
+    @Override
     protected String getDefaultDatabaseProductName() {
         return PRODUCT_NAME;
     }

--- a/liquibase-snowflake/src/main/java/liquibase/executor/jvm/SnowflakeJdbcExecutor.java
+++ b/liquibase-snowflake/src/main/java/liquibase/executor/jvm/SnowflakeJdbcExecutor.java
@@ -28,7 +28,7 @@ public class SnowflakeJdbcExecutor extends JdbcExecutor {
         } catch (DatabaseException e) {
             if (sql instanceof SetColumnRemarksStatement) {
                 if (e.getMessage().contains("Object found is of type 'VIEW', not specified type 'TABLE'")) {
-                    throw new DatabaseException("Snowflake does not support setting column comments on views, only tables.", e);
+                    throw new DatabaseException("setColumnRemarks change type isn't supported on Snowflake for a 'view'", e);
                 }
             }
         }

--- a/liquibase-snowflake/src/main/java/liquibase/executor/jvm/SnowflakeJdbcExecutor.java
+++ b/liquibase-snowflake/src/main/java/liquibase/executor/jvm/SnowflakeJdbcExecutor.java
@@ -9,6 +9,8 @@ import liquibase.statement.core.SetColumnRemarksStatement;
 
 import java.util.List;
 
+import static liquibase.sqlgenerator.core.SetColumnRemarksGeneratorSnowflake.SET_COLUMN_REMARKS_NOT_SUPPORTED_ON_VIEW_MSG;
+
 public class SnowflakeJdbcExecutor extends JdbcExecutor {
 
     @Override
@@ -28,7 +30,7 @@ public class SnowflakeJdbcExecutor extends JdbcExecutor {
         } catch (DatabaseException e) {
             if (sql instanceof SetColumnRemarksStatement) {
                 if (e.getMessage().contains("Object found is of type 'VIEW', not specified type 'TABLE'")) {
-                    throw new DatabaseException("setColumnRemarks change type isn't supported on Snowflake for a 'view'", e);
+                    throw new DatabaseException(SET_COLUMN_REMARKS_NOT_SUPPORTED_ON_VIEW_MSG, e);
                 }
             }
         }

--- a/liquibase-snowflake/src/main/java/liquibase/executor/jvm/SnowflakeJdbcExecutor.java
+++ b/liquibase-snowflake/src/main/java/liquibase/executor/jvm/SnowflakeJdbcExecutor.java
@@ -1,0 +1,36 @@
+package liquibase.executor.jvm;
+
+import liquibase.database.Database;
+import liquibase.database.core.SnowflakeDatabase;
+import liquibase.exception.DatabaseException;
+import liquibase.sql.visitor.SqlVisitor;
+import liquibase.statement.SqlStatement;
+import liquibase.statement.core.SetColumnRemarksStatement;
+
+import java.util.List;
+
+public class SnowflakeJdbcExecutor extends JdbcExecutor {
+
+    @Override
+    public boolean supports(Database database) {
+        return database instanceof SnowflakeDatabase;
+    }
+
+    @Override
+    public int getPriority() {
+        return PRIORITY_SPECIALIZED;
+    }
+
+    @Override
+    public void execute(SqlStatement sql, List<SqlVisitor> sqlVisitors) throws DatabaseException {
+        try {
+            super.execute(sql, sqlVisitors);
+        } catch (DatabaseException e) {
+            if (sql instanceof SetColumnRemarksStatement) {
+                if (e.getMessage().contains("Object found is of type 'VIEW', not specified type 'TABLE'")) {
+                    throw new DatabaseException("Snowflake does not support setting column comments on views, only tables.", e);
+                }
+            }
+        }
+    }
+}

--- a/liquibase-snowflake/src/main/java/liquibase/sqlgenerator/core/SetColumnRemarksGeneratorSnowflake.java
+++ b/liquibase-snowflake/src/main/java/liquibase/sqlgenerator/core/SetColumnRemarksGeneratorSnowflake.java
@@ -15,6 +15,9 @@ import java.util.List;
 import java.util.Map;
 
 public class SetColumnRemarksGeneratorSnowflake extends SetColumnRemarksGenerator {
+
+    public static final String SET_COLUMN_REMARKS_NOT_SUPPORTED_ON_VIEW_MSG = "setColumnRemarks change type isn't supported on Snowflake for a 'view'";
+
     @Override
     public int getPriority() {
         return PRIORITY_DATABASE;
@@ -32,7 +35,7 @@ public class SetColumnRemarksGeneratorSnowflake extends SetColumnRemarksGenerato
             if (statement.getColumnParentType() != null) {
                 // Snowflake doesn't support setting the column remarks on a view.
                 if (statement.getColumnParentType() == ColumnParentType.VIEW) {
-                    validationErrors.addError("Snowflake does not support setting column comments on a view.");
+                    validationErrors.addError(SET_COLUMN_REMARKS_NOT_SUPPORTED_ON_VIEW_MSG);
                 }
             } else {
                 // Check if we're trying to set the column remarks on a view, and if so, note that this is not supported.
@@ -40,7 +43,7 @@ public class SetColumnRemarksGeneratorSnowflake extends SetColumnRemarksGenerato
                     List<Map<String, ?>> viewList = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database).queryForList(
                             new RawSqlStatement(String.format("SHOW VIEWS LIKE '%s'", statement.getTableName())));
                     if (!viewList.isEmpty()) {
-                        validationErrors.addError("Snowflake does not support setting column comments on a view.");
+                        validationErrors.addError(SET_COLUMN_REMARKS_NOT_SUPPORTED_ON_VIEW_MSG);
                     }
                 } catch (DatabaseException e) {
                     Scope.getCurrentScope().getLog(getClass()).severe("Failed to query Snowflake to determine if object is a table or view.", e);

--- a/liquibase-snowflake/src/main/java/liquibase/sqlgenerator/core/SetColumnRemarksGeneratorSnowflake.java
+++ b/liquibase-snowflake/src/main/java/liquibase/sqlgenerator/core/SetColumnRemarksGeneratorSnowflake.java
@@ -28,7 +28,7 @@ public class SetColumnRemarksGeneratorSnowflake extends SetColumnRemarksGenerato
                 // Check if we're trying to set the column remarks on a view, and if so, note that this is not supported.
                 try {
                     List<Map<String, ?>> viewList = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database).queryForList(
-                            new RawSqlStatement("SHOW VIEWS LIKE '" + statement.getTableName() + "'"));
+                            new RawSqlStatement(String.format("SHOW VIEWS LIKE '%s'", statement.getTableName())));
                     return viewList.isEmpty();
                 } catch (DatabaseException e) {
                     Scope.getCurrentScope().getLog(getClass()).severe("Failed to query Snowflake to determine if object is a table or view.", e);

--- a/liquibase-snowflake/src/main/java/liquibase/sqlgenerator/core/SetColumnRemarksGeneratorSnowflake.java
+++ b/liquibase-snowflake/src/main/java/liquibase/sqlgenerator/core/SetColumnRemarksGeneratorSnowflake.java
@@ -1,8 +1,16 @@
 package liquibase.sqlgenerator.core;
 
+import liquibase.Scope;
 import liquibase.database.Database;
 import liquibase.database.core.SnowflakeDatabase;
+import liquibase.exception.DatabaseException;
+import liquibase.executor.ExecutorService;
+import liquibase.statement.core.RawSqlStatement;
 import liquibase.statement.core.SetColumnRemarksStatement;
+import liquibase.util.ColumnParentType;
+
+import java.util.List;
+import java.util.Map;
 
 public class SetColumnRemarksGeneratorSnowflake extends SetColumnRemarksGenerator {
     @Override
@@ -12,6 +20,21 @@ public class SetColumnRemarksGeneratorSnowflake extends SetColumnRemarksGenerato
 
     @Override
     public boolean supports(SetColumnRemarksStatement statement, Database database) {
-        return database instanceof SnowflakeDatabase;
+        if (database instanceof SnowflakeDatabase) {
+            if (statement.getColumnParentType() != null) {
+                // Snowflake doesn't support setting the column remarks on a view.
+                return statement.getColumnParentType() != ColumnParentType.VIEW;
+            } else {
+                // Check if we're trying to set the column remarks on a view, and if so, note that this is not supported.
+                try {
+                    List<Map<String, ?>> viewList = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database).queryForList(
+                            new RawSqlStatement("SHOW VIEWS LIKE '" + statement.getTableName() + "'"));
+                    return viewList.isEmpty();
+                } catch (DatabaseException e) {
+                    Scope.getCurrentScope().getLog(getClass()).severe("Failed to query Snowflake to determine if object is a table or view.", e);
+                }
+            }
+        }
+        return false;
     }
 }

--- a/liquibase-snowflake/src/main/resources/META-INF/services/liquibase.executor.Executor
+++ b/liquibase-snowflake/src/main/resources/META-INF/services/liquibase.executor.Executor
@@ -1,0 +1,1 @@
+liquibase.executor.jvm.SnowflakeJdbcExecutor


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Snowflake does not support setting view column comments after the view has been created, so this change warns the user of that.

## Things to be aware of


## Things to worry about

Performance impact of querying the Snowflake information schema about whether an object is a view.

## Additional Context

