### PR TITLE
add SetNullableGenerator for SQLite

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/SetNullableGeneratorSQLite.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/SetNullableGeneratorSQLite.java
@@ -1,0 +1,81 @@
+package liquibase.sqlgenerator.core;
+
+import liquibase.change.ColumnConfig;
+import liquibase.change.ConstraintsConfig;
+import liquibase.database.Database;
+import liquibase.database.core.SQLiteDatabase;
+import liquibase.exception.DatabaseException;
+import liquibase.exception.UnexpectedLiquibaseException;
+import liquibase.exception.ValidationErrors;
+import liquibase.snapshot.InvalidExampleException;
+import liquibase.snapshot.SnapshotGeneratorFactory;
+import liquibase.sql.Sql;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.statement.core.SetNullableStatement;
+import liquibase.structure.core.*;
+
+public class SetNullableGeneratorSQLite extends AbstractSqlGenerator<SetNullableStatement> {
+
+    @Override
+    public boolean generateStatementsIsVolatile(Database database) {
+        return true;
+    }
+
+    @Override
+    public boolean supports(SetNullableStatement statement, Database database) {
+        return database instanceof SQLiteDatabase;
+    }
+
+    @Override
+    public ValidationErrors validate(SetNullableStatement setNullableStatement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+        ValidationErrors validationErrors = new ValidationErrors();
+
+        validationErrors.checkRequiredField("tableName", setNullableStatement.getTableName());
+        validationErrors.checkRequiredField("columnName", setNullableStatement.getColumnName());
+
+        return validationErrors;
+    }
+
+    @Override
+    public Sql[] generateSql(SetNullableStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+        try {
+            Column columnSnapshot = SnapshotGeneratorFactory.getInstance().createSnapshot(new Column().setName(statement.getColumnName()).setRelation(new Table().setName(statement.getTableName()).setSchema(new Schema(new Catalog(null), null))), database);
+
+            ColumnConfig newColumnConfig = new ColumnConfig(columnSnapshot);
+            if (newColumnConfig.getConstraints() == null) {
+                newColumnConfig.setConstraints(new ConstraintsConfig());
+            }
+            newColumnConfig.getConstraints().setNullable(statement.isNullable());
+            SQLiteDatabase.AlterTableVisitor alterTableVisitor = new SQLiteDatabase.AlterTableVisitor() {
+                @Override
+                public ColumnConfig[] getColumnsToAdd() {
+                    return new ColumnConfig[]{newColumnConfig};
+                }
+
+                @Override
+                public boolean copyThisColumn(ColumnConfig column) {
+                    return !column.getName().equals(newColumnConfig.getName()) || column == newColumnConfig;
+                }
+
+                @Override
+                public boolean createThisColumn(ColumnConfig column) {
+                    return !column.getName().equals(newColumnConfig.getName()) || column == newColumnConfig;
+                }
+
+                @Override
+                public boolean createThisIndex(Index index) {
+                    return true;
+                }
+            };
+
+            Sql[] generatedSqls = SQLiteDatabase.getAlterTableSqls(database, alterTableVisitor, statement.getCatalogName(),
+                    statement.getSchemaName(), statement.getTableName());
+
+            return generatedSqls;
+        } catch (DatabaseException e) {
+            throw new UnexpectedLiquibaseException(e);
+        } catch (InvalidExampleException e) {
+            throw new UnexpectedLiquibaseException(e);
+        }
+    }
+}

--- a/liquibase-standard/src/main/resources/META-INF/services/liquibase.sqlgenerator.SqlGenerator
+++ b/liquibase-standard/src/main/resources/META-INF/services/liquibase.sqlgenerator.SqlGenerator
@@ -94,6 +94,7 @@ liquibase.sqlgenerator.core.SelectFromDatabaseChangeLogGenerator
 liquibase.sqlgenerator.core.SelectFromDatabaseChangeLogLockGenerator
 liquibase.sqlgenerator.core.SetColumnRemarksGenerator
 liquibase.sqlgenerator.core.SetNullableGenerator
+liquibase.sqlgenerator.core.SetNullableGeneratorSQLite
 liquibase.sqlgenerator.core.SetTableRemarksGenerator
 liquibase.sqlgenerator.core.SetViewRemarksGenerator
 liquibase.sqlgenerator.core.StoredProcedureGenerator


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

Currently, we do not support set-nullable changes on SQLite. This PR implements this similar to how we add/rename/drop columns.

We first create a new temporary table with the nullability change, then insert the content of the existing table into it and remove the old table.
For dropping the not-null constraint, this should always work. For creating the not-null constraint, this might fail depending on the data, which seems acceptable to me.

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
