### PR TITLE
Fix liquibase 4.23.1 won't work on windows if there is no JAVA_HOME system variable set

### DIFF
--- a/liquibase-dist/src/main/archive/liquibase.bat
+++ b/liquibase-dist/src/main/archive/liquibase.bat
@@ -9,13 +9,13 @@ set LIQUIBASE_HOME="%~dp0"
 rem remove quotes around LIQUIBASE_HOME
 set LIQUIBASE_HOME=%LIQUIBASE_HOME:"=%
 
-rem remove quotes around JAVA_HOME if set
-if NOT "%JAVA_HOME%" == "" set JAVA_HOME=%JAVA_HOME:"=%
-
 rem set JAVA_HOME to local jre dir if not set
 if exist "%LIQUIBASE_HOME%\jre" if "%JAVA_HOME%"=="" (
     set JAVA_HOME="%LIQUIBASE_HOME%\jre"
 )
+
+rem remove quotes around JAVA_HOME if set
+if NOT "%JAVA_HOME%" == "" set JAVA_HOME=%JAVA_HOME:"=%
 
 if NOT "%JAVA_HOME%" == "" if not exist "%JAVA_HOME%" (
   echo ERROR: The JAVA_HOME environment variable is not defined correctly, so Liquibase cannot be started. JAVA_HOME is set to "%JAVA_HOME%" and it does not exist. >&2


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
Liquibase 4.23.1 won't work on windows if there is no JAVA_HOME system variable set
when run liquibase you get the error
Files\liquibase\\jre"" was unexpected at this time.
caused by https://github.com/liquibase/liquibase/pull/4306