### PR TITLE
add default constructor + setters to `RanChangeSet` & related classes

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/ContextExpression.java
+++ b/liquibase-standard/src/main/java/liquibase/ContextExpression.java
@@ -2,19 +2,22 @@ package liquibase;
 
 import liquibase.util.ExpressionMatcher;
 import liquibase.util.StringUtil;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.*;
 
 /**
  * Encapsulates logic for evaluating if a set of runtime contexts matches a context expression string.
  */
+@NoArgsConstructor
+@Setter
 public class ContextExpression {
 
-    private final HashSet<String> contexts = new HashSet<>();
+    private HashSet<String> contexts = new HashSet<>();
+    @Getter
     private String originalString;
-
-    public ContextExpression() {
-    }
 
     public ContextExpression(String... contexts) {
         if (contexts.length == 1) {
@@ -113,7 +116,4 @@ public class ContextExpression {
         return true;
     }
 
-    public String getOriginalString() {
-        return originalString;
-    }
 }

--- a/liquibase-standard/src/main/java/liquibase/change/CheckSum.java
+++ b/liquibase-standard/src/main/java/liquibase/change/CheckSum.java
@@ -4,6 +4,9 @@ import liquibase.ChecksumVersion;
 import liquibase.Scope;
 import liquibase.util.MD5Util;
 import liquibase.util.StringUtil;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -20,9 +23,16 @@ import java.util.regex.Pattern;
  * <p></p>
  * It is not up to this class to determine what should be storedCheckSum-ed, it simply hashes what is passed to it.
  */
+@NoArgsConstructor
+@Setter
 public final class CheckSum {
-    private final int version;
-    private final String storedCheckSum;
+    /**
+     * -- GETTER --
+     *  Return the Checksum Algorithm version for this CheckSum
+     */
+    @Getter
+    private int version;
+    private String storedCheckSum;
 
     private static final char DELIMITER = ':';
     private static final String CHECKSUM_REGEX = "(^\\d++)" + DELIMITER + "([a-zA-Z0-9]++)";
@@ -112,13 +122,6 @@ public final class CheckSum {
     @Override
     public String toString() {
         return version + String.valueOf(DELIMITER) + storedCheckSum;
-    }
-
-    /**
-     * Return the Checksum Algorithm version for this CheckSum
-     */
-    public int getVersion() {
-        return version;
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/changelog/RanChangeSet.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/RanChangeSet.java
@@ -4,6 +4,9 @@ import liquibase.ChecksumVersion;
 import liquibase.ContextExpression;
 import liquibase.Labels;
 import liquibase.change.CheckSum;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.nio.file.Paths;
 import java.util.Date;
@@ -11,23 +14,25 @@ import java.util.Date;
 /**
  * Encapsulates information about a previously-ran changeset.  Used to build rollback statements.
  */
+@NoArgsConstructor
+@Getter
+@Setter
 public class RanChangeSet {
-    private final String changeLog;
-    private final String storedChangeLog;
-    private final String id;
-    private final String author;
-    private final CheckSum lastCheckSum;
-    private final Date dateExecuted;
+    private String changeLog;
+    private String storedChangeLog;
+    private String id;
+    private String author;
+    private CheckSum lastCheckSum;
+    private Date dateExecuted;
     private String tag;
-    private final ChangeSet.ExecType execType;
+    private ChangeSet.ExecType execType;
     private String description;
     private String comments;
     private Integer orderExecuted;
-    private final ContextExpression contextExpression;
-    private final Labels labels;
+    private ContextExpression contextExpression;
+    private Labels labels;
     private String deploymentId;
     private String liquibaseVersion;
-
 
     public RanChangeSet(ChangeSet changeSet) {
         this(changeSet, null, null, null);
@@ -74,94 +79,11 @@ public class RanChangeSet {
         this.deploymentId = deploymentId;
     }
 
-    public String getChangeLog() {
-        return changeLog;
-    }
-
-    /**
-     * Get the path stored in the DatabaseChangeLog table
-     */
-    public String getStoredChangeLog() {
-        return storedChangeLog;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public String getAuthor() {
-        return author;
-    }
-
-    public CheckSum getLastCheckSum() {
-        return lastCheckSum;
-    }
-
     public Date getDateExecuted() {
         if (dateExecuted == null) {
             return null;
         }
         return (Date) dateExecuted.clone();
-    }
-
-    public String getTag() {
-        return tag;
-    }
-
-    public void setTag(String tag) {
-        this.tag = tag;
-    }
-
-    public ChangeSet.ExecType getExecType() {
-        return execType;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    public String getComments() {
-        return comments;
-    }
-
-    public void setComments(String comments) {
-        this.comments = comments;
-    }
-
-    public ContextExpression getContextExpression() {
-        return contextExpression;
-    }
-
-    public Labels getLabels() {
-        return labels;
-    }
-
-    public Integer getOrderExecuted() {
-        return orderExecuted;
-    }
-
-    public void setOrderExecuted(Integer orderExecuted) {
-        this.orderExecuted = orderExecuted;
-    }
-
-    public String getDeploymentId() {
-        return deploymentId;
-    }
-
-    public void setDeploymentId(String deploymentId) {
-        this.deploymentId = deploymentId;
-    }
-
-    public String getLiquibaseVersion() {
-        return liquibaseVersion;
-    }
-
-    public void setLiquibaseVersion(String liquibaseVersion) {
-        this.liquibaseVersion = liquibaseVersion;
     }
 
     @Override


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

this is needed to be able to de-serialise them using [jackson] which relies on the default constructor & setters.
in the upcoming liquibase-opensearch implementation [opensearch-java] is used, which underneath is using jackson for the (de-)serialisation of classes.

specifically, this is used in the implementation of `AbstractChangeLogHistoryService#queryRanChangeSets` which needs to load `RanChangeSet`s from the DB.

also do some minor cleanups by removing manually implemented getters & setters where lombok annotations can do the job instead (no functional impact).

[jackson]: https://github.com/FasterXML/jackson
[opensearch-java]: https://github.com/opensearch-project/opensearch-java/

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->
n/a

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

n/a

## Additional Context

<!--
Add any other context about the problem here.
-->
for liquibase-opensearch see https://github.com/liquibase/liquibase/issues/4236 & https://github.com/opensearch-project/opensearch-migrations/issues/148 (btw: still waiting for a reply from @nvoxland there! if you have any way of pinging him to get his feedback there that'd be great)