### PR TITLE
Normalize path using static function for Strings rather than Path.nor…

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -228,16 +228,16 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
     }
 
     public ChangeSet getChangeSet(String path, String author, String id) {
-	    final List<ChangeSet> possibleChangeSets = getChangeSets(path, author, id);
-	    if (possibleChangeSets.isEmpty()){
-	    	return null;
-	    }
-	    return possibleChangeSets.get(0);
+        final List<ChangeSet> possibleChangeSets = getChangeSets(path, author, id);
+        if (possibleChangeSets.isEmpty()) {
+            return null;
+        }
+        return possibleChangeSets.get(0);
     }
 
     public List<ChangeSet> getChangeSets(String path, String author, String id) {
-	    final ArrayList<ChangeSet> changeSetsToReturn = new ArrayList<>();
-	    for (ChangeSet changeSet : this.changeSets) {
+        final ArrayList<ChangeSet> changeSetsToReturn = new ArrayList<>();
+        for (ChangeSet changeSet : this.changeSets) {
             final String normalizedPath = normalizePath(changeSet.getFilePath());
             if (normalizedPath != null &&
                     normalizedPath.equalsIgnoreCase(normalizePath(path)) &&
@@ -417,8 +417,8 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                 break;
             case "modifyChangeSets":
                 ModifyChangeSets modifyChangeSets = new ModifyChangeSets(
-                        (String)node.getChildValue(null, "runWith"),
-                        (String)node.getChildValue(null, "runWithSpoolFile"));
+                        (String) node.getChildValue(null, "runWith"),
+                        (String) node.getChildValue(null, "runWithSpoolFile"));
                 nodeScratch = new HashMap<>();
                 nodeScratch.put("modifyChangeSets", modifyChangeSets);
                 for (ParsedNode modifyChildNode : node.getChildren()) {
@@ -448,7 +448,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                             labels,
                             ignore,
                             OnUnknownFileFormat.FAIL,
-                            (ModifyChangeSets)nodeScratch.get("modifyChangeSets"));
+                            (ModifyChangeSets) nodeScratch.get("modifyChangeSets"));
                 } catch (LiquibaseException e) {
                     throw new SetupException(e);
                 }
@@ -502,7 +502,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                         ignore,
                         node.getChildValue(null, "minDepth", 1),
                         node.getChildValue(null, "maxDepth", Integer.MAX_VALUE),
-                        (ModifyChangeSets)nodeScratch.get("modifyChangeSets"));
+                        (ModifyChangeSets) nodeScratch.get("modifyChangeSets"));
                 break;
             }
             case "preConditions": {
@@ -550,8 +550,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                         if (!resource.exists()) {
                             if (errorIfMissing) {
                                 throw new UnexpectedLiquibaseException(FileUtil.getFileNotFoundMessage(file));
-                            }
-                            else {
+                            } else {
                                 Scope.getCurrentScope().getLog(getClass()).warning(FileUtil.getFileNotFoundMessage(file));
                             }
                         } else {
@@ -606,7 +605,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
         }
         String dbmsList = node.getChildValue(null, "dbms", String.class);
         ChangeSet skippedChangeSet =
-            new ChangeSet(id, author, false, false, filePath, null, dbmsList, this);
+                new ChangeSet(id, author, false, false, filePath, null, dbmsList, this);
         skippedChangeSets.add(skippedChangeSet);
     }
 
@@ -651,6 +650,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                 0,
                 Integer.MAX_VALUE);
     }
