### PR TITLE
DAT-13175 Full automation of OSS extension release

### DIFF
--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -3,50 +3,13 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Liquibase Version'
+        description: 'Version to release (4.26.0, 4.26.1, etc.))'
         required: true
-        type: string
 
 jobs:
-  trigger-release:
-    name: "Trigger Releases"
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        extension:
-          - liquibase-bigquery
-          - liquibase-cache
-          - liquibase-cassandra
-          - liquibase-cosmosdb
-          - liquibase-db2i
-          - liquibase-filechangelog
-          - liquibase-nochangeloglock
-          - liquibase-hanadb
-          - liquibase-hibernate
-          - liquibase-maxdb
-          - liquibase-modify-column
-          - liquibase-mssql
-          - liquibase-oracle
-          - liquibase-postgresql
-          - liquibase-redshift
-          - liquibase-sqlfire
-          - liquibase-teradata
-          - liquibase-vertica
-          - liquibase-yugabytedb
-    steps:
-      - name: Release liquibase/${{ matrix.extension }} v${{ github.event.inputs.version }}
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.BOT_TOKEN }}
-          script: |
-            console.log("Sending liquibase-release event to liquibase/${{ matrix.extension }}");
-
-            await github.rest.repos.createDispatchEvent({
-               "owner": "liquibase",
-               "repo": "${{ matrix.extension }}",
-               "event_type": "liquibase-release",
-               "client_payload": {
-                  "liquibaseVersion": "${{ github.event.inputs.version }}"
-                }
-             });
+  automated-os-extensions-release:
+    uses: liquibase/build-logic/.github/workflows/os-extension-automated-release.yml@v0.5.9
+    secrets: inherit
+    with:
+      version: ${{ inputs.version }}
+      


### PR DESCRIPTION
## Description

chore(release-extensions.yml): update release workflow to use automated OS extension release logic

The release workflow for OS extensions has been updated to use the automated release logic provided by the `os-extension-automated-release.yml` workflow. This change simplifies the workflow and ensures consistency across all OS extensions.

The previous implementation included a matrix strategy to trigger releases for different extensions individually. However, this approach was complex and prone to errors. The new implementation uses a single step that invokes the `os-extension-automated-release.yml` workflow, passing the desired version as an input.

This change improves maintainability and reduces duplication of code. It also ensures that all OS extensions follow the same release process, making it easier to manage and track releases.

Note: The `version` input now accepts a specific version number (e.g., 4.26.0, 4.26.1) instead of the previous "Liquibase Version" description.

