### PR TITLE
Fixes problematic V8 checksums for pro CreateFunctionChange

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/util/ValidatingVisitorUtil.java
+++ b/liquibase-standard/src/main/java/liquibase/util/ValidatingVisitorUtil.java
@@ -11,7 +11,6 @@ import liquibase.change.core.DropIndexChange;
 import liquibase.changelog.*;
 import liquibase.database.Database;
 import liquibase.exception.DatabaseException;
-import liquibase.exception.LiquibaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
 
 import java.lang.reflect.InvocationTargetException;
@@ -63,6 +62,12 @@ public class ValidatingVisitorUtil {
         return false;
     }
 
+    /**
+     * CreateFunctionChange checksum had the calculated value changed for Liquibase versions 4.21.X
+     * due to incorrect annotations being added to CreateProcedureChange .
+     * This method validates the v8 checksum using the alternative algorithm as a way to allow users to upgrade to
+     * checksums v9 without facing any errors or unexpected behaviours.
+     */
     private static boolean validateCreateFunctionChangeV8ChecksumVariant(ChangeSet changeSet, RanChangeSet ranChangeSet) {
         if (ChecksumVersion.V8.lowerOrEqualThan(Scope.getCurrentScope().getChecksumVersion())) {
             List<Change> changes = changeSet.getChanges().stream()


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors -->


## Description

Requires https://github.com/liquibase/liquibase-pro/pull/1342

## Other

If we ignore 4.21.x generated checksums this whole PR could be ignored and we would only have 1 line change in pro code.