### PR TITLE
Fixes undesired change to CreateProcedureChange checksum generation

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/change/core/CreateProcedureChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/CreateProcedureChange.java
@@ -105,7 +105,7 @@ public class CreateProcedureChange extends AbstractChange implements DbmsTargete
         this.relativeToChangelogFile = relativeToChangelogFile;
     }
 
-    @DatabaseChangeProperty(isChangeProperty = false)
+    @DatabaseChangeProperty(serializationType = SerializationType.DIRECT_VALUE)
     /**
      * @deprecated Use getProcedureText() instead
      */

--- a/liquibase-standard/src/main/java/liquibase/change/core/CreateProcedureChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/CreateProcedureChange.java
@@ -124,7 +124,7 @@ public class CreateProcedureChange extends AbstractChange implements DbmsTargete
     @DatabaseChangeProperty(
         description = "The SQL creating the procedure. You need to define either this attribute or 'path'. " +
             "procedureText is not supported in the XML format; however, you can specify the procedure SQL inline within the createProcedure definition.",
-            serializationType = SerializationType.DIRECT_VALUE)
+            isChangeProperty = false)
     public String getProcedureText() {
         return procedureText;
     }

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/CreateProcedureChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/CreateProcedureChangeTest.groovy
@@ -47,7 +47,7 @@ public class CreateProcedureChangeTest extends StandardChangeTest {
         change.validate(new OracleDatabase())
 
         then:
-        change.serialize().toString() == "createProcedure[procedureText=create procedure sql]"
+        change.serialize().toString() == "createProcedure[procedureBody=create procedure sql]"
     }
 
     @Unroll


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Rollback annotation settings for CreateProcedureChange .getProcedureText

## Additional Context

This change was introduced by  change https://github.com/liquibase/liquibase/pull/3811  that was meant to be  a documentation update, not behavior change.
