### PR TITLE
Add Snowflake structured data types to unmodifiable Data Types

### DIFF
--- a/liquibase-snowflake/src/main/java/liquibase/database/core/SnowflakeDatabase.java
+++ b/liquibase-snowflake/src/main/java/liquibase/database/core/SnowflakeDatabase.java
@@ -24,7 +24,8 @@ public class SnowflakeDatabase extends AbstractJdbcDatabase {
 
     public SnowflakeDatabase() {
         super.setCurrentDateTimeFunction("current_timestamp::timestamp_ntz");
-        super.unmodifiableDataTypes.addAll(Arrays.asList("integer", "bool", "boolean", "int4", "int8", "float4", "float8", "numeric", "bigserial", "serial", "bytea", "timestamptz"));
+        super.unmodifiableDataTypes.addAll(Arrays.asList("integer", "bool", "boolean", "int4", "int8", "float4", "float8", "numeric",
+            "bigserial", "serial", "bytea", "timestamptz", "array", "object", "variant"));
         super.unquotedObjectsAreUppercased = true;
         super.addReservedWords(getDefaultReservedWords());
         super.defaultAutoIncrementStartWith = BigInteger.ONE;


### PR DESCRIPTION
Add Snowflake structured data types in the unmodifiable Data Types list to avoid the incorrect results of the diffChangeLog command

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Structured data types are compared incorrectly.

Structured data types in the Snowflake can not be created with parameters: https://docs.snowflake.com/en/sql-reference/data-types-semistructured.html

![2023-01-31 12_26_53-DBeaver Ultimate 22 3 3 - _TEST_DB_ Script-85](https://user-images.githubusercontent.com/45152336/215721053-ea701a20-b83e-4231-bdb7-36f3edc82546.png)

But the result of comparing tables with these types of columns with the diffChangeLog command will be

```sql
CREATE OR REPLACE TABLE TEST_SEMI_STRUCTURED(
	var VARIANT(0),
	arr ARRAY(0),
	obj OBJECT(0));
```

because by default Liquibase returns data type name + parameters

And the simplest way to avoid it is adding data types in the unmodifiable types list:

https://github.com/liquibase/liquibase/blob/master/liquibase-core/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java#L435

Steps:

1. Create a table in schema1:

```sql
CREATE TABLE TEST_SEMI_STRUCTURED(
	var VARIANT,
	arr ARRAY,
	obj OBJECT);
```
2. Compare schema1 with an empty schema.

If I need to add tests - please, give me advice on how to do it better. Maybe like MSSQLDatabaseTest#isUnmodifiable? 
If I need to create a ticket for the issue first - tell me also.