### PR TITLE
[DAT-15489] Fixes changelog-sync-to-tag ignores the tag if  it is already in database after 4.23.0

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/command/core/ChangelogSyncCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/ChangelogSyncCommandStep.java
@@ -32,7 +32,7 @@ public class ChangelogSyncCommandStep extends AbstractCommandStep {
     private String tag = null;
 
     static {
-        CommandBuilder builder = new CommandBuilder(COMMAND_NAME);
+        new CommandBuilder(COMMAND_NAME);
     }
 
     @Override
@@ -104,12 +104,12 @@ public class ChangelogSyncCommandStep extends AbstractCommandStep {
         } else {
             List<RanChangeSet> ranChangeSetList = database.getRanChangeSetList();
             return new ChangeLogIterator(changeLog,
+                    new UpToTagChangeSetFilter(tag, ranChangeSetList),
                     new NotRanChangeSetFilter(database.getRanChangeSetList()),
                     new ContextChangeSetFilter(contexts),
                     new LabelChangeSetFilter(labelExpression),
                     new IgnoreChangeSetFilter(),
-                    new DbmsChangeSetFilter(database),
-                    new UpToTagChangeSetFilter(tag, ranChangeSetList));
+                    new DbmsChangeSetFilter(database));
         }
     }
 


### PR DESCRIPTION
## Impact

- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
changelog-sync-to-tag marks as executed all changesets after upgrade to v. 4.23 if the tag  is already in database