### PR TITLE
Apply SQL visitors to prepared SQL

### DIFF
--- a/liquibase-standard/src/test/java/liquibase/statement/InsertExecutablePreparedStatementTest.java
+++ b/liquibase-standard/src/test/java/liquibase/statement/InsertExecutablePreparedStatementTest.java
@@ -8,10 +8,13 @@ import liquibase.change.ColumnConfig;
 import liquibase.changelog.ChangeSet;
 import liquibase.database.Database;
 import liquibase.database.PreparedStatementFactory;
+import liquibase.database.core.H2Database;
 import liquibase.database.core.MSSQLDatabase;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.resource.ResourceAccessor;
+import liquibase.sql.visitor.ReplaceSqlVisitor;
+import liquibase.sql.visitor.SqlVisitor;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -19,6 +22,8 @@ import org.mockito.*;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
+import java.util.List;
+
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.*;
 
@@ -27,6 +32,8 @@ public class InsertExecutablePreparedStatementTest {
 
     @Mock
     private ChangeSet changeSet;
+
+    private List<SqlVisitor> sqlVisitors = new ArrayList<>();
 
     @Mock
     private ResourceAccessor resourceAccessor;
@@ -45,6 +52,7 @@ public class InsertExecutablePreparedStatementTest {
     public void setUp() throws Exception {
         database = new MSSQLDatabase();
         preparedStatementFactory = new PreparedStatementFactory(connection);
+        when(changeSet.getSqlVisitors()).thenReturn(sqlVisitors);
         when(connection.prepareStatement(any(String.class))).thenReturn(ps);
     }
 
@@ -200,5 +208,38 @@ public class InsertExecutablePreparedStatementTest {
         verify(connection).prepareStatement("INSERT INTO DATABASECHANGELOG(MD5SUM, DATEEXECUTED) VALUES(?, GETDATE())");
         verify(ps).setString(1, "7:e27bf9c0c2313160ef960a15d44ced47");
         verify(ps, never()).setNull(eq(2), anyInt());
+    }
+
+    @Test
+    public void testApplySqlVisitors() throws Exception {
+        // given
+        ReplaceSqlVisitor visitor = new ReplaceSqlVisitor();
+        visitor.setReplace("\"KEY\"");
+        visitor.setWith("\"key\"");
+        sqlVisitors.add(visitor);
+        database = new H2Database();
+        InsertExecutablePreparedStatement statement = new InsertExecutablePreparedStatement(
+                database,
+                null,
+                null,
+                "names",
+                new ArrayList<>(Arrays.asList(
+                        new ColumnConfig()
+                                .setName("key")
+                                .setValueNumeric(1),
+                        new ColumnConfig()
+                                .setName("first")
+                                .setValue("john"),
+                        new ColumnConfig()
+                                .setName("last")
+                                .setValue("doe"))),
+                changeSet,
+                resourceAccessor);
+
+        // when
+        statement.execute(preparedStatementFactory);
+
+        // then
+        verify(connection).prepareStatement("INSERT INTO names(\"key\", first, last) VALUES(?, ?, ?)");
     }
 }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors -->


## Description

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

Apply SQL visitors to, and log, prepared SQL.

Fixes #5098.

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

New API `protected String applyVisitors(String sql, List<SqlVisitor> sqlVisitors)` on `ExecutablePreparedStatementBase` is exposed to subclasses.

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

An extension which extends `ExecutablePreparedStatementBase` or implements `ExecutablePreparedStatement` could require some changes to adopt the the desired behavior.

## Additional Context

<!--
Add any other context about the problem here.
-->
