### PR TITLE
add support for the TRAN keyword (T-SQL)

### DIFF
--- a/liquibase-integration-tests/src/test/resources/changelogs/mssql/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/mssql/complete/root.changelog.xml
@@ -349,5 +349,9 @@
         </createTable>
     </changeSet>
 
+    <changeSet id="tranKeywordTest" author="mallod">
+        <sqlFile path="changelogs/mssql/issues/transaction.test.sql" endDelimiter="GO"/>
+    </changeSet>
+
 
 </databaseChangeLog>

--- a/liquibase-integration-tests/src/test/resources/changelogs/mssql/issues/transaction.test.sql
+++ b/liquibase-integration-tests/src/test/resources/changelogs/mssql/issues/transaction.test.sql
@@ -1,0 +1,16 @@
+CREATE OR ALTER PROCEDURE dbo.Test as
+BEGIN TRAN
+CREATE TABLE test.dbo.person (
+                                 id int primary key not null,
+                                 name varchar(50) not null,
+                                 address1 varchar(50),
+                                 address2 varchar(50),
+                                 city varchar(30)
+
+INSERT INTO test.dbo.person(id, name)
+VALUES(1, 'Name1');
+COMMIT
+
+    INSERT INTO test.dbo.person(id, name)
+    VALUES(2, 'Name2');
+GO

--- a/liquibase-integration-tests/src/test/resources/changelogs/mssql/issues/transaction.test.sql
+++ b/liquibase-integration-tests/src/test/resources/changelogs/mssql/issues/transaction.test.sql
@@ -1,12 +1,13 @@
 CREATE OR ALTER PROCEDURE dbo.Test as
 BEGIN TRAN
-CREATE TABLE test.dbo.person (
-                                 id int primary key not null,
-                                 name varchar(50) not null,
-                                 address1 varchar(50),
-                                 address2 varchar(50),
-                                 city varchar(30)
-
+CREATE TABLE test.dbo.person
+(
+    id       int primary key not null,
+    name     varchar(50)     not null,
+    address1 varchar(50),
+    address2 varchar(50),
+    city     varchar(30)
+);
 INSERT INTO test.dbo.person(id, name)
 VALUES(1, 'Name1');
 COMMIT


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

This PR fixes #4098. It add support for the T-SQL Keyword "TRAN".

Currently liquibase splits sql statements only, if there are not between a "BEGIN" and "END" statement. Since most database start transactions with the "BEGIN TRANSACTION" command, the StringUtil class which is responsible for splitting statements, does ignore the "BEGIN" keyword if it is followed by the keyword "TRANSACTION". 

T-SQL (the sql dialect from mssql-server) also supports a shorter version for "TRANSACTION" => "TRAN". The current version of liquibase does not check for keyword "TRAN". This pull request adds support for this keyword. 


## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->
- I just added the new keyword "TRAN" to the if statement, with intention to change as little as possible 

## Things to worry about
- the current code also supports the keyword "TRANS", I don't know any database which supports the keyword "TRANS" to start an transaction, maybe this was just a typo and can be removed. But I don't know maybe there is a reason for this:).  

## Additional Context

<!--
Add any other context about the problem here.
-->
