### PR TITLE
Add missing parameter changeLogFile to update command when running from Main

### DIFF
--- a/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-core/src/main/java/liquibase/integration/commandline/Main.java
@@ -1964,6 +1964,7 @@ public class Main {
 
     private void runUpdateCommandStep() throws CommandLineParsingException, CommandExecutionException, IOException {
         CommandScope updateCommand = new CommandScope("update");
+        updateCommand.addArgumentValue(UpdateCommandStep.CHANGELOG_FILE_ARG, changeLogFile);
         updateCommand.addArgumentValue(UpdateCommandStep.CONTEXTS_ARG, contexts);
         updateCommand.addArgumentValue(UpdateCommandStep.LABEL_FILTER_ARG, labelFilter);
         updateCommand.addArgumentValue(ChangeExecListenerCommandStep.CHANGE_EXEC_LISTENER_CLASS_ARG, changeExecListenerClass);


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

When running Main from java code like below:

```
        String[] arguments = [
                "--url", "jdbc:neo4j:${neo4jContainer.getBoltUrl()}",
                "--username", "neo4j",
                "--password", PASSWORD,
                "--changeLogFile", "/changelog.xml",
                "updateSQL"
        ].toArray()
        Main.run(arguments)
```

Liquibase 4.21.0 throws the following error:

```
liquibase.exception.LiquibaseException: Unexpected error running Liquibase: Unknown reason

	at liquibase.integration.commandline.Main$1.run(Main.java:465)
	at liquibase.integration.commandline.Main$1.run(Main.java:234)
	at liquibase.Scope.child(Scope.java:203)
	at liquibase.Scope.child(Scope.java:179)
	at liquibase.integration.commandline.Main.run(Main.java:234)
	at liquibase.ext.neo4j.Neo4jPluginIT.runs migrations(Neo4jPluginIT.groovy:99)
Caused by: liquibase.exception.CommandValidationException: Invalid argument 'changelogFile': missing required argument
	at liquibase.command.CommandArgumentDefinition.validate(CommandArgumentDefinition.java:139)
	at liquibase.command.CommandScope.validate(CommandScope.java:180)
	at liquibase.command.CommandScope.execute(CommandScope.java:205)
	at liquibase.integration.commandline.Main.runUpdateCommandStep(Main.java:1972)
	at liquibase.integration.commandline.Main.runUsingCommandFramework(Main.java:1876)
	at liquibase.integration.commandline.Main.doMigration(Main.java:1473)
	at liquibase.integration.commandline.Main$1.lambda$run$2(Main.java:417)
	at liquibase.Scope.lambda$child$0(Scope.java:194)
	at liquibase.Scope.child(Scope.java:203)
	at liquibase.Scope.child(Scope.java:193)
	at liquibase.Scope.child(Scope.java:172)
	at liquibase.integration.commandline.Main$1.run(Main.java:416)
	... 5 more
Caused by: liquibase.exception.MissingRequiredArgumentException
	... 17 more
```

This PR adds the missing parameter changeLogFile to update command when running from Main fixing it.
