### PR TITLE
Fixed: Fails to detect LONG VARCHAR as CLOB and LONG BINARY as BLOB

### DIFF
--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
@@ -33,6 +33,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.descriptor.MojoDescriptor;
 import org.apache.maven.plugin.descriptor.Parameter;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.wagon.authentication.AuthenticationInfo;
 import org.liquibase.maven.property.PropertyElement;
@@ -68,6 +69,8 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
      * Suffix for fields that are representing a default value for a another field.
      */
     private static final String DEFAULT_FIELD_SUFFIX = "Default";
+
+    private MavenLog logCache;
 
     /**
      *
@@ -217,6 +220,30 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
      */
     @PropertyElement
     protected String logging;
+
+    /**
+     * Determines the minimum log level liquibase uses when logging.
+     * <p>
+     * Supported values are:
+     *
+     * <ul>
+     *     <li>DEBUG</li>
+     *     <li>INFO</li>
+     *     <li>WARNING</li>
+     *     <li>ERROR</li>
+     * </ul>
+     *
+     * The primary use case for this option is to reduce the amount of logs from liquibase, while
+     * not changing the log level of maven itself, without changing ${maven.home}/conf/logging/simplelogger.properties.
+     * <p>
+     * <b>NOTE:</b> The final log level is the <i>maximum</i> of this value and the maven log level.
+     * Thus, it is not possible to <i>decrease</i> the effective log level with this option.
+     *
+     * @parameter property="liquibase.logLevel" default-value="DEBUG"
+     */
+    @PropertyElement
+    protected String logLevel;
+
     /**
      * Specifies the <i>liquibase.properties</i> you want to use to configure Liquibase.
      *
@@ -1200,6 +1227,14 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
         nativeProperties.computeIfAbsent("liquibase.sqlcmd.logFile", val -> sqlcmdLogFile);
         nativeProperties.computeIfAbsent("liquibase.sqlcmd.catalogName", val -> sqlcmdCatalogName);
         return nativeProperties;
+    }
+
+    @Override
+    public synchronized Log getLog() {
+        if (logCache == null) {
+            logCache = new MavenLog(super.getLog(), logLevel);
+        }
+        return logCache;
     }
 
     /**

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/MavenLog.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/MavenLog.java
@@ -1,0 +1,152 @@
+package org.liquibase.maven.plugins;
+
+import org.apache.maven.plugin.logging.Log;
+
+public class MavenLog implements Log {
+
+    public enum Level {
+        DEBUG(0),
+        INFO(1),
+        WARNING(2),
+        ERROR(3),
+        ;
+
+        private final int level;
+
+        Level(int level) {
+            this.level = level;
+        }
+
+        public boolean isAtLeast(Level other) {
+            return this.level <= other.level;
+        }
+    }
+
+    private final Log actualLog;
+    private final Level level;
+
+    public MavenLog(Log actualLog, Level level) {
+        this.actualLog = actualLog;
+        this.level = level;
+    }
+
+    public MavenLog(Log actualLog, String level) {
+        this(actualLog, Level.valueOf(level));
+    }
+
+    // Debug
+    // =====
+
+    @Override
+    public boolean isDebugEnabled() {
+        return level.isAtLeast(Level.DEBUG) && actualLog.isDebugEnabled();
+    }
+
+    @Override
+    public void debug(CharSequence charSequence) {
+        if (isDebugEnabled()) {
+            actualLog.debug(charSequence);
+        }
+    }
+
+    @Override
+    public void debug(CharSequence charSequence, Throwable throwable) {
+        if (isDebugEnabled()) {
+            actualLog.debug(charSequence, throwable);
+        }
+    }
+
+    @Override
+    public void debug(Throwable throwable) {
+        if (isDebugEnabled()) {
+            actualLog.debug(throwable);
+        }
+    }
+
+    // Info
+    // ====
+
+    @Override
+    public boolean isInfoEnabled() {
+        return level.isAtLeast(Level.INFO) && actualLog.isInfoEnabled();
+    }
+
+    @Override
+    public void info(CharSequence charSequence) {
+        if (isInfoEnabled()) {
+            actualLog.info(charSequence);
+        }
+    }
+
+    @Override
+    public void info(CharSequence charSequence, Throwable throwable) {
+        if (isInfoEnabled()) {
+            actualLog.info(charSequence, throwable);
+        }
+    }
+
+    @Override
+    public void info(Throwable throwable) {
+        if (isInfoEnabled()) {
+            actualLog.info(throwable);
+        }
+    }
+
+    // Warn
+    // ====
+
+    @Override
+    public boolean isWarnEnabled() {
+        return level.isAtLeast(Level.WARNING) && actualLog.isWarnEnabled();
+    }
+
+    @Override
+    public void warn(CharSequence charSequence) {
+        if (isWarnEnabled()) {
+            actualLog.warn(charSequence);
+        }
+    }
+
+    @Override
+    public void warn(CharSequence charSequence, Throwable throwable) {
+        if (isWarnEnabled()) {
+            actualLog.warn(charSequence, throwable);
+        }
+    }
+
+    @Override
+    public void warn(Throwable throwable) {
+        if (isWarnEnabled()) {
+            actualLog.warn(throwable);
+        }
+    }
+
+    // Error
+    // =====
+
+    @Override
+    public boolean isErrorEnabled() {
+        return level.isAtLeast(Level.ERROR) && actualLog.isErrorEnabled();
+    }
+
+    @Override
+    public void error(CharSequence charSequence) {
+        if (isErrorEnabled()) {
+            actualLog.error(charSequence);
+        }
+    }
+
+    @Override
+    public void error(CharSequence charSequence, Throwable throwable) {
+        if (isErrorEnabled()) {
+            actualLog.error(charSequence, throwable);
+        }
+    }
+
+    @Override
+    public void error(Throwable throwable) {
+        if (isErrorEnabled()) {
+            actualLog.error(throwable);
+        }
+    }
+}

--- a/liquibase-standard/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
@@ -265,6 +265,11 @@ class DataTypeFactoryTest extends Specification {
         "INT(20)"                                      | new SybaseDatabase()   | "INT"                                          | IntType       | false
         "SMALLINT(20)"                                 | new SybaseDatabase()   | "SMALLINT"                                     | SmallIntType  | false
         "TINYINT(20)"                                  | new SybaseDatabase()   | "TINYINT"                                      | TinyIntType   | false
+        "long binary"                                  | new SybaseDatabase()   | "IMAGE"                                        | BlobType      | false
+        "long varbinary"                               | new SybaseDatabase()   | "IMAGE"                                        | BlobType      | false
+        "long varchar"                                 | new SybaseDatabase()   | "TEXT"                                         | ClobType      | false
+        "long nvarchar"                                | new SybaseDatabase()   | "TEXT"                                         | ClobType      | false
+        "character varying"                            | new SybaseDatabase()   | "VARCHAR"                                      | VarcharType   | false
     }
 
     @Unroll("#featureName: #object for #database")


### PR DESCRIPTION
Fixes #4669 

## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Liquibase's assumption that a space is solely good for separating *additional information* from the type name is simply wrong. Even the ANSI SQL standard contains type names with blank in the middle.

Hence I have added those special cases that I am aware of (in my case the ones from SQL Anywhere) to the list of known excemptions.

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
