### PR TITLE
support concurrent build in maven plugin

### DIFF
--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
@@ -117,7 +117,7 @@ public abstract class AbstractIntegrationTest {
         this.pathChangeLog = "changelogs/common/pathChangeLog.xml";
         logger = Scope.getCurrentScope().getLog(getClass());
 
-        Scope.setScopeManager(new TestScopeManager());
+        Scope.setScopeManager(new TestScopeManager(Scope.getCurrentScope()));
     }
 
     private void openConnection() throws Exception {

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
@@ -65,6 +65,11 @@ import static liquibase.configuration.LiquibaseConfiguration.REGISTERED_VALUE_PR
 @SuppressWarnings("java:S2583")
 public abstract class AbstractLiquibaseMojo extends AbstractMojo {
 
+    static {
+        // If maven is called with -T and a value larger than 1, it can get confused under heavy thread load
+        Scope.setScopeManager( new ThreadLocalScopeManager(null));
+    }
+
     /**
      * Suffix for fields that are representing a default value for a another field.
      */
@@ -709,8 +714,6 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
             getLog().warn("Liquibase NOT skipped because file " + skipOnFileExists + " does NOT exists");
         }
 
-        // If maven is called with -T and a value larger than 1, it can get confused under heavy thread load
-        Scope.setScopeManager(new ThreadLocalScopeManager());
         try {
             Scope.child(setUpLogging(), () -> {
 

--- a/liquibase-standard/src/main/java/liquibase/Scope.java
+++ b/liquibase-standard/src/main/java/liquibase/Scope.java
@@ -113,21 +113,7 @@ public class Scope {
     }
 
     public static void setScopeManager(ScopeManager scopeManager) {
-        Scope currentScope = getCurrentScope();
-        if (currentScope == null) {
-            currentScope = new Scope();
-        }
-
-        try {
-            currentScope = scopeManager.init(currentScope);
-        } catch (Exception e) {
-            Scope.getCurrentScope().getLog(Scope.class).warning(e.getMessage(), e);
-        }
-        scopeManager.setCurrentScope(currentScope);
-
         Scope.scopeManager = scopeManager;
-
-
     }
 
     /**

--- a/liquibase-standard/src/main/java/liquibase/ThreadLocalScopeManager.java
+++ b/liquibase-standard/src/main/java/liquibase/ThreadLocalScopeManager.java
@@ -14,7 +14,11 @@ public class ThreadLocalScopeManager extends ScopeManager {
     private final ThreadLocal<Scope> threadLocalScopes = new ThreadLocal<>();
 
     public ThreadLocalScopeManager() {
-        this.rootScope = Scope.getCurrentScope();
+        this(Scope.getCurrentScope());
+    }
+
+    public ThreadLocalScopeManager(Scope rootScope) {
+        this.rootScope = rootScope;
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/AbstractOutputWriterCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/AbstractOutputWriterCommandStep.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 public abstract class AbstractOutputWriterCommandStep extends AbstractHelperCommandStep implements CleanUpCommandStep {
 
-    private static OutputStreamWriter outputStreamWriter;
+    private OutputStreamWriter outputStreamWriter;
 
     @Override
     public List<Class<?>> providedDependencies() {

--- a/liquibase-standard/src/main/java/liquibase/resource/ZipResourceAccessor.java
+++ b/liquibase-standard/src/main/java/liquibase/resource/ZipResourceAccessor.java
@@ -42,7 +42,11 @@ public class ZipResourceAccessor extends AbstractPathResourceAccessor {
             try {
                 this.fileSystem = FileSystems.getFileSystem(finalUri);
             } catch (FileSystemNotFoundException e) {
-                this.fileSystem = FileSystems.newFileSystem(finalUri, Collections.emptyMap(), Scope.getCurrentScope().getClassLoader());
+                try {
+                    this.fileSystem = FileSystems.newFileSystem(finalUri, Collections.emptyMap(), Scope.getCurrentScope().getClassLoader());
+                } catch (FileSystemAlreadyExistsException ex) {
+                    this.fileSystem = FileSystems.getFileSystem(finalUri);
+                }
             }
         } catch (Throwable e) {
             throw new IllegalArgumentException(e.getMessage(), e);

--- a/liquibase-standard/src/test/groovy/liquibase/change/StandardChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/StandardChangeTest.groovy
@@ -16,7 +16,7 @@ public abstract class StandardChangeTest extends Specification {
     @Shared resourceSupplier = new ResourceSupplier()
 
     def setup() {
-        Scope.setScopeManager(new TestScopeManager());
+        Scope.setScopeManager(new TestScopeManager(Scope.getCurrentScope()));
     }
 
     def cleanup() {

--- a/liquibase-standard/src/test/java/liquibase/TestScopeManager.java
+++ b/liquibase-standard/src/test/java/liquibase/TestScopeManager.java
@@ -7,8 +7,8 @@ import java.util.Map;
 
 public class TestScopeManager extends SingletonScopeManager {
 
-    public TestScopeManager() {
-
+    public TestScopeManager(Scope scope) throws Exception {
+        setCurrentScope(init(scope));
     }
 
     @Override

--- a/liquibase-standard/src/test/java/liquibase/integration/ant/AbstractAntTaskTest.java
+++ b/liquibase-standard/src/test/java/liquibase/integration/ant/AbstractAntTaskTest.java
@@ -11,8 +11,8 @@ import java.net.URLDecoder;
 public abstract class AbstractAntTaskTest {
 
     @BeforeClass
-    public static void setup() {
-        Scope.setScopeManager(new TestScopeManager());
+    public static void setup() throws Exception {
+        Scope.setScopeManager(new TestScopeManager(Scope.getCurrentScope()));
     }
 
     protected static void setProperties() {

--- a/liquibase-standard/src/test/java/liquibase/verify/change/VerifyChangeClassesTest.java
+++ b/liquibase-standard/src/test/java/liquibase/verify/change/VerifyChangeClassesTest.java
@@ -33,8 +33,8 @@ public class VerifyChangeClassesTest extends AbstractVerifyTest {
 
 
     @BeforeClass
-    public static void setUpClass() {
-        Scope.setScopeManager(new TestScopeManager());
+    public static void setUpClass() throws Exception {
+        Scope.setScopeManager(new TestScopeManager(Scope.getCurrentScope()));
     }
 
     @Test


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors -->


## Description

This is remaining part of https://github.com/liquibase/liquibase/issues/3446

To make liquid base work with maven concurrent build (-T 1C)

It uses scope manager, but it need to be set in static so before any plugins action kick in.
Also it should not inherit any scope, so each plugin execution can start on clean scope isolated from another.

