### PR TITLE
Fixed issue where summary is not displayed when nothing is deployed

### DIFF
--- a/liquibase-core/src/main/java/liquibase/command/core/AbstractUpdateCommandStep.java
+++ b/liquibase-core/src/main/java/liquibase/command/core/AbstractUpdateCommandStep.java
@@ -98,12 +98,11 @@ public abstract class AbstractUpdateCommandStep extends AbstractCommandStep impl
             CompositeLogService compositeLogService = new CompositeLogService(true, bufferLog);
             HashMap<String, Object> scopeValues = new HashMap<>();
             scopeValues.put(Scope.Attr.logService.name(), compositeLogService);
-            scopeValues.put("showSummary", getShowSummary(commandScope));
             Scope.child(scopeValues, () -> {
                 //If we are using hub, we want to use the HubChangeExecListener, which is wrapping all the others. Otherwise, use the default.
                 ChangeExecListener listenerToUse = hubChangeExecListener != null ? hubChangeExecListener : defaultChangeExecListener;
                 runChangeLogIterator.run(new UpdateVisitor(database, listenerToUse), new RuntimeEnvironment(database, contexts, labelExpression));
-                ShowSummaryUtil.showUpdateSummary(databaseChangeLog, statusVisitor, resultsBuilder.getOutputStream());
+                ShowSummaryUtil.showUpdateSummary(databaseChangeLog, getShowSummary(commandScope), statusVisitor, resultsBuilder.getOutputStream());
             });
 
             hubHandler.postUpdateHub(bufferLog);
@@ -250,7 +249,8 @@ public abstract class AbstractUpdateCommandStep extends AbstractCommandStep impl
             StatusVisitor statusVisitor = new StatusVisitor(database);
             ChangeLogIterator shouldRunIterator = getStatusChangelogIterator(commandScope, database, contexts, labelExpression, databaseChangeLog);
             shouldRunIterator.run(statusVisitor, new RuntimeEnvironment(database, contexts, labelExpression));
-            ShowSummaryUtil.showUpdateSummary(databaseChangeLog, statusVisitor, outputStream);
+            UpdateSummaryEnum showSummary = getShowSummary(commandScope);
+            ShowSummaryUtil.showUpdateSummary(databaseChangeLog, showSummary, statusVisitor, outputStream);
             return true;
         }
         return false;

