### PR TITLE
timestamp_column_precision9 should test with 9 and not 6

### DIFF
--- a/liquibase-integration-tests/src/test/resources/changelogs/common/common.tests.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/common/common.tests.changelog.xml
@@ -1062,7 +1062,7 @@
     </changeSet>
 
     <changeSet id="timestamp_column_precision9" author="abuschka"
-               dbms="db2,derby,firebird,h2,hsqldb,informix,mssql,oracle,postgresql,sqlite,asany,sybase">
+               dbms="db2,derby,firebird,h2,hsqldb,informix,mssql,oracle,sqlite,asany,sybase">
         <comment>Test if we (and the JDBC driver) correctly support TIMESTAMP columns with a extra-large precision
             of 9 for supported DBMS.
         </comment>

--- a/liquibase-integration-tests/src/test/resources/changelogs/common/common.tests.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/common/common.tests.changelog.xml
@@ -1067,7 +1067,7 @@
             of 9 for supported DBMS.
         </comment>
         <addColumn tableName="test_timestamp_fractions">
-            <column name="timestampColumnPrec9" type="timestamp(6)"/>
+            <column name="timestampColumnPrec9" type="timestamp(9)"/>
         </addColumn>
     </changeSet>
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Test timestamp_column_precision9 should test with 9 and not 6 . Seems it was changed by an unrelated PR some months ago but we need to restore the old behavior .