### PR TITLE
Makes sure that precondition onErrorMessage and onFailMessage are logged when an error happens

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
@@ -14,12 +14,16 @@ import liquibase.precondition.FailedPrecondition;
 import liquibase.precondition.core.PreconditionContainer;
 import liquibase.util.StringUtil;
 import liquibase.util.ValidatingVisitorUtil;
+import lombok.Getter;
 
 import java.util.*;
 
+@Getter
 public class ValidatingVisitor implements ChangeSetVisitor {
 
     private final List<String> invalidMD5Sums = new ArrayList<>();
+    private String failedPreconditionsMessage = null;
+    private String errorPreconditionsMessage = null;
     private final List<FailedPrecondition> failedPreconditions = new ArrayList<>();
     private final List<ErrorPrecondition> errorPreconditions = new ArrayList<>();
     private final Set<ChangeSet> duplicateChangeSets = new HashSet<>();
@@ -60,10 +64,12 @@ public class ValidatingVisitor implements ChangeSetVisitor {
                 preconditions.check(database, changeLog, null, null);
             }
         } catch (PreconditionFailedException e) {
-            Scope.getCurrentScope().getLog(getClass()).fine("Precondition Failed: "+e.getMessage(), e);
+            Scope.getCurrentScope().getLog(getClass()).warning("Precondition Failed: "+e.getMessage(), e);
+            failedPreconditionsMessage = e.getMessage();
             failedPreconditions.addAll(e.getFailedPreconditions());
         } catch (PreconditionErrorException e) {
-            Scope.getCurrentScope().getLog(getClass()).fine("Precondition Error: "+e.getMessage(), e);
+            Scope.getCurrentScope().getLog(getClass()).severe("Precondition Error: "+e.getMessage(), e);
+            errorPreconditionsMessage = e.getMessage();
             errorPreconditions.addAll(e.getErrorPreconditions());
         } finally {
             try {
@@ -163,7 +169,6 @@ public class ValidatingVisitor implements ChangeSetVisitor {
         String changeSetString = changeSet.toString(false);
         if (seenChangeSets.contains(changeSetString)) {
             duplicateChangeSets.add(changeSet);
-            return;
         } else {
             seenChangeSets.add(changeSetString);
         }
@@ -187,46 +192,10 @@ public class ValidatingVisitor implements ChangeSetVisitor {
         return valid;
     }
 
-    public List<String> getInvalidMD5Sums() {
-        return invalidMD5Sums;
-    }
-
-
-    public List<FailedPrecondition> getFailedPreconditions() {
-        return failedPreconditions;
-    }
-
-    public List<ErrorPrecondition> getErrorPreconditions() {
-        return errorPreconditions;
-    }
-
-    public Set<ChangeSet> getDuplicateChangeSets() {
-        return duplicateChangeSets;
-    }
-
-    public List<SetupException> getSetupExceptions() {
-        return setupExceptions;
-    }
-
-    public List<Throwable> getChangeValidationExceptions() {
-        return changeValidationExceptions;
-    }
-
-    public ValidationErrors getValidationErrors() {
-        return validationErrors;
-    }
-
-    public Warnings getWarnings() {
-        return warnings;
-    }
-
     public boolean validationPassed() {
         return invalidMD5Sums.isEmpty() && failedPreconditions.isEmpty() && errorPreconditions.isEmpty() &&
             duplicateChangeSets.isEmpty() && changeValidationExceptions.isEmpty() && setupExceptions.isEmpty() &&
             !validationErrors.hasErrors();
     }
 
-    public Database getDatabase() {
-        return database;
-    }
 }

--- a/liquibase-standard/src/main/java/liquibase/exception/ValidationFailedException.java
+++ b/liquibase-standard/src/main/java/liquibase/exception/ValidationFailedException.java
@@ -6,6 +6,7 @@ import liquibase.changelog.visitor.ValidatingVisitor;
 import liquibase.precondition.ErrorPrecondition;
 import liquibase.precondition.FailedPrecondition;
 import liquibase.util.StreamUtil;
+import liquibase.util.StringUtil;
 
 import java.io.PrintStream;
 import java.util.List;
@@ -20,7 +21,9 @@ public class ValidationFailedException extends MigrationFailedException {
     public static final String INDENT_SPACES = "     ";
     private static final ResourceBundle coreBundle = getBundle("liquibase/i18n/liquibase-core");
     private final List<String> invalidMD5Sums;
+    private final String failedPreconditionsMessage;
     private final List<FailedPrecondition> failedPreconditions;
+    private final String errorPreconditionMessage;
     private final List<ErrorPrecondition> errorPreconditions;
     private final Set<ChangeSet> duplicateChangeSets;
     private final List<SetupException> setupExceptions;
@@ -29,7 +32,9 @@ public class ValidationFailedException extends MigrationFailedException {
 
     public ValidationFailedException(ValidatingVisitor changeLogHandler) {
         this.invalidMD5Sums = changeLogHandler.getInvalidMD5Sums();
+        this.failedPreconditionsMessage = changeLogHandler.getFailedPreconditionsMessage();
         this.failedPreconditions = changeLogHandler.getFailedPreconditions();
+        this.errorPreconditionMessage = changeLogHandler.getErrorPreconditionsMessage();
         this.errorPreconditions = changeLogHandler.getErrorPreconditions();
         this.duplicateChangeSets = changeLogHandler.getDuplicateChangeSets();
         this.setupExceptions = changeLogHandler.getSetupExceptions();
@@ -54,21 +59,27 @@ public class ValidationFailedException extends MigrationFailedException {
                 message.append(separator);
             }
         }
-        
+
         if (!failedPreconditions.isEmpty()) {
             message.append(INDENT_SPACES).append(
                 String.format(coreBundle.getString("preconditions.failed"), failedPreconditions.size()))
                 .append(separator);
+            if (StringUtil.isNotEmpty(failedPreconditionsMessage)) {
+                message.append(INDENT_SPACES).append(failedPreconditionsMessage).append(separator);
+            }
             for (FailedPrecondition invalid : failedPreconditions) {
                 message.append(INDENT_SPACES).append(invalid.toString());
                 message.append(separator);
             }
         }
-        
+
         if (!errorPreconditions.isEmpty()) {
             message.append(INDENT_SPACES).append(String.format(coreBundle.getString(
                 "preconditions.generated.error"), errorPreconditions.size()))
                 .append(separator);
+            if (StringUtil.isNotEmpty(errorPreconditionMessage)) {
+                message.append(INDENT_SPACES).append(errorPreconditionMessage).append(separator);
+            }
             for (ErrorPrecondition invalid : errorPreconditions) {
                 message.append(INDENT_SPACES).append(invalid.toString());
                 message.append(separator);


### PR DESCRIPTION

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Currently onErrorMessage and onFailMessage are logged only if the log-level property is set to something higher than info. As they are custom error messages they should be logged everytime an error occurs.

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
