### PR TITLE
migrate ChangeLogHistoryServiceFactory to AbstractPluginFactory pattern

### DIFF
--- a/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/command/CommandTests.groovy
+++ b/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/command/CommandTests.groovy
@@ -556,7 +556,7 @@ Long Description: ${commandDefinition.getLongDescription() ?: "NOT SET"}
     }
 
     private static File takeDatabaseSnapshot(Database database, String format) {
-        final ChangeLogHistoryService changeLogService = ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database)
+        final ChangeLogHistoryService changeLogService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database)
         changeLogService.init()
         changeLogService.reset()
 

--- a/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/setup/SetupChangeLogSync.groovy
+++ b/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/setup/SetupChangeLogSync.groovy
@@ -1,6 +1,7 @@
 package liquibase.extension.testing.setup
 
 import liquibase.Liquibase
+import liquibase.Scope
 import liquibase.changelog.ChangeLogHistoryService
 import liquibase.changelog.ChangeLogHistoryServiceFactory
 import liquibase.database.Database
@@ -25,7 +26,7 @@ class SetupChangeLogSync extends TestSetup {
     void setup(TestSetupEnvironment testSetupEnvironment) throws Exception {
         Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(testSetupEnvironment.connection))
 
-        final ChangeLogHistoryService changeLogService = ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database)
+        final ChangeLogHistoryService changeLogService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database)
         changeLogService.init()
         changeLogService.generateDeploymentId()
 

--- a/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/setup/SetupChangelogHistory.groovy
+++ b/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/setup/SetupChangelogHistory.groovy
@@ -1,5 +1,6 @@
 package liquibase.extension.testing.setup
 
+import liquibase.Scope
 import liquibase.changelog.ChangeLogHistoryService
 import liquibase.changelog.ChangeLogHistoryServiceFactory
 import liquibase.changelog.ChangeSet
@@ -20,7 +21,7 @@ class SetupChangelogHistory extends TestSetup {
     void setup(TestSetupEnvironment testSetupEnvironment) throws Exception {
         Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(testSetupEnvironment.connection))
 
-        final ChangeLogHistoryService changeLogService = ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database)
+        final ChangeLogHistoryService changeLogService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database)
         changeLogService.init()
         changeLogService.generateDeploymentId()
 

--- a/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/setup/SetupDatabaseStructure.groovy
+++ b/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/setup/SetupDatabaseStructure.groovy
@@ -23,7 +23,7 @@ class SetupDatabaseStructure extends TestSetup {
     void setup(TestSetupEnvironment testSetupEnvironment) throws Exception {
         Database database = getDatabase(testSetupEnvironment)
 
-        final ChangeLogHistoryService changeLogService = ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database)
+        final ChangeLogHistoryService changeLogService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database)
         changeLogService.init()
         changeLogService.generateDeploymentId()
 

--- a/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/setup/SetupRollbackCount.groovy
+++ b/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/setup/SetupRollbackCount.groovy
@@ -1,6 +1,7 @@
 package liquibase.extension.testing.setup
 
 import liquibase.Liquibase
+import liquibase.Scope
 import liquibase.changelog.ChangeLogHistoryService
 import liquibase.changelog.ChangeLogHistoryServiceFactory
 import liquibase.database.Database
@@ -27,7 +28,7 @@ class SetupRollbackCount extends TestSetup {
     void setup(TestSetupEnvironment testSetupEnvironment) throws Exception {
         Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(testSetupEnvironment.connection))
 
-        final ChangeLogHistoryService changeLogService = ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database)
+        final ChangeLogHistoryService changeLogService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database)
         changeLogService.init()
         changeLogService.generateDeploymentId()
 

--- a/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/setup/SetupRunChangelog.groovy
+++ b/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/setup/SetupRunChangelog.groovy
@@ -48,7 +48,7 @@ class SetupRunChangelog extends TestSetup {
     void setup(TestSetupEnvironment testSetupEnvironment) throws Exception {
         Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(testSetupEnvironment.connection))
 
-        final ChangeLogHistoryService changeLogService = ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database)
+        final ChangeLogHistoryService changeLogService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database)
         changeLogService.init()
         changeLogService.generateDeploymentId()
 

