### PR TITLE
Disable Derby shutdown in Spring Boot context

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/integration/spring/SpringLiquibase.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/spring/SpringLiquibase.java
@@ -6,6 +6,7 @@ import liquibase.database.Database;
 import liquibase.database.DatabaseConnection;
 import liquibase.database.DatabaseFactory;
 import liquibase.database.OfflineConnection;
+import liquibase.database.core.DerbyDatabase;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.LiquibaseException;
@@ -360,6 +361,10 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
 
         liquibase.setShowSummaryOutput(showSummaryOutput);
         liquibase.setShowSummary(showSummary);
+
+        if (liquibase.getDatabase() instanceof DerbyDatabase) {
+            ((DerbyDatabase) liquibase.getDatabase()).setShutdownEmbeddedDerby(false);
+        }
 
 		return liquibase;
 	}


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors -->

`TypeBug`

## Description

After liquibase changelog is applied to a Derby embedded database in Spring Boot context, database is shut down. Spring Boot application cannot run any further, as there is no connection available anymore. Sometimes it still works as the shutdown command isn't executed relyably.

Logic adapted from liquibase.integration.servlet.GenericServletListener.

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->

Not sure why shutdown enabled is the default for Derby databases. Maybe worth to change the default, maybe worth allowing the setting to be overwritten with a property as stated here, but it doesn't work.
https://stackoverflow.com/questions/47314248/why-derby-connection-closed-after-liquibase-update
