### PR TITLE
Fixes issue #4413: Undocumented IT requirement: Username "liquibase"

### DIFF
--- a/liquibase-integration-tests/src/test/resources/changelogs/asany/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/asany/complete/root.changelog.xml
@@ -136,7 +136,7 @@
 
     <changeSet id="16" author="nvoxland">
         <createView viewName="personView">
-            select * from liquibase.person
+            select * from ${loginUser}.person
         </createView>
     </changeSet>
 


### PR DESCRIPTION
Fixes #4413 

## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Despite the title and description of issue #4413, the actual cause of the failing IT was *not* an undocumented IT requirement, but the fact that the author of the IT (unintentionally) used the static prefix "liquibase" instead of the dynamic prefix provided by the test driver.

The solution hence is to replace the static prefix by the dynamic prefix. Hence, there is nothing wrong with the test documentation.

## Things to be aware of

N/A

## Things to worry about

N/A

## Additional Context

N/A