### PR TITLE
Remove unnecessary conditions in IndexComparator

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/diff/compare/core/IndexComparator.java
+++ b/liquibase-standard/src/main/java/liquibase/diff/compare/core/IndexComparator.java
@@ -73,7 +73,7 @@ public class IndexComparator implements DatabaseObjectComparator {
                 }
 
 
-                if ((thisIndexSize > 0) && (otherIndexSize > 0) && (thisIndexSize != otherIndexSize)) {
+                if (thisIndexSize != otherIndexSize) {
                     return false;
                 }
 


### PR DESCRIPTION
This PR removes two unnecessary conditions, which always evaluate to `true`, as detected by IntelliJ.

The reason is: in line 71, if any of them is 0, then the method return.

And since they are the result of `list.size()`, they can not be negative.

And because of the previous two points, both must be more than 0, and so the conditions are not needed.