### PR TITLE
Introduce support for primitive types

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/parser/core/ParsedNode.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/core/ParsedNode.java
@@ -236,21 +236,25 @@ public class ParsedNode {
         try {
             if (type.equals(String.class)) {
                 return (T) rawValue.toString();
-            } else if (type.equals(Integer.class)) {
+            } else if (type.equals(Integer.class) || type.equals(int.class)) {
                 return (T) Integer.valueOf(rawValue.toString());
-            } else if (type.equals(Short.class)) {
+            } else if (type.equals(Byte.class) || type.equals(byte.class)) {
+                return (T) Byte.valueOf(rawValue.toString());
+            } else if ((type.equals(Character.class) || type.equals(char.class)) && (rawValue instanceof String) && ((String) rawValue).length() == 1) {
+                return (T) Character.valueOf(((String) rawValue).charAt(0));
+            } else if (type.equals(Short.class) || type.equals(short.class)) {
                 return (T) Short.valueOf(rawValue.toString());
-            } else if (type.equals(Float.class)) {
+            } else if (type.equals(Float.class) || type.equals(float.class)) {
                 return (T) Float.valueOf(rawValue.toString());
-            } else if (type.equals(Double.class)) {
+            } else if (type.equals(Double.class) || type.equals(double.class)) {
                 return (T) Double.valueOf(rawValue.toString());
-            } else if (type.equals(Long.class)) {
+            } else if (type.equals(Long.class) || type.equals(long.class)) {
                 return (T) Long.valueOf(rawValue.toString());
             } else if (type.equals(BigInteger.class)) {
                 return (T) new BigInteger(rawValue.toString());
             } else if (type.equals(BigDecimal.class)) {
                 return (T) new BigDecimal(rawValue.toString());
-            } else if (type.equals(Boolean.class) && (rawValue instanceof String)) {
+            } else if ((type.equals(Boolean.class) || type.equals(boolean.class)) && (rawValue instanceof String)) {
                 return (T) Boolean.valueOf(rawValue.toString());
             } else if (type.isAssignableFrom(Date.class)) {
                 return (T) new ISODateFormat().parse(rawValue.toString());

--- a/liquibase-standard/src/main/java/liquibase/parser/core/ParsedNode.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/core/ParsedNode.java
@@ -254,7 +254,7 @@ public class ParsedNode {
                 return (T) new BigInteger(rawValue.toString());
             } else if (type.equals(BigDecimal.class)) {
                 return (T) new BigDecimal(rawValue.toString());
-            } else if ((type.equals(Boolean.class) || type.equals(boolean.class)) && (rawValue instanceof String)) {
+            } else if ((type.equals(Boolean.class) || type.equals(boolean.class))) {
                 return (T) Boolean.valueOf(rawValue.toString());
             } else if (type.isAssignableFrom(Date.class)) {
                 return (T) new ISODateFormat().parse(rawValue.toString());

--- a/liquibase-standard/src/test/groovy/liquibase/change/ChangeParameterMetaDataConversionTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/ChangeParameterMetaDataConversionTest.groovy
@@ -1,0 +1,316 @@
+package liquibase.change
+
+import liquibase.ExtensibleObject
+import liquibase.ObjectMetaData
+import liquibase.change.visitor.ChangeVisitor
+import liquibase.changelog.ChangeSet
+import liquibase.database.Database
+import liquibase.exception.RollbackImpossibleException
+import liquibase.exception.SetupException
+import liquibase.exception.ValidationErrors
+import liquibase.exception.Warnings
+import liquibase.parser.core.ParsedNode
+import liquibase.parser.core.ParsedNodeException
+import liquibase.resource.ResourceAccessor
+import liquibase.serializer.LiquibaseSerializable
+import liquibase.statement.SqlStatement
+import liquibase.structure.DatabaseObject
+import spock.lang.Specification
+
+class ChangeParameterMetaDataConversionTest extends Specification {
+
+    def "supports invoking primitive setter with boxed values"() {
+        given:
+        def change = new PrimitiveSettersChange()
+        def metaData = new ChangeParameterMetaData(change, parameterName, parameterName, "", new HashMap<String, Object>(), "", type, new String[0], new String[0], "", LiquibaseSerializable.SerializationType.DIRECT_VALUE)
+
+        and:
+        metaData.setValue(change, boxedValue)
+
+        expect:
+        getter(change) == expectedResult
+
+        where:
+        parameterName | type          | boxedValue                    | getter                                           | expectedResult
+        "aBool"       | boolean.class | Boolean.TRUE                  | { PrimitiveSettersChange it -> it.isaBool() }    | true
+        "aByte"       | byte.class    | Byte.valueOf((byte) 10)       | { PrimitiveSettersChange it -> it.getaByte() }   | (byte) 10
+        "aChar"       | char.class    | Character.valueOf((char) 'a') | { PrimitiveSettersChange it -> it.getaChar() }   | (char) 'a'
+        "aDouble"     | double.class  | Double.valueOf(20.0d)         | { PrimitiveSettersChange it -> it.getaDouble() } | 20.0d
+        "aFloat"      | float.class   | Float.valueOf(30.0f)          | { PrimitiveSettersChange it -> it.getaFloat() }  | 30.0f
+        "anInt"       | int.class     | Integer.valueOf(40)           | { PrimitiveSettersChange it -> it.getanInt() }   | 40
+        "aLong"       | long.class    | Long.valueOf(50L)             | { PrimitiveSettersChange it -> it.getaLong() }   | 50L
+        "aShort"      | short.class   | Short.valueOf((short) 60)     | { PrimitiveSettersChange it -> it.getaShort() }  | (short) 60
+    }
+
+}
+
+
+class PrimitiveSettersChange implements Change {
+    private boolean aBool;
+    private byte aByte;
+    private char aChar;
+    private double aDouble;
+    private float aFloat;
+    private int anInt;
+    private long aLong;
+    private short aShort;
+
+    public boolean isaBool() {
+        return aBool;
+    }
+
+    public void setaBool(boolean aBool) {
+        this.aBool = aBool;
+    }
+
+    public byte getaByte() {
+        return aByte;
+    }
+
+    public void setaByte(byte aByte) {
+        this.aByte = aByte;
+    }
+
+    public char getaChar() {
+        return aChar;
+    }
+
+    public void setaChar(char aChar) {
+        this.aChar = aChar;
+    }
+
+    public double getaDouble() {
+        return aDouble;
+    }
+
+    public void setaDouble(double aDouble) {
+        this.aDouble = aDouble;
+    }
+
+    public float getaFloat() {
+        return aFloat;
+    }
+
+    public void setaFloat(float aFloat) {
+        this.aFloat = aFloat;
+    }
+
+    public int getanInt() {
+        return anInt;
+    }
+
+    public void setanInt(int anInt) {
+        this.anInt = anInt;
+    }
+
+    public long getaLong() {
+        return aLong;
+    }
+
+    public void setaLong(long aLong) {
+        this.aLong = aLong;
+    }
+
+    public short getaShort() {
+        return aShort;
+    }
+
+    public void setaShort(short aShort) {
+        this.aShort = aShort;
+    }
+
+    @Override
+    public SortedSet<String> getAttributes() {
+        return null;
+    }
+
+    @Override
+    public ObjectMetaData getObjectMetaData() {
+        return null;
+    }
+
+    @Override
+    public boolean has(String attribute) {
+        return false;
+    }
+
+    @Override
+    public List getValuePath(String attributePath, Class lastType) {
+        return null;
+    }
+
+    @Override
+    public <T> T get(String attribute, Class<T> type) {
+        return null;
+    }
+
+    @Override
+    public <T> T get(String attribute, T defaultValue) {
+        return null;
+    }
+
+    @Override
+    public ExtensibleObject set(String attribute, Object value) {
+        return null;
+    }
+
+    @Override
+    public String describe() {
+        return null;
+    }
+
+    @Override
+    public Object clone() {
+        return null;
+    }
+
+    @Override
+    public void finishInitialization() throws SetupException {
+
+    }
+
+    @Override
+    public ChangeMetaData createChangeMetaData() {
+        return null;
+    }
+
+    @Override
+    public ChangeSet getChangeSet() {
+        return null;
+    }
+
+    @Override
+    public void setChangeSet(ChangeSet changeSet) {
+
+    }
+
+    @Override
+    public void setResourceAccessor(ResourceAccessor resourceAccessor) {
+
+    }
+
+    @Override
+    public boolean supports(Database database) {
+        return false;
+    }
+
+    @Override
+    public Warnings warn(Database database) {
+        return null;
+    }
+
+    @Override
+    public ValidationErrors validate(Database database) {
+        return null;
+    }
+
+    @Override
+    public Set<DatabaseObject> getAffectedDatabaseObjects(Database database) {
+        return null;
+    }
+
+    @Override
+    public CheckSum generateCheckSum() {
+        return null;
+    }
+
+    @Override
+    public String getConfirmationMessage() {
+        return null;
+    }
+
+    @Override
+    public SqlStatement[] generateStatements(Database database) {
+        return new SqlStatement[0];
+    }
+
+    @Override
+    public boolean generateStatementsVolatile(Database database) {
+        return false;
+    }
+
+    @Override
+    public boolean supportsRollback(Database database) {
+        return false;
+    }
+
+    @Override
+    public SqlStatement[] generateRollbackStatements(Database database) throws RollbackImpossibleException {
+        return new SqlStatement[0];
+    }
+
+    @Override
+    public boolean generateRollbackStatementsVolatile(Database database) {
+        return false;
+    }
+
+    @Override
+    public ChangeStatus checkStatus(Database database) {
+        return null;
+    }
+
+    @Override
+    public String getDescription() {
+        return null;
+    }
+
+    @Override
+    public void modify(ChangeVisitor changeVisitor) throws ParsedNodeException {
+
+    }
+
+    @Override
+    public String getSerializedObjectName() {
+        return null;
+    }
+
+    @Override
+    public Set<String> getSerializableFields() {
+        return null;
+    }
+
+    @Override
+    public Object getSerializableFieldValue(String field) {
+        return null;
+    }
+
+    @Override
+    public SerializationType getSerializableFieldType(String field) {
+        return null;
+    }
+
+    @Override
+    public String getSerializableFieldNamespace(String field) {
+        return null;
+    }
+
+    @Override
+    public String getSerializedObjectNamespace() {
+        return null;
+    }
+
+    @Override
+    public void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException {
+
+    }
+
+    @Override
+    public ParsedNode serialize() throws ParsedNodeException {
+        return null;
+    }
+
+
+    @Override
+    public String toString() {
+        return "PrimitiveSettersChange{" +
+                "aBool=" + aBool +
+                ", aByte=" + aByte +
+                ", aChar=" + aChar +
+                ", aDouble=" + aDouble +
+                ", aFloat=" + aFloat +
+                ", anInt=" + anInt +
+                ", aLong=" + aLong +
+                ", aShort=" + aShort +
+                '}';
+    }
+}

--- a/liquibase-standard/src/test/groovy/liquibase/change/ChangeParameterMetaDataConversionTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/ChangeParameterMetaDataConversionTest.groovy
@@ -1,316 +1,34 @@
 package liquibase.change
 
-import liquibase.ExtensibleObject
-import liquibase.ObjectMetaData
-import liquibase.change.visitor.ChangeVisitor
-import liquibase.changelog.ChangeSet
-import liquibase.database.Database
-import liquibase.exception.RollbackImpossibleException
-import liquibase.exception.SetupException
-import liquibase.exception.ValidationErrors
-import liquibase.exception.Warnings
-import liquibase.parser.core.ParsedNode
-import liquibase.parser.core.ParsedNodeException
-import liquibase.resource.ResourceAccessor
+import com.example.liquibase.change.ChangeWithPrimitiveFields
 import liquibase.serializer.LiquibaseSerializable
-import liquibase.statement.SqlStatement
-import liquibase.structure.DatabaseObject
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class ChangeParameterMetaDataConversionTest extends Specification {
 
-    def "supports invoking primitive setter with boxed values"() {
-        given:
-        def change = new PrimitiveSettersChange()
+    @Unroll
+    def "supports invoking primitive setter with #boxedValue boxed value and expect #expectedResult"() {
+        when:
+        def change = new ChangeWithPrimitiveFields()
         def metaData = new ChangeParameterMetaData(change, parameterName, parameterName, "", new HashMap<String, Object>(), "", type, new String[0], new String[0], "", LiquibaseSerializable.SerializationType.DIRECT_VALUE)
 
         and:
         metaData.setValue(change, boxedValue)
 
-        expect:
+        then:
         getter(change) == expectedResult
 
         where:
         parameterName | type          | boxedValue                    | getter                                           | expectedResult
-        "aBool"       | boolean.class | Boolean.TRUE                  | { PrimitiveSettersChange it -> it.isaBool() }    | true
-        "aByte"       | byte.class    | Byte.valueOf((byte) 10)       | { PrimitiveSettersChange it -> it.getaByte() }   | (byte) 10
-        "aChar"       | char.class    | Character.valueOf((char) 'a') | { PrimitiveSettersChange it -> it.getaChar() }   | (char) 'a'
-        "aDouble"     | double.class  | Double.valueOf(20.0d)         | { PrimitiveSettersChange it -> it.getaDouble() } | 20.0d
-        "aFloat"      | float.class   | Float.valueOf(30.0f)          | { PrimitiveSettersChange it -> it.getaFloat() }  | 30.0f
-        "anInt"       | int.class     | Integer.valueOf(40)           | { PrimitiveSettersChange it -> it.getanInt() }   | 40
-        "aLong"       | long.class    | Long.valueOf(50L)             | { PrimitiveSettersChange it -> it.getaLong() }   | 50L
-        "aShort"      | short.class   | Short.valueOf((short) 60)     | { PrimitiveSettersChange it -> it.getaShort() }  | (short) 60
+        "aBoolean"       | boolean.class | Boolean.TRUE                  | { ChangeWithPrimitiveFields it -> it.isaBoolean() }    | true
+        "aByte"       | byte.class    | Byte.valueOf((byte) 10)       | { ChangeWithPrimitiveFields it -> it.getaByte() }   | (byte) 10
+        "aChar"       | char.class    | Character.valueOf((char) 'a') | { ChangeWithPrimitiveFields it -> it.getaChar() }   | (char) 'a'
+        "aDouble"     | double.class  | Double.valueOf(20.0d)         | { ChangeWithPrimitiveFields it -> it.getaDouble() } | 20.0d
+        "aFloat"      | float.class   | Float.valueOf(30.0f)          | { ChangeWithPrimitiveFields it -> it.getaFloat() }  | 30.0f
+        "anInt"       | int.class     | Integer.valueOf(40)           | { ChangeWithPrimitiveFields it -> it.getAnInt() }   | 40
+        "aLong"       | long.class    | Long.valueOf(50L)             | { ChangeWithPrimitiveFields it -> it.getaLong() }   | 50L
+        "aShort"      | short.class   | Short.valueOf((short) 60)     | { ChangeWithPrimitiveFields it -> it.getaShort() }  | (short) 60
     }
 
-}
-
-
-class PrimitiveSettersChange implements Change {
-    private boolean aBool;
-    private byte aByte;
-    private char aChar;
-    private double aDouble;
-    private float aFloat;
-    private int anInt;
-    private long aLong;
-    private short aShort;
-
-    public boolean isaBool() {
-        return aBool;
-    }
-
-    public void setaBool(boolean aBool) {
-        this.aBool = aBool;
-    }
-
-    public byte getaByte() {
-        return aByte;
-    }
-
-    public void setaByte(byte aByte) {
-        this.aByte = aByte;
-    }
-
-    public char getaChar() {
-        return aChar;
-    }
-
-    public void setaChar(char aChar) {
-        this.aChar = aChar;
-    }
-
-    public double getaDouble() {
-        return aDouble;
-    }
-
-    public void setaDouble(double aDouble) {
-        this.aDouble = aDouble;
-    }
-
-    public float getaFloat() {
-        return aFloat;
-    }
-
-    public void setaFloat(float aFloat) {
-        this.aFloat = aFloat;
-    }
-
-    public int getanInt() {
-        return anInt;
-    }
-
-    public void setanInt(int anInt) {
-        this.anInt = anInt;
-    }
-
-    public long getaLong() {
-        return aLong;
-    }
-
-    public void setaLong(long aLong) {
-        this.aLong = aLong;
-    }
-
-    public short getaShort() {
-        return aShort;
-    }
-
-    public void setaShort(short aShort) {
-        this.aShort = aShort;
-    }
-
-    @Override
-    public SortedSet<String> getAttributes() {
-        return null;
-    }
-
-    @Override
-    public ObjectMetaData getObjectMetaData() {
-        return null;
-    }
-
-    @Override
-    public boolean has(String attribute) {
-        return false;
-    }
-
-    @Override
-    public List getValuePath(String attributePath, Class lastType) {
-        return null;
-    }
-
-    @Override
-    public <T> T get(String attribute, Class<T> type) {
-        return null;
-    }
-
-    @Override
-    public <T> T get(String attribute, T defaultValue) {
-        return null;
-    }
-
-    @Override
-    public ExtensibleObject set(String attribute, Object value) {
-        return null;
-    }
-
-    @Override
-    public String describe() {
-        return null;
-    }
-
-    @Override
-    public Object clone() {
-        return null;
-    }
-
-    @Override
-    public void finishInitialization() throws SetupException {
-
-    }
-
-    @Override
-    public ChangeMetaData createChangeMetaData() {
-        return null;
-    }
-
-    @Override
-    public ChangeSet getChangeSet() {
-        return null;
-    }
-
-    @Override
-    public void setChangeSet(ChangeSet changeSet) {
-
-    }
-
-    @Override
-    public void setResourceAccessor(ResourceAccessor resourceAccessor) {
-
-    }
-
-    @Override
-    public boolean supports(Database database) {
-        return false;
-    }
-
-    @Override
-    public Warnings warn(Database database) {
-        return null;
-    }
-
-    @Override
-    public ValidationErrors validate(Database database) {
-        return null;
-    }
-
-    @Override
-    public Set<DatabaseObject> getAffectedDatabaseObjects(Database database) {
-        return null;
-    }
-
-    @Override
-    public CheckSum generateCheckSum() {
-        return null;
-    }
-
-    @Override
-    public String getConfirmationMessage() {
-        return null;
-    }
-
-    @Override
-    public SqlStatement[] generateStatements(Database database) {
-        return new SqlStatement[0];
-    }
-
-    @Override
-    public boolean generateStatementsVolatile(Database database) {
-        return false;
-    }
-
-    @Override
-    public boolean supportsRollback(Database database) {
-        return false;
-    }
-
-    @Override
-    public SqlStatement[] generateRollbackStatements(Database database) throws RollbackImpossibleException {
-        return new SqlStatement[0];
-    }
-
-    @Override
-    public boolean generateRollbackStatementsVolatile(Database database) {
-        return false;
-    }
-
-    @Override
-    public ChangeStatus checkStatus(Database database) {
-        return null;
-    }
-
-    @Override
-    public String getDescription() {
-        return null;
-    }
-
-    @Override
-    public void modify(ChangeVisitor changeVisitor) throws ParsedNodeException {
-
-    }
-
-    @Override
-    public String getSerializedObjectName() {
-        return null;
-    }
-
-    @Override
-    public Set<String> getSerializableFields() {
-        return null;
-    }
-
-    @Override
-    public Object getSerializableFieldValue(String field) {
-        return null;
-    }
-
-    @Override
-    public SerializationType getSerializableFieldType(String field) {
-        return null;
-    }
-
-    @Override
-    public String getSerializableFieldNamespace(String field) {
-        return null;
-    }
-
-    @Override
-    public String getSerializedObjectNamespace() {
-        return null;
-    }
-
-    @Override
-    public void load(ParsedNode parsedNode, ResourceAccessor resourceAccessor) throws ParsedNodeException {
-
-    }
-
-    @Override
-    public ParsedNode serialize() throws ParsedNodeException {
-        return null;
-    }
-
-
-    @Override
-    public String toString() {
-        return "PrimitiveSettersChange{" +
-                "aBool=" + aBool +
-                ", aByte=" + aByte +
-                ", aChar=" + aChar +
-                ", aDouble=" + aDouble +
-                ", aFloat=" + aFloat +
-                ", anInt=" + anInt +
-                ", aLong=" + aLong +
-                ", aShort=" + aShort +
-                '}';
-    }
 }

--- a/liquibase-standard/src/test/groovy/liquibase/parser/core/ParsedNodeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/parser/core/ParsedNodeTest.groovy
@@ -325,21 +325,22 @@ class ParsedNodeTest extends Specification {
         result == expectedResult
 
         where:
-        input      | targetType      | expectedResult
-        "true"     | Boolean.class   | Boolean.TRUE
-        (byte) 10  | Byte.class      | Byte.valueOf((byte) 10)
-        "10"       | Byte.class      | Byte.valueOf((byte) 10)
-        (short) 20 | Short.class     | Short.valueOf((short) 20)
-        "20"       | Short.class     | Short.valueOf((short) 20)
-        30         | Integer.class   | Integer.valueOf(30)
-        "30"       | Integer.class   | Integer.valueOf(30)
-        40L        | Long.class      | Long.valueOf(40L)
-        "40"       | Long.class      | Long.valueOf(40L)
-        50.0f      | Float.class     | Float.valueOf(50.0f)
-        "50.0"     | Float.class     | Float.valueOf(50.0f)
-        60.0d      | Double.class    | Double.valueOf(60.0d)
-        "60.0"     | Double.class    | Double.valueOf(60.0d)
-        "a"        | Character.class | Character.valueOf((char) 'a')
+        input        | targetType      | expectedResult
+        Boolean.TRUE | Boolean.class   | Boolean.TRUE
+        "true"       | Boolean.class   | Boolean.TRUE
+        (byte) 10    | Byte.class      | Byte.valueOf((byte) 10)
+        "10"         | Byte.class      | Byte.valueOf((byte) 10)
+        (short) 20   | Short.class     | Short.valueOf((short) 20)
+        "20"         | Short.class     | Short.valueOf((short) 20)
+        30           | Integer.class   | Integer.valueOf(30)
+        "30"         | Integer.class   | Integer.valueOf(30)
+        40L          | Long.class      | Long.valueOf(40L)
+        "40"         | Long.class      | Long.valueOf(40L)
+        50.0f        | Float.class     | Float.valueOf(50.0f)
+        "50.0"       | Float.class     | Float.valueOf(50.0f)
+        60.0d        | Double.class    | Double.valueOf(60.0d)
+        "60.0"       | Double.class    | Double.valueOf(60.0d)
+        "a"          | Character.class | Character.valueOf((char) 'a')
     }
 
     def "converts values to primitive types"() {
@@ -351,6 +352,7 @@ class ParsedNodeTest extends Specification {
 
         where:
         input                     | targetType    | expectedResult
+        Boolean.TRUE              | boolean.class | Boolean.TRUE
         "true"                    | boolean.class | true
         Byte.valueOf((byte) 10)   | byte.class    | (byte) 10
         "10"                      | byte.class    | (byte) 10

--- a/liquibase-standard/src/test/groovy/liquibase/parser/core/ParsedNodeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/parser/core/ParsedNodeTest.groovy
@@ -316,4 +316,42 @@ class ParsedNodeTest extends Specification {
         thrown(ParsedNodeException)
 
     }
+
+    def "converts values to boxed types"() {
+        when:
+        def result = new ParsedNode(null, "root").convertObject(input, targetType)
+
+        then:
+        result == expectedResult
+
+        where:
+        input      | targetType      | expectedResult
+        "true"     | Boolean.class   | Boolean.TRUE
+        (byte) 10  | Byte.class      | Byte.valueOf((byte) 10)
+        (short) 20 | Short.class     | Short.valueOf((short) 20)
+        30         | Integer.class   | Integer.valueOf(30)
+        40L        | Long.class      | Long.valueOf(40L)
+        50.0f      | Float.class     | Float.valueOf(50.0f)
+        60.0d      | Double.class    | Double.valueOf(60.0d)
+        "a"        | Character.class | Character.valueOf((char) 'a')
+    }
+
+    def "converts values to primitive types"() {
+        when:
+        def result = new ParsedNode(null, "root").convertObject(input, targetType)
+
+        then:
+        result == expectedResult
+
+        where:
+        input                     | targetType    | expectedResult
+        "true"                    | boolean.class | true
+        Byte.valueOf((byte) 10)   | byte.class    | (byte) 10
+        Short.valueOf((short) 20) | short.class   | (short) 20
+        Integer.valueOf(30)       | int.class     | 30
+        Long.valueOf(40L)         | long.class    | 40L
+        Float.valueOf(50.0f)      | float.class   | 50.0f
+        Double.valueOf(60.0d)     | double.class  | 60.0d
+        "a"                       | char.class    | (char) 'a'
+    }
 }

--- a/liquibase-standard/src/test/groovy/liquibase/parser/core/ParsedNodeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/parser/core/ParsedNodeTest.groovy
@@ -165,7 +165,7 @@ class ParsedNodeTest extends Specification {
                 .addChild(null, "trueValue", true)
                 .addChild(null, "falseValue", false)
                 .addChild(null, "dateTimeString", "2017-02-20 12:31:55")
-                .addChild(null, "dateTimeValue", new ISODateFormat().parse("2013-11-17 19:44:21"));
+                .addChild(null, "dateTimeValue", new ISODateFormat().parse("2013-11-17 19:44:21"))
 
         then:
         assert node.getChildValue(null, attr, type) == expectedValue
@@ -317,7 +317,8 @@ class ParsedNodeTest extends Specification {
 
     }
 
-    def "converts values to boxed types"() {
+    @Unroll
+    def "converts value to boxed types"() {
         when:
         def result = new ParsedNode(null, "root").convertObject(input, targetType)
 
@@ -343,6 +344,7 @@ class ParsedNodeTest extends Specification {
         "a"          | Character.class | Character.valueOf((char) 'a')
     }
 
+    @Unroll
     def "converts values to primitive types"() {
         when:
         def result = new ParsedNode(null, "root").convertObject(input, targetType)

--- a/liquibase-standard/src/test/groovy/liquibase/parser/core/ParsedNodeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/parser/core/ParsedNodeTest.groovy
@@ -328,11 +328,17 @@ class ParsedNodeTest extends Specification {
         input      | targetType      | expectedResult
         "true"     | Boolean.class   | Boolean.TRUE
         (byte) 10  | Byte.class      | Byte.valueOf((byte) 10)
+        "10"       | Byte.class      | Byte.valueOf((byte) 10)
         (short) 20 | Short.class     | Short.valueOf((short) 20)
+        "20"       | Short.class     | Short.valueOf((short) 20)
         30         | Integer.class   | Integer.valueOf(30)
+        "30"       | Integer.class   | Integer.valueOf(30)
         40L        | Long.class      | Long.valueOf(40L)
+        "40"       | Long.class      | Long.valueOf(40L)
         50.0f      | Float.class     | Float.valueOf(50.0f)
+        "50.0"     | Float.class     | Float.valueOf(50.0f)
         60.0d      | Double.class    | Double.valueOf(60.0d)
+        "60.0"     | Double.class    | Double.valueOf(60.0d)
         "a"        | Character.class | Character.valueOf((char) 'a')
     }
 
@@ -347,11 +353,17 @@ class ParsedNodeTest extends Specification {
         input                     | targetType    | expectedResult
         "true"                    | boolean.class | true
         Byte.valueOf((byte) 10)   | byte.class    | (byte) 10
+        "10"                      | byte.class    | (byte) 10
         Short.valueOf((short) 20) | short.class   | (short) 20
+        "20"                      | short.class   | (short) 20
         Integer.valueOf(30)       | int.class     | 30
+        "30"                      | int.class     | 30
         Long.valueOf(40L)         | long.class    | 40L
+        "40"                      | long.class    | 40L
         Float.valueOf(50.0f)      | float.class   | 50.0f
+        "50.0"                    | float.class   | 50.0f
         Double.valueOf(60.0d)     | double.class  | 60.0d
+        "60.0"                    | double.class  | 60.0d
         "a"                       | char.class    | (char) 'a'
     }
 }

--- a/liquibase-standard/src/test/groovy/liquibase/parser/core/xml/XMLChangeLogSAXParser_RealFile_Test.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/parser/core/xml/XMLChangeLogSAXParser_RealFile_Test.groovy
@@ -787,7 +787,7 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
         change1.getColumns().get(0).getType() == "int"
     }
 
-    def "parsesChangeWithPrimitiveFields"() {
+    def "parses change with primitive fields"() {
         given:
         Scope.getCurrentScope().getSingleton(ChangeFactory.class).register(new ChangeWithPrimitiveFields())
 
@@ -802,7 +802,13 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
         def changes = changeSets.first().getChanges()
         assert changes.size() == 1
         def change = changes.first() as ChangeWithPrimitiveFields
-        assert change.aBoolean && change.anInt == 42 && change.aChar == (char) 'b'
+        assert change.aBoolean
+        assert change.aChar == (char) 'b'
+        assert change.aDouble == 0.42d
+        assert change.aFloat == 4.2f
+        assert change.anInt == 42
+        assert change.aLong == 420L
+        assert change.aShort == (short) 4200
     }
 
 }

--- a/liquibase-standard/src/test/groovy/liquibase/parser/core/xml/XMLChangeLogSAXParser_RealFile_Test.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/parser/core/xml/XMLChangeLogSAXParser_RealFile_Test.groovy
@@ -57,7 +57,7 @@ import spock.lang.Unroll
 import static org.hamcrest.Matchers.containsInAnyOrder
 import static spock.util.matcher.HamcrestSupport.that
 
-public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
+class XMLChangeLogSAXParser_RealFile_Test extends Specification {
 
     @Shared resourceSupplier = new ResourceSupplier()
 
@@ -86,8 +86,8 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
         def path = "liquibase/parser/core/xml/simpleChangeLog.xml"
         when:
         def changeLog = new XMLChangeLogSAXParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor());
-        def changeSet = changeLog.changeSets[0];
-        def change = changeSet.changes[0];
+        def changeSet = changeLog.changeSets[0]
+        def change = changeSet.changes[0]
 
         then:
         changeLog.getLogicalFilePath() == path
@@ -338,28 +338,28 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
         changeLog.getPreconditions().getNestedPreconditions().size() == 0
         changeLog.getChangeSets().size() == 1
 
-        ChangeSet changeSet = changeLog.getChangeSets()[0];
+        ChangeSet changeSet = changeLog.getChangeSets()[0]
         changeSet.getAuthor() == "nvoxland"
         changeSet.getId() == "1"
         changeSet.getChanges().size() == 1
         changeSet.getFilePath() == path
         changeSet.getComments() == "Some comments go here"
 
-        Change change = changeSet.getChanges()[0];
+        Change change = changeSet.getChanges()[0]
         Scope.getCurrentScope().getSingleton(ChangeFactory.class).getChangeMetaData(change).getName() == "createTable"
         assert change instanceof CreateTableChange
     }
 
 	def "changeLog parameters are correctly expanded"() throws Exception {
         when:
-        def params = new ChangeLogParameters(new MockDatabase());
+        def params = new ChangeLogParameters(new MockDatabase())
         params.setContexts(new Contexts("prod"))
-		params.set("tablename", "my_table_name");
-        params.set("tablename2", "my_table_name_2");
-        params.set("columnName", "my_column_name");
-        params.set("date", new Date(9999999));
+		params.set("tablename", "my_table_name")
+        params.set("tablename2", "my_table_name_2")
+        params.set("columnName", "my_column_name")
+        params.set("date", new Date(9999999))
         params.set("overridden", "Value passed in")
-		def changeLog = new XMLChangeLogSAXParser().parse("liquibase/parser/core/xml/parametersChangeLog.xml", params, new JUnitResourceAccessor());
+		def changeLog = new XMLChangeLogSAXParser().parse("liquibase/parser/core/xml/parametersChangeLog.xml", params, new JUnitResourceAccessor())
 
         then: "changeSet 1"
 		changeLog.getChangeSets().size() == 2
@@ -401,17 +401,17 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
 	def "tests for particular features and edge conditions part 1 testCasesChangeLog.xml"() throws Exception {
         when:
         def path = "liquibase/parser/core/xml/testCasesChangeLog.xml"
-        DatabaseChangeLog changeLog = new XMLChangeLogSAXParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor());
+        DatabaseChangeLog changeLog = new XMLChangeLogSAXParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then: "before/after/position attributes are read correctly"
-        ((AddColumnChange) changeLog.getChangeSet(path, "cmouttet", "using after column attribute").changes[0]).columns[0].getName() == "middlename";
-        ((AddColumnChange) changeLog.getChangeSet(path, "cmouttet", "using after column attribute").changes[0]).columns[0].getAfterColumn() == "firstname";
+        ((AddColumnChange) changeLog.getChangeSet(path, "cmouttet", "using after column attribute").changes[0]).columns[0].getName() == "middlename"
+        ((AddColumnChange) changeLog.getChangeSet(path, "cmouttet", "using after column attribute").changes[0]).columns[0].getAfterColumn() == "firstname"
 
-        ((AddColumnChange) changeLog.getChangeSet(path, "cmouttet", "using before column attribute").changes[0]).columns[0].getName() == "middlename";
-        ((AddColumnChange) changeLog.getChangeSet(path, "cmouttet", "using before column attribute").changes[0]).columns[0].getBeforeColumn() == "lastname";
+        ((AddColumnChange) changeLog.getChangeSet(path, "cmouttet", "using before column attribute").changes[0]).columns[0].getName() == "middlename"
+        ((AddColumnChange) changeLog.getChangeSet(path, "cmouttet", "using before column attribute").changes[0]).columns[0].getBeforeColumn() == "lastname"
 
-        ((AddColumnChange) changeLog.getChangeSet(path, "cmouttet", "using position attribute").changes[0]).columns[0].getName() == "middlename";
-        ((AddColumnChange) changeLog.getChangeSet(path, "cmouttet", "using position attribute").changes[0]).columns[0].getPosition() == 1;
+        ((AddColumnChange) changeLog.getChangeSet(path, "cmouttet", "using position attribute").changes[0]).columns[0].getName() == "middlename"
+        ((AddColumnChange) changeLog.getChangeSet(path, "cmouttet", "using position attribute").changes[0]).columns[0].getPosition() == 1
 
         and: "validCheckSums are parsed"
         that changeLog.getChangeSet(path, "nvoxland", "validCheckSums set").getValidCheckSums(), containsInAnyOrder([CheckSum.parse("a9b7b29ce3a75940858cd022501852e2"), CheckSum.parse("8:b3d6a29ce3a75940858cd093501151d1")].toArray())
@@ -552,7 +552,7 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
         def path = "liquibase/parser/core/xml/testCasesChangeLog.xml"
         def params = new ChangeLogParameters()
         params.set("loginUser", "sa")
-        DatabaseChangeLog changeLog = new XMLChangeLogSAXParser().parse(path, params, new JUnitResourceAccessor());
+        DatabaseChangeLog changeLog = new XMLChangeLogSAXParser().parse(path, params, new JUnitResourceAccessor())
 
 
         then: "complex preconditions are parsed"
@@ -642,7 +642,7 @@ public class XMLChangeLogSAXParser_RealFile_Test extends Specification {
     def "changelog with multiple dropColumn columns can be parsed"() throws Exception {
         when:
         def path = "liquibase/parser/core/xml/addDropColumnsChangeLog.xml"
-        def changeLog = new XMLChangeLogSAXParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor());
+        def changeLog = new XMLChangeLogSAXParser().parse(path, new ChangeLogParameters(), new JUnitResourceAccessor())
 
         then:  "add columns"
         assert 2 == changeLog.getChangeSets().get(1).getChanges().get(0).getColumns().size()

--- a/liquibase-standard/src/test/groovy/liquibase/parser/core/xml/XMLChangeLogSAXParser_RealFile_Test.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/parser/core/xml/XMLChangeLogSAXParser_RealFile_Test.groovy
@@ -809,6 +809,9 @@ class XMLChangeLogSAXParser_RealFile_Test extends Specification {
         assert change.anInt == 42
         assert change.aLong == 420L
         assert change.aShort == (short) 4200
+
+        cleanup:
+        Scope.getCurrentScope().getSingleton(ChangeFactory.class).unregister("primitiveChange")
     }
 
 }

--- a/liquibase-standard/src/test/groovy/liquibase/resource/ClassLoaderResourceAccessorTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/resource/ClassLoaderResourceAccessorTest.groovy
@@ -78,6 +78,7 @@ class ClassLoaderResourceAccessorTest extends Specification {
                                 "com/example/file with space.txt",
                                 "com/example/file-in-jar.txt",
                                 "com/example/jar/file-in-jar.txt",
+                                "com/example/liquibase/change/ChangeWithPrimitiveFields.class",
                                 "com/example/file-in-zip.txt",
                                 "com/example/liquibase/change/ColumnConfig.class",
                                 "com/example/liquibase/change/ComputedConfig.class",

--- a/liquibase-standard/src/test/groovy/liquibase/resource/DirectoryResourceAccessorTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/resource/DirectoryResourceAccessorTest.groovy
@@ -137,6 +137,7 @@ class DirectoryResourceAccessorTest extends Specification {
                                      "com/example/everywhere/file-everywhere.txt",
                                      "com/example/everywhere/other-file-everywhere.txt",
                                      "com/example/file with space.txt",
+                                     "com/example/liquibase/change/ChangeWithPrimitiveFields.class",
                                      "com/example/liquibase/change/ColumnConfig.class",
                                      "com/example/liquibase/change/ComputedConfig.class",
                                      "com/example/liquibase/change/CreateTableExampleChange.class",

--- a/liquibase-standard/src/test/groovy/liquibase/resource/FileSystemResourceAccessorTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/resource/FileSystemResourceAccessorTest.groovy
@@ -108,6 +108,7 @@ class FileSystemResourceAccessorTest extends Specification {
                                      "com/example/everywhere/file-everywhere.txt",
                                      "com/example/everywhere/other-file-everywhere.txt",
                                      "com/example/file with space.txt",
+                                     "com/example/liquibase/change/ChangeWithPrimitiveFields.class",
                                      "com/example/liquibase/change/ColumnConfig.class",
                                      "com/example/liquibase/change/ComputedConfig.class",
                                      "com/example/liquibase/change/CreateTableExampleChange.class",

--- a/liquibase-standard/src/test/java/com/example/liquibase/change/ChangeWithPrimitiveFields.java
+++ b/liquibase-standard/src/test/java/com/example/liquibase/change/ChangeWithPrimitiveFields.java
@@ -1,0 +1,53 @@
+package com.example.liquibase.change;
+
+import liquibase.change.AbstractChange;
+import liquibase.change.ChangeMetaData;
+import liquibase.change.DatabaseChange;
+import liquibase.database.Database;
+import liquibase.statement.SqlStatement;
+
+@DatabaseChange(
+        name = "primitiveChange",
+        description = "Used in unit tests",
+        priority = ChangeMetaData.PRIORITY_DEFAULT
+)
+public class ChangeWithPrimitiveFields extends AbstractChange {
+
+    private boolean aBoolean;
+    private char aChar;
+    private int anInt;
+
+    @Override
+    public String getConfirmationMessage() {
+        return "Test confirmation message";
+    }
+
+    @Override
+    public SqlStatement[] generateStatements(Database database) {
+        return SqlStatement.EMPTY_SQL_STATEMENT;
+    }
+
+    public boolean isaBoolean() {
+        return aBoolean;
+    }
+
+    public void setaBoolean(boolean aBoolean) {
+        this.aBoolean = aBoolean;
+    }
+
+    public char getaChar() {
+        return aChar;
+    }
+
+    public void setaChar(char aChar) {
+        this.aChar = aChar;
+    }
+
+    public int getAnInt() {
+        return anInt;
+    }
+
+    public void setAnInt(int anInt) {
+        this.anInt = anInt;
+    }
+}

--- a/liquibase-standard/src/test/java/com/example/liquibase/change/ChangeWithPrimitiveFields.java
+++ b/liquibase-standard/src/test/java/com/example/liquibase/change/ChangeWithPrimitiveFields.java
@@ -14,8 +14,13 @@ import liquibase.statement.SqlStatement;
 public class ChangeWithPrimitiveFields extends AbstractChange {
 
     private boolean aBoolean;
+    private byte aByte;
     private char aChar;
+    private double aDouble;
+    private float aFloat;
     private int anInt;
+    private long aLong;
+    private short aShort;
 
     @Override
     public String getConfirmationMessage() {
@@ -35,6 +40,14 @@ public class ChangeWithPrimitiveFields extends AbstractChange {
         this.aBoolean = aBoolean;
     }
 
+    public byte getaByte() {
+        return aByte;
+    }
+
+    public void setaByte(byte aByte) {
+        this.aByte = aByte;
+    }
+
     public char getaChar() {
         return aChar;
     }
@@ -43,11 +56,43 @@ public class ChangeWithPrimitiveFields extends AbstractChange {
         this.aChar = aChar;
     }
 
+    public double getaDouble() {
+        return aDouble;
+    }
+
+    public void setaDouble(double aDouble) {
+        this.aDouble = aDouble;
+    }
+
+    public float getaFloat() {
+        return aFloat;
+    }
+
+    public void setaFloat(float aFloat) {
+        this.aFloat = aFloat;
+    }
+
     public int getAnInt() {
         return anInt;
     }
 
     public void setAnInt(int anInt) {
         this.anInt = anInt;
+    }
+
+    public long getaLong() {
+        return aLong;
+    }
+
+    public void setaLong(long aLong) {
+        this.aLong = aLong;
+    }
+
+    public short getaShort() {
+        return aShort;
+    }
+
+    public void setaShort(short aShort) {
+        this.aShort = aShort;
     }
 }

--- a/liquibase-standard/src/test/java/com/example/liquibase/change/ChangeWithPrimitiveFields.java
+++ b/liquibase-standard/src/test/java/com/example/liquibase/change/ChangeWithPrimitiveFields.java
@@ -95,4 +95,9 @@ public class ChangeWithPrimitiveFields extends AbstractChange {
     public void setaShort(short aShort) {
         this.aShort = aShort;
     }
+
+    @Override
+    public Object clone() {
+        return super.clone();
+    }
 }

--- a/liquibase-standard/src/test/resources/liquibase/parser/core/xml/primitiveChangeLog.xml
+++ b/liquibase-standard/src/test/resources/liquibase/parser/core/xml/primitiveChangeLog.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <changeSet id="1" author="example">
+        <ext:primitiveChange aBoolean="true" anInt="42" aChar="b" />
+    </changeSet>
+
+</databaseChangeLog>

--- a/liquibase-standard/src/test/resources/liquibase/parser/core/xml/primitiveChangeLog.xml
+++ b/liquibase-standard/src/test/resources/liquibase/parser/core/xml/primitiveChangeLog.xml
@@ -7,7 +7,13 @@
         http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
 
     <changeSet id="1" author="example">
-        <ext:primitiveChange aBoolean="true" anInt="42" aChar="b" />
+        <ext:primitiveChange aBoolean="true"
+                             aChar="b"
+                             aDouble="0.42"
+                             aFloat="4.2"
+                             anInt="42"
+                             aLong="420"
+                             aShort="4200" />
     </changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

This adds support for primitive types, particularly for custom change fields.

## Things to be aware of

It could potentially change the converted value type of existing changes, but that's unlikely as the modified function only returns primitive types if explicitly requested.
Since such requests would fail in the past, I doubt this change will have an impact.

## Things to worry about

Changing existing `Change` subclasses to migrate from boxed types to primitive types is likely a bad idea since it may change the generated check sum.
The general change proposed here is however useful for new changes.

## Additional Context

N/A
