### PR TITLE
Use constants instead of arrays with known lengths of zero

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/DropAllForeignKeyConstraintsChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/DropAllForeignKeyConstraintsChange.java
@@ -62,7 +62,7 @@ public class DropAllForeignKeyConstraintsChange extends AbstractChange {
             sqlStatements.addAll(Arrays.asList(change.generateStatements(database)));
         }
 
-        return sqlStatements.toArray(new SqlStatement[0]);
+        return sqlStatements.toArray(SqlStatement.EMPTY_SQL_STATEMENT);
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/change/core/DropColumnChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/DropColumnChange.java
@@ -146,7 +146,7 @@ public class DropColumnChange extends AbstractChange implements ChangeWithColumn
             statements.add(new ReorganizeTableStatement(getCatalogName(), getSchemaName(), getTableName()));
         }
         
-        return statements.toArray(new SqlStatement[0]);
+        return statements.toArray(SqlStatement.EMPTY_SQL_STATEMENT);
     }
     
     private SqlStatement[] generateSingleColumn(Database database) throws DatabaseException {
@@ -162,7 +162,7 @@ public class DropColumnChange extends AbstractChange implements ChangeWithColumn
             statements.add(new ReorganizeTableStatement(getCatalogName(), getSchemaName(), getTableName()));
         }
         
-        return statements.toArray(new SqlStatement[0]);
+        return statements.toArray(SqlStatement.EMPTY_SQL_STATEMENT);
     }
     
     @Override

--- a/liquibase-core/src/main/java/liquibase/change/core/EmptyChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/EmptyChange.java
@@ -11,7 +11,7 @@ public class EmptyChange extends AbstractChange {
 
     @Override
     public SqlStatement[] generateStatements(Database database) {
-        return new SqlStatement[0];
+        return SqlStatement.EMPTY_SQL_STATEMENT;
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/change/core/ExecuteShellCommandChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/ExecuteShellCommandChange.java
@@ -167,7 +167,7 @@ public class ExecuteShellCommandChange extends AbstractChange {
             }
         }
 
-        return new SqlStatement[0];
+        return SqlStatement.EMPTY_SQL_STATEMENT;
     }
 
     protected void nonExecutedCleanup() {

--- a/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/LoadDataChange.java
@@ -484,7 +484,7 @@ public class LoadDataChange extends AbstractTableChange implements ChangeWithCol
                     .getFailOnError()) {
                 LOG.info("Changeset " + getChangeSet().toString(false) +
                         " failed, but failOnError was false.  Error: " + ule.getMessage());
-                return new SqlStatement[0];
+                return SqlStatement.EMPTY_SQL_STATEMENT;
             } else {
                 throw ule;
             }
