### PR TITLE
DAT-13664 - skip MDC logging for MarkChangeSetRanStatement SQLs 

### DIFF
--- a/liquibase-core/src/main/java/liquibase/executor/jvm/ChangelogJdbcMdcListener.java
+++ b/liquibase-core/src/main/java/liquibase/executor/jvm/ChangelogJdbcMdcListener.java
@@ -9,6 +9,7 @@ import liquibase.logging.mdc.MdcKey;
 import liquibase.logging.mdc.MdcValue;
 import liquibase.sqlgenerator.SqlGeneratorFactory;
 import liquibase.statement.SqlStatement;
+import liquibase.statement.core.MarkChangeSetRanStatement;
 import liquibase.util.SqlUtil;
 
 /**
@@ -25,7 +26,9 @@ public class ChangelogJdbcMdcListener {
      * @throws DatabaseException if there was a problem running the sql statement
      */
     public static void execute(SqlStatement statement, Database database, ExecuteJdbc jdbcQuery) throws DatabaseException {
-        addSqlMdc(statement, database);
+        if (!(statement instanceof MarkChangeSetRanStatement)) {
+            addSqlMdc(statement, database);
+        }
         try {
             jdbcQuery.execute(Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database));
             logSuccess();


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Skip MDC logging for MarkChangeSetRanStatement SQLs preventing skipping order executed ids.

## Things to be aware of

I won't call this a fix - it's more of a temporary workaround.
