### PR TITLE
add release-drafter to liquibase

### DIFF
--- a/.github/draft-release.yml
+++ b/.github/draft-release.yml
@@ -1,0 +1,46 @@
+name-template: 'Liquibase v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: ':green_book: Notable Changes'
+    labels: 
+      - 'notablechanges'
+  - title: '🚀 New Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes 🛠'
+    labels:
+      - 'bugfix'
+  - title: ':boom: Breaking Changes'
+    label: 
+      - 'breakingChanges'    
+  - title: 'Security, Driver and other updates'   
+    labels:
+      - 'sdou'
+  - title: '👏 New Contributors'
+    labels:
+      - 'newcontributors'    
+  - title: 'API'
+    label: 
+      - 'API'
+change-template: '- (#$NUMBER) $TITLE @$AUTHOR '
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'feature'
+      - 'enhancement'
+      - 'patch'
+      - 'bugfix'
+      - 'sdou'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Liquibase OSS should have a draft release autogenerated like the extensions.
Every PR should include either of the label which belongs either to :

- notablechanges
- feature
- enhancement
- bugfix
- breakingChanges
- sdou (Security, Driver and other updates)
- newcontributors
- API