@@ -866,7 +866,7 @@ public class LoadDataChange extends AbstractTableChange implements ChangeWithCol
                 if (database instanceof PostgresDatabase || database instanceof MySQLDatabase) {
                     // we don't do batch updates for Postgres but we still send as a prepared statement, see LB-744
                     // mysql supports batch updates, but the performance vs. the big insert is worse
-                    return preparedStatements.toArray(new SqlStatement[0]);
+                    return preparedStatements.toArray(SqlStatement.EMPTY_SQL_STATEMENT);
                 } else {
                     return new SqlStatement[]{
                             new BatchDmlExecutablePreparedStatement(
@@ -877,12 +877,12 @@ public class LoadDataChange extends AbstractTableChange implements ChangeWithCol
                     };
                 }
             } else {
-                return statements.toArray(new SqlStatement[0]);
+                return statements.toArray(SqlStatement.EMPTY_SQL_STATEMENT);
             }
         } else {
             if (statements.isEmpty()) {
                 // avoid returning unnecessary dummy statement
-                return new SqlStatement[0];
+                return SqlStatement.EMPTY_SQL_STATEMENT;
             }
 
             InsertSetStatement statementSet = this.createStatementSet(

--- a/liquibase-core/src/main/java/liquibase/change/core/LoadUpdateDataChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/LoadUpdateDataChange.java
@@ -109,7 +109,7 @@ public class LoadUpdateDataChange extends LoadDataChange {
             statements.add(delete);
         }
 
-        return statements.toArray(new SqlStatement[0]);
+        return statements.toArray(SqlStatement.EMPTY_SQL_STATEMENT);
     }
 
     private String getWhere(InsertOrUpdateStatement insertOrUpdateStatement, Database database) {

--- a/liquibase-core/src/main/java/liquibase/change/core/MergeColumnChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/MergeColumnChange.java
@@ -202,7 +202,7 @@ public class MergeColumnChange extends AbstractChange {
 	        statements.addAll(Arrays.asList(dropColumn2Change.generateStatements(database)));
         
         }
-        return statements.toArray(new SqlStatement[0]);
+        return statements.toArray(SqlStatement.EMPTY_SQL_STATEMENT);
 
     }
 

--- a/liquibase-core/src/main/java/liquibase/change/core/RenameSequenceChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/RenameSequenceChange.java
@@ -63,7 +63,7 @@ public class RenameSequenceChange extends AbstractChange {
     public SqlStatement[] generateStatements(Database database) {
         List<SqlStatement> statements = new ArrayList<>();
         statements.add(new RenameSequenceStatement(getCatalogName(), getSchemaName(), getOldSequenceName(), getNewSequenceName()));
-        return statements.toArray(new SqlStatement[0]);
+        return statements.toArray(SqlStatement.EMPTY_SQL_STATEMENT);
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/change/core/RenameTableChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/RenameTableChange.java
@@ -71,7 +71,7 @@ public class RenameTableChange extends AbstractChange {
             statements.add(new ReorganizeTableStatement(getCatalogName(), getSchemaName(), getNewTableName()));
         }
 
-        return statements.toArray(new SqlStatement[0]);
+        return statements.toArray(SqlStatement.EMPTY_SQL_STATEMENT);
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/change/core/TagDatabaseChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/TagDatabaseChange.java
@@ -29,7 +29,7 @@ public class TagDatabaseChange extends AbstractChange {
      */
     @Override
     public SqlStatement[] generateStatements(Database database) {
-        return new SqlStatement[0];
+        return SqlStatement.EMPTY_SQL_STATEMENT;
     }
 
     @Override

--- a/liquibase-core/src/main/java/liquibase/change/custom/CustomChangeWrapper.java
+++ b/liquibase-core/src/main/java/liquibase/change/custom/CustomChangeWrapper.java
@@ -176,7 +176,7 @@ public class CustomChangeWrapper extends AbstractChange {
         }
 
         if (statements == null) {
-            statements = new SqlStatement[0];
+            statements = SqlStatement.EMPTY_SQL_STATEMENT;
         }
         return statements;
     }
@@ -205,7 +205,7 @@ public class CustomChangeWrapper extends AbstractChange {
         }
 
         if (statements == null) {
-            statements = new SqlStatement[0];
+            statements = SqlStatement.EMPTY_SQL_STATEMENT;
         }
         return statements;
 

--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
@@ -828,7 +828,7 @@ public class ChangeSet implements Conditional, ChangeLogChild {
                     }
                 }
                 if (!statements.isEmpty()) {
-                    database.executeRollbackStatements(statements.toArray(new SqlStatement[]{}), sqlVisitors);
+                    database.executeRollbackStatements(statements.toArray(SqlStatement.EMPTY_SQL_STATEMENT), sqlVisitors);
                 }
 
             } else {

--- a/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingDataExternalFileChangeGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/diff/output/changelog/core/MissingDataExternalFileChangeGenerator.java
@@ -163,7 +163,7 @@ public class MissingDataExternalFileChangeGenerator extends MissingDataChangeGen
                         change
                 };
             }
-            return new Change[]{};
+            return Change.EMPTY_CHANGE;
         } catch (Exception e) {
             throw new UnexpectedLiquibaseException(e);
         } finally {


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

We can save memory reusing the same array instance. Allocations of arrays with known lengths of zero when there is a constant for that in the class of the array's element type. Also, as zero-length arrays are immutable.

Please take a look to this PR 
https://github.com/liquibase/liquibase/pull/3500
