### PR TITLE
Fix poor performance of listunrunchangesets

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -245,14 +245,16 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
 
     public List<ChangeSet> getChangeSets(String path, String author, String id) {
         final ArrayList<ChangeSet> changeSetsToReturn = new ArrayList<>();
-        for (ChangeSet changeSet : this.changeSets) {
-            final String normalizedPath = normalizePath(changeSet.getFilePath());
-            if (normalizedPath != null &&
-                    normalizedPath.equalsIgnoreCase(normalizePath(path)) &&
-                    changeSet.getAuthor().equalsIgnoreCase(author) &&
-                    changeSet.getId().equalsIgnoreCase(id) &&
-                    isDbmsMatch(changeSet.getDbmsSet())) {
-                changeSetsToReturn.add(changeSet);
+        final String normalizedPath = normalizePath(path);
+        if (normalizedPath != null) {
+            for (ChangeSet changeSet : this.changeSets) {
+                if (changeSet.getAuthor().equalsIgnoreCase(author) && changeSet.getId().equalsIgnoreCase(id) && isDbmsMatch(changeSet.getDbmsSet())) {
+                    final String changesetNormalizedPath = normalizePath(changeSet.getFilePath());
+                    if (changesetNormalizedPath != null &&
+                            changesetNormalizedPath.equalsIgnoreCase(normalizedPath)) {
+                        changeSetsToReturn.add(changeSet);
+                    }
+                }
             }
         }
         return changeSetsToReturn;
@@ -353,7 +355,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
         }
     }
 
-    public ChangeSet getChangeSet(RanChangeSet ranChangeSet) {
+    public ChangeSet  getChangeSet(RanChangeSet ranChangeSet) {
         final ChangeSet changeSet = getChangeSet(ranChangeSet.getChangeLog(), ranChangeSet.getAuthor(), ranChangeSet.getId());
         if (changeSet != null) {
             changeSet.setStoredFilePath(ranChangeSet.getStoredChangeLog());

--- a/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -250,8 +250,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
             for (ChangeSet changeSet : this.changeSets) {
                 if (changeSet.getAuthor().equalsIgnoreCase(author) && changeSet.getId().equalsIgnoreCase(id) && isDbmsMatch(changeSet.getDbmsSet())) {
                     final String changesetNormalizedPath = normalizePath(changeSet.getFilePath());
-                    if (changesetNormalizedPath != null &&
-                            changesetNormalizedPath.equalsIgnoreCase(normalizedPath)) {
+                    if (changesetNormalizedPath != null && changesetNormalizedPath.equalsIgnoreCase(normalizedPath)) {
                         changeSetsToReturn.add(changeSet);
                     }
                 }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 

Do not call normalizePath inside the loop for the same variable + just call it if everything else is fine.
