### PR TITLE
Prefer thread safe scope manager when working with Maven

### DIFF
--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
@@ -3,6 +3,7 @@ package org.liquibase.maven.plugins;
 import liquibase.GlobalConfiguration;
 import liquibase.Liquibase;
 import liquibase.Scope;
+import liquibase.ThreadLocalScopeManager;
 import liquibase.changelog.visitor.ChangeExecListener;
 import liquibase.changelog.visitor.DefaultChangeExecListener;
 import liquibase.configuration.LiquibaseConfiguration;
@@ -628,6 +629,8 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
             getLog().error("The liquibase-maven-plugin now manages logging via the standard maven logging config, not the 'logging' configuration. Use the -e, -X or -q flags or see https://maven.apache.org/maven-logging.html");
         }
 
+        // If maven is called with -T and a value larger than 1, it can get confused under heavy thread load
+        Scope.setScopeManager(new ThreadLocalScopeManager());
         try {
             Scope.child(Scope.Attr.logService, new MavenLogService(getLog()), () -> {
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Switch from `SingletonScopeManager` to `ThreadLocalScopeManager` when used within Maven

## Things to be aware of

- In a maven context, where large projects are built in parallel, during the `generate-sources` phase Liquibase often got confused about threads. By switching to a theadsafe implementation this is prevented

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->
- Couldn't directly deduce from the docs whether there is any downside of switching towards `ThreadLocalScopeManager`, especially since it's now also done if `-T1` is supplied.

## Additional Context

Closes https://github.com/liquibase/liquibase/issues/4031
