### PR TITLE
Load properties from defaults-file fixing variable replacement for refactored commands

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/configuration/core/DefaultsFileValueProvider.java
+++ b/liquibase-standard/src/main/java/liquibase/configuration/core/DefaultsFileValueProvider.java
@@ -128,7 +128,7 @@ public class DefaultsFileValueProvider extends AbstractMapConfigurationValueProv
     }
 
     @Override
-    protected Map<?, ?> getMap() {
+    public Map<?, ?> getMap() {
         return properties;
     }
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Before command refactoring, `LiquibaseCommandLine `would execute` Main class` that has a complex way of loading properties values from files (it starts at method` parseDefaultPropertyFiles()` and goes on). 
After command refactoring, `LiquibaseCommandLine `is calling the commands directly without passing by `Main` - so this logic has been lost and properties values were not being provided when `DatabaseChangeLog` is created.

But as `LiquibaseCommandLine` already loads the default-file as a provider into `LiquibaseConfiguration `, instead of copying all the logic from Main this PR just uses the already existing information and populates the parameters from there.

## Additional Context

Fixes bug introduced by command refactoring.
