### PR TITLE
fix standardlockservice when changelog-lock-wait-time-in-minutes is set to 0 and lock does not exist in database

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/lockservice/StandardLockService.java
+++ b/liquibase-standard/src/main/java/liquibase/lockservice/StandardLockService.java
@@ -254,8 +254,9 @@ public class StandardLockService implements LockService {
 
         boolean locked = false;
         long timeToGiveUp = new Date().getTime() + (getChangeLogLockWaitTime() * 1000 * 60);
-        while (!locked && (new Date().getTime() < timeToGiveUp)) {
-            locked = acquireLock();
+
+        locked = acquireLock();
+        do {
             if (!locked) {
                 Scope.getCurrentScope().getLog(getClass()).info("Waiting for changelog lock....");
                 try {
@@ -265,7 +266,8 @@ public class StandardLockService implements LockService {
                     Thread.currentThread().interrupt();
                 }
             }
-        }
+            locked = acquireLock();
+        } while (!locked && (new Date().getTime() < timeToGiveUp));
 
         if (!locked) {
             DatabaseChangeLogLock[] locks = listLocks();


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors -->


## Description

Fixes #4325

If changelog-lock-wait-time-in-minutes was set to 0 and there was not a lock in the database then acquireLock was not called => 
it was not possible to acquire the lock and the error message was wrong : "Could not acquire change log lock.  Currently locked by UNKNOWN"

It's necessary to try at least one time to acquire the lock before waiting (or not if this parameter is set to 0) to retry.

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->
I'm not able to identify if new unit / integration tests are necessary. The current tests are still OK

## Additional Context

<!--
Add any other context about the problem here.
-->
A PR for liquibase-mongodb is already created : https://github.com/liquibase/liquibase-mongodb/pull/375