### PR TITLE
CreateIndex associatedWith property deserialization issue

### DIFF
--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
@@ -7,8 +7,10 @@ import liquibase.change.core.LoadDataChange;
 import liquibase.changelog.ChangeLogHistoryServiceFactory;
 import liquibase.changelog.ChangeSet;
 import liquibase.changelog.DatabaseChangeLog;
+import liquibase.command.CommandResults;
 import liquibase.command.CommandScope;
 import liquibase.command.core.DropAllCommandStep;
+import liquibase.command.core.SnapshotCommandStep;
 import liquibase.command.core.UpdateCommandStep;
 import liquibase.command.core.helpers.DbUrlConnectionCommandStep;
 import liquibase.database.Database;
@@ -96,6 +98,8 @@ public abstract class AbstractIntegrationTest {
     private final String invalidSqlChangeLog;
     private final String objectQuotingStrategyChangeLog;
     private final String commonChangeLog;
+
+    private final String indexWithAssociatedWithChangeLog;
     private Database database;
     private String defaultSchemaName;
 
@@ -117,6 +121,7 @@ public abstract class AbstractIntegrationTest {
         this.objectQuotingStrategyChangeLog = "changelogs/common/object.quoting.strategy.changelog.xml";
         this.emptyRollbackSqlChangeLog = "changelogs/common/rollbackable.changelog.sql";
         this.pathChangeLog = "changelogs/common/pathChangeLog.xml";
+        this.indexWithAssociatedWithChangeLog = "changelogs/common/index.with.associatedwith.changelog.xml";
         logger = Scope.getCurrentScope().getLog(getClass());
 
         Scope.setScopeManager(new TestScopeManager(Scope.getCurrentScope()));
@@ -1278,6 +1283,31 @@ public abstract class AbstractIntegrationTest {
         } finally {
             getDatabase().setDatabaseChangeLogTableName(oldDbChangelogTableName);
         }
+    }
+
+    @Test
+    public void verifyIndexIsCreatedWhenAssociatedWithPropertyIsSetAsNone() throws DatabaseException {
+       clearDatabase();
+        try {
+            Database database = getDatabase();
+            CommandScope commandScope = new CommandScope(UpdateCommandStep.COMMAND_NAME);
+            commandScope.addArgumentValue(DbUrlConnectionCommandStep.DATABASE_ARG, database);
+            commandScope.addArgumentValue(UpdateCommandStep.CHANGELOG_FILE_ARG, indexWithAssociatedWithChangeLog);
+            commandScope.execute();
+
+            final CommandScope snapshotScope = new CommandScope("snapshot");
+            snapshotScope.addArgumentValue(DbUrlConnectionCommandStep.DATABASE_ARG, database);
+            snapshotScope.addArgumentValue(SnapshotCommandStep.SNAPSHOT_FORMAT_ARG, "json");
+            CommandResults results = snapshotScope.execute();
+            DatabaseSnapshot snapshot = (DatabaseSnapshot) results.getResult("snapshot");
+            Index index = snapshot.get(new Index("idx_test"));
+            Assert.assertNotNull(index );
+        } catch (Exception e) {
+            Assert.fail("Should not fail. Reason: " + e.getMessage());
+        } finally {
+            clearDatabase();
+        }
+
     }
 
     private ProcessBuilder prepareExternalLiquibaseProcess() {

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/oracle/OracleIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/oracle/OracleIntegrationTest.java
@@ -4,14 +4,25 @@ import liquibase.Liquibase;
 import liquibase.Scope;
 import liquibase.changelog.ChangeSet;
 import liquibase.changelog.DatabaseChangeLog;
+import liquibase.command.CommandResults;
+import liquibase.command.CommandScope;
+import liquibase.command.core.SnapshotCommandStep;
+import liquibase.command.core.UpdateCommandStep;
+import liquibase.command.core.helpers.DbUrlConnectionCommandStep;
 import liquibase.database.Database;
 import liquibase.database.DatabaseFactory;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.dbtest.AbstractIntegrationTest;
+import liquibase.exception.DatabaseException;
 import liquibase.exception.ValidationFailedException;
+import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.sql.visitor.AbstractSqlVisitor;
+import liquibase.structure.core.Index;
+import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.Date;
@@ -27,12 +38,14 @@ public class OracleIntegrationTest extends AbstractIntegrationTest {
     String indexOnSchemaChangeLog;
     String viewOnSchemaChangeLog;
     String customExecutorChangeLog;
+    String indexWithAssociatedWithChangeLog;
 
     public OracleIntegrationTest() throws Exception {
         super("oracle", DatabaseFactory.getInstance().getDatabase("oracle"));
          indexOnSchemaChangeLog = "changelogs/oracle/complete/indexOnSchema.xml";
          viewOnSchemaChangeLog = "changelogs/oracle/complete/viewOnSchema.xml";
          customExecutorChangeLog = "changelogs/oracle/complete/sqlplusExecutor.xml";
+         indexWithAssociatedWithChangeLog = "changelogs/common/index.with.associatedwith.changelog.xml";
         // Respect a user-defined location for sqlnet.ora, tnsnames.ora etc. stored in the environment
         // variable TNS_ADMIN. This allowes the use of TNSNAMES.
         if (System.getenv("TNS_ADMIN") != null)
@@ -176,5 +189,30 @@ public class OracleIntegrationTest extends AbstractIntegrationTest {
     @Test
     public void testDiffExternalForeignKeys() throws Exception {
         //cross-schema security for oracle is a bother, ignoring test for now
+    }
+
+    @Test
+    public void verifyIndexIsCreatedWhenAssociatedWithPropertyIsSetAsForeignKey() throws DatabaseException {
+        clearDatabase();
+        try {
+            Database database = getDatabase();
+            CommandScope commandScope = new CommandScope(UpdateCommandStep.COMMAND_NAME);
+            commandScope.addArgumentValue(DbUrlConnectionCommandStep.DATABASE_ARG, database);
+            commandScope.addArgumentValue(UpdateCommandStep.CHANGELOG_FILE_ARG, indexWithAssociatedWithChangeLog);
+            commandScope.execute();
+
+            final CommandScope snapshotScope = new CommandScope("snapshot");
+            snapshotScope.addArgumentValue(DbUrlConnectionCommandStep.DATABASE_ARG, database);
+            snapshotScope.addArgumentValue(SnapshotCommandStep.SNAPSHOT_FORMAT_ARG, "json");
+            CommandResults results = snapshotScope.execute();
+            DatabaseSnapshot snapshot = (DatabaseSnapshot) results.getResult("snapshot");
+            Index index = snapshot.get(new Index("idx_test_oracle"));
+            Assert.assertNotNull(index);
+        } catch (Exception e) {
+            Assert.fail("Should not fail. Reason: " + e.getMessage());
+        } finally {
+            clearDatabase();
+        }
+
     }
 }

--- a/liquibase-integration-tests/src/test/resources/changelogs/common/common.tests.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/common/common.tests.changelog.xml
@@ -1335,4 +1335,18 @@
         </preConditions>
     </changeSet>
 
+    <changeSet id="indexTest" author="mallod">
+        <createTable tableName="indexTestTable">
+            <column name="id" type="int">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="firstname" type="varchar(10)"/>
+            <column name="lastname" type="varchar(10)"/>
+        </createTable>
+        <createIndex indexName="idx_test" tableName="indexTestTable" associatedWith="primaryKey">
+            <column name="firstname"/>
+            <column name="lastname"/>
+        </createIndex>
+    </changeSet>
+
 </databaseChangeLog>

--- a/liquibase-integration-tests/src/test/resources/changelogs/common/common.tests.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/common/common.tests.changelog.xml
@@ -1335,18 +1335,4 @@
         </preConditions>
     </changeSet>
 
-    <changeSet id="indexTest" author="mallod">
-        <createTable tableName="indexTestTable">
-            <column name="id" type="int">
-                <constraints primaryKey="true" nullable="false"/>
-            </column>
-            <column name="firstname" type="varchar(10)"/>
-            <column name="lastname" type="varchar(10)"/>
-        </createTable>
-        <createIndex indexName="idx_test" tableName="indexTestTable" associatedWith="primaryKey">
-            <column name="firstname"/>
-            <column name="lastname"/>
-        </createIndex>
-    </changeSet>
-
 </databaseChangeLog>

--- a/liquibase-integration-tests/src/test/resources/changelogs/common/index.with.associatedwith.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/common/index.with.associatedwith.changelog.xml
@@ -1,0 +1,22 @@
+<databaseChangeLog
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet id="createIndexTable" author="mallod">
+        <createTable tableName="indexTestTable">
+            <column name="id" type="int"/>
+            <column name="firstname" type="varchar(10)"/>
+            <column name="lastname" type="varchar(10)"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="createIndexTest" author="mallod">
+        <createIndex indexName="idx_test" tableName="indexTestTable" associatedWith="none">
+            <column name="firstname"/>
+        </createIndex>
+    </changeSet>
+    <changeSet id="createIndexTest2" author="mallod" dbms="oracle">
+        <createIndex indexName="idx_test_oracle" tableName="indexTestTable" associatedWith="foreignKey">
+            <column name="lastname"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>

--- a/liquibase-standard/src/main/java/liquibase/change/core/CreateIndexChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/CreateIndexChange.java
@@ -1,5 +1,6 @@
 package liquibase.change.core;
 
+import liquibase.ChecksumVersion;
 import liquibase.change.*;
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
@@ -242,5 +243,12 @@ public class CreateIndexChange extends AbstractChange implements ChangeWithColum
             }
         }
         return validationErrors;
+    }
+
+    @Override
+    public String[] getExcludedFieldFilters(ChecksumVersion version) {
+        return new String[]{
+                "associatedWith"
+        };
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/change/core/CreateIndexChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/CreateIndexChange.java
@@ -186,8 +186,7 @@ public class CreateIndexChange extends AbstractChange implements ChangeWithColum
      * <li>uniqueConstraint</li>
      * <li>none</li>
      * */
-    @DatabaseChangeProperty(isChangeProperty = false,
-        description = "Index associations. Valid values: primaryKey, foreignKey, uniqueConstriant, none")
+    @DatabaseChangeProperty(description = "Index associations. Valid values: primaryKey, foreignKey, uniqueConstriant, none")
     public String getAssociatedWith() {
         return associatedWith;
     }

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/CreateIndexChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/CreateIndexChangeTest.groovy
@@ -69,4 +69,49 @@ public class CreateIndexChangeTest extends StandardChangeTest {
         then:
         assert change.validate(database).getErrorMessages().size() == 1
     }
+
+    def "validate associatedWith is not computed on CheckSum generation"() {
+        when:
+        def index = new Index("idx_test", null, null, "test_table", new Column("test_col"))
+        index.unique = true
+        def originalChange = new CreateIndexChange()
+        originalChange.indexName = index.name
+        originalChange.tableName = index.relation.name
+        originalChange.columns = [new AddColumnConfig().setName("test_col")]
+        def originalChangeCheckSum = originalChange.generateCheckSum()
+
+        and:
+        def changeWithAssociatedWithSet = new CreateIndexChange()
+        changeWithAssociatedWithSet.indexName = index.name
+        changeWithAssociatedWithSet.tableName = index.relation.name
+        changeWithAssociatedWithSet.associatedWith = "foreignKey"
+        changeWithAssociatedWithSet.columns = [new AddColumnConfig().setName("test_col")]
+        def changeWithAssociatedWithSetCheckSum = changeWithAssociatedWithSet.generateCheckSum()
+
+        then:
+        originalChangeCheckSum == changeWithAssociatedWithSetCheckSum
+    }
+
+    def "validate create index CheckSum value is not the same if any other property is added"() {
+        when:
+        def index = new Index("idx_test", null, null, "test_table", new Column("test_col"))
+        index.unique = true
+        def originalChange = new CreateIndexChange()
+        originalChange.indexName = index.name
+        originalChange.tableName = index.relation.name
+        originalChange.columns = [new AddColumnConfig().setName("test_col")]
+        def originalChangeCheckSum = originalChange.generateCheckSum()
+
+        and:
+        def changeWithAssociatedWithSet = new CreateIndexChange()
+        changeWithAssociatedWithSet.indexName = index.name
+        changeWithAssociatedWithSet.tableName = index.relation.name
+        changeWithAssociatedWithSet.associatedWith = "foreignKey"
+        changeWithAssociatedWithSet.schemaName = "testSchema"
+        changeWithAssociatedWithSet.columns = [new AddColumnConfig().setName("test_col")]
+        def changeWithAssociatedWithSetCheckSum = changeWithAssociatedWithSet.generateCheckSum()
+
+        then:
+        originalChangeCheckSum != changeWithAssociatedWithSetCheckSum
+    }
 }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors -->


## Description
Fixes #4794
Change type: CreateIndex
Issue: the associatedWith property is not deserialized from the changelog definition resulting in property always being null
Resolution: set the isChangeProperty to true on the DatabaseChangeProperty decorating the property accessor. 
<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of
Bug was introduced when the DatabaseChangeProperty annotation was added due to the createChangeMetaData method in AbstractChange expecting the annotation to either exist on the property with a value of isChangeProperty=true or the annotation to be absent entirely (which was the case previously).
<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
