### PR TITLE
SQL Anywhere allows two foreign keys to differ only by name

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -69,6 +69,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -90,7 +92,6 @@ jobs:
       - name: Version Artifact
         run: |
            mvn versions:set "-DnewVersion=${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT"
-           #mvn versions:set "-DnewVersion=${{ inputs.branchName }}-SNAPSHOT"
 
       # Publish to GitHub Packages
       - name: Publish package

--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -23,11 +23,7 @@ jobs:
       thisBranchName: ${{ steps.get-branch-name.outputs.thisBranchName }}
       thisSha: ${{ steps.get-commit-sha.outputs.thisSha }}
       setupSuccessful: "true"
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    permissions:
-      contents: read
-      packages: write
+
     steps:
       - uses: actions/checkout@v3
         with:
@@ -37,7 +33,7 @@ jobs:
         id: get-commit-sha
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.BOT_TOKEN }}
           script: |
               const helper = require('./.github/util/workflow-helper.js')({github, context});
               core.setOutput("thisSha", helper.getCurrentSha());
@@ -69,8 +65,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -92,6 +86,7 @@ jobs:
       - name: Version Artifact
         run: |
            mvn versions:set "-DnewVersion=${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT"
+           #mvn versions:set "-DnewVersion=${{ inputs.branchName }}-SNAPSHOT"
 
       # Publish to GitHub Packages
       - name: Publish package

--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -37,7 +37,7 @@ jobs:
         id: get-commit-sha
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.BOT_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
               const helper = require('./.github/util/workflow-helper.js')({github, context});
               core.setOutput("thisSha", helper.getCurrentSha());

--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -23,7 +23,11 @@ jobs:
       thisBranchName: ${{ steps.get-branch-name.outputs.thisBranchName }}
       thisSha: ${{ steps.get-commit-sha.outputs.thisSha }}
       setupSuccessful: "true"
-
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v3
         with:

--- a/liquibase-standard/src/main/java/liquibase/structure/core/ForeignKey.java
+++ b/liquibase-standard/src/main/java/liquibase/structure/core/ForeignKey.java
@@ -207,6 +207,10 @@ public class ForeignKey extends AbstractDatabaseObject{
 
         ForeignKey that = (ForeignKey) o;
 
+        if (!this.getName().equalsIgnoreCase(that.getName())) {
+            return false;
+        }
+
         if (this.getSchema() != null && that.getSchema() != null) {
             boolean schemasEqual = this.getSchema().equals(that.getSchema());
             if (!schemasEqual) {
@@ -214,9 +218,8 @@ public class ForeignKey extends AbstractDatabaseObject{
             }
         }
 
-
         if (getForeignKeyColumns() == null) {
-            return this.getName().equalsIgnoreCase(that.getName());
+            return true;
         }
 
         StringUtil.StringUtilFormatter<Column> formatter = obj -> obj.toString(false);


### PR DESCRIPTION
## Impact

Fixes #4597 

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Two foreign keys with different names are by definition *different* foreign keys on all RDBMS, not just on SQL Anywhere. It is the administrator's sole discretion to design two identical foreign keys with different names.

## Things to be aware of

This change affects *all* RDBMS, not just SQL Anywhere. It changes Liquibase's general behavior in such a way that the names of foreign keys *always* are considered when comparing two foreign keys. While these keys compare as "being equal", they are not "identical", hence `compare` is not be changed, while `equals` is.

## Things to worry about

N/A

## Additional Context

N/A