### PR TITLE
Set up SEARCH_PATH only once when running an update command

### DIFF
--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/UpdateSqlCommandStepIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/UpdateSqlCommandStepIntegrationTest.groovy
@@ -1,0 +1,51 @@
+package liquibase.command
+
+import liquibase.Scope
+import liquibase.command.core.UpdateSqlCommandStep
+import liquibase.command.core.helpers.DbUrlConnectionArgumentsCommandStep
+import liquibase.executor.Executor
+import liquibase.executor.ExecutorService
+import liquibase.extension.testing.testsystem.DatabaseTestSystem
+import liquibase.extension.testing.testsystem.TestSystemFactory
+import liquibase.extension.testing.testsystem.spock.LiquibaseIntegrationTest
+import liquibase.statement.core.RawSqlStatement
+import spock.lang.Shared
+import spock.lang.Specification
+
+@LiquibaseIntegrationTest
+class UpdateSqlCommandStepIntegrationTest extends Specification{
+
+    @Shared
+    private DatabaseTestSystem postgres = Scope.currentScope.getSingleton(TestSystemFactory).getTestSystem("postgresql") as DatabaseTestSystem
+
+    def "validate UpdateSql only generates SQL statement to set SEARCH_PATH once"() {
+        when:
+        final Executor executor = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", postgres.getDatabaseFromFactory())
+        def catalogName = postgres.getCatalog()
+        def searchPath = executor.queryForObject(new RawSqlStatement("SHOW SEARCH_PATH"), String.class)
+
+        def outputStream = new ByteArrayOutputStream()
+        def updateSqlCommand = new CommandScope(UpdateSqlCommandStep.COMMAND_NAME)
+        updateSqlCommand.addArgumentValue(DbUrlConnectionArgumentsCommandStep.DATABASE_ARG, postgres.getDatabaseFromFactory())
+        updateSqlCommand.addArgumentValue(UpdateSqlCommandStep.CHANGELOG_FILE_ARG, "liquibase/update-tests.yml")
+        updateSqlCommand.setOutput(outputStream)
+        updateSqlCommand.execute()
+        def generatedSql = outputStream.toString()
+
+        then:
+        countSetSearchPathOccurrences(generatedSql, String.format("SET SEARCH_PATH TO %s, %s;", catalogName, searchPath)) == 0
+        countSetSearchPathOccurrences(generatedSql, String.format("ALTER DATABASE %s SET SEARCH_PATH TO %s;", catalogName, searchPath)) == 1
+    }
+
+    private static int countSetSearchPathOccurrences(String updateSqlOutput, String searchPathSetup) {
+        int count = 0;
+        int index = updateSqlOutput.indexOf(searchPathSetup)
+
+        while (index != -1) {
+            count++;
+            index = updateSqlOutput.indexOf(searchPathSetup, index + 1)
+        }
+
+        return count
+    }
+}

--- a/liquibase-standard/src/main/java/liquibase/command/core/AbstractUpdateCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/AbstractUpdateCommandStep.java
@@ -10,6 +10,7 @@ import liquibase.command.CommandResultsBuilder;
 import liquibase.command.CommandScope;
 import liquibase.command.core.helpers.DatabaseChangelogCommandStep;
 import liquibase.database.Database;
+import liquibase.database.core.PostgresDatabase;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.LiquibaseException;
 import liquibase.exception.LockException;
@@ -67,6 +68,9 @@ public abstract class AbstractUpdateCommandStep extends AbstractCommandStep impl
         resultsBuilder.addResult("updateReport", updateReportParameters);
         CommandScope commandScope = resultsBuilder.getCommandScope();
         Database database = (Database) commandScope.getDependency(Database.class);
+        if(database instanceof PostgresDatabase) {
+            ((PostgresDatabase) database).setSearchPathPermanently();
+        }
         updateReportParameters.getDatabaseInfo().setDatabaseType(database.getDatabaseProductName());
         updateReportParameters.getDatabaseInfo().setVersion(database.getDatabaseProductVersion());
         updateReportParameters.setJdbcUrl(database.getConnection().getURL());

--- a/liquibase-standard/src/main/java/liquibase/database/core/DatabaseUtils.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/DatabaseUtils.java
@@ -92,7 +92,7 @@ public class DatabaseUtils {
             try {
                 searchPath = executor.queryForObject(new RawSqlStatement("SHOW SEARCH_PATH"), String.class);
             } catch (Throwable e) {
-                Scope.getCurrentScope().getLog(DatabaseUtils.class).info("Cannot get search_path", e);
+                Scope.getCurrentScope().getLog(DatabaseUtils.class).warning("Cannot get search_path", e);
             }
 
             if(searchPath != null) {
@@ -117,7 +117,7 @@ public class DatabaseUtils {
                     try {
                         executor.execute(new RawSqlStatement(String.format("ALTER DATABASE %s SET SEARCH_PATH TO %s", database.getLiquibaseCatalogName(), finalSearchPath)));
                     } catch (Throwable e) {
-                        Scope.getCurrentScope().getLog(DatabaseUtils.class).info("Cannot set search_path at database level", e);
+                        Scope.getCurrentScope().getLog(DatabaseUtils.class).severe("Cannot set search_path at database level", e);
                     }
                 }
             }

--- a/liquibase-standard/src/main/java/liquibase/database/core/PostgresDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/PostgresDatabase.java
@@ -1,9 +1,9 @@
 package liquibase.database.core;
 
 import liquibase.CatalogAndSchema;
-import liquibase.GlobalConfiguration;
 import liquibase.Scope;
 import liquibase.changelog.column.LiquibaseColumn;
+import liquibase.configuration.GlobalConfiguration;
 import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.DatabaseConnection;
 import liquibase.database.ObjectQuotingStrategy;
@@ -399,9 +399,6 @@ public class PostgresDatabase extends AbstractJdbcDatabase {
     @Override
     public void rollback() throws DatabaseException {
         super.rollback();
-
-        //Rollback in postgresql resets the search path. Need to put it back to the defaults
-        DatabaseUtils.initializeDatabase(getDefaultCatalogName(), getDefaultSchemaName(), this);
     }
 
     @Override
@@ -415,5 +412,9 @@ public class PostgresDatabase extends AbstractJdbcDatabase {
     @Override
     public boolean supportsCreateIfNotExists(Class<? extends DatabaseObject> type) {
         return type.isAssignableFrom(Table.class);
+    }
+
+    public void setSearchPathPermanently() {
+        DatabaseUtils.initializePostgresSearchPathPermanently(defaultCatalogName, defaultSchemaName, this);
     }
 }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

Fixes #5316.

This PR provides a new `DatabaseUtils` method to set up `SEARCH_PATH` variable permanently when running any update family command. Previously when running a `update-sql` command on a Postgres DB we could see multiple `SET SEARCH_PATH...` statements in the generated SQL output. It seems that was happening because of the `DatabaseUtils.initializeDatabase()` call performed in the `rollback()` method from `PostgresDatabase` implementation. With this change that's not happening anymore, but SQL output will be a bit different now, since what we will see is:
```
ALTER DATABASE lbcat SET SEARCH_PATH TO test_schema_daniel, "$user","public";   
```
only once.

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of
- This a Postgres specific change.
<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about
- I guess we might need to apply the same logic in PRO (`update-one-changeset`) if we are happy with these changes. 
<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
