### PR TITLE
Prevents nullpointer when reading Snowflake stored logic

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/structure/core/StoredDatabaseLogic.java
+++ b/liquibase-standard/src/main/java/liquibase/structure/core/StoredDatabaseLogic.java
@@ -76,7 +76,7 @@ public abstract class StoredDatabaseLogic<T extends StoredDatabaseLogic> extends
             }
         }
 
-        return getName().equalsIgnoreCase(that.getName());
+        return StringUtil.trimToEmpty(getName()).equalsIgnoreCase(that.getName());
     }
 
     @Override


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Prevents this:

```
[2023-04-26 17:17:53] SEVERE [liquibase.integration] Cannot invoke "String.equalsIgnoreCase(String)" because the return value of "liquibase.structure.core.StoredDatabaseLogic.getName()" is null
liquibase.exception.CommandExecutionException: java.lang.NullPointerException: Cannot invoke "String.equalsIgnoreCase(String)" because the return value of "liquibase.structure.core.StoredDatabaseLogic.getName()" is null
	at liquibase.command.CommandScope.execute(CommandScope.java:235)
	at liquibase.integration.commandline.CommandRunner.call(CommandRunner.java:55)
	at liquibase.integration.commandline.CommandRunner.call(CommandRunner.java:24)
```