### PR TITLE
Fix #5271: ColumnExistsPrecondition throws error when table is missing

### DIFF
--- a/liquibase-integration-tests/src/test/resources/changelogs/common/common.tests.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/common/common.tests.changelog.xml
@@ -240,6 +240,21 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="column-exists-test" author="januson">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists columnName="A_NEW_COLUMN" tableName="COLUMN_EXISTS_TEST_TABLE"/>
+            </not>
+        </preConditions>
+        <comment>Testing column exists precondition regression</comment>
+        <createTable tableName="COLUMN_EXISTS_TEST_TABLE">
+            <column name="id" type="int"/>
+        </createTable>
+        <addColumn tableName="COLUMN_EXISTS_TEST_TABLE">
+            <column name="A_NEW_COLUMN" type="int" defaultValueNumeric="1"/>
+        </addColumn>
+    </changeSet>
+
     <changeSet id="tablespace-test1" author="alan">
         <comment>Test tablespace support. Ignored if database does not support tablespaces</comment>
         <createTable tableName="TABLESPACE_TEST_TABLE" tablespace="liquibase2">

--- a/liquibase-standard/src/main/java/liquibase/precondition/core/ColumnExistsPrecondition.java
+++ b/liquibase-standard/src/main/java/liquibase/precondition/core/ColumnExistsPrecondition.java
@@ -163,12 +163,11 @@ public class ColumnExistsPrecondition extends AbstractPrecondition {
                             database.escapeObjectName(tableName, Table.class));
                 }
 
-                statement = ((JdbcConnection) database.getConnection())
-                        .prepareStatement(sql);
                 try {
-                    statement.executeQuery().close();
+                    statement = ((JdbcConnection) database.getConnection()).prepareStatement(sql);
+                    statement.executeQuery();
                     // column exists
-                } catch (SQLException e) {
+                } catch (SQLException | DatabaseException e) {
                     // column or table does not exist
                     throw new PreconditionFailedException(format(
                             "Column %s.%s.%s does not exist", schemaName,


### PR DESCRIPTION
- Handled DatabaseException thrown by PreparedStatement when the table is missing
- Added integration test

Fixes #5271
Fixes #5246 

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors -->


## Description

This PR fixes a bug introduced in 4.25.0 where ColumnExistsPrecondition fails with an error PreconditionErrorException when table that is supposed to contain the column is missing.

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
