### PR TITLE
Adding support to parameters referenceLiquibaseCatalogName and referenceLiquibaseSchemaName.

### DIFF
--- a/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/diff.test.groovy
+++ b/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/diff.test.groovy
@@ -46,6 +46,10 @@ Optional Args:
     Default: null
   referenceDriverPropertiesFile (String) The JDBC driver properties file for the reference database
     Default: null
+  referenceLiquibaseCatalogName (String) Reference catalog to use for Liquibase objects
+    Default: null
+  referenceLiquibaseSchemaName (String) Reference schema to use for Liquibase objects
+    Default: null
   referencePassword (String) The reference database password
     Default: null
     OBFUSCATED

--- a/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/diffChangelog.test.groovy
+++ b/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/diffChangelog.test.groovy
@@ -60,6 +60,10 @@ Optional Args:
     Default: null
   referenceDriverPropertiesFile (String) The JDBC driver properties file for the reference database
     Default: null
+  referenceLiquibaseCatalogName (String) Reference catalog to use for Liquibase objects
+    Default: null
+  referenceLiquibaseSchemaName (String) Reference schema to use for Liquibase objects
+    Default: null
   referencePassword (String) The reference database password
     Default: null
     OBFUSCATED

--- a/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/snapshotReference.test.groovy
+++ b/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/snapshotReference.test.groovy
@@ -21,6 +21,10 @@ Optional Args:
     Default: null
   referenceDriverPropertiesFile (String) The JDBC driver properties file for the reference database
     Default: null
+  referenceLiquibaseCatalogName (String) Reference catalog to use for Liquibase objects
+    Default: null
+  referenceLiquibaseSchemaName (String) Reference schema to use for Liquibase objects
+    Default: null
   referencePassword (String) The reference database password
     Default: null
     OBFUSCATED

