### PR TITLE
Liquibase should not fail when change log has only `databaseChangeLog` tag

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/parser/core/yaml/YamlChangeLogParser.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/core/yaml/YamlChangeLogParser.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.util.*;
 
 public class YamlChangeLogParser extends YamlParser implements ChangeLogParser {
+    private static final String DATABASE_CHANGE_LOG = "databaseChangeLog";
 
     @Override
     public DatabaseChangeLog parse(String physicalChangeLogLocation, ChangeLogParameters changeLogParameters, ResourceAccessor resourceAccessor) throws ChangeLogParseException {
@@ -42,9 +43,14 @@ public class YamlChangeLogParser extends YamlParser implements ChangeLogParser {
             }
             DatabaseChangeLog changeLog = new DatabaseChangeLog(DatabaseChangeLog.normalizePath(physicalChangeLogLocation));
 
-            Object rootList = parsedYaml.get("databaseChangeLog");
-            if (rootList == null) {
+            if (!parsedYaml.containsKey(DATABASE_CHANGE_LOG)) {
                 throw new ChangeLogParseException("Could not find databaseChangeLog node");
+            }
+
+            Object rootList = parsedYaml.get(DATABASE_CHANGE_LOG);
+            if (rootList == null) {
+                changeLog.setChangeLogParameters(changeLogParameters);
+                return changeLog;
             }
 
             if (!(rootList instanceof List)) {
@@ -76,7 +82,7 @@ public class YamlChangeLogParser extends YamlParser implements ChangeLogParser {
             replaceParameters(parsedYaml, changeLogParameters, changeLog);
 
             changeLog.setChangeLogParameters(changeLogParameters);
-            ParsedNode databaseChangeLogNode = new ParsedNode(null, "databaseChangeLog");
+            ParsedNode databaseChangeLogNode = new ParsedNode(null, DATABASE_CHANGE_LOG);
             databaseChangeLogNode.setValue(rootList);
 
             changeLog.load(databaseChangeLogNode, resourceAccessor);

--- a/liquibase-standard/src/test/groovy/liquibase/parser/core/yaml/YamlChangeLogParser_RealFile_Test.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/parser/core/yaml/YamlChangeLogParser_RealFile_Test.groovy
@@ -651,4 +651,18 @@ public class YamlChangeLogParser_RealFile_Test extends Specification {
         cleanup:
         Scope.getCurrentScope().getSingleton(ChangeFactory.class).unregister("createTableExample");
     }
+
+
+    def "change set have to empty when change log has only databaseChangeLog tag"() throws ChangeLogParseException {
+        def path = "liquibase/parser/core/yaml/emptyChangeLog.yaml"
+        when:
+        def changeLog = new YamlChangeLogParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor());
+
+        then:
+        changeLog.logicalFilePath == path
+        changeLog.physicalFilePath == path
+
+        changeLog.preconditions.nestedPreconditions.size() == 0
+        changeLog.changeSets.size() == 0
+    }
 }

--- a/liquibase-standard/src/test/groovy/liquibase/parser/core/yaml/YamlChangeLogParser_RealFile_Test.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/parser/core/yaml/YamlChangeLogParser_RealFile_Test.groovy
@@ -653,7 +653,7 @@ public class YamlChangeLogParser_RealFile_Test extends Specification {
     }
 
 
-    def "change set have to empty when change log has only databaseChangeLog tag"() throws ChangeLogParseException {
+    def "Verify Liquibase returns zero changesets when a YAML changelog only has the databaseChangeLog tag"() throws ChangeLogParseException {
         def path = "liquibase/parser/core/yaml/emptyChangeLog.yaml"
         when:
         def changeLog = new YamlChangeLogParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor());

--- a/liquibase-standard/src/test/resources/liquibase/parser/core/yaml/emptyChangeLog.yaml
+++ b/liquibase-standard/src/test/resources/liquibase/parser/core/yaml/emptyChangeLog.yaml
@@ -1,0 +1,1 @@
+databaseChangeLog:


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

This pr created for the https://github.com/liquibase/liquibase/issues/4223 issue. I have to compare xml and yml behavior for understanding expected behavior.

### Xml behavior

````console
$ ./liquibase update
####################################################
##   _     _             _ _                      ##
##  | |   (_)           (_) |                     ##
##  | |    _  __ _ _   _ _| |__   __ _ ___  ___   ##
##  | |   | |/ _` | | | | | '_ \ / _` / __|/ _ \  ##
##  | |___| | (_| | |_| | | |_) | (_| \__ \  __/  ##
##  \_____/_|\__, |\__,_|_|_.__/ \__,_|___/\___|  ##
##              | |                               ##
##              |_|                               ##
##                                                ## 
##  Get documentation at docs.liquibase.com       ##
##  Get certified courses at learn.liquibase.com  ## 
##                                                ##
####################################################
Starting Liquibase at 21:56:52 (version 4.22.0 #9559 built at 2023-05-10 20:45+0000)
Liquibase Version: 4.22.0
Liquibase Open Source 4.22.0 by Liquibase
Database is up to date, no changesets to execute

UPDATE SUMMARY
Run:                          0
Previously run:               0
Filtered out:                 0
-------------------------------
Total change sets:            0

Liquibase command 'update' was executed successfully.
````
### Json behavior

````console
$ ./liquibase update
####################################################
##   _     _             _ _                      ##
##  | |   (_)           (_) |                     ##
##  | |    _  __ _ _   _ _| |__   __ _ ___  ___   ##
##  | |   | |/ _` | | | | | '_ \ / _` / __|/ _ \  ##
##  | |___| | (_| | |_| | | |_) | (_| \__ \  __/  ##
##  \_____/_|\__, |\__,_|_|_.__/ \__,_|___/\___|  ##
##              | |                               ##
##              |_|                               ##
##                                                ## 
##  Get documentation at docs.liquibase.com       ##
##  Get certified courses at learn.liquibase.com  ## 
##                                                ##
####################################################
Starting Liquibase at 22:00:37 (version 4.22.0 #9559 built at 2023-05-10 20:45+0000)
Liquibase Version: 4.22.0
Liquibase Open Source 4.22.0 by Liquibase

Unexpected error running Liquibase: Could not find databaseChangeLog node

For more information, please use the --log-level flag
````

After changes all test pass in `liquibase.parser.core.yaml.YamlChangeLogParser_RealFile_Test`. 

## Things to worry about

This is my first pr for Liquibase. I can broke things by accident :) Maybe my unit test wont enough for it. I test it with only unit test.  