### PR TITLE
Add '@Deprecated' annotation to update() methods

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-standard/src/main/java/liquibase/Liquibase.java
@@ -152,6 +152,10 @@ public class Liquibase implements AutoCloseable {
      *
      * @see <a href="https://docs.liquibase.com/concepts/changelogs/attributes/contexts.html" target="_top">contexts</a> in documentation
      */
+
+    /**
+     * @deprecated use {@link CommandScope}
+     **/
     @Deprecated
     public void update() throws LiquibaseException {
         this.update(new Contexts());
@@ -163,6 +167,10 @@ public class Liquibase implements AutoCloseable {
      *
      * @see <a href="https://docs.liquibase.com/concepts/changelogs/attributes/contexts.html" target="_top">contexts</a> in documentation
      */
+
+    /**
+     * @deprecated use {@link CommandScope}
+     **/
     @Deprecated
     public void update(String contexts) throws LiquibaseException {
         this.update(new Contexts(contexts));
@@ -174,6 +182,10 @@ public class Liquibase implements AutoCloseable {
      *
      * @see <a href="https://docs.liquibase.com/concepts/changelogs/attributes/contexts.html" target="_top">contexts</a> in documentation
      */
+
+    /**
+     * @deprecated use {@link CommandScope}
+     **/
     @Deprecated
     public void update(Contexts contexts) throws LiquibaseException {
         update(contexts, new LabelExpression());
@@ -188,6 +200,10 @@ public class Liquibase implements AutoCloseable {
      * @see <a href="https://docs.liquibase.com/concepts/changelogs/attributes/contexts.html" target="_top">Liquibase Contexts</a> in the Liquibase documentation
      * @see <a href="https://docs.liquibase.com/concepts/changelogs/attributes/labels.html" target="_top">Liquibase Labels</a> in the Liquibase documentation
      */
+
+    /**
+     * @deprecated use {@link CommandScope}
+     **/
     @Deprecated
     public void update(Contexts contexts, LabelExpression labelExpression) throws LiquibaseException {
         update(contexts, labelExpression, true);
@@ -206,6 +222,10 @@ public class Liquibase implements AutoCloseable {
      * @see <a href="https://docs.liquibase.com/concepts/changelogs/attributes/contexts.html" target="_top">Liquibase Contexts</a>
      * @see <a href="https://docs.liquibase.com/concepts/changelogs/attributes/labels.html" target="_top">Liquibase Labels</a>
      */
+
+    /**
+     * @deprecated use {@link CommandScope}
+     **/
     @Deprecated
     public void update(Contexts contexts, LabelExpression labelExpression, boolean checkLiquibaseTables) throws LiquibaseException {
         runInScope(() -> {

--- a/liquibase-standard/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-standard/src/main/java/liquibase/Liquibase.java
@@ -286,18 +286,22 @@ public class Liquibase implements AutoCloseable {
                 new IgnoreChangeSetFilter());
     }
 
+    @Deprecated
     public void update(String contexts, Writer output) throws LiquibaseException {
         this.update(new Contexts(contexts), output);
     }
 
+    @Deprecated
     public void update(Contexts contexts, Writer output) throws LiquibaseException {
         update(contexts, new LabelExpression(), output);
     }
 
+    @Deprecated
     public void update(Contexts contexts, LabelExpression labelExpression, Writer output) throws LiquibaseException {
         update(contexts, labelExpression, output, true);
     }
 
+    @Deprecated
     public void update(Contexts contexts, LabelExpression labelExpression, Writer output, boolean checkLiquibaseTables)
             throws LiquibaseException {
         runInScope(() -> {


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ X ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`**skipReleaseNotes**`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors -->


## Description
Some update() methods were missing the '@Deprecated' annotation, which made the javadocs outdated. I added the annotation to these methods: 
- update(String contexts, Writer output)
- update(Contexts contexts, Writer output)
- update(Contexts contexts, LabelExpression labelExpression, Writer output)
- update(Contexts contexts, LabelExpression labelExpression, Writer output, boolean checkLiquibaseTables)

## Things to be aware of
This will change the javadocs documentation

## Things to worry about
It's my understanding that all liquibase.update() methods are deprecated. If not, ignore this PR.
