### PR TITLE
Proposed fix for #5442 - command "unexpectedChangesets" always reports at least 1 unexpected changeset with initial tag in database

### DIFF
--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/core/UnexpectedChangeSetIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/core/UnexpectedChangeSetIntegrationTest.groovy
@@ -1,0 +1,26 @@
+package liquibase.command.core
+
+import liquibase.Scope
+import liquibase.command.util.CommandUtil
+import liquibase.extension.testing.testsystem.DatabaseTestSystem
+import liquibase.extension.testing.testsystem.TestSystemFactory
+import liquibase.extension.testing.testsystem.spock.LiquibaseIntegrationTest
+import spock.lang.Shared
+import spock.lang.Specification
+
+@LiquibaseIntegrationTest
+class UnexpectedChangeSetIntegrationTest extends Specification{
+
+    @Shared
+    private DatabaseTestSystem mysql = (DatabaseTestSystem) Scope.getCurrentScope().getSingleton(TestSystemFactory.class).getTestSystem("mysql")
+
+    def "validate there is no unexpected changeset reported after an initial tag in the database" () {
+        given:
+        CommandUtil.runTag(mysql,"TestTag")
+        OutputStream outputStream =  new ByteArrayOutputStream();
+        CommandUtil.runUnexpectedChangeSet(mysql,"changelogs/mysql/complete/createtable.and.view.changelog.xml", outputStream)
+
+        expect:
+        outputStream.toString().contains("contains no unexpected changes")
+    }
+}

--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/util/CommandUtil.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/util/CommandUtil.groovy
@@ -153,6 +153,16 @@ class CommandUtil {
         } as Scope.ScopedRunnerWithReturn<Void>)
     }
 
