### PR TITLE
DAT-15030

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"
 
   - package-ecosystem: "maven"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
     schedule:
       interval: "daily"
     labels:
+      - "sdou"
       - "dependencies"
 
   - package-ecosystem: "maven"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -12,13 +12,13 @@ categories:
   - title: '🐛 Bug Fixes 🛠'
     labels:
       - 'TypeBug'
-  - title: ':boom: Breaking Changes'
+  - title: '💥 Breaking Changes'
     labels: 
       - 'breakingChanges'
-  - title: ':boom: API Breaking Changes'
+  - title: '💥 API Breaking Changes'
     labels: 
       - 'APIBreakingChanges'
-  - title: '⬆️ Security, Driver and other updates'
+  - title: '🤖 Security, Driver and other updates'
     collapse-after: 5
     labels:
       - 'sdou'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -13,8 +13,8 @@ categories:
     labels:
       - 'bugfix'
   - title: ':boom: Breaking Changes'
-    label: 
-      - 'breakingChanges'    
+    labels: 
+      - 'breakingChanges'
   - title: 'Security, Driver and other updates'   
     labels:
       - 'sdou'
@@ -22,7 +22,7 @@ categories:
     labels:
       - 'newcontributors'    
   - title: 'API'
-    label: 
+    labels: 
       - 'API'
 change-template: '- (#$NUMBER) $TITLE @$AUTHOR '
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,7 +18,8 @@ categories:
   - title: ':boom: API Breaking Changes'
     labels: 
       - 'APIBreakingChanges'
-  - title: 'Security, Driver and other updates'   
+  - title: '⬆️ Dependencies'
+    collapse-after: 5
     labels:
       - 'dependencies'
   - title: '👏 New Contributors'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,9 +18,10 @@ categories:
   - title: ':boom: API Breaking Changes'
     labels: 
       - 'APIBreakingChanges'
-  - title: '⬆️ Dependencies'
+  - title: '⬆️ Security, Driver and other updates'
     collapse-after: 5
     labels:
+      - 'sdou'
       - 'dependencies'
   - title: '👏 New Contributors'
     labels:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,7 +18,7 @@ categories:
   - title: ':boom: API Breaking Changes'
     labels: 
       - 'APIBreakingChanges'
-  - title: '⬆️ Security, Driver and other updates'
+  - title: ':shield: Security, Driver and other updates'
     collapse-after: 5
     labels:
       - 'sdou'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,7 +18,7 @@ categories:
   - title: '💥 API Breaking Changes'
     labels: 
       - 'APIBreakingChanges'
-  - title: '🤖 Security, Driver and other updates'
+  - title: '🤖 Other Updates'
     collapse-after: 5
     labels:
       - 'sdou'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -7,23 +7,24 @@ categories:
       - 'notablechanges'
   - title: '🚀 New Features'
     labels:
-      - 'feature'
-      - 'enhancement'
+      - 'TypeEnhancement'
+      - 'TypeTest'
   - title: '🐛 Bug Fixes 🛠'
     labels:
-      - 'bugfix'
+      - 'TypeBug'
   - title: ':boom: Breaking Changes'
     labels: 
       - 'breakingChanges'
+  - title: ':boom: API Breaking Changes'
+    labels: 
+      - 'APIBreakingChanges'
   - title: 'Security, Driver and other updates'   
     labels:
-      - 'sdou'
+      - 'dependencies'
   - title: '👏 New Contributors'
     labels:
       - 'newcontributors'    
-  - title: 'API'
-    labels: 
-      - 'API'
+  
 change-template: '- (#$NUMBER) $TITLE @$AUTHOR '
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,7 +18,7 @@ categories:
   - title: ':boom: API Breaking Changes'
     labels: 
       - 'APIBreakingChanges'
-  - title: ':arrow_up: Security, Driver and other updates'
+  - title: '⬆️ Security, Driver and other updates'
     collapse-after: 5
     labels:
       - 'sdou'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,7 +18,7 @@ categories:
   - title: ':boom: API Breaking Changes'
     labels: 
       - 'APIBreakingChanges'
-  - title: ':shield: Security, Driver and other updates'
+  - title: ':arrow_up: Security, Driver and other updates'
     collapse-after: 5
     labels:
       - 'sdou'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,7 +18,7 @@ categories:
   - title: '💥 API Breaking Changes'
     labels: 
       - 'APIBreakingChanges'
-  - title: '🤖 Other Updates'
+  - title: '🤖 Other Security Updates'
     collapse-after: 5
     labels:
       - 'sdou'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,7 +18,7 @@ categories:
   - title: '💥 API Breaking Changes'
     labels: 
       - 'APIBreakingChanges'
-  - title: '🤖 Other Security Updates'
+  - title: '🤖 Security Driver and Other Updates'
     collapse-after: 5
     labels:
       - 'sdou'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,6 +12,12 @@ permissions:
 
 jobs:
   update_release_draft:
+    permissions:
+        # write permission is required to create a github release
+        contents: write
+        # write permission is required for autolabeler
+        # otherwise, read permission is required at least
+        pull-requests: write
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into the default branch


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
Liquibase OSS should have a draft release autogenerated like the extensions.
Every PR should include either of the label which belongs either to :

- notablechanges
- TypeEnhancement
- TypeBug
- TypeTest
- breakingChanges
- The below 2 will be added to all the PR's created by dependabot. For some reason I cannot get any PR created by dependabot with label as "dependencies" under the hood of "Security, Driver and other updates"
  - dependencies
  - sdou 
- newcontributors
- APIBreakingChanges