### PR TITLE
Fix updateTesting rollback replacing rollbackToDate by rollbackCount

### DIFF
--- a/liquibase-core/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-core/src/main/java/liquibase/Liquibase.java
@@ -1523,6 +1523,7 @@ public class Liquibase implements AutoCloseable {
         update(tag, contexts, labelExpression);
         changeLogService.reset();
         int changesetsToRollback = changeLogService.getRanChangeSets().size() - originalSize;
+        Scope.getCurrentScope().getLog(getClass()).info(String.format("Rolling back %d changeset(s).", changesetsToRollback));
         rollback(changesetsToRollback, null, contexts, labelExpression);
         update(tag, contexts, labelExpression);
     }

--- a/liquibase-core/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-core/src/main/java/liquibase/Liquibase.java
@@ -1518,9 +1518,12 @@ public class Liquibase implements AutoCloseable {
         changeLogParameters.setContexts(contexts);
         changeLogParameters.setLabels(labelExpression);
 
-        Date baseDate = new Date();
+        ChangeLogHistoryService changeLogService = ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database);
+        int originalSize = changeLogService.getRanChangeSets().size();
         update(tag, contexts, labelExpression);
-        rollback(baseDate, null, contexts, labelExpression);
+        changeLogService.reset();
+        int changesetsToRollback = changeLogService.getRanChangeSets().size() - originalSize;
+        rollback(changesetsToRollback, null, contexts, labelExpression);
         update(tag, contexts, labelExpression);
     }
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Fix updateTesting rollback: instead of using the date to mark where to rollback, uses the count of the number of changes executed to rollback them.

## Things to be aware of

For some databases like Snowflake, when the database is in a different timezone than the host running liquibase the time returned is different from the local time, thus causing updateTestingRollback to fail.

## Things to worry about

All updateTestingRollback  should keep on working with this new approach.

## Additional Context
