### PR TITLE
Fix Liquibase changeset relative path check

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/changelog/RanChangeSet.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/RanChangeSet.java
@@ -4,8 +4,8 @@ import liquibase.ChecksumVersion;
 import liquibase.ContextExpression;
 import liquibase.Labels;
 import liquibase.change.CheckSum;
-import liquibase.integration.commandline.LiquibaseCommandLineConfiguration;
 
+import java.nio.file.Paths;
 import java.util.Date;
 
 /**
@@ -194,8 +194,23 @@ public class RanChangeSet {
     }
 
     public boolean isSameAs(ChangeSet changeSet) {
-        return DatabaseChangeLog.normalizePath(this.getChangeLog()).equalsIgnoreCase(DatabaseChangeLog.normalizePath(changeSet.getFilePath()))
-                && this.getId().equalsIgnoreCase(changeSet.getId())
-                && this.getAuthor().equalsIgnoreCase(changeSet.getAuthor());
+        return this.getId().equalsIgnoreCase(changeSet.getId())
+                && this.getAuthor().equalsIgnoreCase(changeSet.getAuthor())
+                && isSamePath(changeSet.getFilePath());
+
+    }
+
+    /**
+     * Liquibase path handling has changed over time leading to valid paths not being
+     * accepted thus breaking changesets. This method aims to check for all possible path variations
+     * that Liquibase used over time.
+     *
+     * @param filePath the file path
+     * @return does it somehow match what we have at database?
+     */
+    private boolean isSamePath(String filePath) {
+        String normalizedFilePath = DatabaseChangeLog.normalizePath(this.getChangeLog());
+        return normalizedFilePath.equalsIgnoreCase(DatabaseChangeLog.normalizePath(filePath))
+                || normalizedFilePath.equalsIgnoreCase(Paths.get(filePath).normalize().toString().replace("\\", "/"));
     }
 }

--- a/liquibase-standard/src/test/java/liquibase/changelog/RanChangeSetTest.java
+++ b/liquibase-standard/src/test/java/liquibase/changelog/RanChangeSetTest.java
@@ -7,14 +7,14 @@ import static org.junit.Assert.assertTrue;
 public class RanChangeSetTest {
 
     @Test
-    public void is_same_as_when_both_changelogs_have_classpath_prefix() throws Exception {
+    public void is_same_as_when_both_changelogs_have_classpath_prefix() {
         RanChangeSet ranChangeSet = new RanChangeSet("classpath:/db/file.log", "1", "author", null, null, null, null, null, null, null, null, null);
         ChangeSet incomingChangeSet = new ChangeSet("1", "author", false, false, "classpath:/db/file.log", null, null, null);
         assertTrue(ranChangeSet.isSameAs(incomingChangeSet));
     }
 
     @Test
-    public void is_same_when_we_use_relative_directories() throws Exception {
+    public void is_same_when_we_use_relative_directories() {
         RanChangeSet ranChangeSet = new RanChangeSet("db/file.log", "1", "author", null, null, null, null, null, null, null, null, null);
         ChangeSet incomingChangeSet = new ChangeSet("1", "author", false, false, "db/../db/file.log", null, null, null);
         assertTrue(ranChangeSet.isSameAs(incomingChangeSet));

--- a/liquibase-standard/src/test/java/liquibase/changelog/RanChangeSetTest.java
+++ b/liquibase-standard/src/test/java/liquibase/changelog/RanChangeSetTest.java
@@ -12,4 +12,11 @@ public class RanChangeSetTest {
         ChangeSet incomingChangeSet = new ChangeSet("1", "author", false, false, "classpath:/db/file.log", null, null, null);
         assertTrue(ranChangeSet.isSameAs(incomingChangeSet));
     }
+
+    @Test
+    public void is_same_when_we_use_relative_directories() throws Exception {
+        RanChangeSet ranChangeSet = new RanChangeSet("db/file.log", "1", "author", null, null, null, null, null, null, null, null, null);
+        ChangeSet incomingChangeSet = new ChangeSet("1", "author", false, false, "db/../db/file.log", null, null, null);
+        assertTrue(ranChangeSet.isSameAs(incomingChangeSet));
+    }
 }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors -->


## Description

Liquibase path handling has changed over time leading to valid paths not being accepted thus breaking changesets. This fix aims to check for all possible path variations that Liquibase used over time.
