### PR TITLE
[DAT-14885] Upgrade to v9 after running liquibase update command

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/ChecksumVersions.java
+++ b/liquibase-standard/src/main/java/liquibase/ChecksumVersions.java
@@ -6,15 +6,18 @@ import java.util.Arrays;
 
 public enum ChecksumVersions {
 
-    V8(8, "Version used from Liquibase 3.5.0 until 4.21.1"),
-    V9(9, "Version used from Liquibase 4.22.0 till now");
+    V8(8, "Version used from Liquibase 3.5.0 until 4.21.1", "3.5.0"),
+    V9(9, "Version used from Liquibase 4.22.0 till now", "4.22.0");
 
     private final int version;
+
+    private final String since;
     private final String description;
 
-    ChecksumVersions(int version, String description) {
+    ChecksumVersions(int version, String description, String since) {
         this.version = version;
         this.description = description;
+        this.since = since;
     }
 
     public int getVersion() {

--- a/liquibase-standard/src/main/java/liquibase/changelog/filter/ShouldRunChangeSetFilter.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/filter/ShouldRunChangeSetFilter.java
@@ -71,7 +71,7 @@ public class ShouldRunChangeSetFilter implements ChangeSetFilter {
 
 
     protected boolean checksumChanged(ChangeSet changeSet, RanChangeSet ranChangeSet) {
-        if (ranChangeSet.getLastCheckSum() == null) {
+        if (ranChangeSet.getLastCheckSum() == null || changeSet.getStoredCheckSum() == null) {
             return false;
         }
         return !changeSet.generateCheckSum(ChecksumVersions.enumFromChecksumVersion(changeSet.getStoredCheckSum().getVersion()))

--- a/liquibase-standard/src/main/java/liquibase/changelog/visitor/UpgradeCheckSumVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/visitor/UpgradeCheckSumVisitor.java
@@ -1,0 +1,57 @@
+package liquibase.changelog.visitor;
+
+import liquibase.ChecksumVersions;
+import liquibase.Scope;
+import liquibase.change.CheckSum;
+import liquibase.changelog.ChangeLogHistoryService;
+import liquibase.changelog.ChangeLogHistoryServiceFactory;
+import liquibase.changelog.ChangeSet;
+import liquibase.changelog.DatabaseChangeLog;
+import liquibase.changelog.filter.ChangeSetFilterResult;
+import liquibase.database.Database;
+import liquibase.exception.LiquibaseException;
+import liquibase.executor.Executor;
+import liquibase.executor.ExecutorService;
+import liquibase.executor.LoggingExecutor;
+import liquibase.statement.core.UpdateChangeSetChecksumStatement;
+
+import java.util.Set;
+
+public class UpgradeCheckSumVisitor implements ChangeSetVisitor {
+
+    private final Database database;
+
+    public UpgradeCheckSumVisitor(Database database) {
+        this.database = database;
+    }
+
+    @Override
+    public Direction getDirection() {
+        return Direction.FORWARD;
+    }
+
+    @Override
+    public void visit(ChangeSet changeSet, DatabaseChangeLog databaseChangeLog, Database database,
+                      Set<ChangeSetFilterResult> filterResults) throws LiquibaseException {
+        Executor executor = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database);
+
+        ChangeLogHistoryService changeLogService = ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database);
+        if (changeLogService.isDatabaseChecksumsCompatible() || changeSet.getStoredCheckSum() == null ||
+                changeSet.getStoredCheckSum().getVersion() == ChecksumVersions.latest().getVersion()) {
+            return;
+        }
+
+        CheckSum oldChecksum = changeSet.getStoredCheckSum();
+        changeSet.clearCheckSum();
+        changeSet.setStoredCheckSum(changeSet.generateCheckSum(ChecksumVersions.latest()));
+        if (! (executor instanceof LoggingExecutor)) {
+            Scope.getCurrentScope().getUI().sendMessage(String.format("Upgrading checksum for Changeset %s from %s to %s.",
+                    changeSet, oldChecksum.toString(), changeSet.getStoredCheckSum().toString()));
+        }
+
+        Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database)
+                .execute(new UpdateChangeSetChecksumStatement(changeSet));
+
+        this.database.commit();
+    }
+}

--- a/liquibase-standard/src/main/java/liquibase/command/core/AbstractUpdateCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/AbstractUpdateCommandStep.java
@@ -25,10 +25,7 @@ import liquibase.util.StringUtil;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static liquibase.Liquibase.MSG_COULD_NOT_RELEASE_LOCK;
@@ -114,11 +111,9 @@ public abstract class AbstractUpdateCommandStep extends AbstractCommandStep impl
         if (changeLogService.isDatabaseChecksumsCompatible()) {
             return;
         }
+
         ChangeLogIterator runChangeLogIterator = new ChangeLogIterator(databaseChangeLog,
-                new ContextChangeSetFilter(contexts),
-                new LabelChangeSetFilter(labelExpression),
-                new DbmsChangeSetFilter(database),
-                new IgnoreChangeSetFilter());
+                this.getStandardChangelogIteratorFilters(database, contexts, labelExpression).toArray(new ChangeSetFilter[0]));
 
         runChangeLogIterator.run(new UpgradeCheckSumVisitor(database), new RuntimeEnvironment(database, contexts, labelExpression));
     }
@@ -157,22 +152,23 @@ public abstract class AbstractUpdateCommandStep extends AbstractCommandStep impl
 
     @Beta
     public ChangeLogIterator getStandardChangelogIterator(CommandScope commandScope, Database database, Contexts contexts, LabelExpression labelExpression, DatabaseChangeLog changeLog) throws DatabaseException {
-        return new ChangeLogIterator(changeLog,
-                new ShouldRunChangeSetFilter(database),
-                new ContextChangeSetFilter(contexts),
-                new LabelChangeSetFilter(labelExpression),
-                new DbmsChangeSetFilter(database),
-                new IgnoreChangeSetFilter());
+        List<ChangeSetFilter> changesetFilters = this.getStandardChangelogIteratorFilters(database, contexts, labelExpression);
+        changesetFilters.add(new ShouldRunChangeSetFilter(database));
+        return new ChangeLogIterator(changeLog, changesetFilters.toArray(new ChangeSetFilter[0]));
     }
 
     @Beta
     public ChangeLogIterator getStatusChangelogIterator(CommandScope commandScope, Database database, Contexts contexts, LabelExpression labelExpression, DatabaseChangeLog changeLog) throws DatabaseException {
-        return new StatusChangeLogIterator(changeLog,
-                new ShouldRunChangeSetFilter(database),
-                new ContextChangeSetFilter(contexts),
+        List<ChangeSetFilter> changesetFilters = this.getStandardChangelogIteratorFilters(database, contexts, labelExpression);
+        changesetFilters.add(new ShouldRunChangeSetFilter(database));
+        return new StatusChangeLogIterator(changeLog, changesetFilters.toArray(new ChangeSetFilter[0]));
+    }
+
+    private List<ChangeSetFilter> getStandardChangelogIteratorFilters(Database database, Contexts contexts, LabelExpression labelExpression) {
+        return new ArrayList<>(Arrays.asList(new ContextChangeSetFilter(contexts),
                 new LabelChangeSetFilter(labelExpression),
                 new DbmsChangeSetFilter(database),
-                new IgnoreChangeSetFilter());
+                new IgnoreChangeSetFilter()));
     }
 
     /**

--- a/liquibase-standard/src/main/java/liquibase/exception/UnsupportedChecksumVersionException.java
+++ b/liquibase-standard/src/main/java/liquibase/exception/UnsupportedChecksumVersionException.java
@@ -7,9 +7,8 @@ public class UnsupportedChecksumVersionException extends RuntimeException {
     private static final long serialVersionUID = -229400973681987065L;
 
     public UnsupportedChecksumVersionException(int i) {
-        super(String.format("Liquibase detected an unknown checksum calculation version %s in the DatabaseChangelog table. " +
-                "This can be caused by a previous operation on this changelog with a newer version than your current %S release. " +
-                "Please update your current Liquibase, or clear checksums on changesets you are certain you need " +
-                "to deploy.", i, LiquibaseUtil.getBuildVersionInfo()));
+        super(String.format("Liquibase detected an unknown checksum calculation version %s. This can be caused by a previous " +
+                        "operation on this changelog with a newer version than your current %S release. ",
+                 i, LiquibaseUtil.getBuildVersionInfo()));
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/exception/UnsupportedChecksumVersionException.java
+++ b/liquibase-standard/src/main/java/liquibase/exception/UnsupportedChecksumVersionException.java
@@ -1,10 +1,15 @@
 package liquibase.exception;
 
+import liquibase.util.LiquibaseUtil;
+
 public class UnsupportedChecksumVersionException extends RuntimeException {
 
     private static final long serialVersionUID = -229400973681987065L;
 
     public UnsupportedChecksumVersionException(int i) {
-        super("Unsupported Checksum version: " + i);
+        super(String.format("Liquibase detected an unknown checksum calculation version %s in the DatabaseChangelog table. " +
+                "This can be caused by a previous operation on this changelog with a newer version than your current %S release. " +
+                "Please update your current Liquibase, or clear checksums on changesets you are certain you need " +
+                "to deploy.", i, LiquibaseUtil.getBuildVersionInfo()));
     }
 }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Implementation Details
Add a new visitor class ChecksumsUpgradeVisitor to have the logic to upgrade to v9

Expected result:
After running “update” command all the v8 checksums associated with the changesets that are “checked” should be now v9 (in other words, only changesets which match the supplied filters (ie labels, contexts, dbms, etc) will have their checksums upgraded)