### PR TITLE
Fixed #3971: "SAP SQL Anywhere 17.0.11: Liquibase incorrectly reports that TIMESTAMP requested precision is longer than TIMESTAMP supported precision"

### DIFF
--- a/liquibase-integration-tests/src/test/resources/changelogs/asany/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/asany/complete/root.changelog.xml
@@ -9,6 +9,12 @@
             <runningAs username="${loginUser}"/>
     </preConditions>
 
+    <changeSet id="test-timestamp-with-timezone" author="mkarg">
+        <createTable tableName="SomeTableWithSomeTimezonedColumn">
+            <column defaultValueComputed="CURRENT UTC TIMESTAMP" name="someTimezonedColumn" type="TIMESTAMP WITH TIME ZONE" />
+        </createTable>
+    </changeSet>
+
     <changeSet id="1" author="nvoxland">
         <comment>
             You can add comments to changeSets.

--- a/liquibase-integration-tests/src/test/resources/changelogs/common/common.tests.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/common/common.tests.changelog.xml
@@ -1062,7 +1062,7 @@
     </changeSet>
 
     <changeSet id="timestamp_column_precision9" author="abuschka"
-               dbms="db2,derby,firebird,h2,hsqldb,informix,mssql,oracle,sqlite,sybase"
+               dbms="db2,derby,firebird,h2,hsqldb,informix,mssql,oracle,sqlite,sybase">
         <comment>Test if we (and the JDBC driver) correctly support TIMESTAMP columns with a extra-large precision
             of 9 for supported DBMS.
         </comment>

--- a/liquibase-integration-tests/src/test/resources/changelogs/common/common.tests.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/common/common.tests.changelog.xml
@@ -1062,7 +1062,7 @@
     </changeSet>
 
     <changeSet id="timestamp_column_precision9" author="abuschka"
-               dbms="db2,derby,firebird,h2,hsqldb,informix,mssql,oracle,postgresql,sqlite,asany,sybase">
+               dbms="db2,derby,firebird,h2,hsqldb,informix,mssql,oracle,postgresql,sqlite,sybase">
         <comment>Test if we (and the JDBC driver) correctly support TIMESTAMP columns with a extra-large precision
             of 9 for supported DBMS.
         </comment>

--- a/liquibase-standard/src/main/java/liquibase/database/core/SybaseASADatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/SybaseASADatabase.java
@@ -318,4 +318,13 @@ public class SybaseASADatabase extends AbstractJdbcDatabase {
          */
         return true;
     }
+
+    @Override
+    public int getMaxFractionalDigitsForTimestamp() {
+        /*
+         * SQL Anywhere statically uses exactly 6 decimal places for the fraction.
+         * See: https://help.sap.com/docs/SAP_SQL_Anywhere/93079d4ba8e44920ae63ffb4def91f5b/81fe344c6ce21014a4f29d9e0af358b9.html
+         */
+        return 6;
+    }
 }

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/TimestampType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/TimestampType.java
@@ -101,7 +101,7 @@ public class TimestampType extends DateTimeType {
          */
         DatabaseDataType type;
 
-        if (getParameters().length > 0) {
+        if (getParameters().length > 0 && !(database instanceof SybaseASADatabase)) {
             int fractionalDigits = 0;
             String fractionalDigitsInput = getParameters()[0].toString();
             try {
@@ -130,9 +130,12 @@ public class TimestampType extends DateTimeType {
             && (database instanceof PostgresDatabase
             || database instanceof OracleDatabase
             || database instanceof H2Database
-            || database instanceof HsqlDatabase)) {
+            || database instanceof HsqlDatabase
+            || database instanceof SybaseASADatabase)) {
 
-            if (database instanceof PostgresDatabase || database instanceof H2Database) {
+            if (database instanceof PostgresDatabase
+            || database instanceof H2Database
+            || database instanceof SybaseASADatabase) {
                 type.addAdditionalInformation("WITH TIME ZONE");
             } else {
                 type.addAdditionalInformation("WITH TIMEZONE");
@@ -145,12 +148,14 @@ public class TimestampType extends DateTimeType {
                 && (database instanceof PostgresDatabase
                 || database instanceof OracleDatabase)
                 || database instanceof H2Database
-                || database instanceof HsqlDatabase){
+                || database instanceof HsqlDatabase
+                || database instanceof SybaseASADatabase){
             String additionalInformation = this.getAdditionalInformation();
 
             if (additionalInformation != null) {
                 String additionInformation = additionalInformation.toUpperCase(Locale.US);
-                if ((database instanceof PostgresDatabase || database instanceof H2Database) && additionInformation.toUpperCase(Locale.US).contains("TIMEZONE")) {
+                if ((database instanceof PostgresDatabase || database instanceof H2Database || database instanceof SybaseASADatabase)
+                        && additionInformation.toUpperCase(Locale.US).contains("TIMEZONE")) {
                     additionalInformation = additionInformation.toUpperCase(Locale.US).replace("TIMEZONE", "TIME ZONE");
                 }
                 // CORE-3229 Oracle 11g doesn't support WITHOUT clause in TIMESTAMP data type
@@ -161,6 +166,11 @@ public class TimestampType extends DateTimeType {
 
                 if ((database instanceof H2Database) && additionInformation.startsWith("WITHOUT")) {
                     // http://www.h2database.com/html/datatypes.html
+                    additionalInformation = null;
+                }
+
+                if ((database instanceof SybaseASADatabase) && additionInformation.startsWith("WITHOUT")) {
+                    // https://help.sap.com/docs/SAP_SQL_Anywhere/93079d4ba8e44920ae63ffb4def91f5b/81fe3e6b6ce2101487d8acce02f6aba5.html
                     additionalInformation = null;
                 }
             }

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
@@ -477,9 +477,9 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
          */
         int jdbcType = columnMetadataResultSet.getInt("DATA_TYPE");
 
-        // Java 8 compatibility notes: When upgrading this project to JDK8 and beyond, also execute this if-branch
-        // if jdbcType is TIMESTAMP_WITH_TIMEZONE (does not exist yet in JDK7)
-        if (jdbcType == Types.TIMESTAMP) {
+        if (jdbcType == Types.TIMESTAMP || jdbcType == Types.TIMESTAMP_WITH_TIMEZONE
+            // SQL Anywhere incorrectly reports type VARCHAR for TIMESTAMP_WITZH_TIMEZONE columns
+            || (database instanceof SybaseASADatabase && "timestamp with time zone".equalsIgnoreCase(columnTypeName))) {
 
             if (decimalDigits == null) {
                 type.setColumnSize(null);


### PR DESCRIPTION
Fixes #3971 

## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

This PR tells Liquibase that SQL Anywhere is actually able to deal with the `WITH TIMEZONE` feature of the `TIMESTAMP` data type, and adds a test case to the existing integration test suite which proofs the functionality.

## Things to be aware of

N/A

## Things to worry about

N/A

## Additional Context

Developed using latest SQL Anywhere 17.0.11-7254 on Windows 10 Pro (German) as a standalone engine (hence not using Testcontainers), using latest official product documation from https://help.sap.com/docs/SAP_SQL_Anywhere/93079d4ba8e44920ae63ffb4def91f5b/81fe344c6ce21014a4f29d9e0af358b9.html?locale=en-US&q=TIMESTAMP%20WITH%20TIMEZONE.