### PR TITLE
DAT-14893 - Modify current generateChecksums method for backwards compatibility

### DIFF
--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
@@ -1129,9 +1129,9 @@ public abstract class AbstractIntegrationTest {
         liquibase.update(contexts);
 
         Connection conn = ((JdbcConnection) database.getConnection()).getUnderlyingConnection();
-        conn.createStatement().execute("update DATABASECHANGELOG set md5sum = '1:xxx'");
+        conn.createStatement().execute("update DATABASECHANGELOG set md5sum = null");
         if (!conn.getAutoCommit()) {
-            conn.commit();;
+            conn.commit();
         }
 
         liquibase.getDatabase().getRanChangeSetList();

--- a/liquibase-standard/src/main/java/liquibase/ChecksumVersion.java
+++ b/liquibase-standard/src/main/java/liquibase/ChecksumVersion.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
 /**
  * Enum used to keep track of Liquibase Checksum versions introduced to enable the support of multiple versions at the same time.
  */
-public enum ChecksumVersions {
+public enum ChecksumVersion {
 
     V1(1, "Pass through version for testing purpose", "0"),
     V8(8, "Version used from Liquibase 3.5.0 until 4.21.1", "3.5.0"),
@@ -18,7 +18,7 @@ public enum ChecksumVersions {
     private final String since;
     private final String description;
 
-    ChecksumVersions(int version, String description, String since) {
+    ChecksumVersion(int version, String description, String since) {
         this.version = version;
         this.description = description;
         this.since = since;
@@ -36,11 +36,11 @@ public enum ChecksumVersions {
         return since;
     }
 
-    public static ChecksumVersions enumFromChecksumVersion(int i) {
+    public static ChecksumVersion enumFromChecksumVersion(int i) {
         if (i != 1 && i < 8 || i > 9) {
             throw new UnsupportedChecksumVersionException(i);
         }
-        return Arrays.stream(ChecksumVersions.values()).filter(cv -> cv.getVersion() == i)
+        return Arrays.stream(ChecksumVersion.values()).filter(cv -> cv.getVersion() == i)
                 .findFirst().orElse(null);
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/ChecksumVersion.java
+++ b/liquibase-standard/src/main/java/liquibase/ChecksumVersion.java
@@ -44,11 +44,8 @@ public enum ChecksumVersion {
     }
 
     public static ChecksumVersion enumFromChecksumVersion(int i) {
-        if (i != 1 && i < 8 || i > 9) {
-            throw new UnsupportedChecksumVersionException(i);
-        }
-        return Arrays.stream(ChecksumVersion.values()).filter(cv -> cv.getVersion() == i)
-                .findFirst().orElse(null);
+        return Arrays.stream(ChecksumVersion.values()).filter(cv -> cv.getVersion() == i).findFirst()
+                .orElseThrow(() -> new UnsupportedChecksumVersionException(i));
     }
 
     public boolean lowerOrEqualThan(ChecksumVersion compareTo) {

--- a/liquibase-standard/src/main/java/liquibase/ChecksumVersion.java
+++ b/liquibase-standard/src/main/java/liquibase/ChecksumVersion.java
@@ -9,9 +9,16 @@ import java.util.Arrays;
  */
 public enum ChecksumVersion {
 
-    V1(1, "Pass through version for testing purpose", "0"),
+    V9(9, "Version used from Liquibase 4.22.0 till now", "4.22.0"),
     V8(8, "Version used from Liquibase 3.5.0 until 4.21.1", "3.5.0"),
-    V9(9, "Version used from Liquibase 4.22.0 till now", "4.22.0");
+    V7(7, "Old version", "?"),
+    V6(6, "Old version", "?"),
+    V5(5, "Old version", "?"),
+    V4(4, "Old version", "?"),
+    V3(3, "Old version", "?"),
+    V2(2, "Old version", "?"),
+    V1(1, "Pass through version for testing purpose", "0");
+
 
     private final int version;
 
@@ -42,5 +49,9 @@ public enum ChecksumVersion {
         }
         return Arrays.stream(ChecksumVersion.values()).filter(cv -> cv.getVersion() == i)
                 .findFirst().orElse(null);
+    }
+
+    public boolean lowerOrEqualThan(ChecksumVersion compareTo) {
+        return compareTo != null && this.version <= compareTo.getVersion();
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/ChecksumVersions.java
+++ b/liquibase-standard/src/main/java/liquibase/ChecksumVersions.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
  */
 public enum ChecksumVersions {
 
+    V1(1, "Pass through version for testing purpose", "0"),
     V8(8, "Version used from Liquibase 3.5.0 until 4.21.1", "3.5.0"),
     V9(9, "Version used from Liquibase 4.22.0 till now", "4.22.0");
 
@@ -36,7 +37,7 @@ public enum ChecksumVersions {
     }
 
     public static ChecksumVersions enumFromChecksumVersion(int i) {
-        if (i < 8 || i > 9) {
+        if (i != 1 && i < 8 || i > 9) {
             throw new UnsupportedChecksumVersionException(i);
         }
         return Arrays.stream(ChecksumVersions.values()).filter(cv -> cv.getVersion() == i)

--- a/liquibase-standard/src/main/java/liquibase/Scope.java
+++ b/liquibase-standard/src/main/java/liquibase/Scope.java
@@ -6,6 +6,7 @@ import liquibase.database.DatabaseConnection;
 import liquibase.database.OfflineConnection;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.UnexpectedLiquibaseException;
+import liquibase.integration.commandline.LiquibaseCommandLineConfiguration;
 import liquibase.listener.LiquibaseListener;
 import liquibase.logging.LogService;
 import liquibase.logging.Logger;
@@ -62,7 +63,8 @@ public class Scope {
         fileEncoding,
         databaseChangeLog,
         changeSet,
-        osgiPlatform
+        osgiPlatform,
+        checksumVersion
     }
 
     private static ScopeManager scopeManager;
@@ -85,6 +87,7 @@ public class Scope {
             rootScope.values.put(Attr.logService.name(), new JavaLogService());
             rootScope.values.put(Attr.serviceLocator.name(), new StandardServiceLocator());
             rootScope.values.put(Attr.resourceAccessor.name(), new ClassLoaderResourceAccessor());
+            rootScope.values.put(Attr.checksumVersion.name(), LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue());
 
             rootScope.values.put(Attr.ui.name(), new ConsoleUIService());
             rootScope.getSingleton(LiquibaseConfiguration.class).init(rootScope);
@@ -381,6 +384,10 @@ public class Scope {
 
     public ResourceAccessor getResourceAccessor() {
         return get(Attr.resourceAccessor, ResourceAccessor.class);
+    }
+
+    public ChecksumVersions getChecksumVersion() {
+        return get(Attr.checksumVersion, ChecksumVersions.class);
     }
 
     public String getLineSeparator() {

--- a/liquibase-standard/src/main/java/liquibase/Scope.java
+++ b/liquibase-standard/src/main/java/liquibase/Scope.java
@@ -386,8 +386,8 @@ public class Scope {
         return get(Attr.resourceAccessor, ResourceAccessor.class);
     }
 
-    public ChecksumVersions getChecksumVersion() {
-        return get(Attr.checksumVersion, ChecksumVersions.class);
+    public ChecksumVersion getChecksumVersion() {
+        return get(Attr.checksumVersion, ChecksumVersion.class);
     }
 
     public String getLineSeparator() {

--- a/liquibase-standard/src/main/java/liquibase/change/AbstractChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/AbstractChange.java
@@ -1,6 +1,6 @@
 package liquibase.change;
 
-import liquibase.ChecksumVersions;
+import liquibase.ChecksumVersion;
 import liquibase.Scope;
 import liquibase.changelog.ChangeSet;
 import liquibase.database.Database;
@@ -537,7 +537,7 @@ public abstract class AbstractChange extends AbstractPlugin implements Change {
         }).serialize(this, false));
     }
 
-    public String[] getExcludedFieldFilters(ChecksumVersions version) {
+    public String[] getExcludedFieldFilters(ChecksumVersion version) {
         return new String[0];
     }
 

--- a/liquibase-standard/src/main/java/liquibase/change/AbstractSQLChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/AbstractSQLChange.java
@@ -1,6 +1,6 @@
 package liquibase.change;
 
-import liquibase.ChecksumVersions;
+import liquibase.ChecksumVersion;
 import liquibase.GlobalConfiguration;
 import liquibase.Scope;
 import liquibase.change.core.RawSQLChange;
@@ -206,16 +206,16 @@ public abstract class AbstractSQLChange extends AbstractChange implements DbmsTa
             }
 
             if (sql != null) {
-                ChecksumVersions version = Scope.getCurrentScope().getChecksumVersion();
-                if (version == ChecksumVersions.V8) {
+                ChecksumVersion version = Scope.getCurrentScope().getChecksumVersion();
+                if (version == ChecksumVersion.V8) {
                     stream = new ByteArrayInputStream(sql.getBytes(GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()));
                 } else {
                     stream = new ByteArrayInputStream(sql.getBytes(GlobalConfiguration.FILE_ENCODING.getCurrentValue()));
                 }
             }
 
-            ChecksumVersions version = Scope.getCurrentScope().getChecksumVersion();
-            if (version == ChecksumVersions.V8) {
+            ChecksumVersion version = Scope.getCurrentScope().getChecksumVersion();
+            if (version == ChecksumVersion.V8) {
                 return CheckSum.compute(new NormalizingStreamV8(this.getEndDelimiter(), this.isSplitStatements(), this.isStripComments(), stream), false);
             }
             return CheckSum.compute(new AbstractSQLChange.NormalizingStream(stream), false);
@@ -301,13 +301,6 @@ public abstract class AbstractSQLChange extends AbstractChange implements DbmsTa
 
     public static class NormalizingStream extends InputStream {
         private InputStream stream;
-
-        private final byte[] quickBuffer = new byte[100];
-        private final List<Byte> resizingBuffer = new ArrayList<>();
-
-
-        private int lastChar = 'X';
-        private boolean seenNonSpace;
 
         @Deprecated
         public NormalizingStream(String endDelimiter, Boolean splitStatements, Boolean stripComments, InputStream stream) {

--- a/liquibase-standard/src/main/java/liquibase/change/AbstractSQLChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/AbstractSQLChange.java
@@ -207,7 +207,7 @@ public abstract class AbstractSQLChange extends AbstractChange implements DbmsTa
 
             if (sql != null) {
                 ChecksumVersion version = Scope.getCurrentScope().getChecksumVersion();
-                if (version == ChecksumVersion.V8) {
+                if (version.lowerOrEqualThan(ChecksumVersion.V8)) {
                     stream = new ByteArrayInputStream(sql.getBytes(GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()));
                 } else {
                     stream = new ByteArrayInputStream(sql.getBytes(GlobalConfiguration.FILE_ENCODING.getCurrentValue()));
@@ -215,7 +215,7 @@ public abstract class AbstractSQLChange extends AbstractChange implements DbmsTa
             }
 
             ChecksumVersion version = Scope.getCurrentScope().getChecksumVersion();
-            if (version == ChecksumVersion.V8) {
+            if (version.lowerOrEqualThan(ChecksumVersion.V8)) {
                 return CheckSum.compute(new NormalizingStreamV8(this.getEndDelimiter(), this.isSplitStatements(), this.isStripComments(), stream), false);
             }
             return CheckSum.compute(new AbstractSQLChange.NormalizingStream(stream), false);

--- a/liquibase-standard/src/main/java/liquibase/change/Change.java
+++ b/liquibase-standard/src/main/java/liquibase/change/Change.java
@@ -1,6 +1,5 @@
 package liquibase.change;
 
-import liquibase.ChecksumVersions;
 import liquibase.ExtensibleObject;
 import liquibase.Scope;
 import liquibase.changelog.ChangeSet;
@@ -87,7 +86,7 @@ public interface Change extends LiquibaseSerializable, Plugin, ExtensibleObject 
      * The checksum should take into account all settings that would impact what actually happens to the database
      * and <b>NOT</b> include any settings that do not impact the actual execution of the change.
      */
-    CheckSum generateCheckSum(ChecksumVersions version);
+    CheckSum generateCheckSum();
 
     /**
      * Confirmation message to be displayed after the change is executed. Should include relevant configuration settings to make it as helpful as possible.

--- a/liquibase-standard/src/main/java/liquibase/change/ChangeFactory.java
+++ b/liquibase-standard/src/main/java/liquibase/change/ChangeFactory.java
@@ -59,7 +59,7 @@ public class ChangeFactory extends AbstractPluginFactory<Change>{
     private String generateCacheKey(Change change) {
         String key;
         try {
-            ChecksumVersion version = LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue();
+            ChecksumVersion version = Scope.getCurrentScope().getChecksumVersion();
             if (version == null) {
                  throw new NullPointerException();
             }

--- a/liquibase-standard/src/main/java/liquibase/change/ChangeFactory.java
+++ b/liquibase-standard/src/main/java/liquibase/change/ChangeFactory.java
@@ -1,6 +1,6 @@
 package liquibase.change;
 
-import liquibase.ChecksumVersions;
+import liquibase.ChecksumVersion;
 import liquibase.Scope;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.integration.commandline.LiquibaseCommandLineConfiguration;
@@ -52,16 +52,14 @@ public class ChangeFactory extends AbstractPluginFactory<Change>{
 
     public ChangeMetaData getChangeMetaData(Change change) {
         String cacheKey = generateCacheKey(change);
-        if (!cachedMetadata.containsKey(cacheKey)) {
-            cachedMetadata.put(cacheKey, change.createChangeMetaData());
-        }
+        cachedMetadata.putIfAbsent(cacheKey, change.createChangeMetaData());
         return cachedMetadata.get(cacheKey);
     }
 
     private String generateCacheKey(Change change) {
         String key;
         try {
-            ChecksumVersions version = LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue();
+            ChecksumVersion version = LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue();
             if (version == null) {
                  throw new NullPointerException();
             }

--- a/liquibase-standard/src/main/java/liquibase/change/CheckSum.java
+++ b/liquibase-standard/src/main/java/liquibase/change/CheckSum.java
@@ -1,6 +1,6 @@
 package liquibase.change;
 
-import liquibase.ChecksumVersions;
+import liquibase.Scope;
 import liquibase.integration.commandline.LiquibaseCommandLineConfiguration;
 import liquibase.util.MD5Util;
 import liquibase.util.StringUtil;
@@ -71,18 +71,18 @@ public final class CheckSum {
     /**
      * Compute a storedCheckSum of the given string.
      */
-    public static CheckSum compute(String valueToChecksum, ChecksumVersions version) {
+    public static CheckSum compute(String valueToChecksum) {
         return new CheckSum(MD5Util.computeMD5(
                 //remove "Unknown" unicode char 65533
                 Normalizer.normalize(StringUtil.standardizeLineEndings(valueToChecksum)
                         .replace("\uFFFD", ""), Normalizer.Form.NFC)
-        ), version.getVersion());
+        ), Scope.getCurrentScope().getChecksumVersion().getVersion());
     }
 
     /**
      * Compute a CheckSum of the given data stream (no normalization of line endings!)
      */
-    public static CheckSum compute(final InputStream stream, boolean standardizeLineEndings, ChecksumVersions version) {
+    public static CheckSum compute(final InputStream stream, boolean standardizeLineEndings) {
         InputStream newStream = stream;
         if (standardizeLineEndings) {
             newStream = new InputStream() {
@@ -106,7 +106,7 @@ public final class CheckSum {
             };
         }
 
-        return new CheckSum(MD5Util.computeMD5(newStream), version.getVersion());
+        return new CheckSum(MD5Util.computeMD5(newStream), Scope.getCurrentScope().getChecksumVersion().getVersion());
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/change/DatabaseChangeProperty.java
+++ b/liquibase-standard/src/main/java/liquibase/change/DatabaseChangeProperty.java
@@ -1,6 +1,6 @@
 package liquibase.change;
 
-import liquibase.ChecksumVersions;
+import liquibase.ChecksumVersion;
 import liquibase.database.Database;
 import liquibase.serializer.LiquibaseSerializable;
 
@@ -73,5 +73,5 @@ public @interface DatabaseChangeProperty {
      * and checksum calculation for version 8 is requested, the first annotation is used. If any other checksum version
      * is requested, the second annotation is used.
      */
-    ChecksumVersions[] version() default {};
+    ChecksumVersion[] version() default {};
 }

--- a/liquibase-standard/src/main/java/liquibase/change/core/CreateProcedureChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/CreateProcedureChange.java
@@ -1,6 +1,6 @@
 package liquibase.change.core;
 
-import liquibase.ChecksumVersions;
+import liquibase.ChecksumVersion;
 import liquibase.GlobalConfiguration;
 import liquibase.Scope;
 import liquibase.change.*;
@@ -108,7 +108,7 @@ public class CreateProcedureChange extends AbstractChange implements DbmsTargete
         this.relativeToChangelogFile = relativeToChangelogFile;
     }
 
-    @DatabaseChangeProperty(serializationType = SerializationType.DIRECT_VALUE, version = {ChecksumVersions.V8})
+    @DatabaseChangeProperty(serializationType = SerializationType.DIRECT_VALUE, version = {ChecksumVersion.V8})
     @DatabaseChangeProperty(isChangeProperty = false)
     /**
      * @deprecated Use getProcedureText() instead
@@ -129,7 +129,7 @@ public class CreateProcedureChange extends AbstractChange implements DbmsTargete
             "procedureText is not supported in the XML format; however, you can specify the procedure SQL inline within the createProcedure definition.";
     @DatabaseChangeProperty(
         description = procedureTextDescription,
-            isChangeProperty = false, version = {ChecksumVersions.V8})
+            isChangeProperty = false, version = {ChecksumVersion.V8})
     @DatabaseChangeProperty(
         description = procedureTextDescription,
             serializationType = SerializationType.DIRECT_VALUE)
@@ -246,8 +246,8 @@ public class CreateProcedureChange extends AbstractChange implements DbmsTargete
      */
     @Override
     public CheckSum generateCheckSum() {
-        ChecksumVersions version = Scope.getCurrentScope().getChecksumVersion();
-        if (version == ChecksumVersions.V8) {
+        ChecksumVersion version = Scope.getCurrentScope().getChecksumVersion();
+        if (version == ChecksumVersion.V8) {
             return generateCheckSumV8();
         }
         return generateCheckSumLatest(this.procedureText);
@@ -341,8 +341,8 @@ public class CreateProcedureChange extends AbstractChange implements DbmsTargete
      * change types.
      */
     @Override
-    public String[] getExcludedFieldFilters(ChecksumVersions version) {
-        if (version == ChecksumVersions.V8) {
+    public String[] getExcludedFieldFilters(ChecksumVersion version) {
+        if (version == ChecksumVersion.V8) {
             return new String[0];
         }
         return new String[]{

--- a/liquibase-standard/src/main/java/liquibase/change/core/CreateProcedureChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/CreateProcedureChange.java
@@ -247,7 +247,7 @@ public class CreateProcedureChange extends AbstractChange implements DbmsTargete
     @Override
     public CheckSum generateCheckSum() {
         ChecksumVersion version = Scope.getCurrentScope().getChecksumVersion();
-        if (version == ChecksumVersion.V8) {
+        if (version.lowerOrEqualThan(ChecksumVersion.V8)) {
             return generateCheckSumV8();
         }
         return generateCheckSumLatest(this.procedureText);
@@ -342,7 +342,7 @@ public class CreateProcedureChange extends AbstractChange implements DbmsTargete
      */
     @Override
     public String[] getExcludedFieldFilters(ChecksumVersion version) {
-        if (version == ChecksumVersion.V8) {
+        if (version.lowerOrEqualThan(ChecksumVersion.V8)) {
             return new String[0];
         }
         return new String[]{

--- a/liquibase-standard/src/main/java/liquibase/change/core/CreateProcedureChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/CreateProcedureChange.java
@@ -242,20 +242,21 @@ public class CreateProcedureChange extends AbstractChange implements DbmsTargete
     /**
      * Calculates the checksum based on the contained SQL.
      *
-     * @see Change#generateCheckSum(ChecksumVersions)
+     * @see Change#generateCheckSum()
      */
     @Override
-    public CheckSum generateCheckSum(ChecksumVersions version) {
+    public CheckSum generateCheckSum() {
+        ChecksumVersions version = Scope.getCurrentScope().getChecksumVersion();
         if (version == ChecksumVersions.V8) {
-            return generateCheckSumV8(version);
+            return generateCheckSumV8();
         }
-        return generateCheckSumLatest(this.procedureText, version);
+        return generateCheckSumLatest(this.procedureText);
     }
 
     @Deprecated
-    private CheckSum generateCheckSumV8(ChecksumVersions version) {
+    private CheckSum generateCheckSumV8() {
         if (this.path == null) {
-            return super.generateCheckSum(version);
+            return super.generateCheckSum();
         }
 
         InputStream stream = null;
@@ -271,21 +272,21 @@ public class CreateProcedureChange extends AbstractChange implements DbmsTargete
                 procedureText = "";
             }
 
-            String encoding = GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue();
+            String localEncoding = GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue();
             if (procedureText != null) {
                 try {
-                    stream = new ByteArrayInputStream(procedureText.getBytes(encoding));
+                    stream = new ByteArrayInputStream(procedureText.getBytes(localEncoding));
                 } catch (UnsupportedEncodingException e) {
-                    throw new AssertionError(encoding +
+                    throw new AssertionError(localEncoding +
                             " is not supported by the JVM, this should not happen according to the JavaDoc of " +
                             "the Charset class"
                     );
                 }
             }
 
-            CheckSum checkSum = CheckSum.compute(new NormalizingStreamV8(";", false, false, stream), false, version);
+            CheckSum checkSum = CheckSum.compute(new NormalizingStreamV8(";", false, false, stream), false);
 
-            return CheckSum.compute(super.generateCheckSum(version).toString() + ":" + checkSum, version);
+            return CheckSum.compute(super.generateCheckSum().toString() + ":" + checkSum);
         } finally {
             if (stream != null) {
                 try {
@@ -297,7 +298,7 @@ public class CreateProcedureChange extends AbstractChange implements DbmsTargete
         }
     }
 
-    protected CheckSum generateCheckSumLatest(String sqlText, ChecksumVersions version) {
+    protected CheckSum generateCheckSumLatest(String sqlText) {
         InputStream stream = null;
         CheckSum checkSum;
         try {
@@ -312,8 +313,8 @@ public class CreateProcedureChange extends AbstractChange implements DbmsTargete
                 stream = openSqlStream();
                 stream = new PropertyExpandingStream(this.getChangeSet(), stream);
             }
-            checkSum = CheckSum.compute(new AbstractSQLChange.NormalizingStream(stream), false, version);
-            return CheckSum.compute(super.generateCheckSum(version).toString() + ":" + checkSum, version);
+            checkSum = CheckSum.compute(new AbstractSQLChange.NormalizingStream(stream), false);
+            return CheckSum.compute(super.generateCheckSum().toString() + ":" + checkSum);
 
         } catch (IOException e) {
             throw new UnexpectedLiquibaseException(e);

--- a/liquibase-standard/src/main/java/liquibase/change/core/CreateViewChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/CreateViewChange.java
@@ -206,9 +206,10 @@ public class CreateViewChange extends AbstractChange {
      * @see Change#generateCheckSum(ChecksumVersions)
      */
     @Override
-    public CheckSum generateCheckSum(ChecksumVersions version) {
+    public CheckSum generateCheckSum() {
+        ChecksumVersions version = Scope.getCurrentScope().getChecksumVersion();
         if (version == ChecksumVersions.V8) {
-            return generateCheckSumV8(version);
+            return generateCheckSumV8();
         }
         return generateCheckSumLatest(version);
     }
@@ -228,8 +229,8 @@ public class CreateViewChange extends AbstractChange {
                 stream = openSqlStream();
                 stream = new PropertyExpandingStream(this.getChangeSet(), stream);
             }
-            checkSum = CheckSum.compute(new AbstractSQLChange.NormalizingStream(stream), false, version);
-            return CheckSum.compute(super.generateCheckSum(version).toString() + ":" + checkSum, version);
+            checkSum = CheckSum.compute(new AbstractSQLChange.NormalizingStream(stream), false);
+            return CheckSum.compute(super.generateCheckSum().toString() + ":" + checkSum);
 
         } catch (IOException e) {
             throw new UnexpectedLiquibaseException(e);
@@ -244,9 +245,9 @@ public class CreateViewChange extends AbstractChange {
     }
 
     @Deprecated
-    private CheckSum generateCheckSumV8(ChecksumVersions version) {
+    private CheckSum generateCheckSumV8() {
         if (this.path == null) {
-            return super.generateCheckSum(version);
+            return super.generateCheckSum();
         }
 
         InputStream stream = null;
@@ -271,9 +272,9 @@ public class CreateViewChange extends AbstractChange {
                 }
             }
 
-            CheckSum checkSum = CheckSum.compute(new NormalizingStreamV8(";", false, false, stream), false, version);
+            CheckSum checkSum = CheckSum.compute(new NormalizingStreamV8(";", false, false, stream), false);
 
-            return CheckSum.compute(super.generateCheckSum(version).toString() + ":" + checkSum, version);
+            return CheckSum.compute(super.generateCheckSum().toString() + ":" + checkSum);
         } finally {
             if (stream != null) {
                 try {

--- a/liquibase-standard/src/main/java/liquibase/change/core/CreateViewChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/CreateViewChange.java
@@ -1,6 +1,6 @@
 package liquibase.change.core;
 
-import liquibase.ChecksumVersions;
+import liquibase.ChecksumVersion;
 import liquibase.GlobalConfiguration;
 import liquibase.Scope;
 import liquibase.change.*;
@@ -188,8 +188,8 @@ public class CreateViewChange extends AbstractChange {
     }
 
     @Override
-    public String[] getExcludedFieldFilters(ChecksumVersions version) {
-        if (version == ChecksumVersions.V8) {
+    public String[] getExcludedFieldFilters(ChecksumVersion version) {
+        if (version == ChecksumVersion.V8) {
             return new String[0];
         }
         return new String[] {
@@ -203,18 +203,18 @@ public class CreateViewChange extends AbstractChange {
     /**
      * Calculates the checksum based on the contained SQL.
      *
-     * @see Change#generateCheckSum(ChecksumVersions)
+     * @see Change#generateCheckSum(ChecksumVersion)
      */
     @Override
     public CheckSum generateCheckSum() {
-        ChecksumVersions version = Scope.getCurrentScope().getChecksumVersion();
-        if (version == ChecksumVersions.V8) {
+        ChecksumVersion version = Scope.getCurrentScope().getChecksumVersion();
+        if (version == ChecksumVersion.V8) {
             return generateCheckSumV8();
         }
         return generateCheckSumLatest(version);
     }
 
-    private CheckSum generateCheckSumLatest(ChecksumVersions version) {
+    private CheckSum generateCheckSumLatest(ChecksumVersion version) {
         InputStream stream = null;
         CheckSum checkSum;
         try {

--- a/liquibase-standard/src/main/java/liquibase/change/core/CreateViewChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/CreateViewChange.java
@@ -189,7 +189,7 @@ public class CreateViewChange extends AbstractChange {
 
     @Override
     public String[] getExcludedFieldFilters(ChecksumVersion version) {
-        if (version == ChecksumVersion.V8) {
+        if (version.lowerOrEqualThan(ChecksumVersion.V8)) {
             return new String[0];
         }
         return new String[] {
@@ -208,7 +208,7 @@ public class CreateViewChange extends AbstractChange {
     @Override
     public CheckSum generateCheckSum() {
         ChecksumVersion version = Scope.getCurrentScope().getChecksumVersion();
-        if (version == ChecksumVersion.V8) {
+        if (version.lowerOrEqualThan(ChecksumVersion.V8)) {
             return generateCheckSumV8();
         }
         return generateCheckSumLatest(version);

--- a/liquibase-standard/src/main/java/liquibase/change/core/LoadDataChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/LoadDataChange.java
@@ -773,7 +773,7 @@ public class LoadDataChange extends AbstractTableChange implements ChangeWithCol
     }
 
     @Override
-    public CheckSum generateCheckSum(ChecksumVersions version) {
+    public CheckSum generateCheckSum() {
         InputStream stream = null;
         try {
             ResourceAccessor resourceAccessor = Scope.getCurrentScope().getResourceAccessor();
@@ -785,7 +785,7 @@ public class LoadDataChange extends AbstractTableChange implements ChangeWithCol
             }
 
             stream = new EmptyLineAndCommentSkippingInputStream(resource.openInputStream(), commentLineStartsWith);
-            return CheckSum.compute(getTableName() + ":" + CheckSum.compute(stream, /*standardizeLineEndings*/ true, version), version);
+            return CheckSum.compute(getTableName() + ":" + CheckSum.compute(stream, /*standardizeLineEndings*/ true));
         } catch (IOException e) {
             throw new UnexpectedLiquibaseException(e);
         } finally {

--- a/liquibase-standard/src/main/java/liquibase/change/core/LoadDataChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/LoadDataChange.java
@@ -2,7 +2,6 @@ package liquibase.change.core;
 
 import com.opencsv.exceptions.CsvMalformedLineException;
 import liquibase.CatalogAndSchema;
-import liquibase.ChecksumVersions;
 import liquibase.Scope;
 import liquibase.change.*;
 import liquibase.changelog.ChangeSet;

--- a/liquibase-standard/src/main/java/liquibase/change/core/SQLFileChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/SQLFileChange.java
@@ -1,6 +1,6 @@
 package liquibase.change.core;
 
-import liquibase.ChecksumVersions;
+import liquibase.ChecksumVersion;
 import liquibase.GlobalConfiguration;
 import liquibase.Scope;
 import liquibase.change.*;
@@ -165,8 +165,8 @@ public class SQLFileChange extends AbstractSQLChange {
 
     @Override
     public CheckSum generateCheckSum() {
-        ChecksumVersions version = Scope.getCurrentScope().getChecksumVersion();
-        if (version == ChecksumVersions.V8) {
+        ChecksumVersion version = Scope.getCurrentScope().getChecksumVersion();
+        if (version == ChecksumVersion.V8) {
             return super.generateCheckSum();
         }
         InputStream stream = null;

--- a/liquibase-standard/src/main/java/liquibase/change/core/SQLFileChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/SQLFileChange.java
@@ -164,17 +164,17 @@ public class SQLFileChange extends AbstractSQLChange {
     }
 
     @Override
-    public CheckSum generateCheckSum(ChecksumVersions version) {
+    public CheckSum generateCheckSum() {
+        ChecksumVersions version = Scope.getCurrentScope().getChecksumVersion();
         if (version == ChecksumVersions.V8) {
-            return super.generateCheckSum(version);
+            return super.generateCheckSum();
         }
         InputStream stream = null;
         try {
             String sqlContent = getSql();
             Charset encoding = GlobalConfiguration.FILE_ENCODING.getCurrentValue();
             stream = new ByteArrayInputStream(sqlContent.getBytes(encoding));
-            CheckSum checkSum = CheckSum.compute(new AbstractSQLChange.NormalizingStream(stream), false, version);
-            return checkSum;
+            return CheckSum.compute(new AbstractSQLChange.NormalizingStream(stream), false);
         }
         finally {
             if (stream != null) {

--- a/liquibase-standard/src/main/java/liquibase/change/core/SQLFileChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/SQLFileChange.java
@@ -166,7 +166,7 @@ public class SQLFileChange extends AbstractSQLChange {
     @Override
     public CheckSum generateCheckSum() {
         ChecksumVersion version = Scope.getCurrentScope().getChecksumVersion();
-        if (version == ChecksumVersion.V8) {
+        if (version.lowerOrEqualThan(ChecksumVersion.V8)) {
             return super.generateCheckSum();
         }
         InputStream stream = null;

--- a/liquibase-standard/src/main/java/liquibase/changelog/AbstractChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/AbstractChangeLogHistoryService.java
@@ -111,7 +111,7 @@ public abstract class AbstractChangeLogHistoryService implements ChangeLogHistor
      */
      public String getLastDeploymentId() throws DatabaseException {
          List<RanChangeSet> ranChangeSetsList = getRanChangeSets();
-         if (ranChangeSetsList == null || ranChangeSetsList.isEmpty()0) {
+         if (ranChangeSetsList == null || ranChangeSetsList.isEmpty()) {
              return null;
          }
          RanChangeSet lastRanChangeSet = ranChangeSetsList.get(ranChangeSetsList.size() - 1);

--- a/liquibase-standard/src/main/java/liquibase/changelog/AbstractChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/AbstractChangeLogHistoryService.java
@@ -1,6 +1,6 @@
 package liquibase.changelog;
 
-import liquibase.ChecksumVersions;
+import liquibase.ChecksumVersion;
 import liquibase.Contexts;
 import liquibase.LabelExpression;
 import liquibase.Scope;
@@ -51,7 +51,7 @@ public abstract class AbstractChangeLogHistoryService implements ChangeLogHistor
                 return ChangeSet.RunStatus.ALREADY_RAN;
             } else {
                 if (foundRan.getLastCheckSum().equals(changeSet.generateCheckSum(
-                        ChecksumVersions.enumFromChecksumVersion(foundRan.getLastCheckSum().getVersion())))) {
+                        ChecksumVersion.enumFromChecksumVersion(foundRan.getLastCheckSum().getVersion())))) {
                     return ChangeSet.RunStatus.ALREADY_RAN;
                 } else {
                     if (changeSet.shouldRunOnChange()) {
@@ -111,7 +111,7 @@ public abstract class AbstractChangeLogHistoryService implements ChangeLogHistor
      */
      public String getLastDeploymentId() throws DatabaseException {
          List<RanChangeSet> ranChangeSetsList = getRanChangeSets();
-         if (ranChangeSetsList == null || ranChangeSetsList.size() == 0) {
+         if (ranChangeSetsList == null || ranChangeSetsList.isEmpty()0) {
              return null;
          }
          RanChangeSet lastRanChangeSet = ranChangeSetsList.get(ranChangeSetsList.size() - 1);

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeSet.java
@@ -1,6 +1,6 @@
 package liquibase.changelog;
 
-import liquibase.ChecksumVersions;
+import liquibase.ChecksumVersion;
 import liquibase.ContextExpression;
 import liquibase.Labels;
 import liquibase.Scope;
@@ -339,7 +339,7 @@ public class ChangeSet implements Conditional, ChangeLogChild {
         this.checkSum = null;
     }
 
-    public CheckSum generateCheckSum(ChecksumVersions version) {
+    public CheckSum generateCheckSum(ChecksumVersion version) {
         try {
             return Scope.child(Collections.singletonMap(Scope.Attr.checksumVersion.name(), version), () -> {
                 if (checkSum == null) {
@@ -1126,7 +1126,7 @@ public class ChangeSet implements Conditional, ChangeLogChild {
     }
 
     public String toString(boolean includeMD5Sum) {
-        ChecksumVersions checksumVersion = ChecksumVersions.enumFromChecksumVersion(this.checkSum != null ? this.checkSum.getVersion() : CheckSum.getCurrentVersion());
+        ChecksumVersion checksumVersion = ChecksumVersion.enumFromChecksumVersion(this.checkSum != null ? this.checkSum.getVersion() : CheckSum.getCurrentVersion());
         return filePath + "::" + getId() + "::" + getAuthor() +
                 (includeMD5Sum ? ("::(Checksum: " + generateCheckSum(checksumVersion) + ")") : "");
     }
@@ -1246,7 +1246,7 @@ public class ChangeSet implements Conditional, ChangeLogChild {
                 return true;
             }
         }
-        CheckSum currentMd5Sum = storedCheckSum != null ? generateCheckSum(ChecksumVersions.enumFromChecksumVersion(storedCheckSum.getVersion())) : null;
+        CheckSum currentMd5Sum = storedCheckSum != null ? generateCheckSum(ChecksumVersion.enumFromChecksumVersion(storedCheckSum.getVersion())) : null;
         if (currentMd5Sum == null) {
             return true;
         }

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeSetStatus.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeSetStatus.java
@@ -1,6 +1,6 @@
 package liquibase.changelog;
 
-import liquibase.ChecksumVersions;
+import liquibase.ChecksumVersion;
 import liquibase.change.CheckSum;
 import liquibase.changelog.filter.ChangeSetFilter;
 import liquibase.changelog.filter.ChangeSetFilterResult;
@@ -31,8 +31,8 @@ public class ChangeSetStatus {
 
     public ChangeSetStatus(ChangeSet changeSet) {
         this.changeSet = changeSet;
-        ChecksumVersions version = changeSet.getStoredCheckSum() != null ?
-                ChecksumVersions.enumFromChecksumVersion(changeSet.getStoredCheckSum().getVersion()) :
+        ChecksumVersion version = changeSet.getStoredCheckSum() != null ?
+                ChecksumVersion.enumFromChecksumVersion(changeSet.getStoredCheckSum().getVersion()) :
                 LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue();
         this.currentCheckSum = changeSet.generateCheckSum(version);
         this.description = changeSet.getDescription();

--- a/liquibase-standard/src/main/java/liquibase/changelog/OfflineChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/OfflineChangeLogHistoryService.java
@@ -296,7 +296,7 @@ public class OfflineChangeLogHistoryService extends AbstractChangeLogHistoryServ
             replaceChangeSet(changeSet, line -> {
                 line[Columns.DATEEXECUTED.ordinal()] = new ISODateFormat().format(new java.sql.Timestamp(new Date().getTime()));
                 line[Columns.MD5SUM.ordinal()] = changeSet.generateCheckSum(
-                        ChecksumVersions.enumFromChecksumVersion(changeSet.getStoredCheckSum().getVersion())).toString();
+                        ChecksumVersion.enumFromChecksumVersion(changeSet.getStoredCheckSum().getVersion())).toString();
                 line[Columns.EXECTYPE.ordinal()] = execType.value;
                 return line;
             });

--- a/liquibase-standard/src/main/java/liquibase/changelog/RanChangeSet.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/RanChangeSet.java
@@ -1,6 +1,6 @@
 package liquibase.changelog;
 
-import liquibase.ChecksumVersions;
+import liquibase.ChecksumVersion;
 import liquibase.ContextExpression;
 import liquibase.Labels;
 import liquibase.change.CheckSum;
@@ -38,7 +38,7 @@ public class RanChangeSet {
                 changeSet.getId(),
                 changeSet.getAuthor(),
                 changeSet.generateCheckSum((changeSet.getStoredCheckSum() != null) ?
-                        ChecksumVersions.enumFromChecksumVersion(changeSet.getStoredCheckSum().getVersion()) : LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue()),
+                        ChecksumVersion.enumFromChecksumVersion(changeSet.getStoredCheckSum().getVersion()) : LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue()),
                 new Date(),
                 null,
                 execType,

--- a/liquibase-standard/src/main/java/liquibase/changelog/filter/ShouldRunChangeSetFilter.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/filter/ShouldRunChangeSetFilter.java
@@ -1,6 +1,6 @@
 package liquibase.changelog.filter;
 
-import liquibase.ChecksumVersions;
+import liquibase.ChecksumVersion;
 import liquibase.changelog.ChangeSet;
 import liquibase.changelog.RanChangeSet;
 import liquibase.database.Database;
@@ -74,7 +74,7 @@ public class ShouldRunChangeSetFilter implements ChangeSetFilter {
         if (ranChangeSet.getLastCheckSum() == null) {
             return false;
         }
-        return !changeSet.generateCheckSum(ChecksumVersions.enumFromChecksumVersion(ranChangeSet.getLastCheckSum().getVersion()))
+        return !changeSet.generateCheckSum(ChecksumVersion.enumFromChecksumVersion(ranChangeSet.getLastCheckSum().getVersion()))
                 .equals(ranChangeSet.getLastCheckSum());
     }
 

--- a/liquibase-standard/src/main/java/liquibase/changelog/filter/ShouldRunChangeSetFilter.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/filter/ShouldRunChangeSetFilter.java
@@ -72,8 +72,12 @@ public class ShouldRunChangeSetFilter implements ChangeSetFilter {
 
     protected boolean checksumChanged(ChangeSet changeSet, RanChangeSet ranChangeSet) {
         if (ranChangeSet.getLastCheckSum() == null) {
+            // we don't have a last checksum to compare to, so we are not able to compare both. This may be the case of a
+            // new changeset or after a clearChecksums execution, so we return false as we are unable to test it
             return false;
         }
+        // generate the checksum for the current changeset loaded from changelog files using the same checksum version
+        // that we have at database so we are able to compare them
         return !changeSet.generateCheckSum(ChecksumVersion.enumFromChecksumVersion(ranChangeSet.getLastCheckSum().getVersion()))
                 .equals(ranChangeSet.getLastCheckSum());
     }

--- a/liquibase-standard/src/main/java/liquibase/changelog/filter/ShouldRunChangeSetFilter.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/filter/ShouldRunChangeSetFilter.java
@@ -71,10 +71,10 @@ public class ShouldRunChangeSetFilter implements ChangeSetFilter {
 
 
     protected boolean checksumChanged(ChangeSet changeSet, RanChangeSet ranChangeSet) {
-        if (ranChangeSet.getLastCheckSum() == null || changeSet.getStoredCheckSum() == null) {
+        if (ranChangeSet.getLastCheckSum() == null) {
             return false;
         }
-        return !changeSet.generateCheckSum(ChecksumVersions.enumFromChecksumVersion(changeSet.getStoredCheckSum().getVersion()))
+        return !changeSet.generateCheckSum(ChecksumVersions.enumFromChecksumVersion(ranChangeSet.getLastCheckSum().getVersion()))
                 .equals(ranChangeSet.getLastCheckSum());
     }
 

--- a/liquibase-standard/src/main/java/liquibase/changelog/visitor/UpdateVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/visitor/UpdateVisitor.java
@@ -1,6 +1,5 @@
 package liquibase.changelog.visitor;
 
-import liquibase.ChecksumVersions;
 import liquibase.Scope;
 import liquibase.change.CheckSum;
 import liquibase.changelog.ChangeLogHistoryService;

--- a/liquibase-standard/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
@@ -1,6 +1,6 @@
 package liquibase.changelog.visitor;
 
-import liquibase.ChecksumVersions;
+import liquibase.ChecksumVersion;
 import liquibase.GlobalConfiguration;
 import liquibase.Scope;
 import liquibase.change.Change;
@@ -149,7 +149,7 @@ public class ValidatingVisitor implements ChangeSetVisitor {
             if (!changeSet.isCheckSumValid(ranChangeSet.getLastCheckSum())) {
                 if (!changeSet.shouldRunOnChange()) {
                     invalidMD5Sums.add(changeSet.toString(false)+" was: "+ranChangeSet.getLastCheckSum().toString()
-                            +" but is now: "+changeSet.generateCheckSum(ChecksumVersions.enumFromChecksumVersion(ranChangeSet.getLastCheckSum().getVersion())).toString());
+                            +" but is now: "+changeSet.generateCheckSum(ChecksumVersion.enumFromChecksumVersion(ranChangeSet.getLastCheckSum().getVersion())).toString());
                 }
             }
         }

--- a/liquibase-standard/src/main/java/liquibase/command/core/CalculateChecksumCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/CalculateChecksumCommandStep.java
@@ -1,6 +1,6 @@
 package liquibase.command.core;
 
-import liquibase.ChecksumVersions;
+import liquibase.ChecksumVersion;
 import liquibase.Scope;
 import liquibase.change.CheckSum;
 import liquibase.changelog.*;
@@ -75,7 +75,7 @@ public class CalculateChecksumCommandStep extends AbstractCommandStep {
 
         sendMessages(resultsBuilder, changeSet.generateCheckSum(
                 ranChangeSet != null && ranChangeSet.getLastCheckSum() != null ?
-                        ChecksumVersions.enumFromChecksumVersion(ranChangeSet.getLastCheckSum().getVersion()) : LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue()
+                        ChecksumVersion.enumFromChecksumVersion(ranChangeSet.getLastCheckSum().getVersion()) : LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue()
                 )
         );
     }

--- a/liquibase-standard/src/main/java/liquibase/integration/commandline/LiquibaseCommandLineConfiguration.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/commandline/LiquibaseCommandLineConfiguration.java
@@ -1,6 +1,6 @@
 package liquibase.integration.commandline;
 
-import liquibase.ChecksumVersions;
+import liquibase.ChecksumVersion;
 import liquibase.configuration.AutoloadedConfigurations;
 import liquibase.configuration.ConfigurationDefinition;
 import liquibase.configuration.ConfigurationValueConverter;
@@ -32,7 +32,7 @@ public class LiquibaseCommandLineConfiguration implements AutoloadedConfiguratio
     public static final ConfigurationDefinition<Boolean> SHOULD_RUN;
     public static final ConfigurationDefinition<ArgumentConverter> ARGUMENT_CONVERTER;
     public static final ConfigurationDefinition<String> MONITOR_PERFORMANCE;
-    public static final ConfigurationDefinition<ChecksumVersions> CHECKSUM_VERSION;
+    public static final ConfigurationDefinition<ChecksumVersion> CHECKSUM_VERSION;
 
     static {
         ConfigurationDefinition.Builder builder = new ConfigurationDefinition.Builder("liquibase");
@@ -95,7 +95,7 @@ public class LiquibaseCommandLineConfiguration implements AutoloadedConfiguratio
                         "Open Source users default to unstructured \"" + LogFormat.TEXT + "\" logs to the console or output log files. " +
                         "Pro users have the option to set value as \"" + LogFormat.JSON + "\" or \"" + LogFormat.JSON_PRETTY + "\" to enable json-structured log files to the console or output log files.")
                 .setDefaultValue(LogFormat.TEXT)
-                .setValueHandler((logFormat) -> {
+                .setValueHandler(logFormat -> {
                     if (logFormat == null) {
                         return null;
                     }
@@ -116,10 +116,10 @@ public class LiquibaseCommandLineConfiguration implements AutoloadedConfiguratio
                 })
                 .build();
 
-        CHECKSUM_VERSION = builder.define("checksumVersion", ChecksumVersions.class)
+        CHECKSUM_VERSION = builder.define("checksumVersion", ChecksumVersion.class)
                 .setDescription("Optionally, force Liquibase to use a different version of the checksum calculation " +
                         "algorithm. It is not recommended that this setting be used.")
-                .setDefaultValue(ChecksumVersions.V9)
+                .setDefaultValue(ChecksumVersion.V9)
                 .setHidden(true)
                 .build();
 

--- a/liquibase-standard/src/main/java/liquibase/sql/visitor/AbstractSqlVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/sql/visitor/AbstractSqlVisitor.java
@@ -3,6 +3,7 @@ package liquibase.sql.visitor;
 import liquibase.ChecksumVersions;
 import liquibase.ContextExpression;
 import liquibase.Labels;
+import liquibase.Scope;
 import liquibase.change.CheckSum;
 import liquibase.parser.core.ParsedNode;
 import liquibase.parser.core.ParsedNodeException;
@@ -79,7 +80,8 @@ public abstract class AbstractSqlVisitor implements SqlVisitor {
     }
 
     @Override
-    public CheckSum generateCheckSum(ChecksumVersions version) {
+    public CheckSum generateCheckSum() {
+        ChecksumVersions version = Scope.getCurrentScope().getChecksumVersion();
         return CheckSum.compute(new StringChangeLogSerializer(new StringChangeLogSerializer.FieldFilter(){
             @Override
             public boolean include(Object obj, String field, Object value) {
@@ -88,7 +90,7 @@ public abstract class AbstractSqlVisitor implements SqlVisitor {
                 }
                 return super.include(obj, field, value);
             }
-        }).serialize(this, false), version);
+        }).serialize(this, false));
     }
 
     public String[] getExcludedFieldFilters(ChecksumVersions version) {

--- a/liquibase-standard/src/main/java/liquibase/sql/visitor/AbstractSqlVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/sql/visitor/AbstractSqlVisitor.java
@@ -1,6 +1,6 @@
 package liquibase.sql.visitor;
 
-import liquibase.ChecksumVersions;
+import liquibase.ChecksumVersion;
 import liquibase.ContextExpression;
 import liquibase.Labels;
 import liquibase.Scope;
@@ -81,7 +81,7 @@ public abstract class AbstractSqlVisitor implements SqlVisitor {
 
     @Override
     public CheckSum generateCheckSum() {
-        ChecksumVersions version = Scope.getCurrentScope().getChecksumVersion();
+        ChecksumVersion version = Scope.getCurrentScope().getChecksumVersion();
         return CheckSum.compute(new StringChangeLogSerializer(new StringChangeLogSerializer.FieldFilter(){
             @Override
             public boolean include(Object obj, String field, Object value) {
@@ -93,8 +93,8 @@ public abstract class AbstractSqlVisitor implements SqlVisitor {
         }).serialize(this, false));
     }
 
-    public String[] getExcludedFieldFilters(ChecksumVersions version) {
-        if (version == ChecksumVersions.V8){
+    public String[] getExcludedFieldFilters(ChecksumVersion version) {
+        if (version == ChecksumVersion.V8){
             return new String[0];
         }
         return new String[]{

--- a/liquibase-standard/src/main/java/liquibase/sql/visitor/AbstractSqlVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/sql/visitor/AbstractSqlVisitor.java
@@ -94,7 +94,7 @@ public abstract class AbstractSqlVisitor implements SqlVisitor {
     }
 
     public String[] getExcludedFieldFilters(ChecksumVersion version) {
-        if (version == ChecksumVersion.V8){
+        if (version.lowerOrEqualThan(ChecksumVersion.V8)) {
             return new String[0];
         }
         return new String[]{

--- a/liquibase-standard/src/main/java/liquibase/sql/visitor/SqlVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/sql/visitor/SqlVisitor.java
@@ -1,6 +1,5 @@
 package liquibase.sql.visitor;
 
-import liquibase.ChecksumVersions;
 import liquibase.ContextExpression;
 import liquibase.Labels;
 import liquibase.change.CheckSum;
@@ -30,6 +29,6 @@ public interface SqlVisitor extends LiquibaseSerializable {
     Labels getLabels();
     void setLabels(Labels labels);
 
-    CheckSum generateCheckSum(ChecksumVersions version);
+    CheckSum generateCheckSum();
 
 }

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/MarkChangeSetRanGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/MarkChangeSetRanGenerator.java
@@ -1,8 +1,6 @@
 package liquibase.sqlgenerator.core;
 
-import liquibase.ChecksumVersions;
 import liquibase.change.Change;
-import liquibase.change.CheckSum;
 import liquibase.change.core.TagDatabaseChange;
 import liquibase.changelog.ChangeLogHistoryServiceFactory;
 import liquibase.changelog.ChangeSet;

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/UpdateChangeSetChecksumGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/UpdateChangeSetChecksumGenerator.java
@@ -1,6 +1,5 @@
 package liquibase.sqlgenerator.core;
 
-import liquibase.ChecksumVersions;
 import liquibase.changelog.ChangeSet;
 import liquibase.changelog.column.LiquibaseColumn;
 import liquibase.database.Database;

--- a/liquibase-standard/src/test/groovy/liquibase/change/AbstractChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/AbstractChangeTest.groovy
@@ -1,6 +1,6 @@
 package liquibase.change
 
-import liquibase.ChecksumVersions
+import liquibase.ChecksumVersion
 import liquibase.ContextExpression
 import liquibase.Labels
 import liquibase.Scope
@@ -33,7 +33,7 @@ class AbstractChangeTest extends Specification {
         def methods = object.getMethods()
         expect:
         for (def method : methods) {
-            Set<ChecksumVersions> seenVersions = new HashSet<>()
+            Set<ChecksumVersion> seenVersions = new HashSet<>()
             def annotations = method.getAnnotationsByType(DatabaseChangeProperty.class)
             for (def annotation : annotations) {
                 def versions = annotation.version()
@@ -372,7 +372,7 @@ class AbstractChangeTest extends Specification {
     }
 
     @Unroll
-    def "context filter checksum generation - #version"(ChecksumVersions version, String originalChecksum, String updatedChecksum) {
+    def "context filter checksum generation - #version"(ChecksumVersion version, String originalChecksum, String updatedChecksum) {
         when:
         ChangeSet originalChange = new ChangeSet("testId", "testAuthor", false, false, "path/changelog", null, null, null)
         ChangeSet changeWithContext = originalChange
@@ -387,12 +387,12 @@ class AbstractChangeTest extends Specification {
 
         where:
         version | originalChecksum | updatedChecksum
-        ChecksumVersions.V8 | "8:d41d8cd98f00b204e9800998ecf8427e" | "8:d41d8cd98f00b204e9800998ecf8427e"
+        ChecksumVersion.V8 | "8:d41d8cd98f00b204e9800998ecf8427e" | "8:d41d8cd98f00b204e9800998ecf8427e"
         LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue() | "9:d41d8cd98f00b204e9800998ecf8427e" | "9:d41d8cd98f00b204e9800998ecf8427e"
     }
 
     @Unroll
-    def "label checksum generation - #version"(ChecksumVersions version, String originalChecksum, String updatedChecksum) {
+    def "label checksum generation - #version"(ChecksumVersion version, String originalChecksum, String updatedChecksum) {
         when:
         ChangeSet originalChange = new ChangeSet("testId", "testAuthor", false, false, "path/changelog", null, null, null)
         ChangeSet changeWithLabel = originalChange
@@ -407,12 +407,12 @@ class AbstractChangeTest extends Specification {
 
         where:
         version | originalChecksum | updatedChecksum
-        ChecksumVersions.V8 | "8:d41d8cd98f00b204e9800998ecf8427e" | "8:d41d8cd98f00b204e9800998ecf8427e"
+        ChecksumVersion.V8 | "8:d41d8cd98f00b204e9800998ecf8427e" | "8:d41d8cd98f00b204e9800998ecf8427e"
         LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue() | "9:d41d8cd98f00b204e9800998ecf8427e" | "9:d41d8cd98f00b204e9800998ecf8427e"
     }
 
     @Unroll
-    def "dbms checksum generation - #version"(ChecksumVersions version, String originalChecksum, String updatedChecksum) {
+    def "dbms checksum generation - #version"(ChecksumVersion version, String originalChecksum, String updatedChecksum) {
         when:
         ChangeSet originalChange = new ChangeSet("testId", "testAuthor", false, false, "path/changelog", null, null, null)
         ChangeSet changeWithDbms = originalChange
@@ -427,12 +427,12 @@ class AbstractChangeTest extends Specification {
 
         where:
         version | originalChecksum | updatedChecksum
-        ChecksumVersions.V8 | "8:d41d8cd98f00b204e9800998ecf8427e" | "8:d41d8cd98f00b204e9800998ecf8427e"
+        ChecksumVersion.V8 | "8:d41d8cd98f00b204e9800998ecf8427e" | "8:d41d8cd98f00b204e9800998ecf8427e"
         LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue() | "9:d41d8cd98f00b204e9800998ecf8427e" | "9:d41d8cd98f00b204e9800998ecf8427e"
     }
 
     @Unroll
-    def "comment checksum generation - #version"(ChecksumVersions version, String originalChecksum, String updatedChecksum) {
+    def "comment checksum generation - #version"(ChecksumVersion version, String originalChecksum, String updatedChecksum) {
         when:
         ChangeSet originalChange = new ChangeSet("testId", "testAuthor", false, false, "path/changelog", null, null, null)
         ChangeSet changeWithComment = originalChange
@@ -447,7 +447,7 @@ class AbstractChangeTest extends Specification {
 
         where:
         version | originalChecksum | updatedChecksum
-        ChecksumVersions.V8 | "8:d41d8cd98f00b204e9800998ecf8427e" | "8:d41d8cd98f00b204e9800998ecf8427e"
+        ChecksumVersion.V8 | "8:d41d8cd98f00b204e9800998ecf8427e" | "8:d41d8cd98f00b204e9800998ecf8427e"
         LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue() | "9:d41d8cd98f00b204e9800998ecf8427e" | "9:d41d8cd98f00b204e9800998ecf8427e"
     }
 

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/CreateProcedureChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/CreateProcedureChangeTest.groovy
@@ -106,11 +106,16 @@ class CreateProcedureChangeTest extends StandardChangeTest {
         when:
         CreateProcedureChange change = new CreateProcedureChange()
         change.setProcedureText(PROCEDURE_TEXT)
-        CheckSum procedureCheckSumWithoutDbms = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return change.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn)
+        CheckSum procedureCheckSumWithoutDbms = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return change.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>) as CheckSum
+
         CreateProcedureChange change2 = new CreateProcedureChange()
         change2.setProcedureText(PROCEDURE_TEXT)
         change2.setDbms("postgresql")
-        CheckSum procedureCheckSumWithDbms = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return change2.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn)
+        CheckSum procedureCheckSumWithDbms = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return change2.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>) as CheckSum
 
         then:
         procedureCheckSumWithoutDbms.toString() == originalChecksum
@@ -134,11 +139,17 @@ class CreateProcedureChangeTest extends StandardChangeTest {
 
         CreateProcedureChange change = new CreateProcedureChange()
         change.setProcedureText(PROCEDURE_TEXT)
-        CheckSum procedureCheckSumWithoutPath = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return change.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn)
+        CheckSum procedureCheckSumWithoutPath = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return change.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>) as CheckSum
+
         CreateProcedureChange change2 = new CreateProcedureChange()
         change2.setPath("test.sql")
-        //Below check sum generation should not take path property into account
-        CheckSum procedureCheckSumWithPath = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return change2.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn)
+        //Below check sum generation should not take path property into account to v9
+        CheckSum procedureCheckSumWithPath = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return change2.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>) as CheckSum
+
         //TODO: Move this Scope.exit() call into a cleanUpSpec method
         Scope.exit(testScopeId)
 
@@ -157,11 +168,16 @@ class CreateProcedureChangeTest extends StandardChangeTest {
         when:
         CreateProcedureChange change = new CreateProcedureChange()
         change.setProcedureText(PROCEDURE_TEXT)
-        CheckSum procedureCheckSumWithoutComments = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return change.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn)
+        CheckSum procedureCheckSumWithoutComments = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return change.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>) as CheckSum
+
         CreateProcedureChange change2 = new CreateProcedureChange()
         change2.setProcedureText(PROCEDURE_TEXT)
         change2.setComments("This is a test")
-        CheckSum procedureCheckSumWithComments = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return change2.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn)
+        CheckSum procedureCheckSumWithComments = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return change2.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>) as CheckSum
 
         then:
         procedureCheckSumWithoutComments.toString() == originalChecksum
@@ -178,11 +194,16 @@ class CreateProcedureChangeTest extends StandardChangeTest {
         when:
         CreateProcedureChange change = new CreateProcedureChange()
         change.setProcedureText(PROCEDURE_TEXT)
-        CheckSum procedureCheckSumWithoutEncoding = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return change.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn)
+        CheckSum procedureCheckSumWithoutEncoding = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return change.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>) as CheckSum
+
         CreateProcedureChange change2 = new CreateProcedureChange()
         change2.setProcedureText(PROCEDURE_TEXT)
         change2.setEncoding("UTF-8")
-        CheckSum procedureCheckSumWithEncoding = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return change2.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn)
+        CheckSum procedureCheckSumWithEncoding = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return change2.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>) as CheckSum
 
         then:
         procedureCheckSumWithoutEncoding.toString() == originalChecksum
@@ -199,10 +220,15 @@ class CreateProcedureChangeTest extends StandardChangeTest {
         when:
         CreateProcedureChange change = new CreateProcedureChange()
         change.setProcedureText(PROCEDURE_TEXT)
-        CheckSum procedureTextCheckSum = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return change.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn)
+        CheckSum procedureTextCheckSum = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return change.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>) as CheckSum
+
         CreateProcedureChange change2 = new CreateProcedureChange()
         change2.setProcedureText(PROCEDURE_TEXT.concat("      \n"))
-        CheckSum procedureTextModifiedCheckSum = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return change2.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn)
+        CheckSum procedureTextModifiedCheckSum = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return change2.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>) as CheckSum
 
         then:
         procedureTextCheckSum.toString() == originalChecksum
@@ -219,12 +245,16 @@ class CreateProcedureChangeTest extends StandardChangeTest {
         when:
         CreateProcedureChange change = new CreateProcedureChange()
         change.setProcedureText(PROCEDURE_TEXT)
-        CheckSum procedureTextOriginalCheckSum = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return change.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn)
+        CheckSum procedureTextOriginalCheckSum = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return change.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>) as CheckSum
 
         StringBuilder procedureTextUpdated = new StringBuilder(PROCEDURE_TEXT)
         procedureTextUpdated.append(" WHERE 1=1")
         change.setProcedureText(procedureTextUpdated.toString())
-        CheckSum procedureTextUpdatedCheckSum = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return change.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn)
+        CheckSum procedureTextUpdatedCheckSum = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return change.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>) as CheckSum
 
         then:
         procedureTextOriginalCheckSum.toString() == originalChecksum
@@ -251,12 +281,16 @@ class CreateProcedureChangeTest extends StandardChangeTest {
         procedureText = procedureText.replace("valueToReplace", "value1")
         change.setProcedureText(procedureText)
 
-        def checkSumFirstReplacement = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return change.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn).toString()
+        def checkSumFirstReplacement = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return change.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>).toString()
 
         procedureText = procedureText.replace("value1", "value2")
         change.setProcedureText(procedureText)
 
-        def checkSumSecondReplacement = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return change.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn).toString()
+        def checkSumSecondReplacement = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return change.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>).toString()
 
         then:
         checkSumFirstReplacement == originalChecksum
@@ -273,12 +307,16 @@ class CreateProcedureChangeTest extends StandardChangeTest {
         when:
         CreateProcedureChange changeWithoutRelativeToChangelogFileAttribSet = new CreateProcedureChange()
         changeWithoutRelativeToChangelogFileAttribSet.setProcedureText(PROCEDURE_TEXT)
-        CheckSum changeWithoutRelativeToChangelogFileAttribSetCheckSum = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return changeWithoutRelativeToChangelogFileAttribSet.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn)
+        CheckSum changeWithoutRelativeToChangelogFileAttribSetCheckSum = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return changeWithoutRelativeToChangelogFileAttribSet.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>) as CheckSum
 
         CreateProcedureChange changeWithRelativeToChangelogFileAttribSet = new CreateProcedureChange()
         changeWithRelativeToChangelogFileAttribSet.setProcedureText(PROCEDURE_TEXT)
         changeWithRelativeToChangelogFileAttribSet.setRelativeToChangelogFile(true)
-        CheckSum changeWithRelativeToChangelogFileAttribSetCheckSum = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return changeWithRelativeToChangelogFileAttribSet.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn)
+        CheckSum changeWithRelativeToChangelogFileAttribSetCheckSum = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return changeWithRelativeToChangelogFileAttribSet.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>) as CheckSum
 
         then:
         changeWithoutRelativeToChangelogFileAttribSetCheckSum.toString() == originalChecksum

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/CreateProcedureChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/CreateProcedureChangeTest.groovy
@@ -1,6 +1,6 @@
 package liquibase.change.core
 
-import liquibase.ChecksumVersions
+import liquibase.ChecksumVersion
 import liquibase.Scope
 import liquibase.change.CheckSum
 import liquibase.change.StandardChangeTest
@@ -102,7 +102,7 @@ class CreateProcedureChangeTest extends StandardChangeTest {
     }
 
     @Unroll
-    def "dbms checksum generation - #version"(ChecksumVersions version, String originalChecksum, String updatedChecksum) {
+    def "dbms checksum generation - #version"(ChecksumVersion version, String originalChecksum, String updatedChecksum) {
         when:
         CreateProcedureChange change = new CreateProcedureChange()
         change.setProcedureText(PROCEDURE_TEXT)
@@ -123,13 +123,13 @@ class CreateProcedureChangeTest extends StandardChangeTest {
 
         where:
         version | originalChecksum | updatedChecksum
-        ChecksumVersions.V8 | "8:977441683eb54d6ee1b2de400adb5eed" | "8:63f00c8a5e353ec6d400b0c5a5f7b013"
+        ChecksumVersion.V8 | "8:977441683eb54d6ee1b2de400adb5eed" | "8:63f00c8a5e353ec6d400b0c5a5f7b013"
         LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue() | "9:4ec1db90234ea750169f7d94f7e5c425" | "9:4ec1db90234ea750169f7d94f7e5c425"
 
     }
 
     @Unroll
-    def "path checksum generation - #version"(ChecksumVersions version, String originalChecksum, String updatedChecksum) {
+    def "path checksum generation - #version"(ChecksumVersion version, String originalChecksum, String updatedChecksum) {
         when:
         String testScopeId = Scope.enter([
                 "resourceAccessor": new MockResourceAccessor([
@@ -159,12 +159,12 @@ class CreateProcedureChangeTest extends StandardChangeTest {
 
         where:
         version | originalChecksum | updatedChecksum
-        ChecksumVersions.V8 | "8:977441683eb54d6ee1b2de400adb5eed" | "8:39bcca9579db76270fcbedf41ef2e61a"
+        ChecksumVersion.V8 | "8:977441683eb54d6ee1b2de400adb5eed" | "8:39bcca9579db76270fcbedf41ef2e61a"
         LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue() | "9:4ec1db90234ea750169f7d94f7e5c425" | "9:4ec1db90234ea750169f7d94f7e5c425"
     }
 
     @Unroll
-    def "comment checksum generation - #version"(ChecksumVersions version, String originalChecksum, String updatedChecksum) {
+    def "comment checksum generation - #version"(ChecksumVersion version, String originalChecksum, String updatedChecksum) {
         when:
         CreateProcedureChange change = new CreateProcedureChange()
         change.setProcedureText(PROCEDURE_TEXT)
@@ -185,12 +185,12 @@ class CreateProcedureChangeTest extends StandardChangeTest {
 
         where:
         version | originalChecksum | updatedChecksum
-        ChecksumVersions.V8 | "8:977441683eb54d6ee1b2de400adb5eed" | "8:f834f1891f07c1a2242c346499e16b22"
+        ChecksumVersion.V8 | "8:977441683eb54d6ee1b2de400adb5eed" | "8:f834f1891f07c1a2242c346499e16b22"
         LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue() | "9:4ec1db90234ea750169f7d94f7e5c425" | "9:4ec1db90234ea750169f7d94f7e5c425"
     }
 
     @Unroll
-    def "encoding checksum generation - #version"(ChecksumVersions version, String originalChecksum, String updatedChecksum) {
+    def "encoding checksum generation - #version"(ChecksumVersion version, String originalChecksum, String updatedChecksum) {
         when:
         CreateProcedureChange change = new CreateProcedureChange()
         change.setProcedureText(PROCEDURE_TEXT)
@@ -211,12 +211,12 @@ class CreateProcedureChangeTest extends StandardChangeTest {
 
         where:
         version | originalChecksum | updatedChecksum
-        ChecksumVersions.V8 | "8:977441683eb54d6ee1b2de400adb5eed" | "8:a5244728b4370b3e7e642523539b10a1"
+        ChecksumVersion.V8 | "8:977441683eb54d6ee1b2de400adb5eed" | "8:a5244728b4370b3e7e642523539b10a1"
         LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue() | "9:4ec1db90234ea750169f7d94f7e5c425" | "9:4ec1db90234ea750169f7d94f7e5c425"
     }
 
     @Unroll
-    def "procedure text updated with whitespaces checksum - #version"(ChecksumVersions version, String originalChecksum, String updatedChecksum) {
+    def "procedure text updated with whitespaces checksum - #version"(ChecksumVersion version, String originalChecksum, String updatedChecksum) {
         when:
         CreateProcedureChange change = new CreateProcedureChange()
         change.setProcedureText(PROCEDURE_TEXT)
@@ -236,12 +236,12 @@ class CreateProcedureChangeTest extends StandardChangeTest {
 
         where:
         version | originalChecksum | updatedChecksum
-        ChecksumVersions.V8 | "8:977441683eb54d6ee1b2de400adb5eed" | "8:08289655a87e3a5ef12e2a62e3168105"
+        ChecksumVersion.V8 | "8:977441683eb54d6ee1b2de400adb5eed" | "8:08289655a87e3a5ef12e2a62e3168105"
         LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue() | "9:4ec1db90234ea750169f7d94f7e5c425" | "9:4ec1db90234ea750169f7d94f7e5c425"
     }
 
     @Unroll
-    def "checksum change on procedure text - #version"(ChecksumVersions version, String originalChecksum, String updatedChecksum) {
+    def "checksum change on procedure text - #version"(ChecksumVersion version, String originalChecksum, String updatedChecksum) {
         when:
         CreateProcedureChange change = new CreateProcedureChange()
         change.setProcedureText(PROCEDURE_TEXT)
@@ -262,12 +262,12 @@ class CreateProcedureChangeTest extends StandardChangeTest {
 
         where:
         version | originalChecksum | updatedChecksum
-        ChecksumVersions.V8 | "8:977441683eb54d6ee1b2de400adb5eed" | "8:55058b1ccfdae7d3e486a53b6f3357e5"
+        ChecksumVersion.V8 | "8:977441683eb54d6ee1b2de400adb5eed" | "8:55058b1ccfdae7d3e486a53b6f3357e5"
         LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue() | "9:4ec1db90234ea750169f7d94f7e5c425" | "9:36f93561a3ca75d53c84639669d74b51"
     }
 
     @Unroll
-    def "validate checksum gets re-computed if procedure text gets updated - #version"(ChecksumVersions version, String originalChecksum, String updatedChecksum) {
+    def "validate checksum gets re-computed if procedure text gets updated - #version"(ChecksumVersion version, String originalChecksum, String updatedChecksum) {
         when:
         String procedureText =
                 """CREATE OR REPLACE PROCEDURE testHello()
@@ -298,12 +298,12 @@ class CreateProcedureChangeTest extends StandardChangeTest {
 
         where:
         version | originalChecksum | updatedChecksum
-        ChecksumVersions.V8 | "8:633d7b88ffefdea580a8c5671b284cc9" | "8:b7d57ddf12ba7f8a12d342b0f833c11d"
+        ChecksumVersion.V8 | "8:633d7b88ffefdea580a8c5671b284cc9" | "8:b7d57ddf12ba7f8a12d342b0f833c11d"
         LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue() | "9:eec1dde2b2197528f030a2917d2602c3" | "9:06085ea7538bfe94b70b7196d520cc2f"
     }
 
     @Unroll
-    def "relativeToChangelogFile attribute checksum generation - #version"(ChecksumVersions version, String originalChecksum, String updatedChecksum) {
+    def "relativeToChangelogFile attribute checksum generation - #version"(ChecksumVersion version, String originalChecksum, String updatedChecksum) {
         when:
         CreateProcedureChange changeWithoutRelativeToChangelogFileAttribSet = new CreateProcedureChange()
         changeWithoutRelativeToChangelogFileAttribSet.setProcedureText(PROCEDURE_TEXT)
@@ -324,7 +324,7 @@ class CreateProcedureChangeTest extends StandardChangeTest {
 
         where:
         version | originalChecksum | updatedChecksum
-        ChecksumVersions.V8 | "8:977441683eb54d6ee1b2de400adb5eed" | "8:20536e4edf2d1dfa3d892063830f38ae"
+        ChecksumVersion.V8 | "8:977441683eb54d6ee1b2de400adb5eed" | "8:20536e4edf2d1dfa3d892063830f38ae"
         LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue() | "9:4ec1db90234ea750169f7d94f7e5c425" | "9:4ec1db90234ea750169f7d94f7e5c425"
     }
 }

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/CreateViewChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/CreateViewChangeTest.groovy
@@ -106,10 +106,16 @@ class CreateViewChangeTest extends StandardChangeTest {
 
         CreateViewChange change = new CreateViewChange()
         change.setSelectQuery(SELECT_QUERY)
-        CheckSum viewCheckSumWithoutPath = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return change.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn)
+        CheckSum viewCheckSumWithoutPath = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return change.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>) as CheckSum
+
         CreateViewChange change2 = new CreateViewChange()
         change2.setPath("viewTest.sql")
-        CheckSum viewCheckSumWithPath = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return change2.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn)
+        CheckSum viewCheckSumWithPath = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return change2.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>) as CheckSum
+
         //TODO: Move this Scope.exit() call into a cleanUpSpec method
         Scope.exit(testScopeId)
 
@@ -128,11 +134,16 @@ class CreateViewChangeTest extends StandardChangeTest {
         when:
         CreateViewChange change = new CreateViewChange()
         change.setSelectQuery(SELECT_QUERY)
-        CheckSum viewCheckSumWithoutEncoding = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return change.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn)
+        CheckSum viewCheckSumWithoutEncoding = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return change.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>) as CheckSum
+
         CreateViewChange change2 = new CreateViewChange()
         change2.setSelectQuery(SELECT_QUERY)
         change2.setEncoding("UTF-8")
-        CheckSum viewCheckSumWithEncoding = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return change2.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn)
+        CheckSum viewCheckSumWithEncoding = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return change2.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>) as CheckSum
 
         then:
         viewCheckSumWithoutEncoding.toString() == originalChecksum
@@ -149,10 +160,14 @@ class CreateViewChangeTest extends StandardChangeTest {
         when:
         CreateViewChange change = new CreateViewChange()
         change.setSelectQuery(SELECT_QUERY)
-        CheckSum viewTextCheckSum = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return change.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn)
+        CheckSum viewTextCheckSum = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return change.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>) as CheckSum
         CreateViewChange change2 = new CreateViewChange()
         change2.setSelectQuery(SELECT_QUERY.concat("      \n"))
-        CheckSum viewTextModifiedCheckSum = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return change2.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn)
+        CheckSum viewTextModifiedCheckSum = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return change2.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>) as CheckSum
 
         then:
         viewTextCheckSum.toString() == originalChecksum
@@ -169,12 +184,16 @@ class CreateViewChangeTest extends StandardChangeTest {
         when:
         CreateViewChange change = new CreateViewChange()
         change.setSelectQuery(SELECT_QUERY)
-        CheckSum viewTextOriginalCheckSum = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return change.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn)
+        CheckSum viewTextOriginalCheckSum = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return change.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>) as CheckSum
 
         StringBuilder selectQueryUpdated = new StringBuilder(SELECT_QUERY)
         selectQueryUpdated.append(" WHERE 1=1")
         change.setSelectQuery(selectQueryUpdated.toString())
-        CheckSum viewTextUpdatedCheckSum = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return change.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn);
+        CheckSum viewTextUpdatedCheckSum = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return change.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>) as CheckSum
 
         then:
         viewTextOriginalCheckSum.toString() == originalChecksum
@@ -195,12 +214,16 @@ class CreateViewChangeTest extends StandardChangeTest {
         def change = new CreateViewChange();
         change.setSelectQuery(selectQueryText)
 
-        def checkSumFirstReplacement = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return change.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn).toString()
+        def checkSumFirstReplacement = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return change.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>).toString()
 
         selectQueryText = selectQueryText.replace("value1", "value2")
         change.setSelectQuery(selectQueryText)
 
-        def checkSumSecondReplacement = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return change.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn).toString()
+        def checkSumSecondReplacement = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return change.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>).toString()
 
         then:
         checkSumFirstReplacement.toString() == originalChecksum
@@ -217,12 +240,16 @@ class CreateViewChangeTest extends StandardChangeTest {
         when:
         CreateViewChange changeWithoutRelativeToChangelogFileAttribSet = new CreateViewChange()
         changeWithoutRelativeToChangelogFileAttribSet.setSelectQuery(SELECT_QUERY)
-        CheckSum changeWithoutRelativeToChangelogFileAttribSetCheckSum = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return changeWithoutRelativeToChangelogFileAttribSet.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn)
+        CheckSum changeWithoutRelativeToChangelogFileAttribSetCheckSum = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return changeWithoutRelativeToChangelogFileAttribSet.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>) as CheckSum
 
         CreateViewChange changeWithRelativeToChangelogFileAttribSet = new CreateViewChange()
         changeWithRelativeToChangelogFileAttribSet.setSelectQuery(SELECT_QUERY)
         changeWithRelativeToChangelogFileAttribSet.setRelativeToChangelogFile(true)
-        CheckSum changeWithRelativeToChangelogFileAttribSetCheckSum = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return changeWithRelativeToChangelogFileAttribSet.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn)
+        CheckSum changeWithRelativeToChangelogFileAttribSetCheckSum = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return changeWithRelativeToChangelogFileAttribSet.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn<CheckSum>) as CheckSum
 
         then:
         changeWithoutRelativeToChangelogFileAttribSetCheckSum.toString() == originalChecksum

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/CreateViewChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/CreateViewChangeTest.groovy
@@ -1,6 +1,6 @@
 package liquibase.change.core
 
-import liquibase.ChecksumVersions
+import liquibase.ChecksumVersion
 import liquibase.Scope
 import liquibase.change.ChangeStatus
 import liquibase.change.CheckSum
@@ -96,7 +96,7 @@ class CreateViewChangeTest extends StandardChangeTest {
     }
 
     @Unroll
-    def "path checksum generation - #version"(ChecksumVersions version, String originalChecksum, String updatedChecksum) {
+    def "path checksum generation - #version"(ChecksumVersion version, String originalChecksum, String updatedChecksum) {
         when:
         String testScopeId = Scope.enter([
                 "resourceAccessor": new MockResourceAccessor([
@@ -125,12 +125,12 @@ class CreateViewChangeTest extends StandardChangeTest {
 
         where:
         version | originalChecksum | updatedChecksum
-        ChecksumVersions.V8 | "8:dcb086e83731ee5f3e04af0a7010dd69" | "8:93ebeea10f821f8f9582450fcfcfbe0f"
+        ChecksumVersion.V8 | "8:dcb086e83731ee5f3e04af0a7010dd69" | "8:93ebeea10f821f8f9582450fcfcfbe0f"
         LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue() | "9:44c9d30cc310fbecd58e03d557fe85df" | "9:44c9d30cc310fbecd58e03d557fe85df"
     }
 
     @Unroll
-    def "encoding checksum generation - #version"(ChecksumVersions version, String originalChecksum, String updatedChecksum) {
+    def "encoding checksum generation - #version"(ChecksumVersion version, String originalChecksum, String updatedChecksum) {
         when:
         CreateViewChange change = new CreateViewChange()
         change.setSelectQuery(SELECT_QUERY)
@@ -151,12 +151,12 @@ class CreateViewChangeTest extends StandardChangeTest {
 
         where:
         version | originalChecksum | updatedChecksum
-        ChecksumVersions.V8 | "8:dcb086e83731ee5f3e04af0a7010dd69" | "8:fe5f671b0280cca6fd47ba1cb0f6f521"
+        ChecksumVersion.V8 | "8:dcb086e83731ee5f3e04af0a7010dd69" | "8:fe5f671b0280cca6fd47ba1cb0f6f521"
         LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue() | "9:44c9d30cc310fbecd58e03d557fe85df" | "9:44c9d30cc310fbecd58e03d557fe85df"
     }
 
     @Unroll
-    def "select query updated with whitespaces checksum - #version"(ChecksumVersions version, String originalChecksum, String updatedChecksum) {
+    def "select query updated with whitespaces checksum - #version"(ChecksumVersion version, String originalChecksum, String updatedChecksum) {
         when:
         CreateViewChange change = new CreateViewChange()
         change.setSelectQuery(SELECT_QUERY)
@@ -175,12 +175,12 @@ class CreateViewChangeTest extends StandardChangeTest {
 
         where:
         version | originalChecksum | updatedChecksum
-        ChecksumVersions.V8 | "8:dcb086e83731ee5f3e04af0a7010dd69" | "8:39739d2b228cbfc3f8a4f4b44d0d168e"
+        ChecksumVersion.V8 | "8:dcb086e83731ee5f3e04af0a7010dd69" | "8:39739d2b228cbfc3f8a4f4b44d0d168e"
         LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue() | "9:44c9d30cc310fbecd58e03d557fe85df" | "9:44c9d30cc310fbecd58e03d557fe85df"
     }
 
     @Unroll
-    def "checksum change on select query - #version"(ChecksumVersions version, String originalChecksum, String updatedChecksum) {
+    def "checksum change on select query - #version"(ChecksumVersion version, String originalChecksum, String updatedChecksum) {
         when:
         CreateViewChange change = new CreateViewChange()
         change.setSelectQuery(SELECT_QUERY)
@@ -201,12 +201,12 @@ class CreateViewChangeTest extends StandardChangeTest {
 
         where:
         version | originalChecksum | updatedChecksum
-        ChecksumVersions.V8 | "8:dcb086e83731ee5f3e04af0a7010dd69" | "8:6ade9a5def82e9f15d2f353e97c41784"
+        ChecksumVersion.V8 | "8:dcb086e83731ee5f3e04af0a7010dd69" | "8:6ade9a5def82e9f15d2f353e97c41784"
         LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue() | "9:44c9d30cc310fbecd58e03d557fe85df" | "9:43b9ff024ff5b5212a12e4ffc13f4790"
     }
 
     @Unroll
-    def "validate checksum if select query text gets updated - #version"(ChecksumVersions version, String originalChecksum, String updatedChecksum) {
+    def "validate checksum if select query text gets updated - #version"(ChecksumVersion version, String originalChecksum, String updatedChecksum) {
         when:
         String selectQueryText = "SELECT id, name FROM person WHERE id > valueToReplace;"
 
@@ -231,12 +231,12 @@ class CreateViewChangeTest extends StandardChangeTest {
 
         where:
         version | originalChecksum | updatedChecksum
-        ChecksumVersions.V8 | "8:09bbf3defde77019c8f8dc32f8f84908" | "8:c4a6c3c5a7d2b519d83d27351b7919e7"
+        ChecksumVersion.V8 | "8:09bbf3defde77019c8f8dc32f8f84908" | "8:c4a6c3c5a7d2b519d83d27351b7919e7"
         LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue() | "9:e70628fe4f941c2d8822214dbd7cd28f" | "9:ed9a064736c8974be6ac35bb231032ff"
     }
 
     @Unroll
-    def "relativeToChangelogFile attribute checksum generation - #version"(ChecksumVersions version, String originalChecksum, String updatedChecksum) {
+    def "relativeToChangelogFile attribute checksum generation - #version"(ChecksumVersion version, String originalChecksum, String updatedChecksum) {
         when:
         CreateViewChange changeWithoutRelativeToChangelogFileAttribSet = new CreateViewChange()
         changeWithoutRelativeToChangelogFileAttribSet.setSelectQuery(SELECT_QUERY)
@@ -257,7 +257,7 @@ class CreateViewChangeTest extends StandardChangeTest {
 
         where:
         version | originalChecksum | updatedChecksum
-        ChecksumVersions.V8 | "8:dcb086e83731ee5f3e04af0a7010dd69" | "8:5effbea4284f4277c1bdd81505787591"
+        ChecksumVersion.V8 | "8:dcb086e83731ee5f3e04af0a7010dd69" | "8:5effbea4284f4277c1bdd81505787591"
         LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue() | "9:44c9d30cc310fbecd58e03d557fe85df" | "9:44c9d30cc310fbecd58e03d557fe85df"
     }
 }

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
@@ -2,7 +2,9 @@ package liquibase.change.core
 
 import liquibase.ChecksumVersions
 import liquibase.Scope
+import liquibase.change.AbstractSQLChangeTest
 import liquibase.change.ChangeStatus
+import liquibase.change.CheckSum
 import liquibase.change.StandardChangeTest
 import liquibase.changelog.ChangeSet
 import liquibase.changelog.DatabaseChangeLog
@@ -310,10 +312,14 @@ public class LoadDataChangeTest extends StandardChangeTest {
         refactoring.setTableName("TABLE_NAME");
         refactoring.setFile("liquibase/change/core/sample.data1.csv");
 
-        String md5sum1 = refactoring.generateCheckSum(version).toString();
+        String md5sum1 = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return refactoring.generateCheckSum().toString()
+        } as Scope.ScopedRunnerWithReturn<String>)
 
         refactoring.setFile("liquibase/change/core/sample.data2.csv");
-        String md5sum2 = refactoring.generateCheckSum(version).toString();
+        String md5sum2 = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return refactoring.generateCheckSum().toString()
+        } as Scope.ScopedRunnerWithReturn<String>)
 
         then:
         md5sum1 == originalChecksum
@@ -430,10 +436,14 @@ public class LoadDataChangeTest extends StandardChangeTest {
         refactoring.setFile("liquibase/change/core/sample.data1.csv");
 
         refactoring.setCommentLineStartsWith("") //comments disabled
-        String md5sum1 = refactoring.generateCheckSum(version).toString();
+        String md5sum1 = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return refactoring.generateCheckSum().toString()
+        } as Scope.ScopedRunnerWithReturn<String>)
 
         refactoring.setCommentLineStartsWith("#");
-        String md5sum2 = refactoring.generateCheckSum(version).toString();
+        String md5sum2 = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return refactoring.generateCheckSum().toString()
+        } as Scope.ScopedRunnerWithReturn<String>)
 
         then:
         md5sum1 == originalChecksum
@@ -454,10 +464,14 @@ public class LoadDataChangeTest extends StandardChangeTest {
         refactoring.setFile("liquibase/change/core/sample.data1-withComments.csv");
 
         refactoring.setCommentLineStartsWith("") //comments disabled
-        String md5sum1 = refactoring.generateCheckSum(version).toString();
+        String md5sum1 = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return refactoring.generateCheckSum().toString()
+        } as Scope.ScopedRunnerWithReturn<String>)
 
         refactoring.setCommentLineStartsWith("#");
-        String md5sum2 = refactoring.generateCheckSum(version).toString();
+        String md5sum2 = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return refactoring.generateCheckSum().toString()
+        } as Scope.ScopedRunnerWithReturn<String>)
 
         then:
         md5sum1 == originalChecksum
@@ -478,11 +492,15 @@ public class LoadDataChangeTest extends StandardChangeTest {
         refactoring.setFile("liquibase/change/core/sample.data1-withComments.csv");
 
         refactoring.setCommentLineStartsWith("#");
-        String md5sum1 = refactoring.generateCheckSum(version).toString();
+        String md5sum1 = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return refactoring.generateCheckSum().toString()
+        } as Scope.ScopedRunnerWithReturn<String>)
 
         refactoring.setFile("liquibase/change/core/sample.data1-removedComments.csv");
         refactoring.setCommentLineStartsWith(""); //disable comments just in case
-        String md5sum2 = refactoring.generateCheckSum(version).toString();
+        String md5sum2 = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return refactoring.generateCheckSum().toString()
+        } as Scope.ScopedRunnerWithReturn<String>)
 
         then:
         md5sum1 == originalChecksum

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
@@ -1,10 +1,8 @@
 package liquibase.change.core
 
-import liquibase.ChecksumVersions
+import liquibase.ChecksumVersion
 import liquibase.Scope
-import liquibase.change.AbstractSQLChangeTest
 import liquibase.change.ChangeStatus
-import liquibase.change.CheckSum
 import liquibase.change.StandardChangeTest
 import liquibase.changelog.ChangeSet
 import liquibase.changelog.DatabaseChangeLog
@@ -305,7 +303,7 @@ public class LoadDataChangeTest extends StandardChangeTest {
     }
 
     @Unroll
-    def "generateChecksum produces different values with each field - #version"(ChecksumVersions version, String originalChecksum, String updatedChecksum) {
+    def "generateChecksum produces different values with each field - #version"(ChecksumVersion version, String originalChecksum, String updatedChecksum) {
         when:
         LoadDataChange refactoring = new LoadDataChange();
         refactoring.setSchemaName("SCHEMA_NAME");
@@ -327,7 +325,7 @@ public class LoadDataChangeTest extends StandardChangeTest {
 
         where:
         version | originalChecksum | updatedChecksum
-        ChecksumVersions.V8 | "8:a91f2379b2b3b4c4a5a571b8e7409081" | "8:cce1423feea9e29192ef7c306eda0c94"
+        ChecksumVersion.V8 | "8:a91f2379b2b3b4c4a5a571b8e7409081" | "8:cce1423feea9e29192ef7c306eda0c94"
         LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue() | "9:55d574d66869989f7208b9f05b7409bb" | "9:b0cc70905a4b9db9211c05392fd08f08"
     }
 
@@ -428,7 +426,7 @@ public class LoadDataChangeTest extends StandardChangeTest {
     }
 
     @Unroll
-    def "checksum does not change when no comments in CSV and comment property changes - #version"(ChecksumVersions version, String originalChecksum, String updatedChecksum) {
+    def "checksum does not change when no comments in CSV and comment property changes - #version"(ChecksumVersion version, String originalChecksum, String updatedChecksum) {
         when:
         LoadDataChange refactoring = new LoadDataChange();
         refactoring.setSchemaName("SCHEMA_NAME");
@@ -451,12 +449,12 @@ public class LoadDataChangeTest extends StandardChangeTest {
 
         where:
         version | originalChecksum | updatedChecksum
-        ChecksumVersions.V8 | "8:a91f2379b2b3b4c4a5a571b8e7409081" | "8:a91f2379b2b3b4c4a5a571b8e7409081"
+        ChecksumVersion.V8 | "8:a91f2379b2b3b4c4a5a571b8e7409081" | "8:a91f2379b2b3b4c4a5a571b8e7409081"
         LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue() | "9:55d574d66869989f7208b9f05b7409bb" | "9:55d574d66869989f7208b9f05b7409bb"
     }
 
     @Unroll
-    def "checksum changes when there are comments in CSV - #version"(ChecksumVersions version, String originalChecksum, String updatedChecksum) {
+    def "checksum changes when there are comments in CSV - #version"(ChecksumVersion version, String originalChecksum, String updatedChecksum) {
         when:
         LoadDataChange refactoring = new LoadDataChange();
         refactoring.setSchemaName("SCHEMA_NAME");
@@ -479,12 +477,12 @@ public class LoadDataChangeTest extends StandardChangeTest {
 
         where:
         version | originalChecksum | updatedChecksum
-        ChecksumVersions.V8 | "8:becddfbcfda2ec516371ed36aaf1137a" | "8:e51a6408e921cfa151c50c7d90cf5baa"
+        ChecksumVersion.V8 | "8:becddfbcfda2ec516371ed36aaf1137a" | "8:e51a6408e921cfa151c50c7d90cf5baa"
         LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue() | "9:c02972964ae29d51fa8e7801951fbb70" | "9:91298c1042fcb57394a242e8c838ce51"
     }
 
     @Unroll
-    def "checksum same for CSV files with comments and file with removed comments manually - #version"(ChecksumVersions version, String originalChecksum, String updatedChecksum) {
+    def "checksum same for CSV files with comments and file with removed comments manually - #version"(ChecksumVersion version, String originalChecksum, String updatedChecksum) {
         when:
         LoadDataChange refactoring = new LoadDataChange();
         refactoring.setSchemaName("SCHEMA_NAME");
@@ -508,7 +506,7 @@ public class LoadDataChangeTest extends StandardChangeTest {
 
         where:
         version | originalChecksum | updatedChecksum
-        ChecksumVersions.V8 | "8:e51a6408e921cfa151c50c7d90cf5baa" | "8:e51a6408e921cfa151c50c7d90cf5baa"
+        ChecksumVersion.V8 | "8:e51a6408e921cfa151c50c7d90cf5baa" | "8:e51a6408e921cfa151c50c7d90cf5baa"
         LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue() | "9:91298c1042fcb57394a242e8c838ce51" | "9:91298c1042fcb57394a242e8c838ce51"
     }
 

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/LoadUpdateDataChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/LoadUpdateDataChangeTest.groovy
@@ -1,9 +1,8 @@
 package liquibase.change.core
 
-import liquibase.ChecksumVersions
+import liquibase.ChecksumVersion
 import liquibase.Scope
 import liquibase.change.ChangeStatus
-import liquibase.change.CheckSum
 import liquibase.database.core.PostgresDatabase
 import liquibase.database.DatabaseConnection
 import liquibase.integration.commandline.LiquibaseCommandLineConfiguration
@@ -13,12 +12,9 @@ import liquibase.change.StandardChangeTest;
 import liquibase.database.core.MockDatabase
 import liquibase.resource.ClassLoaderResourceAccessor;
 import liquibase.statement.SqlStatement
-import liquibase.statement.core.InsertOrUpdateStatement;
-import liquibase.test.JUnitResourceAccessor
+import liquibase.statement.core.InsertOrUpdateStatement
 import liquibase.database.core.MSSQLDatabase
 import spock.lang.Unroll
-
-import static org.junit.Assert.*
 
 public class LoadUpdateDataChangeTest extends StandardChangeTest {
 
@@ -125,7 +121,7 @@ public class LoadUpdateDataChangeTest extends StandardChangeTest {
     }
 
     @Unroll
-    def "generateChecksum produces different values with each field - #version"(ChecksumVersions version, String originalChecksum, String updatedChecksum) {
+    def "generateChecksum produces different values with each field - #version"(ChecksumVersion version, String originalChecksum, String updatedChecksum) {
         when:
         LoadUpdateDataChange refactoring = new LoadUpdateDataChange();
         refactoring.setSchemaName("SCHEMA_NAME");
@@ -146,7 +142,7 @@ public class LoadUpdateDataChangeTest extends StandardChangeTest {
 
         where:
         version | originalChecksum | updatedChecksum
-        ChecksumVersions.V8 | "8:a91f2379b2b3b4c4a5a571b8e7409081" | "8:cce1423feea9e29192ef7c306eda0c94"
+        ChecksumVersion.V8 | "8:a91f2379b2b3b4c4a5a571b8e7409081" | "8:cce1423feea9e29192ef7c306eda0c94"
         LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue() | "9:55d574d66869989f7208b9f05b7409bb" | "9:b0cc70905a4b9db9211c05392fd08f08"
     }
 
@@ -169,7 +165,7 @@ public class LoadUpdateDataChangeTest extends StandardChangeTest {
     }
 
     @Unroll
-    def "checksum does not change when no comments in CSV and comment property changes"(ChecksumVersions version, String originalChecksum, String updatedChecksum) {
+    def "checksum does not change when no comments in CSV and comment property changes"(ChecksumVersion version, String originalChecksum, String updatedChecksum) {
         when:
         LoadUpdateDataChange refactoring = new LoadUpdateDataChange();
         refactoring.setSchemaName("SCHEMA_NAME");
@@ -193,12 +189,12 @@ public class LoadUpdateDataChangeTest extends StandardChangeTest {
 
         where:
         version | originalChecksum | updatedChecksum
-        ChecksumVersions.V8 | "8:a91f2379b2b3b4c4a5a571b8e7409081" | "8:a91f2379b2b3b4c4a5a571b8e7409081"
+        ChecksumVersion.V8 | "8:a91f2379b2b3b4c4a5a571b8e7409081" | "8:a91f2379b2b3b4c4a5a571b8e7409081"
         LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue() | "9:55d574d66869989f7208b9f05b7409bb" | "9:55d574d66869989f7208b9f05b7409bb"
     }
 
     @Unroll
-    def "checksum changes when there are comments in CSV"(ChecksumVersions version, String originalChecksum, String updatedChecksum) {
+    def "checksum changes when there are comments in CSV"(ChecksumVersion version, String originalChecksum, String updatedChecksum) {
         when:
         LoadUpdateDataChange refactoring = new LoadUpdateDataChange();
         refactoring.setSchemaName("SCHEMA_NAME");
@@ -221,12 +217,12 @@ public class LoadUpdateDataChangeTest extends StandardChangeTest {
 
         where:
         version | originalChecksum | updatedChecksum
-        ChecksumVersions.V8 | "8:becddfbcfda2ec516371ed36aaf1137a" | "8:e51a6408e921cfa151c50c7d90cf5baa"
+        ChecksumVersion.V8 | "8:becddfbcfda2ec516371ed36aaf1137a" | "8:e51a6408e921cfa151c50c7d90cf5baa"
         LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue() | "9:c02972964ae29d51fa8e7801951fbb70" | "9:91298c1042fcb57394a242e8c838ce51"
     }
 
     @Unroll
-    def "checksum same for CSV files with comments and file with removed comments manually - #version"(ChecksumVersions version, String originalChecksum, String updatedChecksum) {
+    def "checksum same for CSV files with comments and file with removed comments manually - #version"(ChecksumVersion version, String originalChecksum, String updatedChecksum) {
         when:
         LoadUpdateDataChange refactoring = new LoadUpdateDataChange();
         refactoring.setSchemaName("SCHEMA_NAME");
@@ -250,7 +246,7 @@ public class LoadUpdateDataChangeTest extends StandardChangeTest {
 
         where:
         version | originalChecksum | updatedChecksum
-        ChecksumVersions.V8 | "8:e51a6408e921cfa151c50c7d90cf5baa" | "8:e51a6408e921cfa151c50c7d90cf5baa"
+        ChecksumVersion.V8 | "8:e51a6408e921cfa151c50c7d90cf5baa" | "8:e51a6408e921cfa151c50c7d90cf5baa"
         LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue() | "9:91298c1042fcb57394a242e8c838ce51" | "9:91298c1042fcb57394a242e8c838ce51"
     }
 }

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/LoadUpdateDataChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/LoadUpdateDataChangeTest.groovy
@@ -1,7 +1,9 @@
 package liquibase.change.core
 
 import liquibase.ChecksumVersions
+import liquibase.Scope
 import liquibase.change.ChangeStatus
+import liquibase.change.CheckSum
 import liquibase.database.core.PostgresDatabase
 import liquibase.database.DatabaseConnection
 import liquibase.integration.commandline.LiquibaseCommandLineConfiguration
@@ -130,11 +132,14 @@ public class LoadUpdateDataChangeTest extends StandardChangeTest {
         refactoring.setTableName("TABLE_NAME");
         refactoring.setFile("liquibase/change/core/sample.data1.csv");
 
-        String md5sum1 = refactoring.generateCheckSum(version).toString();
+        String md5sum1 = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return refactoring.generateCheckSum().toString()
+        } as Scope.ScopedRunnerWithReturn<String>)
 
         refactoring.setFile("liquibase/change/core/sample.data2.csv");
-        String md5sum2 = refactoring.generateCheckSum(version).toString();
-
+        String md5sum2 = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return refactoring.generateCheckSum().toString()
+        } as Scope.ScopedRunnerWithReturn<String>)
         then:
         md5sum1 == originalChecksum
         md5sum2 == updatedChecksum
@@ -173,10 +178,14 @@ public class LoadUpdateDataChangeTest extends StandardChangeTest {
         //refactoring.setFileOpener(new JUnitResourceAccessor());
 
         refactoring.setCommentLineStartsWith("") //comments disabled
-        String md5sum1 = refactoring.generateCheckSum(version).toString();
+        String md5sum1 = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return refactoring.generateCheckSum().toString()
+        } as Scope.ScopedRunnerWithReturn<String>)
 
         refactoring.setCommentLineStartsWith("#");
-        String md5sum2 = refactoring.generateCheckSum(version).toString();
+        String md5sum2 = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return refactoring.generateCheckSum().toString()
+        } as Scope.ScopedRunnerWithReturn<String>)
 
         then:
         md5sum1 == originalChecksum
@@ -197,10 +206,14 @@ public class LoadUpdateDataChangeTest extends StandardChangeTest {
         refactoring.setFile("liquibase/change/core/sample.data1-withComments.csv");
 
         refactoring.setCommentLineStartsWith("") //comments disabled
-        String md5sum1 = refactoring.generateCheckSum(version).toString();
+        String md5sum1 = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return refactoring.generateCheckSum().toString()
+        } as Scope.ScopedRunnerWithReturn<String>)
 
         refactoring.setCommentLineStartsWith("#");
-        String md5sum2 = refactoring.generateCheckSum(version).toString();
+        String md5sum2 = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return refactoring.generateCheckSum().toString()
+        } as Scope.ScopedRunnerWithReturn<String>)
 
         then:
         md5sum1 == originalChecksum
@@ -221,11 +234,15 @@ public class LoadUpdateDataChangeTest extends StandardChangeTest {
         refactoring.setFile("liquibase/change/core/sample.data1-withComments.csv");
 
         refactoring.setCommentLineStartsWith("#");
-        String md5sum1 = refactoring.generateCheckSum(version).toString();
+        String md5sum1 = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return refactoring.generateCheckSum().toString()
+        } as Scope.ScopedRunnerWithReturn<String>)
 
         refactoring.setFile("liquibase/change/core/sample.data1-removedComments.csv");
         refactoring.setCommentLineStartsWith(""); //disable comments just in case
-        String md5sum2 = refactoring.generateCheckSum(version).toString();
+        String md5sum2 = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return refactoring.generateCheckSum().toString()
+        } as Scope.ScopedRunnerWithReturn<String>)
 
         then:
         md5sum1 == originalChecksum

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/SQLFileChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/SQLFileChangeTest.groovy
@@ -159,12 +159,16 @@ class SQLFileChangeTest extends StandardChangeTest {
         procedureText = procedureText.replace("valueToReplace", "value1")
         change.setSql(procedureText)
 
-        def checkSumFirstReplacement = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return change.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn).toString()
+        def checkSumFirstReplacement = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return change.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn).toString()
 
         procedureText = procedureText.replace("value1", "value2")
         change.setSql(procedureText)
 
-        def checkSumSecondReplacement = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), version), { -> return change.generateCheckSum(version) } as Scope.ScopedRunnerWithReturn).toString()
+        def checkSumSecondReplacement = Scope.child([(Scope.Attr.checksumVersion.name()): version], {
+            return change.generateCheckSum()
+        } as Scope.ScopedRunnerWithReturn).toString()
 
         then:
         checkSumFirstReplacement == originalChecksum

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/SQLFileChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/SQLFileChangeTest.groovy
@@ -1,6 +1,6 @@
 package liquibase.change.core
 
-import liquibase.ChecksumVersions
+import liquibase.ChecksumVersion
 import liquibase.Scope
 import liquibase.change.Change
 import liquibase.change.ChangeStatus
@@ -145,7 +145,7 @@ class SQLFileChangeTest extends StandardChangeTest {
     }
 
     @Unroll
-    def "validate checksum if sql(file) content change - #version"(ChecksumVersions version, String originalChecksum, String updatedChecksum) {
+    def "validate checksum if sql(file) content change - #version"(ChecksumVersion version, String originalChecksum, String updatedChecksum) {
         when:
         String procedureText =
         """CREATE OR REPLACE PROCEDURE testHello()
@@ -176,7 +176,7 @@ class SQLFileChangeTest extends StandardChangeTest {
 
         where:
         version | originalChecksum | updatedChecksum
-        ChecksumVersions.V8 | "8:25560f4c442fa581b820d0a6206fd14e" | "8:b934d68e53222bc7b5cbf147ce6746b4"
+        ChecksumVersion.V8 | "8:25560f4c442fa581b820d0a6206fd14e" | "8:b934d68e53222bc7b5cbf147ce6746b4"
         LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue() | "9:8cfbd3e5970885470db17cd149feb637" | "9:f6302129ace10ca356faa21343dd1aa8"
     }
 }

--- a/liquibase-standard/src/test/groovy/liquibase/changelog/ChangeSetTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/changelog/ChangeSetTest.groovy
@@ -92,7 +92,7 @@ public class ChangeSetTest extends Specification {
 
     def isCheckSumValid_invalidCheckSum() {
         when:
-        def checkSum = CheckSum.parse("2:asdf");
+        def checkSum = CheckSum.parse("8:asdf");
         def changeSet = new ChangeSet("1", "2", false, false, "/test.xml", null, null, null);
 
         then:
@@ -101,7 +101,7 @@ public class ChangeSetTest extends Specification {
 
     def isCheckSumValid_differentButValidCheckSum() {
         when:
-        CheckSum checkSum = CheckSum.parse("2:asdf");
+        CheckSum checkSum = CheckSum.parse("8:asdf");
 
         ChangeSet changeSet = new ChangeSet("1", "2", false, false, "/test.xml", null, null, null);
         changeSet.addValidCheckSum(changeSet.generateCheckSum().toString());

--- a/liquibase-standard/src/test/java/liquibase/change/AbstractSQLChangeTest.java
+++ b/liquibase-standard/src/test/java/liquibase/change/AbstractSQLChangeTest.java
@@ -1,9 +1,8 @@
 package liquibase.change;
 
-import liquibase.ChecksumVersions;
+import liquibase.ChecksumVersion;
 import liquibase.Scope;
 import liquibase.database.core.MSSQLDatabase;
-import liquibase.integration.commandline.LiquibaseCommandLineConfiguration;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.RawSqlStatement;
 import liquibase.util.StreamUtil;
@@ -85,7 +84,7 @@ public class AbstractSQLChangeTest {
         CheckSum sql = new ExampleAbstractSQLChange("LINE 1;\nLINE 2;\nLINE3;").generateCheckSum();
         CheckSum sqlCRLF = new ExampleAbstractSQLChange("LINE 1;\r\nLINE 2;\r\nLINE3;").generateCheckSum();
         CheckSum sqlLF = new ExampleAbstractSQLChange("LINE 1;\rLINE 2;\rLINE3;").generateCheckSum();
-        CheckSum sqlDifferent = Scope.child(Collections.singletonMap(Scope.Attr.checksumVersion.name(), ChecksumVersions.V8), () ->
+        CheckSum sqlDifferent = Scope.child(Collections.singletonMap(Scope.Attr.checksumVersion.name(), ChecksumVersion.V8), () ->
                 new ExampleAbstractSQLChange("Something Completely Different").generateCheckSum());
 
         assertEquals(sql.toString(), sqlCRLF.toString());
@@ -121,17 +120,17 @@ public class AbstractSQLChangeTest {
 
         final ExampleAbstractSQLChange change = new ExampleAbstractSQLChange("SOME SQL");
         change.setSplitStatements(false);
-        assertNotEquals(baseCheckSum.toString(), Scope.child(Collections.singletonMap(Scope.Attr.checksumVersion.name(), ChecksumVersions.V8), () ->
+        assertNotEquals(baseCheckSum.toString(), Scope.child(Collections.singletonMap(Scope.Attr.checksumVersion.name(), ChecksumVersion.V8), () ->
                 change.generateCheckSum().toString()));
 
         final ExampleAbstractSQLChange change2 = new ExampleAbstractSQLChange("SOME SQL");
         change2.setEndDelimiter("X");
-        assertNotEquals(baseCheckSum.toString(),  Scope.child(Collections.singletonMap(Scope.Attr.checksumVersion.name(), ChecksumVersions.V8), () ->
+        assertNotEquals(baseCheckSum.toString(),  Scope.child(Collections.singletonMap(Scope.Attr.checksumVersion.name(), ChecksumVersion.V8), () ->
                 change2.generateCheckSum().toString()));
 
         final ExampleAbstractSQLChange change3 = new ExampleAbstractSQLChange("SOME SQL");
         change3.setStripComments(true);
-        assertNotEquals(baseCheckSum.toString(),  Scope.child(Collections.singletonMap(Scope.Attr.checksumVersion.name(), ChecksumVersions.V8), () ->
+        assertNotEquals(baseCheckSum.toString(),  Scope.child(Collections.singletonMap(Scope.Attr.checksumVersion.name(), ChecksumVersion.V8), () ->
                 change3.generateCheckSum().toString()));
     }
 

--- a/liquibase-standard/src/test/java/liquibase/change/AbstractSQLChangeTest.java
+++ b/liquibase-standard/src/test/java/liquibase/change/AbstractSQLChangeTest.java
@@ -248,21 +248,21 @@ public class AbstractSQLChangeTest {
 
     @Test
     public void normalizeSql_V8() throws IOException {
-        assertNormalizingStreamCorrectV8("singlelineString", "single line String");
-        assertNormalizingStreamCorrectV8("singlelinestringwithwhitespace", "single line string with      whitespace");
-        assertNormalizingStreamCorrectV8("multiplelinestring", "\r\nmultiple\r\nline\r\nstring\r\n");
-        assertNormalizingStreamCorrectV8("multiplelinestring", "\rmultiple\rline\rstring\r");
-        assertNormalizingStreamCorrectV8("multiplelinestring", "\nmultiple\nline\nstring\n");
-        assertNormalizingStreamCorrectV8("alinewithdoublenewlines", "\n\na\nline \n with \r\n \r\n double \n \n \n \n newlines");
+        assertNormalizingStreamCorrectV8("single line String", "single line String");
+        assertNormalizingStreamCorrectV8("single line string with whitespace", "single line string with      whitespace");
+        assertNormalizingStreamCorrectV8("multiple line string", "\r\nmultiple\r\nline\r\nstring\r\n");
+        assertNormalizingStreamCorrectV8("multiple line string", "\rmultiple\rline\rstring\r");
+        assertNormalizingStreamCorrectV8("multiple line string", "\nmultiple\nline\nstring\n");
+        assertNormalizingStreamCorrectV8("a line with double newlines", "\n\na\nline \n with \r\n \r\n double \n \n \n \n newlines");
 //        assertNormalizingStreamCorrectV8("", null);
         assertNormalizingStreamCorrectV8("", "    ");
         assertNormalizingStreamCorrectV8("", " \n \n \n   \n  ");
 
         //test quickBuffer -> resizingBuffer handoff
         String longSpaceString = "a line with a lot of: wait for it....                                                                                                                                                                                                                                                                                         spaces";
-        assertNormalizingStreamCorrectV8("alinewithalotof:waitforit....spaces", longSpaceString);
+        assertNormalizingStreamCorrectV8("a line with a lot of: wait for it.... spaces", longSpaceString);
 
-        String versionNormalized = "INSERTINTOrecommendation_list(instanceId,name,publicId)SELECTDISTINCTinstanceId,\"default\"asname,\"default\"aspublicIdFROMrecommendation;";
+        String versionNormalized = "INSERT INTO recommendation_list(instanceId, name, publicId) SELECT DISTINCT instanceId, \"default\" as name, \"default\" as publicId FROM recommendation;";
 
         String version1 = "INSERT INTO recommendation_list(instanceId, name, publicId)\n" +
                 "SELECT DISTINCT instanceId, \"default\" as name, \"default\" as publicId\n" +

--- a/liquibase-standard/src/test/java/liquibase/change/ChangeFactoryTest.java
+++ b/liquibase-standard/src/test/java/liquibase/change/ChangeFactoryTest.java
@@ -49,8 +49,8 @@ public class ChangeFactoryTest {
         Change change8 = new CreateTableChange();
         Change change9 = new CreateTableChange();
 
-        ChangeMetaData changeMetaData8 = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), ChecksumVersion.V8), () -> changeFactory.getChangeMetaData(change8));
-        ChangeMetaData changeMetaData9 = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), ChecksumVersion.V9), () -> changeFactory.getChangeMetaData(change9));
+        ChangeMetaData changeMetaData8 = Scope.child(Collections.singletonMap(Scope.Attr.checksumVersion.name(), ChecksumVersion.V8), () -> changeFactory.getChangeMetaData(change8));
+        ChangeMetaData changeMetaData9 = Scope.child(Collections.singletonMap(Scope.Attr.checksumVersion.name(), ChecksumVersion.V9), () -> changeFactory.getChangeMetaData(change9));
 
         assertNotEquals(changeMetaData8, changeMetaData9);
     }

--- a/liquibase-standard/src/test/java/liquibase/change/ChangeFactoryTest.java
+++ b/liquibase-standard/src/test/java/liquibase/change/ChangeFactoryTest.java
@@ -1,6 +1,6 @@
 package liquibase.change;
 
-import liquibase.ChecksumVersions;
+import liquibase.ChecksumVersion;
 import liquibase.Scope;
 import liquibase.change.core.CreateTableChange;
 import liquibase.database.core.MSSQLDatabase;
@@ -49,8 +49,8 @@ public class ChangeFactoryTest {
         Change change8 = new CreateTableChange();
         Change change9 = new CreateTableChange();
 
-        ChangeMetaData changeMetaData8 = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), ChecksumVersions.V8), () -> changeFactory.getChangeMetaData(change8));
-        ChangeMetaData changeMetaData9 = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), ChecksumVersions.V9), () -> changeFactory.getChangeMetaData(change9));
+        ChangeMetaData changeMetaData8 = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), ChecksumVersion.V8), () -> changeFactory.getChangeMetaData(change8));
+        ChangeMetaData changeMetaData9 = Scope.child(Collections.singletonMap(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getKey(), ChecksumVersion.V9), () -> changeFactory.getChangeMetaData(change9));
 
         assertNotEquals(changeMetaData8, changeMetaData9);
     }

--- a/liquibase-standard/src/test/java/liquibase/change/CheckSumTest.java
+++ b/liquibase-standard/src/test/java/liquibase/change/CheckSumTest.java
@@ -1,6 +1,6 @@
 package liquibase.change;
 
-import liquibase.ChecksumVersions;
+import liquibase.ChecksumVersion;
 import liquibase.integration.commandline.LiquibaseCommandLineConfiguration;
 import org.junit.Test;
 
@@ -33,7 +33,7 @@ public class CheckSumTest {
 
     @Test
     public void getCurrentVersion() {
-        assertEquals(ChecksumVersions.V9, LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue());
+        assertEquals(ChecksumVersion.V9, LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue());
     }
 
     @Test

--- a/liquibase-standard/src/test/java/liquibase/change/CheckSumTest.java
+++ b/liquibase-standard/src/test/java/liquibase/change/CheckSumTest.java
@@ -39,15 +39,15 @@ public class CheckSumTest {
     @Test
     public void compute_String() {
         String valueToHash = "asdf";
-        CheckSum checkSum = CheckSum.compute(valueToHash, LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue());
+        CheckSum checkSum = CheckSum.compute(valueToHash);
         assertEquals(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue().getVersion(), checkSum.getVersion());
         assertNotEquals(checkSum.toString(), valueToHash);
     }
 
     @Test
     public void compute_String_shouldIgnoreUnknownUnicodeChar() {
-        CheckSum checkSum1 = CheckSum.compute("asdfa", LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue());
-        CheckSum checkSum2 = CheckSum.compute("as\uFFFDdf\uFFFDa", LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue());
+        CheckSum checkSum1 = CheckSum.compute("asdfa");
+        CheckSum checkSum2 = CheckSum.compute("as\uFFFDdf\uFFFDa");
 
         assertEquals(checkSum2, checkSum1);
     }
@@ -55,10 +55,10 @@ public class CheckSumTest {
     @Test
     public void compute_Stream() {
         String valueToHash = "asdf";
-        CheckSum checkSum = CheckSum.compute(new ByteArrayInputStream(valueToHash.getBytes()), false, LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue());
+        CheckSum checkSum = CheckSum.compute(new ByteArrayInputStream(valueToHash.getBytes()), false);
         assertEquals(LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue().getVersion(), checkSum.getVersion());
         assertNotEquals(checkSum.toString(), valueToHash);
-        assertEquals(CheckSum.compute(valueToHash, LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue()).toString(), checkSum.toString());
+        assertEquals(CheckSum.compute(valueToHash).toString(), checkSum.toString());
     }
 
     @Test
@@ -78,27 +78,27 @@ public class CheckSumTest {
 
     @Test
     public void compute_lineEndingsDontMatter() {
-        String checkSum = CheckSum.compute("a string\nwith\nlines", LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue()).toString();
-        assertEquals(checkSum, CheckSum.compute("a string\rwith\rlines", LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue()).toString());
-        assertEquals(checkSum, CheckSum.compute("a string\r\nwith\r\nlines", LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue()).toString());
-        assertEquals(checkSum, CheckSum.compute("a string\rwith\nlines", LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue()).toString());
+        String checkSum = CheckSum.compute("a string\nwith\nlines").toString();
+        assertEquals(checkSum, CheckSum.compute("a string\rwith\rlines").toString());
+        assertEquals(checkSum, CheckSum.compute("a string\r\nwith\r\nlines").toString());
+        assertEquals(checkSum, CheckSum.compute("a string\rwith\nlines").toString());
 
-        assertNotEquals(checkSum, CheckSum.compute("a string\n\nwith\n\nlines", LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue()).toString());
+        assertNotEquals(checkSum, CheckSum.compute("a string\n\nwith\n\nlines").toString());
 
-        assertEquals(checkSum, CheckSum.compute(new ByteArrayInputStream("a string\nwith\nlines".getBytes()), true, LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue()).toString());
-        assertEquals(checkSum, CheckSum.compute(new ByteArrayInputStream("a string\rwith\rlines".getBytes()), true, LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue()).toString());
-        assertEquals(checkSum, CheckSum.compute(new ByteArrayInputStream("a string\r\nwith\r\nlines".getBytes()), true, LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue()).toString());
-        assertEquals(checkSum, CheckSum.compute(new ByteArrayInputStream("a string\rwith\r\nlines".getBytes()), true, LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue()).toString());
+        assertEquals(checkSum, CheckSum.compute(new ByteArrayInputStream("a string\nwith\nlines".getBytes()), true).toString());
+        assertEquals(checkSum, CheckSum.compute(new ByteArrayInputStream("a string\rwith\rlines".getBytes()), true).toString());
+        assertEquals(checkSum, CheckSum.compute(new ByteArrayInputStream("a string\r\nwith\r\nlines".getBytes()), true).toString());
+        assertEquals(checkSum, CheckSum.compute(new ByteArrayInputStream("a string\rwith\r\nlines".getBytes()), true).toString());
     }
 
     @Test
     public void compute_lineEndingsDontMatter_multiline() {
-        String checkSum = CheckSum.compute("a string\n\nwith\n\nlines", LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue()).toString();
-        assertEquals(checkSum, CheckSum.compute("a string\r\rwith\r\rlines", LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue()).toString());
-        assertEquals(checkSum, CheckSum.compute("a string\r\n\r\nwith\r\n\r\nlines", LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue()).toString());
+        String checkSum = CheckSum.compute("a string\n\nwith\n\nlines").toString();
+        assertEquals(checkSum, CheckSum.compute("a string\r\rwith\r\rlines").toString());
+        assertEquals(checkSum, CheckSum.compute("a string\r\n\r\nwith\r\n\r\nlines").toString());
 
-        assertEquals(checkSum, CheckSum.compute(new ByteArrayInputStream("a string\n\nwith\n\nlines".getBytes()), true, LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue()).toString());
-        assertEquals(checkSum, CheckSum.compute(new ByteArrayInputStream("a string\r\rwith\r\rlines".getBytes()), true, LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue()).toString());
-        assertEquals(checkSum, CheckSum.compute(new ByteArrayInputStream("a string\r\n\r\nwith\r\n\r\nlines".getBytes()), true, LiquibaseCommandLineConfiguration.CHECKSUM_VERSION.getCurrentValue()).toString());
+        assertEquals(checkSum, CheckSum.compute(new ByteArrayInputStream("a string\n\nwith\n\nlines".getBytes()), true).toString());
+        assertEquals(checkSum, CheckSum.compute(new ByteArrayInputStream("a string\r\rwith\r\rlines".getBytes()), true).toString());
+        assertEquals(checkSum, CheckSum.compute(new ByteArrayInputStream("a string\r\n\r\nwith\r\n\r\nlines".getBytes()), true).toString());
     }
 }

--- a/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/UpdateChangeSetChecksumGeneratorTest.java
+++ b/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/UpdateChangeSetChecksumGeneratorTest.java
@@ -1,6 +1,5 @@
 package liquibase.sqlgenerator.core;
 
-import liquibase.ChecksumVersions;
 import liquibase.change.CheckSum;
 import liquibase.changelog.ChangeSet;
 import liquibase.database.Database;


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

- Rename Enum ChecksumVersions to ChecksumVersion (-s)
- Add all previous versions to the enum (v1, V2, etc)
- Compare using version.lowerOrEqualThan(V8) instead of version.equals(v8)
- Add ChecksumVersion Enum to the scope inside of Changeset.generateCheckSum() using Scope.child
- Downwards methods can use ChecksumVersion  from the scope instead of getting it from parameter, so restoring the previous method signatures.
- Re-add remaining generateChecksums() for backwards compatibility
- Mark the method as deprecated
