### PR TITLE
normalize path of json and yaml changelogs when parsing (DAT-11891)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/parser/core/yaml/YamlChangeLogParser.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/yaml/YamlChangeLogParser.java
@@ -37,7 +37,7 @@ public class YamlChangeLogParser extends YamlParser implements ChangeLogParser {
             if ((parsedYaml == null) || parsedYaml.isEmpty()) {
                 throw new ChangeLogParseException("Empty file " + physicalChangeLogLocation);
             }
-            DatabaseChangeLog changeLog = new DatabaseChangeLog(physicalChangeLogLocation);
+            DatabaseChangeLog changeLog = new DatabaseChangeLog(DatabaseChangeLog.normalizePath(physicalChangeLogLocation));
 
             Object rootList = parsedYaml.get("databaseChangeLog");
             if (rootList == null) {


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

A continuation of #3664, which fixes the same bug with JSON and YAML changelogs, by normalizing the file path when parsing the changelog.

## Things to be aware of

Tests are in the pro repo.

## Things to worry about


## Additional Context


