### PR TITLE
Rollback Snakeyaml default config to allow duplicate keys.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/parser/core/yaml/YamlParser.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/yaml/YamlParser.java
@@ -15,7 +15,6 @@ public abstract class YamlParser implements LiquibaseParser {
         LoaderOptions options = new LoaderOptions();
         SnakeYamlUtil.setCodePointLimitSafely(options, Integer.MAX_VALUE);
         SnakeYamlUtil.setProcessCommentsSafely(options, false);
-        options.setAllowDuplicateKeys(true);
         options.setAllowRecursiveKeys(false);
         return options;
     }

--- a/liquibase-core/src/main/java/liquibase/parser/core/yaml/YamlParser.java
+++ b/liquibase-core/src/main/java/liquibase/parser/core/yaml/YamlParser.java
@@ -15,7 +15,7 @@ public abstract class YamlParser implements LiquibaseParser {
         LoaderOptions options = new LoaderOptions();
         SnakeYamlUtil.setCodePointLimitSafely(options, Integer.MAX_VALUE);
         SnakeYamlUtil.setProcessCommentsSafely(options, false);
-        options.setAllowDuplicateKeys(false);
+        options.setAllowDuplicateKeys(true);
         options.setAllowRecursiveKeys(false);
         return options;
     }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Go back to the old default of allowing duplicate keys. This change was added as part of  PR https://github.com/liquibase/liquibase/pull/3632 that removed deprecate methods, but it is a behavior change that we don't want.

## Things to be aware of

## Things to worry about


## Additional Context

It breaks flow tests.