--- a/liquibase-integration-tests/src/test/groovy/liquibase/LiquibaseTestIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/LiquibaseTestIntegrationTest.groovy
@@ -183,7 +183,7 @@ class LiquibaseTestIntegrationTest extends Specification {
         liquibase.clearCheckSums()
 
         then:
-        List<RanChangeSet> ranChangeSets = ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(liquibase.getDatabase()).getRanChangeSets()
+        List<RanChangeSet> ranChangeSets = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(liquibase.getDatabase()).getRanChangeSets()
         assert ranChangeSets.get(0).getLastCheckSum() == null
 
         cleanup:

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
@@ -154,7 +154,7 @@ public abstract class AbstractIntegrationTest {
         LockServiceFactory.getInstance().resetAll();
         LockServiceFactory.getInstance().getLockService(database).init();
 
-        ChangeLogHistoryServiceFactory.getInstance().resetAll();
+        Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).resetAll();
     }
 
     /**

--- a/liquibase-integration-tests/src/test/java/liquibase/statementexecute/AbstractExecuteTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/statementexecute/AbstractExecuteTest.java
@@ -98,7 +98,7 @@ public abstract class AbstractExecuteTest {
                     testedDatabases.add(database.getClass());
 
                     if (database.getConnection() != null) {
-                        ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database).init();
+                        Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database).init();
                         LockServiceFactory.getInstance().getLockService(database).init();
                     }
 

--- a/liquibase-integration-tests/src/test/java/liquibase/statementexecute/MarkChangeSetRanExecuteTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/statementexecute/MarkChangeSetRanExecuteTest.java
@@ -1,5 +1,6 @@
 package liquibase.statementexecute;
 
+import liquibase.Scope;
 import liquibase.changelog.ChangeLogHistoryServiceFactory;
 import liquibase.changelog.ChangeSet;
 import liquibase.database.Database;
@@ -23,7 +24,7 @@ public class MarkChangeSetRanExecuteTest extends AbstractExecuteTest {
 
     @Test
     public void generateSql_insert() throws Exception {
-        ChangeLogHistoryServiceFactory.getInstance().resetAll();
+        Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).resetAll();
 
         this.statementUnderTest = new MarkChangeSetRanStatement(new ChangeSet("a", "b", false, false, "c", "e", "f",
                 null), ChangeSet.ExecType.EXECUTED);
@@ -119,7 +120,7 @@ public class MarkChangeSetRanExecuteTest extends AbstractExecuteTest {
 
     @Test
     public void generateSql_update() throws Exception {
-        ChangeLogHistoryServiceFactory.getInstance().resetAll();
+        Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).resetAll();
 
         this.statementUnderTest = new MarkChangeSetRanStatement(new ChangeSet("a", "b", false, false, "c", "e", "f",
                 null), ChangeSet.ExecType.RERAN);

--- a/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/update.test.groovy
+++ b/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/update.test.groovy
@@ -67,7 +67,7 @@ Optional Args:
          expectations = {
              // Check that the order executed number increments by 1 for each changeset
              def database = (Database) Scope.getCurrentScope().get("database", null)
-             def changelogHistoryService = ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database)
+             def changelogHistoryService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database)
              List<RanChangeSet> ranChangeSets = changelogHistoryService.getRanChangeSets()
              int expectedOrder = 1
              for (RanChangeSet ranChangeSet : ranChangeSets) {

--- a/liquibase-standard/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-standard/src/main/java/liquibase/Liquibase.java
@@ -947,7 +947,7 @@ public class Liquibase implements AutoCloseable {
 
     protected void resetServices() {
         LockServiceFactory.getInstance().resetAll();
-        ChangeLogHistoryServiceFactory.getInstance().resetAll();
+        Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).resetAll();
         Scope.getCurrentScope().getSingleton(ExecutorService.class).reset();
     }
 
@@ -1040,7 +1040,7 @@ public class Liquibase implements AutoCloseable {
     public void checkLiquibaseTables(boolean updateExistingNullChecksums, DatabaseChangeLog databaseChangeLog,
                                      Contexts contexts, LabelExpression labelExpression) throws LiquibaseException {
         ChangeLogHistoryService changeLogHistoryService =
-                ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(getDatabase());
+            Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(getDatabase());
         changeLogHistoryService.init();
         if (updateExistingNullChecksums) {
             changeLogHistoryService.upgradeChecksums(databaseChangeLog, contexts, labelExpression);
@@ -1230,7 +1230,7 @@ public class Liquibase implements AutoCloseable {
 
             try {
                 checkLiquibaseTables(false, null, new Contexts(), new LabelExpression());
-                ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database).clearAllCheckSums();
+                Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database).clearAllCheckSums();
             } finally {
                 try {
                     lockService.releaseLock();

--- a/liquibase-standard/src/main/java/liquibase/change/core/TagDatabaseChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/TagDatabaseChange.java
@@ -1,5 +1,6 @@
 package liquibase.change.core;
 
+import liquibase.Scope;
 import liquibase.change.*;
 import liquibase.changelog.ChangeLogHistoryServiceFactory;
 import liquibase.database.Database;
@@ -36,7 +37,8 @@ public class TagDatabaseChange extends AbstractChange {
     @Override
     public ChangeStatus checkStatus(Database database) {
         try {
-            return new ChangeStatus().assertComplete(ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database).tagExists(getTag()), "Database not tagged");
+            return new ChangeStatus().assertComplete(
+                Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database).tagExists(getTag()), "Database not tagged");
         } catch (DatabaseException e) {
             return new ChangeStatus().unknown(e);
         }

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryService.java
@@ -6,12 +6,14 @@ import liquibase.database.Database;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.DatabaseHistoryException;
 import liquibase.exception.LiquibaseException;
+import liquibase.plugin.Plugin;
 import liquibase.servicelocator.PrioritizedService;
 
 import java.util.Date;
 import java.util.List;
 
-public interface ChangeLogHistoryService extends PrioritizedService {
+public interface ChangeLogHistoryService extends Plugin {
+    int getPriority();
 
     boolean supports(Database database);
 

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryServiceFactory.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryServiceFactory.java
@@ -39,7 +39,7 @@ public class ChangeLogHistoryServiceFactory extends AbstractPluginFactory<Change
     }
 
     @Override
-    public void register(final ChangeLogHistoryService plugin) {
+    public synchronized void register(final ChangeLogHistoryService plugin) {
         super.register(plugin);
         explicitRegistered.add(plugin);
     }
@@ -76,11 +76,11 @@ public class ChangeLogHistoryServiceFactory extends AbstractPluginFactory<Change
             }
     }
 
-    public void unregister(final ChangeLogHistoryService service) {
+    public synchronized void unregister(final ChangeLogHistoryService service) {
         removeInstance(service);
     }
 
-    public void resetAll() {
+    public synchronized void resetAll() {
         for (ChangeLogHistoryService changeLogHistoryService : findAllInstances()) {
             changeLogHistoryService.reset();
         }

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryServiceFactory.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryServiceFactory.java
@@ -1,74 +1,58 @@
 package liquibase.changelog;
 
-import liquibase.Scope;
 import liquibase.database.Database;
 import liquibase.exception.UnexpectedLiquibaseException;
-
-import java.util.*;
+import liquibase.plugin.AbstractPluginFactory;
+import liquibase.plugin.Plugin;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class ChangeLogHistoryServiceFactory {
+public class ChangeLogHistoryServiceFactory extends AbstractPluginFactory<ChangeLogHistoryService> {
 
-    private static ChangeLogHistoryServiceFactory instance;
-
-    private final List<ChangeLogHistoryService> registry = new ArrayList<>();
-
+    private final List<ChangeLogHistoryService> explicitRegistered = new ArrayList<>();
     private final Map<Database, ChangeLogHistoryService> services = new ConcurrentHashMap<>();
 
-    public static synchronized ChangeLogHistoryServiceFactory getInstance() {
-        if (instance == null) {
-            instance = new ChangeLogHistoryServiceFactory();
-        }
-        return instance;
-    }
-
-    /**
-     * Set the instance used by this singleton. Used primarily for testing.
-     */
-    public static synchronized void setInstance(ChangeLogHistoryServiceFactory changeLogHistoryServiceFactory) {
-        ChangeLogHistoryServiceFactory.instance = changeLogHistoryServiceFactory;
-    }
-
-
-    public static synchronized void reset() {
-        instance = null;
-    }
-
     private ChangeLogHistoryServiceFactory() {
-        try {
-            for (ChangeLogHistoryService service : Scope.getCurrentScope().getServiceLocator().findInstances(ChangeLogHistoryService.class)) {
-                register(service);
-            }
+    }
 
-        } catch (Exception e) {
-            throw new UnexpectedLiquibaseException(e);
+    @Override
+    protected Class<ChangeLogHistoryService> getPluginClass() {
+        return ChangeLogHistoryService.class;
+    }
+
+    @Override
+    protected int getPriority(final ChangeLogHistoryService changeLogHistoryService, final Object... args) {
+        Database database = (Database) args[0];
+        if (changeLogHistoryService.supports(database)) {
+            return changeLogHistoryService.getPriority();
+        } else {
+            return Plugin.PRIORITY_NOT_APPLICABLE;
         }
     }
 
-    public void register(ChangeLogHistoryService changeLogHistoryService) {
-        registry.add(0, changeLogHistoryService);
+    @Override
+    public void register(final ChangeLogHistoryService plugin) {
+        super.register(plugin);
+        explicitRegistered.add(plugin);
     }
+
 
     public ChangeLogHistoryService getChangeLogService(Database database) {
             if (services.containsKey(database)) {
                 return services.get(database);
             }
-            SortedSet<ChangeLogHistoryService> foundServices = new TreeSet<>((o1, o2) -> -1 * Integer.compare(o1.getPriority(), o2.getPriority()));
 
-            for (ChangeLogHistoryService service : registry) {
-                if (service.supports(database)) {
-                    foundServices.add(service);
-                }
-            }
+            ChangeLogHistoryService plugin = getPlugin(database);
 
-            if (foundServices.isEmpty()) {
+            if (plugin == null) {
                 throw new UnexpectedLiquibaseException("Cannot find ChangeLogHistoryService for " +
                     database.getShortName());
             }
 
             try {
-                ChangeLogHistoryService exampleService = foundServices.iterator().next();
-                Class<? extends ChangeLogHistoryService> aClass = exampleService.getClass();
+                Class<? extends ChangeLogHistoryService> aClass = plugin.getClass();
                 ChangeLogHistoryService service;
                 try {
                     aClass.getConstructor();
@@ -76,7 +60,7 @@ public class ChangeLogHistoryServiceFactory {
                     service.setDatabase(database);
                 } catch (NoSuchMethodException e) {
                     // must have been manually added to the registry and so already configured.
-                    service = exampleService;
+                    service = plugin;
                 }
 
                 services.put(database, service);
@@ -86,13 +70,18 @@ public class ChangeLogHistoryServiceFactory {
             }
     }
 
+    public void unregister(final ChangeLogHistoryService service) {
+        removeInstance(service);
+    }
+
     public void resetAll() {
-        synchronized (ChangeLogHistoryServiceFactory.class) {
-            for (ChangeLogHistoryService changeLogHistoryService : registry) {
-                changeLogHistoryService.reset();
-            }
-            instance = null;
+        for (ChangeLogHistoryService changeLogHistoryService : findAllInstances()) {
+            changeLogHistoryService.reset();
         }
+        services.clear();
+        // unregister all self-registered
+        explicitRegistered.forEach(this::removeInstance);
+        explicitRegistered.clear();
     }
 }
 

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryServiceFactory.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryServiceFactory.java
@@ -1,5 +1,6 @@
 package liquibase.changelog;
 
+import liquibase.Scope;
 import liquibase.database.Database;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.plugin.AbstractPluginFactory;
@@ -13,6 +14,11 @@ public class ChangeLogHistoryServiceFactory extends AbstractPluginFactory<Change
 
     private final List<ChangeLogHistoryService> explicitRegistered = new ArrayList<>();
     private final Map<Database, ChangeLogHistoryService> services = new ConcurrentHashMap<>();
+
+    @Deprecated // use Scope instead
+    public static synchronized ChangeLogHistoryServiceFactory getInstance() {
+        return Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class);
+    }
 
     private ChangeLogHistoryServiceFactory() {
     }

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryServiceFactory.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryServiceFactory.java
@@ -15,7 +15,10 @@ public class ChangeLogHistoryServiceFactory extends AbstractPluginFactory<Change
     private final List<ChangeLogHistoryService> explicitRegistered = new ArrayList<>();
     private final Map<Database, ChangeLogHistoryService> services = new ConcurrentHashMap<>();
 
-    @Deprecated // use Scope instead
+    /**
+     * @deprecated Instead use Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class)
+     */
+    @Deprecated
     public static synchronized ChangeLogHistoryServiceFactory getInstance() {
         return Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class);
     }

--- a/liquibase-standard/src/main/java/liquibase/changelog/MockChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/MockChangeLogHistoryService.java
@@ -31,7 +31,7 @@ public class MockChangeLogHistoryService implements ChangeLogHistoryService {
 
     @Override
     public int getPriority() {
-        return PRIORITY_DATABASE;
+        return 5;
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/changelog/visitor/ChangeLogSyncVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/visitor/ChangeLogSyncVisitor.java
@@ -61,7 +61,7 @@ public class ChangeLogSyncVisitor implements ChangeSetVisitor {
 
     private void postRunMdc() {
         try {
-            ChangeLogHistoryServiceFactory instance = ChangeLogHistoryServiceFactory.getInstance();
+            ChangeLogHistoryServiceFactory instance = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class);
             String deploymentId = instance.getChangeLogService(database).getDeploymentId();
             Scope.getCurrentScope().addMdcValue(MdcKey.DEPLOYMENT_ID, deploymentId);
         } catch (Exception e) {

--- a/liquibase-standard/src/main/java/liquibase/changelog/visitor/StatusVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/visitor/StatusVisitor.java
@@ -1,5 +1,6 @@
 package liquibase.changelog.visitor;
 
+import liquibase.Scope;
 import liquibase.changelog.*;
 import liquibase.changelog.filter.ChangeSetFilterResult;
 import liquibase.changelog.filter.NotInChangeLogChangeSetFilter;
@@ -18,7 +19,8 @@ public class StatusVisitor implements ChangeSetVisitor, SkippedChangeSetVisitor 
     private final List<RanChangeSet> ranChangeSets;
 
     public StatusVisitor(Database database) throws LiquibaseException {
-        ranChangeSets = new ArrayList<>(ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database).getRanChangeSets());
+        ranChangeSets = new ArrayList<>(
+            Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database).getRanChangeSets());
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/changelog/visitor/UpdateVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/visitor/UpdateVisitor.java
@@ -95,7 +95,7 @@ public class UpdateVisitor implements ChangeSetVisitor {
 
     private void addAttributesForMdc(ChangeSet changeSet, ExecType execType) {
         changeSet.setAttribute("updateExecType", execType);
-        ChangeLogHistoryService changelogService = ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database);
+        ChangeLogHistoryService changelogService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database);
         String deploymentId = changelogService.getDeploymentId();
         changeSet.setAttribute("deploymentId", deploymentId);
     }

--- a/liquibase-standard/src/main/java/liquibase/command/core/AbstractFutureRollbackCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/AbstractFutureRollbackCommandStep.java
@@ -69,7 +69,7 @@ public abstract class AbstractFutureRollbackCommandStep extends AbstractCommandS
         lockService.waitForLock();
 
         try {
-            ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database).generateDeploymentId();
+            Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database).generateDeploymentId();
 
             changeLog.validate(database, contexts, labelExpression);
 

--- a/liquibase-standard/src/main/java/liquibase/command/core/AbstractUpdateCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/AbstractUpdateCommandStep.java
@@ -70,7 +70,7 @@ public abstract class AbstractUpdateCommandStep extends AbstractCommandStep impl
             if (isUpToDate(commandScope, database, databaseChangeLog, contexts, labelExpression, resultsBuilder.getOutputStream())) {
                 return;
             }
-            ChangeLogHistoryService changelogService = ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database);
+            ChangeLogHistoryService changelogService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database);
             Scope.getCurrentScope().addMdcValue(MdcKey.DEPLOYMENT_ID, changelogService.getDeploymentId());
             Scope.getCurrentScope().getLog(getClass()).info(String.format("Using deploymentId: %s", changelogService.getDeploymentId()));
 
@@ -122,7 +122,7 @@ public abstract class AbstractUpdateCommandStep extends AbstractCommandStep impl
     @Override
     public void cleanUp(CommandResultsBuilder resultsBuilder) {
         LockServiceFactory.getInstance().resetAll();
-        ChangeLogHistoryServiceFactory.getInstance().resetAll();
+        Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).resetAll();
         Scope.getCurrentScope().getSingleton(ExecutorService.class).reset();
     }
 
@@ -188,7 +188,7 @@ public abstract class AbstractUpdateCommandStep extends AbstractCommandStep impl
                 // Discard the cached fetched un-run changeset list, as if
                 // another peer is running the changesets in parallel, we may
                 // get a different answer after taking out the write lock
-                ChangeLogHistoryService changeLogService = ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database);
+                ChangeLogHistoryService changeLogService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database);
                 changeLogService.reset();
             }
         }

