### PR TITLE
[DAT-16006] Fixing v8 Checksum calculation issue when using sql dbms attribute

### DIFF
--- a/liquibase-integration-tests/src/test/resources/changelogs/h2/checksum/create-table.sql
+++ b/liquibase-integration-tests/src/test/resources/changelogs/h2/checksum/create-table.sql
@@ -1,0 +1,1 @@
+create table thisShouldRun(id int)

--- a/liquibase-integration-tests/src/test/resources/changelogs/h2/checksum/dbms-filter-changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/h2/checksum/dbms-filter-changelog.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
+    http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd ">
+
+    <changeSet author="fl" id="1">
+        <sql dbms="thisDbWillNeverExist">
+                I can write anything here as this content will only be used
+                  to generate checksum on versions before 9 </sql>
+    </changeSet>
+
+    <changeSet author="fl" id="2">
+        <sqlFile dbms="thisDbWillNeverExist" relativeToChangelogFile="true" path="create-table.sql" />
+        <sqlFile dbms="h2" relativeToChangelogFile="true" path="create-table.sql" />
+    </changeSet>
+
+    <changeSet author="fl" id="3">
+            <!-- this will run succesfully too -->
+        <sql dbms="h2">select 1</sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogIterator.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogIterator.java
@@ -4,7 +4,6 @@ import liquibase.ContextExpression;
 import liquibase.Labels;
 import liquibase.RuntimeEnvironment;
 import liquibase.Scope;
-import liquibase.change.CheckSum;
 import liquibase.changelog.filter.ChangeSetFilter;
 import liquibase.changelog.filter.ChangeSetFilterResult;
 import liquibase.changelog.visitor.ChangeSetVisitor;
@@ -97,7 +96,12 @@ public class ChangeLogIterator {
                         }
 
                         boolean finalShouldVisit = shouldVisit;
-                        Scope.child(Scope.Attr.changeSet.name(), changeSet, () -> {
+
+                        Map<String, Object> scopeValues = new HashMap<>();
+                        scopeValues.put(Scope.Attr.changeSet.name(), changeSet);
+                        scopeValues.put(Scope.Attr.database.name(), env.getTargetDatabase());
+
+                        Scope.child(scopeValues, () -> {
                             if (finalShouldVisit) {
                                 //
                                 // Go validate any changesets with an Executor if

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeSet.java
@@ -363,7 +363,11 @@ public class ChangeSet implements Conditional, ChangeLogChild {
                 if (checkSum == null) {
                     StringBuilder stringToMD5 = new StringBuilder();
                     for (Change change : this.getChanges()) {
-                        stringToMD5.append(change.generateCheckSum()).append(":");
+                        if (Scope.getCurrentScope().getChecksumVersion().lowerOrEqualThan(ChecksumVersion.V8) ||
+                            !(change instanceof DbmsTargetedChange) ||
+                            DatabaseList.definitionMatches(((DbmsTargetedChange) change).getDbms(), Scope.getCurrentScope().getDatabase(), true)) {
+                            stringToMD5.append(change.generateCheckSum()).append(":");
+                        }
                     }
 
                     for (SqlVisitor visitor : this.getSqlVisitors()) {

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeSet.java
@@ -363,9 +363,11 @@ public class ChangeSet implements Conditional, ChangeLogChild {
                 if (checkSum == null) {
                     StringBuilder stringToMD5 = new StringBuilder();
                     for (Change change : this.getChanges()) {
-                        if (Scope.getCurrentScope().getChecksumVersion().lowerOrEqualThan(ChecksumVersion.V8) ||
-                            !(change instanceof DbmsTargetedChange) ||
-                            DatabaseList.definitionMatches(((DbmsTargetedChange) change).getDbms(), Scope.getCurrentScope().getDatabase(), true)) {
+                        // checksum v8 requires changes that are applied even to other databases to be calculated
+                        // checksum v9 excludes them from calculation
+                        if (!(change instanceof DbmsTargetedChange) ||
+                                Scope.getCurrentScope().getChecksumVersion().lowerOrEqualThan(ChecksumVersion.V8) ||
+                                DatabaseList.definitionMatches(((DbmsTargetedChange) change).getDbms(), Scope.getCurrentScope().getDatabase(), true)) {
                             stringToMD5.append(change.generateCheckSum()).append(":");
                         }
                     }

--- a/liquibase-standard/src/main/java/liquibase/changelog/filter/DbmsChangeSetFilter.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/filter/DbmsChangeSetFilter.java
@@ -27,20 +27,12 @@ public class DbmsChangeSetFilter implements ChangeSetFilter {
             return new ChangeSetFilterResult(true, "No database connection, cannot evaluate dbms attribute", this.getClass(), getMdcName(), getDisplayName());
         }
         List<SqlVisitor> visitorsToRemove = new ArrayList<>();
-        List<Change> changesToRemove = new ArrayList<>();
         for (SqlVisitor visitor : changeSet.getSqlVisitors()) {
             if (!DatabaseList.definitionMatches(visitor.getApplicableDbms(), database, true)) {
                 visitorsToRemove.add(visitor);
             }
         }
-        for(Change change : changeSet.getChanges()){
-            if (((change instanceof DbmsTargetedChange)) && !DatabaseList.definitionMatches(((DbmsTargetedChange) change).getDbms(), database, true)){
-                changesToRemove.add(change);
-            }
-        }
-
         changeSet.getSqlVisitors().removeAll(visitorsToRemove);
-        changeSet.removeAllChanges(changesToRemove);
 
         String dbmsList;
         if ((changeSet.getDbmsSet() == null) || changeSet.getDbmsSet().isEmpty()) {


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Checksums (v8) are calculated differently for XML changesets with the dbms attribute on the change itself (instead of the changeset) after 4.22.0 .

Fixes #4665
Fixes #4457
