### PR TITLE
Fixes #3625 JAVA_HOME Path when parenthesis are present

### DIFF
--- a/liquibase-dist/src/main/archive/liquibase.bat
+++ b/liquibase-dist/src/main/archive/liquibase.bat
@@ -14,7 +14,7 @@ if NOT "%JAVA_HOME%" == "" set JAVA_HOME=%JAVA_HOME:"=%
 
 rem set JAVA_HOME to local jre dir if not set
 if exist "%LIQUIBASE_HOME%\jre" if "%JAVA_HOME%"=="" (
-    set JAVA_HOME=%LIQUIBASE_HOME%\jre
+    set JAVA_HOME="%LIQUIBASE_HOME%\jre"
 )
 
 if NOT "%JAVA_HOME%" == "" if not exist "%JAVA_HOME%" (


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

**Fixes #3625 JAVA_HOME Path when parenthesis are present**

Inside the liquibase.bat file the JAVA_HOME could not be processed due to parenthesis. The issue is fixed when the path is wrapped by quotes.

Users can now start liquibase also from directories which includes parenthesis in their path.

## Things to be aware of

## Things to worry about

## Additional Context