--- a/liquibase-standard/src/main/java/liquibase/command/core/InternalHistoryCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/InternalHistoryCommandStep.java
@@ -65,7 +65,7 @@ public class InternalHistoryCommandStep extends AbstractCommandStep {
 
         Database database = commandScope.getArgumentValue(DATABASE_ARG);
 
-        ChangeLogHistoryService historyService = ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database);
+        ChangeLogHistoryService historyService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database);
 
         String headerMsg = "Liquibase History for " + database.getConnection().getURL();
         output.println(headerMsg);

--- a/liquibase-standard/src/main/java/liquibase/command/core/ListLocksCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/ListLocksCommandStep.java
@@ -2,6 +2,7 @@ package liquibase.command.core;
 
 import liquibase.Contexts;
 import liquibase.LabelExpression;
+import liquibase.Scope;
 import liquibase.changelog.ChangeLogHistoryService;
 import liquibase.changelog.ChangeLogHistoryServiceFactory;
 import liquibase.changelog.DatabaseChangeLog;
@@ -73,7 +74,7 @@ public class ListLocksCommandStep extends AbstractCommandStep {
     public static void checkLiquibaseTables(boolean updateExistingNullChecksums, DatabaseChangeLog databaseChangeLog,
                                      Contexts contexts, LabelExpression labelExpression, Database database) throws LiquibaseException {
         ChangeLogHistoryService changeLogHistoryService =
-                ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database);
+            Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database);
         changeLogHistoryService.init();
         if (updateExistingNullChecksums) {
             changeLogHistoryService.upgradeChecksums(databaseChangeLog, contexts, labelExpression);

--- a/liquibase-standard/src/main/java/liquibase/command/core/TagCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/TagCommandStep.java
@@ -31,7 +31,7 @@ public class TagCommandStep extends AbstractCommandStep {
     public void run(CommandResultsBuilder resultsBuilder) throws Exception {
         CommandScope commandScope = resultsBuilder.getCommandScope();
         Database database = (Database) commandScope.getDependency(Database.class);
-        ChangeLogHistoryService changeLogService = ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database);
+        ChangeLogHistoryService changeLogService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database);
         changeLogService.generateDeploymentId();
         changeLogService.init();
         LockServiceFactory.getInstance().getLockService(database).init();

--- a/liquibase-standard/src/main/java/liquibase/command/core/TagExistsCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/TagExistsCommandStep.java
@@ -34,7 +34,7 @@ public class TagExistsCommandStep  extends AbstractCommandStep {
     public void run(CommandResultsBuilder resultsBuilder) throws Exception {
         CommandScope commandScope = resultsBuilder.getCommandScope();
         Database database = (Database) commandScope.getDependency(Database.class);
-        ChangeLogHistoryService changeLogService = ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database);
+        ChangeLogHistoryService changeLogService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database);
         changeLogService.init();
         LockServiceFactory.getInstance().getLockService(database).init();
 

--- a/liquibase-standard/src/main/java/liquibase/command/core/UpdateTestingRollbackCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/UpdateTestingRollbackCommandStep.java
@@ -54,7 +54,7 @@ public class UpdateTestingRollbackCommandStep extends AbstractCommandStep {
         Liquibase liquibase = new Liquibase(databaseChangeLog, Scope.getCurrentScope().getResourceAccessor(), database);
         liquibase.setChangeExecListener(changeExecListener);
 
-        ChangeLogHistoryService changeLogService = ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database);
+        ChangeLogHistoryService changeLogService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database);
         int originalSize = changeLogService.getRanChangeSets().size();
         liquibase.update(tag, contexts, labelExpression);
         changeLogService.reset();

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/DatabaseChangelogCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/DatabaseChangelogCommandStep.java
@@ -91,7 +91,7 @@ public class DatabaseChangelogCommandStep extends AbstractHelperCommandStep impl
 
         DatabaseChangeLog databaseChangeLog = getDatabaseChangeLog(changeLogFile, changeLogParameters);
         checkLiquibaseTables(shouldUpdateChecksums, databaseChangeLog, changeLogParameters.getContexts(), changeLogParameters.getLabels(), database);
