### PR TITLE
SQL Anywhere: Not trimming anything, as SQL Anywhere does not need it but supports distinction-by-blank

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/snapshot/ResultSetCache.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/ResultSetCache.java
@@ -3,6 +3,7 @@ package liquibase.snapshot;
 import liquibase.CatalogAndSchema;
 import liquibase.database.Database;
 import liquibase.database.core.InformixDatabase;
+import liquibase.database.core.SybaseASADatabase;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
@@ -58,6 +59,7 @@ public class ResultSetCache {
                 }
 
                 results = resultSetExtractor.bulkFetch();
+
                 didBulkQuery.put(schemaKey, bulkTracking);
                 bulkQueried = true;
             } else {
@@ -94,7 +96,6 @@ public class ResultSetCache {
                 returnList = new ArrayList<>();
             }
             return returnList;
-
 
         } catch (SQLException e) {
             throw new DatabaseException(e);
@@ -293,6 +294,11 @@ public class ResultSetCache {
                     protected Object getColumnValue(ResultSet rs, int index) throws SQLException {
                         Object value = super.getColumnValue(rs, index);
                         if ((value instanceof String)) {
+                            if (database instanceof SybaseASADatabase) {
+                                // SQL Anywhere does not need any trimming as it never provides any extra whitespace padding,
+                                // but it does support duplicate object names differing by whitespace only.
+                                return value;
+                            }
 
                             // Don't trim for informix database,
                             // We need to discern the space in front of an index name,


### PR DESCRIPTION
Closes #4521 

## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

SQL Anywhere does never blank-pad any information provided to Liquibase, so there is no need for trimming.

SQL Anywhere does support duplicate names that differ only by blank padding. For example, one can have all the tables or columns `X`, `X `, ` X` and ` X `, and SQL Anywhere correctly can tell which one you want as long as they are correctly double-quoted.


## Things to be aware of

N/A

## Things to worry about

N/A

## Additional Context

N/A