### PR TITLE
Fix null md5sum issues during checksum upgrades

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/changelog/AbstractChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/AbstractChangeLogHistoryService.java
@@ -74,8 +74,6 @@ public abstract class AbstractChangeLogHistoryService implements ChangeLogHistor
                         Scope.getCurrentScope().getLog(getClass()).fine(
                                 "Updating null or out of date checksum on changeSet " + changeSet + " to correct value"
                         );
-                        // to allow switching between saving normalized or configured path
-                        changeSet.setStoredFilePath(ranChangeSet.getStoredChangeLog());
                         replaceChecksum(changeSet);
                     }
                 }

--- a/liquibase-standard/src/main/java/liquibase/changelog/AbstractChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/AbstractChangeLogHistoryService.java
@@ -74,6 +74,8 @@ public abstract class AbstractChangeLogHistoryService implements ChangeLogHistor
                         Scope.getCurrentScope().getLog(getClass()).fine(
                                 "Updating null or out of date checksum on changeSet " + changeSet + " to correct value"
                         );
+                        // to allow switching between saving normalized or configured path
+                        changeSet.setStoredFilePath(ranChangeSet.getStoredChangeLog());
                         replaceChecksum(changeSet);
                     }
                 }

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogIterator.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogIterator.java
@@ -14,8 +14,6 @@ import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.exception.ValidationErrors;
 import liquibase.executor.Executor;
 import liquibase.executor.ExecutorService;
-import liquibase.logging.core.BufferedLogService;
-import liquibase.logging.core.CompositeLogService;
 import liquibase.util.StringUtil;
 
 import java.util.*;
@@ -43,6 +41,7 @@ public class ChangeLogIterator {
                 if (changeSet != null) {
                     changeSet.setFilePath(DatabaseChangeLog.normalizePath(ranChangeSet.getChangeLog()));
                     changeSet.setDeploymentId(ranChangeSet.getDeploymentId());
+                    changeSet.setStoredFilePath(ranChangeSet.getStoredChangeLog());
                     changeSets.add(changeSet);
                 }
 	        }

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogIterator.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogIterator.java
@@ -41,7 +41,6 @@ public class ChangeLogIterator {
                 if (changeSet != null) {
                     changeSet.setFilePath(DatabaseChangeLog.normalizePath(ranChangeSet.getChangeLog()));
                     changeSet.setDeploymentId(ranChangeSet.getDeploymentId());
-                    changeSet.setStoredFilePath(ranChangeSet.getStoredChangeLog());
                     changeSets.add(changeSet);
                 }
 	        }

--- a/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -364,7 +364,9 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
     }
 
     public List<ChangeSet> getChangeSets(RanChangeSet ranChangeSet) {
-        return getChangeSets(ranChangeSet.getChangeLog(), ranChangeSet.getAuthor(), ranChangeSet.getId());
+        List<ChangeSet> changesets = getChangeSets(ranChangeSet.getChangeLog(), ranChangeSet.getAuthor(), ranChangeSet.getId());
+        changesets.forEach(c -> c.setStoredFilePath(ranChangeSet.getStoredChangeLog()));
+        return changesets;
     }
 
     public void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException, SetupException {

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/UpdateChangeSetChecksumGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/UpdateChangeSetChecksumGenerator.java
@@ -11,6 +11,7 @@ import liquibase.sqlgenerator.SqlGeneratorFactory;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.UpdateChangeSetChecksumStatement;
 import liquibase.statement.core.UpdateStatement;
+import liquibase.util.StringUtil;
 
 public class UpdateChangeSetChecksumGenerator extends AbstractSqlGenerator<UpdateChangeSetChecksumStatement> {
     @Override
@@ -33,11 +34,18 @@ public class UpdateChangeSetChecksumGenerator extends AbstractSqlGenerator<Updat
                     .setWhereClause(database.escapeObjectName("ID", LiquibaseColumn.class) + " = ? " +
                             "AND " + database.escapeObjectName("AUTHOR", LiquibaseColumn.class) + " = ? " +
                             "AND " + database.escapeObjectName("FILENAME", LiquibaseColumn.class) + " = ?")
-                    .addWhereParameters(changeSet.getId(), changeSet.getAuthor(), changeSet.getFilePath());
+                    .addWhereParameters(changeSet.getId(), changeSet.getAuthor(), this.getFilePath(changeSet));
 
             return SqlGeneratorFactory.getInstance().generateSql(runStatement, database);
         } finally {
             database.setObjectQuotingStrategy(currentStrategy);
         }
+    }
+
+    private String getFilePath(ChangeSet changeSet) {
+        if (StringUtil.isNotEmpty(changeSet.getStoredFilePath())) {
+            return changeSet.getStoredFilePath();
+        }
+        return changeSet.getFilePath();
     }
 }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

When updating checksums make sure to use the stored file path instead of the generated one as we changed the way that we store paths during the years.