### PR TITLE
not to use class field for thread safe.

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/LockServiceCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/LockServiceCommandStep.java
@@ -2,7 +2,9 @@ package liquibase.command.core.helpers;
 
 import liquibase.Liquibase;
 import liquibase.Scope;
-import liquibase.command.*;
+import liquibase.command.CleanUpCommandStep;
+import liquibase.command.CommandResultsBuilder;
+import liquibase.command.CommandScope;
 import liquibase.database.Database;
 import liquibase.exception.LockException;
 import liquibase.lockservice.LockService;
@@ -18,8 +20,6 @@ public class LockServiceCommandStep extends AbstractHelperCommandStep implements
 
     protected static final String[] COMMAND_NAME = {"lockServiceCommandStep"};
 
-    private Database database;
-
     @Override
     public List<Class<?>> requiredDependencies() {
         return Collections.singletonList(Database.class);
@@ -33,7 +33,7 @@ public class LockServiceCommandStep extends AbstractHelperCommandStep implements
     @Override
     public void run(CommandResultsBuilder resultsBuilder) throws Exception {
         CommandScope commandScope = resultsBuilder.getCommandScope();
-        database = (Database) commandScope.getDependency(Database.class);
+        Database database = (Database) commandScope.getDependency(Database.class);
         LockServiceFactory.getInstance().getLockService(database).waitForLock();
     }
 

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/LockServiceCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/LockServiceCommandStep.java
@@ -45,7 +45,9 @@ public class LockServiceCommandStep extends AbstractHelperCommandStep implements
     @Override
     public void cleanUp(CommandResultsBuilder resultsBuilder) {
         try {
-            LockServiceFactory.getInstance().getLockService(database).releaseLock();
+            LockServiceFactory.getInstance().getLockService(
+                (Database) resultsBuilder.getCommandScope().getDependency(Database.class)
+            ).releaseLock();
         } catch (LockException e) {
             Scope.getCurrentScope().getLog(getClass()).severe(Liquibase.MSG_COULD_NOT_RELEASE_LOCK, e);
         }

--- a/liquibase-standard/src/test/groovy/liquibase/ThreadLocalScopeManagerTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/ThreadLocalScopeManagerTest.groovy
@@ -35,7 +35,6 @@ class ThreadLocalScopeManagerTest extends Specification {
 
     }
 
-    @Ignore
     void "maintain databases in parallel"() {
         when:
         /*


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Liquibase commands are not thread safe even with ThreadLocalScopeManager . 

Exception StackTrace

```
Caused by: liquibase.exception.CommandExecutionException: liquibase.exception.LockException: liquibase.exception.DatabaseException: liquibase.exception.DatabaseException: Error executing SQL CREATE TABLE PUBLIC.DATABASECHANGELOGLOCK (ID INT NOT NULL, LOCKED BOOLEAN NOT NULL, LOCKGRANTED TIMESTAMP, LOCKEDBY VARCHAR(255), CONSTRAINT PK_DATABASECHANGELOGLOCK PRIMARY KEY (ID)): The object is already closed [90007-193]
	at liquibase.command.CommandScope.execute(CommandScope.java:235)
	at liquibase.Liquibase.lambda$update$0(Liquibase.java:237)
	at liquibase.Scope.lambda$child$0(Scope.java:194)
	at liquibase.Scope.child(Scope.java:203)
	at liquibase.Scope.child(Scope.java:193)
	at liquibase.Scope.child(Scope.java:172)
	at liquibase.Liquibase.runInScope(Liquibase.java:1605)
	at liquibase.Liquibase.update(Liquibase.java:229)
	at liquibase.Liquibase.update(Liquibase.java:213)
	at com.example.persistence.dbmigration.ThreadLocalScopeManagerTest.maintainDatabase(ThreadLocalScopeManagerTest.java:89)
	... 6 more
Caused by: liquibase.exception.LockException: liquibase.exception.DatabaseException: liquibase.exception.DatabaseException: Error executing SQL CREATE TABLE PUBLIC.DATABASECHANGELOGLOCK (ID INT NOT NULL, LOCKED BOOLEAN NOT NULL, LOCKGRANTED TIMESTAMP, LOCKEDBY VARCHAR(255), CONSTRAINT PK_DATABASECHANGELOGLOCK PRIMARY KEY (ID)): The object is already closed [90007-193]
	at liquibase.lockservice.StandardLockService.acquireLock(StandardLockService.java:337)
	at liquibase.lockservice.StandardLockService.waitForLock(StandardLockService.java:254)
	at liquibase.command.core.helpers.LockServiceCommandStep.run(LockServiceCommandStep.java:37)
	at liquibase.command.CommandScope.execute(CommandScope.java:212)
	... 15 more
Caused by: liquibase.exception.DatabaseException: liquibase.exception.DatabaseException: Error executing SQL CREATE TABLE PUBLIC.DATABASECHANGELOGLOCK (ID INT NOT NULL, LOCKED BOOLEAN NOT NULL, LOCKGRANTED TIMESTAMP, LOCKEDBY VARCHAR(255), CONSTRAINT PK_DATABASECHANGELOGLOCK PRIMARY KEY (ID)): The object is already closed [90007-193]
	at liquibase.executor.jvm.ChangelogJdbcMdcListener.execute(ChangelogJdbcMdcListener.java:39)
	at liquibase.lockservice.StandardLockService.init(StandardLockService.java:117)
	at liquibase.lockservice.StandardLockService.acquireLock(StandardLockService.java:293)
	... 18 more
Caused by: liquibase.exception.DatabaseException: Error executing SQL CREATE TABLE PUBLIC.DATABASECHANGELOGLOCK (ID INT NOT NULL, LOCKED BOOLEAN NOT NULL, LOCKGRANTED TIMESTAMP, LOCKEDBY VARCHAR(255), CONSTRAINT PK_DATABASECHANGELOGLOCK PRIMARY KEY (ID)): The object is already closed [90007-193]
	at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:89)
	at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:160)
	at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:125)
	at liquibase.lockservice.StandardLockService.lambda$init$0(StandardLockService.java:117)
	at liquibase.executor.jvm.ChangelogJdbcMdcListener.lambda$execute$0(ChangelogJdbcMdcListener.java:33)
	at liquibase.Scope.lambda$child$0(Scope.java:194)
	at liquibase.Scope.child(Scope.java:203)
	at liquibase.Scope.child(Scope.java:193)
	at liquibase.Scope.child(Scope.java:172)
	at liquibase.executor.jvm.ChangelogJdbcMdcListener.execute(ChangelogJdbcMdcListener.java:32)
	... 20 more
Caused by: org.h2.jdbc.JdbcSQLException: The object is already closed [90007-193]
	at org.h2.message.DbException.getJdbcSQLException(DbException.java:345)
	at org.h2.message.DbException.get(DbException.java:179)
	at org.h2.message.DbException.get(DbException.java:155)
	at org.h2.message.DbException.get(DbException.java:144)
	at org.h2.jdbc.JdbcConnection.checkClosed(JdbcConnection.java:1480)
	at org.h2.jdbc.JdbcConnection.checkClosed(JdbcConnection.java:1458)
	at org.h2.jdbc.JdbcConnection.createStatement(JdbcConnection.java:202)
	at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:74)
	... 29 more
```

Fix #4376