--- a/liquibase-standard/src/main/java/liquibase/command/core/GenerateChangelogCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/GenerateChangelogCommandStep.java
@@ -46,6 +46,8 @@ public class GenerateChangelogCommandStep extends AbstractCommandStep {
     public static final CommandArgumentDefinition<String> REFERENCE_DRIVER_ARG;
     public static final CommandArgumentDefinition<String> REFERENCE_DRIVER_PROPERTIES_FILE_ARG;
     public static final CommandArgumentDefinition<String> REFERENCE_SCHEMAS_ARG;
+    public static final CommandArgumentDefinition<String> REFERENCE_LIQUIBASE_SCHEMA_NAME_ARG;
+    public static final CommandArgumentDefinition<String> REFERENCE_LIQUIBASE_CATALOG_NAME_ARG;
 
     static {
         final CommandBuilder builder = new CommandBuilder(COMMAND_NAME);
@@ -82,6 +84,10 @@ public class GenerateChangelogCommandStep extends AbstractCommandStep {
         REFERENCE_PASSWORD_ARG = builder.argument("referencePassword", String.class).hidden()
                 .setValueObfuscator(ConfigurationValueObfuscator.STANDARD).build();
         REFERENCE_SCHEMAS_ARG = builder.argument("referenceSchemas", String.class).hidden().build();
+        REFERENCE_LIQUIBASE_SCHEMA_NAME_ARG = builder.argument("referenceLiquibaseSchemaName", String.class)
+                .hidden().build();
+        REFERENCE_LIQUIBASE_CATALOG_NAME_ARG = builder.argument("referenceLiquibaseCatalogName", String.class)
+                .hidden().build();
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/AbstractDatabaseConnectionCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/AbstractDatabaseConnectionCommandStep.java
@@ -9,7 +9,6 @@ import liquibase.database.DatabaseFactory;
 import liquibase.database.core.DatabaseUtils;
 import liquibase.exception.DatabaseException;
 import liquibase.integration.commandline.LiquibaseCommandLineConfiguration;
-import liquibase.logging.mdc.MdcKey;
 import liquibase.resource.ResourceAccessor;
 import liquibase.util.StringUtil;
 
@@ -49,8 +48,9 @@ public abstract class AbstractDatabaseConnectionCommandStep extends AbstractHelp
                                         String defaultSchemaName,
                                         String defaultCatalogName,
                                         String driver,
-                                        String driverPropertiesFile)
-            throws DatabaseException {
+                                        String driverPropertiesFile,
+                                        String liquibaseCatalogName,
+                                        String liquibaseSchemaName) throws DatabaseException {
         ResourceAccessor resourceAccessor = Scope.getCurrentScope().getResourceAccessor();
         String databaseClassName = null;
         Class<?> databaseClass = LiquibaseCommandLineConfiguration.DATABASE_CLASS.getCurrentValue();
@@ -62,8 +62,6 @@ public abstract class AbstractDatabaseConnectionCommandStep extends AbstractHelp
         if (clazz != null) {
             propertyProviderClass = clazz.getName();
         }
-        String liquibaseCatalogName = StringUtil.trimToNull(GlobalConfiguration.LIQUIBASE_CATALOG_NAME.getCurrentValue());
-        String liquibaseSchemaName = StringUtil.trimToNull(GlobalConfiguration.LIQUIBASE_SCHEMA_NAME.getCurrentValue());
         String databaseChangeLogTablespaceName = StringUtil.trimToNull(GlobalConfiguration.LIQUIBASE_TABLESPACE_NAME.getCurrentValue());
         String databaseChangeLogLockTableName = StringUtil.trimToNull(GlobalConfiguration.DATABASECHANGELOGLOCK_TABLE_NAME.getCurrentValue());
         String databaseChangeLogTableName = StringUtil.trimToNull(GlobalConfiguration.DATABASECHANGELOG_TABLE_NAME.getCurrentValue());

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/DbUrlConnectionCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/DbUrlConnectionCommandStep.java
@@ -1,12 +1,14 @@
 package liquibase.command.core.helpers;
 
 import liquibase.Beta;
+import liquibase.GlobalConfiguration;
 import liquibase.Scope;
 import liquibase.command.*;
 import liquibase.configuration.ConfigurationValueObfuscator;
 import liquibase.database.Database;
 import liquibase.exception.DatabaseException;
 import liquibase.logging.mdc.MdcKey;
+import liquibase.util.StringUtil;
 
 import java.util.Collections;
 import java.util.List;
@@ -89,7 +91,9 @@ public class DbUrlConnectionCommandStep extends AbstractDatabaseConnectionComman
             String defaultCatalogName = commandScope.getArgumentValue(DEFAULT_CATALOG_NAME_ARG);
             String driver = commandScope.getArgumentValue(DRIVER_ARG);
             String driverPropertiesFile = commandScope.getArgumentValue(DRIVER_PROPERTIES_FILE_ARG);
-            Database database = createDatabaseObject(url, username, password, defaultSchemaName, defaultCatalogName, driver, driverPropertiesFile);
+            Database database = createDatabaseObject(url, username, password, defaultSchemaName, defaultCatalogName, driver, driverPropertiesFile,
+                    StringUtil.trimToNull(GlobalConfiguration.LIQUIBASE_CATALOG_NAME.getCurrentValue()),
+                    StringUtil.trimToNull(GlobalConfiguration.LIQUIBASE_SCHEMA_NAME.getCurrentValue()));
             logMdc(url, database);
             return database;
         } else {

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/ReferenceDbUrlConnectionCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/ReferenceDbUrlConnectionCommandStep.java
@@ -7,6 +7,7 @@ import liquibase.configuration.ConfigurationValueObfuscator;
 import liquibase.database.Database;
 import liquibase.exception.DatabaseException;
 import liquibase.logging.mdc.MdcKey;
+import liquibase.util.StringUtil;
 
 import java.util.Collections;
 import java.util.List;
@@ -26,6 +27,8 @@ public class ReferenceDbUrlConnectionCommandStep extends AbstractDatabaseConnect
     public static final CommandArgumentDefinition<String> REFERENCE_DEFAULT_CATALOG_NAME_ARG;
     public static final CommandArgumentDefinition<String> REFERENCE_DRIVER_ARG;
     public static final CommandArgumentDefinition<String> REFERENCE_DRIVER_PROPERTIES_FILE_ARG;
+    public static final CommandArgumentDefinition<String> REFERENCE_LIQUIBASE_SCHEMA_NAME_ARG;
+    public static final CommandArgumentDefinition<String> REFERENCE_LIQUIBASE_CATALOG_NAME_ARG;
 
 
     static {
@@ -48,6 +51,11 @@ public class ReferenceDbUrlConnectionCommandStep extends AbstractDatabaseConnect
         REFERENCE_URL_ARG = builder.argument("referenceUrl", String.class).required().supersededBy(REFERENCE_DATABASE_ARG)
                 .description("The JDBC reference database connection URL").build();
         REFERENCE_DATABASE_ARG.setSupersededBy(REFERENCE_URL_ARG);
+
+        REFERENCE_LIQUIBASE_SCHEMA_NAME_ARG = builder.argument("referenceLiquibaseSchemaName", String.class)
+                .description("Reference schema to use for Liquibase objects").build();
+        REFERENCE_LIQUIBASE_CATALOG_NAME_ARG = builder.argument("referenceLiquibaseCatalogName", String.class)
+                .description("Reference catalog to use for Liquibase objects").build();
     }
 
     @Override
@@ -77,7 +85,9 @@ public class ReferenceDbUrlConnectionCommandStep extends AbstractDatabaseConnect
             String driver = commandScope.getArgumentValue(REFERENCE_DRIVER_ARG);
             String driverPropertiesFile = commandScope.getArgumentValue(REFERENCE_DRIVER_PROPERTIES_FILE_ARG);
             logMdc(url, username, defaultSchemaName, defaultCatalogName);
-            return createDatabaseObject(url, username, password, defaultSchemaName, defaultCatalogName, driver, driverPropertiesFile);
+            return createDatabaseObject(url, username, password, defaultSchemaName, defaultCatalogName, driver, driverPropertiesFile,
+                    StringUtil.trimToNull(commandScope.getArgumentValue(REFERENCE_LIQUIBASE_CATALOG_NAME_ARG)),
+                    StringUtil.trimToNull(commandScope.getArgumentValue(REFERENCE_LIQUIBASE_SCHEMA_NAME_ARG)));
         } else {
             return commandScope.getArgumentValue(REFERENCE_DATABASE_ARG);
         }


### PR DESCRIPTION

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Adding support to parameters referenceLiquibaseCatalogName and referenceLiquibaseSchemaName.

Instead of adding a global parameter as referenceCatalogName and referenceSchemaName, it was added as a parameter only to the commands that would use it, namely: Diff, diffChangelog and SnapshotReference .