### PR TITLE
Global flag to restore behaviour of not failing on duplicated changeset identifiers 

### DIFF
--- a/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineTest.groovy
+++ b/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineTest.groovy
@@ -19,6 +19,16 @@ Usage: liquibase [GLOBAL OPTIONS] [COMMAND] [COMMAND OPTIONS]
 Command-specific help: "liquibase <command-name> --help"
 
 Global Options
+      --allow-duplicated-changeset-identifiers=PARAM
+                             Allows duplicated changeset identifiers without
+                               failing Liquibase execution.
+                             DEFAULT: false
+                             (defaults file: 'liquibase.
+                               allowDuplicatedChangesetIdentifiers',
+                               environment variable:
+                               'LIQUIBASE_ALLOW_DUPLICATED_CHANGESET_IDENTIFIERS
+                               ')
+
       --always-drop-instead-of-replace=PARAM
                              If true, drop and recreate a view instead of
                                replacing it.

--- a/liquibase-standard/src/main/java/liquibase/GlobalConfiguration.java
+++ b/liquibase-standard/src/main/java/liquibase/GlobalConfiguration.java
@@ -36,6 +36,7 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
     public static final ConfigurationDefinition<Boolean> SHOW_BANNER;
     public static final ConfigurationDefinition<Boolean> ALWAYS_DROP_INSTEAD_OF_REPLACE;
     public static final ConfigurationDefinition<DuplicateFileMode> DUPLICATE_FILE_MODE;
+    public static final ConfigurationDefinition<Boolean> ALLOW_DUPLICATED_CHANGESETS_IDENTIFIERS;
 
     public static final ConfigurationDefinition<Boolean> VALIDATE_XML_CHANGELOG_FILES;
 
@@ -241,6 +242,12 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
         ALWAYS_DROP_INSTEAD_OF_REPLACE = builder.define("alwaysDropInsteadOfReplace", Boolean.class)
                 .setDescription("If true, drop and recreate a view instead of replacing it.")
                 .setValueHandler(ValueHandlerUtil::booleanValueHandler)
+                .build();
+
+        ALLOW_DUPLICATED_CHANGESETS_IDENTIFIERS = builder.define("allowDuplicatedChangesetIdentifiers", Boolean.class)
+                .setDescription("Allows duplicated changeset identifiers without failing Liquibase execution.")
+                .setValueHandler(ValueHandlerUtil::booleanValueHandler)
+                .setDefaultValue(false)
                 .build();
 
         VALIDATE_XML_CHANGELOG_FILES = builder.define("validateXmlChangelogFiles", Boolean.class)

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogIterator.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogIterator.java
@@ -45,7 +45,7 @@ public class ChangeLogIterator {
     @Getter
     private final List<ChangeSet> skippedDueToExceptionChangeSets = new ArrayList<>();
 
-    private static final Boolean ALLOW_DUPLICATED_CHANGESETS_IDENTIFIERS = GlobalConfiguration.ALLOW_DUPLICATED_CHANGESETS_IDENTIFIERS.getCurrentValue();
+    private final Boolean allowDuplicatedChangesetsIdentifiers = GlobalConfiguration.ALLOW_DUPLICATED_CHANGESETS_IDENTIFIERS.getCurrentValue();
 
     public ChangeLogIterator(DatabaseChangeLog databaseChangeLog, ChangeSetFilter... changeSetFilters) {
         this(databaseChangeLog, Arrays.asList(changeSetFilters));
@@ -212,7 +212,7 @@ public class ChangeLogIterator {
      * ALLOW_DUPLICATED_CHANGESETS_IDENTIFIERS
      */
     private boolean alreadySaw(ChangeSet changeSet) {
-        if (BooleanUtil.isTrue(ALLOW_DUPLICATED_CHANGESETS_IDENTIFIERS)) {
+        if (BooleanUtil.isTrue(allowDuplicatedChangesetsIdentifiers)) {
             if (changeSet.key == null) {
                 changeSet.key = createKey(changeSet);
             }

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogIterator.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogIterator.java
@@ -22,10 +22,7 @@ import static java.util.ResourceBundle.getBundle;
 /**
  * The ChangeLogIterator class is responsible for iterating through a list of ChangeSets in a DatabaseChangeLog
  * and executing a visitor for each ChangeSet that passes the specified filters.
- *
  * It provides methods for running the visitor and validating the Executor for each ChangeSet.
- *
- * @since 1.0.0
  */
 public class ChangeLogIterator {
 

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogIterator.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogIterator.java
@@ -1,9 +1,6 @@
 package liquibase.changelog;
 
-import liquibase.ContextExpression;
-import liquibase.Labels;
-import liquibase.RuntimeEnvironment;
-import liquibase.Scope;
+import liquibase.*;
 import liquibase.changelog.filter.ChangeSetFilter;
 import liquibase.changelog.filter.ChangeSetFilterResult;
 import liquibase.changelog.visitor.ChangeSetVisitor;
@@ -14,6 +11,7 @@ import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.exception.ValidationErrors;
 import liquibase.executor.Executor;
 import liquibase.executor.ExecutorService;
+import liquibase.util.BooleanUtil;
 import liquibase.util.StringUtil;
 import lombok.Getter;
 
@@ -21,6 +19,14 @@ import java.util.*;
 
 import static java.util.ResourceBundle.getBundle;
 
+/**
+ * The ChangeLogIterator class is responsible for iterating through a list of ChangeSets in a DatabaseChangeLog
+ * and executing a visitor for each ChangeSet that passes the specified filters.
+ *
+ * It provides methods for running the visitor and validating the Executor for each ChangeSet.
+ *
+ * @since 1.0.0
+ */
 public class ChangeLogIterator {
 
     protected final DatabaseChangeLog databaseChangeLog;
@@ -38,6 +44,8 @@ public class ChangeLogIterator {
      */
     @Getter
     private final List<ChangeSet> skippedDueToExceptionChangeSets = new ArrayList<>();
+
+    private static final Boolean ALLOW_DUPLICATED_CHANGESETS_IDENTIFIERS = GlobalConfiguration.ALLOW_DUPLICATED_CHANGESETS_IDENTIFIERS.getCurrentValue();
 
     public ChangeLogIterator(DatabaseChangeLog databaseChangeLog, ChangeSetFilter... changeSetFilters) {
         this(databaseChangeLog, Arrays.asList(changeSetFilters));
@@ -115,7 +123,7 @@ public class ChangeLogIterator {
 
                         int finalI = i;
                         Scope.child(scopeValues, () -> {
-                            if (finalShouldVisit) {
+                            if (finalShouldVisit && !alreadySaw(changeSet)) {
                                 //
                                 // Go validate any changesets with an Executor if
                                 // we are using a ValidatingVisitor
@@ -193,9 +201,24 @@ public class ChangeLogIterator {
         if (changeSet.key == null) {
             changeSet.key = createKey(changeSet);
         }
-
         seenChangeSets.add(changeSet.key);
+    }
 
+
+    /**
+     * By default, this returns false as finalShouldVisit logic has better performance.
+     * But prior to 4.19.1 the below logic worked, were if a changeset was already saw we would
+     * just ignore it instead of throwing an error. This logic was backported under flag
+     * ALLOW_DUPLICATED_CHANGESETS_IDENTIFIERS
+     */
+    private boolean alreadySaw(ChangeSet changeSet) {
+        if (BooleanUtil.isTrue(ALLOW_DUPLICATED_CHANGESETS_IDENTIFIERS)) {
+            if (changeSet.key == null) {
+                changeSet.key = createKey(changeSet);
+            }
+            return seenChangeSets.contains(changeSet.key);
+        }
+        return false;
     }
 
     /**
@@ -204,7 +227,6 @@ public class ChangeLogIterator {
     protected String createKey(ChangeSet changeSet) {
         Labels labels = changeSet.getLabels();
         ContextExpression contexts = changeSet.getContextFilter();
-        changeSet.getRunOrder();
 
         return changeSet.toString(false)
                 + ":" + (labels == null ? null : labels.toString())

--- a/liquibase-standard/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
@@ -186,7 +186,7 @@ public class ValidatingVisitor implements ChangeSetVisitor {
 
     public boolean validationPassed() {
         return invalidMD5Sums.isEmpty() && failedPreconditions.isEmpty() && errorPreconditions.isEmpty() &&
-                duplicateChangeSets.isEmpty() && changeValidationExceptions.isEmpty() && setupExceptions.isEmpty() &&
+            duplicateChangeSets.isEmpty() && changeValidationExceptions.isEmpty() && setupExceptions.isEmpty() &&
             !validationErrors.hasErrors();
     }
 

--- a/liquibase-standard/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
@@ -37,8 +37,6 @@ public class ValidatingVisitor implements ChangeSetVisitor {
     private Map<String, RanChangeSet> ranIndex;
     private Database database;
 
-    private static final Boolean ALLOW_DUPLICATED_CHANGESETS_IDENTIFIERS = GlobalConfiguration.ALLOW_DUPLICATED_CHANGESETS_IDENTIFIERS.getCurrentValue();
-
     //
     // Added for test
     //
@@ -187,10 +185,9 @@ public class ValidatingVisitor implements ChangeSetVisitor {
     }
 
     public boolean validationPassed() {
-        boolean noDuplicateChangeSets = ALLOW_DUPLICATED_CHANGESETS_IDENTIFIERS || duplicateChangeSets.isEmpty();
         return invalidMD5Sums.isEmpty() && failedPreconditions.isEmpty() && errorPreconditions.isEmpty() &&
-            changeValidationExceptions.isEmpty() && setupExceptions.isEmpty() &&
-            !validationErrors.hasErrors() &&noDuplicateChangeSets;
+                duplicateChangeSets.isEmpty() && changeValidationExceptions.isEmpty() && setupExceptions.isEmpty() &&
+            !validationErrors.hasErrors();
     }
 
 }

--- a/liquibase-standard/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
@@ -37,6 +37,8 @@ public class ValidatingVisitor implements ChangeSetVisitor {
     private Map<String, RanChangeSet> ranIndex;
     private Database database;
 
+    private static final Boolean ALLOW_DUPLICATED_CHANGESETS_IDENTIFIERS = GlobalConfiguration.ALLOW_DUPLICATED_CHANGESETS_IDENTIFIERS.getCurrentValue();
+
     //
     // Added for test
     //
@@ -185,9 +187,10 @@ public class ValidatingVisitor implements ChangeSetVisitor {
     }
 
     public boolean validationPassed() {
+        boolean noDuplicateChangeSets = ALLOW_DUPLICATED_CHANGESETS_IDENTIFIERS || duplicateChangeSets.isEmpty();
         return invalidMD5Sums.isEmpty() && failedPreconditions.isEmpty() && errorPreconditions.isEmpty() &&
-            duplicateChangeSets.isEmpty() && changeValidationExceptions.isEmpty() && setupExceptions.isEmpty() &&
-            !validationErrors.hasErrors();
+            changeValidationExceptions.isEmpty() && setupExceptions.isEmpty() &&
+            !validationErrors.hasErrors() &&noDuplicateChangeSets;
     }
 
 }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Adjust duplicate changeset validation

Added logic in the class to handle duplicate changeset identifiers based on a global configuration flag. This change provides an allowance for duplicated changesets but only when the flag is enabled in GlobalConfiguration. This was done to maintain backward compatibility with versions prior to 4.19.1 where ignoring duplicates was the default behavior (PR #3790) .

when this flag is set to true Liquibase won't fail with message:
```
Unexpected error running Liquibase: Validation Failed:
     1 changesets had duplicate identifiers
          a.xml::20231024-122624-01::fl
```


Fix #3881

