### PR TITLE
Add OUTPUT_FILE and OUTPUT_FILE_ENCODING to MDC DAT-14017

### DIFF
--- a/liquibase-core/src/main/java/liquibase/command/CommandScope.java
+++ b/liquibase-core/src/main/java/liquibase/command/CommandScope.java
@@ -264,9 +264,9 @@ public class CommandScope {
                 Scope.getCurrentScope().addMdcValue(MdcKey.OUTPUT_FILE_ENCODING, outputFileEncoding);
             }
             if (outputFilePath != null) {
-                Scope.getCurrentScope().getLog(CommandScope.class).info("Writing output to '" + outputFilePath + "' with encoding '" + outputFileEncoding + "'");
+                Scope.getCurrentScope().getLog(CommandScope.class).fine("Writing output to '" + outputFilePath + "' with encoding '" + outputFileEncoding + "'");
             } else {
-                Scope.getCurrentScope().getLog(CommandScope.class).info("Writing output with encoding '" + outputFileEncoding + "'");
+                Scope.getCurrentScope().getLog(CommandScope.class).fine("Writing output with encoding '" + outputFileEncoding + "'");
             }
         });
     }

--- a/liquibase-core/src/main/java/liquibase/logging/mdc/MdcKey.java
+++ b/liquibase-core/src/main/java/liquibase/logging/mdc/MdcKey.java
@@ -21,6 +21,8 @@ public class MdcKey {
     public static final String LIQUIBASE_VERSION = "liquibaseVersion";
     public static final String LIQUIBASE_SYSTEM_NAME = "liquibaseSystemName";
     public static final String LIQUIBASE_SYSTEM_USER = "liquibaseSystemUser";
+    public static final String OUTPUT_FILE = "outputFile";
+    public static final String OUTPUT_FILE_ENCODING = "outputFileEncoding";
     public static final String ROLLBACK_TO_TAG = "rollbackToTag";
     public static final String CHANGELOG_FILE = "changelogFile";
     public static final String ROLLBACK_SCRIPT = "rollbackScript";

--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/util/CommandUtil.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/util/CommandUtil.groovy
@@ -7,7 +7,8 @@ import liquibase.command.CommandScope;
 import liquibase.command.core.DropAllCommandStep;
 import liquibase.command.core.GenerateChangelogCommandStep;
 import liquibase.command.core.UpdateCommandStep;
-import liquibase.command.core.helpers.DbUrlConnectionCommandStep;
+import liquibase.command.core.helpers.DbUrlConnectionCommandStep
+import liquibase.command.core.helpers.ShowSummaryArgument;
 import liquibase.exception.CommandExecutionException;
 import liquibase.extension.testing.testsystem.DatabaseTestSystem;
 import liquibase.resource.SearchPathResourceAccessor
@@ -89,7 +90,7 @@ class CommandUtil {
             commandScope.addArgumentValue(UpdateCommandStep.CHANGELOG_FILE_ARG, changelogFile)
             commandScope.addArgumentValue(UpdateCommandStep.LABEL_FILTER_ARG, labels)
             commandScope.addArgumentValue(UpdateCommandStep.CONTEXTS_ARG, contexts)
-            commandScope.addArgumentValue(UpdateCommandStep.SHOW_SUMMARY, UpdateSummaryEnum.SUMMARY)
+            commandScope.addArgumentValue(ShowSummaryArgument.SHOW_SUMMARY, UpdateSummaryEnum.SUMMARY)
             if (outputFile != null) {
                 OutputStream outputStream = new FileOutputStream(new File(outputFile))
                 commandScope.setOutput(outputStream)


### PR DESCRIPTION


## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description
Added these keys to the MDC so that they will show up in structured logging

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
