### PR TITLE
Rollbacks Oracle Driver to LTS series 19.x 

### DIFF
--- a/liquibase-dist/pom.xml
+++ b/liquibase-dist/pom.xml
@@ -22,7 +22,7 @@
 		<mssql.version>12.4.1.jre8</mssql.version>
 		<mysql.version>8.0.21</mysql.version>
 		<mariadb.version>3.1.4</mariadb.version>
-		<oracle.version>23.2.0.0</oracle.version>
+		<oracle.version>19.20.0.0</oracle.version>
 		<sqlite.version>3.43.0.0</sqlite.version>
 		<db2.version>11.5.8.0</db2.version>
 		<firebird.version>5.0.2.java8</firebird.version>

--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
-            <version>23.2.0.0</version>
+            <version>19.20.0.0</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Description

As per https://oracledbwr.com/oracle-release-schedule-of-current-database-releases/ , Oracle driver 19.x is the current LTS supported version . This PR rollback Oracle driver version from 23 to 19 .

Fixes #4903 