### PR TITLE
Implements equals method on AbstractChange to make sure that we can compare Changes correctly

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/change/AbstractChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/AbstractChange.java
@@ -868,4 +868,22 @@ public abstract class AbstractChange extends AbstractPlugin implements Change {
         return description;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        if (o instanceof DbmsTargetedChange && this instanceof DbmsTargetedChange) {
+            if (!((DbmsTargetedChange)o).getDbms().equals(((DbmsTargetedChange)this).getDbms())) {
+                return false;
+            }
+        }
+        AbstractChange that = (AbstractChange) o;
+        return Objects.equals(changeSet, that.changeSet);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), changeSet);
+    }
 }

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeSet.java
@@ -960,7 +960,7 @@ public class ChangeSet implements Conditional, ChangeLogChild {
      * Method created to remove changes from a changeset
      * @param collection
      */
-    public void removeAllChanges(Collection<?> collection) {
+    public void removeAllChanges(Collection<Change> collection) {
         this.changes.removeAll(collection);
     }
 


### PR DESCRIPTION


## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Commit https://github.com/liquibase/liquibase/pull/3616/commits/279b1b35d9c5f984d2f8542b792c870fd71c3ec0# that is part of checksums upgrade moved the dbms logic from Changeset to DbmsFilter. But it happens that Change object and all of the inheriting classes to not implement equals method. So when it calls collection.removeAll(object) it is ending up removing all changes that are of the specific type (for instance AbstractSqlChange), and not only the expected change. 

So if you execute a sample changelog like the one below in a `H2 `database:

```
    <changeSet id="0" author="fl" >
        <sql>create table anydb(id boolean default true, status varchar(2))</sql>
        <sql dbms="oracle">create table oraculo(id boolean default true, status varchar(2))</sql>
        <dropTable tableName="anydb" />
    </changeSet>
```

The expected result would be to create anydb table then drop it; but it is just dropping the table.

This PR fixes this issue.
