### PR TITLE
Cleanup **DAT** branches

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -37,6 +37,8 @@ jobs:
       # This would still deploy a package if there are test failures. Might help to have build.yml complete and then run this workflow
       # Publish to GitHub Packages
       - name: Publish package
-        run: mvn -B clean deploy -DskipTests=true
+        run: |
+          mvn -B clean deploy -DskipTests=true
+          
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cleanup-branch-builds.yml
+++ b/.github/workflows/cleanup-branch-builds.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         version: "${{ github.event.ref }}-SNAPSHOT"
 
-    - uses: actions/delete-package-versions@v3
+    - uses: actions/delete-package-versions@v4
       if: ${{ steps.version.outputs.ids != '' }}
       with:
         # Name of the package.
@@ -36,4 +36,4 @@ jobs:
 
         # Can be a single package version id, or a comma separated list of package version ids.
         # Defaults to an empty string.
-        package-version-ids: "${{ steps.version.outputs.ids }}"
+        package-version-ids: "${{ steps.versions.outputs.ids }}"

--- a/.github/workflows/cleanup-branch-builds.yml
+++ b/.github/workflows/cleanup-branch-builds.yml
@@ -23,11 +23,6 @@ jobs:
     - uses: actions/delete-package-versions@v4
       if: ${{ steps.version.outputs.ids != '' }}
       with:
-        # Name of the package.
-        # Defaults to an empty string.
-        # Required if `package-version-ids` input is not given.
-        package-name: ${{ matrix.packages_to_delete }}
-
         # The number of latest versions to keep.
         # This cannot be specified with `num-old-versions-to-delete`. By default, `num-old-versions-to-delete` takes precedence over `min-versions-to-keep`.
         # When set to 0, all deletable versions will be deleted.


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 

- cleanup branch delete job.
- We had previously specified "package-name" which contains the matrix of the packages. But it's "Required if `package-version-ids` input is not given". It fetches ALL the id's of the packages in the first run and then ofcourse it complains about "No PackageVersion with ID:" in the later runs for other packages. 