### PR TITLE
Implement autorollback for <empty/> and <output/> changes

### DIFF
--- a/liquibase-core/src/main/java/liquibase/change/core/EmptyChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/EmptyChange.java
@@ -1,6 +1,7 @@
 package liquibase.change.core;
 
 import liquibase.change.AbstractChange;
+import liquibase.change.Change;
 import liquibase.change.ChangeMetaData;
 import liquibase.change.DatabaseChange;
 import liquibase.database.Database;
@@ -22,5 +23,10 @@ public class EmptyChange extends AbstractChange {
     @Override
     public String getSerializedObjectNamespace() {
         return STANDARD_CHANGELOG_NAMESPACE;
+    }
+
+    @Override
+    protected Change[] createInverses() {
+        return EMPTY_CHANGE;
     }
 }

--- a/liquibase-core/src/main/java/liquibase/change/core/OutputChange.java
+++ b/liquibase-core/src/main/java/liquibase/change/core/OutputChange.java
@@ -2,6 +2,7 @@ package liquibase.change.core;
 
 import liquibase.Scope;
 import liquibase.change.AbstractChange;
+import liquibase.change.Change;
 import liquibase.change.ChangeMetaData;
 import liquibase.change.DatabaseChange;
 import liquibase.change.DatabaseChangeProperty;
@@ -94,5 +95,10 @@ public class OutputChange extends AbstractChange {
             return null;
         }
         return value;
+    }
+
+    @Override
+    protected Change[] createInverses() {
+        return EMPTY_CHANGE;
     }
 }

--- a/liquibase-core/src/test/java/liquibase/change/ChangeRollbackTest.java
+++ b/liquibase-core/src/test/java/liquibase/change/ChangeRollbackTest.java
@@ -1,0 +1,36 @@
+package liquibase.change;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import liquibase.change.AddColumnConfig;
+import liquibase.change.ConstraintsConfig;
+import liquibase.change.core.AddColumnChange;
+import liquibase.change.core.EmptyChange;
+import liquibase.change.core.OutputChange;
+import liquibase.database.core.DB2Database;
+import liquibase.database.core.MockDatabase;
+import liquibase.exception.RollbackImpossibleException;
+import liquibase.statement.SqlStatement;
+import liquibase.statement.core.AddColumnStatement;
+import liquibase.statement.core.DropColumnStatement;
+import liquibase.statement.core.ReorganizeTableStatement;
+
+public class ChangeRollbackTest {
+
+    @Test
+    public void generateRollbackStatements_for_empty_change_must_succeed() throws RollbackImpossibleException {
+        EmptyChange change = new EmptyChange();
+        SqlStatement[] statements = change.generateRollbackStatements(new MockDatabase());
+        Assert.assertEquals(0, statements.length);
+    }
+
+    @Test
+    public void generateRollbackStatements_for_output_change_must_succeed() throws RollbackImpossibleException {
+        OutputChange change = new OutputChange();
+        change.setMessage("Irrelevant for the test");
+        SqlStatement[] statements = change.generateRollbackStatements(new MockDatabase());
+        Assert.assertEquals(0, statements.length);
+    }
+
+}


### PR DESCRIPTION
## Impact

- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Currently, trying to rollback a changeset with either an `<empty />` or `<output />` change, is unsupported, the library raises `liquibase.exception.RollbackImpossibleException`.

Due to the nature of both type of changes `Liquibase` must support auto rollback for them.

This PR address the issue by providing a convenient implementation of the `AbstractChange`'s `createInverses` method.

Fixes #4095.

## Things to be aware of

Nothing.

## Things to worry about

Nothing.

## Additional Context

N/A.
