### PR TITLE
Fixes support for special characters in schema name

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/database/core/DatabaseUtils.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/DatabaseUtils.java
@@ -8,6 +8,7 @@ import liquibase.exception.DatabaseException;
 import liquibase.executor.Executor;
 import liquibase.executor.ExecutorService;
 import liquibase.statement.core.RawSqlStatement;
+import liquibase.structure.core.Catalog;
 import liquibase.structure.core.Schema;
 import liquibase.util.StringUtil;
 
@@ -45,7 +46,7 @@ public class DatabaseUtils {
                     if (GlobalConfiguration.PRESERVE_SCHEMA_CASE.getCurrentValue()) {
                         finalSearchPath = ((PostgresDatabase) database).quoteObject(defaultSchemaName, Schema.class);
                     } else {
-                        finalSearchPath = defaultSchemaName;
+                        finalSearchPath = database.escapeObjectName(defaultSchemaName, Schema.class);
                     }
 
                     if (StringUtil.isNotEmpty(searchPath)) {
@@ -66,6 +67,7 @@ public class DatabaseUtils {
                 if (schema == null) {
                     schema = defaultSchemaName;
                 }
+                database.escapeObjectName(schema, Schema.class);
                 executor.execute(new RawSqlStatement("SET CURRENT SCHEMA "
                         + schema));
             } else if (database instanceof MySQLDatabase) {
@@ -73,12 +75,14 @@ public class DatabaseUtils {
                 if (schema == null) {
                     schema = defaultSchemaName;
                 }
+                database.escapeObjectName(schema, Schema.class);
                 executor.execute(new RawSqlStatement("USE " + schema));
             } else if (database instanceof MSSQLDatabase) {
-                    defaultCatalogName = StringUtil.trimToNull(defaultCatalogName);
-                    if (defaultCatalogName != null) {
-                        executor.execute(new RawSqlStatement(String.format("USE %s", defaultCatalogName)));
-                    }
+                defaultCatalogName = StringUtil.trimToNull(defaultCatalogName);
+                if (defaultCatalogName != null) {
+                    database.escapeObjectName(defaultCatalogName, Catalog.class);
+                    executor.execute(new RawSqlStatement(String.format("USE %s", defaultCatalogName)));
+                }
             }
         }
     }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors -->


## Description

Previously the `DatabaseUtils` class didn't add quotes for schema names where it should have done it. Due to that, schema names with a dash (`-`) were not working. 

This fixes it so schema names with a dash now work. 

I checked it manually for PostgreSQL and it works as expected for me. 
This affects several databases looking both at the original issue and the code, and I applied the change for all of them.

Fixes #1640

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

Looking at the code of `escapeObjectName` it will only add quotes where needed, so the existing behavior should not be affected.

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

I didn't add a new test. A pointer to the test base would be appreciated.

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
