### PR TITLE
prevent multiple databases in test classes

### DIFF
--- a/liquibase-extension-testing/src/main/java/liquibase/extension/testing/testsystem/spock/LiquibaseIntegrationMethodInterceptor.java
+++ b/liquibase-extension-testing/src/main/java/liquibase/extension/testing/testsystem/spock/LiquibaseIntegrationMethodInterceptor.java
@@ -3,6 +3,8 @@ package liquibase.extension.testing.testsystem.spock;
 import liquibase.Scope;
 import liquibase.configuration.ConfigurationValueConverter;
 import liquibase.configuration.LiquibaseConfiguration;
+import liquibase.exception.UnexpectedLiquibaseException;
+import liquibase.extension.testing.testsystem.DatabaseTestSystem;
 import liquibase.extension.testing.testsystem.TestSystem;
 import org.junit.Assume;
 import org.spockframework.runtime.extension.AbstractMethodInterceptor;
@@ -33,8 +35,22 @@ public class LiquibaseIntegrationMethodInterceptor extends AbstractMethodInterce
     }
 
     LiquibaseIntegrationMethodInterceptor(SpecInfo spec, LiquibaseIntegrationTestExtension.ErrorListener errorListener) {
+        verifyNoMultipleDatabases(spec);
         this.spec = spec;
         this.errorListener = errorListener;
+    }
+
+    private void verifyNoMultipleDatabases(SpecInfo spec) {
+        List<FieldInfo> allFields = spec.getAllFields();
+        int databases = 0;
+        for (FieldInfo field : allFields) {
+            if (field.getType().isAssignableFrom(DatabaseTestSystem.class)) {
+                databases++;
+            }
+        }
+        if (databases > 1) {
+            throw new UnexpectedLiquibaseException(spec.getName() + " defines more than one " + DatabaseTestSystem.class.getSimpleName() + ". This is not permitted because the test will not be run in any of the matrices on GitHub Actions. You'll need to make a separate class for each of the databases.");
+        }
     }
 
     @Override

--- a/liquibase-extension-testing/src/main/java/liquibase/extension/testing/testsystem/spock/LiquibaseIntegrationMethodInterceptor.java
+++ b/liquibase-extension-testing/src/main/java/liquibase/extension/testing/testsystem/spock/LiquibaseIntegrationMethodInterceptor.java
@@ -44,7 +44,7 @@ public class LiquibaseIntegrationMethodInterceptor extends AbstractMethodInterce
         List<FieldInfo> allFields = spec.getAllFields();
         int databases = 0;
         for (FieldInfo field : allFields) {
-            if (field.getType().isAssignableFrom(DatabaseTestSystem.class)) {
+            if (field.getType() != Object.class && field.getType().isAssignableFrom(DatabaseTestSystem.class)) {
                 databases++;
             }
         }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

Due to a combination of the logic in `liquibase-extension-testing` used to determine whether a particular test class matches the specified databases, and the fact that the integration tests run in a matrix in GHA, test classes with more than one `DatabaseTestSystem` specified will not run on any platform in GHA. This PR prevents someone from accidentally creating a test class that has more than one `DatabaseTestSystem`.

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
