### PR TITLE
fix hub for update-family of commands (DAT-6600)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/command/core/AbstractUpdateCommandStep.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/AbstractUpdateCommandStep.java
@@ -44,6 +44,7 @@ public abstract class AbstractUpdateCommandStep extends AbstractCommandStep impl
     public abstract UpdateSummaryEnum getShowSummary(CommandScope commandScope);
     public abstract String getChangeExecListenerClassArg(CommandScope commandScope);
     protected abstract String getChangeExecListenerPropertiesFileArg(CommandScope commandScope);
+    protected abstract String getHubOperation();
 
     @Override
     public List<Class<?>> requiredDependencies() {
@@ -90,7 +91,7 @@ public abstract class AbstractUpdateCommandStep extends AbstractCommandStep impl
             shouldRunIterator.run(statusVisitor, new RuntimeEnvironment(database, contexts, labelExpression));
 
             //Remember we built our hubHandler with our DefaultChangeExecListener so this HubChangeExecListener is delegating to them.
-            ChangeExecListener hubChangeExecListener = hubHandler.startHubForUpdate(changeLogParameters, changeLogIterator);
+            ChangeExecListener hubChangeExecListener = hubHandler.startHubForUpdate(changeLogParameters, changeLogIterator, getHubOperation());
             resultsBuilder.addResult(DEFAULT_CHANGE_EXEC_LISTENER_RESULT_KEY, defaultChangeExecListener);
             ChangeLogIterator runChangeLogIterator = getStandardChangelogIterator(commandScope, database, contexts, labelExpression, databaseChangeLog);
             CompositeLogService compositeLogService = new CompositeLogService(true, bufferLog);

--- a/liquibase-core/src/main/java/liquibase/command/core/UpdateCommandStep.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/UpdateCommandStep.java
@@ -111,4 +111,9 @@ public class UpdateCommandStep extends AbstractUpdateCommandStep implements Clea
     public void postUpdateLog() {
         Scope.getCurrentScope().getUI().sendMessage(coreBundle.getString("update.successful"));
     }
+
+    @Override
+    public String getHubOperation() {
+        return "update";
+    }
 }

--- a/liquibase-core/src/main/java/liquibase/command/core/UpdateCountCommandStep.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/UpdateCountCommandStep.java
@@ -138,4 +138,9 @@ public class UpdateCountCommandStep extends AbstractUpdateCommandStep {
                 new IgnoreChangeSetFilter(),
                 new CountChangeSetFilter(commandScope.getArgumentValue(COUNT_ARG)));
     }
+
+    @Override
+    public String getHubOperation() {
+        return "update-count";
+    }
 }

--- a/liquibase-core/src/main/java/liquibase/command/core/UpdateCountSqlCommandStep.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/UpdateCountSqlCommandStep.java
@@ -68,4 +68,9 @@ public class UpdateCountSqlCommandStep extends UpdateCountCommandStep {
         dependencies.addAll(super.requiredDependencies());
         return dependencies;
     }
+
+    @Override
+    public String getHubOperation() {
+        return "update-count";
+    }
 }

--- a/liquibase-core/src/main/java/liquibase/command/core/UpdateSqlCommandStep.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/UpdateSqlCommandStep.java
@@ -128,4 +128,9 @@ public class UpdateSqlCommandStep extends AbstractUpdateCommandStep {
     protected String getChangeExecListenerPropertiesFileArg(CommandScope commandScope) {
         return commandScope.getArgumentValue(CHANGE_EXEC_LISTENER_PROPERTIES_FILE_ARG);
     }
+
+    @Override
+    public String getHubOperation() {
+        return "update";
+    }
 }

--- a/liquibase-core/src/main/java/liquibase/command/core/helpers/HubHandler.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/helpers/HubHandler.java
@@ -59,9 +59,8 @@ public class HubHandler {
         return null;
     }
 
-    public HubChangeExecListener startHubForUpdate(ChangeLogParameters changeLogParameters, ChangeLogIterator listLogIterator) throws LiquibaseException, SQLException {
+    public HubChangeExecListener startHubForUpdate(ChangeLogParameters changeLogParameters, ChangeLogIterator listLogIterator, String operationCommand) throws LiquibaseException, SQLException {
         if (isConnected()) {
-            String operationCommand = "update";
             operation = hubUpdater.preUpdateHub("UPDATE",
                     operationCommand,
                     connection,


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Authored by Alex, this fixes the hub interactions for the update-family of commands.

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
