### PR TITLE
add option to show hidden arguments in help output

### DIFF
--- a/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
+++ b/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
@@ -957,7 +957,7 @@ public class LiquibaseCommandLine {
                     if (i > 0) {
                         builder.hidden(true);
                     } else {
-                        builder.hidden(def.getHidden());
+                        builder.hidden(def.getHidden() && !LiquibaseCommandLineConfiguration.SHOW_HIDDEN_ARGS.getCurrentValue());
                     }
 
                     subCommandSpec.addOption(builder.build());
@@ -1128,7 +1128,7 @@ public class LiquibaseCommandLine {
                 }
 
                 //only show the first/standard variation of a name
-                if (i > 0 || def.isHidden()) {
+                if (i > 0 || (def.isHidden() && !LiquibaseCommandLineConfiguration.SHOW_HIDDEN_ARGS.getCurrentValue())) {
                     optionBuilder.hidden(true);
                 }
 

--- a/liquibase-standard/src/main/java/liquibase/command/AbstractCliWrapperCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/AbstractCliWrapperCommandStep.java
@@ -1,6 +1,7 @@
 package liquibase.command;
 
 import liquibase.exception.CommandExecutionException;
+import liquibase.integration.commandline.LiquibaseCommandLineConfiguration;
 import liquibase.integration.commandline.Main;
 
 import java.io.OutputStream;
@@ -70,7 +71,7 @@ public abstract class AbstractCliWrapperCommandStep extends AbstractCommandStep 
         List<String> argsList = new ArrayList<>();
         Map<String, CommandArgumentDefinition<?>> arguments = commandScope.getCommand().getArguments();
         arguments.forEach((key, value) -> {
-            if (value.getHidden()) { // This may impact tests that use the legacy Main class. Previously hidden arguments were not being hidden when executing.
+            if (value.getHidden() && !LiquibaseCommandLineConfiguration.SHOW_HIDDEN_ARGS.getCurrentValue()) { // This may impact tests that use the legacy Main class. Previously hidden arguments were not being hidden when executing.
                 return;
             }
             if (finalLegacyCommandArguments.contains(key)) {

--- a/liquibase-standard/src/main/java/liquibase/integration/commandline/LiquibaseCommandLineConfiguration.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/commandline/LiquibaseCommandLineConfiguration.java
@@ -33,6 +33,7 @@ public class LiquibaseCommandLineConfiguration implements AutoloadedConfiguratio
     public static final ConfigurationDefinition<ArgumentConverter> ARGUMENT_CONVERTER;
     public static final ConfigurationDefinition<String> MONITOR_PERFORMANCE;
     public static final ConfigurationDefinition<Boolean> ADD_EMPTY_MDC_VALUES;
+    public static final ConfigurationDefinition<Boolean> SHOW_HIDDEN_ARGS;
 
     static {
         ConfigurationDefinition.Builder builder = new ConfigurationDefinition.Builder("liquibase");
@@ -119,6 +120,12 @@ public class LiquibaseCommandLineConfiguration implements AutoloadedConfiguratio
         ADD_EMPTY_MDC_VALUES = builder.define("addEmptyMdcValues", Boolean.class)
                 .setDescription("If true, a subset of the MdcKeys, as defined by product, will be set to empty strings upon system startup.")
                 .setDefaultValue(true)
+                .setHidden(true)
+                .build();
+
+        SHOW_HIDDEN_ARGS = builder.define("showHiddenArgs", Boolean.class)
+                .setDescription("If true, all command arguments marked as hidden will be shown in the help output, ignoring the hidden flag. NOTE, due to the order of value provider loading at such an early point in Liquibase startup, you MUST set this as a environment variable. Command line parameters will not be recognized.")
+                .setDefaultValue(false)
                 .setHidden(true)
                 .build();
    }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors -->


## Description

If true, all command arguments marked as hidden will be shown in the help output, ignoring the hidden flag. NOTE, due to the order of value provider loading at such an early point in Liquibase startup, you MUST set this as a environment variable. Command line parameters will not be recognized.

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