+    static void runUnexpectedChangeSet(DatabaseTestSystem db, String changelog, OutputStream outputStream) {
+        CommandScope commandScope = new CommandScope(UnexpectedChangesetsCommandStep.COMMAND_NAME)
+        commandScope.addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_FILE_ARG, changelog)
+        commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.URL_ARG, db.getConnectionUrl())
+        commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.USERNAME_ARG, db.getUsername())
+        commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.PASSWORD_ARG, db.getPassword())
+        commandScope.setOutput(outputStream)
+        commandScope.execute()
+    }
+
     private static void execUpdateCommandInScope(SearchPathResourceAccessor resourceAccessor, DatabaseTestSystem db, String changelogFile,
                                                  String labels, String contexts, String outputFile) {
         def scopeSettings = [

--- a/liquibase-standard/src/main/java/liquibase/changelog/RanChangeSet.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/RanChangeSet.java
@@ -121,7 +121,7 @@ public class RanChangeSet {
                 && isSamePath(changeSet.getFilePath());
     }
 
-    public boolean isSameAsIgnoreLiquibaseInternalChangeset(ChangeSet changeSet) {
+    public boolean isSameAsOrIsLiquibaseInternalChangeset(ChangeSet changeSet) {
         String ranChangesetPath = DatabaseChangeLog.normalizePath(this.getChangeLog());
         return ranChangesetPath.equalsIgnoreCase("liquibase-internal") || isSameAs(changeSet);
     }

--- a/liquibase-standard/src/main/java/liquibase/changelog/RanChangeSet.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/RanChangeSet.java
@@ -117,7 +117,7 @@ public class RanChangeSet {
 
     public boolean isSameAs(ChangeSet changeSet) {
         String normalizedFilePath = DatabaseChangeLog.normalizePath(this.getChangeLog());
-        return normalizedFilePath.equalsIgnoreCase("liquibase-internal") || (this.getId().equalsIgnoreCase(changeSet.getId())
+        return (this.getId().equalsIgnoreCase(changeSet.getId())
                 && this.getAuthor().equalsIgnoreCase(changeSet.getAuthor())
                 && isSamePath(changeSet.getFilePath(), normalizedFilePath));
     }

--- a/liquibase-standard/src/main/java/liquibase/changelog/RanChangeSet.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/RanChangeSet.java
@@ -119,7 +119,11 @@ public class RanChangeSet {
         return this.getId().equalsIgnoreCase(changeSet.getId())
                 && this.getAuthor().equalsIgnoreCase(changeSet.getAuthor())
                 && isSamePath(changeSet.getFilePath());
+    }
 
+    public boolean isSameAsIgnoreLiquibaseInternalChangeset(ChangeSet changeSet) {
+        String ranChangesetPath = DatabaseChangeLog.normalizePath(this.getChangeLog());
+        return ranChangesetPath.equalsIgnoreCase("liquibase-internal") || isSameAs(changeSet);
     }
 
     /**

--- a/liquibase-standard/src/main/java/liquibase/changelog/RanChangeSet.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/RanChangeSet.java
@@ -116,14 +116,10 @@ public class RanChangeSet {
     }
 
     public boolean isSameAs(ChangeSet changeSet) {
-        return this.getId().equalsIgnoreCase(changeSet.getId())
+        String normalizedFilePath = DatabaseChangeLog.normalizePath(this.getChangeLog());
+        return normalizedFilePath.equalsIgnoreCase("liquibase-internal") || (this.getId().equalsIgnoreCase(changeSet.getId())
                 && this.getAuthor().equalsIgnoreCase(changeSet.getAuthor())
-                && isSamePath(changeSet.getFilePath());
-    }
-
-    public boolean isSameAsOrIsLiquibaseInternalChangeset(ChangeSet changeSet) {
-        String ranChangesetPath = DatabaseChangeLog.normalizePath(this.getChangeLog());
-        return ranChangesetPath.equalsIgnoreCase("liquibase-internal") || isSameAs(changeSet);
+                && isSamePath(changeSet.getFilePath(), normalizedFilePath));
     }
 
     /**
@@ -134,8 +130,8 @@ public class RanChangeSet {
      * @param filePath the file path
      * @return does it somehow match what we have at database?
      */
-    private boolean isSamePath(String filePath) {
-        String normalizedFilePath = DatabaseChangeLog.normalizePath(this.getChangeLog());
+    private boolean isSamePath(String filePath, String normalizedFilePath) {
+        //String normalizedFilePath = DatabaseChangeLog.normalizePath(this.getChangeLog());
         return normalizedFilePath.equalsIgnoreCase(DatabaseChangeLog.normalizePath(filePath))
                 || normalizedFilePath.equalsIgnoreCase(Paths.get(filePath).normalize().toString().replace("\\", "/"));
     }

--- a/liquibase-standard/src/main/java/liquibase/changelog/RanChangeSet.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/RanChangeSet.java
@@ -131,7 +131,6 @@ public class RanChangeSet {
      * @return does it somehow match what we have at database?
      */
     private boolean isSamePath(String filePath, String normalizedFilePath) {
-        //String normalizedFilePath = DatabaseChangeLog.normalizePath(this.getChangeLog());
         return normalizedFilePath.equalsIgnoreCase(DatabaseChangeLog.normalizePath(filePath))
                 || normalizedFilePath.equalsIgnoreCase(Paths.get(filePath).normalize().toString().replace("\\", "/"));
     }

--- a/liquibase-standard/src/main/java/liquibase/changelog/RanChangeSet.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/RanChangeSet.java
@@ -116,10 +116,10 @@ public class RanChangeSet {
     }
 
     public boolean isSameAs(ChangeSet changeSet) {
-        String normalizedFilePath = DatabaseChangeLog.normalizePath(this.getChangeLog());
-        return (this.getId().equalsIgnoreCase(changeSet.getId())
+        return this.getId().equalsIgnoreCase(changeSet.getId())
                 && this.getAuthor().equalsIgnoreCase(changeSet.getAuthor())
-                && isSamePath(changeSet.getFilePath(), normalizedFilePath));
+                && isSamePath(changeSet.getFilePath());
+
     }
 
     /**
@@ -130,7 +130,8 @@ public class RanChangeSet {
      * @param filePath the file path
      * @return does it somehow match what we have at database?
      */
-    private boolean isSamePath(String filePath, String normalizedFilePath) {
+    private boolean isSamePath(String filePath) {
+        String normalizedFilePath = DatabaseChangeLog.normalizePath(this.getChangeLog());
         return normalizedFilePath.equalsIgnoreCase(DatabaseChangeLog.normalizePath(filePath))
                 || normalizedFilePath.equalsIgnoreCase(Paths.get(filePath).normalize().toString().replace("\\", "/"));
     }

--- a/liquibase-standard/src/main/java/liquibase/changelog/visitor/ExpectedChangesVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/visitor/ExpectedChangesVisitor.java
@@ -23,7 +23,7 @@ public class ExpectedChangesVisitor implements ChangeSetVisitor {
 
     @Override
     public void visit(ChangeSet changeSet, DatabaseChangeLog databaseChangeLog, Database database, Set<ChangeSetFilterResult> filterResults) throws LiquibaseException {
-        unexpectedChangeSets.removeIf(ranChangeSet -> ranChangeSet.isSameAs(changeSet));
+        unexpectedChangeSets.removeIf(ranChangeSet -> ranChangeSet.isSameAs(changeSet) || ranChangeSet.getChangeLog().equalsIgnoreCase("liquibase-internal"));
     }
 
     public Collection<RanChangeSet> getUnexpectedChangeSets() {

--- a/liquibase-standard/src/main/java/liquibase/changelog/visitor/ExpectedChangesVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/visitor/ExpectedChangesVisitor.java
@@ -23,7 +23,7 @@ public class ExpectedChangesVisitor implements ChangeSetVisitor {
 
     @Override
     public void visit(ChangeSet changeSet, DatabaseChangeLog databaseChangeLog, Database database, Set<ChangeSetFilterResult> filterResults) throws LiquibaseException {
-        unexpectedChangeSets.removeIf(ranChangeSet -> ranChangeSet.isSameAsOrIsLiquibaseInternalChangeset(changeSet));
+        unexpectedChangeSets.removeIf(ranChangeSet -> ranChangeSet.isSameAs(changeSet));
     }
 
     public Collection<RanChangeSet> getUnexpectedChangeSets() {

--- a/liquibase-standard/src/main/java/liquibase/changelog/visitor/ExpectedChangesVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/visitor/ExpectedChangesVisitor.java
@@ -23,7 +23,7 @@ public class ExpectedChangesVisitor implements ChangeSetVisitor {
 
     @Override
     public void visit(ChangeSet changeSet, DatabaseChangeLog databaseChangeLog, Database database, Set<ChangeSetFilterResult> filterResults) throws LiquibaseException {
-        unexpectedChangeSets.removeIf(ranChangeSet -> ranChangeSet.isSameAsIgnoreLiquibaseInternalChangeset(changeSet));
+        unexpectedChangeSets.removeIf(ranChangeSet -> ranChangeSet.isSameAsOrIsLiquibaseInternalChangeset(changeSet));
     }
 
     public Collection<RanChangeSet> getUnexpectedChangeSets() {

--- a/liquibase-standard/src/main/java/liquibase/changelog/visitor/ExpectedChangesVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/visitor/ExpectedChangesVisitor.java
@@ -23,7 +23,7 @@ public class ExpectedChangesVisitor implements ChangeSetVisitor {
 
     @Override
     public void visit(ChangeSet changeSet, DatabaseChangeLog databaseChangeLog, Database database, Set<ChangeSetFilterResult> filterResults) throws LiquibaseException {
-        unexpectedChangeSets.removeIf(ranChangeSet -> ranChangeSet.isSameAs(changeSet));
+        unexpectedChangeSets.removeIf(ranChangeSet -> ranChangeSet.isSameAsIgnoreLiquibaseInternalChangeset(changeSet));
     }
 
     public Collection<RanChangeSet> getUnexpectedChangeSets() {


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

Issue #5442 outlines an odd behavior where the `unexpected-changesets` command shows the `tag` changeset as unexpected. If using the `tag` command itself, a changeset is not added to the changelog, but an internal Liquibase changeset will be added to the DBCL table. This would cause the `unexpected-changesets `to always show the internal Liquibase changeset as unexpected. Side note, the `generate-changelog` does not create the changeset in a changelog if it exists in the DBCL, so there isn't a way to make the tag expected.

This fix adds a function that is called first to determine if the file path is the **liquibase-internal** changeset. If it is, it removes it from the unexpected list. 

Fixes #5442 


## Things to be aware of

I couldn't find a way to capture the file path for the ran changeset in the RanChangesSet.java file, so I did the same call that occurs in the isSameAs function (occurs in the isSamePath function technically), so it could be refactored to be more efficient. 

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

There isn't any additional tests associated with the change. I have found that there is a file unexpectedChangesets.test.groovy, but was unsure how to get the `tag` command to execute first. I would be happy to write test cases/modify the existing ones.

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->

N/A