### PR TITLE
Remove native executor name property (DAT-13580)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-core/src/main/java/liquibase/changelog/ChangeSet.java
@@ -815,8 +815,12 @@ public class ChangeSet implements Conditional, ChangeLogChild {
             return null;
         }
         String key = "liquibase." + executorName.toLowerCase() + ".executor";
-        String replacementExecutorName =
-                (String) Scope.getCurrentScope().getSingleton(LiquibaseConfiguration.class).getCurrentConfiguredValue(null, null, key).getValue();
+        if (executorName.equalsIgnoreCase("psql") || executorName.equalsIgnoreCase("sqlcmd") || executorName.equalsIgnoreCase("sqlplus")) {
+            return executorName;
+        }
+        String replacementExecutorName = (String) Scope.getCurrentScope().getSingleton(LiquibaseConfiguration.class)
+                .getCurrentConfiguredValue(null, null, key)
+                .getValue();
         if (replacementExecutorName != null) {
             Scope.getCurrentScope().getLog(ChangeSet.class).info("Mapped '" + executorName + "' to executor '" + replacementExecutorName + "'");
             return replacementExecutorName;

--- a/liquibase-core/src/main/resources/liquibase/examples/sql/liquibase.psql.conf
+++ b/liquibase-core/src/main/resources/liquibase/examples/sql/liquibase.psql.conf
@@ -40,7 +40,3 @@ liquibase.psql.keep.temp=false
 
 # OPTIONAL Path to a log file for the psql output
 # liquibase.psql.logFile=
-
-# OPTIONAL Name of a custom executor to use instead of psql
-# The Executor must be on the Liquibase classpath
-# liquibase.psql.executor=

--- a/liquibase-core/src/main/resources/liquibase/examples/sql/liquibase.sqlcmd.conf
+++ b/liquibase-core/src/main/resources/liquibase/examples/sql/liquibase.sqlcmd.conf
@@ -48,8 +48,3 @@ liquibase.sqlcmd.keep.temp=true
 
 # OPTIONAL Path to a log file for the SQLCMD output
 # liquibase.sqlcmd.logFile=
-#
-
-# OPTIONAL Name of a custom executor to use instead of SQLCMD
-# The Executor must be on the Liquibase classpath
-# liquibase.sqlcmd.executor=

--- a/liquibase-core/src/main/resources/liquibase/examples/sql/liquibase.sqlplus.conf
+++ b/liquibase-core/src/main/resources/liquibase/examples/sql/liquibase.sqlplus.conf
@@ -45,7 +45,3 @@ liquibase.sqlplus.keep.temp=true
 # Learn about SQLPLUS args at https://docs.oracle.com/cd/B10501_01/server.920/a90842/ch4.htm
 # Note: The delimiter for args is a space eg:" " and not "," or ";" separated.
 # liquibase.sqlplus.args=
-
-# OPTIONAL Name of a custom executor to use instead of SQLPLUS
-# The Executor must be on the Liquibase classpath
-# liquibase.sqlplus.executor=

--- a/liquibase-core/src/main/resources/liquibase/examples/xml/liquibase.psql.conf
+++ b/liquibase-core/src/main/resources/liquibase/examples/xml/liquibase.psql.conf
@@ -40,7 +40,3 @@ liquibase.psql.keep.temp=false
 
 # OPTIONAL Path to a log file for the psql output
 # liquibase.psql.logFile=
-
-# OPTIONAL Name of a custom executor to use instead of psql
-# The Executor must be on the Liquibase classpath
-# liquibase.psql.executor=

--- a/liquibase-core/src/main/resources/liquibase/examples/xml/liquibase.sqlcmd.conf
+++ b/liquibase-core/src/main/resources/liquibase/examples/xml/liquibase.sqlcmd.conf
@@ -48,7 +48,3 @@ liquibase.sqlcmd.keep.temp=true
 
 # OPTIONAL Path to a log file for the SQLCMD output
 # liquibase.sqlcmd.logFile=
-
-# OPTIONAL Name of a custom executor to use instead of SQLCMD
-# The Executor must be on the Liquibase classpath
-# liquibase.sqlcmd.executor=

--- a/liquibase-core/src/main/resources/liquibase/examples/xml/liquibase.sqlplus.conf
+++ b/liquibase-core/src/main/resources/liquibase/examples/xml/liquibase.sqlplus.conf
@@ -45,7 +45,3 @@ liquibase.sqlplus.keep.temp=true
 # Learn about SQLPLUS args at https://docs.oracle.com/cd/B10501_01/server.920/a90842/ch4.htm
 # Note: The delimiter for args is a space eg:" " and not "," or ";" separated.
 # liquibase.sqlplus.args=
-
-# OPTIONAL Name of a custom executor to use instead of SQLPLUS 
-# The Executor must be on the Liquibase classpath
-# liquibase.sqlplus.executor=

--- a/liquibase-integration-tests/src/test/groovy/liquibase/snapshot/IndexWithDescendingColumnSnapshotTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/snapshot/IndexWithDescendingColumnSnapshotTest.groovy
@@ -25,9 +25,11 @@ import liquibase.structure.DatabaseObject
 import liquibase.structure.core.Index
 import liquibase.util.StringUtil
 import org.junit.Rule
+import spock.lang.Ignore
 import spock.lang.Specification
 import spock.lang.Unroll
 
+@Ignore
 class IndexWithDescendingColumnSnapshotTest extends Specification {
     @Rule
     public DatabaseTestSystem mssqlDb = Scope.currentScope.getSingleton(TestSystemFactory).getTestSystem("mssql")

--- a/liquibase-integration-tests/src/test/groovy/liquibase/snapshot/IndexWithDescendingColumnSnapshotTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/snapshot/IndexWithDescendingColumnSnapshotTest.groovy
@@ -25,11 +25,9 @@ import liquibase.structure.DatabaseObject
 import liquibase.structure.core.Index
 import liquibase.util.StringUtil
 import org.junit.Rule
-import spock.lang.Ignore
 import spock.lang.Specification
 import spock.lang.Unroll
 
-@Ignore
 class IndexWithDescendingColumnSnapshotTest extends Specification {
     @Rule
     public DatabaseTestSystem mssqlDb = Scope.currentScope.getSingleton(TestSystemFactory).getTestSystem("mssql")

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
@@ -405,14 +405,6 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
     protected String psqlArgs;
 
     /**
-     * Specifies psql executor name.
-     *
-     * @parameter property="liquibase.psql.executor"
-     */
-    @PropertyElement
-    protected String psqlExecutorName;
-
-    /**
      * Specifies psql timeout.
      *
      * @parameter property="liquibase.psql.timeout"
@@ -477,14 +469,6 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
     protected String sqlPlusArgs;
 
     /**
-     * Specifies sqlPlus executor name.
-     *
-     * @parameter property="liquibase.sqlplus.executor"
-     */
-    @PropertyElement
-    protected String sqlPlusExecutorName;
-
-    /**
      * Specifies sqlplus timeout.
      *
      * @parameter property="liquibase.sqlplus.timeout"
@@ -547,14 +531,6 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
      */
     @PropertyElement
     protected String sqlcmdArgs;
-
-    /**
-     * Specifies sqlcmd executor name.
-     *
-     * @parameter property="liquibase.sqlcmd.executor"
-     */
-    @PropertyElement
-    protected String sqlcmdExecutorName;
 
     /**
      * Specifies sqlcmd timeout.
@@ -1127,7 +1103,6 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
         nativeProperties.computeIfAbsent("liquibase.psql.keep.temp.name", val -> psqlKeepTempName);
         nativeProperties.computeIfAbsent("liquibase.psql.keep.temp.path", val -> psqlKeepTempPath);
         nativeProperties.computeIfAbsent("liquibase.psql.args", val -> psqlArgs);
-        nativeProperties.computeIfAbsent("liquibase.psql.executor", val -> psqlExecutorName);
         nativeProperties.computeIfAbsent("liquibase.psql.timeout", val -> psqlTimeout);
         nativeProperties.computeIfAbsent("liquibase.psql.logFile", val -> psqlLogFile);
         nativeProperties.computeIfAbsent("liquibase.sqlplus.path", val -> sqlPlusPath);
@@ -1136,7 +1111,6 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
         nativeProperties.computeIfAbsent("liquibase.sqlplus.keep.temp.path", val -> sqlPlusKeepTempPath);
         nativeProperties.computeIfAbsent("liquibase.sqlplus.keep.temp.overwrite", val -> sqlPlusKeepTempOverwrite);
         nativeProperties.computeIfAbsent("liquibase.sqlplus.args", val -> sqlPlusArgs);
-        nativeProperties.computeIfAbsent("liquibase.sqlplus.executor", val -> sqlPlusExecutorName);
         nativeProperties.computeIfAbsent("liquibase.sqlplus.timeout", val -> sqlPlusTimeout);
         nativeProperties.computeIfAbsent("liquibase.sqlplus.logFile", val -> sqlPlusLogFile);
         nativeProperties.computeIfAbsent("liquibase.sqlcmd.path", val -> sqlcmdPath);
@@ -1145,7 +1119,6 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
         nativeProperties.computeIfAbsent("liquibase.sqlcmd.keep.temp.path", val -> sqlcmdKeepTempPath);
         nativeProperties.computeIfAbsent("liquibase.sqlcmd.keep.temp.overwrite", val -> sqlcmdKeepTempOverwrite);
         nativeProperties.computeIfAbsent("liquibase.sqlcmd.args", val -> sqlcmdArgs);
-        nativeProperties.computeIfAbsent("liquibase.sqlcmd.executor", val -> sqlcmdExecutorName);
         nativeProperties.computeIfAbsent("liquibase.sqlcmd.timeout", val -> sqlcmdTimeout);
         nativeProperties.computeIfAbsent("liquibase.sqlcmd.logFile", val -> sqlcmdLogFile);
         nativeProperties.computeIfAbsent("liquibase.sqlcmd.catalogName", val -> sqlcmdCatalogName);


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description
Removes `liquibase.psql/sqlcmd/sqlplus.executor` property because this property is not respected.
<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
