### PR TITLE
PD-3241: failOnError syntax

### DIFF
--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseUpdateMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseUpdateMojo.java
@@ -30,7 +30,7 @@ public abstract class AbstractLiquibaseUpdateMojo extends AbstractLiquibaseChang
   protected String toTag;
 
   /**
-   * If set to true and any changeset in a deployment fails, then the update operation stops, and liquibase attempts to rollback all changesets just deployed. A changeset marked "fail-on-error=false" does not trigger as an error, therefore rollback-on-error will not occur. Additionally, if a changeset is not auto-rollback compliant or does not have a rollback script, then no rollback-on-error will occur for any changeset.
+   * If set to true and any changeset in a deployment fails, then the update operation stops, and liquibase attempts to rollback all changesets just deployed. A changeset marked "failOnError=false" does not trigger as an error, therefore rollback-on-error will not occur. Additionally, if a changeset is not auto-rollback compliant or does not have a rollback script, then no rollback-on-error will occur for any changeset.
    *
    * @parameter property="liquibase.rollbackOnError" default-value="false"
    */


### PR DESCRIPTION
https://datical.atlassian.net/browse/PD-3241

Fixing `liquibase update --help` description: failOnError is a changeset attribute that should be specified in camelCase, *not* a CLI attribute that should be specified in kebab-case.

https://docs.liquibase.com/concepts/changelogs/attributes/fail-on-error.html

PR contains no changes to functionality.