### PR TITLE
Fix update fast check behavior

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/command/core/AbstractUpdateCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/AbstractUpdateCommandStep.java
@@ -190,10 +190,10 @@ public abstract class AbstractUpdateCommandStep extends AbstractCommandStep impl
      * <p>
      * NOTE: to reduce the number of queries to the databasehistory table, this method will cache the "fast check" results within this instance under the assumption that the total changesets will not change within this instance.
      */
-    private static final Map<String, Boolean> upToDateFastCheck = new ConcurrentHashMap<>();
+    private final Map<String, Boolean> upToDateFastCheck = new ConcurrentHashMap<>();
 
     public boolean isUpToDateFastCheck(CommandScope commandScope, Database database, DatabaseChangeLog databaseChangeLog, Contexts contexts, LabelExpression labelExpression) throws LiquibaseException {
-        String cacheKey = contexts + "/" + labelExpression;
+        String cacheKey = String.format("%s/%s/%s/%s/%s", contexts, labelExpression, database.getDefaultSchemaName(), database.getDefaultCatalogName(), database.getConnection().getURL());
         if (!upToDateFastCheck.containsKey(cacheKey)) {
             ChangeLogHistoryService changeLogService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database);
             try {

--- a/liquibase-standard/src/main/java/liquibase/command/core/AbstractUpdateCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/AbstractUpdateCommandStep.java
@@ -62,7 +62,6 @@ public abstract class AbstractUpdateCommandStep extends AbstractCommandStep impl
             if (isFastCheckEnabled && isUpToDate(commandScope, database, databaseChangeLog, contexts, labelExpression, resultsBuilder.getOutputStream())) {
                 return;
             }
-
             if(!isDBLocked) {
                 LockServiceFactory.getInstance().getLockService(database).waitForLock();
             }

--- a/liquibase-standard/src/main/java/liquibase/command/core/UpdateCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/UpdateCommandStep.java
@@ -2,11 +2,15 @@ package liquibase.command.core;
 
 import liquibase.Scope;
 import liquibase.UpdateSummaryEnum;
+import liquibase.changelog.ChangeLogParameters;
+import liquibase.changelog.DatabaseChangeLog;
+import liquibase.changelog.visitor.ChangeExecListener;
 import liquibase.command.*;
 import liquibase.command.core.helpers.DatabaseChangelogCommandStep;
+import liquibase.database.Database;
 import liquibase.exception.CommandValidationException;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class UpdateCommandStep extends AbstractUpdateCommandStep implements CleanUpCommandStep {
@@ -83,8 +87,13 @@ public class UpdateCommandStep extends AbstractUpdateCommandStep implements Clea
 
     @Override
     public List<Class<?>> requiredDependencies() {
-        List<Class<?>> deps = new ArrayList<>(super.requiredDependencies());
-        deps.add(UpdateSummaryEnum.class);
+        List<Class<?>> deps = Arrays.asList(Database.class, DatabaseChangeLog.class, ChangeExecListener.class, ChangeLogParameters.class, UpdateSummaryEnum.class);
         return deps;
+    }
+
+    @Override
+    public void run(CommandResultsBuilder resultsBuilder) throws Exception {
+        setDBLock(false);
+        super.run(resultsBuilder);
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/DatabaseChangelogCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/DatabaseChangelogCommandStep.java
@@ -66,7 +66,7 @@ public class DatabaseChangelogCommandStep extends AbstractHelperCommandStep impl
 
     @Override
     public List<Class<?>> requiredDependencies() {
-        return Arrays.asList(Database.class, LockService.class);
+        return Arrays.asList(Database.class);
     }
 
     @Override


### PR DESCRIPTION
With the latest command refactoring, we performed some changes which unintentionally stops getting the performance benefits we got after merging #2190.

In order to get the same result we come up with a new solution, that after the command refactoring was performed would be easier than reusing the same code provided by #2190. We have added a new flag (`isDBLocked`) to control whether it's needed to acquire the lock before running the update command. 

Also after command refactoring uptodateFastCheck started to provide false positives in multi tenant environments as reported on https://github.com/liquibase/liquibase/issues/4304 .

Fixes #4312 
Fixes #4304 

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

- With new command refactoring changes made recently and now using the new attribute added (`isDBLocked`) we think there is no need to have lock service as a dependency of **DatabaseChangelogCommandStep** and **UpdateCommandStep**.

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->
- None

## Additional Context

<!--
Add any other context about the problem here.
-->
- None
