### PR TITLE
Split calculate-checksum parameter changeSetIdentifier into changeSetPath / changesetId / changeSetAuthor 

### DIFF
--- a/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
+++ b/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
@@ -108,7 +108,7 @@ public class LiquibaseCommandLine {
 
     public LiquibaseCommandLine() {
         this.legacyPositionalArguments = new HashMap<>();
-        this.legacyPositionalArguments.put("calculatechecksum", CalculateChecksumCommandStep.CHANGESET_IDENTIFIER_ARG.getName());
+        this.legacyPositionalArguments.put("calculatechecksum", CalculateChecksumCommandStep.CHANGESET_ID_ARG.getName());
         this.legacyPositionalArguments.put("changelogsynctotag", ChangelogSyncToTagCommandStep.TAG_ARG.getName());
         this.legacyPositionalArguments.put("changelogsynctotagsql", ChangelogSyncToTagSqlCommandStep.TAG_ARG.getName());
         this.legacyPositionalArguments.put("dbdoc", DbDocCommandStep.OUTPUT_DIRECTORY_ARG.getName());

--- a/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
+++ b/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
@@ -108,7 +108,7 @@ public class LiquibaseCommandLine {
 
     public LiquibaseCommandLine() {
         this.legacyPositionalArguments = new HashMap<>();
-        this.legacyPositionalArguments.put("calculatechecksum", CalculateChecksumCommandStep.CHANGESET_ID_ARG.getName());
+        this.legacyPositionalArguments.put("calculatechecksum", CalculateChecksumCommandStep.CHANGESET_IDENTIFIER_ARG.getName());
         this.legacyPositionalArguments.put("changelogsynctotag", ChangelogSyncToTagCommandStep.TAG_ARG.getName());
         this.legacyPositionalArguments.put("changelogsynctotagsql", ChangelogSyncToTagSqlCommandStep.TAG_ARG.getName());
         this.legacyPositionalArguments.put("dbdoc", DbDocCommandStep.OUTPUT_DIRECTORY_ARG.getName());

--- a/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/calculateChecksum.test.groovy
+++ b/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/calculateChecksum.test.groovy
@@ -11,10 +11,17 @@ Short Description: Calculates and prints a checksum for the changeset
 Long Description: Calculates and prints a checksum for the changeset with the given id in the format filepath::id::author
 Required Args:
   changelogFile (String) The root changelog file
-  changesetIdentifier (String) Changeset ID identifier of form filepath::id::author
   url (String) The JDBC database connection URL
     OBFUSCATED
 Optional Args:
+  changeSetAuthor (String) ChangeSet Author attribute
+    Default: null
+  changeSetId (String) ChangeSet ID attribute
+    Default: null
+  changeSetIdentifier (String) ChangeSet identifier of form filepath::id::author
+    Default: null
+  changeSetPath (String) Changelog path in which the changeSet is included
+    Default: null
   defaultCatalogName (String) The default catalog name to use for the database connection
     Default: null
   defaultSchemaName (String) The default schema name to use for the database connection
@@ -30,12 +37,28 @@ Optional Args:
     Default: null
 """
 
-    run "Happy path", {
+    run "Happy path using changeSetIdentifier", {
         arguments = [
                 url              : { it.altUrl },
                 username         : { it.altUsername },
                 password         : { it.altPassword },
-                changesetIdentifier: "changelogs/h2/complete/rollback.tag.changelog.xml::1::nvoxland",
+                changeSetIdentifier: "changelogs/h2/complete/rollback.tag.changelog.xml::1::nvoxland",
+                changelogFile    : "changelogs/h2/complete/rollback.tag.changelog.xml"
+        ]
+
+        expectedResults = [
+                checksumResult   : "9:10de8cd690aed1d88d837cbe555d1684"
+        ]
+    }
+
+    run "Happy path using changeSetPath, ChangeSetId and ChangeSetPath", {
+        arguments = [
+                url              : { it.altUrl },
+                username         : { it.altUsername },
+                password         : { it.altPassword },
+                changeSetPath    : "changelogs/h2/complete/rollback.tag.changelog.xml",
+                changeSetId      : "1",
+                changeSetAuthor  : "nvoxland",
                 changelogFile    : "changelogs/h2/complete/rollback.tag.changelog.xml"
         ]
 
@@ -46,27 +69,18 @@ Optional Args:
 
     run "Run without changelogFile should throw an exception",  {
         arguments = [
-                changesetIdentifier: "changelogs/h2/complete/rollback.tag.changelog.xml::1::nvoxland",
+                changeSetIdentifier: "changelogs/h2/complete/rollback.tag.changelog.xml::1::nvoxland",
         ]
 
         expectedException = CommandValidationException.class
         expectedExceptionMessage = 'Invalid argument \'changelogFile\': missing required argument'
     }
 
-    run "Run without changesetIdentifier should throw an exception",  {
-        arguments = [
-                changelogFile    : "changelogs/h2/complete/rollback.tag.changelog.xml"
-        ]
-
-        expectedException = CommandValidationException.class
-        expectedExceptionMessage = "Invalid argument \'changesetIdentifier\': missing required argument"
-    }
-
     run "Run without URL should throw an exception",  {
         arguments = [
                 url: "",
                 changelogFile    : "changelogs/h2/complete/rollback.tag.changelog.xml",
-                changesetIdentifier: "changelogs/h2/complete/rollback.tag.changelog.xml::1::nvoxland",
+                changeSetIdentifier: "changelogs/h2/complete/rollback.tag.changelog.xml::1::nvoxland",
         ]
 
         expectedException = CommandValidationException.class

--- a/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/calculateChecksum.test.groovy
+++ b/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/calculateChecksum.test.groovy
@@ -14,13 +14,13 @@ Required Args:
   url (String) The JDBC database connection URL
     OBFUSCATED
 Optional Args:
-  changeSetAuthor (String) ChangeSet Author attribute
+  changesetAuthor (String) ChangeSet Author attribute
     Default: null
-  changeSetId (String) ChangeSet ID attribute
+  changesetId (String) ChangeSet ID attribute
     Default: null
-  changeSetIdentifier (String) ChangeSet identifier of form filepath::id::author
+  changesetIdentifier (String) ChangeSet identifier of form filepath::id::author
     Default: null
-  changeSetPath (String) Changelog path in which the changeSet is included
+  changesetPath (String) Changelog path in which the changeSet is included
     Default: null
   defaultCatalogName (String) The default catalog name to use for the database connection
     Default: null
@@ -42,7 +42,7 @@ Optional Args:
                 url              : { it.altUrl },
                 username         : { it.altUsername },
                 password         : { it.altPassword },
-                changeSetIdentifier: "changelogs/h2/complete/rollback.tag.changelog.xml::1::nvoxland",
+                changesetIdentifier: "changelogs/h2/complete/rollback.tag.changelog.xml::1::nvoxland",
                 changelogFile    : "changelogs/h2/complete/rollback.tag.changelog.xml"
         ]
 
@@ -56,9 +56,9 @@ Optional Args:
                 url              : { it.altUrl },
                 username         : { it.altUsername },
                 password         : { it.altPassword },
-                changeSetPath    : "changelogs/h2/complete/rollback.tag.changelog.xml",
-                changeSetId      : "1",
-                changeSetAuthor  : "nvoxland",
+                changesetPath    : "changelogs/h2/complete/rollback.tag.changelog.xml",
+                changesetId      : "1",
+                changesetAuthor  : "nvoxland",
                 changelogFile    : "changelogs/h2/complete/rollback.tag.changelog.xml"
         ]
 
@@ -69,7 +69,7 @@ Optional Args:
 
     run "Run without changelogFile should throw an exception",  {
         arguments = [
-                changeSetIdentifier: "changelogs/h2/complete/rollback.tag.changelog.xml::1::nvoxland",
+                changesetIdentifier: "changelogs/h2/complete/rollback.tag.changelog.xml::1::nvoxland",
         ]
 
         expectedException = CommandValidationException.class
@@ -80,7 +80,7 @@ Optional Args:
         arguments = [
                 url: "",
                 changelogFile    : "changelogs/h2/complete/rollback.tag.changelog.xml",
-                changeSetIdentifier: "changelogs/h2/complete/rollback.tag.changelog.xml::1::nvoxland",
+                changesetIdentifier: "changelogs/h2/complete/rollback.tag.changelog.xml::1::nvoxland",
         ]
 
         expectedException = CommandValidationException.class

--- a/liquibase-standard/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-standard/src/main/java/liquibase/Liquibase.java
@@ -1229,24 +1229,15 @@ public class Liquibase implements AutoCloseable {
      * @deprecated Use {link {@link CommandScope(String)}.
      */
     @Deprecated
-    public final CheckSum calculateCheckSum(final String changeSetIdentifier) throws LiquibaseException {
+    public final CheckSum calculateCheckSum(final String changeSetPath, final String changeSetId, final String changeSetAuthor) throws LiquibaseException {
         CommandResults commandResults = new CommandScope("calculateChecksum")
                 .addArgumentValue(DbUrlConnectionCommandStep.DATABASE_ARG, database)
-                .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_IDENTIFIER_ARG, changeSetIdentifier)
+                .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_PATH_ARG, changeSetPath)
+                .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_ID_ARG, changeSetId)
+                .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_AUTHOR_ARG, changeSetAuthor)
                 .addArgumentValue(CalculateChecksumCommandStep.CHANGELOG_FILE_ARG, this.changeLogFile)
                 .execute();
         return commandResults.getResult(CalculateChecksumCommandStep.CHECKSUM_RESULT);
-    }
-
-    /**
-     * Calculates the checksum for the values that form a given identifier
-     *
-     * @deprecated Use {link {@link CommandScope(String)}.
-     */
-    @Deprecated
-    public CheckSum calculateCheckSum(final String filename, final String id, final String author)
-            throws LiquibaseException {
-        return this.calculateCheckSum(String.format("%s::%s::%s", filename, id, author));
     }
 
     @Deprecated

--- a/liquibase-standard/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-standard/src/main/java/liquibase/Liquibase.java
@@ -1229,12 +1229,23 @@ public class Liquibase implements AutoCloseable {
      * @deprecated Use {link {@link CommandScope(String)}.
      */
     @Deprecated
-    public final CheckSum calculateCheckSum(final String changeSetPath, final String changeSetId, final String changeSetAuthor) throws LiquibaseException {
+    public final CheckSum calculateCheckSum(final String changeSetIdentifier) throws LiquibaseException {
+        String changeSetAttributes[] = changeSetIdentifier.split("::");
+        //validate changeSet parameters and return an error or removed/ignore any other '::' occurrence when processing either a path, id or author.
+        return this.calculateCheckSum(changeSetAttributes[0], changeSetAttributes[1], changeSetAttributes[2]);
+    }
+
+    /**
+     * Calculate the checksum for a given changeset specified by path, changeset id and author
+     */
+    public CheckSum calculateCheckSum(final String changeSetPath, final String changeSetId, final String changeSetAuthor)
+            throws LiquibaseException {
         CommandResults commandResults = new CommandScope("calculateChecksum")
                 .addArgumentValue(DbUrlConnectionCommandStep.DATABASE_ARG, database)
                 .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_PATH_ARG, changeSetPath)
                 .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_ID_ARG, changeSetId)
                 .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_AUTHOR_ARG, changeSetAuthor)
+                .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_IDENTIFIER_ARG, String.format("%s::%s::%s", changeSetPath, changeSetId, changeSetAuthor))
                 .addArgumentValue(CalculateChecksumCommandStep.CHANGELOG_FILE_ARG, this.changeLogFile)
                 .execute();
         return commandResults.getResult(CalculateChecksumCommandStep.CHECKSUM_RESULT);

--- a/liquibase-standard/src/main/java/liquibase/command/core/CalculateChecksumCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/CalculateChecksumCommandStep.java
@@ -92,42 +92,7 @@ public class CalculateChecksumCommandStep extends AbstractCommandStep {
 
         final boolean isChangeSetIdentifierPassed = changeSetIdentifier != null;
 
-        final boolean isRequiredCompositeIdentifierMissing = (commandScope.getArgumentValue(CHANGESET_ID_ARG) == null ||
-                commandScope.getArgumentValue(CHANGESET_AUTHOR_ARG) == null || commandScope.getArgumentValue(CHANGESET_PATH_ARG) == null)
-                && changeSetIdentifier == null;
-
-        final boolean isAmbiguousNumberOfIdentifierProvided = (commandScope.getArgumentValue(CHANGESET_ID_ARG) != null ||
-                commandScope.getArgumentValue(CHANGESET_AUTHOR_ARG) != null || commandScope.getArgumentValue(CHANGESET_PATH_ARG) != null)
-                && changeSetIdentifier != null;
-
-        if (isAmbiguousNumberOfIdentifierProvided)  {
-            String errorMessage = "Error encountered while parsing the command line. " +
-                    "'--changeset-identifier' cannot be provided alongside other changeset arguments: " +
-                    "'--changeset-id', '--changeset-path', '--changeset-author'.";
-            throw new LiquibaseException(new IllegalArgumentException(errorMessage));
-        }
-
-        if (isRequiredCompositeIdentifierMissing) {
-            String errorMessage = "Error encountered while parsing the command line. " +
-                    "If --changeset-identifier is not provided than --changeset-id, --changeset-author and --changeset-path must be specified. " +
-                    "Missing argument: ";
-
-            if (commandScope.getArgumentValue(CHANGESET_ID_ARG) == null) {
-                errorMessage = errorMessage + " '--changeset-id',";
-            }
-
-            if (commandScope.getArgumentValue(CHANGESET_AUTHOR_ARG) == null) {
-                errorMessage = errorMessage + " '--changeset-author',";
-            }
-
-            if (commandScope.getArgumentValue(CHANGESET_PATH_ARG) == null) {
-                errorMessage = errorMessage + " '--changeset-path',";
-            }
-
-            errorMessage = errorMessage.substring(0,errorMessage.length() - 1) + ".";
-
-            throw new LiquibaseException(new IllegalArgumentException(errorMessage));
-        }
+        validateIdentifierParameters(commandScope, changeSetIdentifier);
 
         if (isChangeSetIdentifierPassed) {
             List<String> parts = validateAndExtractParts(changeSetIdentifier, changeLogFile);
@@ -169,6 +134,45 @@ public class CalculateChecksumCommandStep extends AbstractCommandStep {
                                      ChecksumVersion.enumFromChecksumVersion(ranChangeSet.getLastCheckSum().getVersion()) : ChecksumVersion.latest()
                      )
         );
+    }
+
+    private void validateIdentifierParameters(CommandScope commandScope, String changeSetIdentifier) throws LiquibaseException {
+        final boolean isAmbiguousNumberOfIdentifierProvided = (commandScope.getArgumentValue(CHANGESET_ID_ARG) != null ||
+                commandScope.getArgumentValue(CHANGESET_AUTHOR_ARG) != null || commandScope.getArgumentValue(CHANGESET_PATH_ARG) != null)
+                && changeSetIdentifier != null;
+
+        if (isAmbiguousNumberOfIdentifierProvided)  {
+            String errorMessage = "Error encountered while parsing the command line. " +
+                    "'--changeset-identifier' cannot be provided alongside other changeset arguments: " +
+                    "'--changeset-id', '--changeset-path', '--changeset-author'.";
+            throw new LiquibaseException(new IllegalArgumentException(errorMessage));
+        }
+
+        final boolean isRequiredCompositeIdentifierMissing = (commandScope.getArgumentValue(CHANGESET_ID_ARG) == null ||
+                commandScope.getArgumentValue(CHANGESET_AUTHOR_ARG) == null || commandScope.getArgumentValue(CHANGESET_PATH_ARG) == null)
+                && changeSetIdentifier == null;
+
+        if (isRequiredCompositeIdentifierMissing) {
+            String errorMessage = "Error encountered while parsing the command line. " +
+                    "If --changeset-identifier is not provided than --changeset-id, --changeset-author and --changeset-path must be specified. " +
+                    "Missing argument: ";
+
+            if (commandScope.getArgumentValue(CHANGESET_ID_ARG) == null) {
+                errorMessage = errorMessage + " '--changeset-id',";
+            }
+
+            if (commandScope.getArgumentValue(CHANGESET_AUTHOR_ARG) == null) {
+                errorMessage = errorMessage + " '--changeset-author',";
+            }
+
+            if (commandScope.getArgumentValue(CHANGESET_PATH_ARG) == null) {
+                errorMessage = errorMessage + " '--changeset-path',";
+            }
+
+            errorMessage = errorMessage.substring(0,errorMessage.length() - 1) + ".";
+
+            throw new LiquibaseException(new IllegalArgumentException(errorMessage));
+        }
     }
 
     private List<String> validateAndExtractParts(String changeSetIdentifier, String changeLogFile) throws LiquibaseException {

--- a/liquibase-standard/src/main/java/liquibase/command/core/CalculateChecksumCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/CalculateChecksumCommandStep.java
@@ -51,19 +51,19 @@ public class CalculateChecksumCommandStep extends AbstractCommandStep {
         CHANGELOG_FILE_ARG = builder.argument(CommonArgumentNames.CHANGELOG_FILE, String.class).required()
                                     .description("The root changelog file").build();
 
-        CHANGESET_IDENTIFIER_ARG = builder.argument("changeSetIdentifier", String.class)
+        CHANGESET_IDENTIFIER_ARG = builder.argument("changesetIdentifier", String.class)
                                     .description("ChangeSet identifier of form filepath::id::author")
                                     .build();
 
-        CHANGESET_PATH_ARG = builder.argument("changeSetPath", String.class)
+        CHANGESET_PATH_ARG = builder.argument("changesetPath", String.class)
                                     .description("Changelog path in which the changeSet is included")
                                     .build();
 
-        CHANGESET_ID_ARG = builder.argument("changeSetId", String.class)
+        CHANGESET_ID_ARG = builder.argument("changesetId", String.class)
                                   .description("ChangeSet ID attribute")
                                   .build();
 
-        CHANGESET_AUTHOR_ARG = builder.argument("changeSetAuthor", String.class)
+        CHANGESET_AUTHOR_ARG = builder.argument("changesetAuthor", String.class)
                                       .description("ChangeSet Author attribute")
                                       .build();
 
@@ -165,11 +165,11 @@ public class CalculateChecksumCommandStep extends AbstractCommandStep {
         commandDefinition.setHelpFooter("\nCalculate checksum provides two ways to identify a changeSet.\n\n" +
                                         "1. Composite changeSet identifier\n\n" +
                                         "The composite changeSet identifier must be passed in the following pattern myPath::myId::myAuthor.\n\n" +
-                                        "liquibase calculateCheckSum --changeSetIdentifier myFile::myId::myAuthor\n\n" +
+                                        "liquibase calculateCheckSum --changesetIdentifier myFile::myId::myAuthor\n\n" +
                                         "2. Individual changeSet parameters\n\n" +
                                         "The second option requires all three parameters to be defined.\n" +
                                         "This variant offers some more flexibility in naming conventions for path, id and author.\n\n"+
-                                        "liquibase calculateCheckSum --changeSetId myId --changeSetAuthor myAuthor --changeSetPath myPath\n"
+                                        "liquibase calculateCheckSum --changesetId myId --changesetAuthor myAuthor --changesetPath myPath\n"
         );
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/command/core/CalculateChecksumCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/CalculateChecksumCommandStep.java
@@ -41,6 +41,10 @@ public class CalculateChecksumCommandStep extends AbstractCommandStep {
 
     public static final CommandArgumentDefinition<String> CHANGESET_IDENTIFIER_ARG;
 
+    private static final int CHANGESET_IDENTIFIER_PARTS_LENGTH = 3;
+    private static final int CHANGESET_IDENTIFIER_AUTHOR_PART = 2;
+    private static final int CHANGESET_IDENTIFIER_ID_PART = 1;
+    private static final int CHANGESET_IDENTIFIER_PATH_PART = 0;
 
     static {
         CommandBuilder builder = new CommandBuilder(COMMAND_NAME);
@@ -48,23 +52,19 @@ public class CalculateChecksumCommandStep extends AbstractCommandStep {
                                     .description("The root changelog file").build();
 
         CHANGESET_IDENTIFIER_ARG = builder.argument("changeSetIdentifier", String.class)
-                                    .required()
-                                    .description("Changeset ID identifier of form filepath::id::author")
+                                    .description("ChangeSet ID identifier of form filepath::id::author")
                                     .build();
 
         CHANGESET_PATH_ARG = builder.argument("changeSetPath", String.class)
-                                    .required()
-                                    .description("Changelog path in which the changeset is included")
+                                    .description("Changelog path in which the changeSet is included")
                                     .build();
 
         CHANGESET_ID_ARG = builder.argument("changesetId", String.class)
-                                  .required()
-                                  .description("Changeset ID attribute")
+                                  .description("ChangeSet ID attribute")
                                   .build();
 
         CHANGESET_AUTHOR_ARG = builder.argument("changeSetAuthor", String.class)
-                                      .required()
-                                      .description("Changeset Author attribute")
+                                      .description("ChangeSet Author attribute")
                                       .build();
 
         CHECKSUM_RESULT = builder.result("checksumResult", CheckSum.class).description("Calculated checksum").build();
@@ -83,10 +83,26 @@ public class CalculateChecksumCommandStep extends AbstractCommandStep {
     @Override
     public void run(CommandResultsBuilder resultsBuilder) throws Exception {
         CommandScope commandScope = resultsBuilder.getCommandScope();
-        final String changeSetPath = commandScope.getArgumentValue(CHANGESET_PATH_ARG);
-        final String changeSetId = commandScope.getArgumentValue(CHANGESET_ID_ARG);
-        final String changeSetAuthor = commandScope.getArgumentValue(CHANGESET_AUTHOR_ARG);
+
+        final String changeSetIdentifier = commandScope.getArgumentValue(CHANGESET_IDENTIFIER_ARG);
         final String changeLogFile = commandScope.getArgumentValue(CHANGELOG_FILE_ARG).replace('\\', '/');
+        String changeSetPath;
+        String changeSetId;
+        String changeSetAuthor;
+
+        Boolean isChangeSetIdentifierPassed = changeSetIdentifier != null;
+
+        if (isChangeSetIdentifierPassed) {
+            List<String> parts = validateAndExtractParts(changeSetIdentifier, changeLogFile);
+            changeSetPath = parts.get(CHANGESET_IDENTIFIER_PATH_PART);
+            changeSetId = parts.get(CHANGESET_IDENTIFIER_ID_PART);
+            changeSetAuthor = parts.get(CHANGESET_IDENTIFIER_AUTHOR_PART);
+        } else {
+            changeSetPath = commandScope.getArgumentValue(CHANGESET_PATH_ARG);
+            changeSetId = commandScope.getArgumentValue(CHANGESET_ID_ARG);
+            changeSetAuthor = commandScope.getArgumentValue(CHANGESET_AUTHOR_ARG);
+        }
+
         final Database database = (Database) commandScope.getDependency(Database.class);
 
         Scope.getCurrentScope().getLog(getClass()).info(String.format("Calculating checksum for changeset identified by changeset id: %s, author: %s, path: %s",
@@ -118,6 +134,24 @@ public class CalculateChecksumCommandStep extends AbstractCommandStep {
         );
     }
 
+    private List<String> validateAndExtractParts(String changeSetIdentifier, String changeLogFile) throws LiquibaseException {
+        if (StringUtil.isEmpty(changeSetIdentifier)) {
+            throw new LiquibaseException(new IllegalArgumentException(CHANGESET_IDENTIFIER_ARG.getName()));
+        }
+
+        if (StringUtil.isEmpty(changeLogFile)) {
+            throw new LiquibaseException(new IllegalArgumentException(CHANGELOG_FILE_ARG.getName()));
+        }
+
+        final List<String> parts = StringUtil.splitAndTrim(changeSetIdentifier, "::");
+        if ((parts == null) || (parts.size() < CHANGESET_IDENTIFIER_PARTS_LENGTH)) {
+            throw new LiquibaseException(
+                    new IllegalArgumentException("Invalid changeSet identifier: " + changeSetIdentifier)
+            );
+        }
+        return parts;
+    }
+
     private static void sendMessages(CommandResultsBuilder resultsBuilder, CheckSum checkSum) {
         resultsBuilder.addResult(CHECKSUM_RESULT, checkSum);
         Scope.getCurrentScope().getUI().sendMessage(checkSum.toString());
@@ -128,5 +162,14 @@ public class CalculateChecksumCommandStep extends AbstractCommandStep {
         commandDefinition.setShortDescription("Calculates and prints a checksum for the changeset");
         commandDefinition.setLongDescription(
                 "Calculates and prints a checksum for the changeset with the given id in the format filepath::id::author");
+        commandDefinition.setHelpFooter("Calculate checksum provides two ways to identify a changeset.\n\n" +
+                                        "1. Composite changeset identifier\n\n" +
+                                        "The composite changeset identifier must be passed in the following pattern myPath::myId::myAuthor\n" +
+                                        "liquibase calculateCheckSum --changeSetIdentifier myFile::myId::myAuthor\n\n" +
+                                        "2. Individual changeset parameters\n\n" +
+                                        "The second option requires all three parameters to be defined\n" +
+                                        "This variant offers some more flexibility in naming conventions for path, id and author\n"+
+                                        "liquibase calculateCheckSum --changesetId myId --changesetAuthor myAuthor --changesetPath myPath\n"
+        );
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/command/core/CalculateChecksumCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/CalculateChecksumCommandStep.java
@@ -92,6 +92,41 @@ public class CalculateChecksumCommandStep extends AbstractCommandStep {
 
         final boolean isChangeSetIdentifierPassed = changeSetIdentifier != null;
 
+        final boolean isRequiredCompositeIdentifierMissing = (commandScope.getArgumentValue(CHANGESET_ID_ARG) == null ||
+                commandScope.getArgumentValue(CHANGESET_AUTHOR_ARG) == null || commandScope.getArgumentValue(CHANGESET_PATH_ARG) == null)
+                && changeSetIdentifier == null;
+
+        final boolean isAmbiguousNumberOfIdentifierProvided = (commandScope.getArgumentValue(CHANGESET_ID_ARG) != null ||
+                commandScope.getArgumentValue(CHANGESET_AUTHOR_ARG) != null || commandScope.getArgumentValue(CHANGESET_PATH_ARG) != null)
+                && changeSetIdentifier != null;
+
+        if (isAmbiguousNumberOfIdentifierProvided)  {
+            String errorMessage = "Error encountered while parsing the command line. " +
+                    "'--changeset-identifier' cannot be provided alongside other changeset arguments: " +
+                    "'--changeset-id', '--changeset-path', '--changeset-author'.";
+            throw new LiquibaseException(new IllegalArgumentException(errorMessage));
+        }
+
+        if (isRequiredCompositeIdentifierMissing) {
+            String errorMessage = "Required arguments missing: ";
+
+            if (commandScope.getArgumentValue(CHANGESET_ID_ARG) == null) {
+                errorMessage = errorMessage + " '--changeset-id',";
+            }
+
+            if (commandScope.getArgumentValue(CHANGESET_AUTHOR_ARG) == null) {
+                errorMessage = errorMessage + " '--changeset-author',";
+            }
+
+            if (commandScope.getArgumentValue(CHANGESET_PATH_ARG) == null) {
+                errorMessage = errorMessage + " '--changeset-path',";
+            }
+
+            errorMessage = errorMessage.substring(0,errorMessage.length() - 1) + ".";
+
+            throw new LiquibaseException(new IllegalArgumentException(errorMessage));
+        }
+
         if (isChangeSetIdentifierPassed) {
             List<String> parts = validateAndExtractParts(changeSetIdentifier, changeLogFile);
             changeSetPath = parts.get(CHANGESET_IDENTIFIER_PATH_PART);

--- a/liquibase-standard/src/main/java/liquibase/command/core/CalculateChecksumCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/CalculateChecksumCommandStep.java
@@ -164,11 +164,11 @@ public class CalculateChecksumCommandStep extends AbstractCommandStep {
                 "Calculates and prints a checksum for the changeset with the given id in the format filepath::id::author");
         commandDefinition.setHelpFooter("Calculate checksum provides two ways to identify a changeset.\n\n" +
                                         "1. Composite changeset identifier\n\n" +
-                                        "The composite changeset identifier must be passed in the following pattern myPath::myId::myAuthor\n" +
+                                        "The composite changeset identifier must be passed in the following pattern myPath::myId::myAuthor.\n" +
                                         "liquibase calculateCheckSum --changeSetIdentifier myFile::myId::myAuthor\n\n" +
                                         "2. Individual changeset parameters\n\n" +
-                                        "The second option requires all three parameters to be defined\n" +
-                                        "This variant offers some more flexibility in naming conventions for path, id and author\n"+
+                                        "The second option requires all three parameters to be defined.\n" +
+                                        "This variant offers some more flexibility in naming conventions for path, id and author.\n"+
                                         "liquibase calculateCheckSum --changesetId myId --changesetAuthor myAuthor --changesetPath myPath\n"
         );
     }

--- a/liquibase-standard/src/main/java/liquibase/command/core/CalculateChecksumCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/CalculateChecksumCommandStep.java
@@ -90,7 +90,7 @@ public class CalculateChecksumCommandStep extends AbstractCommandStep {
         String changeSetId;
         String changeSetAuthor;
 
-        Boolean isChangeSetIdentifierPassed = changeSetIdentifier != null;
+        final boolean isChangeSetIdentifierPassed = changeSetIdentifier != null;
 
         if (isChangeSetIdentifierPassed) {
             List<String> parts = validateAndExtractParts(changeSetIdentifier, changeLogFile);

--- a/liquibase-standard/src/main/java/liquibase/command/core/CalculateChecksumCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/CalculateChecksumCommandStep.java
@@ -108,7 +108,9 @@ public class CalculateChecksumCommandStep extends AbstractCommandStep {
         }
 
         if (isRequiredCompositeIdentifierMissing) {
-            String errorMessage = "Required arguments missing: ";
+            String errorMessage = "Error encountered while parsing the command line. " +
+                    "If --changeset-identifier is not provided than --changeset-id, --changeset-author and --changeset-path must be specified. " +
+                    "Missing argument: ";
 
             if (commandScope.getArgumentValue(CHANGESET_ID_ARG) == null) {
                 errorMessage = errorMessage + " '--changeset-id',";

--- a/liquibase-standard/src/main/java/liquibase/command/core/CalculateChecksumCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/CalculateChecksumCommandStep.java
@@ -52,14 +52,14 @@ public class CalculateChecksumCommandStep extends AbstractCommandStep {
                                     .description("The root changelog file").build();
 
         CHANGESET_IDENTIFIER_ARG = builder.argument("changeSetIdentifier", String.class)
-                                    .description("ChangeSet ID identifier of form filepath::id::author")
+                                    .description("ChangeSet identifier of form filepath::id::author")
                                     .build();
 
         CHANGESET_PATH_ARG = builder.argument("changeSetPath", String.class)
                                     .description("Changelog path in which the changeSet is included")
                                     .build();
 
-        CHANGESET_ID_ARG = builder.argument("changesetId", String.class)
+        CHANGESET_ID_ARG = builder.argument("changeSetId", String.class)
                                   .description("ChangeSet ID attribute")
                                   .build();
 
@@ -105,7 +105,7 @@ public class CalculateChecksumCommandStep extends AbstractCommandStep {
 
         final Database database = (Database) commandScope.getDependency(Database.class);
 
-        Scope.getCurrentScope().getLog(getClass()).info(String.format("Calculating checksum for changeset identified by changeset id: %s, author: %s, path: %s",
+        Scope.getCurrentScope().getLog(getClass()).info(String.format("Calculating checksum for changeSet identified by changeSet id: %s, author: %s, path: %s",
                                                                       changeSetId,
                                                                       changeSetAuthor,
                                                                       changeSetPath
@@ -117,7 +117,7 @@ public class CalculateChecksumCommandStep extends AbstractCommandStep {
 
         ChangeSet changeSet = changeLog.getChangeSet(changeSetPath, changeSetAuthor, changeSetId);
         if (changeSet == null) {
-            throw new LiquibaseException(new IllegalArgumentException(String.format("No such changeset identified by changeset id: %s, author: %s, path: %s",
+            throw new LiquibaseException(new IllegalArgumentException(String.format("No such changeSet identified by changeSet id: %s, author: %s, path: %s",
                                                                                     changeSetId,
                                                                                     changeSetAuthor,
                                                                                     changeSetPath
@@ -162,14 +162,14 @@ public class CalculateChecksumCommandStep extends AbstractCommandStep {
         commandDefinition.setShortDescription("Calculates and prints a checksum for the changeset");
         commandDefinition.setLongDescription(
                 "Calculates and prints a checksum for the changeset with the given id in the format filepath::id::author");
-        commandDefinition.setHelpFooter("Calculate checksum provides two ways to identify a changeset.\n\n" +
-                                        "1. Composite changeset identifier\n\n" +
-                                        "The composite changeset identifier must be passed in the following pattern myPath::myId::myAuthor.\n" +
+        commandDefinition.setHelpFooter("\nCalculate checksum provides two ways to identify a changeSet.\n\n" +
+                                        "1. Composite changeSet identifier\n\n" +
+                                        "The composite changeSet identifier must be passed in the following pattern myPath::myId::myAuthor.\n\n" +
                                         "liquibase calculateCheckSum --changeSetIdentifier myFile::myId::myAuthor\n\n" +
-                                        "2. Individual changeset parameters\n\n" +
+                                        "2. Individual changeSet parameters\n\n" +
                                         "The second option requires all three parameters to be defined.\n" +
-                                        "This variant offers some more flexibility in naming conventions for path, id and author.\n"+
-                                        "liquibase calculateCheckSum --changesetId myId --changesetAuthor myAuthor --changesetPath myPath\n"
+                                        "This variant offers some more flexibility in naming conventions for path, id and author.\n\n"+
+                                        "liquibase calculateCheckSum --changeSetId myId --changeSetAuthor myAuthor --changeSetPath myPath\n"
         );
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/commandline/Main.java
@@ -974,19 +974,7 @@ public class Main {
             return;
         }
 
-        final int CHANGESET_MINIMUM_IDENTIFIER_PARTS = 3;
-
-        if (COMMANDS.CALCULATE_CHECKSUM.equalsIgnoreCase(command)) {
-            for (final String param : commandParams) {
-                if ((param != null) && !param.startsWith("-")) {
-                    final String[] parts = param.split("::");
-                    if (parts.length < CHANGESET_MINIMUM_IDENTIFIER_PARTS) {
-                        messages.add(coreBundle.getString("changeset.identifier.must.have.form.filepath.id.author"));
-                        break;
-                    }
-                }
-            }
-        } else if (COMMANDS.DIFF_CHANGELOG.equalsIgnoreCase(command) && (diffTypes != null) && diffTypes.toLowerCase
+       if (COMMANDS.DIFF_CHANGELOG.equalsIgnoreCase(command) && (diffTypes != null) && diffTypes.toLowerCase
                 ().contains("data")) {
             messages.add(String.format(coreBundle.getString("including.data.diffchangelog.has.no.effect"),
                     OPTIONS.DIFF_TYPES, COMMANDS.GENERATE_CHANGELOG
@@ -1514,7 +1502,11 @@ public class Main {
                 liquibase.clearCheckSums();
                 return;
             } else if (COMMANDS.CALCULATE_CHECKSUM.equalsIgnoreCase(command)) {
-                liquibase.calculateCheckSum(commandParams.iterator().next());
+                liquibase.calculateCheckSum(
+                        getCommandParam(OPTIONS.CHANGE_SET_PATH, null),
+                        getCommandParam(OPTIONS.CHANGE_SET_ID, null),
+                        getCommandParam(OPTIONS.CHANGE_SET_AUTHOR, null)
+                );
                 return;
             } else if (COMMANDS.DB_DOC.equalsIgnoreCase(command)) {
                 if (commandParams.isEmpty()) {

--- a/liquibase-standard/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/commandline/Main.java
@@ -2,7 +2,6 @@ package liquibase.integration.commandline;
 
 import liquibase.*;
 import liquibase.changelog.ChangeLogParameters;
-import liquibase.changelog.DatabaseChangeLog;
 import liquibase.changelog.visitor.ChangeExecListener;
 import liquibase.changelog.visitor.DefaultChangeExecListener;
 import liquibase.command.CommandResults;
@@ -1506,9 +1505,10 @@ public class Main {
 
                 calculateChecksumCommand
                         .addArgumentValue(DbUrlConnectionCommandStep.DATABASE_ARG, database)
-                        .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_PATH_ARG, OPTIONS.CHANGE_SET_PATH)
-                        .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_ID_ARG, OPTIONS.CHANGE_SET_ID)
-                        .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_AUTHOR_ARG, OPTIONS.CHANGE_SET_AUTHOR)
+                        .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_PATH_ARG, getCommandParam(OPTIONS.CHANGE_SET_PATH, null))
+                        .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_ID_ARG, getCommandParam(OPTIONS.CHANGE_SET_ID, null))
+                        .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_AUTHOR_ARG, getCommandParam(OPTIONS.CHANGE_SET_AUTHOR, null))
+                        .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_IDENTIFIER_ARG, getCommandParam(OPTIONS.CHANGE_SET_IDENTIFIER, null))
                         .addArgumentValue(CalculateChecksumCommandStep.CHANGELOG_FILE_ARG, this.changeLogFile);
 
                 calculateChecksumCommand.execute();
@@ -2183,6 +2183,8 @@ public class Main {
         private static final String CHANGELOG_FILE = "changeLogFile";
         private static final String DATA_OUTPUT_DIRECTORY = "dataOutputDirectory";
         private static final String DIFF_TYPES = "diffTypes";
+
+        public static final String CHANGE_SET_IDENTIFIER = "changeSetIdentifier";
         private static final String CHANGE_SET_ID = "changeSetId";
         private static final String CHANGE_SET_AUTHOR = "changeSetAuthor";
         private static final String CHANGE_SET_PATH = "changeSetPath";

--- a/liquibase-standard/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/commandline/Main.java
@@ -1502,11 +1502,16 @@ public class Main {
                 liquibase.clearCheckSums();
                 return;
             } else if (COMMANDS.CALCULATE_CHECKSUM.equalsIgnoreCase(command)) {
-                liquibase.calculateCheckSum(
-                        getCommandParam(OPTIONS.CHANGE_SET_PATH, null),
-                        getCommandParam(OPTIONS.CHANGE_SET_ID, null),
-                        getCommandParam(OPTIONS.CHANGE_SET_AUTHOR, null)
-                );
+                CommandScope calculateChecksumCommand = new CommandScope("calculateChecksum");
+
+                calculateChecksumCommand
+                        .addArgumentValue(DbUrlConnectionCommandStep.DATABASE_ARG, database)
+                        .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_PATH_ARG, OPTIONS.CHANGE_SET_PATH)
+                        .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_ID_ARG, OPTIONS.CHANGE_SET_ID)
+                        .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_AUTHOR_ARG, OPTIONS.CHANGE_SET_AUTHOR)
+                        .addArgumentValue(CalculateChecksumCommandStep.CHANGELOG_FILE_ARG, this.changeLogFile);
+
+                calculateChecksumCommand.execute();
                 return;
             } else if (COMMANDS.DB_DOC.equalsIgnoreCase(command)) {
                 if (commandParams.isEmpty()) {


### PR DESCRIPTION
## Impact
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
 
`TypeBug`       
`APIBreakingChanges`
`newContributors` 


## Description
As described in #3814 the calculate-checksum command was not able to parse arguments which contains ``::`` characters. So the user is not able to use this command in conjuction with changeset Identifiers containing ``::``.
As suggested in the issue I have split the parameter changeSetIdentifier into three seperate parameters
- changeSetPath
- changeSetId
- changeSetAuthor

Herefor I made changes to the ``CalculateChecksumCommandStep`` and introduced the parameters mentioned above. I had to adjust the calculate-checksum API in Main and the Liquibase class.

So the user has to adjust his use of the calculate-checksum command with the new parameters like so.
``liquibase calculate-checksum --changeSetPath="changelog.xml"  --changeSetId="1::createTable" --changeSetAuthor="Me"``

Fixes #3814 

## Things to be aware of
- No Tests were written / adjusted until now
- New Contributor

## Things to worry about

## Additional Context

### Manual Test

**Run config**

![image](https://github.com/liquibase/liquibase/assets/37811304/492b336c-10a6-4a7e-854c-f5878935f668)

**Result**

![image](https://github.com/liquibase/liquibase/assets/37811304/811561d7-3de8-4c21-b65f-34f8971de67d)
