### PR TITLE
low-skilled attempt at fixing #4048

### DIFF
--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/ColumnAutoIncrementService.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/ColumnAutoIncrementService.java
@@ -44,14 +44,14 @@ public class ColumnAutoIncrementService {
      * @param snapshot snapshot data used to store cache information.
      * @return Map with the sequence name and auto increment details
      */
-    public Map<String, Column.AutoIncrementInformation> obtainSequencesInformation(Database database, DatabaseSnapshot snapshot) {
+    public Map<String, Column.AutoIncrementInformation> obtainSequencesInformation(Database database, Schema schema, DatabaseSnapshot snapshot) {
         if (autoIncrementColumns != null) {
             return autoIncrementColumns;
         } else {
             autoIncrementColumns = new ConcurrentHashMap<>();
             Executor executor = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database);
             try {
-                String query = this.getQueryForDatabase(database);
+                String query = this.getQueryForDatabaseAndSchema(database, schema);
                 List<Map<String, ?>> rows = executor.queryForList(new RawSqlStatement(query));
                 for (Map<String, ?> row : rows) {
                     String schemaName = (String) row.get("SCHEMA_NAME");
@@ -74,12 +74,13 @@ public class ColumnAutoIncrementService {
         return autoIncrementColumns;
     }
 
-    private String getQueryForDatabase(Database database) throws LiquibaseException {
+    private String getQueryForDatabaseAndSchema(Database database, Schema schema) throws LiquibaseException {
         if (database instanceof MSSQLDatabase) {
             return "SELECT object_schema_name(object_id) AS schema_name, " +
                     "object_name(object_id) AS table_name, name AS column_name, " +
                     "CAST(seed_value AS bigint) AS start_value, " +
                     "CAST(increment_value AS bigint) AS increment_by " +
+                    ()
                     "FROM sys.identity_columns";
         } else if (database instanceof PostgresDatabase) {
             int version = 9;
@@ -116,7 +117,7 @@ public class ColumnAutoIncrementService {
                         "    JOIN pg_depend d ON c.oid = d.objid " +
                         "    JOIN pg_class td ON td.oid = d.refobjid " +
                         "    JOIN pg_attribute pa ON  pa.attrelid=td.oid AND pa.attnum=d.refobjsubid " +
-                        "WHERE c.relkind = 'S' AND d.deptype = 'a'";
+                        "WHERE c.relkind = 'S' AND d.deptype = 'a' AND ns.nspname = '" + schema.getName() + "'";
             }
         }
 

--- a/liquibase-core/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
@@ -218,7 +218,7 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
                 (column.getRelation() != null) && (column.getSchema() != null)) {
 
             Column.AutoIncrementInformation autoIncrementInformation =
-                    this.columnAutoIncrementService.obtainSequencesInformation(database, snapshot)
+                    this.columnAutoIncrementService.obtainSequencesInformation(database, column.getSchema(), snapshot)
                             .get(String.format("%s.%s.%s", column.getSchema().getName(), column.getRelation().getName(), column.getName()));
             if (autoIncrementInformation != null) {
                 column.setAutoIncrementInformation(autoIncrementInformation);


### PR DESCRIPTION
## Impact

- [X ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description
https://github.com/liquibase/liquibase/issues/4048 description and discussion indicate that (at least in postgres) the search for the sequences referring to a specific column should be restricted to the schema the column resides in.

## Things to be aware of

Injected the schema name from the column in the function. Renamed a private method that is used only here.

## Things to worry about

Please note that this was not tested, as I am not an active java dev, and am only trying to help in advancing a possible solution for the simple issue.

