### PR TITLE
DAT-14194

### DIFF
--- a/.github/util/re-version.sh
+++ b/.github/util/re-version.sh
@@ -95,7 +95,7 @@ do
   rm -rf $workdir/rebuild
 
   cp $workdir/$jar $outdir
-  rename 0-SNAPSHOT $version $outdir/$jar
+  mv -v 0-SNAPSHOT $version $outdir/$jar
 done
 
 ## Test jar structure

--- a/.github/util/re-version.sh
+++ b/.github/util/re-version.sh
@@ -74,8 +74,9 @@ do
   mv $workdir/finalize-jar/META-INF/MANIFEST.MF $workdir/tmp-manifest.mf
   (cd $workdir/finalize-jar && jar cfm $workdir/$jar $workdir/tmp-manifest.mf .)
 
-  cp $workdir/$jar $outdir
-  rename.ul 0-SNAPSHOT $version $outdir/$jar
+  RENAME_SNAPSHOTS=$(ls $outdir/$jar | sed -e "s/0-SNAPSHOT/$version/g")
+  mv $outdir/$jar $RENAME_SNAPSHOTS
+  
 done
 
 #### Update  javadoc jars

--- a/.github/util/re-version.sh
+++ b/.github/util/re-version.sh
@@ -75,7 +75,7 @@ do
   (cd $workdir/finalize-jar && jar cfm $workdir/$jar $workdir/tmp-manifest.mf .)
 
   RENAME_SNAPSHOTS=$(ls $outdir/$jar | sed -e "s/0-SNAPSHOT/$version/g")
-  mv $outdir/$jar $RENAME_SNAPSHOTS
+  mv $outdir/$jar "$RENAME_SNAPSHOTS"
   
 done
 

--- a/.github/util/re-version.sh
+++ b/.github/util/re-version.sh
@@ -95,7 +95,8 @@ do
   rm -rf $workdir/rebuild
 
   cp $workdir/$jar $outdir
-  mv -v 0-SNAPSHOT $version $outdir/$jar
+  RENAME_JAVADOC_SNAPSHOTS=$(ls $outdir/$jar | sed -e "s/0-SNAPSHOT/$version/g")
+  mv -v $outdir/$jar $RENAME_JAVADOC_SNAPSHOTS
 done
 
 ## Test jar structure

--- a/.github/util/re-version.sh
+++ b/.github/util/re-version.sh
@@ -93,7 +93,7 @@ do
   rm -rf $workdir/rebuild
 
   cp $workdir/$jar $outdir
-  rename.ul 0-SNAPSHOT $version $outdir/$jar
+  rename 0-SNAPSHOT $version $outdir/$jar
 done
 
 ## Test jar structure

--- a/.github/util/re-version.sh
+++ b/.github/util/re-version.sh
@@ -74,6 +74,7 @@ do
   mv $workdir/finalize-jar/META-INF/MANIFEST.MF $workdir/tmp-manifest.mf
   (cd $workdir/finalize-jar && jar cfm $workdir/$jar $workdir/tmp-manifest.mf .)
 
+  cp $workdir/$jar $outdir
   RENAME_SNAPSHOTS=$(ls $outdir/$jar | sed -e "s/0-SNAPSHOT/$version/g")
   mv -v $outdir/$jar $RENAME_SNAPSHOTS
   

--- a/.github/util/re-version.sh
+++ b/.github/util/re-version.sh
@@ -75,7 +75,7 @@ do
   (cd $workdir/finalize-jar && jar cfm $workdir/$jar $workdir/tmp-manifest.mf .)
 
   RENAME_SNAPSHOTS=$(ls $outdir/$jar | sed -e "s/0-SNAPSHOT/$version/g")
-  mv $outdir/$jar "$RENAME_SNAPSHOTS"
+  mv -v $outdir/$jar $RENAME_SNAPSHOTS
   
 done
 

--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   build:
     name: Build & Package
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   build-master:
     name: Build & Package Master
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write
@@ -45,7 +45,7 @@ jobs:
 
   build-sha:
     name: Build & Package SHA
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/cleanup-branch-builds.yml
+++ b/.github/workflows/cleanup-branch-builds.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   delete-package:
     name: Delete Github Package for Branch
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       # Get version id(s) based on version name
     - uses: castlabs/get-package-version-id-action@v2.1

--- a/.github/workflows/cleanup-master-builds.yml
+++ b/.github/workflows/cleanup-master-builds.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   delete-package:
     name: Delete Github Packages for Master/Main
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
 
     - uses: actions/delete-package-versions@v4

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   setup:
     name: Setup
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.collect-data.outputs.version }}
       branch: ${{ steps.collect-data.outputs.branch }}
@@ -34,7 +34,7 @@ jobs:
   reversion:
     needs: [ setup ]
     name: Re-version artifacts ${{ needs.setup.outputs.version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   trigger-release:
     name: "Trigger Releases"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   setup:
     name: Setup
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       tag: ${{ steps.collect-data.outputs.tag }}
       version: ${{ steps.collect-data.outputs.version }}
@@ -40,7 +40,7 @@ jobs:
   deploy_maven:
     name: Deploy to Maven
     needs: [ setup ]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Download release assets
         uses: robinraju/release-downloader@v1.7
@@ -186,7 +186,7 @@ jobs:
   deploy_javadocs:
     name: Upload Javadocs
     needs: [ setup ]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
       id-token: write
@@ -221,7 +221,7 @@ jobs:
 
   publish_to_github_packages:
     name: Publish artifacts to Github Packages
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [ setup ]
     permissions:
       contents: read
@@ -254,7 +254,7 @@ jobs:
   deploy_xsd:
       name: Upload xsds
       needs: [ setup ]
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-22.04
       outputs:
           tag: ${{ steps.collect-data.outputs.tag }}
           version: ${{ needs.setup.outputs.version }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.repository == 'liquibase/liquibase'
 
     name: Snyk Security Scan
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/url-check.yml
+++ b/.github/workflows/url-check.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   urlcheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Check URLs


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

- Upgrade-all-github-runner-images-to-Ubuntu-22.04
- Github runner images were upgraded to Ubuntu 22.04 on `core/build.yml`, but all the other scripts remain on Ubuntu 20.04 
- There is a known issue: Ubuntu 22.04 is missing the command `rename.ul`, used at script re-version.sh, which only runs at release time. 