### PR TITLE
remove step- Don't run liquibase/liquibase builds on labels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,11 +43,7 @@ jobs:
           echo "PR from Fork is NOT safe to build"
           echo "A member of Liquibase team needs to apply label 'SafeToBuild'! "
           exit 1
-      - name: Run needed builds
-        if: github.event.action == 'labeled' && github.event.pull_request.head.repo.full_name == 'liquibase/liquibase'
-        run: |
-          echo "Don't run liquibase/liquibase builds on labels"
-          exit 1
+
   setup:
     name: Setup
     needs: check_build_safety


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Due to many failures on builds while adding `labels` to a PR, we are removing the step which includes "Don't run liquibase/liquibase builds on labels". Not sure why it was added in the first place. 
PR successful on this branch `fix-fail_on_labels_gha` : https://github.com/liquibase/liquibase/actions/runs/5414147945