### PR TITLE
Fixed: #4682 - MSSQL: Doesn't support (n CHAR) syntax, but only (n) syntax

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/datatype/core/CharType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/CharType.java
@@ -22,7 +22,9 @@ public class CharType extends LiquibaseDataType {
         if (database instanceof MSSQLDatabase) {
             Object[] parameters = getParameters();
             if (parameters.length > 0) {
-                String param1 = parameters[0].toString();
+                // MSSQL only supports (n) syntax but not (n CHAR) syntax, so we need to remove CHAR.
+                final String param1 = parameters[0].toString().replaceFirst("(?<=\\d+)\\s*(?i)CHAR$", "");
+                parameters[0] =  param1;
                 if (!param1.matches("\\d+") || (new BigInteger(param1).compareTo(BigInteger.valueOf(8000)) > 0)) {
 
                     DatabaseDataType type = new DatabaseDataType(database.escapeDataTypeName("char"), 8000);

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/VarcharType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/VarcharType.java
@@ -26,7 +26,9 @@ public class VarcharType extends CharType {
         if (database instanceof MSSQLDatabase) {
             Object[] parameters = getParameters();
             if (parameters.length > 0) {
-                String param1 = parameters[0].toString();
+                // MSSQL only supports (n) syntax but not (n CHAR) syntax, so we need to remove CHAR.
+                final String param1 = parameters[0].toString().replaceFirst("(?<=\\d+)\\s*(?i)CHAR$", "");
+                parameters[0] =  param1;
                 if (!param1.matches("\\d+") || (new BigInteger(param1).compareTo(BigInteger.valueOf(8000L)) > 0)) {
 
                     DatabaseDataType type = new DatabaseDataType(database.escapeDataTypeName("varchar"), "MAX");

--- a/liquibase-standard/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
@@ -191,6 +191,9 @@ class DataTypeFactoryTest extends Specification {
         "[varchar](255) COLLATE Latin1_General_BIN"    | new MSSQLDatabase()    | "varchar(255) COLLATE Latin1_General_BIN"      | VarcharType   | false
         "varchar(MAX) COLLATE Latin1_General_BIN"      | new MSSQLDatabase()    | "varchar(MAX) COLLATE Latin1_General_BIN"      | VarcharType   | false
         "[varchar](MAX) COLLATE Latin1_General_BIN"    | new MSSQLDatabase()    | "varchar(MAX) COLLATE Latin1_General_BIN"      | VarcharType   | false
+        "VARCHAR(20 CHAR)"                             | new MSSQLDatabase()    | "varchar(20)"                                  | VarcharType   | false
+        "varchar(20 char)"                             | new MSSQLDatabase()    | "varchar(20)"                                  | VarcharType   | false
+        "CHAR(20 CHAR)"                                | new MSSQLDatabase()    | "char(20)"                                     | CharType      | false
         "INT"                                          | new MySQLDatabase()    | "INT"                                          | IntType       | false
         "INT UNSIGNED"                                 | new MySQLDatabase()    | "INT UNSIGNED"                                 | IntType       | false
         "INT(11) UNSIGNED"                             | new MySQLDatabase()    | "INT UNSIGNED"                                 | IntType       | false


### PR DESCRIPTION
Fixes #4682 

## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

This PR cuts away the CHAR ending when it is found in the sole parameter, and the value's pattern is "the word CHAR follows a number". This is correct, as MSSQL expects the number to be given in characters, but just does not understand the subsequent word "CHAR".

## Things to be aware of

N/A

## Things to worry about

N/A

## Additional Context

N/A