### PR TITLE
Fetch ran change sets before updating check sums

### DIFF
--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/core/UpgradeChecksumVersionIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/core/UpgradeChecksumVersionIntegrationTest.groovy
@@ -14,6 +14,7 @@ import liquibase.extension.testing.testsystem.spock.LiquibaseIntegrationTest
 import liquibase.statement.core.RawSqlStatement
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Unroll
 
 @LiquibaseIntegrationTest
 class UpgradeChecksumVersionIntegrationTest extends Specification{
@@ -34,11 +35,12 @@ VALUES('1', 'your.name', '$changelogfile', '2023-05-31 14:33:39.108', 1, 'EXECUT
 """))
     }
 
+    @Unroll
     def "update command should upgrade all checksums when no filters supplied" () {
         def changesetFilepath = "changelogs/common/checksum-changelog.xml"
         final ChangeLogHistoryService changeLogService = ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(mysql.getDatabaseFromFactory())
         changeLogService.init()
-        insertDbclRecord(changesetFilepath)
+        insertDbclRecord(storedFilepathPrefix + changesetFilepath)
 
         when:
         def ranChangeSets = getRanChangesets(changeLogService)
@@ -62,6 +64,11 @@ VALUES('1', 'your.name', '$changelogfile', '2023-05-31 14:33:39.108', 1, 'EXECUT
 
         cleanup:
         CommandUtil.runDropAll(mysql)
+
+        where:
+        storedFilepathPrefix | _
+        "" | _
+        "classpath:" | _
     }
 
     def "update command should upgrade only matching changesets when filter is applied" () {

--- a/liquibase-standard/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
@@ -107,6 +107,7 @@ public class ValidatingVisitor implements ChangeSetVisitor {
             DatabaseList.validateDefinitions(changeSet.getDbmsSet(), validationErrors);
         }
         changeSet.setStoredCheckSum(ran?ranChangeSet.getLastCheckSum():null);
+        changeSet.setStoredFilePath(ran?ranChangeSet.getStoredChangeLog():null);
         boolean shouldValidate = !ran || changeSet.shouldRunOnChange() || changeSet.shouldAlwaysRun();
 
         if (!areChangeSetAttributesValid(changeSet)) {


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors -->


## Description

Fixes #4460.

The fix ensures that the field `storedFilePath` for each `changeSet` in `UpdateChangeSetChecksumGenerator` is set. Then, the `WHERE` condition of the produced `UPDATE` statements matches the database entry for the respective change set.

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
