### PR TITLE
Lowers message log level.

### DIFF
--- a/liquibase-core/src/main/java/liquibase/executor/jvm/ChangelogJdbcMdcListener.java
+++ b/liquibase-core/src/main/java/liquibase/executor/jvm/ChangelogJdbcMdcListener.java
@@ -65,7 +65,7 @@ public class ChangelogJdbcMdcListener {
 
     private static void logSuccess() {
         Scope.getCurrentScope().addMdcValue(MdcKey.DATABASE_CHANGELOG_TABLE_OUTCOME, MdcValue.DATABASE_CHANGELOG_OUTCOME_SUCCESS);
-        Scope.getCurrentScope().getLog(ChangelogJdbcMdcListener.class).info("Changelog query completed.");
+        Scope.getCurrentScope().getLog(ChangelogJdbcMdcListener.class).fine("Changelog query completed.");
         Scope.getCurrentScope().getMdcManager().remove(MdcKey.DATABASE_CHANGELOG_TABLE_OUTCOME);
         Scope.getCurrentScope().getMdcManager().remove(MdcKey.DATABASE_CHANGELOG_SQL);
     }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Downgrades  log level of message "Changelog query completed" as it is showing up too much in info logs.