### PR TITLE
Standardize commandLabelFilter/commandContextFilter mdc value format (DAT-12958)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/ContextExpression.java
+++ b/liquibase-core/src/main/java/liquibase/ContextExpression.java
@@ -108,4 +108,8 @@ public class ContextExpression {
         }
         return true;
     }
+
+    public String getOriginalString() {
+        return originalString;
+    }
 }

--- a/liquibase-core/src/main/java/liquibase/LabelExpression.java
+++ b/liquibase-core/src/main/java/liquibase/LabelExpression.java
@@ -129,4 +129,7 @@ public class LabelExpression {
         return (this.labels == null) || this.labels.isEmpty();
     }
 
+    public String getOriginalString() {
+        return originalString;
+    }
 }

--- a/liquibase-core/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-core/src/main/java/liquibase/Liquibase.java
@@ -1071,12 +1071,10 @@ public class Liquibase implements AutoCloseable {
     }
 
     private void addCommandFiltersMdc(LabelExpression labelExpression, Contexts contexts) {
-        Scope.getCurrentScope().addMdcValue(MdcKey.COMMAND_LABEL_FILTER, formatMdcCommandFilters(labelExpression));
-        Scope.getCurrentScope().addMdcValue(MdcKey.COMMAND_CONTEXT_FILTER, formatMdcCommandFilters(contexts));
-    }
-
-    private String formatMdcCommandFilters(Object filter) {
-        return filter == null || filter.toString().equalsIgnoreCase("()") ? "" : filter.toString();
+        String labelFilterMdc = labelExpression != null && labelExpression.getOriginalString() != null ? labelExpression.getOriginalString() : "";
+        String contextFilterMdc = contexts != null ? contexts.toString() : "";
+        Scope.getCurrentScope().addMdcValue(MdcKey.COMMAND_LABEL_FILTER, labelFilterMdc);
+        Scope.getCurrentScope().addMdcValue(MdcKey.COMMAND_CONTEXT_FILTER, contextFilterMdc);
     }
 
     private void generateDeploymentId() {

--- a/liquibase-core/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-core/src/main/java/liquibase/Liquibase.java
@@ -1071,8 +1071,12 @@ public class Liquibase implements AutoCloseable {
     }
 
     private void addCommandFiltersMdc(LabelExpression labelExpression, Contexts contexts) {
-        Scope.getCurrentScope().addMdcValue(MdcKey.COMMAND_LABEL_FILTER, labelExpression != null ? labelExpression.toString(): "");
-        Scope.getCurrentScope().addMdcValue(MdcKey.COMMAND_CONTEXT_FILTER, contexts != null ? contexts.toString() : "");
+        Scope.getCurrentScope().addMdcValue(MdcKey.COMMAND_LABEL_FILTER, formatMdcCommandFilters(labelExpression));
+        Scope.getCurrentScope().addMdcValue(MdcKey.COMMAND_CONTEXT_FILTER, formatMdcCommandFilters(contexts));
+    }
+
+    private String formatMdcCommandFilters(Object filter) {
+        return filter == null || filter.toString().equalsIgnoreCase("()") ? "" : filter.toString();
     }
 
     private void generateDeploymentId() {

--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
@@ -1479,7 +1479,7 @@ public class ChangeSet implements Conditional, ChangeLogChild {
     private void addChangeSetMdcProperties() {
         String commentMdc = comments != null ? comments : "";
         String labelMdc = labels != null ? labels.toString() : "";
-        String contextsMdc = contextFilter != null ? contextFilter.toString() : "";
+        String contextsMdc = contextFilter != null && contextFilter.getOriginalString() != null ? contextFilter.getOriginalString() : "";
         Scope.getCurrentScope().addMdcValue(MdcKey.CHANGESET_COMMENT, commentMdc);
         Scope.getCurrentScope().addMdcValue(MdcKey.CHANGESET_LABEL, labelMdc);
         Scope.getCurrentScope().addMdcValue(MdcKey.CHANGESET_CONTEXT, contextsMdc);


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description
Formats all labelFilters and contextFilters to "", not "()". 
<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
