### PR TITLE
Fix LabelExpression constructors when using array or collection

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/ContextExpression.java
+++ b/liquibase-standard/src/main/java/liquibase/ContextExpression.java
@@ -19,10 +19,12 @@ public class ContextExpression {
     public ContextExpression(String... contexts) {
         if (contexts.length == 1) {
             parseContextString(contexts[0]);
+            originalString = contexts[0];
         } else {
             for (String context : contexts) {
                 parseContextString(context.toLowerCase());
             }
+            originalString = StringUtil.join(contexts, ",");
         }
     }
 
@@ -36,6 +38,7 @@ public class ContextExpression {
             for (String context : contexts) {
                 this.contexts.add(context.toLowerCase());
             }
+            originalString = StringUtil.join(contexts, ",");
         }
     }
 

--- a/liquibase-standard/src/main/java/liquibase/LabelExpression.java
+++ b/liquibase-standard/src/main/java/liquibase/LabelExpression.java
@@ -27,10 +27,12 @@ public class LabelExpression {
     public LabelExpression(String... labels) {
         if (labels.length == 1) {
             parseLabelString(labels[0]);
+            originalString = labels[0];
         } else {
             for (String label : labels) {
                 parseLabelString(label.toLowerCase());
             }
+            originalString = StringUtil.join(labels, ",");
         }
     }
 
@@ -47,6 +49,7 @@ public class LabelExpression {
             for (String label : labels) {
                 this.labels.add(label.toLowerCase());
             }
+            originalString = StringUtil.join(labels, ",");
         }
     }
 

--- a/liquibase-standard/src/test/groovy/liquibase/ContextExpressionTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/ContextExpressionTest.groovy
@@ -1,5 +1,6 @@
 package liquibase
 
+import liquibase.util.StringUtil
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -199,6 +200,27 @@ class ContextExpressionTest extends Specification {
         ""             | true
         "test"         | false
         "test1, test2" | false
+    }
 
+    def "make sure originalString returns all available contexts set as a string"() {
+        expect:
+        def contexts = new ContextExpression("test,test2")
+        assert contexts.getOriginalString() == "test,test2"
+    }
+
+    def "make sure originalString returns all available contexts set as an array of strings"() {
+        expect:
+        def contexts = new ContextExpression((String[])["test", "test2"])
+        assert contexts.getOriginalString() == "test,test2"
+    }
+
+    @Unroll("#featureName. label: #testContexts")
+    def "make sure originalString returns all available contexts set as a collection"() {
+        expect:
+        def contexts = new ContextExpression(testContexts)
+        assert contexts.getOriginalString() == StringUtil.join(testContexts, ",")
+
+        where:
+        testContexts << [["test"], ["test1", "test2"]]
     }
 }

--- a/liquibase-standard/src/test/groovy/liquibase/LabelExpressionTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/LabelExpressionTest.groovy
@@ -1,5 +1,6 @@
 package liquibase
 
+import liquibase.util.StringUtil
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -211,6 +212,27 @@ class LabelExpressionTest extends Specification {
         ""             | true
         "test"         | false
         "test1, test2" | false
+    }
 
+    def "make sure originalString returns all available labels set as a string"() {
+        expect:
+        def labels = new LabelExpression("test,test2")
+        assert labels.getOriginalString() == "test,test2"
+    }
+
+    def "make sure originalString returns all available labels set as an array of strings"() {
+        expect:
+        def labels = new LabelExpression((String[])["test", "test2"])
+        assert labels.getOriginalString() == "test,test2"
+    }
+
+    @Unroll("#featureName. label: #testLabels")
+    def "make sure originalString returns all available labels set as a collection"() {
+        expect:
+        def labels = new LabelExpression(testLabels)
+        assert labels.getOriginalString() == StringUtil.join(testLabels, ",")
+
+        where:
+        testLabels << [["test"], ["test1", "test2"]]
     }
 }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors -->


## Description

Fixes #4763 

Having a changeset like the one below:

```
<changeSet author="Liquibase" id="labelExpressionIssue" labels="foo">
        <!-- GOOD CHANGE -->
        <createTable tableName="TABLE_1">
            <column name="COL1" type="INT"/>
        </createTable>
    </changeSet>
```

When a LabelExpression is defined as:

```
new LabelExpression(new String[]{"bar", "test"})
```

or:
```
new ArrayList<>(List.of("bar, test"))
```

What was happening was that labels were ignored and changesets were deployed anyway. 

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
