### PR TITLE
Added default method isFolder to Resource interface DAT-15388

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -693,6 +693,9 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
             Set<String> seenChangelogPaths = Scope.getCurrentScope().get(SEEN_CHANGELOGS_PATHS_SCOPE_KEY, new HashSet<>());
             Scope.child(Collections.singletonMap(SEEN_CHANGELOGS_PATHS_SCOPE_KEY, seenChangelogPaths), () -> {
                 for (Resource resource : resources) {
+                    if (resource.isFolder(resource.getUri().toString())) {
+                        continue;
+                    }
                     Scope.getCurrentScope().getLog(getClass()).info("Reading resource: " + resource);
                     include(resource.getPath(), false, errorIfMissingOrEmpty, resourceAccessor, includeContextFilter,
                             labels, ignore, OnUnknownFileFormat.WARN, modifyChangeSets);

--- a/liquibase-standard/src/main/java/liquibase/resource/Resource.java
+++ b/liquibase-standard/src/main/java/liquibase/resource/Resource.java
@@ -30,6 +30,18 @@ public interface Resource {
     boolean isWritable();
 
     /**
+     *
+     * Default implementation
+     *
+     * @param   possibleFolder    Path to check for a folder
+     * @return  boolean
+     *
+     */
+    default boolean isFolder(String possibleFolder) {
+       return false;
+    }
+
+    /**
      * @return true if the resource defined by this object currently exists.
      */
     boolean exists();


### PR DESCRIPTION
Adding a new Resource interface method `isFolder` with a default implementation.  This will allow the S3Resource implementation to skip over folders that are returned during `getAll`.

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors -->


## Description

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
