### PR TITLE
Fix addDefaultValue checksum calculation when providing schema name

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/change/core/AddDefaultValueChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/AddDefaultValueChange.java
@@ -219,7 +219,7 @@ public class AddDefaultValueChange extends AbstractChange {
                 defaultValue = new DatabaseFunction(getDefaultValueDate());
             }
         } else if (getDefaultValueComputed() != null) {
-            defaultValue = new DatabaseFunction(getDefaultValueComputed().getValue(), getDefaultValueComputed().getSchemaName());
+            defaultValue = getDefaultValueComputed();
         } else if (getDefaultValueSequenceNext() != null) {
             defaultValue = new SequenceNextValueFunction(this.getSchemaName(), getDefaultValueSequenceNext().getValue());
         }

--- a/liquibase-standard/src/main/java/liquibase/change/core/AddDefaultValueChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/AddDefaultValueChange.java
@@ -219,10 +219,9 @@ public class AddDefaultValueChange extends AbstractChange {
                 defaultValue = new DatabaseFunction(getDefaultValueDate());
             }
         } else if (getDefaultValueComputed() != null) {
-            defaultValue = getDefaultValueComputed();
+            defaultValue = new DatabaseFunction(getDefaultValueComputed().getValue(), getDefaultValueComputed().getSchemaName());
         } else if (getDefaultValueSequenceNext() != null) {
-            defaultValue = getDefaultValueSequenceNext();
-            ((SequenceNextValueFunction) defaultValue).setSchemaName(this.getSchemaName());
+            defaultValue = new SequenceNextValueFunction(this.getSchemaName(), getDefaultValueSequenceNext().getValue());
         }
 
         AddDefaultValueStatement statement = new AddDefaultValueStatement(getCatalogName(), getSchemaName(), getTableName(), getColumnName(), getColumnDataType(), defaultValue);

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/AddDefaultValueChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/AddDefaultValueChangeTest.groovy
@@ -1,12 +1,13 @@
 package liquibase.change.core
 
 import liquibase.change.ChangeStatus
-import liquibase.change.StandardChangeTest;
+import liquibase.change.StandardChangeTest
 import liquibase.database.core.MockDatabase
 import liquibase.snapshot.MockSnapshotGeneratorFactory
 import liquibase.snapshot.SnapshotGeneratorFactory
 import liquibase.statement.DatabaseFunction
 import liquibase.statement.SequenceNextValueFunction
+import liquibase.statement.core.AddDefaultValueStatement
 import liquibase.structure.core.Column
 import liquibase.structure.core.Table
 import liquibase.util.ISODateFormat
@@ -16,13 +17,33 @@ public class AddDefaultValueChangeTest extends StandardChangeTest {
 
     def getConfirmationMessage() throws Exception {
         when:
-        def change = new AddDefaultValueChange();
-        change.setSchemaName("SCHEMA_NAME");
-        change.setTableName("TABLE_NAME");
-        change.setColumnName("COLUMN_NAME");
+        def change = new AddDefaultValueChange()
+        change.setSchemaName("SCHEMA_NAME")
+        change.setTableName("TABLE_NAME")
+        change.setColumnName("COLUMN_NAME")
 
         then:
         change.getConfirmationMessage() == "Default value added to TABLE_NAME.COLUMN_NAME"
+    }
+
+    @Unroll
+    def "Make sure that generateStatements is not changing internal structures"() {
+        given:
+        def database = new MockDatabase()
+        def change = new AddDefaultValueChange()
+        change.schemaName = "schema"
+        change.setDefaultValueSequenceNext(new SequenceNextValueFunction("seq_name"))
+
+        when:
+        def statements = change.generateStatements(database)
+        def defaultValueStatement = (SequenceNextValueFunction)((AddDefaultValueStatement)statements[0]).defaultValue
+
+        then:
+        assert defaultValueStatement != change.defaultValueSequenceNext
+        assert defaultValueStatement.getValue() == change.defaultValueSequenceNext.value
+
+        assert change.defaultValueSequenceNext.schemaName == null
+        assert defaultValueStatement.schemaName == change.schemaName
     }
 
     @Unroll


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Make sure we create new objects instead of modifying the existing ones when processing addDefaultValue change type.


## Things to be aware of

It changes checksum value so it must be merged in the same release as https://github.com/liquibase/liquibase/pull/3914 .
