### PR TITLE
DAT-13659 Fix nullpointers on table output

### DIFF
--- a/liquibase-core/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-core/src/main/java/liquibase/Liquibase.java
@@ -260,15 +260,13 @@ public class Liquibase implements AutoCloseable {
                     checkLiquibaseTables(true, changeLog, contexts, labelExpression);
                 }
 
-                //
+                changeLog.validate(database, contexts, labelExpression);
+
                 // Let the user know that they can register for Hub
-                //
                 hubUpdater = new HubUpdater(new Date(), changeLog, database);
                 hubUpdater.register(changeLogFile);
 
                 generateDeploymentId();
-
-                changeLog.validate(database, contexts, labelExpression);
 
                 //
                 // Create or retrieve the Connection if this is not SQL generation

--- a/liquibase-core/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-core/src/main/java/liquibase/Liquibase.java
@@ -259,15 +259,16 @@ public class Liquibase implements AutoCloseable {
                 if (checkLiquibaseTables) {
                     checkLiquibaseTables(true, changeLog, contexts, labelExpression);
                 }
-                generateDeploymentId();
-
-                changeLog.validate(database, contexts, labelExpression);
 
                 //
                 // Let the user know that they can register for Hub
                 //
                 hubUpdater = new HubUpdater(new Date(), changeLog, database);
                 hubUpdater.register(changeLogFile);
+
+                generateDeploymentId();
+
+                changeLog.validate(database, contexts, labelExpression);
 
                 //
                 // Create or retrieve the Connection if this is not SQL generation

--- a/liquibase-core/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-core/src/main/java/liquibase/Liquibase.java
@@ -1809,7 +1809,6 @@ public class Liquibase implements AutoCloseable {
                 try {
                     changeLog = getDatabaseChangeLog();
                     checkLiquibaseTables(true, changeLog, contexts, labelExpression);
-                    ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database).generateDeploymentId();
 
                     changeLog.validate(database, contexts, labelExpression);
 
@@ -1818,6 +1817,8 @@ public class Liquibase implements AutoCloseable {
                     //
                     hubUpdater = new HubUpdater(new Date(), changeLog, database);
                     hubUpdater.register(changeLogFile);
+
+                    ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database).generateDeploymentId();
 
                     //
                     // Create an iterator which will be used with a ListVisitor

--- a/liquibase-core/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-core/src/main/java/liquibase/Liquibase.java
@@ -262,7 +262,9 @@ public class Liquibase implements AutoCloseable {
 
                 changeLog.validate(database, contexts, labelExpression);
 
+                //
                 // Let the user know that they can register for Hub
+                //
                 hubUpdater = new HubUpdater(new Date(), changeLog, database);
                 hubUpdater.register(changeLogFile);
 
@@ -774,8 +776,6 @@ public class Liquibase implements AutoCloseable {
                     changeLog = getDatabaseChangeLog();
 
                     checkLiquibaseTables(true, changeLog, contexts, labelExpression);
-                    generateDeploymentId();
-
 
                     changeLog.validate(database, contexts, labelExpression);
 
@@ -784,6 +784,8 @@ public class Liquibase implements AutoCloseable {
                     //
                     hubUpdater = new HubUpdater(new Date(), changeLog, database);
                     hubUpdater.register(changeLogFile);
+
+                    generateDeploymentId();
 
                     //
                     // Create an iterator which will be used with a ListVisitor
@@ -910,8 +912,6 @@ public class Liquibase implements AutoCloseable {
 
                     checkLiquibaseTables(true, changeLog, contexts, labelExpression);
 
-                    generateDeploymentId();
-
                     changeLog.validate(database, contexts, labelExpression);
 
                     //
@@ -919,6 +919,8 @@ public class Liquibase implements AutoCloseable {
                     //
                     hubUpdater = new HubUpdater(new Date(), changeLog, database);
                     hubUpdater.register(changeLogFile);
+
+                    generateDeploymentId();
 
                     //
                     // Create an iterator which will be used with a ListVisitor

--- a/liquibase-core/src/main/java/liquibase/util/TableOutput.java
+++ b/liquibase-core/src/main/java/liquibase/util/TableOutput.java
@@ -242,7 +242,7 @@ public class TableOutput {
             }
             for (int i = 0; i < row.length; i++) {
                 String column = row[i];
-                if (column.length() > widths.get(i)) {
+                if (column != null && column.length() > widths.get(i)) {
                     widths.set(i, column.length());
                 }
             }
@@ -263,7 +263,7 @@ public class TableOutput {
         // If the column is null or shorter than the maxWidth AND the column does not contain a line separator,
         // return it unmodified. If it contains a line separator, then it does not matter if it is shorter than the max
         // width, because it must be split on the line separator to flow into multiple lines.
-        if ((col == null || col.length() <= maxWidth) && (col != null && !col.contains(System.lineSeparator()))) {
+        if (col == null || (col.length() <= maxWidth && !col.contains(System.lineSeparator()))) {
             return col;
         }
         String[] parts = col.split(" ");


### PR DESCRIPTION
Fix logic that clear out deploymentId when calling hub.register

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Since Liquibase 4.18, `StandardLockService.reset` calls out `changelogService.reset()` that clears de deployment id. HubService.regsiter is releasing the lock to wait for user input, so it's also clearing the deployment id.
