### PR TITLE
Allow whitespace within a foreign key statement

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/AddColumnGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/AddColumnGenerator.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
 
 public class AddColumnGenerator extends AbstractSqlGenerator<AddColumnStatement> {
 
-    private static final String REFERENCE_REGEX = "([\\w\\._]+)\\(([\\w_]+)\\)";
+    private static final String REFERENCE_REGEX = "([\\w\\._]+)\\s*\\(([\\w_]+)\\)";
     public static final Pattern REFERENCE_PATTERN = Pattern.compile(REFERENCE_REGEX);
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/AddColumnGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/AddColumnGenerator.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
 
 public class AddColumnGenerator extends AbstractSqlGenerator<AddColumnStatement> {
 
-    private static final String REFERENCE_REGEX = "([\\w\\._]+)\\s*\\(([\\w_]+)\\)";
+    private static final String REFERENCE_REGEX = "([\\w\\._]+)\\s*\\(\\s*([\\w_]+)\\s*\\)";
     public static final Pattern REFERENCE_PATTERN = Pattern.compile(REFERENCE_REGEX);
 
     @Override

--- a/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/AddColumnGeneratorTest.java
+++ b/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/AddColumnGeneratorTest.java
@@ -10,10 +10,7 @@ import liquibase.sqlgenerator.AbstractSqlGeneratorTest;
 import liquibase.sqlgenerator.MockSqlGeneratorChain;
 import liquibase.sqlgenerator.SqlGenerator;
 import liquibase.sqlgenerator.SqlGeneratorFactory;
-import liquibase.statement.AutoIncrementConstraint;
-import liquibase.statement.NotNullConstraint;
-import liquibase.statement.PrimaryKeyConstraint;
-import liquibase.statement.SqlStatement;
+import liquibase.statement.*;
 import liquibase.statement.core.AddColumnStatement;
 import org.junit.Test;
 
@@ -131,6 +128,21 @@ public class AddColumnGeneratorTest extends AbstractSqlGeneratorTest<AddColumnSt
 
         assertEquals(1, sql.length);
         assertEquals("ALTER TABLE table_name ADD ID BIGINT NOT NULL PRIMARY KEY", sql[0].toSql());
+    }
+
+    @Test
+    public void testAddForeignKeyWithEmptySpaces() {
+        AddColumnStatement columns = new AddColumnStatement(null, null, TABLE_NAME, "ID", "BIGINT", null,
+                new ForeignKeyConstraint("fk_name", "table1 ( id )"));
+
+        H2Database h2Database = new H2Database();
+        assertFalse(generatorUnderTest.validate(columns, h2Database, new MockSqlGeneratorChain()).hasErrors());
+
+        Sql[] sql = generatorUnderTest.generateSql(columns, h2Database, new MockSqlGeneratorChain());
+
+
+        assertEquals(2, sql.length);
+        assertEquals("ALTER TABLE table_name ADD CONSTRAINT fk_name FOREIGN KEY (ID) REFERENCES table1 (id)", sql[1].toSql());
     }
 
     @Test


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Before, only `references: tablename(columnname)` worked. Now both `tablename(columnname)` and `tablename ( columnname )` work.

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
