### PR TITLE
SnowflakeDatabase allows catalog name in identifiers

### DIFF
--- a/liquibase-integration-tests/src/test/java/liquibase/statementexecute/AddUniqueConstraintExecutorTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/statementexecute/AddUniqueConstraintExecutorTest.java
@@ -160,7 +160,7 @@ public class AddUniqueConstraintExecutorTest extends AbstractExecuteTest {
         assertCorrect("alter table \"lbcat2\".[adduqtest] add constraint [uq_test] unique ([coltomakeuq])", DB2Database.class, Db2zDatabase.class);
         assertCorrect("alter table [lbschem2].[adduqtest] add constraint [uq_test] unique ([coltomakeuq])", H2Database.class);
         assertCorrect("alter table [lbschem2].[adduqtest] add constraint [uq_test] unique ([coltomakeuq])", Ingres9Database.class);
-        assertCorrect("alter table [lbschem2].[adduqtest] add constraint [uq_test] unique ([coltomakeuq])", SnowflakeDatabase.class);
+        assertCorrect("alter table [lbcat2].[lbschem2].[adduqtest] add constraint [uq_test] unique ([coltomakeuq])", SnowflakeDatabase.class);
         assertCorrectOnRest("alter table [lbcat2].[adduqtest] add constraint [uq_test] unique ([coltomakeuq])");
 
     }

--- a/liquibase-snowflake/src/main/java/liquibase/database/core/SnowflakeDatabase.java
+++ b/liquibase-snowflake/src/main/java/liquibase/database/core/SnowflakeDatabase.java
@@ -9,6 +9,9 @@ import liquibase.exception.DatabaseException;
 import liquibase.executor.ExecutorService;
 import liquibase.statement.core.RawSqlStatement;
 import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.StoredProcedure;
+import liquibase.structure.core.Table;
+import liquibase.structure.core.View;
 import liquibase.util.SystemUtil;
 
 import java.math.BigInteger;
@@ -102,7 +105,7 @@ public class SnowflakeDatabase extends AbstractJdbcDatabase {
 
     @Override
     public boolean supportsCatalogInObjectName(Class<? extends DatabaseObject> type) {
-        return false;
+        return type == Table.class || type == View.class || type == StoredProcedure.class;
     }
 
     @Override


### PR DESCRIPTION

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Make SnowflakeDatabase report catalog names in identifiers as supported feature.

Snowflake supports fully qualified names in tables/views/procedures. 

Without this, Snowflake change sets get their catalog name forcefully removed. Combined with Snowflake automatically switching current database/schema on each CREATE DATABASE statement, this discrepancy makes managing high level Snowflake objects with Liquibase very tedious & fragile, as it often can't find its DATABASECHANGELOG after having executed those change sets.

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

I can't find where Snowflake's support for fully qualified names is documented, but it works in our accounts.

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->

Resolves #3036
