### PR TITLE
[DAT-15924] Handle AbstractSQLChange runWith checksum v8 variants

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/change/AbstractSQLChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/AbstractSQLChange.java
@@ -62,6 +62,10 @@ public abstract class AbstractSQLChange extends AbstractChange implements DbmsTa
         this.originalSplitStatements = originalSplitStatements;
     }
 
+    public Boolean isOriginalSplitStatements() {
+        return originalSplitStatements;
+    }
+
     public InputStream openSqlStream() throws IOException {
         return null;
     }

--- a/liquibase-standard/src/main/java/liquibase/change/AbstractSQLChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/AbstractSQLChange.java
@@ -38,7 +38,7 @@ public abstract class AbstractSQLChange extends AbstractChange implements DbmsTa
     private boolean stripComments;
     private boolean splitStatements;
 
-    private boolean originalSplitStatements;
+    private Boolean originalSplitStatements;
     /**
      *
      * @deprecated  To be removed when splitStatements is changed to be type Boolean
@@ -59,7 +59,7 @@ public abstract class AbstractSQLChange extends AbstractChange implements DbmsTa
     }
 
     @Deprecated
-    public void setOriginalSplitStatements(boolean originalSplitStatements) {
+    public void setOriginalSplitStatements(Boolean originalSplitStatements) {
         this.originalSplitStatements = originalSplitStatements;
     }
 
@@ -67,7 +67,7 @@ public abstract class AbstractSQLChange extends AbstractChange implements DbmsTa
      * isOriginalSplitStatements is used by checksums v8 calculator only to define splitStatements behavior
      */
     @Deprecated
