### PR TITLE
log generated databasechangelogsql without erroneously incrementing the order executed by 2 (DAT-13680)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
@@ -246,7 +246,7 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
 
             SqlStatement databaseChangeLogStatement = new SelectFromDatabaseChangeLogStatement(new SelectFromDatabaseChangeLogStatement.ByNotNullCheckSum(),
                     new ColumnConfig().setName("MD5SUM")).setLimit(1);
-            List<Map<String, ?>> md5sumRS = ChangelogJdbcMdcListener.query(databaseChangeLogStatement, getDatabase(), ex -> ex.queryForList(databaseChangeLogStatement));
+            List<Map<String, ?>> md5sumRS = ChangelogJdbcMdcListener.query(getDatabase(), ex -> ex.queryForList(databaseChangeLogStatement));
 
             if (!md5sumRS.isEmpty()) {
                 String md5sum = md5sumRS.get(0).get("MD5SUM").toString();
@@ -282,7 +282,7 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
 
         for (SqlStatement sql : statementsToExecute) {
             if (SqlGeneratorFactory.getInstance().supports(sql, database)) {
-                ChangelogJdbcMdcListener.execute(sql, getDatabase(), ex -> ex.execute(sql));
+                ChangelogJdbcMdcListener.execute(getDatabase(), ex -> ex.execute(sql));
                 getDatabase().commit();
             } else {
                 Scope.getCurrentScope().getLog(getClass()).info("Cannot run " + sql.getClass().getSimpleName() + " on" +
@@ -372,7 +372,7 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
     public List<Map<String, ?>> queryDatabaseChangeLogTable(Database database) throws DatabaseException {
         SelectFromDatabaseChangeLogStatement select = new SelectFromDatabaseChangeLogStatement(new ColumnConfig()
             .setName("*").setComputed(true)).setOrderBy("DATEEXECUTED ASC", "ORDEREXECUTED ASC");
-        return ChangelogJdbcMdcListener.query(select, getDatabase(), executor -> executor.queryForList(select));
+        return ChangelogJdbcMdcListener.query(getDatabase(), executor -> executor.queryForList(select));
     }
 
     @Override
@@ -396,7 +396,7 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
     @Override
     public void setExecType(ChangeSet changeSet, ChangeSet.ExecType execType) throws DatabaseException {
         SqlStatement markChangeSetRanStatement = new MarkChangeSetRanStatement(changeSet, execType);
-        ChangelogJdbcMdcListener.execute(markChangeSetRanStatement, getDatabase(), executor -> executor.execute(markChangeSetRanStatement));
+        ChangelogJdbcMdcListener.execute(getDatabase(), executor -> executor.execute(markChangeSetRanStatement));
         getDatabase().commit();
         if (this.ranChangeSetList != null) {
             this.ranChangeSetList.add(new RanChangeSet(changeSet, execType, null, null));
@@ -407,7 +407,7 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
     @Override
     public void removeFromHistory(final ChangeSet changeSet) throws DatabaseException {
         SqlStatement removeChangeSetRanStatusStatement = new RemoveChangeSetRanStatusStatement(changeSet);
-        ChangelogJdbcMdcListener.execute(removeChangeSetRanStatusStatement, getDatabase(), executor -> executor.execute(removeChangeSetRanStatusStatement));
+        ChangelogJdbcMdcListener.execute(getDatabase(), executor -> executor.execute(removeChangeSetRanStatusStatement));
         getDatabase().commit();
 
         if (this.ranChangeSetList != null) {
@@ -422,7 +422,7 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
                 lastChangeSetSequenceValue = 0;
             } else {
                 SqlStatement nextChangeSetSequenceValueStatement = new GetNextChangeSetSequenceValueStatement();
-                lastChangeSetSequenceValue = ChangelogJdbcMdcListener.query(nextChangeSetSequenceValueStatement, getDatabase(), executor -> executor.queryForInt(nextChangeSetSequenceValueStatement));
+                lastChangeSetSequenceValue = ChangelogJdbcMdcListener.query(getDatabase(), executor -> executor.queryForInt(nextChangeSetSequenceValueStatement));
             }
         }
 
@@ -435,7 +435,7 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
     @Override
     public void tag(final String tagString) throws DatabaseException {
         SqlStatement totalRowsStatement = new SelectFromDatabaseChangeLogStatement(new ColumnConfig().setName("COUNT(*)", true));
-        int totalRows = ChangelogJdbcMdcListener.query(totalRowsStatement, getDatabase(), executor -> executor.queryForInt(totalRowsStatement));
+        int totalRows = ChangelogJdbcMdcListener.query(getDatabase(), executor -> executor.queryForInt(totalRowsStatement));
         if (totalRows == 0) {
             ChangeSet emptyChangeSet = new ChangeSet(String.valueOf(new Date().getTime()), "liquibase",
                 false,false, "liquibase-internal", null, null,
@@ -443,7 +443,7 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
             this.setExecType(emptyChangeSet, ChangeSet.ExecType.EXECUTED);
         }
         SqlStatement tagStatement = new TagDatabaseStatement(tagString);
-        ChangelogJdbcMdcListener.execute(tagStatement, getDatabase(), executor -> executor.execute(tagStatement));
+        ChangelogJdbcMdcListener.execute(getDatabase(), executor -> executor.execute(tagStatement));
         getDatabase().commit();
 
         if (this.ranChangeSetList != null) {
@@ -455,7 +455,7 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
     public boolean tagExists(final String tag) throws DatabaseException {
         SqlStatement selectChangelogStatement = new SelectFromDatabaseChangeLogStatement(new SelectFromDatabaseChangeLogStatement.ByTag(tag),
                 new ColumnConfig().setName("COUNT(*)", true));
-        int count = ChangelogJdbcMdcListener.query(selectChangelogStatement, getDatabase(), executor -> executor.queryForInt(selectChangelogStatement));
+        int count = ChangelogJdbcMdcListener.query(getDatabase(), executor -> executor.queryForInt(selectChangelogStatement));
         return count > 0;
     }
 
@@ -465,7 +465,7 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
         UpdateStatement updateStatement = new UpdateStatement(database.getLiquibaseCatalogName(), database
             .getLiquibaseSchemaName(), database.getDatabaseChangeLogTableName());
         updateStatement.addNewColumnValue("MD5SUM", null);
-        ChangelogJdbcMdcListener.execute(updateStatement, getDatabase(), executor -> executor.execute(updateStatement));
+        ChangelogJdbcMdcListener.execute(getDatabase(), executor -> executor.execute(updateStatement));
         database.commit();
     }
 
@@ -492,7 +492,7 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
                 Change[] change = ChangeGeneratorFactory.getInstance().fixUnexpected(table, diffOutputControl,database
                     , database);
                 SqlStatement[] sqlStatement = change[0].generateStatements(database);
-                ChangelogJdbcMdcListener.execute(sqlStatement[0], getDatabase(), executor -> executor.execute(sqlStatement[0]));
+                ChangelogJdbcMdcListener.execute(getDatabase(), executor -> executor.execute(sqlStatement[0]));
             }
             reset();
         } catch (InvalidExampleException e) {

--- a/liquibase-core/src/main/java/liquibase/executor/jvm/ChangelogJdbcMdcListener.java
+++ b/liquibase-core/src/main/java/liquibase/executor/jvm/ChangelogJdbcMdcListener.java
@@ -7,10 +7,13 @@ import liquibase.executor.Executor;
 import liquibase.executor.ExecutorService;
 import liquibase.logging.mdc.MdcKey;
 import liquibase.logging.mdc.MdcValue;
+import liquibase.sql.Sql;
 import liquibase.sqlgenerator.SqlGeneratorFactory;
 import liquibase.statement.SqlStatement;
-import liquibase.statement.core.MarkChangeSetRanStatement;
 import liquibase.util.SqlUtil;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * A wrapper utility class around the standard JdbcExecutor used to monitor and log sql from Jdbc queries
@@ -26,13 +29,14 @@ public class ChangelogJdbcMdcListener {
      * @throws DatabaseException if there was a problem running the sql statement
      */
     public static void execute(SqlStatement statement, Database database, ExecuteJdbc jdbcQuery) throws DatabaseException {
-        if (!(statement instanceof MarkChangeSetRanStatement)) {
-            addSqlMdc(statement, database);
-        }
         try {
-            jdbcQuery.execute(Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database));
+            AtomicReference<Sql[]> sqls = new AtomicReference<>(null);
+            Scope.child(Collections.singletonMap(SqlGeneratorFactory.GENERATED_SQL_ARRAY_SCOPE_KEY, sqls), () -> {
+                jdbcQuery.execute(Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database));
+            });
+            addSqlMdc(sqls);
             logSuccess();
-        } catch (DatabaseException e) {
+        } catch (Exception e) {
             Scope.getCurrentScope().addMdcValue(MdcKey.DATABASE_CHANGELOG_TABLE_OUTCOME, MdcValue.DATABASE_CHANGELOG_OUTCOME_FAILED);
             throw new DatabaseException(e);
         }
@@ -48,19 +52,25 @@ public class ChangelogJdbcMdcListener {
      * @throws DatabaseException if there was a problem running the sql statement
      */
     public static <T> T query(SqlStatement statement, Database database, QueryJdbc<T> jdbcQuery) throws DatabaseException {
-        addSqlMdc(statement, database);
         try {
-            T value = jdbcQuery.execute(Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database));
+            AtomicReference<Sql[]> sqls = new AtomicReference<>(null);
+            T value = Scope.child(Collections.singletonMap(SqlGeneratorFactory.GENERATED_SQL_ARRAY_SCOPE_KEY, sqls), () -> jdbcQuery.execute(Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database)));
+            addSqlMdc(sqls);
             logSuccess();
             return value;
-        } catch (DatabaseException e) {
+        } catch (Exception e) {
             Scope.getCurrentScope().addMdcValue(MdcKey.DATABASE_CHANGELOG_TABLE_OUTCOME, MdcValue.DATABASE_CHANGELOG_OUTCOME_FAILED);
             throw new DatabaseException(e);
         }
     }
 
-    private static void addSqlMdc(SqlStatement statement, Database database) {
-        Scope.getCurrentScope().addMdcValue(MdcKey.DATABASE_CHANGELOG_SQL, SqlUtil.getSqlString(statement, SqlGeneratorFactory.getInstance(), database));
+    private static void addSqlMdc(AtomicReference<Sql[]> sqlsRef) {
+        if (sqlsRef != null) {
+            Sql[] sqls = sqlsRef.get();
+            if (sqls != null) {
+                Scope.getCurrentScope().addMdcValue(MdcKey.DATABASE_CHANGELOG_SQL, SqlUtil.convertSqlArrayToString(sqls));
+            }
+        }
     }
 
     private static void logSuccess() {

--- a/liquibase-core/src/main/java/liquibase/executor/jvm/ChangelogJdbcMdcListener.java
+++ b/liquibase-core/src/main/java/liquibase/executor/jvm/ChangelogJdbcMdcListener.java
@@ -9,7 +9,6 @@ import liquibase.logging.mdc.MdcKey;
 import liquibase.logging.mdc.MdcValue;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.SqlGeneratorFactory;
-import liquibase.statement.SqlStatement;
 import liquibase.util.SqlUtil;
 
 import java.util.Collections;
@@ -23,12 +22,11 @@ public class ChangelogJdbcMdcListener {
     /**
      * Execute the given statement via the jdbc executor. Adds MDC of the statement sql and outcome to logging.
      *
-     * @param statement the statement to execute
      * @param database  the database to execute against
      * @param jdbcQuery the executor function to apply
      * @throws DatabaseException if there was a problem running the sql statement
      */
-    public static void execute(SqlStatement statement, Database database, ExecuteJdbc jdbcQuery) throws DatabaseException {
+    public static void execute(Database database, ExecuteJdbc jdbcQuery) throws DatabaseException {
         try {
             AtomicReference<Sql[]> sqls = new AtomicReference<>(null);
             Scope.child(Collections.singletonMap(SqlGeneratorFactory.GENERATED_SQL_ARRAY_SCOPE_KEY, sqls), () -> {
@@ -45,13 +43,12 @@ public class ChangelogJdbcMdcListener {
     /**
      * Execute the given statement via the jdbc executor. Adds MDC of the statement sql and outcome to logging.
      *
-     * @param statement the statement to execute
      * @param database  the database to execute against
      * @param jdbcQuery the executor function to apply
      * @return the result of the executor function
      * @throws DatabaseException if there was a problem running the sql statement
      */
-    public static <T> T query(SqlStatement statement, Database database, QueryJdbc<T> jdbcQuery) throws DatabaseException {
+    public static <T> T query(Database database, QueryJdbc<T> jdbcQuery) throws DatabaseException {
         try {
             AtomicReference<Sql[]> sqls = new AtomicReference<>(null);
             T value = Scope.child(Collections.singletonMap(SqlGeneratorFactory.GENERATED_SQL_ARRAY_SCOPE_KEY, sqls), () -> jdbcQuery.execute(Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database)));

--- a/liquibase-core/src/main/java/liquibase/util/SqlUtil.java
+++ b/liquibase-core/src/main/java/liquibase/util/SqlUtil.java
@@ -359,6 +359,15 @@ public abstract class SqlUtil {
      */
     public static String getSqlString(SqlStatement statement, SqlGeneratorFactory sqlGeneratorFactory, Database database) {
         Sql[] sqlStatements = sqlGeneratorFactory.generateSql(statement, database);
+        return convertSqlArrayToString(sqlStatements);
+    }
+
+    /**
+     * Given an array of sql, get the string sql statements.
+     * @param sqlStatements the statements to stringify
+     * @return the sql string or an empty string if there are no statements to generate
+     */
+    public static String convertSqlArrayToString(Sql[] sqlStatements) {
         if (sqlStatements != null) {
             return Arrays.stream(sqlStatements)
                     .map(sql -> sql.toSql().endsWith(sql.getEndDelimiter()) ? sql.toSql() : sql.toSql() + sql.getEndDelimiter())

--- a/liquibase-core/src/test/java/liquibase/lockservice/StandardLockServiceTest.java
+++ b/liquibase-core/src/test/java/liquibase/lockservice/StandardLockServiceTest.java
@@ -36,22 +36,7 @@ public class StandardLockServiceTest {
 
     @Before
     public void before() throws Exception {
-        Executor executor = Mockito.mock(Executor.class);
-        Mockito
-            .when(executor.queryForList(Mockito.any()))
-            .thenReturn(sampleLockData());
-        ExecutorService executorService = Mockito.mock(ExecutorService.class);
-        Mockito
-            .when(executorService.getExecutor(Mockito.any(), Mockito.any()))
-            .thenReturn(executor);
-
-        Map<String, Object> scopeValues = new TreeMap<>();
-
-        scopeValues.put(ExecutorService.class.getName(), executorService);
-        scopeValues.put(SqlGeneratorFactory.class.getName(), SqlGeneratorFactory.getInstance());
-
         mockedScope = Mockito.mock(Scope.class);
-        Mockito.when(mockedScope.getSingleton(ExecutorService.class)).thenReturn(executorService);
         Logger logger = Mockito.mock(Logger.class);
         MdcManager mdcManager = Mockito.mock(MdcManager.class);
         Mockito.when(mockedScope.getLog(Mockito.any())).thenReturn(logger);
@@ -70,6 +55,7 @@ public class StandardLockServiceTest {
     public void shouldAcceptLocaldatetimeInLOCKGRANTED() throws LockException {
         try (MockedStatic<Scope> scope = Mockito.mockStatic(Scope.class)) {
             scope.when(Scope::getCurrentScope).thenReturn(mockedScope);
+            scope.when(() -> Scope.child(Mockito.anyMap(), Mockito.any(Scope.ScopedRunnerWithReturn.class))).thenReturn(sampleLockData());
             DatabaseChangeLogLock[] databaseChangeLogLocks = lockService.listLocks();
 
             Assertions.assertThat(databaseChangeLogLocks)

--- a/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/update.test.groovy
+++ b/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/update.test.groovy
@@ -1,9 +1,15 @@
 package liquibase.extension.testing.command
 
+import liquibase.Scope
+import liquibase.changelog.ChangeLogHistoryServiceFactory
+import liquibase.changelog.RanChangeSet
+import liquibase.database.Database
 import liquibase.exception.CommandExecutionException
 import liquibase.exception.CommandValidationException
 
 import java.util.regex.Pattern
+
+import static org.junit.Assert.assertEquals
 
 CommandTests.define {
     command = ["update"]
@@ -57,6 +63,18 @@ Optional Args:
                 "txt": [Pattern.compile(".*liquibase.structure.core.Table:.*ADDRESS.*", Pattern.MULTILINE | Pattern.DOTALL | Pattern.CASE_INSENSITIVE),
                         Pattern.compile(".*liquibase.structure.core.Table:.*ADDRESS.*columns:.*city.*", Pattern.MULTILINE | Pattern.DOTALL | Pattern.CASE_INSENSITIVE)]
         ]
+
+         expectations = {
+             // Check that the order executed number increments by 1 for each changeset
+             def database = (Database) Scope.getCurrentScope().get("database", null)
+             def changelogHistoryService = ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database)
+             List<RanChangeSet> ranChangeSets = changelogHistoryService.getRanChangeSets()
+             int expectedOrder = 1
+             for (RanChangeSet ranChangeSet : ranChangeSets) {
+                 assertEquals(expectedOrder, ranChangeSet.getOrderExecuted())
+                 expectedOrder++
+             }
+        }
 
     }
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

This is a proper fix for https://github.com/liquibase/liquibase/pull/3869.

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

Complexity of having the SqlGeneratorFactory be responsible for storing the generated SQL in the scope using an AtomicReference. I don't know of a better way for the factory to pass the generated SQL "back" to the caller without a larger refactoring and breaking changes.

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
