### PR TITLE
Quick incomplete patch for #4239

### DIFF
--- a/liquibase-integration-tests/src/test/groovy/liquibase/diffchangelog/DiffChangelogIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/diffchangelog/DiffChangelogIntegrationTest.groovy
@@ -1,7 +1,6 @@
 package liquibase.diffchangelog
 
 import liquibase.Scope
-import liquibase.UpdateSummaryEnum
 import liquibase.change.core.AddForeignKeyConstraintChange
 import liquibase.change.core.DropForeignKeyConstraintChange
 import liquibase.changelog.ChangeLogParameters
@@ -9,7 +8,6 @@ import liquibase.changelog.ChangeSet
 import liquibase.changelog.DatabaseChangeLog
 import liquibase.command.CommandScope
 import liquibase.command.core.DiffChangelogCommandStep
-import liquibase.command.core.UpdateCommandStep
 import liquibase.command.core.helpers.*
 import liquibase.command.util.CommandUtil
 import liquibase.database.Database
@@ -100,7 +98,7 @@ CREATE TABLE $tableName ( product_no varchar(20) DEFAULT nextval('$sequenceName'
         commandScope.execute()
         def generatedChangelog = new File(diffChangelogFile)
         DatabaseChangeLog changelog =
-                new JsonChangeLogParser().parse(diffChangelogFile, new ChangeLogParameters(), new SearchPathResourceAccessor("."))
+                new JsonChangeLogParser().parse(diffChangelogFile, null, new ChangeLogParameters(), new SearchPathResourceAccessor("."))
         List<ChangeSet> changeSets = changelog.getChangeSets()
 
         then:

--- a/liquibase-integration-tests/src/test/groovy/liquibase/snapshot/IndexWithDescendingColumnSnapshotIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/snapshot/IndexWithDescendingColumnSnapshotIntegrationTest.groovy
@@ -171,7 +171,7 @@ class IndexWithDescendingColumnSnapshotIntegrationTest extends Specification {
         generateChangelogScope.execute()
 
         ResourceAccessor resourceAccessor = new SearchPathResourceAccessor(".")
-        DatabaseChangeLog changelog = new JsonChangeLogParser().parse(changelogFile, new ChangeLogParameters(), resourceAccessor)
+        DatabaseChangeLog changelog = new JsonChangeLogParser().parse(changelogFile, null, new ChangeLogParameters(), resourceAccessor)
         def changeSets = changelog.getChangeSets()
         ChangeSet indexChangeSet = changeSets.get(1)
         CreateIndexChange createIndexChange = indexChangeSet.getChanges().get(0)

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/IntXMLChangeLogSAXParserTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/IntXMLChangeLogSAXParserTest.java
@@ -8,19 +8,19 @@ import org.junit.Test;
 public class IntXMLChangeLogSAXParserTest {
     @Test
     public void sampleChangeLogs() throws Exception {
-        new XMLChangeLogSAXParser().parse("changelogs/cache/complete/root.changelog.xml", new ChangeLogParameters(), new JUnitResourceAccessor());
-        new XMLChangeLogSAXParser().parse("changelogs/db2/complete/root.changelog.xml", new ChangeLogParameters(), new JUnitResourceAccessor());
-        new XMLChangeLogSAXParser().parse("changelogs/derby/complete/root.changelog.xml", new ChangeLogParameters(), new JUnitResourceAccessor());
-        new XMLChangeLogSAXParser().parse("changelogs/firebird/complete/root.changelog.xml", new ChangeLogParameters(), new JUnitResourceAccessor());
-        new XMLChangeLogSAXParser().parse("changelogs/h2/complete/root.changelog.xml", new ChangeLogParameters(), new JUnitResourceAccessor());
-        new XMLChangeLogSAXParser().parse("changelogs/hsqldb/complete/root.changelog.xml", new ChangeLogParameters(), new JUnitResourceAccessor());
-        new XMLChangeLogSAXParser().parse("changelogs/maxdb/complete/root.changelog.xml", new ChangeLogParameters(), new JUnitResourceAccessor());
-        new XMLChangeLogSAXParser().parse("changelogs/mysql/complete/root.changelog.xml", new ChangeLogParameters(), new JUnitResourceAccessor());
-        new XMLChangeLogSAXParser().parse("changelogs/oracle/complete/root.changelog.xml", new ChangeLogParameters(), new JUnitResourceAccessor());
-        new XMLChangeLogSAXParser().parse("changelogs/pgsql/complete/root.changelog.xml", new ChangeLogParameters(), new JUnitResourceAccessor());
-        new XMLChangeLogSAXParser().parse("changelogs/sybase/complete/root.changelog.xml", new ChangeLogParameters(), new JUnitResourceAccessor());
-        new XMLChangeLogSAXParser().parse("changelogs/asany/complete/root.changelog.xml", new ChangeLogParameters(), new JUnitResourceAccessor());
-        new XMLChangeLogSAXParser().parse("changelogs/unsupported/complete/root.changelog.xml", new ChangeLogParameters(), new JUnitResourceAccessor());
+        new XMLChangeLogSAXParser().parse("changelogs/cache/complete/root.changelog.xml", null, new ChangeLogParameters(), new JUnitResourceAccessor());
+        new XMLChangeLogSAXParser().parse("changelogs/db2/complete/root.changelog.xml", null, new ChangeLogParameters(), new JUnitResourceAccessor());
+        new XMLChangeLogSAXParser().parse("changelogs/derby/complete/root.changelog.xml", null, new ChangeLogParameters(), new JUnitResourceAccessor());
+        new XMLChangeLogSAXParser().parse("changelogs/firebird/complete/root.changelog.xml", null, new ChangeLogParameters(), new JUnitResourceAccessor());
+        new XMLChangeLogSAXParser().parse("changelogs/h2/complete/root.changelog.xml", null, new ChangeLogParameters(), new JUnitResourceAccessor());
+        new XMLChangeLogSAXParser().parse("changelogs/hsqldb/complete/root.changelog.xml", null, new ChangeLogParameters(), new JUnitResourceAccessor());
+        new XMLChangeLogSAXParser().parse("changelogs/maxdb/complete/root.changelog.xml", null, new ChangeLogParameters(), new JUnitResourceAccessor());
+        new XMLChangeLogSAXParser().parse("changelogs/mysql/complete/root.changelog.xml", null, new ChangeLogParameters(), new JUnitResourceAccessor());
+        new XMLChangeLogSAXParser().parse("changelogs/oracle/complete/root.changelog.xml", null, new ChangeLogParameters(), new JUnitResourceAccessor());
+        new XMLChangeLogSAXParser().parse("changelogs/pgsql/complete/root.changelog.xml", null, new ChangeLogParameters(), new JUnitResourceAccessor());
+        new XMLChangeLogSAXParser().parse("changelogs/sybase/complete/root.changelog.xml", null, new ChangeLogParameters(), new JUnitResourceAccessor());
+        new XMLChangeLogSAXParser().parse("changelogs/asany/complete/root.changelog.xml", null, new ChangeLogParameters(), new JUnitResourceAccessor());
+        new XMLChangeLogSAXParser().parse("changelogs/unsupported/complete/root.changelog.xml", null, new ChangeLogParameters(), new JUnitResourceAccessor());
     }
 
 }

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
@@ -624,7 +624,7 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
         boolean useScopeLogger = false;
         if (this.logFormat != null) {
             try {
-                useScopeLogger = LogFormat.valueOf(this.logFormat.toUpperCase()).isUseScopeLoggerInMaven();
+//                useScopeLogger = LogFormat.valueOf(this.logFormat.toUpperCase()).isUseScopeLoggerInMaven();
             } catch (Exception ignored) {
 
             }
@@ -645,9 +645,9 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
             LogService newLogService = Scope.child(scopeAttrs, () -> Scope.getCurrentScope().getSingleton(LogServiceFactory.class).getDefaultLogService());
             // Set the formatter on all the handlers.
             java.util.logging.Logger rootLogger = java.util.logging.Logger.getLogger("");
-            for (Handler handler : rootLogger.getHandlers()) {
-                JavaLogService.setFormatterOnHandler(newLogService, handler);
-            }
+//            for (Handler handler : rootLogger.getHandlers()) {
+//                JavaLogService.setFormatterOnHandler(newLogService, handler);
+//            }
             scopeAttrs.put(Scope.Attr.logService.name(), newLogService);
             return scopeAttrs;
         }

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseDatabaseDiff.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseDatabaseDiff.java
@@ -258,17 +258,13 @@ public class LiquibaseDatabaseDiff extends AbstractLiquibaseChangeLogMojo {
 
             CompareControl.SchemaComparison[] schemaComparisons = createSchemaComparisons(db);
             if (diffChangeLogFile != null) {
-                try {
-                    DiffOutputControl diffOutputControl = new DiffOutputControl(diffIncludeCatalog, diffIncludeSchema, diffIncludeTablespace, null).addIncludedSchema(new CatalogAndSchema(referenceDefaultCatalogName, referenceDefaultSchemaName));
-                    diffOutputControl.setObjectChangeFilter(objectChangeFilter);
-                    CommandLineUtils.doDiffToChangeLog(diffChangeLogFile, referenceDatabase, db, changeSetAuthor, diffOutputControl,
-                            objectChangeFilter, StringUtil.trimToNull(diffTypes), schemaComparisons);
-                    if (new File(diffChangeLogFile).exists()) {
-                        getLog().info("Differences written to Change Log File, " + diffChangeLogFile);
-                    }
-                } catch (IOException | ParserConfigurationException e) {
-                    throw new LiquibaseException(e);
-                }
+                DiffOutputControl diffOutputControl = new DiffOutputControl(diffIncludeCatalog, diffIncludeSchema, diffIncludeTablespace, null).addIncludedSchema(new CatalogAndSchema(referenceDefaultCatalogName, referenceDefaultSchemaName));
+                diffOutputControl.setObjectChangeFilter(objectChangeFilter);
+//                    CommandLineUtils.doDiffToChangeLog(diffChangeLogFile, referenceDatabase, db, changeSetAuthor, diffOutputControl,
+//                            objectChangeFilter, StringUtil.trimToNull(diffTypes), schemaComparisons);
+//                if (new File(diffChangeLogFile).exists()) {
+//                    getLog().info("Differences written to Change Log File, " + diffChangeLogFile);
+//                }
             } else {
                 PrintStream output = createPrintStream();
                 CommandScope liquibaseCommand = new CommandScope("diff");

--- a/liquibase-standard/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-standard/src/main/java/liquibase/Liquibase.java
@@ -29,20 +29,16 @@ import liquibase.io.WriterOutputStream;
 import liquibase.lockservice.DatabaseChangeLogLock;
 import liquibase.lockservice.LockService;
 import liquibase.lockservice.LockServiceFactory;
-import liquibase.logging.LogService;
 import liquibase.logging.Logger;
 import liquibase.logging.mdc.MdcKey;
 import liquibase.logging.mdc.customobjects.ChangesetsRolledback;
 import liquibase.parser.ChangeLogParser;
 import liquibase.parser.ChangeLogParserFactory;
 import liquibase.parser.core.xml.XMLChangeLogSAXParser;
-import liquibase.resource.PathHandlerFactory;
-import liquibase.resource.Resource;
 import liquibase.resource.ResourceAccessor;
 import liquibase.serializer.ChangeLogSerializer;
 import liquibase.structure.DatabaseObject;
 import liquibase.util.LoggingExecutorTextUtil;
-import liquibase.util.StreamUtil;
 import liquibase.util.StringUtil;
 
 import java.io.IOException;
@@ -260,7 +256,7 @@ public class Liquibase implements AutoCloseable {
             if (parser instanceof XMLChangeLogSAXParser) {
                 ((XMLChangeLogSAXParser) parser).setShouldWarnOnMismatchedXsdVersion(shouldWarnOnMismatchedXsdVersion);
             }
-            databaseChangeLog = parser.parse(changeLogFile, changeLogParameters, resourceAccessor);
+            databaseChangeLog = parser.parse(changeLogFile, database, changeLogParameters, resourceAccessor);
             Scope.getCurrentScope().getLog(Liquibase.class).info("Parsed changelog file '" + changeLogFile + "'");
             if (StringUtil.isNotEmpty(databaseChangeLog.getLogicalFilePath())) {
                 Scope.getCurrentScope().addMdcValue(MdcKey.CHANGELOG_FILE, databaseChangeLog.getLogicalFilePath());

--- a/liquibase-standard/src/main/java/liquibase/change/AbstractChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/AbstractChange.java
@@ -631,7 +631,7 @@ public abstract class AbstractChange extends AbstractPlugin implements Change {
     }
 
     @Override
-    public void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException {
+    public void load(ParsedNode parsedNode, Database database, ResourceAccessor resourceAccessor) throws ParsedNodeException {
         ChangeMetaData metaData = Scope.getCurrentScope().getSingleton(ChangeFactory.class).getChangeMetaData(this);
 
         try {
@@ -664,12 +664,12 @@ public abstract class AbstractChange extends AbstractPlugin implements Change {
                                     if ((columnChildren != null) && !columnChildren.isEmpty()) {
                                         for (ParsedNode columnChild : columnChildren) {
                                             ColumnConfig columnConfig = createEmptyColumnConfig(collectionType);
-                                            columnConfig.load(columnChild, resourceAccessor);
+                                            columnConfig.load(columnChild, null, resourceAccessor);
                                             ((ChangeWithColumns) this).addColumn(columnConfig);
                                         }
                                     } else {
                                         ColumnConfig columnConfig = createEmptyColumnConfig(collectionType);
-                                        columnConfig.load(child, resourceAccessor);
+                                        columnConfig.load(child, null, resourceAccessor);
                                         ((ChangeWithColumns) this).addColumn(columnConfig);
                                     }
                                 }
@@ -707,13 +707,13 @@ public abstract class AbstractChange extends AbstractPlugin implements Change {
                                         for (ParsedNode childNode : childNodes) {
                                             LiquibaseSerializable childObject =
                                                 (LiquibaseSerializable)collectionType.getConstructor().newInstance();
-                                            childObject.load(childNode, resourceAccessor);
+                                            childObject.load(childNode, null, resourceAccessor);
                                             ((Collection) param.getCurrentValue(this)).add(childObject);
                                         }
                                     } else {
                                         LiquibaseSerializable childObject =
                                             (LiquibaseSerializable) collectionType.getConstructor().newInstance();
-                                        childObject.load(node, resourceAccessor);
+                                        childObject.load(node, null, resourceAccessor);
                                         ((Collection) param.getCurrentValue(this)).add(childObject);
                                     }
                                }
@@ -729,7 +729,7 @@ public abstract class AbstractChange extends AbstractPlugin implements Change {
                             if (child != null) {
                                 LiquibaseSerializable serializableChild =
                                     (LiquibaseSerializable) param.getDataTypeClass().getConstructor().newInstance();
-                                serializableChild.load(child, resourceAccessor);
+                                serializableChild.load(child, null, resourceAccessor);
                                 param.setValue(this, serializableChild);
                             }
                         } catch (ReflectiveOperationException e) {

--- a/liquibase-standard/src/main/java/liquibase/change/AddColumnConfig.java
+++ b/liquibase-standard/src/main/java/liquibase/change/AddColumnConfig.java
@@ -1,6 +1,7 @@
 package liquibase.change;
 
 
+import liquibase.database.Database;
 import liquibase.parser.core.ParsedNode;
 import liquibase.parser.core.ParsedNodeException;
 import liquibase.resource.ResourceAccessor;
@@ -44,8 +45,8 @@ public class AddColumnConfig extends ColumnConfig {
     }
 
     @Override
-    public void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException {
-        super.load(parsedNode, resourceAccessor);
+    public void load(ParsedNode parsedNode, Database database, ResourceAccessor resourceAccessor) throws ParsedNodeException {
+        super.load(parsedNode, database, resourceAccessor);
         this.beforeColumn = parsedNode.getChildValue(null, "beforeColumn", String.class);
         this.afterColumn = parsedNode.getChildValue(null, "afterColumn", String.class);
         this.position = parsedNode.getChildValue(null, "position", Integer.class);

--- a/liquibase-standard/src/main/java/liquibase/change/ColumnConfig.java
+++ b/liquibase-standard/src/main/java/liquibase/change/ColumnConfig.java
@@ -1,5 +1,6 @@
 package liquibase.change;
 
+import liquibase.database.Database;
 import liquibase.exception.DateParseException;
 import liquibase.parser.core.ParsedNode;
 import liquibase.parser.core.ParsedNodeException;
@@ -778,7 +779,7 @@ public class ColumnConfig extends AbstractLiquibaseSerializable {
     }
 
     @Override
-    public void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException {
+    public void load(ParsedNode parsedNode, Database database, ResourceAccessor resourceAccessor) throws ParsedNodeException {
         for (ParsedNode child : parsedNode.getChildren()) {
             if (!ObjectUtil.hasProperty(this, child.getName())) {
                 throw new ParsedNodeException("Unexpected node: "+child.getName());

--- a/liquibase-standard/src/main/java/liquibase/change/ConstraintsConfig.java
+++ b/liquibase-standard/src/main/java/liquibase/change/ConstraintsConfig.java
@@ -1,5 +1,6 @@
 package liquibase.change;
 
+import liquibase.database.Database;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.parser.core.ParsedNode;
 import liquibase.parser.core.ParsedNodeException;
@@ -433,7 +434,7 @@ public class ConstraintsConfig extends AbstractLiquibaseSerializable {
     }
 
     @Override
-    public void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException {
+    public void load(ParsedNode parsedNode, Database database, ResourceAccessor resourceAccessor) throws ParsedNodeException {
         throw new RuntimeException("TODO");
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/change/core/DeleteDataChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/DeleteDataChange.java
@@ -50,7 +50,7 @@ public class DeleteDataChange extends AbstractModifyDataChange {
             for (ParsedNode param : whereParams.getChildren(null, "param")) {
                 ColumnConfig columnConfig = new ColumnConfig();
                 try {
-                    columnConfig.load(param, resourceAccessor);
+                    columnConfig.load(param, null, resourceAccessor);
                 } catch (ParsedNodeException e) {
                     e.printStackTrace();
                 }

--- a/liquibase-standard/src/main/java/liquibase/change/core/LoadDataColumnConfig.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/LoadDataColumnConfig.java
@@ -1,6 +1,7 @@
 package liquibase.change.core;
 
 import liquibase.change.ColumnConfig;
+import liquibase.database.Database;
 import liquibase.parser.core.ParsedNode;
 import liquibase.parser.core.ParsedNodeException;
 import liquibase.resource.ResourceAccessor;
@@ -41,8 +42,8 @@ public class LoadDataColumnConfig extends ColumnConfig {
 	}
 
     @Override
-    public void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException {
-        super.load(parsedNode, resourceAccessor);
+    public void load(ParsedNode parsedNode, Database database, ResourceAccessor resourceAccessor) throws ParsedNodeException {
+        super.load(parsedNode, database, resourceAccessor);
         this.index = parsedNode.getChildValue(null, "index", Integer.class);
         this.header = parsedNode.getChildValue(null, "header", String.class);
         this.allowUpdate = parsedNode.getChildValue(null, "allowUpdate", Boolean.class);

--- a/liquibase-standard/src/main/java/liquibase/change/core/UpdateDataChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/UpdateDataChange.java
@@ -138,7 +138,7 @@ public class UpdateDataChange extends AbstractModifyDataChange implements Change
             for (ParsedNode param : whereParams.getChildren(null, "param")) {
                 ColumnConfig columnConfig = new ColumnConfig();
                 try {
-                    columnConfig.load(param, resourceAccessor);
+                    columnConfig.load(param, null, resourceAccessor);
                 } catch (ParsedNodeException e) {
                     e.printStackTrace();
                 }

--- a/liquibase-standard/src/main/java/liquibase/change/custom/CustomChangeWrapper.java
+++ b/liquibase-standard/src/main/java/liquibase/change/custom/CustomChangeWrapper.java
@@ -287,7 +287,7 @@ public class CustomChangeWrapper extends AbstractChange {
     }
 
     @Override
-    public void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException {
+    public void load(ParsedNode parsedNode, Database database, ResourceAccessor resourceAccessor) throws ParsedNodeException {
         try {
             String classNameValue = parsedNode.getChildValue(null, "class", String.class);
             if (classNameValue == null) {
@@ -297,7 +297,7 @@ public class CustomChangeWrapper extends AbstractChange {
         } catch (CustomChangeException e) {
             throw new ParsedNodeException(e);
         }
-        super.load(parsedNode, resourceAccessor);
+        super.load(parsedNode, database, resourceAccessor);
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/command/core/CalculateChecksumCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/CalculateChecksumCommandStep.java
@@ -12,7 +12,6 @@ import liquibase.parser.ChangeLogParserFactory;
 import liquibase.resource.ResourceAccessor;
 import liquibase.util.StringUtil;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -63,7 +62,7 @@ public class CalculateChecksumCommandStep extends AbstractCommandStep {
 
         ResourceAccessor resourceAccessor = Scope.getCurrentScope().getResourceAccessor();
         DatabaseChangeLog changeLog = ChangeLogParserFactory.getInstance().getParser(
-                        changeLogFile, resourceAccessor).parse(changeLogFile, new ChangeLogParameters(database), resourceAccessor);
+                        changeLogFile, resourceAccessor).parse(changeLogFile, null, new ChangeLogParameters(database), resourceAccessor);
 
         ChangeSet changeSet = changeLog.getChangeSet(parts.get(CHANGESET_ID_CHANGELOG_PART), parts.get(CHANGESET_ID_AUTHOR_PART),
                 parts.get(CHANGESET_ID_CHANGESET_PART));

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/DatabaseChangelogCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/DatabaseChangelogCommandStep.java
@@ -111,7 +111,7 @@ public class DatabaseChangelogCommandStep extends AbstractHelperCommandStep impl
         if (parser instanceof XMLChangeLogSAXParser) {
             ((XMLChangeLogSAXParser) parser).setShouldWarnOnMismatchedXsdVersion(false);
         }
-        DatabaseChangeLog changelog = parser.parse(changeLogFile, changeLogParameters, resourceAccessor);
+        DatabaseChangeLog changelog = parser.parse(changeLogFile, null, changeLogParameters, resourceAccessor);
         if (StringUtil.isNotEmpty(changelog.getLogicalFilePath())) {
             Scope.getCurrentScope().addMdcValue(MdcKey.CHANGELOG_FILE, changelog.getLogicalFilePath());
         } else {

--- a/liquibase-standard/src/main/java/liquibase/parser/ChangeLogParser.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/ChangeLogParser.java
@@ -2,6 +2,7 @@ package liquibase.parser;
 
 import liquibase.changelog.ChangeLogParameters;
 import liquibase.changelog.DatabaseChangeLog;
+import liquibase.database.Database;
 import liquibase.exception.ChangeLogParseException;
 import liquibase.resource.ResourceAccessor;
 
@@ -13,15 +14,17 @@ public interface ChangeLogParser extends LiquibaseParser {
     
     /**
      * Parses a Liquibase database changelog and returns the parsed form as an object.
+     *
      * @param physicalChangeLogLocation the physical location of the changelog. The exact file formats and locations
-     * where can load changelog files from depend on the implementations and capabilities of the implementing parsers.
-     * @param changeLogParameters parameters given by the end user that should be applied while parsing the changelog
-     *  (i.e. replacement of ${placeholders} inside the changelogs with user-defined content)
-     * @param resourceAccessor a Java resource accessor
+     *                                  where can load changelog files from depend on the implementations and capabilities of the implementing parsers.
+     * @param database
+     * @param changeLogParameters       parameters given by the end user that should be applied while parsing the changelog
+     *                                  (i.e. replacement of ${placeholders} inside the changelogs with user-defined content)
+     * @param resourceAccessor          a Java resource accessor
      * @return the parsed ChangeLog in object form
      * @throws ChangeLogParseException if an error occurs during parsing of the ChangeLog
      */
-    DatabaseChangeLog parse(String physicalChangeLogLocation, ChangeLogParameters changeLogParameters,
+    DatabaseChangeLog parse(String physicalChangeLogLocation, Database database, ChangeLogParameters changeLogParameters,
                             ResourceAccessor resourceAccessor) throws ChangeLogParseException;
     
     /**

--- a/liquibase-standard/src/main/java/liquibase/parser/core/ParsedNode.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/core/ParsedNode.java
@@ -1,6 +1,7 @@
 package liquibase.parser.core;
 
 import liquibase.exception.UnexpectedLiquibaseException;
+import liquibase.serializer.LiquibaseSerializable;
 import liquibase.statement.DatabaseFunction;
 import liquibase.statement.SequenceCurrentValueFunction;
 import liquibase.statement.SequenceNextValueFunction;
@@ -15,7 +16,7 @@ import java.util.*;
  * Acts as a standard abstract syntax layer for changelogs defined in different formats.
  * {@link liquibase.parser.ChangeLogParser} implementations and other classes that work with multiple formats can create objects
  * directs or create instances of this class which can then be passed to the load() method of the object they want to configure.
- * For example, {@link liquibase.change.Change#load(ParsedNode, liquibase.resource.ResourceAccessor)}.
+ * For example, {@link LiquibaseSerializable#load(ParsedNode, liquibase.database.Database, liquibase.resource.ResourceAccessor)}.
  * <p/>
  * ParsedNodes are a simple key/value structure with the following characteristics:
  * <ul>

--- a/liquibase-standard/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
@@ -8,6 +8,7 @@ import liquibase.change.core.RawSQLChange;
 import liquibase.changelog.ChangeLogParameters;
 import liquibase.changelog.ChangeSet;
 import liquibase.changelog.DatabaseChangeLog;
+import liquibase.database.Database;
 import liquibase.exception.ChangeLogParseException;
 import liquibase.parser.ChangeLogParser;
 import liquibase.precondition.core.PreconditionContainer;
@@ -215,7 +216,7 @@ public class FormattedSqlChangeLogParser implements ChangeLogParser {
     }
 
     @Override
-    public DatabaseChangeLog parse(String physicalChangeLogLocation, ChangeLogParameters changeLogParameters, ResourceAccessor resourceAccessor) throws ChangeLogParseException {
+    public DatabaseChangeLog parse(String physicalChangeLogLocation, Database database, ChangeLogParameters changeLogParameters, ResourceAccessor resourceAccessor) throws ChangeLogParseException {
 
         DatabaseChangeLog changeLog = new DatabaseChangeLog();
         changeLog.setChangeLogParameters(changeLogParameters);

--- a/liquibase-standard/src/main/java/liquibase/parser/core/sql/SqlChangeLogParser.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/core/sql/SqlChangeLogParser.java
@@ -4,6 +4,7 @@ import liquibase.change.core.RawSQLChange;
 import liquibase.changelog.ChangeLogParameters;
 import liquibase.changelog.ChangeSet;
 import liquibase.changelog.DatabaseChangeLog;
+import liquibase.database.Database;
 import liquibase.database.ObjectQuotingStrategy;
 import liquibase.exception.ChangeLogParseException;
 import liquibase.parser.ChangeLogParser;
@@ -27,7 +28,7 @@ public class SqlChangeLogParser implements ChangeLogParser {
     }
     
     @Override
-    public DatabaseChangeLog parse(String physicalChangeLogLocation, ChangeLogParameters changeLogParameters, ResourceAccessor resourceAccessor) throws ChangeLogParseException {
+    public DatabaseChangeLog parse(String physicalChangeLogLocation, Database database, ChangeLogParameters changeLogParameters, ResourceAccessor resourceAccessor) throws ChangeLogParseException {
 
         DatabaseChangeLog changeLog = new DatabaseChangeLog();
         changeLog.setPhysicalFilePath(physicalChangeLogLocation);

--- a/liquibase-standard/src/main/java/liquibase/parser/core/xml/AbstractChangeLogParser.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/core/xml/AbstractChangeLogParser.java
@@ -2,6 +2,7 @@ package liquibase.parser.core.xml;
 
 import liquibase.changelog.ChangeLogParameters;
 import liquibase.changelog.DatabaseChangeLog;
+import liquibase.database.Database;
 import liquibase.exception.ChangeLogParseException;
 import liquibase.parser.ChangeLogParser;
 import liquibase.parser.core.ParsedNode;
@@ -10,7 +11,7 @@ import liquibase.resource.ResourceAccessor;
 public abstract class AbstractChangeLogParser implements ChangeLogParser {
 
     @Override
-    public DatabaseChangeLog parse(String physicalChangeLogLocation, ChangeLogParameters changeLogParameters,
+    public DatabaseChangeLog parse(String physicalChangeLogLocation, Database database, ChangeLogParameters changeLogParameters,
                                    ResourceAccessor resourceAccessor) throws ChangeLogParseException {
         ParsedNode parsedNode = parseToNode(physicalChangeLogLocation, changeLogParameters, resourceAccessor);
         if (parsedNode == null) {
@@ -20,7 +21,7 @@ public abstract class AbstractChangeLogParser implements ChangeLogParser {
         DatabaseChangeLog changeLog = new DatabaseChangeLog(DatabaseChangeLog.normalizePath(physicalChangeLogLocation));
         changeLog.setChangeLogParameters(changeLogParameters);
         try {
-            changeLog.load(parsedNode, resourceAccessor);
+            changeLog.load(parsedNode, database, resourceAccessor);
         } catch (Exception e) {
             throw new ChangeLogParseException(e);
         }

--- a/liquibase-standard/src/main/java/liquibase/parser/core/yaml/YamlChangeLogParser.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/core/yaml/YamlChangeLogParser.java
@@ -4,9 +4,9 @@ import liquibase.ContextExpression;
 import liquibase.Labels;
 import liquibase.changelog.ChangeLogParameters;
 import liquibase.changelog.DatabaseChangeLog;
+import liquibase.database.Database;
 import liquibase.exception.ChangeLogParseException;
 import liquibase.exception.LiquibaseException;
-import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.parser.ChangeLogParser;
 import liquibase.parser.core.ParsedNode;
 import liquibase.resource.Resource;
@@ -16,13 +16,12 @@ import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Paths;
 import java.util.*;
 
 public class YamlChangeLogParser extends YamlParser implements ChangeLogParser {
 
     @Override
-    public DatabaseChangeLog parse(String physicalChangeLogLocation, ChangeLogParameters changeLogParameters, ResourceAccessor resourceAccessor) throws ChangeLogParseException {
+    public DatabaseChangeLog parse(String physicalChangeLogLocation, Database database, ChangeLogParameters changeLogParameters, ResourceAccessor resourceAccessor) throws ChangeLogParseException {
         Yaml yaml = new Yaml(new SafeConstructor(createLoaderOptions()));
 
         try {
@@ -78,7 +77,7 @@ public class YamlChangeLogParser extends YamlParser implements ChangeLogParser {
             ParsedNode databaseChangeLogNode = new ParsedNode(null, "databaseChangeLog");
             databaseChangeLogNode.setValue(rootList);
 
-            changeLog.load(databaseChangeLogNode, resourceAccessor);
+            changeLog.load(databaseChangeLogNode, database, resourceAccessor);
 
             return changeLog;
         } catch (ChangeLogParseException e) {

--- a/liquibase-standard/src/main/java/liquibase/parser/core/yaml/YamlSnapshotParser.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/core/yaml/YamlSnapshotParser.java
@@ -62,7 +62,7 @@ public class YamlSnapshotParser extends YamlParser implements SnapshotParser {
                 snapshot.getMetadata().putAll(metadata);
             }
 
-            snapshot.load(snapshotNode, resourceAccessor);
+            snapshot.load(snapshotNode, null, resourceAccessor);
 
             return snapshot;
         } catch (LiquibaseParseException e) {

--- a/liquibase-standard/src/main/java/liquibase/plugin/AbstractPluginFactory.java
+++ b/liquibase-standard/src/main/java/liquibase/plugin/AbstractPluginFactory.java
@@ -5,7 +5,9 @@ import liquibase.servicelocator.ServiceLocator;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.ServiceLoader;
+import java.util.Set;
 import java.util.TreeSet;
 
 /**
@@ -37,12 +39,22 @@ public abstract class AbstractPluginFactory<T extends Plugin> implements PluginF
      * @return null if no plugins are found or have a priority greater than zero.
      */
     protected T getPlugin(final Object... args) {
+        Set<T> applicable = getPlugins(args);
+        if (applicable.size() == 0) {
+            return null;
+        }
+        return applicable.iterator().next();
+    }
+
+    protected Set<T> getPlugins(final Object... args) {
         final String pluginClassName = getPluginClass().getName();
         final Class forcedPlugin = Scope.getCurrentScope().get("liquibase.plugin." + pluginClassName, Class.class);
         if (forcedPlugin != null) {
             for (T plugin : findAllInstances()) {
                 if (plugin.getClass().equals(forcedPlugin)) {
-                    return plugin;
+                    Set<T> set = new HashSet<>();
+                    set.add(plugin);
+                    return set;
                 }
             }
             throw new RuntimeException("No registered " + pluginClassName + " plugin " + forcedPlugin.getName());
@@ -64,13 +76,7 @@ public abstract class AbstractPluginFactory<T extends Plugin> implements PluginF
                 applicable.add(plugin);
             }
         }
-
-        if (applicable.size() == 0) {
-            return null;
-        }
-
-        return applicable.iterator().next();
-
+        return applicable;
     }
 
 

--- a/liquibase-standard/src/main/java/liquibase/precondition/CustomPreconditionWrapper.java
+++ b/liquibase-standard/src/main/java/liquibase/precondition/CustomPreconditionWrapper.java
@@ -119,7 +119,7 @@ public class CustomPreconditionWrapper extends AbstractPrecondition {
     }
 
     @Override
-    public void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException {
+    public void load(ParsedNode parsedNode, Database database, ResourceAccessor resourceAccessor) throws ParsedNodeException {
         setClassName(parsedNode.getChildValue(null, "className", String.class));
 
         ParsedNode paramsNode = parsedNode.getChild(null, "params");
@@ -137,7 +137,7 @@ public class CustomPreconditionWrapper extends AbstractPrecondition {
             }
             this.setParam(child.getChildValue(null, "name", String.class), (String) value);
         }
-        super.load(parsedNode, resourceAccessor);
+        super.load(parsedNode, database, resourceAccessor);
 
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/precondition/Precondition.java
+++ b/liquibase-standard/src/main/java/liquibase/precondition/Precondition.java
@@ -26,5 +26,5 @@ public interface Precondition extends LiquibaseSerializable {
     void check(Database database, DatabaseChangeLog changeLog, ChangeSet changeSet, ChangeExecListener changeExecListener)
             throws PreconditionFailedException, PreconditionErrorException;
 
-    void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException;
+    void load(ParsedNode parsedNode, Database database, ResourceAccessor resourceAccessor) throws ParsedNodeException;
 }

--- a/liquibase-standard/src/main/java/liquibase/precondition/PreconditionLogic.java
+++ b/liquibase-standard/src/main/java/liquibase/precondition/PreconditionLogic.java
@@ -37,8 +37,8 @@ public abstract class PreconditionLogic extends AbstractPrecondition {
     }
 
     @Override
-    public void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException {
-        super.load(parsedNode, resourceAccessor);
+    public void load(ParsedNode parsedNode, Database database, ResourceAccessor resourceAccessor) throws ParsedNodeException {
+        super.load(parsedNode, database, resourceAccessor);
 
         for (ParsedNode child : parsedNode.getChildren()) {
             addNestedPrecondition(toPrecondition(child, resourceAccessor));
@@ -55,7 +55,7 @@ public abstract class PreconditionLogic extends AbstractPrecondition {
             return null;
         }
 
-        precondition.load(node, resourceAccessor);
+        precondition.load(node, null, resourceAccessor);
         return precondition;
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/precondition/core/PreconditionContainer.java
+++ b/liquibase-standard/src/main/java/liquibase/precondition/core/PreconditionContainer.java
@@ -269,14 +269,14 @@ public class PreconditionContainer extends AndPrecondition implements ChangeLogC
     }
 
     @Override
-    public void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException {
+    public void load(ParsedNode parsedNode, Database database, ResourceAccessor resourceAccessor) throws ParsedNodeException {
         this.setOnError(parsedNode.getChildValue(null, "onError", String.class));
         this.setOnErrorMessage(parsedNode.getChildValue(null, "onErrorMessage", String.class));
         this.setOnFail(parsedNode.getChildValue(null, "onFail", String.class));
         this.setOnFailMessage(parsedNode.getChildValue(null, "onFailMessage", String.class));
         this.setOnSqlOutput(parsedNode.getChildValue(null, "onSqlOutput", String.class));
 
-        super.load(parsedNode, resourceAccessor);
+        super.load(parsedNode, database, resourceAccessor);
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/serializer/AbstractLiquibaseSerializable.java
+++ b/liquibase-standard/src/main/java/liquibase/serializer/AbstractLiquibaseSerializable.java
@@ -1,5 +1,6 @@
 package liquibase.serializer;
 
+import liquibase.database.Database;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.parser.core.ParsedNode;
 import liquibase.parser.core.ParsedNodeException;
@@ -19,7 +20,7 @@ public abstract class AbstractLiquibaseSerializable implements LiquibaseSerializ
     private Set<String> serializableFields;
 
     @Override
-    public void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException {
+    public void load(ParsedNode parsedNode, Database database, ResourceAccessor resourceAccessor) throws ParsedNodeException {
         for (ParsedNode childNode : parsedNode.getChildren()) {
             if (!shouldAutoLoad(childNode)) {
                 continue;
@@ -51,7 +52,7 @@ public abstract class AbstractLiquibaseSerializable implements LiquibaseSerializ
                                     Collection collection = ((Collection) getSerializableFieldValue(childNode.getName()));
                                     for (ParsedNode node : elementNodes) {
                                         LiquibaseSerializable childObject = (LiquibaseSerializable) collectionType.getConstructor().newInstance();
-                                        childObject.load(node, resourceAccessor);
+                                        childObject.load(node, null, resourceAccessor);
                                         collection.add(childObject);
                                     }
                                 }
@@ -62,7 +63,7 @@ public abstract class AbstractLiquibaseSerializable implements LiquibaseSerializ
                                 && !Modifier.isAbstract(dataTypeClass.getModifiers())) {
 
                             LiquibaseSerializable childObject = (LiquibaseSerializable) dataTypeClass.getConstructor().newInstance();
-                            childObject.load(childNode, resourceAccessor);
+                            childObject.load(childNode, null, resourceAccessor);
                             setSerializableFieldValue(childNode.getName(), childObject);
                         }
                     } else if (childNode.getValue() != null) {
@@ -95,7 +96,7 @@ public abstract class AbstractLiquibaseSerializable implements LiquibaseSerializ
                                         Collection collection = ((Collection) getSerializableFieldValue(field));
                                         for (ParsedNode node : elementNodes) {
                                             LiquibaseSerializable childObject = (LiquibaseSerializable) collectionType.getConstructor().newInstance();
-                                            childObject.load(node, resourceAccessor);
+                                            childObject.load(node, null, resourceAccessor);
                                             collection.add(childObject);
                                         }
                                     }

--- a/liquibase-standard/src/main/java/liquibase/serializer/LiquibaseSerializable.java
+++ b/liquibase-standard/src/main/java/liquibase/serializer/LiquibaseSerializable.java
@@ -1,5 +1,6 @@
 package liquibase.serializer;
 
+import liquibase.database.Database;
 import liquibase.parser.core.ParsedNode;
 import liquibase.parser.core.ParsedNodeException;
 import liquibase.resource.ResourceAccessor;
@@ -32,7 +33,7 @@ public interface LiquibaseSerializable {
 
     String getSerializedObjectNamespace();
 
-    void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException;
+    void load(ParsedNode parsedNode, Database database, ResourceAccessor resourceAccessor) throws ParsedNodeException;
 
     ParsedNode serialize() throws ParsedNodeException;
 

--- a/liquibase-standard/src/main/java/liquibase/snapshot/DatabaseSnapshot.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/DatabaseSnapshot.java
@@ -591,7 +591,7 @@ public abstract class DatabaseSnapshot implements LiquibaseSerializable {
     }
 
     @Override
-    public void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException {
+    public void load(ParsedNode parsedNode, Database database, ResourceAccessor resourceAccessor) throws ParsedNodeException {
         try {
             Map<String, DatabaseObject> referencedObjects = new HashMap<>();
             Map<String, DatabaseObject> objects = new HashMap<>();
@@ -669,7 +669,7 @@ public abstract class DatabaseSnapshot implements LiquibaseSerializable {
             Class<? extends DatabaseObject> objectType = (Class<? extends DatabaseObject>) Class.forName(typeNode.getName());
             for (ParsedNode objectNode : typeNode.getChildren()) {
                 DatabaseObject databaseObject = objectType.getConstructor().newInstance();
-                databaseObject.load(objectNode, resourceAccessor);
+                databaseObject.load(objectNode, null, resourceAccessor);
                 String key = objectType.getName() + "#" + databaseObject.getSnapshotId();
                 objectMap.put(key, databaseObject);
                 allObjects.put(key, databaseObject);

--- a/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotControl.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotControl.java
@@ -160,7 +160,7 @@ public class SnapshotControl implements LiquibaseSerializable {
     }
 
     @Override
-    public void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException {
+    public void load(ParsedNode parsedNode, Database database, ResourceAccessor resourceAccessor) throws ParsedNodeException {
         throw new RuntimeException("TODO");
     }
 

--- a/liquibase-standard/src/main/java/liquibase/sql/visitor/AbstractSqlVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/sql/visitor/AbstractSqlVisitor.java
@@ -3,6 +3,7 @@ package liquibase.sql.visitor;
 import liquibase.ContextExpression;
 import liquibase.Labels;
 import liquibase.change.CheckSum;
+import liquibase.database.Database;
 import liquibase.parser.core.ParsedNode;
 import liquibase.parser.core.ParsedNodeException;
 import liquibase.resource.ResourceAccessor;
@@ -130,7 +131,7 @@ public abstract class AbstractSqlVisitor implements SqlVisitor {
 
 
     @Override
-    public void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException {
+    public void load(ParsedNode parsedNode, Database database, ResourceAccessor resourceAccessor) throws ParsedNodeException {
         for (ParsedNode childNode : parsedNode.getChildren()) {
             try {
                if ("dbms".equals(childNode.getName())) {

--- a/liquibase-standard/src/main/java/liquibase/structure/AbstractDatabaseObject.java
+++ b/liquibase-standard/src/main/java/liquibase/structure/AbstractDatabaseObject.java
@@ -1,6 +1,7 @@
 package liquibase.structure;
 
 import liquibase.GlobalConfiguration;
+import liquibase.database.Database;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.parser.core.ParsedNode;
 import liquibase.parser.core.ParsedNodeException;
@@ -23,7 +24,7 @@ import java.util.regex.Pattern;
  * {@link liquibase.structure.core.PrimaryKey} and {@link liquibase.structure.core.Column}.
  * <p/>
  * Core features of this class include the functionality for the attributes collection ( {@link #getAttributes()} }
- * and the ability to load an object from a serialised form {@link #load(ParsedNode, ResourceAccessor)} .
+ * and the ability to load an object from a serialised form {@link LiquibaseSerializable#load(ParsedNode, Database, ResourceAccessor)} .
  */
 public abstract class AbstractDatabaseObject implements DatabaseObject {
 
@@ -180,7 +181,7 @@ public abstract class AbstractDatabaseObject implements DatabaseObject {
     }
 
     @Override
-    public void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException {
+    public void load(ParsedNode parsedNode, Database database, ResourceAccessor resourceAccessor) throws ParsedNodeException {
         for (ParsedNode child : parsedNode.getChildren()) {
             String name = child.getName();
             if ("snapshotId".equals(name)) {

--- a/liquibase-standard/src/main/java/liquibase/structure/DatabaseObjectCollection.java
+++ b/liquibase-standard/src/main/java/liquibase/structure/DatabaseObjectCollection.java
@@ -146,7 +146,7 @@ public class DatabaseObjectCollection implements LiquibaseSerializable {
     }
 
     @Override
-    public void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException {
+    public void load(ParsedNode parsedNode, Database database, ResourceAccessor resourceAccessor) throws ParsedNodeException {
         throw new RuntimeException("TODO");
     }
 

--- a/liquibase-standard/src/main/java/liquibase/structure/core/Column.java
+++ b/liquibase-standard/src/main/java/liquibase/structure/core/Column.java
@@ -2,6 +2,7 @@ package liquibase.structure.core;
 
 import liquibase.change.ColumnConfig;
 import liquibase.change.ConstraintsConfig;
+import liquibase.database.Database;
 import liquibase.parser.core.ParsedNode;
 import liquibase.parser.core.ParsedNodeException;
 import liquibase.resource.ResourceAccessor;
@@ -388,18 +389,18 @@ public class Column extends AbstractDatabaseObject {
     }
 
     @Override
-    public void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException {
-        super.load(parsedNode, resourceAccessor);
+    public void load(ParsedNode parsedNode, Database database, ResourceAccessor resourceAccessor) throws ParsedNodeException {
+        super.load(parsedNode, database, resourceAccessor);
         ParsedNode typeNode = parsedNode.getChild(null, "type");
         if (typeNode != null) {
             DataType type = new DataType();
-            type.load(typeNode, resourceAccessor);
+            type.load(typeNode, null, resourceAccessor);
             setType(type);
         }
         ParsedNode autoIncrementInformation = parsedNode.getChild(null, "autoIncrementInformation");
         if (autoIncrementInformation != null) {
             AutoIncrementInformation info = new AutoIncrementInformation();
-            info.load(autoIncrementInformation, resourceAccessor);
+            info.load(autoIncrementInformation, null, resourceAccessor);
             setAutoIncrementInformation(info);
         }
     }
@@ -460,7 +461,7 @@ public class Column extends AbstractDatabaseObject {
         }
 
         @Override
-        public void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException {
+        public void load(ParsedNode parsedNode, Database database, ResourceAccessor resourceAccessor) throws ParsedNodeException {
             this.startWith = (BigInteger) convertEscaped(parsedNode.getChildValue(null, "startWith"));
             this.incrementBy = (BigInteger) convertEscaped(parsedNode.getChildValue(null, "incrementBy"));
             this.defaultOnNull = parsedNode.getChildValue(null, "defaultOnNull", Boolean.class);

--- a/liquibase-standard/src/main/java/liquibase/structure/core/Index.java
+++ b/liquibase-standard/src/main/java/liquibase/structure/core/Index.java
@@ -1,5 +1,6 @@
 package liquibase.structure.core;
 
+import liquibase.database.Database;
 import liquibase.parser.core.ParsedNode;
 import liquibase.parser.core.ParsedNodeException;
 import liquibase.resource.ResourceAccessor;
@@ -177,14 +178,14 @@ public class Index extends AbstractDatabaseObject {
     }
 
     @Override
-    public void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException {
-        super.load(parsedNode, resourceAccessor);
+    public void load(ParsedNode parsedNode, Database database, ResourceAccessor resourceAccessor) throws ParsedNodeException {
+        super.load(parsedNode, database, resourceAccessor);
         ParsedNode columns = parsedNode.getChild(null, "columns");
         List<ParsedNode> nodes = columns.getChildren(null, "column");
         for (int i=0; i < nodes.size(); i++) {
             ParsedNode node = nodes.get(i);
             Column column = new Column();
-            column.load(node, resourceAccessor);
+            column.load(node, null, resourceAccessor);
             column.setName((String) node.getChildren(null, "name").get(0).getValue());
             column.setDescending(node.getChildValue(null, "descending", Boolean.class));
             column.setComputed(node.getChildValue(null, "computed", Boolean.class));

--- a/liquibase-standard/src/main/java/liquibase/structure/core/UniqueConstraint.java
+++ b/liquibase-standard/src/main/java/liquibase/structure/core/UniqueConstraint.java
@@ -1,5 +1,6 @@
 package liquibase.structure.core;
 
+import liquibase.database.Database;
 import liquibase.parser.core.ParsedNode;
 import liquibase.parser.core.ParsedNodeException;
 import liquibase.resource.ResourceAccessor;
@@ -233,8 +234,8 @@ public class UniqueConstraint extends AbstractDatabaseObject {
 	}
 
     @Override
-    public void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException {
-        super.load(parsedNode, resourceAccessor);
+    public void load(ParsedNode parsedNode, Database database, ResourceAccessor resourceAccessor) throws ParsedNodeException {
+        super.load(parsedNode, database, resourceAccessor);
     }
 
     @Override

--- a/liquibase-standard/src/test/groovy/liquibase/change/AddColumnConfigTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/AddColumnConfigTest.groovy
@@ -16,7 +16,7 @@ class AddColumnConfigTest extends Specification {
         def node = new ParsedNode(null, "column").addChildren([beforeColumn: "before_col", afterColumn: "after_col", position: 4, name: "col_name"])
         def column = new AddColumnConfig()
         try {
-            column.load(node, resourceSupplier.simpleResourceAccessor)
+            column.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         } catch (SetupException e) {

--- a/liquibase-standard/src/test/groovy/liquibase/change/ColumnConfigTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/ColumnConfigTest.groovy
@@ -433,7 +433,7 @@ public class ColumnConfigTest extends Specification {
         }
         node.addChild(null, field, testValue)
         try {
-            column.load(node, resourceSupplier.simpleResourceAccessor)
+            column.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -461,7 +461,7 @@ public class ColumnConfigTest extends Specification {
         }
         constraintNode.addChild(null, field, testValue)
         try {
-            column.load(node, resourceSupplier.simpleResourceAccessor)
+            column.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -478,7 +478,7 @@ public class ColumnConfigTest extends Specification {
         when:
         def column = new ColumnConfig()
         try {
-            column.load(new liquibase.parser.core.ParsedNode(null, "column").addChild(null, param, value), resourceSupplier.simpleResourceAccessor)
+            column.load(new liquibase.parser.core.ParsedNode(null, "column").addChild(null, param, value), null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }

--- a/liquibase-standard/src/test/groovy/liquibase/change/StandardChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/StandardChangeTest.groovy
@@ -25,7 +25,7 @@ public abstract class StandardChangeTest extends Specification {
 
     def "refactoring name matches expected class name"() {
         expect:
-        assert Scope.getCurrentScope().getSingleton(ChangeFactory.class).getChangeMetaData(getChangeClass().getConstructor().newInstance()).getName().toLowerCase() == getExpectedChangeName()
+        assert Scope.getCurrentScope().getSingleton(ChangeFactory.class).getChangeMetaData(getChangeClass().getConstructor().newInstance(), null).getName().toLowerCase() == getExpectedChangeName()
     }
 
     protected String getExpectedChangeName() {

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/AddColumnChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/AddColumnChangeTest.groovy
@@ -13,7 +13,6 @@ import liquibase.parser.core.ParsedNodeException
 import liquibase.snapshot.MockSnapshotGeneratorFactory
 import liquibase.snapshot.SnapshotGeneratorFactory
 import liquibase.sqlgenerator.SqlGeneratorFactory
-import liquibase.statement.SqlStatement
 import liquibase.structure.core.Column
 import liquibase.structure.core.PrimaryKey
 import liquibase.structure.core.Table
@@ -158,7 +157,7 @@ class AddColumnChangeTest extends StandardChangeTest {
                 .addChild(new ParsedNode(null, "column").addChildren([name: "col_2", type: "int", position: "3"]))
         def change = new AddColumnChange()
         try {
-            change.load(node, resourceSupplier.simpleResourceAccessor)
+            change.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         } catch (SetupException e) {

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/CreateProcedureChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/CreateProcedureChangeTest.groovy
@@ -44,7 +44,7 @@ class CreateProcedureChangeTest extends StandardChangeTest {
     def "load with inline sql"() {
         when:
         def change = new CreateProcedureChange()
-        change.load(new ParsedNode(null, "createProcedure").setValue("create procedure sql"), new MockResourceAccessor())
+        change.load(new ParsedNode(null, "createProcedure").setValue("create procedure sql"), null, new MockResourceAccessor())
         change.validate(new OracleDatabase())
 
         then:

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/CreateTableChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/CreateTableChangeTest.groovy
@@ -238,7 +238,7 @@ public class CreateTableChangeTest extends StandardChangeTest {
                 .addChildren([column: [name: "column2", type: "type2"]])
         def change = new CreateTableChange()
         try {
-            change.load(node, resourceSupplier.simpleResourceAccessor)
+            change.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -259,7 +259,7 @@ public class CreateTableChangeTest extends StandardChangeTest {
                 .addChild(null, "columns", [[column: [name: "column1", type: "type1"]], [column: [name: "column2", type: "type2"]]])
         def change = new CreateTableChange()
         try {
-            change.load(node, resourceSupplier.simpleResourceAccessor)
+            change.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/CreateViewChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/CreateViewChangeTest.groovy
@@ -54,7 +54,7 @@ class CreateViewChangeTest extends StandardChangeTest {
         when:
         def change = new CreateViewChange()
         try {
-            change.load(new liquibase.parser.core.ParsedNode(null, "createView").addChild(null, "viewName", "my_view").setValue("select * from test"), resourceSupplier.simpleResourceAccessor)
+            change.load(new liquibase.parser.core.ParsedNode(null, "createView").addChild(null, "viewName", "my_view").setValue("select * from test"), null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         } catch (SetupException e) {

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/DeleteDataChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/DeleteDataChangeTest.groovy
@@ -17,7 +17,7 @@ class DeleteDataChangeTest extends Specification {
                 .addChild(new ParsedNode(null, "param").addChild(null, "valueNumeric", "134"))
                 .addChild(new ParsedNode(null, "param").addChildren([name: "other_val", value: "asdf"]))
         try {
-            change.load(new liquibase.parser.core.ParsedNode(null, "delete").addChild(null, "tableName", "deleteTest").addChild(whereParams), resourceSupplier.simpleResourceAccessor)
+            change.load(new liquibase.parser.core.ParsedNode(null, "delete").addChild(null, "tableName", "deleteTest").addChild(whereParams), null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/ExecuteShellCommandChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/ExecuteShellCommandChangeTest.groovy
@@ -20,7 +20,7 @@ class ExecuteShellCommandChangeTest extends Specification {
             change.load(new liquibase.parser.core.ParsedNode(null, "executeCommand")
                     .addChildren([executable: "/usr/bin/test", os: "linux,mac"])
                     .addChild(new liquibase.parser.core.ParsedNode(null, "arg").addChild(null, "value", "-out"))
-                    .addChild(new liquibase.parser.core.ParsedNode(null, "arg").addChild(null, "value", "-test"))
+                    .addChild(new liquibase.parser.core.ParsedNode(null, "arg").addChild(null, "value", "-test")), null
                     , resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
@@ -41,9 +41,9 @@ class ExecuteShellCommandChangeTest extends Specification {
             change.load(new liquibase.parser.core.ParsedNode(null, "executeCommand")
                     .addChildren([executable: "/usr/bin/test", os: "linux,mac"])
                     .addChild(new liquibase.parser.core.ParsedNode(null, "args")
-                    .addChild(new liquibase.parser.core.ParsedNode(null, "arg").addChild(null, "value", "-out"))
-                    .addChild(new liquibase.parser.core.ParsedNode(null, "arg").addChild(null, "value", "-test"))
-            ), resourceSupplier.simpleResourceAccessor)
+                            .addChild(new liquibase.parser.core.ParsedNode(null, "arg").addChild(null, "value", "-out"))
+                            .addChild(new liquibase.parser.core.ParsedNode(null, "arg").addChild(null, "value", "-test"))
+                    ), null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -59,11 +59,11 @@ class ExecuteShellCommandChangeTest extends Specification {
         def change = new ExecuteShellCommandChange()
         try {
             change.load(new liquibase.parser.core.ParsedNode(null, "executeCommand")
-                    .addChildren([executable: "/usr/bin/test", os: "linux,mac", timeout:"10s"])
+                    .addChildren([executable: "/usr/bin/test", os: "linux,mac", timeout: "10s"])
                     .addChild(new liquibase.parser.core.ParsedNode(null, "args")
-                    .addChild(new liquibase.parser.core.ParsedNode(null, "arg").addChild(null, "value", "-out"))
-                    .addChild(new liquibase.parser.core.ParsedNode(null, "arg").addChild(null, "value", "-test"))
-            ), resourceSupplier.simpleResourceAccessor)
+                            .addChild(new liquibase.parser.core.ParsedNode(null, "arg").addChild(null, "value", "-out"))
+                            .addChild(new liquibase.parser.core.ParsedNode(null, "arg").addChild(null, "value", "-test"))
+                    ), null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
@@ -341,7 +341,7 @@ public class LoadDataChangeTest extends StandardChangeTest {
             change.load(new liquibase.parser.core.ParsedNode(null, "loadData").setValue([
                     [column: [name: "id"]],
                     [column: [name: "new_col", header: "new_col_header"]],
-            ]), resourceSupplier.simpleResourceAccessor)
+            ]), null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -638,7 +638,7 @@ public class LoadDataChangeTest extends StandardChangeTest {
                 [column: [name: "name", defaultValue: "defName"]],
                 [column: [name: "date", defaultValueDate: "2020-01-02 03:04:05"]],
                 [column: [name: "bool", defaultValueBoolean: "true"]]
-        ]), new ClassLoaderResourceAccessor())
+        ]), null, new ClassLoaderResourceAccessor())
 
         SnapshotGeneratorFactory.instance = new MockSnapshotGeneratorFactory(table)
 
@@ -676,7 +676,7 @@ public class LoadDataChangeTest extends StandardChangeTest {
                 [column: [name: "name", defaultValue: "defName"]],
                 [column: [name: "date", defaultValue: "2020-01-02 03:04:05"]],
                 [column: [name: "bool", defaultValue: "t"]]
-        ]), new ClassLoaderResourceAccessor())
+        ]), null, new ClassLoaderResourceAccessor())
 
         SnapshotGeneratorFactory.instance = new MockSnapshotGeneratorFactory(table)
 
@@ -711,7 +711,7 @@ public class LoadDataChangeTest extends StandardChangeTest {
         ]).setValue([
                 [column: [name: "name", type: "STRING"]],
                 [column: [name: "date"]],
-        ]), new ClassLoaderResourceAccessor())
+        ]), null, new ClassLoaderResourceAccessor())
 
         SnapshotGeneratorFactory.instance = new MockSnapshotGeneratorFactory()
 
@@ -738,7 +738,7 @@ public class LoadDataChangeTest extends StandardChangeTest {
                 [column: [name: "date", type: "DATE"]],
                 [column: [name: "datetime", type: "DATETIME"]],
                 [column: [name: "time", type: "TIME"]],
-        ]), new ClassLoaderResourceAccessor())
+        ]), null, new ClassLoaderResourceAccessor())
 
         SnapshotGeneratorFactory.instance = new MockSnapshotGeneratorFactory()
 
@@ -788,9 +788,9 @@ public class LoadDataChangeTest extends StandardChangeTest {
                 file     : "liquibase/change/core/sample.data1.csv",
                 tableName: "table.name"
         ]).setValue([
-                [column: [name: "a", header:"name", index:1, type: "STRING"]],
+                [column: [name: "a", header: "name", index: 1, type: "STRING"]],
                 [column: [name: "username", type: "STRING"]]
-        ]), new ClassLoaderResourceAccessor())
+        ]), null, new ClassLoaderResourceAccessor())
         ValidationErrors foundErrors = change.validate(mockDB);
         SqlStatement[] sqlStatements = change.generateStatements(mockDB)
 
@@ -810,10 +810,10 @@ public class LoadDataChangeTest extends StandardChangeTest {
                 file     : "liquibase/change/core/sample.data1.csv",
                 tableName: ""
         ]).setValue([
-                [column: [name: "a", header:"", index:1, type: "STRING", defaultValue: ""]],
+                [column: [name: "a", header: "", index: 1, type: "STRING", defaultValue: ""]],
                 [column: [name: "", type: ""]],
                 [column: []]
-        ]), new ClassLoaderResourceAccessor())
+        ]), null, new ClassLoaderResourceAccessor())
 
         ValidationErrors errors = change.validate(mockDB)
         then:

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/LoadDataColumnConfigTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/LoadDataColumnConfigTest.groovy
@@ -18,7 +18,7 @@ class LoadDataColumnConfigTest extends Specification {
                               defaultValueNumeric: "1", type: "NUMERIC"])
         def column = new LoadDataColumnConfig()
         try {
-            column.load(node, resourceSupplier.simpleResourceAccessor)
+            column.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         } catch (SetupException e) {

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/RawSQLChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/RawSQLChangeTest.groovy
@@ -45,7 +45,7 @@ public class RawSQLChangeTest extends StandardChangeTest {
         when:
         def changeFromValue = new RawSQLChange()
         try {
-            changeFromValue.load(new liquibase.parser.core.ParsedNode(null, "sql").setValue("select * from x"), resourceSupplier.simpleResourceAccessor)
+            changeFromValue.load(new liquibase.parser.core.ParsedNode(null, "sql").setValue("select * from x"), null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e1) {
             e1.printStackTrace()
         } catch (SetupException e1) {
@@ -54,7 +54,7 @@ public class RawSQLChangeTest extends StandardChangeTest {
 
         def changeFromChild = new RawSQLChange()
         try {
-            changeFromChild.load(new liquibase.parser.core.ParsedNode(null, "sql").addChild(null, "sql", "select * from y"), resourceSupplier.simpleResourceAccessor)
+            changeFromChild.load(new liquibase.parser.core.ParsedNode(null, "sql").addChild(null, "sql", "select * from y"), null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         } catch (SetupException e) {

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/StopChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/StopChangeTest.groovy
@@ -14,7 +14,7 @@ class StopChangeTest extends Specification {
         when:
         def change = new StopChange()
         try {
-            change.load(new liquibase.parser.core.ParsedNode(null, "stop").setValue("stopping..."), resourceSupplier.simpleResourceAccessor)
+            change.load(new liquibase.parser.core.ParsedNode(null, "stop").setValue("stopping..."), null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         } catch (SetupException e) {

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/UpdateDataChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/UpdateDataChangeTest.groovy
@@ -43,7 +43,7 @@ public class UpdateDataChangeTest extends StandardChangeTest {
                 .addChild(new ParsedNode(null, "param").addChild(null, "valueNumeric", "134"))
                 .addChild(new ParsedNode(null, "param").addChildren([name: "other_val", value: "asdf"]))
         try {
-            change.load(new liquibase.parser.core.ParsedNode(null, "updateData").addChild(null, "tableName", "updateTest").addChild(whereParams), resourceSupplier.simpleResourceAccessor)
+            change.load(new liquibase.parser.core.ParsedNode(null, "updateData").addChild(null, "tableName", "updateTest").addChild(whereParams), null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }

--- a/liquibase-standard/src/test/groovy/liquibase/change/custom/CustomChangeWrapperTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/custom/CustomChangeWrapperTest.groovy
@@ -243,7 +243,7 @@ class CustomChangeWrapperTest extends Specification {
                 .addChild(new ParsedNode(null, "param").addChildren([name: "param 3"]).setValue("param 3 value"))
         def change = new CustomChangeWrapper()
         try {
-            change.load(node, resourceSupplier.simpleResourceAccessor)
+            change.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -266,7 +266,7 @@ class CustomChangeWrapperTest extends Specification {
                 .addChild(new ParsedNode(null, "otherNode").setValue("should be ignored"))
                 .addChild(new ParsedNode(null, "param").addChildren([name: "param 3"]).setValue("param 3 value"))
         def change = new CustomChangeWrapper()
-        change.load(node, resourceSupplier.simpleResourceAccessor)
+        change.load(node, null, resourceSupplier.simpleResourceAccessor)
 
         then:
         thrown(ParsedNodeException.class)
@@ -277,7 +277,7 @@ class CustomChangeWrapperTest extends Specification {
         when:
         def node = new ParsedNode(null, "customChange")
         def change = new CustomChangeWrapper()
-        change.load(node, resourceSupplier.simpleResourceAccessor)
+        change.load(node, null, resourceSupplier.simpleResourceAccessor)
 
         then:
         thrown(ParsedNodeException.class)
@@ -293,7 +293,7 @@ class CustomChangeWrapperTest extends Specification {
                                            new ParsedNode(null, "param").addChildren([name: "param 3"]).setValue("param 3 value")])
         def change = new CustomChangeWrapper()
         try {
-            change.load(node, resourceSupplier.simpleResourceAccessor)
+            change.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -311,7 +311,7 @@ class CustomChangeWrapperTest extends Specification {
         def change = new CustomChangeWrapper()
         try {
             change.load(new liquibase.parser.core.ParsedNode(null, "customChange")
-                    .addChildren([class: "liquibase.change.custom.ExampleCustomSqlChange", tableName: "my_table", columnName: "my_col", unusedParam: "unused value"]), resourceSupplier.simpleResourceAccessor)
+                    .addChildren([class: "liquibase.change.custom.ExampleCustomSqlChange", tableName: "my_table", columnName: "my_col", unusedParam: "unused value"]), null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }

--- a/liquibase-standard/src/test/groovy/liquibase/changelog/ChangeSetTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/changelog/ChangeSetTest.groovy
@@ -115,7 +115,7 @@ public class ChangeSetTest extends Specification {
         def changeSet = new ChangeSet(new DatabaseChangeLog("com/example/test.xml"))
         def node = new ParsedNode(null, "changeSet").addChildren([id: "1", author: "nvoxland"])
         try {
-            changeSet.load(node, resourceSupplier.simpleResourceAccessor)
+            changeSet.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -153,7 +153,7 @@ public class ChangeSetTest extends Specification {
         }
         node.addChild(null, "onValidationFail", "MARK_RAN")
         try {
-            changeSet.load(node, resourceSupplier.simpleResourceAccessor)
+            changeSet.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -178,7 +178,7 @@ public class ChangeSetTest extends Specification {
                 .addChild(new ParsedNode(null, "createTable").addChild(null, "tableName", "table_1"))
                 .addChild(new ParsedNode(null, "createTable").addChild(null, "tableName", "table_2"))
         try {
-            changeSet.load(node, resourceSupplier.simpleResourceAccessor)
+            changeSet.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -198,7 +198,7 @@ public class ChangeSetTest extends Specification {
                 .addChildren([id: "1", author: "nvoxland"])
                 .addChild(new ParsedNode(null, "createTable").addChild(null, "tableName", "table_1"))
                 .addChild(new ParsedNode(null, "invalid").addChild(null, "tableName", "table_2"))
-        changeSet.load(node, resourceSupplier.simpleResourceAccessor)
+        changeSet.load(node, null, resourceSupplier.simpleResourceAccessor)
 
         then:
         def e = thrown(ParsedNodeException)
@@ -215,7 +215,7 @@ public class ChangeSetTest extends Specification {
 
         Scope.child([(ChangeLogParserConfiguration.CHANGELOG_PARSE_MODE.getKey()): ChangeLogParserConfiguration.ChangelogParseMode.LAX], {
             ->
-            changeSet.load(node, resourceSupplier.simpleResourceAccessor)
+            changeSet.load(node, null, resourceSupplier.simpleResourceAccessor)
         } as Scope.ScopedRunner)
 
 
@@ -231,7 +231,7 @@ public class ChangeSetTest extends Specification {
                 .addChild(new ParsedNode(null, "createTable").addChild(null, "tableName", "table_1"))
                 .setValue(new ParsedNode(null, "rollback").setValue("rollback logic here"))
         try {
-            changeSet.load(node, resourceSupplier.simpleResourceAccessor)
+            changeSet.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -249,7 +249,7 @@ public class ChangeSetTest extends Specification {
                 .addChild(new ParsedNode(null, "createTable").addChild(null, "tableName", "table_1"))
                 .setValue(new ParsedNode(null, "rollback").setValue(new ParsedNode(null, "renameTable").addChild(null, "newTableName", "rename_to_x")))
         try {
-            changeSet.load(node, resourceSupplier.simpleResourceAccessor)
+            changeSet.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -270,7 +270,7 @@ public class ChangeSetTest extends Specification {
                 new ParsedNode(null, "rollback").setValue(new ParsedNode(null, "renameTable").addChild(null, "newTableName", "rename_to_y"))
         ])
         try {
-            changeSet.load(node, resourceSupplier.simpleResourceAccessor)
+            changeSet.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -292,7 +292,7 @@ public class ChangeSetTest extends Specification {
                 .addChild(new ParsedNode(null, "rollback").setValue("rollback sql"))
 
         try {
-            changeSet.load(node, resourceSupplier.simpleResourceAccessor)
+            changeSet.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -313,7 +313,7 @@ public class ChangeSetTest extends Specification {
                 .addChild(new ParsedNode(null, "rollback").setValue("\n--a comment here\nrollback sql 1;\nrollback sql 2\n--final comment"))
 
         try {
-            changeSet.load(node, resourceSupplier.simpleResourceAccessor)
+            changeSet.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -332,7 +332,7 @@ public class ChangeSetTest extends Specification {
                 .addChild(null, "validCheckSum", "c2b7b29ce3a75940893cd022501852e2")
                 .addChild(null, "validCheckSum", "8:d54da29ce3a75940858cd093501158b8")
         try {
-            changeSet.load(node, resourceSupplier.simpleResourceAccessor)
+            changeSet.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -351,7 +351,7 @@ public class ChangeSetTest extends Specification {
                 new ParsedNode(null, "validCheckSum").setValue("8:d54da29ce3a75940858cd093501158b8")
         ])
         try {
-            changeSet.load(node, resourceSupplier.simpleResourceAccessor)
+            changeSet.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -369,7 +369,7 @@ public class ChangeSetTest extends Specification {
             changeSet.load(new ParsedNode(null, "changeSet").addChildren([preConditions: [
                     [runningAs: [username: "my_user"]],
                     [runningAs: [username: "my_other_user"]],
-            ]]), resourceSupplier.simpleResourceAccessor)
+            ]]), null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -387,7 +387,7 @@ public class ChangeSetTest extends Specification {
             changeSet.load(new ParsedNode(null, "changeSet").setValue(new ParsedNode(null, "preConditions").setValue([
                     [runningAs: [username: "my_user"]],
                     [runningAs: [username: "my_other_user"]],
-            ])), resourceSupplier.simpleResourceAccessor)
+            ])), null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -408,7 +408,7 @@ public class ChangeSetTest extends Specification {
                             [replace: [replace: "x1", with: "y1"]],
                             [replace: [replace: "x2", with: "y2"]],
                     ])
-            ]), resourceSupplier.simpleResourceAccessor)
+            ]), null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -436,7 +436,7 @@ public class ChangeSetTest extends Specification {
         when:
         def changeSet = new ChangeSet(new DatabaseChangeLog("com/example/test.xml"))
         try {
-            changeSet.load(new ParsedNode(null, "changeSet").addChild(new ParsedNode(null, "rollback")), resourceSupplier.simpleResourceAccessor)
+            changeSet.load(new ParsedNode(null, "changeSet").addChild(new ParsedNode(null, "rollback")), null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -454,7 +454,7 @@ public class ChangeSetTest extends Specification {
             def commentNode = new ParsedNode(null, "comment").setValue("comment here")
             def rollbackNode = new ParsedNode(null, "rollback").addChild(commentNode)
             def changeSetNode = new ParsedNode(null, "changeSet").addChild(rollbackNode)
-            changeSet.load(changeSetNode, resourceSupplier.simpleResourceAccessor)
+            changeSet.load(changeSetNode, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -473,7 +473,7 @@ public class ChangeSetTest extends Specification {
         def rollbackNode = new ParsedNode(null, "rollback").addChild(commentNode).addChild(renameTableNode)
         def changeSetNode = new ParsedNode(null, "changeSet").addChild(createTableNode).addChild(rollbackNode)
         try {
-            changeSet.load(changeSetNode, resourceSupplier.simpleResourceAccessor)
+            changeSet.load(changeSetNode, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -514,7 +514,7 @@ public class ChangeSetTest extends Specification {
                 new ParsedNode(null, "createTable").addChild(null, "tableName", "table_2")
         ]])
         try {
-            changeSet.load(node, resourceSupplier.simpleResourceAccessor)
+            changeSet.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -531,7 +531,7 @@ public class ChangeSetTest extends Specification {
         when:
         def changeSet = new ChangeSet(new DatabaseChangeLog("com/example/test.xml"))
         try {
-            changeSet.load(new ParsedNode(null, "changeSet").addChild(null, param, value), resourceSupplier.simpleResourceAccessor)
+            changeSet.load(new ParsedNode(null, "changeSet").addChild(null, param, value), null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -552,7 +552,7 @@ public class ChangeSetTest extends Specification {
         when:
         def changeSet = new ChangeSet(new DatabaseChangeLog("com/example/test.xml"))
         try {
-            changeSet.load(new ParsedNode(null, "changeSet").addChild(null, param, value), resourceSupplier.simpleResourceAccessor)
+            changeSet.load(new ParsedNode(null, "changeSet").addChild(null, param, value), null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }

--- a/liquibase-standard/src/test/groovy/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.groovy
@@ -255,14 +255,14 @@ CREATE TABLE ALL_CAPS_TABLE_2 (
 
     def invalidPrecondition() throws Exception {
         when:
-        new MockFormattedSqlChangeLogParser(INVALID_CHANGELOG_INVALID_PRECONDITION).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+        new MockFormattedSqlChangeLogParser(INVALID_CHANGELOG_INVALID_PRECONDITION).parse("asdf.sql", null, new ChangeLogParameters(), new JUnitResourceAccessor())
         then:
         thrown(ChangeLogParseException)
     }
 
     def invalidPreconditionPattern() throws Exception {
         when:
-        new MockFormattedSqlChangeLogParser(INVALID_CHANGELOG_INVALID_PRECONDITION_PATTERN).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+        new MockFormattedSqlChangeLogParser(INVALID_CHANGELOG_INVALID_PRECONDITION_PATTERN).parse("asdf.sql", null, new ChangeLogParameters(), new JUnitResourceAccessor())
         then:
         def e = thrown(ChangeLogParseException)
         assert e != null
@@ -274,7 +274,7 @@ CREATE TABLE ALL_CAPS_TABLE_2 (
         expect:
         ChangeLogParameters params = new ChangeLogParameters()
         params.set("tablename", "table4")
-        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(VALID_CHANGELOG).parse("asdf.sql", params, new JUnitResourceAccessor())
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(VALID_CHANGELOG).parse("asdf.sql", null, params, new JUnitResourceAccessor())
 
         changeLog.getLogicalFilePath() == "asdf.sql"
 
@@ -419,7 +419,7 @@ CREATE TABLE ALL_CAPS_TABLE_2 (
     def parseIgnoreProperty() throws Exception {
         expect:
         ChangeLogParameters params = new ChangeLogParameters()
-        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(VALID_CHANGELOG_WITH_IGNORE_PROP).parse("asdf.sql", params, new JUnitResourceAccessor())
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(VALID_CHANGELOG_WITH_IGNORE_PROP).parse("asdf.sql", null, params, new JUnitResourceAccessor())
 
         changeLog.getChangeSets().get(0).getAuthor() == "sk"
         changeLog.getChangeSets().get(0).getId() == "1"
@@ -437,7 +437,7 @@ CREATE TABLE ALL_CAPS_TABLE_2 (
                 "lastname VARCHAR(255))" +
                 ");\n"
 
-        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithOneGoodOneBad).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithOneGoodOneBad).parse("asdf.sql", null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         ChangeSet changeSet = changeLog.getChangeSets().get(0)
@@ -456,7 +456,7 @@ CREATE TABLE ALL_CAPS_TABLE_2 (
                 "lastname VARCHAR(255))" +
                 ");\n"
 
-        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithInvalidChangeSetAttributes).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithInvalidChangeSetAttributes).parse("asdf.sql", null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         def e = thrown(ChangeLogParseException)
@@ -470,7 +470,7 @@ CREATE TABLE ALL_CAPS_TABLE_2 (
                 "--preconditions onFail:HALT onSqlOutput:TEST\n" +
                 "--precondition-sql-check expectedResult:1 select count(*) from dual where 1=2;\n" +
                 "create table pctest2 (id number);"
-        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithOnSqlOutputPrecondition).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithOnSqlOutputPrecondition).parse("asdf.sql", null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         assert changeLog.getPreconditions().getOnSqlOutput() == PreconditionContainer.OnSqlOutputOption.TEST
@@ -483,7 +483,7 @@ CREATE TABLE ALL_CAPS_TABLE_2 (
                 "--preconditions onFail:HALT onUpdateSQL:TEST onSqlOutput:TEST\n" +
                 "--precondition-sql-check expectedResult:1 select count(*) from dual where 1=2;\n" +
                 "create table pctest2 (id number);"
-        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithOnSqlOutputPrecondition).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithOnSqlOutputPrecondition).parse("asdf.sql", null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         thrown(IllegalArgumentException.class)
@@ -502,7 +502,7 @@ CREATE TABLE ALL_CAPS_TABLE_2 (
                 "--changeset Steve\n" +
                 "create table test (id int);\n"
 
-        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithOneGoodOneBad).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithOneGoodOneBad).parse("asdf.sql", null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         thrown(ChangeLogParseException)
@@ -515,7 +515,7 @@ CREATE TABLE ALL_CAPS_TABLE_2 (
                 "--changeset Steve\n" +
                 "create table test (id int);\n"
 
-        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithOnlyAuthor).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithOnlyAuthor).parse("asdf.sql", null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         def e = thrown(ChangeLogParseException)
@@ -529,7 +529,7 @@ CREATE TABLE ALL_CAPS_TABLE_2 (
                 "--changeset John Doe:12345\n" +
                 "create table test (id int);\n"
 
-        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithSpace).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithSpace).parse("asdf.sql", null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         changeLog.getChangeSets().size() == 1
@@ -543,7 +543,7 @@ CREATE TABLE ALL_CAPS_TABLE_2 (
                 "--changeset John Doe:12345\n" +
                 "create table test (id int);\n"
 
-        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithSpace).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithSpace).parse("asdf.sql", null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         changeLog.getChangeSets().size() == 1
@@ -558,7 +558,7 @@ CREATE TABLE ALL_CAPS_TABLE_2 (
                 "-changeset John Doe:12345\n" +
                 "create table test (id int);\n"
 
-        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithOneDash).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithOneDash).parse("asdf.sql", null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         thrown(ChangeLogParseException)
@@ -572,7 +572,7 @@ CREATE TABLE ALL_CAPS_TABLE_2 (
                 "create table test (id int);\n" +
                 "-rollback drop table test;\n"
 
-        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithOneDash).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithOneDash).parse("asdf.sql", null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         def e = thrown(ChangeLogParseException)
@@ -589,7 +589,7 @@ CREATE TABLE ALL_CAPS_TABLE_2 (
                 "create table test (id int);\n" +
                 "-rollback drop table test;\n"
 
-        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithOneDash).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithOneDash).parse("asdf.sql", null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         def e = thrown(ChangeLogParseException)
@@ -624,7 +624,7 @@ not validCheckSum here
 not ignoreLines here
 - not ignoreLines here
 -- not ignoreLines here
-""".trim()).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+""".trim()).parse("asdf.sql", null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         StringUtil.standardizeLineEndings(((RawSQLChange) changeLog.getChangeSets()[0].getChanges()[0]).getSql().trim()) == StringUtil.standardizeLineEndings("""
@@ -659,7 +659,7 @@ not ignoreLines here
                 "--comment: This is a test comment\n" +
                 "create table test (id int);\n"
 
-        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithComment).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithComment).parse("asdf.sql", null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         changeLog.getChangeSets().size() == 1
@@ -674,7 +674,7 @@ not ignoreLines here
                 "--changeset JohnDoe:12345\n" +
                 "-comment: This is a test comment\n" +
                 "create table test (id int);\n"
-        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithComment).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithComment).parse("asdf.sql", null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         thrown(ChangeLogParseException)
@@ -686,7 +686,7 @@ not ignoreLines here
                 "--changeset JohnDoe:12345\n" +
                 "--comments: This is a test comment\n" +
                 "create table test (id int);\n"
-        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithComment).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithComment).parse("asdf.sql", null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         thrown(ChangeLogParseException)
@@ -703,7 +703,7 @@ not ignoreLines here
                 "--ignore:1\n" +
                 "foo\n" +
                 "create table tbl_dat7721e ( ID int not null, FNAME varchar(100) not null);\n"
-        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithComment).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithComment).parse("asdf.sql", null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         def e = thrown(ChangeLogParseException)
@@ -721,7 +721,7 @@ not ignoreLines here
                 "--ignore:1\n" +
                 "foo\n" +
                 "create table tbl_dat7721e ( ID int not null, FNAME varchar(100) not null);\n"
-        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogString).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogString).parse("asdf.sql", null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         def e = thrown(ChangeLogParseException)
@@ -740,7 +740,7 @@ not ignoreLines here
                 "foo\n" +
                 "-ignoreLines:end\n" +
                 "create table tbl_dat7721e ( ID int not null, FNAME varchar(100) not null);\n"
-        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogString).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogString).parse("asdf.sql", null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         def e = thrown(ChangeLogParseException)
@@ -751,7 +751,7 @@ not ignoreLines here
     @Unroll
     def parse_multipleDbms() throws Exception {
         when:
-        def changeLog = new MockFormattedSqlChangeLogParser(changelog).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+        def changeLog = new MockFormattedSqlChangeLogParser(changelog).parse("asdf.sql", null, new ChangeLogParameters(), new JUnitResourceAccessor())
         def dbmsSet = changeLog.getChangeSets().get(0).getDbmsSet()
 
         then:
@@ -773,7 +773,7 @@ not ignoreLines here
     def parse_withEndDelimiter() throws Exception {
         expect:
         ChangeLogParameters params = new ChangeLogParameters()
-        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(END_DELIMITER_CHANGELOG).parse("asdf.sql", params, new JUnitResourceAccessor())
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(END_DELIMITER_CHANGELOG).parse("asdf.sql", null, params, new JUnitResourceAccessor())
 
         changeLog.getLogicalFilePath() == "asdf.sql"
         changeLog.getChangeSets().size() == 1
@@ -792,7 +792,7 @@ not ignoreLines here
     @Unroll("#featureName: #example")
     def "example file"() {
         when:
-        def changeLog = new MockFormattedSqlChangeLogParser(example).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+        def changeLog = new MockFormattedSqlChangeLogParser(example).parse("asdf.sql", null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         ((RawSQLChange) changeLog.changeSets[0].changes[0]).sql.replace("\r\n", "\n") == expected
@@ -806,7 +806,7 @@ not ignoreLines here
 
     def parse_withAllCaps() {
         when:
-        def changeLog = new MockFormattedSqlChangeLogParser(VALID_ALL_CAPS_CHANGELOG).parse("ALL_CAPS.SQL", new ChangeLogParameters(), new JUnitResourceAccessor())
+        def changeLog = new MockFormattedSqlChangeLogParser(VALID_ALL_CAPS_CHANGELOG).parse("ALL_CAPS.SQL", null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         changeLog.getChangeSets().size() == 2
@@ -829,7 +829,7 @@ create table table1 (
 */
                """.trim()
 
-        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithMultiLineRollback).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithMultiLineRollback).parse("asdf.sql", null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         changeLog.getChangeSets().size() == 1
@@ -868,7 +868,7 @@ select (*) from table3;
 --rollback empty
                """.trim()
 
-        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithMultiLineRollback).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithMultiLineRollback).parse("asdf.sql", null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         changeLog.getChangeSets().size() == 3
@@ -905,7 +905,7 @@ create table table1 (
  drop table table1; */
                """.trim()
 
-        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithMultiLineRollback).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithMultiLineRollback).parse("asdf.sql", null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         changeLog.getChangeSets().size() == 1

--- a/liquibase-standard/src/test/groovy/liquibase/parser/core/xml/AbstractChangeLogParserTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/parser/core/xml/AbstractChangeLogParserTest.groovy
@@ -15,7 +15,7 @@ class AbstractChangeLogParserTest extends Specification {
 
     def "null node creates null changelog object"() {
         when:
-        def changeLog = createParser(null).parse("com/example/changelog.xml", new ChangeLogParameters(), resourceSupplier.simpleResourceAccessor)
+        def changeLog = createParser(null).parse("com/example/changelog.xml", null, new ChangeLogParameters(), resourceSupplier.simpleResourceAccessor)
         then:
         changeLog == null
     }
@@ -23,7 +23,7 @@ class AbstractChangeLogParserTest extends Specification {
     def "empty node creates empty changelog object"() {
         when:
         def changeLogNode = new ParsedNode(null, "databaseChangeLog")
-        def changeLog = createParser(changeLogNode).parse("com/example/changelog.xml", new ChangeLogParameters(), resourceSupplier.simpleResourceAccessor)
+        def changeLog = createParser(changeLogNode).parse("com/example/changelog.xml", null, new ChangeLogParameters(), resourceSupplier.simpleResourceAccessor)
 
         then:
         changeLog.physicalFilePath == "com/example/changelog.xml"
@@ -38,7 +38,7 @@ class AbstractChangeLogParserTest extends Specification {
         changeLogNode.addChildren([changeSet: [id: "2", author: "nvoxland"]]).children[1].value = [sql: "select * from y"]
         changeLogNode.addChildren([changeSet: [id: "3", author: "nvoxland"]]).children[2].value = [sql: "select * from z"]
 
-        def changeLog = createParser(changeLogNode).parse("com/example/changelog.xml", new ChangeLogParameters(), resourceSupplier.simpleResourceAccessor)
+        def changeLog = createParser(changeLogNode).parse("com/example/changelog.xml", null, new ChangeLogParameters(), resourceSupplier.simpleResourceAccessor)
 
         then:
         changeLog.preconditions.nestedPreconditions.size() == 0

--- a/liquibase-standard/src/test/groovy/liquibase/parser/core/xml/XMLChangeLogSAXParserTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/parser/core/xml/XMLChangeLogSAXParserTest.groovy
@@ -53,7 +53,7 @@ class XMLChangeLogSAXParserTest extends Specification {
     def testAllProvidedChangesetsAreLoaded() throws ChangeLogParseException, Exception {
         when:
         def xmlParser = new XMLChangeLogSAXParser()
-        def changeLog = xmlParser.parse("liquibase/parser/core/xml/ignoreDuplicatedChangeLogs/master.changelog.xml",
+        def changeLog = xmlParser.parse("liquibase/parser/core/xml/ignoreDuplicatedChangeLogs/master.changelog.xml", null,
                 new ChangeLogParameters(), new JUnitResourceAccessor())
 
         final List<ChangeSet> changeSets = new ArrayList<ChangeSet>()
@@ -92,7 +92,7 @@ class XMLChangeLogSAXParserTest extends Specification {
         when:
         def resourceAccessor = new MockResourceAccessor(["com/example/insecure.xml": INSECURE_XML])
 
-        new XMLChangeLogSAXParser().parse("com/example/insecure.xml", new ChangeLogParameters(), resourceAccessor)
+        new XMLChangeLogSAXParser().parse("com/example/insecure.xml", null, new ChangeLogParameters(), resourceAccessor)
 
         then:
         def e = thrown(ChangeLogParseException)
@@ -104,7 +104,7 @@ class XMLChangeLogSAXParserTest extends Specification {
         def resourceAccessor = new MockResourceAccessor(["com/example/insecure.xml": INSECURE_XML])
 
         Scope.child(GlobalConfiguration.SECURE_PARSING.key, "false", { ->
-            new XMLChangeLogSAXParser().parse("com/example/insecure.xml", new ChangeLogParameters(), resourceAccessor)
+            new XMLChangeLogSAXParser().parse("com/example/insecure.xml", null, new ChangeLogParameters(), resourceAccessor)
         })
 
 
@@ -119,7 +119,7 @@ class XMLChangeLogSAXParserTest extends Specification {
 
         when:
         def resourceAccessor = new MockResourceAccessor(["com/example/invalid.xml": INVALID_XML])
-        new XMLChangeLogSAXParser().parse(file, new ChangeLogParameters(), resourceAccessor)
+        new XMLChangeLogSAXParser().parse(file, null, new ChangeLogParameters(), resourceAccessor)
 
         then:
         def e = thrown(ChangeLogParseException)
@@ -138,7 +138,7 @@ class XMLChangeLogSAXParserTest extends Specification {
 
         then:
         Scope.child(GlobalConfiguration.VALIDATE_XML_CHANGELOG_FILES.key, "false", { ->
-            def d = new XMLChangeLogSAXParser().parse(file, new ChangeLogParameters(), resourceAccessor)
+            def d = new XMLChangeLogSAXParser().parse(file, null, new ChangeLogParameters(), resourceAccessor)
             assert d.physicalFilePath == file
             assert d.getChangeSets().isEmpty()
         })

--- a/liquibase-standard/src/test/groovy/liquibase/parser/core/xml/XMLChangeLogSAXParser_RealFile_Test.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/parser/core/xml/XMLChangeLogSAXParser_RealFile_Test.groovy
@@ -10,7 +10,6 @@ import com.example.liquibase.change.PrimaryKeyConfig
 import com.example.liquibase.change.UniqueConstraintConfig
 
 import liquibase.Contexts
-import liquibase.GlobalConfiguration
 import liquibase.Scope
 import liquibase.change.Change
 import liquibase.change.ChangeFactory
@@ -21,7 +20,6 @@ import liquibase.change.custom.ExampleCustomSqlChange
 import liquibase.changelog.ChangeLogParameters
 import liquibase.changelog.ChangeSet
 import liquibase.changelog.DatabaseChangeLog
-import liquibase.configuration.LiquibaseConfiguration
 import liquibase.database.ObjectQuotingStrategy
 import liquibase.database.core.H2Database
 import liquibase.database.core.MSSQLDatabase
@@ -68,7 +66,7 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
     def "able to parse a simple changelog simpleChangeLog.xml"() throws Exception {
         def path = "liquibase/parser/core/xml/simpleChangeLog.xml"
         when:
-        def changeLog = new XMLChangeLogSAXParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor());
+        def changeLog = new XMLChangeLogSAXParser().parse(path, null, new ChangeLogParameters(), new JUnitResourceAccessor());
         def changeSet = changeLog.changeSets[0];
         def change = changeSet.changes[0];
 
@@ -109,7 +107,7 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
     def "able to parse a changelog with multiple changeSets multiChangeSetChangeLog.xml"() throws Exception {
         def path = "liquibase/parser/core/xml/multiChangeSetChangeLog.xml"
         when:
-        DatabaseChangeLog changeLog = new XMLChangeLogSAXParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor());
+        DatabaseChangeLog changeLog = new XMLChangeLogSAXParser().parse(path, null, new ChangeLogParameters(), new JUnitResourceAccessor());
 
         then:
         changeLog.getLogicalFilePath() == path
@@ -171,7 +169,7 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
     def "local path can be set in changelog file logicalPathChangeLog.xml"() throws Exception {
         when:
         def physicalPath = "liquibase/parser/core/xml/logicalPathChangeLog.xml"
-        def changeLog = new XMLChangeLogSAXParser().parse(physicalPath, new ChangeLogParameters(), new JUnitResourceAccessor())
+        def changeLog = new XMLChangeLogSAXParser().parse(physicalPath, null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         changeLog.getLogicalFilePath() == "liquibase/parser-logical/xml/logicalPathChangeLog.xml"
@@ -188,7 +186,7 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
         def path = "liquibase/parser/core/xml/preconditionsChangeLog.xml"
         def params = new ChangeLogParameters()
         params.set("loginUser", "testUser")
-        def changeLog = new XMLChangeLogSAXParser().parse(path, params, new JUnitResourceAccessor());
+        def changeLog = new XMLChangeLogSAXParser().parse(path, null, params, new JUnitResourceAccessor());
 
         then:
         changeLog.getLogicalFilePath() == path
@@ -212,7 +210,7 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
     @Unroll("#featureName #path")
     def "changeSets with one level of includes parse correctly"() throws Exception {
         when:
-        DatabaseChangeLog changeLog = new XMLChangeLogSAXParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor())
+        DatabaseChangeLog changeLog = new XMLChangeLogSAXParser().parse(path, null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         changeLog.getLogicalFilePath() == path
@@ -241,7 +239,7 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
     @Unroll("#featureName #doubleNestedFileName")
     def "changeSets with two levels of includes parse correctly"() throws Exception {
         when:
-        DatabaseChangeLog changeLog = new XMLChangeLogSAXParser().parse(doubleNestedFileName, new ChangeLogParameters(), new JUnitResourceAccessor());
+        DatabaseChangeLog changeLog = new XMLChangeLogSAXParser().parse(doubleNestedFileName, null, new ChangeLogParameters(), new JUnitResourceAccessor());
 
         then:
         changeLog.getLogicalFilePath() == doubleNestedFileName
@@ -275,7 +273,7 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
     def "ChangeLogParseException thrown if changelog does not exist"() throws Exception {
         when:
         def path = "liquibase/changelog/parser/xml/missingChangeLog.xml"
-        new XMLChangeLogSAXParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor())
+        new XMLChangeLogSAXParser().parse(path, null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         def e = thrown(ChangeLogParseException)
@@ -284,7 +282,7 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
 
     def "ChangeLogParseException is thrown if the changeset has invalid tags"() throws Exception {
         when:
-        new XMLChangeLogSAXParser().parse("liquibase/parser/core/xml/malformedChangeLog.xml", new ChangeLogParameters(), new JUnitResourceAccessor())
+        new XMLChangeLogSAXParser().parse("liquibase/parser/core/xml/malformedChangeLog.xml", null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         def e = thrown(ChangeLogParseException)
@@ -293,7 +291,7 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
 
     def "ChangeLogParseException is thrown if validation is enabled and changelog has invalid tags"() throws Exception {
         when:
-        new XMLChangeLogSAXParser().parse("liquibase/parser/core/xml/malformedChangeLog.xml", new ChangeLogParameters(), new JUnitResourceAccessor())
+        new XMLChangeLogSAXParser().parse("liquibase/parser/core/xml/malformedChangeLog.xml", null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         def e = thrown(ChangeLogParseException)
@@ -302,7 +300,7 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
 
     def "ChangeLogParseException thrown if changelog is invalid XML: invalidChangeLog.xml"() throws Exception {
         when:
-        new XMLChangeLogSAXParser().parse("liquibase/parser/core/xml/invalidChangeLog.xml", new ChangeLogParameters(), new JUnitResourceAccessor())
+        new XMLChangeLogSAXParser().parse("liquibase/parser/core/xml/invalidChangeLog.xml", null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         def e = thrown(ChangeLogParseException)
@@ -313,7 +311,7 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
     def "tags that don't correspond to anything in liquibase are ignored"() throws Exception {
         def path = "liquibase/parser/core/xml/unusedTagsChangeLog.xml"
         expect:
-        DatabaseChangeLog changeLog = new XMLChangeLogSAXParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor());
+        DatabaseChangeLog changeLog = new XMLChangeLogSAXParser().parse(path, null, new ChangeLogParameters(), new JUnitResourceAccessor());
 
         changeLog.getLogicalFilePath() == path
         changeLog.getPhysicalFilePath() == path
@@ -342,7 +340,7 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
         params.set("columnName", "my_column_name");
         params.set("date", new Date(9999999));
         params.set("overridden", "Value passed in")
-		def changeLog = new XMLChangeLogSAXParser().parse("liquibase/parser/core/xml/parametersChangeLog.xml", params, new JUnitResourceAccessor());
+		def changeLog = new XMLChangeLogSAXParser().parse("liquibase/parser/core/xml/parametersChangeLog.xml", null, params, new JUnitResourceAccessor());
 
         then: "changeSet 1"
 		changeLog.getChangeSets().size() == 2
@@ -367,7 +365,7 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
 	def "tests for particular features and edge conditions part 1 testCasesChangeLog.xml"() throws Exception {
         when:
         def path = "liquibase/parser/core/xml/testCasesChangeLog.xml"
-        DatabaseChangeLog changeLog = new XMLChangeLogSAXParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor());
+        DatabaseChangeLog changeLog = new XMLChangeLogSAXParser().parse(path, null, new ChangeLogParameters(), new JUnitResourceAccessor());
 
         then: "before/after/position attributes are read correctly"
         ((AddColumnChange) changeLog.getChangeSet(path, "cmouttet", "using after column attribute").changes[0]).columns[0].getName() == "middlename";
@@ -428,7 +426,7 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
     def "tests for particular features and edge conditions part 2 testCasesChangeLog.xml"() throws Exception {
         when:
         def path = "liquibase/parser/core/xml/testCasesChangeLog.xml"
-        DatabaseChangeLog changeLog = new XMLChangeLogSAXParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor());
+        DatabaseChangeLog changeLog = new XMLChangeLogSAXParser().parse(path, null, new ChangeLogParameters(), new JUnitResourceAccessor());
 
 
         then: "comment in sql is parsed correctly"
@@ -518,7 +516,7 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
         def path = "liquibase/parser/core/xml/testCasesChangeLog.xml"
         def params = new ChangeLogParameters()
         params.set("loginUser", "sa")
-        DatabaseChangeLog changeLog = new XMLChangeLogSAXParser().parse(path, params, new JUnitResourceAccessor());
+        DatabaseChangeLog changeLog = new XMLChangeLogSAXParser().parse(path, null, params, new JUnitResourceAccessor());
 
 
         then: "complex preconditions are parsed"
@@ -608,7 +606,7 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
     def "changelog with multiple dropColumn columns can be parsed"() throws Exception {
         when:
         def path = "liquibase/parser/core/xml/addDropColumnsChangeLog.xml"
-        def changeLog = new XMLChangeLogSAXParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor());
+        def changeLog = new XMLChangeLogSAXParser().parse(path, null, new ChangeLogParameters(), new JUnitResourceAccessor());
 
         then:  "add columns"
         assert 2 == changeLog.getChangeSets().get(1).getChanges().get(0).getColumns().size()
@@ -631,7 +629,7 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
 
         when:
         def path = "liquibase/parser/core/xml/nestedObjectsChangeLog.xml"
-        def changeLog = new XMLChangeLogSAXParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor())
+        def changeLog = new XMLChangeLogSAXParser().parse(path, null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         changeLog.getChangeSets().size() == 1
@@ -711,7 +709,7 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
         when:
         def path = "liquibase/parser/core/xml/rollbackWithDbmsChangeLog.xml"
         def database = new MSSQLDatabase()
-        def changeLog = new XMLChangeLogSAXParser().parse(path, new ChangeLogParameters(database), new JUnitResourceAccessor())
+        def changeLog = new XMLChangeLogSAXParser().parse(path, null, new ChangeLogParameters(database), new JUnitResourceAccessor())
 
         then:
         changeLog.getChangeSets().size() == 4
@@ -721,7 +719,7 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
         when:
         def path = "liquibase/parser/core/xml/rollbackWithDbmsChangeLog.xml"
         def database = new H2Database()
-        def changeLog = new XMLChangeLogSAXParser().parse(path, new ChangeLogParameters(database), new JUnitResourceAccessor())
+        def changeLog = new XMLChangeLogSAXParser().parse(path, null, new ChangeLogParameters(database), new JUnitResourceAccessor())
 
         then:
         changeLog.getChangeSets().size() == 2
@@ -731,7 +729,7 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
         when:
         def path = "liquibase/parser/core/xml/excludeDbmsChangeLog.xml"
         def database = new MSSQLDatabase()
-        def changeLog = new XMLChangeLogSAXParser().parse(path, new ChangeLogParameters(database), new JUnitResourceAccessor())
+        def changeLog = new XMLChangeLogSAXParser().parse(path, null, new ChangeLogParameters(database), new JUnitResourceAccessor())
 
         then:
         changeLog.getChangeSets().size() == 2
@@ -744,7 +742,7 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
         when:
         def path = "liquibase/parser/core/xml/excludeDbmsChangeLog.xml"
         def database = new H2Database()
-        def changeLog = new XMLChangeLogSAXParser().parse(path, new ChangeLogParameters(database), new JUnitResourceAccessor())
+        def changeLog = new XMLChangeLogSAXParser().parse(path, null, new ChangeLogParameters(database), new JUnitResourceAccessor())
 
         then:
         changeLog.getChangeSets().size() == 2

--- a/liquibase-standard/src/test/groovy/liquibase/parser/core/yaml/YamlChangeLogParser_RealFile_Test.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/parser/core/yaml/YamlChangeLogParser_RealFile_Test.groovy
@@ -11,7 +11,6 @@ import com.example.liquibase.change.UniqueConstraintConfig
 
 import liquibase.Contexts
 import liquibase.Scope
-import liquibase.change.Change
 import liquibase.change.ChangeFactory
 import liquibase.change.CheckSum
 import liquibase.change.core.AddColumnChange
@@ -77,7 +76,7 @@ public class YamlChangeLogParser_RealFile_Test extends Specification {
     def "able to parse a simple changelog simpleChangeLog.yaml"() throws ChangeLogParseException {
         def path = "liquibase/parser/core/yaml/simpleChangeLog.yaml"
         when:
-        def changeLog = new YamlChangeLogParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor());
+        def changeLog = new YamlChangeLogParser().parse(path, null, new ChangeLogParameters(), new JUnitResourceAccessor());
         def changeSet = changeLog.changeSets[0]
         def change = changeSet.changes[0]
 
@@ -117,7 +116,7 @@ public class YamlChangeLogParser_RealFile_Test extends Specification {
     def "throws a nice validation error when changeSet node has typo in name"() throws ChangeLogParseException {
         def path = "liquibase/parser/core/yaml/typoChangeLog.yaml"
         when:
-        new YamlChangeLogParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor());
+        new YamlChangeLogParser().parse(path, null, new ChangeLogParameters(), new JUnitResourceAccessor());
 
         then:
         thrown(ChangeLogParseException.class)
@@ -126,7 +125,7 @@ public class YamlChangeLogParser_RealFile_Test extends Specification {
     def "able to parse a changelog with multiple changeSets multiChangeSetChangeLog.yaml"() throws Exception {
         def path = "liquibase/parser/core/yaml/multiChangeSetChangeLog.yaml"
         when:
-        DatabaseChangeLog changeLog = new YamlChangeLogParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor());
+        DatabaseChangeLog changeLog = new YamlChangeLogParser().parse(path, null, new ChangeLogParameters(), new JUnitResourceAccessor());
 
         then:
         changeLog.getLogicalFilePath() == path
@@ -183,7 +182,7 @@ public class YamlChangeLogParser_RealFile_Test extends Specification {
     def "local path can be set in changelog file logicalPathChangeLog.yaml"() throws Exception {
         when:
         def physicalPath = "liquibase/parser/core/yaml/logicalPathChangeLog.yaml"
-        def changeLog = new YamlChangeLogParser().parse(physicalPath, new ChangeLogParameters(), new JUnitResourceAccessor())
+        def changeLog = new YamlChangeLogParser().parse(physicalPath, null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         changeLog.getLogicalFilePath() == "liquibase/parser-logical/yaml/logicalPathChangeLog.yaml"
@@ -198,7 +197,7 @@ public class YamlChangeLogParser_RealFile_Test extends Specification {
     def "changelog with preconditions can be parsed: preconditionsChangeLog.yaml"() throws Exception {
         when:
         def path = "liquibase/parser/core/yaml/preconditionsChangeLog.yaml"
-        def changeLog = new YamlChangeLogParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor());
+        def changeLog = new YamlChangeLogParser().parse(path, null, new ChangeLogParameters(), new JUnitResourceAccessor());
 
         then:
         changeLog.getLogicalFilePath() == path
@@ -222,7 +221,7 @@ public class YamlChangeLogParser_RealFile_Test extends Specification {
     @Unroll("#featureName #path")
     def "changeSets with one level of includes parse correctly"() throws Exception {
         when:
-        DatabaseChangeLog changeLog = new YamlChangeLogParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor())
+        DatabaseChangeLog changeLog = new YamlChangeLogParser().parse(path, null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         changeLog.getLogicalFilePath() == path
@@ -251,7 +250,7 @@ public class YamlChangeLogParser_RealFile_Test extends Specification {
     @Unroll("#featureName #doubleNestedFileName")
     def "changeSets with two levels of includes parse correctly"() throws Exception {
         when:
-        DatabaseChangeLog changeLog = new YamlChangeLogParser().parse(doubleNestedFileName, new ChangeLogParameters(), new JUnitResourceAccessor());
+        DatabaseChangeLog changeLog = new YamlChangeLogParser().parse(doubleNestedFileName, null, new ChangeLogParameters(), new JUnitResourceAccessor());
 
         then:
         changeLog.getLogicalFilePath() == doubleNestedFileName
@@ -284,7 +283,7 @@ public class YamlChangeLogParser_RealFile_Test extends Specification {
     def "ChangeLogParseException thrown if changelog does not exist"() throws Exception {
         when:
         def path = "liquibase/changelog/parser/yaml/missingChangeLog.yaml"
-        new YamlChangeLogParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor())
+        new YamlChangeLogParser().parse(path, null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         def e = thrown(ChangeLogParseException)
@@ -293,7 +292,7 @@ public class YamlChangeLogParser_RealFile_Test extends Specification {
 
     def "ChangeLogParseException thrown if changelog has invalid tags"() throws Exception {
         when:
-        new YamlChangeLogParser().parse("liquibase/parser/core/yaml/malformedChangeLog.yaml", new ChangeLogParameters(), new JUnitResourceAccessor())
+        new YamlChangeLogParser().parse("liquibase/parser/core/yaml/malformedChangeLog.yaml", null, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:
         def e = thrown(ChangeLogParseException)
@@ -309,7 +308,7 @@ public class YamlChangeLogParser_RealFile_Test extends Specification {
         params.set("columnName", "my_column_name");
         params.set("date", new Date(9999999));
         params.set("overridden", "Value passed in")
-        def changeLog = new YamlChangeLogParser().parse("liquibase/parser/core/yaml/parametersChangeLog.yaml", params, new JUnitResourceAccessor());
+        def changeLog = new YamlChangeLogParser().parse("liquibase/parser/core/yaml/parametersChangeLog.yaml", null, params, new JUnitResourceAccessor());
 
         then: "changeSet 1"
         changeLog.getChangeSets().size() == 2
@@ -335,7 +334,7 @@ public class YamlChangeLogParser_RealFile_Test extends Specification {
     def "tests for particular features and edge conditions part 1 testCasesChangeLog.yaml"() throws Exception {
         when:
         def path = "liquibase/parser/core/yaml/testCasesChangeLog.yaml"
-        DatabaseChangeLog changeLog = new YamlChangeLogParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor());
+        DatabaseChangeLog changeLog = new YamlChangeLogParser().parse(path, null, new ChangeLogParameters(), new JUnitResourceAccessor());
 
         then: "before/after/position attributes are read correctly"
         ((AddColumnChange) changeLog.getChangeSet(path, "cmouttet", "using after column attribute").changes[0]).columns[0].getName() == "middlename";
@@ -396,7 +395,7 @@ public class YamlChangeLogParser_RealFile_Test extends Specification {
     def "tests for particular features and edge conditions part 2 testCasesChangeLog.yaml"() throws Exception {
         when:
         def path = "liquibase/parser/core/yaml/testCasesChangeLog.yaml"
-        DatabaseChangeLog changeLog = new YamlChangeLogParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor());
+        DatabaseChangeLog changeLog = new YamlChangeLogParser().parse(path, null, new ChangeLogParameters(), new JUnitResourceAccessor());
 
 
         then: "comment in sql is parsed correctly"
@@ -484,7 +483,7 @@ public class YamlChangeLogParser_RealFile_Test extends Specification {
     def "tests for particular features and edge conditions part 3 testCasesChangeLog.yaml"() throws Exception {
         when:
         def path = "liquibase/parser/core/yaml/testCasesChangeLog.yaml"
-        DatabaseChangeLog changeLog = new YamlChangeLogParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor());
+        DatabaseChangeLog changeLog = new YamlChangeLogParser().parse(path, null, new ChangeLogParameters(), new JUnitResourceAccessor());
 
 
         then: "complex preconditions are parsed"
@@ -575,7 +574,7 @@ public class YamlChangeLogParser_RealFile_Test extends Specification {
 
         when:
         def path = "liquibase/parser/core/yaml/nestedObjectsChangeLog.yaml"
-        def changeLog = new YamlChangeLogParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor());
+        def changeLog = new YamlChangeLogParser().parse(path, null, new ChangeLogParameters(), new JUnitResourceAccessor());
 
         then:
         changeLog.getChangeSets().size() == 1

--- a/liquibase-standard/src/test/groovy/liquibase/precondition/CustomPreconditionWrapperTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/precondition/CustomPreconditionWrapperTest.groovy
@@ -21,7 +21,7 @@ class CustomPreconditionWrapperTest extends Specification {
                 .addChild(new ParsedNode(null, "param").addChildren([name: "param 3"]).setValue("param 3 value"))
         def precondition = new CustomPreconditionWrapper()
         try {
-            precondition.load(node, resourceSupplier.simpleResourceAccessor)
+            precondition.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }
@@ -47,7 +47,7 @@ class CustomPreconditionWrapperTest extends Specification {
         )
         def precondition = new CustomPreconditionWrapper()
         try {
-            precondition.load(node, resourceSupplier.simpleResourceAccessor)
+            precondition.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }

--- a/liquibase-standard/src/test/groovy/liquibase/precondition/core/PreconditionContainerTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/precondition/core/PreconditionContainerTest.groovy
@@ -1,6 +1,6 @@
 package liquibase.precondition.core
 
-import liquibase.GlobalConfiguration
+
 import liquibase.Scope
 import liquibase.exception.SetupException
 import liquibase.parser.ChangeLogParserConfiguration
@@ -20,7 +20,7 @@ class PreconditionContainerTest extends Specification {
         def node = new ParsedNode(null, "preConditions").addChildren([onFail: "MARK_RAN", onError: "CONTINUE", onSqlOutput: "IGNORE", onFailMessage: "I Failed", onErrorMessage: "I Errored"])
         def container = new PreconditionContainer()
         try {
-            container.load(node, resourceSupplier.simpleResourceAccessor)
+            container.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         } catch (SetupException e) {
@@ -40,7 +40,7 @@ class PreconditionContainerTest extends Specification {
         def node = new ParsedNode(null, "preConditions").addChildren([onFail: "MARK_RAN"]).setValue(new ParsedNode(null, "tableExists").addChildren([tableName: "my_table"]))
         def container = new PreconditionContainer()
         try {
-            container.load(node, resourceSupplier.simpleResourceAccessor)
+            container.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         } catch (SetupException e) {
@@ -62,7 +62,7 @@ class PreconditionContainerTest extends Specification {
         ])
         def container = new PreconditionContainer()
         try {
-            container.load(node, resourceSupplier.simpleResourceAccessor)
+            container.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         } catch (SetupException e) {
@@ -85,7 +85,7 @@ class PreconditionContainerTest extends Specification {
 
         def container = new PreconditionContainer()
         try {
-            container.load(node, resourceSupplier.simpleResourceAccessor)
+            container.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         } catch (SetupException e) {
@@ -112,7 +112,7 @@ class PreconditionContainerTest extends Specification {
 
         def container = new PreconditionContainer()
         try {
-            container.load(node, resourceSupplier.simpleResourceAccessor)
+            container.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         } catch (SetupException e) {
@@ -139,7 +139,7 @@ class PreconditionContainerTest extends Specification {
                 .addChild(new ParsedNode(null, "tableExists").addChildren([tableName: "my_table"]))
 
         def container = new PreconditionContainer()
-        container.load(node, resourceSupplier.simpleResourceAccessor)
+        container.load(node, null, resourceSupplier.simpleResourceAccessor)
 
         then:
         def e = thrown(ParsedNodeException)
@@ -155,7 +155,7 @@ class PreconditionContainerTest extends Specification {
         def container = new PreconditionContainer()
         Scope.currentScope.child([(ChangeLogParserConfiguration.CHANGELOG_PARSE_MODE.key): ChangeLogParserConfiguration.ChangelogParseMode.LAX], {
             ->
-            container.load(node, resourceSupplier.simpleResourceAccessor)
+            container.load(node, null, resourceSupplier.simpleResourceAccessor)
         } as Scope.ScopedRunner)
 
 

--- a/liquibase-standard/src/test/groovy/liquibase/precondition/core/SqlPreconditionTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/precondition/core/SqlPreconditionTest.groovy
@@ -12,7 +12,7 @@ class SqlPreconditionTest extends Specification {
         when:
         def precondition = new SqlPrecondition()
         try {
-            precondition.load(new liquibase.parser.core.ParsedNode(null, "sqlCheck").addChild(null, "expectedResult", "5").setValue("select count(*) from test"), resourceSupplier.simpleResourceAccessor)
+            precondition.load(new liquibase.parser.core.ParsedNode(null, "sqlCheck").addChild(null, "expectedResult", "5").setValue("select count(*) from test"), null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         }

--- a/liquibase-standard/src/test/groovy/liquibase/sql/visitor/StandardSqlVisitorTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/sql/visitor/StandardSqlVisitorTest.groovy
@@ -20,7 +20,7 @@ abstract class StandardSqlVisitorTest extends Specification {
         def fieldValue = "value for ${field}"
         node.addChild(null, field, fieldValue)
         try {
-            visitor.load(node, resourceSupplier.simpleResourceAccessor)
+            visitor.load(node, null, resourceSupplier.simpleResourceAccessor)
         } catch (ParsedNodeException e) {
             e.printStackTrace()
         } catch (SetupException e) {

--- a/liquibase-standard/src/test/java/liquibase/change/ChangeFactoryTest.java
+++ b/liquibase-standard/src/test/java/liquibase/change/ChangeFactoryTest.java
@@ -36,17 +36,17 @@ public class ChangeFactoryTest {
 
     @Test
     public void create_exists() {
-        Change change = Scope.getCurrentScope().getSingleton(ChangeFactory.class).create("createTable");
+        Change change = Scope.getCurrentScope().getSingleton(ChangeFactory.class).create("createTable", null);
 
         assertNotNull(change);
         assertTrue(change instanceof CreateTableChange);
 
-        assertNotSame(change, Scope.getCurrentScope().getSingleton(ChangeFactory.class).create("createTable"));
+        assertNotSame(change, Scope.getCurrentScope().getSingleton(ChangeFactory.class).create("createTable", null));
     }
 
     @Test
     public void create_notExists() {
-        Change change = Scope.getCurrentScope().getSingleton(ChangeFactory.class).create("badChangeName");
+        Change change = Scope.getCurrentScope().getSingleton(ChangeFactory.class).create("badChangeName", null);
 
         assertNull(change);
 

--- a/liquibase-standard/src/test/java/liquibase/parser/MockChangeLogParser.java
+++ b/liquibase-standard/src/test/java/liquibase/parser/MockChangeLogParser.java
@@ -2,6 +2,7 @@ package liquibase.parser;
 
 import liquibase.changelog.ChangeLogParameters;
 import liquibase.changelog.DatabaseChangeLog;
+import liquibase.database.Database;
 import liquibase.exception.ChangeLogParseException;
 import liquibase.resource.ResourceAccessor;
 import liquibase.servicelocator.LiquibaseService;
@@ -41,7 +42,7 @@ public class MockChangeLogParser implements ChangeLogParser {
     }
 
     @Override
-    public DatabaseChangeLog parse(String physicalChangeLogLocation, ChangeLogParameters changeLogParameters,
+    public DatabaseChangeLog parse(String physicalChangeLogLocation, Database database, ChangeLogParameters changeLogParameters,
                                    ResourceAccessor resourceAccessor) throws ChangeLogParseException {
         return changeLogs.get(physicalChangeLogLocation);
     }

--- a/liquibase-standard/src/test/java/liquibase/precondition/MockPrecondition.java
+++ b/liquibase-standard/src/test/java/liquibase/precondition/MockPrecondition.java
@@ -38,7 +38,7 @@ public class MockPrecondition implements Precondition {
     }
 
     @Override
-    public void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException {
+    public void load(ParsedNode parsedNode, Database database, ResourceAccessor resourceAccessor) throws ParsedNodeException {
 
     }
 

--- a/liquibase-standard/src/test/java/liquibase/verify/change/VerifyChangeClassesTest.java
+++ b/liquibase-standard/src/test/java/liquibase/verify/change/VerifyChangeClassesTest.java
@@ -61,7 +61,7 @@ public class VerifyChangeClassesTest extends AbstractVerifyTest {
                 TestState state = new TestState(name.getMethodName(), changeName, database.getShortName(), TestState.Type.SQL);
                 state.addComment("Database: " + database.getShortName());
 
-                Change change = changeFactory.create(changeName);
+                Change change = changeFactory.create(changeName, database);
                 if (!change.supports(database)) {
                     continue;
                 }
@@ -162,7 +162,7 @@ public class VerifyChangeClassesTest extends AbstractVerifyTest {
                     continue; //need to better handle strange "one of path or body is required" logic
                 }
 
-                Change change = changeFactory.create(changeName);
+                Change change = changeFactory.create(changeName, database);
                 if (!change.supports(database)) {
                     continue;
                 }
@@ -212,7 +212,7 @@ public class VerifyChangeClassesTest extends AbstractVerifyTest {
                 TestState state = new TestState(name.getMethodName(), changeName, database.getShortName(), TestState.Type.SQL);
                 state.addComment("Database: " + database.getShortName());
 
-                Change baseChange = changeFactory.create(changeName);
+                Change baseChange = changeFactory.create(changeName, database);
                 if (!baseChange.supports(database)) {
                     continue;
                 }
@@ -235,7 +235,7 @@ public class VerifyChangeClassesTest extends AbstractVerifyTest {
                     }
                 });
                 for (List<String> permutation : paramLists) {
-                    Change change = changeFactory.create(changeName);
+                    Change change = changeFactory.create(changeName, database);
 //
                     for (String paramName : new TreeSet<String>(changeMetaData.getRequiredParameters(database).keySet())) {
                         ChangeParameterMetaData param = changeMetaData.getParameters().get(paramName);


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

This tentatively fixes an issue where database-specific change subclasses are selected for databases they do not support. See #4239.

## Things to be aware of

I made it so `ChangeSet#toChange` gets access to the current `Database` instance, but propagating that information touches many many areas.

## Things to worry about

I've defaulted the newly exposed `Database` instance to `null`, but it would need to be properly passed.
The current approach is likely a no-go since that breaks compatibility with (at least) the `ChangeLogParser`.

Consider a basis for discussion instead.
