### PR TITLE
Allow DiffResults to be reused in pipeline after running DiffChangelogCommandStep (DAT-16374)

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/diff/output/changelog/core/MissingPrimaryKeyChangeGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/diff/output/changelog/core/MissingPrimaryKeyChangeGenerator.java
@@ -78,8 +78,12 @@ public class MissingPrimaryKeyChangeGenerator extends AbstractChangeGenerator im
             .getBackingIndex() != null) && !comparisonDatabase.isSystemObject(pk.getBackingIndex()))) {
             Index backingIndex = pk.getBackingIndex();
             if ((backingIndex != null) && (backingIndex.getName() != null)) {
+                Schema originalRelationSchema = backingIndex.getRelation().getSchema();
                 try {
+                    // Save the original schema and catalog, so we can find it again if we need to examine diff results
+                    // after standard command execution
                     if (!control.getIncludeCatalog() && !control.getIncludeSchema()) {
+                        // I'm not too sure what this if is accomplishing
                         CatalogAndSchema schema = comparisonDatabase.getDefaultSchema().customize(comparisonDatabase);
                         backingIndex.getRelation().setSchema(schema.getCatalogName(), schema.getSchemaName()); //set table schema so it is found in the correct schema
                     }
@@ -93,7 +97,6 @@ public class MissingPrimaryKeyChangeGenerator extends AbstractChangeGenerator im
                                 }
                             }
                         }
-
                     }
                 } catch (Exception e) {
                     throw new UnexpectedLiquibaseException(e);
@@ -110,6 +113,8 @@ public class MissingPrimaryKeyChangeGenerator extends AbstractChangeGenerator im
                         change.setForIndexSchemaName(schema.getName());
                     }
                 }
+                // We've generated our changes with the updated schema if needed, set it back to the original.
+                backingIndex.getRelation().setSchema(originalRelationSchema);
             }
         }
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description
When generating missing primary keys, set relation back to original relation once we have generated changes with it to allow reuse of DiffResults in subsequent command steps.
<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of
Pro is consuming the DiffResult generated from DiffCommandStep and DiffChangelogCommandStep. The modification `backingIndex.getRelation().setSchema(schema.getCatalogName(), schema.getSchemaName());` breaks the `DiffResult#changedObjects` field if we generate a primary key column by updating the `key` of `changedObjects` to be something different than what the snapshot associated with the DiffResult expects.
<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about
This code has existed in this form since around 2015-2018. I'm a bit scared to touch it. 
<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
