### PR TITLE
Fix deploymentId not populating after locking

### DIFF
--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/UpdateCommandsIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/UpdateCommandsIntegrationTest.groovy
@@ -58,6 +58,10 @@ class UpdateCommandsIntegrationTest extends Specification {
         resultSet.next()
         resultSet.getInt(1) == 1
 
+        def detailsResultSet = h2.getConnection().createStatement().executeQuery("select DEPLOYMENT_ID from databasechangelog")
+        detailsResultSet.next()
+        assert detailsResultSet.getString(1) != null : "No deployment ID found for the update"
+
         def rsTableExist = h2.getConnection().createStatement().executeQuery("select count(1) from example_table")
         rsTableExist.next()
         rsTableExist.getInt(1) == 0

--- a/liquibase-standard/src/main/java/liquibase/command/core/AbstractUpdateCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/AbstractUpdateCommandStep.java
@@ -64,6 +64,10 @@ public abstract class AbstractUpdateCommandStep extends AbstractCommandStep impl
             }
             if(!isDBLocked) {
                 LockServiceFactory.getInstance().getLockService(database).waitForLock();
+                // waitForLock resets the changelog history service, so we need to rebuild that and generate a final deploymentId.
+                ChangeLogHistoryService changeLogHistoryService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database);
+                changeLogHistoryService.init();
+                changeLogHistoryService.generateDeploymentId();
             }
 
             ChangeLogHistoryService changelogService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database);

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/DatabaseChangelogCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/DatabaseChangelogCommandStep.java
@@ -14,7 +14,6 @@ import liquibase.configuration.LiquibaseConfiguration;
 import liquibase.configuration.core.DefaultsFileValueProvider;
 import liquibase.database.Database;
 import liquibase.exception.LiquibaseException;
-import liquibase.lockservice.LockService;
 import liquibase.lockservice.LockServiceFactory;
 import liquibase.logging.mdc.MdcKey;
 import liquibase.parser.ChangeLogParser;
@@ -91,7 +90,6 @@ public class DatabaseChangelogCommandStep extends AbstractHelperCommandStep impl
 
         DatabaseChangeLog databaseChangeLog = getDatabaseChangeLog(changeLogFile, changeLogParameters);
         checkLiquibaseTables(shouldUpdateNullChecksums, databaseChangeLog, changeLogParameters.getContexts(), changeLogParameters.getLabels(), database);
-        Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database).generateDeploymentId();
         databaseChangeLog.validate(database, changeLogParameters.getContexts(), changeLogParameters.getLabels());
 
         commandScope.provideDependency(DatabaseChangeLog.class, databaseChangeLog);


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors -->


## Description
Fix issue: #4448 
I spent a while trying to implement a `FastCheckCommandStep` class because the root cause really is `we want to not lock the database if fastcheck reports we are up to date`, but ending up stumbling on a number of issues relating to the different usages of the `LockServiceCommandStep`. Because the lock service step is so "low level" it doesn't really work to add the necessary parameters to support a fast check. I thought about implementing a `FastCheckLockServiceCommandStep` but just resolved I was getting in too deep and should be able to fix this in a few lines of code for now.

I'm not sure if `FastCheckLockServiceCommandStep` is the right move for the future or if we should choose some other route.   

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