+
     public void includeAll(String pathName,
                            boolean isRelativeToChangelogFile,
                            IncludeAllFilter resourceFilter,
@@ -664,7 +664,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                            int maxDepth)
             throws SetupException {
         includeAll(pathName, isRelativeToChangelogFile, resourceFilter, errorIfMissingOrEmpty, resourceComparator,
-                   resourceAccessor, includeContextFilter, labels, ignore, minDepth, maxDepth, new ModifyChangeSets(null, null));
+                resourceAccessor, includeContextFilter, labels, ignore, minDepth, maxDepth, new ModifyChangeSets(null, null));
     }
 
     public void includeAll(String pathName,
@@ -704,14 +704,14 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
     }
 
     public SortedSet<Resource> findResources(
-                               String pathName,
-                               boolean isRelativeToChangelogFile,
-                               IncludeAllFilter resourceFilter,
-                               boolean errorIfMissingOrEmpty,
-                               Comparator<String> resourceComparator,
-                               ResourceAccessor resourceAccessor,
-                               int minDepth,
-                               int maxDepth)
+            String pathName,
+            boolean isRelativeToChangelogFile,
+            IncludeAllFilter resourceFilter,
+            boolean errorIfMissingOrEmpty,
+            Comparator<String> resourceComparator,
+            ResourceAccessor resourceAccessor,
+            int minDepth,
+            int maxDepth)
             throws SetupException {
         try {
             if (pathName == null) {
@@ -770,8 +770,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
             path = pathName;
         } else {
             path = resourceAccessor.get(relativeTo).resolveSibling(pathName).getPath();
-            path = Paths.get(path).normalize().toString()
-                    .replace("\\", "/");
+            path = normalizePath(path);
         }
 
         path = path.replace("\\", "/");
@@ -853,8 +852,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
         if (isRelativePath) {
             try {
                 fileName = resourceAccessor.get(this.getPhysicalFilePath()).resolveSibling(fileName).getPath();
-                fileName = Paths.get(fileName).normalize().toString()
-                        .replace("\\", "/");
+                fileName = normalizePath(Paths.get(fileName).toString());
             } catch (IOException e) {
                 throw new UnexpectedLiquibaseException(e);
             }
@@ -868,7 +866,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
             DatabaseChangeLog parentChangeLog = PARENT_CHANGE_LOG.get();
             PARENT_CHANGE_LOG.set(this);
             try {
-                if(!resourceAccessor.get(fileName).exists()) {
+                if (!resourceAccessor.get(fileName).exists()) {
                     if (ChangeLogParserConfiguration.ON_MISSING_INCLUDE_CHANGELOG.getCurrentValue().equals(ChangeLogParserConfiguration.MissingIncludeConfiguration.WARN)
                             || !errorIfMissing) {
                         Scope.getCurrentScope().getLog(getClass()).warning(FileUtil.getFileNotFoundMessage(fileName));
@@ -904,8 +902,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                 );
             }
             return false;
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             throw new LiquibaseException(e.getMessage(), e);
         }
         PreconditionContainer preconditions = changeLog.getPreconditions();
@@ -982,20 +979,16 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
     }
 
     /**
-     *
      * Container class to handle the modifyChangeSets tag.
      * Other attributes may be added later
-     *
      */
     private static class ModifyChangeSets {
         private final String runWith;
         private final String runWithSpool;
 
         /**
-         *
-         * @param  runWith                The native executor to execute all included change sets with. Can be null
-         * @param  runWithSpool           The name of the spool file to be created
-         *
+         * @param runWith      The native executor to execute all included change sets with. Can be null
+         * @param runWithSpool The name of the spool file to be created
          */
         public ModifyChangeSets(String runWith, String runWithSpool) {
             this.runWith = runWith;
@@ -1005,7 +998,10 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
         public String getRunWith() {
             return runWith;
         }
-        public String getRunWithSpool() { return runWithSpool; }
+
+        public String getRunWithSpool() {
+            return runWithSpool;
+        }
     }
 
     /**
@@ -1051,6 +1047,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
 
     /**
      * Initialize and set min/max depth values validating maxDepth cannot be a lower value than minDepth
+     *
      * @param minDepth
      * @param maxDepth
      * @return ResourceAccessor.SearchOptions
@@ -1065,9 +1062,8 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
 
             searchOptions.setMinDepth(minDepth);
             searchOptions.setMaxDepth(maxDepth);
-        }
-        catch (IllegalArgumentException e){
-            throw new SetupException("Error in includeAll setup: "+ e.getMessage(), e);
+        } catch (IllegalArgumentException e) {
+            throw new SetupException("Error in includeAll setup: " + e.getMessage(), e);
         }
         return searchOptions;
     }

--- a/liquibase-standard/src/test/groovy/liquibase/changelog/DatabaseChangeLogTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/changelog/DatabaseChangeLogTest.groovy
@@ -658,7 +658,7 @@ http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbch
 
         when:
         boolean result = changelog.include("../../path/changelog.xml", true, false,
-                resourceAccessor, null, new Labels(), false, false)
+                resourceAccessor, null, new Labels(), false, DatabaseChangeLog.OnUnknownFileFormat.WARN)
 
         then:
         result

--- a/liquibase-standard/src/test/groovy/liquibase/changelog/DatabaseChangeLogTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/changelog/DatabaseChangeLogTest.groovy
@@ -23,6 +23,7 @@ import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import java.nio.file.Paths
 import java.util.logging.Level
 
 class DatabaseChangeLogTest extends Specification {
@@ -194,9 +195,9 @@ create view sql_view as select * from sql_table;'''
     def "included changelog files inside modifyChangeSets set runWith"() {
         when:
         def resourceAccessor =
-           new MockResourceAccessor(["com/example/test1.xml": test1Xml, "com/example/test2.xml": test1Xml
-                   .replace("\${loginUser}", "otherUser")
-                   .replace("person", "person2")])
+                new MockResourceAccessor(["com/example/test1.xml": test1Xml, "com/example/test2.xml": test1Xml
+                        .replace("\${loginUser}", "otherUser")
+                        .replace("person", "person2")])
 
         def rootChangeLog = new DatabaseChangeLog("com/example/root.xml")
         rootChangeLog.setChangeLogParameters(new ChangeLogParameters())
@@ -205,12 +206,12 @@ create view sql_view as select * from sql_table;'''
 
         def topLevel =
                 new ParsedNode(null, "databaseChangeLog")
-                    .addChildren([changeSet: [id: "1", author: "nvoxland", createTable: [tableName: "test_table", schemaName: "test_schema"]]])
+                        .addChildren([changeSet: [id: "1", author: "nvoxland", createTable: [tableName: "test_table", schemaName: "test_schema"]]])
         def modifyNode =
                 new ParsedNode(null, "modifyChangeSets").addChildren([runWith: "psql"])
         modifyNode
-           .addChildren([include: [file: "com/example/test1.xml"]])
-           .addChildren([include: [file: "com/example/test2.xml"]])
+                .addChildren([include: [file: "com/example/test1.xml"]])
+                .addChildren([include: [file: "com/example/test2.xml"]])
         topLevel.addChild(modifyNode)
         rootChangeLog.load(topLevel, resourceAccessor)
 
@@ -371,7 +372,7 @@ create view sql_view as select * from sql_table;'''
         ])
         def changeLogFile = new DatabaseChangeLog("com/example/root.xml")
         changeLogFile
-                .includeAll("com/example/children", false, null, true, changeLogFile.getStandardChangeLogComparator(), resourceAccessor, new ContextExpression(), new Labels(), false,0,
+                .includeAll("com/example/children", false, null, true, changeLogFile.getStandardChangeLogComparator(), resourceAccessor, new ContextExpression(), new Labels(), false, 0,
                         Integer.MAX_VALUE)
 
         then:
@@ -386,7 +387,7 @@ create view sql_view as select * from sql_table;'''
                 "com/example/children/file2.sql": "file 2",
                 "com/example/children/file3.sql": "file 3",
                 "com/example/children/file1.sql": "file 1",
-                "com/example/not/fileX.sql"          : "file X",
+                "com/example/not/fileX.sql"     : "file X",
         ]) {
             private callingPath
 
@@ -397,7 +398,7 @@ create view sql_view as select * from sql_table;'''
             }
         }
         def changeLogFile = new DatabaseChangeLog("com/example/children/root.xml")
-        changeLogFile.includeAll("", true, { r -> r != changeLogFile.physicalFilePath}, true, changeLogFile.getStandardChangeLogComparator(), resourceAccessor, new ContextExpression(), new LabelExpression(), false)
+        changeLogFile.includeAll("", true, { r -> r != changeLogFile.physicalFilePath }, true, changeLogFile.getStandardChangeLogComparator(), resourceAccessor, new ContextExpression(), new LabelExpression(), false)
 
         then:
         resourceAccessor.callingPath == "com/example/children/"
@@ -468,7 +469,7 @@ http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbch
 """.trim()
 
         def resourceAccessor = new MockResourceAccessor([
-                "include-all.xml": changelogText,
+                "include-all.xml"                : changelogText,
                 "include-all-dir/include-all.xml": changelogText,
         ])
         def changeLogFile = new DatabaseChangeLog("com/example/root.xml")
@@ -583,13 +584,13 @@ http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbch
         assert e.getMessage() == FileUtil.getFileNotFoundMessage(fileDef)
 
         where:
-        errorIfMissingDef    | relativeToChangelogFileDef    | fileDef
-        null                        | null                          | "file.properties"
-        null                        | false                         | "file.properties"
-        null                        | true                          | "com/example/file.properties"
-        true                        | null                          | "file.properties"
-        true                        | false                         | "file.properties"
-        true                        | true                          | "com/example/file.properties"
+        errorIfMissingDef | relativeToChangelogFileDef | fileDef
+        null              | null                       | "file.properties"
+        null              | false                      | "file.properties"
+        null              | true                       | "com/example/file.properties"
+        true              | null                       | "file.properties"
+        true              | false                      | "file.properties"
+        true              | true                       | "com/example/file.properties"
     }
 
     @Unroll
@@ -610,16 +611,16 @@ http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbch
         rootChangeLog.getChangeLogParameters().getValue("context", rootChangeLog) == "test"
 
         where:
-        errorIfMissingDef    | relativeToChangelogFileDef    | fileDef
-        null                        | null                          | "com/example/file.properties"
-        null                        | false                         | "com/example/file.properties"
-        null                        | true                          | "file.properties"
-        true                        | null                          | "com/example/file.properties"
-        true                        | false                         | "com/example/file.properties"
-        true                        | true                          | "file.properties"
-        false                       | null                          | "com/example/file.properties"
-        false                       | false                         | "com/example/file.properties"
-        false                       | true                          | "file.properties"
+        errorIfMissingDef | relativeToChangelogFileDef | fileDef
+        null              | null                       | "com/example/file.properties"
+        null              | false                      | "com/example/file.properties"
+        null              | true                       | "file.properties"
+        true              | null                       | "com/example/file.properties"
+        true              | false                      | "com/example/file.properties"
+        true              | true                       | "file.properties"
+        false             | null                       | "com/example/file.properties"
+        false             | false                      | "com/example/file.properties"
+        false             | true                       | "file.properties"
     }
 
     @Unroll
@@ -649,6 +650,21 @@ http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbch
         "../../path/changelog.xml"            | "../../path/changelog.xml"
     }
 
+    def "relative paths for changelog include are not resolved to their full path"() {
+        given:
+        def changelog = new DatabaseChangeLog("com/example/root1.xml")
+        def resourceAccessor = new MockResourceAccessor(["com/example/root1.xml"               : test1Xml,
+                                                         "com/example/../../path/changelog.xml": test2Xml])
+
+        when:
+        boolean result = changelog.include("../../path/changelog.xml", true, false,
+                resourceAccessor, null, new Labels(), false, false)
+
+        then:
+        result
+    }
+
+
     def "warning message is logged when changelog include fails because file does not exist"() {
         when:
         def rootChangeLogPath = "com/example/root.xml"
@@ -666,8 +682,8 @@ http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbch
         ], new Scope.ScopedRunner() {
             @Override
             void run() throws Exception {
-                    rootChangeLog
-                            .include(includedChangeLogPath, false, true, resourceAccessor, null, null, false, null, null);
+                rootChangeLog
+                        .include(includedChangeLogPath, false, true, resourceAccessor, null, null, false, null, null);
             }
         })
 
@@ -680,26 +696,26 @@ http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbch
         when:
         def rootChangeLogPath = "com/example/root.xml"
         def includedAllChangeLogPath = "changelogs"
-        def resourceAccessor = new MockResourceAccessor(["com/example/root.xml": "",
-                                                         "changelogs/changelog-1.xml": test2Xml,
-                                                         "changelogs/morechangelogs/changelog-2.xml": test2Xml,
+        def resourceAccessor = new MockResourceAccessor(["com/example/root.xml"                              : "",
+                                                         "changelogs/changelog-1.xml"                        : test2Xml,
+                                                         "changelogs/morechangelogs/changelog-2.xml"         : test2Xml,
                                                          "changelogs/morechangelogs/withMore/changelog-3.xml": test2Xml,
-                                                         "changelogs/morechangelogs/AndMore/changelog-4.xml": test2Xml])
+                                                         "changelogs/morechangelogs/AndMore/changelog-4.xml" : test2Xml])
 
         def rootChangeLog = new DatabaseChangeLog(rootChangeLogPath)
         rootChangeLog.load(new ParsedNode(null, "databaseChangeLog")
-                .addChildren([includeAll: [path: includedAllChangeLogPath, minDepth:minDepth, maxDepth:maxDepth, errorIfMissingOrEmpty:false]]), resourceAccessor)
+                .addChildren([includeAll: [path: includedAllChangeLogPath, minDepth: minDepth, maxDepth: maxDepth, errorIfMissingOrEmpty: false]]), resourceAccessor)
 
         then:
         rootChangeLog.getChangeSets().size() == expectedIncludeAllChangesetsToDeploy
 
         where:
-        minDepth | maxDepth | expectedIncludeAllChangesetsToDeploy
-        0        | 0        | 0
-        0        | 1        | 1
-        1        | 1        | 1
-        1        | 3        | 4
-        0        | 2        | 2
+        minDepth | maxDepth          | expectedIncludeAllChangesetsToDeploy
+        0        | 0                 | 0
+        0        | 1                 | 1
+        1        | 1                 | 1
+        1        | 3                 | 4
+        0        | 2                 | 2
         0        | Integer.MAX_VALUE | 4
     }
 


### PR DESCRIPTION

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Use the `DatabaseChangeLog.normalizePath(string)` function instead of `Path.normalize` to normalize the string to avoid generating a different path to previous versions. Reverses https://github.com/liquibase/liquibase/commit/351cbbc41c1f69d311c41b4bd74761c6ef979c60

Fixes: https://github.com/liquibase/liquibase/issues/4412

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
