### PR TITLE
Fixed changelog parsing performance issue

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/change/ChangeFactory.java
+++ b/liquibase-standard/src/main/java/liquibase/change/ChangeFactory.java
@@ -53,7 +53,7 @@ public class ChangeFactory extends AbstractPluginFactory<Change>{
 
     public ChangeMetaData getChangeMetaData(Change change) {
         String cacheKey = generateCacheKey(change);
-        cachedMetadata.putIfAbsent(cacheKey, change.createChangeMetaData());
+        cachedMetadata.computeIfAbsent(cacheKey, c -> change.createChangeMetaData());
         return cachedMetadata.get(cacheKey);
     }
 


### PR DESCRIPTION
…s always calling it and ignoring the result.

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors -->


## Description

Method should be invoked only if we have a cache miss - putIfAbsent is always calling it and ignoring the result.