### PR TITLE
Do not add endDelimiter to MDC generated SQL if it is already there DAT-13911

### DIFF
--- a/liquibase-core/src/main/java/liquibase/util/SqlUtil.java
+++ b/liquibase-core/src/main/java/liquibase/util/SqlUtil.java
@@ -361,7 +361,7 @@ public abstract class SqlUtil {
         Sql[] sqlStatements = sqlGeneratorFactory.generateSql(statement, database);
         if (sqlStatements != null) {
             return Arrays.stream(sqlStatements)
-                    .map(sql -> sql.toSql() + sql.getEndDelimiter())
+                    .map(sql -> sql.toSql().endsWith(sql.getEndDelimiter()) ? sql.toSql() : sql.toSql() + sql.getEndDelimiter())
                     .collect(Collectors.joining("\n"));
         } else {
             return "";


### PR DESCRIPTION
DAT-13911

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

The generated SQL in the MDC should not include an extra semi-colon 

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
