### PR TITLE
Fix paths starting with dot dot

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -935,9 +935,10 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
             filePath = NO_LETTER_PATTERN.matcher(filePath).replaceFirst("");
         }
 
-        if (filePath.startsWith(".")) {
+        if (filePath.startsWith("./")) {
             filePath = filePath.substring(1);
         }
+
         if (filePath.startsWith("/")) {
             filePath = filePath.substring(1);
         }

--- a/liquibase-standard/src/test/groovy/liquibase/changelog/DatabaseChangeLogTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/changelog/DatabaseChangeLogTest.groovy
@@ -642,6 +642,10 @@ http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbch
         "c:\\path\\to\\changelog.xml"         | "path/to/changelog.xml"
         "c:/path/to/changelog.xml"            | "path/to/changelog.xml"
         "D:\\a\\liquibase\\DBDocTaskTest.xml" | "a/liquibase/DBDocTaskTest.xml"
+        "..\\path\\to\\changelog.xml"         | "../path/to/changelog.xml"
+        "../path/changelog.xml"               | "../path/changelog.xml"
+        "..\\..\\path\\changelog.xml"         | "../../path/changelog.xml"
+        "../../path/changelog.xml"            | "../../path/changelog.xml"
     }
 
     def "warning message is logged when changelog include fails because file does not exist"() {


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

If a changelog file path starts with ".." , Liquibase was removing the first "." thus could not find the file. This PR fixes this behavior.

## Additional Context

Bug introduced in Liquibase 4.21.0 by PR https://github.com/liquibase/liquibase/pull/3853 .
