### PR TITLE
Fix checksum upgrade changes preventing useless updates and using AbstractChangeLogHistoryService for extensions compatibility

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/changelog/AbstractChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/AbstractChangeLogHistoryService.java
@@ -9,6 +9,8 @@ import liquibase.changelog.filter.DbmsChangeSetFilter;
 import liquibase.database.Database;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.DatabaseHistoryException;
+import liquibase.executor.ExecutorService;
+import liquibase.statement.core.UpdateChangeSetChecksumStatement;
 
 import java.util.Date;
 import java.util.List;
@@ -118,7 +120,13 @@ public abstract class AbstractChangeLogHistoryService implements ChangeLogHistor
          return lastRanChangeSet.getDeploymentId();
     }
 
-    public abstract void replaceChecksum(ChangeSet changeSet) throws DatabaseException;
+    @Override
+    public void replaceChecksum(ChangeSet changeSet) throws DatabaseException {
+        Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", getDatabase()).execute(new UpdateChangeSetChecksumStatement
+                (changeSet));
+        getDatabase().commit();
+        reset();
+    }
 
     @Override
     public String getDeploymentId() {

--- a/liquibase-standard/src/main/java/liquibase/changelog/AbstractChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/AbstractChangeLogHistoryService.java
@@ -118,7 +118,7 @@ public abstract class AbstractChangeLogHistoryService implements ChangeLogHistor
          return lastRanChangeSet.getDeploymentId();
     }
 
