### PR TITLE
DAT-15853  DevOps :: Deprecate Snyk and replace with GHAS

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,9 +1,0 @@
-# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.22.1
-# ignores vulnerabilities until expiry date; change duration by modifying expiry date
-ignore:
-  SNYK-JAVA-ORGLIQUIBASE-2419059:
-    - '*':
-        reason: ignore liquibase version
-        created: 2022-03-07T15:57:03.089Z
-patch: {}


### PR DESCRIPTION
## Description

chore(.snyk): remove .snyk file as it is no longer needed for vulnerability management

