### PR TITLE
Do not throw exception when runWith is empty string (DAT-14316)

### DIFF
--- a/liquibase-integration-tests/src/test/resources/changelogs/h2/complete/empty.runWith.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/h2/complete/empty.runWith.changelog.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet id="1" author="your.name" labels="example-label" context="example-context" runWith="">
+        <comment>example-comment</comment>
+        <createTable tableName="person">
+            <column name="id" type="int" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="name" type="varchar(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="address1" type="varchar(50)"/>
+            <column name="address2" type="varchar(50)"/>
+            <column name="city" type="varchar(30)"/>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/update.test.groovy
+++ b/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/update.test.groovy
@@ -386,4 +386,18 @@ Optional Args:
                 'EVENT: ran fired',
         ]
     }
+
+    run "Should fall back to jdbc executor when runWith is an empty string", {
+        arguments = [
+                url                    : { it.url },
+                username               : { it.username },
+                password               : { it.password },
+                changelogFile          : 'changelogs/h2/complete/empty.runWith.changelog.xml',
+        ]
+
+        expectedResults = [
+                statusCode: 0,
+                defaultChangeExecListener: 'not_null'
+        ]
+    }
 }

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeSet.java
@@ -319,8 +319,11 @@ public class ChangeSet implements Conditional, ChangeLogChild {
         this.storedFilePath = storedFilePath;
     }
 
+    /**
+     * @return the runWith value. If the runWith value is empty or not set this method will return null.
+     */
     public String getRunWith() {
-        return runWith;
+        return runWith == null || runWith.isEmpty() ? null : runWith;
     }
 
     public void setRunWith(String runWith) {


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors -->


## Description
Modifies `ChangeSet` getter to return null when runWith is set to an empty string. 
<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of
I know people aren't always necessarily fans of having logic in getters but I'd have needed to add a conditional `|| getRunWith().isEmpty()` to like 4 different places or so I opted for this route. I'd be happy to swap to the other method though and leave the getter alone. 
<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
