### PR TITLE
DAT-14418 javadocs extraction fix

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -205,12 +205,17 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.JAVADOCS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.JAVADOCS_SECRET_ACCESS_KEY }}
         AWS_DEFAULT_REGION: us-east-1
+      # unzip archives, create directory for each jar, and extract jar contents to directory.  Then delete the jar and zip files.  Then upload to s3.
       run: |
-        unzip -j '*.zip' '*javadoc*.jar'
-        unzip '*liquibase-cdi*.jar' -d liquibase-cdi/
-        unzip '*liquibase-commercial*.jar' -d liquibase-commercial/
-        unzip '*liquibase-core*.jar' -d liquibase-core/
-        unzip '*liquibase-maven-plugin*.jar' -d liquibase-maven-plugin/
+        unzip -j '*.zip' '*javadoc*.jar' 
+        
+        for jar in *liquibase*.jar; do
+          dir_name=$(basename "$jar" .jar)
+          dir_name=$(echo "$dir_name" | sed -E 's/(-[0-9]+(\.[0-9]+)*(-javadoc)?)//')
+          mkdir -p "$dir_name"
+          unzip -o "$jar" -d "$dir_name"
+        done
+        
         rm -rf *.jar *.zip
         aws s3 sync . s3://javadocsliquibasecom-origin --only-show-errors
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Javadocs extraction conflict due to both `liquibase-cdi` and `liquibase-cdi-jakarta` matching the `liquibase-cdi*.jar`.  Instead, lets use a loop to extract the dir name based on the jar file name (excluding the version and the word javadocs) and then extract the jar files there.


## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
