### PR TITLE
fixed typo that is inherited to other extensions

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/lockservice/LockService.java
+++ b/liquibase-standard/src/main/java/liquibase/lockservice/LockService.java
@@ -13,7 +13,7 @@ public interface LockService extends PrioritizedService {
 
     void setChangeLogLockWaitTime(long changeLogLockWaitTime);
 
-    void setChangeLogLockRecheckTime(long changeLogLocRecheckTime);
+    void setChangeLogLockRecheckTime(long changeLogLockRecheckTime);
 
     boolean hasChangeLogLock();
 

--- a/liquibase-standard/src/main/java/liquibase/lockservice/MockLockService.java
+++ b/liquibase-standard/src/main/java/liquibase/lockservice/MockLockService.java
@@ -28,7 +28,7 @@ public class MockLockService implements LockService {
     }
 
     @Override
-    public void setChangeLogLockRecheckTime(long changeLogLocRecheckTime) {
+    public void setChangeLogLockRecheckTime(long changeLogLockRecheckTime) {
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/lockservice/OfflineLockService.java
+++ b/liquibase-standard/src/main/java/liquibase/lockservice/OfflineLockService.java
@@ -36,7 +36,7 @@ public class OfflineLockService implements LockService {
     }
 
     @Override
-    public void setChangeLogLockRecheckTime(long changeLogLocRecheckTime) {
+    public void setChangeLogLockRecheckTime(long changeLogLockRecheckTime) {
 
     }
 


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
 

## Description

When creating a new class that implements LockService interface, parameter names are inherited by default, with an existing typo in the word 'Lock'. Fixed that.
 There is no impact of existing realizations, StandardLockService already has this typo fixed.



