### PR TITLE
Fixed: #4662 - PostgreSQL: Doesn't support (n CHAR) syntax, but only (n) syntax.

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/datatype/core/CharType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/CharType.java
@@ -41,13 +41,19 @@ public class CharType extends LiquibaseDataType {
             type.addAdditionalInformation(getAdditionalInformation());
             return type;
         } else if (database instanceof PostgresDatabase){
-            if ((getParameters() != null) && (getParameters().length == 1) && "2147483647".equals(getParameters()[0]
-                .toString())) {
-                DatabaseDataType type = new DatabaseDataType("CHARACTER");
-                type.addAdditionalInformation("VARYING");
-                return type;
+            final Object[] parameters = getParameters();
+            if ((parameters != null) && (parameters.length == 1)) {
+                // PostgreSQL only supports (n) syntax but not (n CHAR) syntax, so we need to remove CHAR.
+                final String parameter = parameters[0].toString().replaceFirst("(?<=\\d+)\\s*(?i)CHAR$", "");
+                // PostgreSQL uses max. length implicitly if no length is provided to CHARACTER VARYING, so we can spare it.
+                if ("2147483647".equals(parameter)) {
+                    DatabaseDataType type = new DatabaseDataType("CHARACTER");
+                    type.addAdditionalInformation("VARYING");
+                    return type;
+                }
+                parameters[0] = parameter;
+                return new DatabaseDataType("CHARACTER", parameters);
             }
-            return super.toDatabaseDataType(database);
         } else if (database instanceof H2Database) {
             if (getRawDefinition().toLowerCase(Locale.US).contains("large object")) {
                 return new DatabaseDataType("CHARACTER LARGE OBJECT");

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/CharType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/CharType.java
@@ -52,7 +52,9 @@ public class CharType extends LiquibaseDataType {
                     return type;
                 }
                 parameters[0] = parameter;
-                return new DatabaseDataType("CHARACTER", parameters);
+                DatabaseDataType type = new DatabaseDataType(this.getName().toUpperCase(Locale.US), parameters);
+                type.addAdditionalInformation(this.getAdditionalInformation());
+                return type;
             }
         } else if (database instanceof H2Database) {
             if (getRawDefinition().toLowerCase(Locale.US).contains("large object")) {

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/VarcharType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/VarcharType.java
@@ -45,11 +45,18 @@ public class VarcharType extends CharType {
             type.addAdditionalInformation(getAdditionalInformation());
             return type;
         } else if (database instanceof PostgresDatabase) {
-            if ((getParameters() != null) && (getParameters().length == 1) && "2147483647".equals(getParameters()[0]
-                .toString())) {
-                DatabaseDataType type = new DatabaseDataType("CHARACTER");
-                type.addAdditionalInformation("VARYING");
-                return type;
+            final Object[] parameters = getParameters();
+            if ((parameters != null) && (parameters.length == 1)) {
+                // PostgreSQL only supports (n) syntax but not (n CHAR) syntax, so we need to remove CHAR.
+                final String parameter = parameters[0].toString().replaceFirst("(?<=\\d+)\\s*(?i)CHAR$", "");
+                // PostgreSQL uses max. length implicitly if no length is provided, so we can spare it.
+                if ("2147483647".equals(parameter)) {
+                    DatabaseDataType type = new DatabaseDataType("CHARACTER");
+                    type.addAdditionalInformation("VARYING");
+                    return type;
+                }
+                parameters[0] = parameter;
+                return new DatabaseDataType("CHARACTER VARYING", parameters);
             }
         }
 

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/VarcharType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/VarcharType.java
@@ -8,6 +8,7 @@ import liquibase.datatype.LiquibaseDataType;
 
 import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.Locale;
 
 @DataTypeInfo(name="varchar", aliases = {"java.sql.Types.VARCHAR", "java.lang.String", "varchar2", "character varying"}, minParameters = 0, maxParameters = 1, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class VarcharType extends CharType {
@@ -56,7 +57,9 @@ public class VarcharType extends CharType {
                     return type;
                 }
                 parameters[0] = parameter;
-                return new DatabaseDataType("CHARACTER VARYING", parameters);
+                DatabaseDataType type = new DatabaseDataType(this.getName().toUpperCase(Locale.US), parameters);
+                type.addAdditionalInformation(this.getAdditionalInformation());
+                return type;
             }
         }
 

--- a/liquibase-standard/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/mergeColumns/postgresql.sql
+++ b/liquibase-standard/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/mergeColumns/postgresql.sql
@@ -4,7 +4,7 @@
 -- Change Parameter: finalColumnName=full_name
 -- Change Parameter: finalColumnType=varchar(255)
 -- Change Parameter: tableName=person
-ALTER TABLE person ADD full_name CHARACTER VARYING(255);
+ALTER TABLE person ADD full_name VARCHAR(255);
 UPDATE person SET full_name = first_name || 'null' || last_name;
 ALTER TABLE person DROP COLUMN first_name;
 ALTER TABLE person DROP COLUMN last_name;

--- a/liquibase-standard/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/mergeColumns/postgresql.sql
+++ b/liquibase-standard/src/test/java/liquibase/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/mergeColumns/postgresql.sql
@@ -4,7 +4,7 @@
 -- Change Parameter: finalColumnName=full_name
 -- Change Parameter: finalColumnType=varchar(255)
 -- Change Parameter: tableName=person
-ALTER TABLE person ADD full_name VARCHAR(255);
+ALTER TABLE person ADD full_name CHARACTER VARYING(255);
 UPDATE person SET full_name = first_name || 'null' || last_name;
 ALTER TABLE person DROP COLUMN first_name;
 ALTER TABLE person DROP COLUMN last_name;


### PR DESCRIPTION
Fixes #4662 

## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

This PR cuts away the CHAR ending when it is found in the sole parameter, and the value's pattern is "the word CHAR follows a number". This is correct, as PostgreSQL expects the number to be given in characters, but just does not understand the subsequent word "CHAR".

## Things to be aware of

N/A

## Things to worry about

I noticed that special handling was in place producing "CHARACTER VARYING" when "CHARACTER (2147483647)" was found. I kept that solution and extended it to apply to "CHARACTER (2147483647 CHAR)", too. Nevertheless, IMHO that special handling is wrong for "CHARACTER" (while it is correct for "CHARACTER VARYING") as it produces a VARCHAR on the database, not a CHAR. As this failure existed before this PR, it is not the task of this PR to resolve that bug. Nevertheless, it makes sense to fix that in a separate PR eventually.

## Additional Context

N/A