### PR TITLE
Fixed: LONG VARCHAR DEFAULT NULL instead of LONG VARCHAR DEFAULT 'NULL'

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/util/SqlUtil.java
+++ b/liquibase-standard/src/main/java/liquibase/util/SqlUtil.java
@@ -237,11 +237,11 @@ public abstract class SqlUtil {
             } else if (typeId == Types.JAVA_OBJECT) {
                 return new DatabaseFunction(stringVal);
             } else if (typeId == Types.LONGNVARCHAR) {
-                return stringVal;
+                return strippedSingleQuotes ? stringVal : new DatabaseFunction(stringVal);
             } else if (typeId == Types.LONGVARBINARY) {
                 return new DatabaseFunction(stringVal);
             } else if (typeId == Types.LONGVARCHAR) {
-                return stringVal;
+                return strippedSingleQuotes ? stringVal : new DatabaseFunction(stringVal);
             } else if (liquibaseDataType instanceof NCharType || typeId == Types.NCHAR || liquibaseDataType.getName().equalsIgnoreCase("NCLOB")) {
                 return stringVal;
             } else if (typeId == Types.NCLOB) {


### PR DESCRIPTION
## Impact

Fixes https://github.com/liquibase/liquibase/issues/4514.

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR implements for `LONG VARCHAR` and `LONG NVARCHAR` the similar solution as implemented for `BLOB`, but with the distinction for single-quoted strings.

## Things to be aware of

The fix assumes that the RDBMS is compliant with the description found at https://docs.oracle.com/javase/8/docs/api/java/sql/DatabaseMetaData.html#getColumns-java.lang.String-java.lang.String-java.lang.String-java.lang.String-:
>COLUMN_DEF String => default value for the column, which should be interpreted as a string **when the value is enclosed in single quotes** (may be `null`)

## Additional Context

N/A