--- a/liquibase-core/src/main/java/liquibase/util/ShowSummaryUtil.java
+++ b/liquibase-core/src/main/java/liquibase/util/ShowSummaryUtil.java
@@ -40,19 +40,18 @@ public class ShowSummaryUtil {
      * Show a summary of the changesets which were executed
      *
      * @param   changeLog                          The changelog used in this update
+     * @param   showSummary                        Flag to control whether or not we show the summary
      * @param   statusVisitor                      The StatusVisitor used to determine statuses
      * @param   outputStream                       The OutputStream to use for the summary
      * @throws  LiquibaseException                 Thrown by this method
      * @throws  IOException                        Thrown by this method
      *
      */
-    public static void showUpdateSummary(DatabaseChangeLog changeLog, StatusVisitor statusVisitor, OutputStream outputStream)
+    public static void showUpdateSummary(DatabaseChangeLog changeLog, UpdateSummaryEnum showSummary, StatusVisitor statusVisitor, OutputStream outputStream)
             throws LiquibaseException, IOException {
         //
         // Check the global flag to turn the summary off
         //
-        String showSummaryString = Scope.getCurrentScope().get("showSummary", String.class);
-        UpdateSummaryEnum showSummary = showSummaryString != null ? UpdateSummaryEnum.valueOf(showSummaryString) : UpdateSummaryEnum.OFF;
         if (showSummary == UpdateSummaryEnum.OFF) {
             return;
         }

--- a/liquibase-integration-tests/src/test/groovy/liquibase/util/ShowSummaryUtilCommandTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/util/ShowSummaryUtilCommandTest.groovy
@@ -1,0 +1,43 @@
+package liquibase.util
+
+import liquibase.Scope
+import liquibase.command.util.CommandUtil
+import liquibase.extension.testing.testsystem.DatabaseTestSystem
+import liquibase.extension.testing.testsystem.TestSystemFactory
+import liquibase.extension.testing.testsystem.spock.LiquibaseIntegrationTest
+import liquibase.util.FileUtil
+import spock.lang.Shared
+import spock.lang.Specification
+
+@LiquibaseIntegrationTest
+class ShowSummaryUtilCommandTest extends Specification {
+    @Shared
+    private DatabaseTestSystem postgres = (DatabaseTestSystem) Scope.getCurrentScope().getSingleton(TestSystemFactory.class).getTestSystem("postgresql")
+
+    def "Should show summary output when run multiple times"() {
+        given:
+        String outputFile = "target/test-classes/output.txt"
+
+        when:
+        new File(outputFile).delete()
+        CommandUtil.runUpdate(postgres,'changelogs/pgsql/update/showSummaryWithLabels.xml', "testtable1", "none", outputFile)
+
+        then:
+        new File(outputFile).getText("UTF-8").contains("Run:                          2")
+        new File(outputFile).getText("UTF-8").contains("Filtered out:                 4")
+
+        when:
+        new File(outputFile).delete()
+        CommandUtil.runUpdate(postgres,'changelogs/pgsql/update/showSummaryWithLabels.xml', "testtable1", "none", outputFile)
+
+        then:
+        new File(outputFile).getText("UTF-8").contains("Run:                          0")
+        new File(outputFile).getText("UTF-8").contains("Filtered out:                 4")
+
+        cleanup:
+        CommandUtil.runDropAll(postgres)
+        if (postgres.getConnection() != null) {
+            postgres.getConnection().close()
+        }
+    }
+}

--- a/liquibase-integration-tests/src/test/resources/changelogs/pgsql/update/showSummaryWithLabels.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/pgsql/update/showSummaryWithLabels.xml
@@ -1,0 +1,47 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog
+xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+
+  <changeSet author="lbuser" id="1-table" labels="testtable1" contextFilter="none">
+        <createTable tableName="testtable1">
+            <column name="supplier_id" type="numeric(4)"/>
+            <column name="supplier_name" type="VARCHAR(50)"/>
+        </createTable>
+    </changeSet>
+
+  <changeSet author="lbuser" id="2-table" labels="testtable2" context="some">
+        <createTable tableName="testtable2">
+            <column name="supplier_id" type="numeric(4)"/>
+            <column name="supplier_name" type="VARCHAR(50)"/>
+        </createTable>
+    </changeSet>
+
+  <changeSet author="lbuser" id="3-table" labels="testtable3" context="none" dbms="postgres">
+        <createTable tableName="testtable3">
+            <column name="supplier_id" type="numeric(4)"/>
+            <column name="supplier_name" type="VARCHAR(50)"/>
+        </createTable>
+    </changeSet>
+
+  <changeSet  author="Liquibase Pro User" id="tagDatabaseforUpdate" labels="tagIt" contextFilter="tagIt">
+    <tagDatabase tag="updateTag"/>
+  </changeSet>
+
+  <changeSet author="lbuser" id="4-table" labels="testtable4" contextFilter="none">
+        <createTable tableName="testtable4">
+            <column name="supplier_id" type="numeric(4)"/>
+            <column name="supplier_name" type="VARCHAR(50)"/>
+        </createTable>
+    </changeSet>
+
+  <changeSet author="lbuser" id="5-table">
+        <createTable tableName="testtable5">
+            <column name="supplier_id" type="numeric(4)"/>
+            <column name="supplier_name" type="VARCHAR(50)"/>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description
In the case where nothing is deployed, no summary was displayed.  Fixed and added integration test.

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
