### PR TITLE
Fix calculateCheckSum issue when using Liquibase API method

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-standard/src/main/java/liquibase/Liquibase.java
@@ -1273,7 +1273,6 @@ public class Liquibase implements AutoCloseable {
                 .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_PATH_ARG, changeSetPath)
                 .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_ID_ARG, changeSetId)
                 .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_AUTHOR_ARG, changeSetAuthor)
-                .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_IDENTIFIER_ARG, String.format("%s::%s::%s", changeSetPath, changeSetId, changeSetAuthor))
                 .addArgumentValue(CalculateChecksumCommandStep.CHANGELOG_FILE_ARG, this.changeLogFile)
                 .execute();
         return commandResults.getResult(CalculateChecksumCommandStep.CHECKSUM_RESULT);

--- a/liquibase-standard/src/main/java/liquibase/command/core/CalculateChecksumCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/CalculateChecksumCommandStep.java
@@ -157,15 +157,15 @@ public class CalculateChecksumCommandStep extends AbstractCommandStep {
                     "If --changeset-identifier is not provided than --changeset-id, --changeset-author and --changeset-path must be specified. " +
                     "Missing argument: ";
 
-            if (commandScope.getArgumentValue(CHANGESET_ID_ARG) == null) {
+            if (StringUtil.isEmpty(commandScope.getArgumentValue(CHANGESET_ID_ARG))) {
                 errorMessage = errorMessage + " '--changeset-id',";
             }
 
-            if (commandScope.getArgumentValue(CHANGESET_AUTHOR_ARG) == null) {
+            if (StringUtil.isEmpty(commandScope.getArgumentValue(CHANGESET_AUTHOR_ARG))) {
                 errorMessage = errorMessage + " '--changeset-author',";
             }
 
-            if (commandScope.getArgumentValue(CHANGESET_PATH_ARG) == null) {
+            if (StringUtil.isEmpty(commandScope.getArgumentValue(CHANGESET_PATH_ARG))) {
                 errorMessage = errorMessage + " '--changeset-path',";
             }
 

--- a/liquibase-standard/src/test/groovy/liquibase/command/CalculateChecksumCommandStepTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/command/CalculateChecksumCommandStepTest.groovy
@@ -1,0 +1,120 @@
+package liquibase.command
+
+import liquibase.Scope
+import liquibase.command.core.CalculateChecksumCommandStep
+import liquibase.command.core.helpers.DbUrlConnectionCommandStep
+import liquibase.database.core.MockDatabase
+import liquibase.exception.CommandExecutionException
+import liquibase.resource.SearchPathResourceAccessor
+import liquibase.util.StringUtil
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class CalculateChecksumCommandStepTest extends Specification {
+
+    def validateCheckSumIsCalculatedSuccessfully() {
+        when:
+        def generatedCheckSum = calculateCheckSum("tagged-changelog.xml", "1", "liquibase")
+
+        then:
+        StringUtil.isNotEmpty(generatedCheckSum.toString())
+    }
+
+    //Negative Tests
+    @Unroll
+    def "validate CheckSum is not calculated having a missing path argument"(String path) {
+        when:
+        def generatedCheckSum = calculateCheckSum(path, "1", "liquibase")
+
+        then:
+        StringUtil.isEmpty(generatedCheckSum)
+        def e = thrown(CommandExecutionException)
+        e.message.contains("Missing argument:  '--changeset-path'")
+
+        where:
+        path << ["", null]
+    }
+
+    @Unroll
+    def "validate CheckSum is not calculated having a missing author argument"(String author) {
+        when:
+        def generatedCheckSum = calculateCheckSum("tagged-changelog.xml", "1", author)
+
+        then:
+        StringUtil.isEmpty(generatedCheckSum)
+        def e = thrown(CommandExecutionException)
+        e.message.contains("Missing argument:  '--changeset-author'")
+
+        where:
+        author << ["", null]
+    }
+
+    @Unroll
+    def "validate CheckSum is not calculated having a missing Id argument"(String id) {
+        when:
+        def generatedCheckSum = calculateCheckSum("tagged-changelog.xml", id, "liquibase")
+
+        then:
+        StringUtil.isEmpty(generatedCheckSum)
+        def e = thrown(CommandExecutionException)
+        e.message.contains("Missing argument:  '--changeset-id'")
+
+        where:
+        id << ["", null]
+    }
+
+    def "validate error is returned when changesetIdentifier and the three separate arguments are provided at the same time"() {
+        when:
+        def resourceAccessor = new SearchPathResourceAccessor("target/test-classes/liquibase")
+        def scopeSettings = [
+                (Scope.Attr.resourceAccessor.name()): resourceAccessor
+        ]
+
+        def generatedCheckSum = ""
+
+        Scope.child(scopeSettings, {
+            CommandResults commandResults = new CommandScope("calculateChecksum")
+                    .addArgumentValue(CalculateChecksumCommandStep.CHANGELOG_FILE_ARG, "tagged-changelog.xml")
+                    .addArgumentValue(DbUrlConnectionCommandStep.DATABASE_ARG, new MockDatabase())
+                    .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_PATH_ARG, "tagged-changelog.xml")
+                    .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_ID_ARG, "1")
+                    .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_AUTHOR_ARG, "liquibase")
+                    .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_IDENTIFIER_ARG, "tagged-changelog.xml::1::liquibase")
+                    .execute()
+            generatedCheckSum = commandResults.getResult("checksumResult")
+        } as Scope.ScopedRunner)
+
+        then:
+        StringUtil.isEmpty(generatedCheckSum)
+        def e = thrown(CommandExecutionException)
+        e.message.contains("'--changeset-identifier' cannot be provided alongside other changeset arguments: '--changeset-id', '--changeset-path', '--changeset-author'")
+    }
+
+    private String calculateCheckSum(String path, String id, String author) {
+        try {
+            def resourceAccessor = new SearchPathResourceAccessor("target/test-classes/liquibase")
+            def scopeSettings = [
+                    (Scope.Attr.resourceAccessor.name()): resourceAccessor
+            ]
+
+            def generatedCheckSum = ""
+
+            Scope.child(scopeSettings, {
+                CommandResults commandResults = new CommandScope("calculateChecksum")
+                        .addArgumentValue(CalculateChecksumCommandStep.CHANGELOG_FILE_ARG, "tagged-changelog.xml")
+                        .addArgumentValue(DbUrlConnectionCommandStep.DATABASE_ARG, new MockDatabase())
+                        .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_PATH_ARG, path)
+                        .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_ID_ARG, id)
+                        .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_AUTHOR_ARG, author)
+                        .execute()
+                generatedCheckSum = commandResults.getResult("checksumResult")
+            } as Scope.ScopedRunner)
+
+            return generatedCheckSum
+        }
+        catch (CommandExecutionException e) {
+            throw e
+        }
+
+    }
+}


### PR DESCRIPTION
 Fixes #5225 

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors -->


## Description

`CalculateCheckSum()` Liquibase API method was failing, because internally when using the command step we were proving both arguments at the same time and this was causing a validation to return an error because both argument options were provided at the same time when only one should be provided at a single time. This error has been fixed and some unit tests have been added.



<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of
- None
<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about
- None
<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context
-
<!--
Add any other context about the problem here.
-->
