### PR TITLE
Replaces pom.xml target and source by release configuration

### DIFF
--- a/liquibase-cdi-jakarta/pom.xml
+++ b/liquibase-cdi-jakarta/pom.xml
@@ -13,6 +13,7 @@
     <artifactId>liquibase-cdi-jakarta</artifactId>
 
     <properties>
+        <maven.compiler.release>11</maven.compiler.release>
         <maven.install.skip>false</maven.install.skip>
         <maven.deploy.skip>false</maven.deploy.skip>
         <maven.javadoc.skip>false</maven.javadoc.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,7 @@
     </scm>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <maven.enforcer.requireMavenVersion>3.6</maven.enforcer.requireMavenVersion>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mmZ</maven.build.timestamp.format>
         <maven.deploy.skip>true</maven.deploy.skip>


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

The release property is equivalent to defining the same value for source and target, but it adds something else: it indicates which version of the libraries should be used.

During a build, the libraries used are those that correspond to the JDK we are using to compile. Now that we are compiling with Java 11 targeting Java 8 this is a more efficient way of handling the build, making sure that we are not using Java 11 libraries expecting it to run on Java 8 later.