-        ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database).generateDeploymentId();
+        Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database).generateDeploymentId();
         databaseChangeLog.validate(database, changeLogParameters.getContexts(), changeLogParameters.getLabels());
 
         commandScope.provideDependency(DatabaseChangeLog.class, databaseChangeLog);
@@ -122,7 +122,7 @@ public class DatabaseChangelogCommandStep extends AbstractHelperCommandStep impl
 
     private void checkLiquibaseTables(boolean updateExistingNullChecksums, DatabaseChangeLog databaseChangeLog,
                                       Contexts contexts, LabelExpression labelExpression, Database database) throws LiquibaseException {
-        ChangeLogHistoryService changeLogHistoryService = ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database);
+        ChangeLogHistoryService changeLogHistoryService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database);
         changeLogHistoryService.init();
         if (updateExistingNullChecksums) {
             changeLogHistoryService.upgradeChecksums(databaseChangeLog, contexts, labelExpression);
@@ -137,7 +137,7 @@ public class DatabaseChangelogCommandStep extends AbstractHelperCommandStep impl
 
     @Override
     public void cleanUp(CommandResultsBuilder resultsBuilder) {
-        ChangeLogHistoryServiceFactory.getInstance().resetAll();
+        Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).resetAll();
     }
 
     /**

--- a/liquibase-standard/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -688,7 +688,7 @@ public abstract class AbstractJdbcDatabase implements Database {
     }
 
     protected boolean canCreateChangeLogTable() throws DatabaseException {
-        return ((StandardChangeLogHistoryService) ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(this)).canCreateChangeLogTable();
+        return ((StandardChangeLogHistoryService) Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(this)).canCreateChangeLogTable();
     }
 
     @Override
@@ -840,7 +840,7 @@ public abstract class AbstractJdbcDatabase implements Database {
                 }
             }
 
-            ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(this).destroy();
+            Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(this).destroy();
             LockServiceFactory.getInstance().getLockService(this).destroy();
 
             this.setAutoCommit(previousAutoCommit);
@@ -901,12 +901,12 @@ public abstract class AbstractJdbcDatabase implements Database {
 
     @Override
     public void tag(final String tagString) throws DatabaseException {
-        ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(this).tag(tagString);
+        Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(this).tag(tagString);
     }
 
     @Override
     public boolean doesTagExist(final String tag) throws DatabaseException {
-        return ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(this).tagExists(tag);
+        return Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(this).tagExists(tag);
     }
 
     @Override
@@ -1143,32 +1143,32 @@ public abstract class AbstractJdbcDatabase implements Database {
 
     @Override
     public ChangeSet.RunStatus getRunStatus(final ChangeSet changeSet) throws DatabaseException, DatabaseHistoryException {
-        return ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(this).getRunStatus(changeSet);
+        return Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(this).getRunStatus(changeSet);
     }
 
     @Override
     public RanChangeSet getRanChangeSet(final ChangeSet changeSet) throws DatabaseException, DatabaseHistoryException {
-        return ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(this).getRanChangeSet(changeSet);
+        return Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(this).getRanChangeSet(changeSet);
     }
 
     @Override
     public List<RanChangeSet> getRanChangeSetList() throws DatabaseException {
-        return ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(this).getRanChangeSets();
+        return Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(this).getRanChangeSets();
     }
 
     @Override
     public Date getRanDate(final ChangeSet changeSet) throws DatabaseException, DatabaseHistoryException {
-        return ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(this).getRanDate(changeSet);
+        return Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(this).getRanDate(changeSet);
     }
 
     @Override
     public void markChangeSetExecStatus(final ChangeSet changeSet, final ChangeSet.ExecType execType) throws DatabaseException {
-        ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(this).setExecType(changeSet, execType);
+        Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(this).setExecType(changeSet, execType);
     }
 
     @Override
     public void removeRanStatus(final ChangeSet changeSet) throws DatabaseException {
-        ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(this).removeFromHistory(changeSet);
+        Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(this).removeFromHistory(changeSet);
     }
 
     @Override
@@ -1367,7 +1367,7 @@ public abstract class AbstractJdbcDatabase implements Database {
 
     @Override
     public void resetInternalState() {
-        ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(this).reset();
+        Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(this).reset();
         LockServiceFactory.getInstance().getLockService(this).reset();
     }
 

--- a/liquibase-standard/src/main/java/liquibase/database/OfflineConnection.java
+++ b/liquibase-standard/src/main/java/liquibase/database/OfflineConnection.java
@@ -161,7 +161,7 @@ public class OfflineConnection implements DatabaseConnection {
             }
         }
 
-        ChangeLogHistoryServiceFactory.getInstance().register(createChangeLogHistoryService(database));
+        Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).register(createChangeLogHistoryService(database));
     }
 
     protected ChangeLogHistoryService createChangeLogHistoryService(Database database) {

--- a/liquibase-standard/src/main/java/liquibase/database/core/MockDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/MockDatabase.java
@@ -2,6 +2,7 @@ package liquibase.database.core;
 
 import liquibase.CatalogAndSchema;
 import liquibase.Liquibase;
+import liquibase.Scope;
 import liquibase.change.Change;
 import liquibase.changelog.*;
 import liquibase.database.*;
@@ -472,18 +473,18 @@ public class MockDatabase implements Database, InternalDatabase {
 
     @Override
     public RanChangeSet getRanChangeSet(final ChangeSet changeSet) throws DatabaseException, DatabaseHistoryException {
-        return ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(this).getRanChangeSet(changeSet);
+        return Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(this).getRanChangeSet(changeSet);
 
     }
 
     @Override
     public void markChangeSetExecStatus(final ChangeSet changeSet, final ChangeSet.ExecType execType) throws DatabaseException {
-        ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(this).setExecType(changeSet, execType);
+        Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(this).setExecType(changeSet, execType);
     }
 
     @Override
     public List<RanChangeSet> getRanChangeSetList() throws DatabaseException {
-        return ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(this).getRanChangeSets();
+        return Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(this).getRanChangeSets();
     }
 
     @Override
@@ -493,7 +494,7 @@ public class MockDatabase implements Database, InternalDatabase {
 
     @Override
     public void removeRanStatus(final ChangeSet changeSet) throws DatabaseException {
-        ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(this).removeFromHistory(changeSet);
+        Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(this).removeFromHistory(changeSet);
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/lockservice/StandardLockService.java
+++ b/liquibase-standard/src/main/java/liquibase/lockservice/StandardLockService.java
@@ -333,7 +333,7 @@ public class StandardLockService implements LockService {
 
                 hasChangeLogLock = true;
 
-                ChangeLogHistoryServiceFactory.getInstance().resetAll();
+                Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).resetAll();
                 database.setCanCacheLiquibaseTableInfo(true);
                 return true;
             }
@@ -475,7 +475,7 @@ public class StandardLockService implements LockService {
         isDatabaseChangeLogLockTableInitialized = false;
 
         if (this.database != null) {
-            ChangeLogHistoryService changelogService = ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database);
+            ChangeLogHistoryService changelogService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database);
             // On reseting the lock the changelog service has to be invalidated due to the fact that
             // some liquibase component released the lock temporarily. In this time span another JVM instance
             // might have acquired the database lock and could have applied further changesets to prevent that

--- a/liquibase-standard/src/main/java/liquibase/plugin/AbstractPluginFactory.java
+++ b/liquibase-standard/src/main/java/liquibase/plugin/AbstractPluginFactory.java
@@ -74,7 +74,7 @@ public abstract class AbstractPluginFactory<T extends Plugin> implements PluginF
     }
 
 
-    public void register(T plugin) {
+    public synchronized void register(T plugin) {
         this.findAllInstances();
         this.allInstances.add(plugin);
     }
@@ -95,7 +95,7 @@ public abstract class AbstractPluginFactory<T extends Plugin> implements PluginF
         return this.allInstances;
     }
 
-    protected void removeInstance(T instance) {
+    protected synchronized void removeInstance(T instance) {
         if (this.allInstances == null) {
             return;
         }

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/MarkChangeSetRanGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/MarkChangeSetRanGenerator.java
@@ -1,5 +1,6 @@
 package liquibase.sqlgenerator.core;
 
+import liquibase.Scope;
 import liquibase.change.Change;
 import liquibase.change.core.TagDatabaseChange;
 import liquibase.changelog.ChangeLogHistoryServiceFactory;
@@ -62,10 +63,10 @@ public class MarkChangeSetRanGenerator extends AbstractSqlGenerator<MarkChangeSe
             if (statement.getExecType().ranBefore) {
                 runStatement = new UpdateStatement(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogTableName())
                         .addNewColumnValue("DATEEXECUTED", new DatabaseFunction(dateValue))
-                        .addNewColumnValue("ORDEREXECUTED", ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database).getNextSequenceValue())
+                        .addNewColumnValue("ORDEREXECUTED", Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database).getNextSequenceValue())
                         .addNewColumnValue("MD5SUM", changeSet.generateCheckSum().toString())
                         .addNewColumnValue("EXECTYPE", statement.getExecType().value)
-                        .addNewColumnValue("DEPLOYMENT_ID", ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database).getDeploymentId())
+                        .addNewColumnValue("DEPLOYMENT_ID", Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database).getDeploymentId())
                         .addNewColumnValue(COMMENTS, getCommentsColumn(changeSet))
                         .addNewColumnValue(CONTEXTS, getContextsColumn(changeSet))
                         .addNewColumnValue(LABELS, getLabelsColumn(changeSet))
@@ -83,7 +84,7 @@ public class MarkChangeSetRanGenerator extends AbstractSqlGenerator<MarkChangeSe
                             .addColumnValue("AUTHOR", changeSet.getAuthor())
                             .addColumnValue("FILENAME", changeSet.getFilePath())
                             .addColumnValue("DATEEXECUTED", new DatabaseFunction(dateValue))
-                            .addColumnValue("ORDEREXECUTED", ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database).getNextSequenceValue())
+                            .addColumnValue("ORDEREXECUTED", Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database).getNextSequenceValue())
                             .addColumnValue("MD5SUM", changeSet.generateCheckSum().toString())
                             .addColumnValue("DESCRIPTION", limitSize(changeSet.getDescription()))
                             .addColumnValue(COMMENTS, getCommentsColumn(changeSet))
@@ -95,7 +96,7 @@ public class MarkChangeSetRanGenerator extends AbstractSqlGenerator<MarkChangeSe
                                                                                             .replaceAll("beta", "b")
                                                                                             .replaceAll("alpha", "b"), 20)
                             )
-                            .addColumnValue("DEPLOYMENT_ID", ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database).getDeploymentId());
+                            .addColumnValue("DEPLOYMENT_ID", Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database).getDeploymentId());
 
                     if (tag != null) {
                         ((InsertStatement) runStatement).addColumnValue("TAG", tag);

--- a/liquibase-standard/src/test/java/liquibase/changelog/OfflineChangeLogHistoryServiceTest.java
+++ b/liquibase-standard/src/test/java/liquibase/changelog/OfflineChangeLogHistoryServiceTest.java
@@ -6,6 +6,7 @@ import liquibase.database.core.HsqlDatabase;
 import liquibase.executor.ExecutorService;
 import liquibase.executor.LoggingExecutor;
 import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -28,18 +29,6 @@ public class OfflineChangeLogHistoryServiceTest {
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-    private File getResourceAsFile(String resourceName) {
-        URL resourceUrl = getClass().getResource(resourceName);
-        if (resourceUrl == null) {
-            throw new IllegalArgumentException("Resource "+resourceName+" not found for class "+getClass().getName());
-        }
-        try {
-            return new File(resourceUrl.toURI());
-        } catch (URISyntaxException e) {
-            return new File(resourceUrl.getPath());
-        }
-    }
-
     /**
      * Test ChangeLog table update SQL generation with outputLiquibaseSql=true and outputLiquibaseSql=true
      */
