### PR TITLE
Invoke database.commit only if needed

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/changelog/visitor/UpdateVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/visitor/UpdateVisitor.java
@@ -66,10 +66,11 @@ public class UpdateVisitor implements ChangeSetVisitor {
         CheckSum oldChecksum = updateCheckSumIfRequired(changeSet);
         if (isAccepted) {
             executeAcceptedChange(changeSet, databaseChangeLog, database);
+            this.database.commit();
         } else if ((oldChecksum == null || oldChecksum.getVersion() < ChecksumVersion.latest().getVersion())) {
             upgradeCheckSumVersionForAlreadyExecutedOrNullChange(changeSet, database, oldChecksum);
+            this.database.commit();
         }
-        this.database.commit();
     }
 
     /**


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 

## Description
Invoke database.commit only if something was executed

When running over large changesets , every commit means a request and for cloud databases it means a new request to the cloud that can take up some time.