-    public boolean isOriginalSplitStatements() {
+    public Boolean isOriginalSplitStatements() {
         return originalSplitStatements;
     }
 

--- a/liquibase-standard/src/main/java/liquibase/change/AbstractSQLChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/AbstractSQLChange.java
@@ -38,7 +38,11 @@ public abstract class AbstractSQLChange extends AbstractChange implements DbmsTa
     private boolean stripComments;
     private boolean splitStatements;
 
+    @Deprecated
     private Boolean originalSplitStatements;
+
+    @Deprecated
+    private boolean ignoreOriginalSplitStatements = false;
     /**
      *
      * @deprecated  To be removed when splitStatements is changed to be type Boolean
@@ -67,8 +71,13 @@ public abstract class AbstractSQLChange extends AbstractChange implements DbmsTa
      * isOriginalSplitStatements is used by checksums v8 calculator only to define splitStatements behavior
      */
     @Deprecated
-    public Boolean isOriginalSplitStatements() {
-        return originalSplitStatements;
+    public void setIgnoreOriginalSplitStatements(boolean ignoreOriginalSplitStatements) {
+        this.ignoreOriginalSplitStatements = ignoreOriginalSplitStatements;
+    }
+
+    @Deprecated
+    public boolean isIgnoreOriginalSplitStatements() {
+        return ignoreOriginalSplitStatements;
     }
 
     public InputStream openSqlStream() throws IOException {
@@ -233,7 +242,8 @@ public abstract class AbstractSQLChange extends AbstractChange implements DbmsTa
             ChecksumVersion version = Scope.getCurrentScope().getChecksumVersion();
             if (version.lowerOrEqualThan(ChecksumVersion.V8)) {
                 boolean isSplitStatements = this.isSplitStatements();
-                if (getChangeSet() != null && getChangeSet().getRunWith() != null) {
+                if (getChangeSet() != null && getChangeSet().getRunWith() != null
+                        && !isIgnoreOriginalSplitStatements() && !isSplitStatements) {
                     isSplitStatements = BooleanUtil.isTrue(originalSplitStatements);
                 }
                 return CheckSum.compute(new NormalizingStreamV8(this.getEndDelimiter(), isSplitStatements, this.isStripComments(), stream), false);

--- a/liquibase-standard/src/main/java/liquibase/change/AbstractSQLChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/AbstractSQLChange.java
@@ -58,10 +58,15 @@ public abstract class AbstractSQLChange extends AbstractChange implements DbmsTa
         setSplitStatements(null);
     }
 
+    @Deprecated
     public void setOriginalSplitStatements(Boolean originalSplitStatements) {
         this.originalSplitStatements = originalSplitStatements;
     }
 
+    /**
+     * isOriginalSplitStatements is used by checksums v8 calculator only to define splitStatements behavior
+     */
+    @Deprecated
     public Boolean isOriginalSplitStatements() {
         return originalSplitStatements;
     }

--- a/liquibase-standard/src/main/java/liquibase/change/AbstractSQLChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/AbstractSQLChange.java
@@ -42,7 +42,7 @@ public abstract class AbstractSQLChange extends AbstractChange implements DbmsTa
     private Boolean originalSplitStatements;
 
     @Deprecated
-    private boolean ignoreOriginalSplitStatements = false;
+    private Boolean ignoreOriginalSplitStatements;
     /**
      *
      * @deprecated  To be removed when splitStatements is changed to be type Boolean
@@ -71,12 +71,12 @@ public abstract class AbstractSQLChange extends AbstractChange implements DbmsTa
      * isOriginalSplitStatements is used by checksums v8 calculator only to define splitStatements behavior
      */
     @Deprecated
-    public void setIgnoreOriginalSplitStatements(boolean ignoreOriginalSplitStatements) {
+    public void setIgnoreOriginalSplitStatements(Boolean ignoreOriginalSplitStatements) {
         this.ignoreOriginalSplitStatements = ignoreOriginalSplitStatements;
     }
 
     @Deprecated
-    public boolean isIgnoreOriginalSplitStatements() {
+    public Boolean isIgnoreOriginalSplitStatements() {
         return ignoreOriginalSplitStatements;
     }
 
@@ -243,7 +243,7 @@ public abstract class AbstractSQLChange extends AbstractChange implements DbmsTa
             if (version.lowerOrEqualThan(ChecksumVersion.V8)) {
                 boolean isSplitStatements = this.isSplitStatements();
                 if (getChangeSet() != null && getChangeSet().getRunWith() != null
-                        && !isIgnoreOriginalSplitStatements() && !isSplitStatements) {
+                        && !BooleanUtil.isTrue(isIgnoreOriginalSplitStatements()) && !isSplitStatements) {
                     isSplitStatements = BooleanUtil.isTrue(originalSplitStatements);
                 }
                 return CheckSum.compute(new NormalizingStreamV8(this.getEndDelimiter(), isSplitStatements, this.isStripComments(), stream), false);

--- a/liquibase-standard/src/main/java/liquibase/change/AbstractSQLChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/AbstractSQLChange.java
@@ -38,7 +38,7 @@ public abstract class AbstractSQLChange extends AbstractChange implements DbmsTa
     private boolean stripComments;
     private boolean splitStatements;
 
-    private Boolean originalSplitStatements;
+    private boolean originalSplitStatements;
     /**
      *
      * @deprecated  To be removed when splitStatements is changed to be type Boolean
@@ -59,7 +59,7 @@ public abstract class AbstractSQLChange extends AbstractChange implements DbmsTa
     }
 
     @Deprecated
-    public void setOriginalSplitStatements(Boolean originalSplitStatements) {
+    public void setOriginalSplitStatements(boolean originalSplitStatements) {
         this.originalSplitStatements = originalSplitStatements;
     }
 
@@ -67,7 +67,7 @@ public abstract class AbstractSQLChange extends AbstractChange implements DbmsTa
      * isOriginalSplitStatements is used by checksums v8 calculator only to define splitStatements behavior
      */
     @Deprecated
-    public Boolean isOriginalSplitStatements() {
+    public boolean isOriginalSplitStatements() {
         return originalSplitStatements;
     }
 

--- a/liquibase-standard/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
@@ -149,9 +149,9 @@ public class ValidatingVisitor implements ChangeSetVisitor {
             }
         }
 
-        if(ranChangeSet != null){
+        if(ranChangeSet != null) {
             if (!changeSet.isCheckSumValid(ranChangeSet.getLastCheckSum()) &&
-                !ValidatingVisitorUtil.validateMongoDbExtensionIssue(changeSet, ranChangeSet, databaseChangeLog, database) &&
+                !ValidatingVisitorUtil.isChecksumIssue(changeSet, ranChangeSet, databaseChangeLog, database) &&
                 !changeSet.shouldRunOnChange() &&
                 !changeSet.shouldAlwaysRun()) {
                     invalidMD5Sums.add(changeSet.toString(false)+" was: "+ranChangeSet.getLastCheckSum().toString()

--- a/liquibase-standard/src/main/java/liquibase/util/ValidatingVisitorUtil.java
+++ b/liquibase-standard/src/main/java/liquibase/util/ValidatingVisitorUtil.java
@@ -1,6 +1,8 @@
 package liquibase.util;
 
+import liquibase.ChecksumVersion;
 import liquibase.Scope;
+import liquibase.change.AbstractSQLChange;
 import liquibase.change.Change;
 import liquibase.change.ChangeFactory;
 import liquibase.change.DatabaseChange;
@@ -11,7 +13,9 @@ import liquibase.database.Database;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Util class to offload methods that are used by {@link liquibase.changelog.visitor.ValidatingVisitor} class
@@ -20,6 +24,48 @@ import java.util.Optional;
 public class ValidatingVisitorUtil {
 
     private ValidatingVisitorUtil() {}
+
+    public static boolean isChecksumIssue(ChangeSet changeSet, RanChangeSet ranChangeSet, DatabaseChangeLog databaseChangeLog, Database database) {
+        return ValidatingVisitorUtil.validateMongoDbExtensionIssue(changeSet, ranChangeSet, databaseChangeLog, database) ||
+               ValidatingVisitorUtil.validateAbstractSqlChangeV8ChecksumVariant(changeSet, ranChangeSet, databaseChangeLog, database);
+    }
+
+
+    /**
+     * AbstractSqlChange checksum had the default calculated value changed from Liquibase versions 4.19.1 to 4.23.1
+     * when using runWith="anything". This method validatesthe v8 checksum using the alternative algorithm as a way
+     * to allow users to upgrade to checksums v9 without facing any errors or unexpected behaviours. To accomplish
+     * that it will check for:
+     * * do we have runWith set?
+     * * are we working with a v8 checksum?
+     * * does this change extends from AbstractSQLChange?
+     * * Changing splitStaments makes it work?
+     */
+    private static boolean validateAbstractSqlChangeV8ChecksumVariant(ChangeSet changeSet, RanChangeSet ranChangeSet, DatabaseChangeLog databaseChangeLog, Database database) {
+        if (StringUtil.isNotEmpty(changeSet.getRunWith()) &&
+            ChecksumVersion.V8.lowerOrEqualThan(Scope.getCurrentScope().getChecksumVersion())) {
+
+            List<Change> changes = changeSet.getChanges().stream()
+                    .filter(AbstractSQLChange.class::isInstance).collect(Collectors.toList());
+            if (!changes.isEmpty()) {
+                clearChecksumAndRevertOriginalSpliStatements(changeSet, changes);
+                boolean valid = changeSet.isCheckSumValid(ranChangeSet.getLastCheckSum());
+                if (!valid) { // whops, something really changed. Revert what we just did.
+                    clearChecksumAndRevertOriginalSpliStatements(changeSet, changes);
+                }
+                return valid;
+            }
+        }
+        return false;
+    }
+
+    private static void clearChecksumAndRevertOriginalSpliStatements(ChangeSet changeSet, List<Change> changes) {
+        changes.forEach(change -> {
+            AbstractSQLChange abstractSQLChange = (AbstractSQLChange) change;
+            abstractSQLChange.setOriginalSplitStatements(!abstractSQLChange.isOriginalSplitStatements());
+        });
+        changeSet.clearCheckSum();
+    }
 
     /**
      * MongoDB's extension was incorrectly messing with CreateIndex and DropIndex checksums when the extension was added to the lib folder
@@ -30,7 +76,7 @@ public class ValidatingVisitorUtil {
      * * If I use CreateIndex or DropIndex from mongo extension, does the checksum matches?
      * If everything matches than we fix the checksum on the database and say it's fine to continue.
      */
-    public static boolean validateMongoDbExtensionIssue(ChangeSet changeSet, RanChangeSet ranChangeSet, DatabaseChangeLog databaseChangeLog, Database database) {
+    private static boolean validateMongoDbExtensionIssue(ChangeSet changeSet, RanChangeSet ranChangeSet, DatabaseChangeLog databaseChangeLog, Database database) {
         Optional<Change> change = changeSet.getChanges().stream()
                 .filter(c -> c instanceof CreateIndexChange || c instanceof DropIndexChange).findFirst();
         if (change.isPresent() && !database.getShortName().equals("mongodb")) {

--- a/liquibase-standard/src/main/java/liquibase/util/ValidatingVisitorUtil.java
+++ b/liquibase-standard/src/main/java/liquibase/util/ValidatingVisitorUtil.java
@@ -49,10 +49,10 @@ public class ValidatingVisitorUtil {
                     .filter(AbstractSQLChange.class::isInstance).map(c -> (AbstractSQLChange) c)
                     .collect(Collectors.toList());
             if (!changes.isEmpty()) {
-                clearChecksumAndRevertOriginalSplitStatements(changeSet, changes);
+                revertIgnoreOriginalSplitStatementsFlag(changeSet, changes);
                 boolean valid = changeSet.isCheckSumValid(ranChangeSet.getLastCheckSum());
                 if (!valid) { // whops, something really changed. Revert what we just did.
-                    clearChecksumAndRevertOriginalSplitStatements(changeSet, changes);
+                    revertIgnoreOriginalSplitStatementsFlag(changeSet, changes);
                 }
                 return valid;
             }
@@ -61,14 +61,12 @@ public class ValidatingVisitorUtil {
     }
 
     /**
-     * This method reverses flag originalSplitStatements on the AbstractSQLChange list and clears the changeset calculated checksum
+     * This method reverses flag ignoreOriginalSplitStatements on the AbstractSQLChange list and clears the changeset calculated checksum
      *  so it is recalculated when it's used again
      */
-    private static void clearChecksumAndRevertOriginalSplitStatements(ChangeSet changeSet, List<AbstractSQLChange> changes) {
-        changes.forEach(change -> {
-            change.setOriginalSplitStatements( !change.isSplitStatements() ? false :
-                    !BooleanUtil.isTrue(change.isOriginalSplitStatements()));
-        });
+
+    private static void revertIgnoreOriginalSplitStatementsFlag(ChangeSet changeSet, List<AbstractSQLChange> changes) {
+        changes.forEach(change -> change.setIgnoreOriginalSplitStatements(!change.isIgnoreOriginalSplitStatements()));
         changeSet.clearCheckSum();
     }
 

--- a/liquibase-standard/src/main/java/liquibase/util/ValidatingVisitorUtil.java
+++ b/liquibase-standard/src/main/java/liquibase/util/ValidatingVisitorUtil.java
@@ -49,10 +49,10 @@ public class ValidatingVisitorUtil {
                     .filter(AbstractSQLChange.class::isInstance).map(c -> (AbstractSQLChange) c)
                     .collect(Collectors.toList());
             if (!changes.isEmpty()) {
-                clearChecksumAndRevertOriginalSpliStatements(changeSet, changes);
+                clearChecksumAndRevertOriginalSplitStatements(changeSet, changes);
                 boolean valid = changeSet.isCheckSumValid(ranChangeSet.getLastCheckSum());
                 if (!valid) { // whops, something really changed. Revert what we just did.
-                    clearChecksumAndRevertOriginalSpliStatements(changeSet, changes);
+                    clearChecksumAndRevertOriginalSplitStatements(changeSet, changes);
                 }
                 return valid;
             }
@@ -64,7 +64,7 @@ public class ValidatingVisitorUtil {
      * This method reverses flag originalSplitStatements on the AbstractSQLChange list and clears the changeset calculated checksum
      *  so it is recalculated when it's used again
      */
-    private static void clearChecksumAndRevertOriginalSpliStatements(ChangeSet changeSet, List<AbstractSQLChange> changes) {
+    private static void clearChecksumAndRevertOriginalSplitStatements(ChangeSet changeSet, List<AbstractSQLChange> changes) {
         changes.forEach(change -> {
             change.setOriginalSplitStatements(!change.isOriginalSplitStatements());
         });

--- a/liquibase-standard/src/main/java/liquibase/util/ValidatingVisitorUtil.java
+++ b/liquibase-standard/src/main/java/liquibase/util/ValidatingVisitorUtil.java
@@ -66,7 +66,8 @@ public class ValidatingVisitorUtil {
      */
     private static void clearChecksumAndRevertOriginalSplitStatements(ChangeSet changeSet, List<AbstractSQLChange> changes) {
         changes.forEach(change -> {
-            change.setOriginalSplitStatements(!BooleanUtil.isTrue(change.isOriginalSplitStatements()));
+            change.setOriginalSplitStatements( !change.isSplitStatements() ? false :
+                    !BooleanUtil.isTrue(change.isOriginalSplitStatements()));
         });
         changeSet.clearCheckSum();
     }

--- a/liquibase-standard/src/main/java/liquibase/util/ValidatingVisitorUtil.java
+++ b/liquibase-standard/src/main/java/liquibase/util/ValidatingVisitorUtil.java
@@ -32,10 +32,10 @@ public class ValidatingVisitorUtil {
 
 
     /**
-     * AbstractSqlChange checksum had the default calculated value changed from Liquibase versions 4.19.1 to 4.23.1
-     * when using runWith="anything". This method validatesthe v8 checksum using the alternative algorithm as a way
-     * to allow users to upgrade to checksums v9 without facing any errors or unexpected behaviours. To accomplish
-     * that it will check for:
+     * AbstractSqlChange checksum had the checksum calculated value changed for Liquibase versions 4.19.1 to 4.23.1
+     * due to some changes on the way that we call it when using runWith="anything".
+     * This method validates the v8 checksum using the alternative algorithm as a way to allow users to upgrade to
+     * checksums v9 without facing any errors or unexpected behaviours. To accomplish that it will check for:
      * * do we have runWith set?
      * * are we working with a v8 checksum?
      * * does this change extends from AbstractSQLChange?

--- a/liquibase-standard/src/main/java/liquibase/util/ValidatingVisitorUtil.java
+++ b/liquibase-standard/src/main/java/liquibase/util/ValidatingVisitorUtil.java
@@ -45,8 +45,9 @@ public class ValidatingVisitorUtil {
         if (StringUtil.isNotEmpty(changeSet.getRunWith()) &&
             ChecksumVersion.V8.lowerOrEqualThan(Scope.getCurrentScope().getChecksumVersion())) {
 
-            List<Change> changes = changeSet.getChanges().stream()
-                    .filter(AbstractSQLChange.class::isInstance).collect(Collectors.toList());
+            List<AbstractSQLChange> changes = changeSet.getChanges().stream()
+                    .filter(AbstractSQLChange.class::isInstance).map(c -> (AbstractSQLChange) c)
+                    .collect(Collectors.toList());
             if (!changes.isEmpty()) {
                 clearChecksumAndRevertOriginalSpliStatements(changeSet, changes);
                 boolean valid = changeSet.isCheckSumValid(ranChangeSet.getLastCheckSum());
@@ -59,10 +60,13 @@ public class ValidatingVisitorUtil {
         return false;
     }
 
-    private static void clearChecksumAndRevertOriginalSpliStatements(ChangeSet changeSet, List<Change> changes) {
+    /**
+     * This method reverses flag originalSplitStatements on the AbstractSQLChange list and clears the changeset calculated checksum
+     *  so it is recalculated when it's used again
+     */
+    private static void clearChecksumAndRevertOriginalSpliStatements(ChangeSet changeSet, List<AbstractSQLChange> changes) {
         changes.forEach(change -> {
-            AbstractSQLChange abstractSQLChange = (AbstractSQLChange) change;
-            abstractSQLChange.setOriginalSplitStatements(!abstractSQLChange.isOriginalSplitStatements());
+            change.setOriginalSplitStatements(!change.isOriginalSplitStatements());
         });
         changeSet.clearCheckSum();
     }

--- a/liquibase-standard/src/main/java/liquibase/util/ValidatingVisitorUtil.java
+++ b/liquibase-standard/src/main/java/liquibase/util/ValidatingVisitorUtil.java
@@ -66,7 +66,7 @@ public class ValidatingVisitorUtil {
      */
     private static void clearChecksumAndRevertOriginalSplitStatements(ChangeSet changeSet, List<AbstractSQLChange> changes) {
         changes.forEach(change -> {
-            change.setOriginalSplitStatements(!change.isOriginalSplitStatements());
+            change.setOriginalSplitStatements(!BooleanUtil.isTrue(change.isOriginalSplitStatements()));
         });
         changeSet.clearCheckSum();
     }

--- a/liquibase-standard/src/main/java/liquibase/util/ValidatingVisitorUtil.java
+++ b/liquibase-standard/src/main/java/liquibase/util/ValidatingVisitorUtil.java
@@ -66,7 +66,7 @@ public class ValidatingVisitorUtil {
      */
 
     private static void revertIgnoreOriginalSplitStatementsFlag(ChangeSet changeSet, List<AbstractSQLChange> changes) {
-        changes.forEach(change -> change.setIgnoreOriginalSplitStatements(!change.isIgnoreOriginalSplitStatements()));
+        changes.forEach(change -> change.setIgnoreOriginalSplitStatements(!BooleanUtil.isTrue(change.isIgnoreOriginalSplitStatements())));
         changeSet.clearCheckSum();
     }
 

--- a/liquibase-standard/src/main/java/liquibase/util/ValidatingVisitorUtil.java
+++ b/liquibase-standard/src/main/java/liquibase/util/ValidatingVisitorUtil.java
@@ -27,7 +27,7 @@ public class ValidatingVisitorUtil {
 
     public static boolean isChecksumIssue(ChangeSet changeSet, RanChangeSet ranChangeSet, DatabaseChangeLog databaseChangeLog, Database database) {
         return ValidatingVisitorUtil.validateMongoDbExtensionIssue(changeSet, ranChangeSet, databaseChangeLog, database) ||
-               ValidatingVisitorUtil.validateAbstractSqlChangeV8ChecksumVariant(changeSet, ranChangeSet, databaseChangeLog, database);
+               ValidatingVisitorUtil.validateAbstractSqlChangeV8ChecksumVariant(changeSet, ranChangeSet);
     }
 
 
@@ -41,7 +41,7 @@ public class ValidatingVisitorUtil {
      * * does this change extends from AbstractSQLChange?
      * * Changing splitStaments makes it work?
      */
-    private static boolean validateAbstractSqlChangeV8ChecksumVariant(ChangeSet changeSet, RanChangeSet ranChangeSet, DatabaseChangeLog databaseChangeLog, Database database) {
+    private static boolean validateAbstractSqlChangeV8ChecksumVariant(ChangeSet changeSet, RanChangeSet ranChangeSet) {
         if (StringUtil.isNotEmpty(changeSet.getRunWith()) &&
             ChecksumVersion.V8.lowerOrEqualThan(Scope.getCurrentScope().getChecksumVersion())) {
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

AbstractSqlChange checksum had the checksum calculated value changed for Liquibase versions 4.19.1 to 4.23.1 due to some changes on the way that we call it when using runWith="anything". This PR validates the v8 checksum using the alternative algorithm as a way to allow users to upgrade to checksums v9 without facing any errors or unexpected behaviours
