### PR TITLE
Adds databaseChangelogTableOutcome mdc (DAT-12978)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/executor/jvm/ChangelogJdbcMdcListener.java
+++ b/liquibase-core/src/main/java/liquibase/executor/jvm/ChangelogJdbcMdcListener.java
@@ -1,0 +1,77 @@
+package liquibase.executor.jvm;
+
+import liquibase.Scope;
+import liquibase.database.Database;
+import liquibase.exception.DatabaseException;
+import liquibase.executor.Executor;
+import liquibase.executor.ExecutorService;
+import liquibase.logging.mdc.MdcKey;
+import liquibase.logging.mdc.MdcValue;
+import liquibase.sqlgenerator.SqlGeneratorFactory;
+import liquibase.statement.SqlStatement;
+import liquibase.util.SqlUtil;
+
+/**
+ * A wrapper utility class around the standard JdbcExecutor used to monitor and log sql from Jdbc queries
+ */
+public class ChangelogJdbcMdcListener {
+
+    /**
+     * Execute the given statement via the jdbc executor. Adds MDC of the statement sql and outcome to logging.
+     *
+     * @param statement the statement to execute
+     * @param database  the database to execute against
+     * @param jdbcQuery the executor function to apply
+     * @throws DatabaseException if there was a problem running the sql statement
+     */
+    public static void execute(SqlStatement statement, Database database, ExecuteJdbc jdbcQuery) throws DatabaseException {
+        addSqlMdc(statement, database);
+        try {
+            jdbcQuery.execute(Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database));
+            logSuccess();
+        } catch (DatabaseException e) {
+            Scope.getCurrentScope().addMdcValue(MdcKey.DATABASE_CHANGELOG_OUTCOME, MdcValue.DATABASE_CHANGELOG_OUTCOME_FAILED);
+            throw new DatabaseException(e);
+        }
+    }
+
+    /**
+     * Execute the given statement via the jdbc executor. Adds MDC of the statement sql and outcome to logging.
+     *
+     * @param statement the statement to execute
+     * @param database  the database to execute against
+     * @param jdbcQuery the executor function to apply
+     * @return the result of the executor function
+     * @throws DatabaseException if there was a problem running the sql statement
+     */
+    public static <T> T query(SqlStatement statement, Database database, QueryJdbc<T> jdbcQuery) throws DatabaseException {
+        addSqlMdc(statement, database);
+        try {
+            T value = jdbcQuery.execute(Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database));
+            logSuccess();
+            return value;
+        } catch (DatabaseException e) {
+            Scope.getCurrentScope().addMdcValue(MdcKey.DATABASE_CHANGELOG_OUTCOME, MdcValue.DATABASE_CHANGELOG_OUTCOME_FAILED);
+            throw new DatabaseException(e);
+        }
+    }
+
+    private static void addSqlMdc(SqlStatement statement, Database database) {
+        Scope.getCurrentScope().addMdcValue(MdcKey.DATABASE_CHANGELOG_SQL, SqlUtil.getSqlString(statement, SqlGeneratorFactory.getInstance(), database));
+    }
+
+    private static void logSuccess() {
+        Scope.getCurrentScope().addMdcValue(MdcKey.DATABASE_CHANGELOG_OUTCOME, MdcValue.DATABASE_CHANGELOG_OUTCOME_SUCCESS);
+        Scope.getCurrentScope().getLog(ChangelogJdbcMdcListener.class).info("Changelog query completed.");
+        Scope.getCurrentScope().getMdcManager().remove(MdcKey.DATABASE_CHANGELOG_OUTCOME);
+        Scope.getCurrentScope().getMdcManager().remove(MdcKey.DATABASE_CHANGELOG_SQL);
+    }
+
+    public interface QueryJdbc<T> {
+        T execute(Executor executor) throws DatabaseException;
+    }
+
+    public interface ExecuteJdbc {
+        void execute(Executor executor) throws DatabaseException;
+    }
+}

--- a/liquibase-core/src/main/java/liquibase/logging/mdc/MdcKey.java
+++ b/liquibase-core/src/main/java/liquibase/logging/mdc/MdcKey.java
@@ -33,4 +33,5 @@ public class MdcKey {
     public static final String ROLLBACK_ONE_UPDATE_FORCE = "rollbackOneUpdateForce";
     public static final String ROLLBACK_TO_DATE = "rollbackToDate";
     public static final String DATABASE_CHANGELOG_SQL = "databaseChangelogSQL";
+    public static final String DATABASE_CHANGELOG_OUTCOME = "databaseChangelogTableOutcome";
 }

--- a/liquibase-core/src/main/java/liquibase/logging/mdc/MdcValue.java
+++ b/liquibase-core/src/main/java/liquibase/logging/mdc/MdcValue.java
@@ -4,4 +4,6 @@ public class MdcValue {
     public static final String COMMAND_SUCCESSFUL = "success";
     public static final String COMMAND_FAILED = "fail";
     public static final String URL_DATABASE_TARGET = "url";
+    public static final String DATABASE_CHANGELOG_OUTCOME_SUCCESS = "executed";
+    public static final String DATABASE_CHANGELOG_OUTCOME_FAILED = "failed";
 }

--- a/liquibase-core/src/test/java/liquibase/lockservice/StandardLockServiceTest.java
+++ b/liquibase-core/src/test/java/liquibase/lockservice/StandardLockServiceTest.java
@@ -6,6 +6,8 @@ import liquibase.exception.DatabaseException;
 import liquibase.exception.LockException;
 import liquibase.executor.Executor;
 import liquibase.executor.ExecutorService;
+import liquibase.logging.Logger;
+import liquibase.logging.mdc.MdcManager;
 import liquibase.sqlgenerator.SqlGeneratorFactory;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
@@ -50,6 +52,10 @@ public class StandardLockServiceTest {
 
         mockedScope = Mockito.mock(Scope.class);
         Mockito.when(mockedScope.getSingleton(ExecutorService.class)).thenReturn(executorService);
+        Logger logger = Mockito.mock(Logger.class);
+        MdcManager mdcManager = Mockito.mock(MdcManager.class);
+        Mockito.when(mockedScope.getLog(Mockito.any())).thenReturn(logger);
+        Mockito.when(mockedScope.getMdcManager()).thenReturn(mdcManager);
 
         lockService = new StandardLockService() {
             @Override


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description
Adds `ChangelogJdbcMdcListener` used to handle DATABASECHANGELOG and DATABASECHANGELOGLOCK queries and log relevant sql and outcomes. 

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
