### PR TITLE
No action

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ForeignKeySnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ForeignKeySnapshotGenerator.java
@@ -224,6 +224,10 @@ public class ForeignKeySnapshotGenerator extends JdbcSnapshotGenerator {
             if (jdbcType == DatabaseMetaData.importedKeyCascade) {
                 return ForeignKeyConstraintType.importedKeyCascade;
             } else if (jdbcType == DatabaseMetaData.importedKeyNoAction) {
+                if (database instanceof SybaseASADatabase) {
+                    //SQL Anywhere doesn't support NO ACTION, but reports it instead of SET DEFAULT
+                    return ForeignKeyConstraintType.importedKeySetDefault;
+                }
                 return ForeignKeyConstraintType.importedKeyNoAction;
             } else if (jdbcType == DatabaseMetaData.importedKeyRestrict) {
                 if (database instanceof MSSQLDatabase) {

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/AddForeignKeyConstraintGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/AddForeignKeyConstraintGenerator.java
@@ -36,6 +36,10 @@ public class AddForeignKeyConstraintGenerator extends AbstractSqlGenerator<AddFo
 
         validationErrors.checkDisallowedField("onDelete", addForeignKeyConstraintStatement.getOnDelete(), database, SybaseDatabase.class);
 
+        if (database instanceof SybaseASADatabase) {
+            validationErrors.addWarning("SQL Anywhere will apply RESTRICT instead of NO ACTION.");
+        }
+
         return validationErrors;
     }
 
@@ -66,6 +70,8 @@ public class AddForeignKeyConstraintGenerator extends AbstractSqlGenerator<AddFo
                 //don't use
             } else if (database instanceof SybaseDatabase) {
                 //don't use
+            } else if ((database instanceof SybaseASADatabase) && "NO ACTION".equalsIgnoreCase(statement.getOnUpdate())) {
+                //SQL Anywhere cannot do "nothing", so we let SQL Aynwhere choose its implicit default (i. e. RESTRICT)
             } else {
                 sb.append(" ON UPDATE ").append(statement.getOnUpdate());
             }
@@ -84,6 +90,8 @@ public class AddForeignKeyConstraintGenerator extends AbstractSqlGenerator<AddFo
                 //don't use
             } else if (database instanceof SybaseDatabase) {
                 //don't use
+            } else if ((database instanceof SybaseASADatabase) && "NO ACTION".equalsIgnoreCase(statement.getOnDelete())) {
+                //SQL Anywhere cannot do "nothing", so we let SQL Aynwhere choose its implicit default (i. e. RESTRICT)
             } else {
                 sb.append(" ON DELETE ").append(statement.getOnDelete());
             }


### PR DESCRIPTION
## Impact

Fixes  https://github.com/liquibase/liquibase/issues/4530
Fixes https://github.com/liquibase/liquibase/issues/4522

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

SQL Anywhere does not support `NO ACTION` (but supports `RESTRICT`, and uses `RESTRICT` as the default action if no action is provided), but its JDBC driver `sajdbc4.jar` reports `importedKeyNoAction` instead of `importedKeySetDefault`.

This PR changes Liquibase's behavior in three ways to deal with this situation in the least annoying way:
* If a changelog contains `NO ACTION` then for SQL Anyway *no* action is explicitly configured, resulting in effectively `RESTRICT` getting used. A validation warning is provided in that case.
* Liquibase will not generate changelogs containing `NO ACTION` when snapshotting SQL Anywhere, as that would be wrong; instead, `SET DEFAULT` is used, as this is correct.

## Things to be aware of

N/A

## Things to worry about

N/A

## Additional Context

N/A