### PR TITLE
Fix failing EnvironmentValueProviderTest

### DIFF
--- a/liquibase-core/src/test/groovy/liquibase/configuration/core/EnvironmentValueProviderTest.groovy
+++ b/liquibase-core/src/test/groovy/liquibase/configuration/core/EnvironmentValueProviderTest.groovy
@@ -1,87 +1,14 @@
 package liquibase.configuration.core
 
 import liquibase.GlobalConfiguration
-import liquibase.Scope
 import liquibase.hub.HubConfiguration
-import liquibase.license.LicenseInstallResult
-import liquibase.license.LicenseService
-import liquibase.license.LicenseServiceFactory
-import liquibase.license.Location
 import spock.lang.Specification
 import spock.lang.Unroll
 
 class EnvironmentValueProviderTest extends Specification {
-    static boolean licenseValid = false;
-    static final mockLicenseService = new LicenseService() {
-        @Override
-        int getPriority() {
-            return Integer.MAX_VALUE
-        }
-
-        @Override
-        boolean licenseIsInstalled() {
-            return false
-        }
-
-        @Override
-        boolean licenseIsValid(String subject) {
-            return licenseValid
-        }
-
-        @Override
-        String getLicenseInfo() {
-            return "Mock license"
-        }
-
-        @Override
-        LicenseInstallResult installLicense(Location... locations) {
-            return null
-        }
-
-        @Override
-        void disable() {
-
-        }
-
-        @Override
-        boolean licenseIsAboutToExpire() {
-            return false
-        }
-
-        @Override
-        int daysTilExpiration() {
-            return 100
-        }
-
-        void setLicenseValid(boolean aBoolean) {
-            this.licenseValid = aBoolean
-        }
-    }
-
-    def setup() {
-        def licenseFactory = Scope.currentScope.getSingleton(LicenseServiceFactory)
-        licenseFactory.register(mockLicenseService)
-    }
-
-    def cleanup() {
-        def licenseFactory = Scope.currentScope.getSingleton(LicenseServiceFactory)
-        licenseFactory.unregister(mockLicenseService)
-    }
 
     @Unroll
-    def "getProvidedValue doesn't require license"() {
-        setup:
-        mockLicenseService.setLicenseValid(false)
-
-        expect:
-        new EnvironmentValueProvider().getProvidedValue("java.home") != null
-    }
-
-    @Unroll
-    def "getProvidedValue with license"() {
-        setup:
-        mockLicenseService.setLicenseValid(true)
-
+    def "getProvidedValue"() {
         when:
         def provider = new EnvironmentValueProvider() {
             @Override


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

The `getProvidedValue doesn't require license` test is looking for a `java_home` environment variable, and so it fails on any development environments where that variable is not set.

I could have tried to find a different environment variable that's consistently available across all OS's and/or used a custom map like the other tests, but because the class under test has no references to LicenseService anymore it seemed like an unnecessary test to fix.

## Things to be aware of

Only removes a sometimes-failing test.

## Things to worry about

Nothing