-    protected abstract void replaceChecksum(ChangeSet changeSet) throws DatabaseException;
+    public abstract void replaceChecksum(ChangeSet changeSet) throws DatabaseException;
 
     @Override
     public String getDeploymentId() {

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryService.java
@@ -32,7 +32,14 @@ public interface ChangeLogHistoryService extends Plugin {
 
     List<RanChangeSet> getRanChangeSets() throws DatabaseException;
 
-    List<RanChangeSet> getRanChangeSets(boolean allowChecksumsUpgrade) throws DatabaseException;
+    /**
+     * Use  {@link #getRanChangeSets()} instead
+     * @deprecated
+     */
+    @Deprecated
+    default List<RanChangeSet> getRanChangeSets(boolean allowChecksumsUpgrade) throws DatabaseException {
+        return this.getRanChangeSets();
+    }
 
     RanChangeSet getRanChangeSet(ChangeSet changeSet) throws DatabaseException, DatabaseHistoryException;
 

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryService.java
@@ -7,7 +7,6 @@ import liquibase.exception.DatabaseException;
 import liquibase.exception.DatabaseHistoryException;
 import liquibase.exception.LiquibaseException;
 import liquibase.plugin.Plugin;
-import liquibase.servicelocator.PrioritizedService;
 
 import java.util.Date;
 import java.util.List;
@@ -65,4 +64,11 @@ public interface ChangeLogHistoryService extends Plugin {
     void generateDeploymentId();
 
     boolean isDatabaseChecksumsCompatible();
+
+    /**
+     * By default does nothing to keep compatibility with older versions, but subclasses may like to implement
+     * this method to support checksum upgrades.
+     */
+    default void replaceChecksum(ChangeSet changeSet) throws DatabaseException {
+    }
 }

--- a/liquibase-standard/src/main/java/liquibase/changelog/OfflineChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/OfflineChangeLogHistoryService.java
@@ -145,11 +145,6 @@ public class OfflineChangeLogHistoryService extends AbstractChangeLogHistoryServ
 
     @Override
     public List<RanChangeSet> getRanChangeSets() throws DatabaseException {
-        return this.getRanChangeSets(false);
-    }
-
-    @Override
-    public List<RanChangeSet> getRanChangeSets(boolean allowUpgrade) throws DatabaseException {
         try (
                 Reader reader = new InputStreamReader(Files.newInputStream(this.changeLogFile.toPath()), GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue())
         )

--- a/liquibase-standard/src/main/java/liquibase/changelog/OfflineChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/OfflineChangeLogHistoryService.java
@@ -11,7 +11,6 @@ import liquibase.exception.DatabaseException;
 import liquibase.exception.LiquibaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.executor.ExecutorService;
-import liquibase.integration.commandline.LiquibaseCommandLineConfiguration;
 import liquibase.servicelocator.LiquibaseService;
 import liquibase.statement.core.CreateDatabaseChangeLogTableStatement;
 import liquibase.statement.core.MarkChangeSetRanStatement;
@@ -134,7 +133,7 @@ public class OfflineChangeLogHistoryService extends AbstractChangeLogHistoryServ
     }
 
     @Override
-    protected void replaceChecksum(final ChangeSet changeSet) throws DatabaseException {
+    public void replaceChecksum(final ChangeSet changeSet) throws DatabaseException {
         if (isExecuteDmlAgainstDatabase()) {
             Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", getDatabase()).execute(new UpdateChangeSetChecksumStatement(changeSet));
         }

--- a/liquibase-standard/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
@@ -17,7 +17,6 @@ import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.executor.Executor;
 import liquibase.executor.ExecutorService;
 import liquibase.executor.jvm.ChangelogJdbcMdcListener;
-import liquibase.integration.commandline.LiquibaseCommandLineConfiguration;
 import liquibase.snapshot.InvalidExampleException;
 import liquibase.snapshot.SnapshotControl;
 import liquibase.snapshot.SnapshotGeneratorFactory;
@@ -374,7 +373,7 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
     }
 
     @Override
-    protected void replaceChecksum(ChangeSet changeSet) throws DatabaseException {
+    public void replaceChecksum(ChangeSet changeSet) throws DatabaseException {
         Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", getDatabase()).execute(new UpdateChangeSetChecksumStatement
             (changeSet));
 

--- a/liquibase-standard/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
@@ -373,15 +373,6 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
     }
 
     @Override
-    public void replaceChecksum(ChangeSet changeSet) throws DatabaseException {
-        Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", getDatabase()).execute(new UpdateChangeSetChecksumStatement
-            (changeSet));
-
-        getDatabase().commit();
-        reset();
-    }
-
-    @Override
     public RanChangeSet getRanChangeSet(final ChangeSet changeSet) throws DatabaseException, DatabaseHistoryException {
         if (!hasDatabaseChangeLogTable()) {
             return null;

--- a/liquibase-standard/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
@@ -301,11 +301,6 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
      */
     @Override
     public List<RanChangeSet> getRanChangeSets() throws DatabaseException {
-        return this.getRanChangeSets(false);
-    }
-
-    @Override
-    public List<RanChangeSet> getRanChangeSets(boolean allowChecksumsUpgrade) throws DatabaseException {
         if (this.ranChangeSetList == null) {
             Database database = getDatabase();
             String databaseChangeLogTableName = getDatabase().escapeTableName(getLiquibaseCatalogName(),
@@ -319,7 +314,7 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
                     String fileName = DatabaseChangeLog.normalizePath(storedFileName);
                     String author = rs.get("AUTHOR").toString();
                     String id = rs.get("ID").toString();
-                    boolean isUpgrade = allowChecksumsUpgrade && !databaseChecksumsCompatible;
+                    boolean isUpgrade = !databaseChecksumsCompatible;
                     String md5sum = ((rs.get("MD5SUM") == null) || isUpgrade) ? null : rs.get("MD5SUM").toString();
                     String description = (rs.get("DESCRIPTION") == null) ? null : rs.get("DESCRIPTION").toString();
                     String comments = (rs.get("COMMENTS") == null) ? null : rs.get("COMMENTS").toString();

--- a/liquibase-standard/src/main/java/liquibase/changelog/visitor/UpdateVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/visitor/UpdateVisitor.java
@@ -20,7 +20,6 @@ import liquibase.exception.MigrationFailedException;
 import liquibase.executor.Executor;
 import liquibase.executor.ExecutorService;
 import liquibase.executor.LoggingExecutor;
-import liquibase.integration.commandline.LiquibaseCommandLineConfiguration;
 import liquibase.statement.core.UpdateChangeSetChecksumStatement;
 
 import java.util.Objects;
@@ -81,9 +80,8 @@ public class UpdateVisitor implements ChangeSetVisitor {
      * @return oldChecksum the former checksum
      */
     private static CheckSum updateCheckSumIfRequired(ChangeSet changeSet) {
-        CheckSum oldChecksum = null;
-        if (changeSet.getStoredCheckSum() == null || changeSet.getStoredCheckSum().getVersion() < ChecksumVersion.latest().getVersion()) {
-            oldChecksum = changeSet.getStoredCheckSum();
+        CheckSum oldChecksum = changeSet.getStoredCheckSum();
+        if (oldChecksum == null || oldChecksum.getVersion() < ChecksumVersion.latest().getVersion()) {
             changeSet.clearCheckSum();
             changeSet.setStoredCheckSum(changeSet.generateCheckSum(ChecksumVersion.latest()));
         }

--- a/liquibase-standard/src/main/java/liquibase/changelog/visitor/UpdateVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/visitor/UpdateVisitor.java
@@ -3,12 +3,9 @@ package liquibase.changelog.visitor;
 import liquibase.ChecksumVersion;
 import liquibase.Scope;
 import liquibase.change.CheckSum;
-import liquibase.changelog.ChangeLogHistoryService;
-import liquibase.changelog.ChangeLogHistoryServiceFactory;
-import liquibase.changelog.ChangeSet;
+import liquibase.changelog.*;
 import liquibase.changelog.ChangeSet.ExecType;
 import liquibase.changelog.ChangeSet.RunStatus;
-import liquibase.changelog.DatabaseChangeLog;
 import liquibase.changelog.filter.ChangeSetFilterResult;
 import liquibase.changelog.filter.ShouldRunChangeSetFilter;
 import liquibase.database.Database;
@@ -97,8 +94,13 @@ public class UpdateVisitor implements ChangeSetVisitor {
             Scope.getCurrentScope().getUI().sendMessage(String.format("Upgrading checksum for Changeset %s from %s to %s.",
                     changeSet, oldChecksum, changeSet.getStoredCheckSum()));
         }
-        Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database)
-                .execute(new UpdateChangeSetChecksumStatement(changeSet));
+        ChangeLogHistoryService changeLogService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database);
+        if (changeLogService instanceof AbstractChangeLogHistoryService) {
+            ((AbstractChangeLogHistoryService) changeLogService).replaceChecksum(changeSet);
+        } else {
+            Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database)
+                    .execute(new UpdateChangeSetChecksumStatement(changeSet));
+        }
     }
 
     /**

--- a/liquibase-standard/src/main/java/liquibase/changelog/visitor/UpdateVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/visitor/UpdateVisitor.java
@@ -157,3 +157,4 @@ public class UpdateVisitor implements ChangeSetVisitor {
         changeSet.setAttribute("deploymentId", deploymentId);
     }
 }
+

--- a/liquibase-standard/src/main/java/liquibase/changelog/visitor/UpdateVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/visitor/UpdateVisitor.java
@@ -3,9 +3,12 @@ package liquibase.changelog.visitor;
 import liquibase.ChecksumVersion;
 import liquibase.Scope;
 import liquibase.change.CheckSum;
-import liquibase.changelog.*;
+import liquibase.changelog.ChangeLogHistoryService;
+import liquibase.changelog.ChangeLogHistoryServiceFactory;
+import liquibase.changelog.ChangeSet;
 import liquibase.changelog.ChangeSet.ExecType;
 import liquibase.changelog.ChangeSet.RunStatus;
+import liquibase.changelog.DatabaseChangeLog;
 import liquibase.changelog.filter.ChangeSetFilterResult;
 import liquibase.changelog.filter.ShouldRunChangeSetFilter;
 import liquibase.database.Database;
@@ -17,7 +20,6 @@ import liquibase.exception.MigrationFailedException;
 import liquibase.executor.Executor;
 import liquibase.executor.ExecutorService;
 import liquibase.executor.LoggingExecutor;
-import liquibase.statement.core.UpdateChangeSetChecksumStatement;
 
 import java.util.Objects;
 import java.util.Set;
@@ -95,12 +97,7 @@ public class UpdateVisitor implements ChangeSetVisitor {
                     changeSet, oldChecksum, changeSet.getStoredCheckSum()));
         }
         ChangeLogHistoryService changeLogService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database);
-        if (changeLogService instanceof AbstractChangeLogHistoryService) {
-            ((AbstractChangeLogHistoryService) changeLogService).replaceChecksum(changeSet);
-        } else {
-            Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database)
-                    .execute(new UpdateChangeSetChecksumStatement(changeSet));
-        }
+        changeLogService.replaceChecksum(changeSet);
     }
 
     /**


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

New method liquibase.changelog.visitor.UpdateVisitor#updateCheckSumIfRequired returns null if the change set has a stored checkSum, but it should return the old checksum value.
So everytime we get here we are updating the checksums for already executed checksums with the same value. It's not breaking anything but performance will be affected.

Steps To Reproduce
Run update using a changelog with 1 changeset
Add a new changeset to changelog
Run update SQL: first changelog will have the checksum updated and the second will execute just fine.
ex:

```
UPDATE public.databasechangelog SET MD5SUM = '9:56da2f293105bdbf802515b0581600f1' WHERE ID = '2' AND AUTHOR = 'fl' AND FILENAME = 'changelogs/changelog/simple_changelog.xml';

INSERT INTO public.databasechangelog (ID, AUTHOR, FILENAME, DATEEXECUTED, ORDEREXECUTED, MD5SUM, DESCRIPTION, COMMENTS, EXECTYPE, CONTEXTS, LABELS, LIQUIBASE, DEPLOYMENT_ID, TAG) VALUES ('2.5', 'fl', 'changelogs/changelog/simple_changelog.xml', NOW(), 4, '9:9a2f4bc8afbf0c9587b25b2ffd922d2e', 'tagDatabase', '', 'EXECUTED', 'v8', NULL, 'DEV', '7973169078', 'rb1');
```