### PR TITLE
generateChangelog creates crippled view definition SQL

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -94,7 +94,7 @@ public abstract class AbstractJdbcDatabase implements Database {
     private static final String NON_WORD_REGEX = ".*\\W.*";
     private static final Pattern NON_WORD_PATTERN = Pattern.compile(NON_WORD_REGEX);
 
-    private static final String CREATE_VIEW_AS_REGEX = "^CREATE\\s+.*?VIEW\\s+.*?AS\\s+";
+    private static final String CREATE_VIEW_AS_REGEX = "^CREATE\\s+.*?VIEW\\s+.*?\\s+AS(?:\\s+|(?:>\\()?)";
     private static final Pattern CREATE_VIEW_AS_PATTERN = Pattern.compile(CREATE_VIEW_AS_REGEX, Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
     private static final String DATE_ONLY_REGEX = "^\\d{4}\\-\\d{2}\\-\\d{2}$";

--- a/liquibase-standard/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -94,7 +94,7 @@ public abstract class AbstractJdbcDatabase implements Database {
     private static final String NON_WORD_REGEX = ".*\\W.*";
     private static final Pattern NON_WORD_PATTERN = Pattern.compile(NON_WORD_REGEX);
 
-    private static final String CREATE_VIEW_AS_REGEX = "^CREATE\\s+.*?VIEW\\s+.*?\\s+AS(?:\\s+|(?:>\\()?)";
+    private static final String CREATE_VIEW_AS_REGEX = "^CREATE\\s+.*?VIEW\\s+.*?\\s+AS(?:\\s+|(?=\\())";
     private static final Pattern CREATE_VIEW_AS_PATTERN = Pattern.compile(CREATE_VIEW_AS_REGEX, Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
     private static final String DATE_ONLY_REGEX = "^\\d{4}\\-\\d{2}\\-\\d{2}$";


### PR DESCRIPTION
## Impact

Fixes #4518

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

This PR fixes both cases described in #4518:

### Case 1: Parenthesis instead of whitespace in `CREATE VIEW ... AS(`

The solution is to lookahead (but not capture) for a subsequent opening parenthesis adjacent *after* `AS`.

### Case 2: `AS` within view name

The solution is to require (and capture) whitespace *before* `AS`.

## Things to be aware of

The solution might be incomplete, as there might be more cases to cover, e. g. when a RDBMS allows `AS` adjacent after the quotes of a quoted view name, etc. The target of this PR is **not** to resolve hypothetical or synthetical cases, but to resolve only actual cases proven to fail in reality (here: both cases were reported to actually fail in existing SQL Anywhere databases).

## Things to worry about

N/A

## Additional Context

N/A