### PR TITLE
DAT-16300      WPEngine :: Update index.html with the released version of OSS xsd

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -358,6 +358,18 @@ jobs:
           forceUpload: true
           localDir: 'liquibase-pro-repo/pro/src/main/resources/schemas/'
           remoteDir: '/json/schema/'
+
+      - name: Liquibase index.htm SFTP upload
+        uses: wangyucode/sftp-upload-action@v2.0.2
+        with:
+          host: ${{ secrets.WPENGINE_SFTP_HOST }}
+          port: ${{ secrets.WPENGINE_SFTP_PORT }}
+          username: ${{ secrets.WPENGINE_SFTP_USER }}
+          password: ${{ secrets.WPENGINE_SFTP_PASSWORD }} 
+          compress: false
+          forceUpload: true
+          localDir: 'index-file/'
+          remoteDir: '/xml/ns/dbchangelog/'
           
   release-docker:
     name: Release docker images


### PR DESCRIPTION
## Description

chore(release-published.yml): add SFTP upload step for Liquibase index.htm file to remote directory '/xml/ns/dbchangelog/'

I am reusing the generated `index.htm` file from the previous workflow step:

```
      - name: Index.htm file upload
        env:
          AWS_ACCESS_KEY_ID: ${{ secrets.LIQUIBASEORIGIN_ACCESS_KEY_ID }}
          AWS_SECRET_ACCESS_KEY: ${{ secrets.LIQUIBASEORIGIN_SECRET_ACCESS_KEY }}
          AWS_DEFAULT_REGION: us-east-1
        # get the major.minor xsd version. grab the index.htm from s3, add the new verison of xsd and sync with the s3 again
        run: |
          version=${{ needs.setup.outputs.version }}
          arr=(${version//./ })
          xsd_version=${arr[0]}"."${arr[1]}
          mkdir index-file
          aws s3 cp s3://liquibaseorg-origin/xml/ns/dbchangelog/index.htm index-file
          if ! grep -q ${xsd_version} index-file/index.htm ; then
            sed -ie "s/<\/ul>/  <li><a href=\"\/xml\/ns\/dbchangelog\/dbchangelog-${xsd_version}.xsd\">dbchangelog-${xsd_version}.xsd<\/a><\/li>\n<\/ul>/" index-file/index.htm
            aws s3 sync index-file s3://liquibaseorg-origin/xml/ns/dbchangelog/ --only-show-errors
          fi
```