@@ -53,6 +42,8 @@ public class OfflineChangeLogHistoryServiceTest {
         service.init();
         service.setExecType(changeSet, ChangeSet.ExecType.EXECUTED);
         writer.close();
+        unregisterService(service);
+
         // Assert
         assertTrue(writer.toString().contains("CREATE TABLE PUBLIC.DATABASECHANGELOG"));
         assertTrue(writer.toString().contains("INSERT INTO PUBLIC.DATABASECHANGELOG"));
@@ -72,6 +63,7 @@ public class OfflineChangeLogHistoryServiceTest {
         service.init();
         service.setExecType(changeSet, ChangeSet.ExecType.EXECUTED);
         writer.close();
+        unregisterService(service);
 
         // Assert
         assertTrue(new File(temporaryFolder.getRoot(), CHANGE_LOG_CSV).exists());
@@ -91,6 +83,7 @@ public class OfflineChangeLogHistoryServiceTest {
         service.init();
         service.setExecType(changeSet, ChangeSet.ExecType.EXECUTED);
         writer.close();
+        unregisterService(service);
         // Assert
         assertFalse(writer.toString().contains("CREATE TABLE PUBLIC.DATABASECHANGELOG"));
         assertTrue(writer.toString().contains("INSERT INTO PUBLIC.DATABASECHANGELOG"));
@@ -105,8 +98,7 @@ public class OfflineChangeLogHistoryServiceTest {
         File changeLogCsvFile = new File(temporaryFolder.getRoot(), CHANGE_LOG_CSV);
         OfflineConnection connection = new OfflineConnection("offline:hsqldb?changeLogFile="+changeLogCsvFile.getAbsolutePath() + "&outputLiquibaseSql=" + outputLiquibaseSql, new ClassLoaderResourceAccessor());
         database.setConnection(connection);
-        connection.attached(database);
-        OfflineChangeLogHistoryService changeLogHistoryService = (OfflineChangeLogHistoryService) ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database);
+        OfflineChangeLogHistoryService changeLogHistoryService = (OfflineChangeLogHistoryService) Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database);
 
         //
         // Create the new LoggingExecutor and give it the original Executor as a delegator
@@ -116,6 +108,10 @@ public class OfflineChangeLogHistoryServiceTest {
         Scope.getCurrentScope().getSingleton(ExecutorService.class).setExecutor("logging", database, loggingExecutor);
         Scope.getCurrentScope().getSingleton(ExecutorService.class).setExecutor("jdbc", database, loggingExecutor);
         return changeLogHistoryService;
+    }
+
+    private void unregisterService(OfflineChangeLogHistoryService service) {
+        Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).unregister(service);
     }
 
     /**

--- a/liquibase-standard/src/test/java/liquibase/changelog/OfflineChangeLogHistoryServiceTest.java
+++ b/liquibase-standard/src/test/java/liquibase/changelog/OfflineChangeLogHistoryServiceTest.java
@@ -29,6 +29,11 @@ public class OfflineChangeLogHistoryServiceTest {
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
+    @Before
+    public void setUp() throws Exception {
+        Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).resetAll();
+    }
+
     /**
      * Test ChangeLog table update SQL generation with outputLiquibaseSql=true and outputLiquibaseSql=true
      */


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Migrate ChangeLogHistoryServiceFactory to AbstractPluginFactory as suggested in https://github.com/liquibase/liquibase/issues/3446

This should enable to have different instance in scope, rather than using static class that does not behave well in multithreaded setup

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

it is foundation for issue https://github.com/liquibase/liquibase/issues/3446
