### PR TITLE
MariaDB boolean: back to TINYINT(1) instead of TINYINT (MySQL)

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/datatype/core/BooleanType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/BooleanType.java
@@ -40,7 +40,7 @@ public class BooleanType extends LiquibaseDataType {
             if (originalDefinition.toLowerCase(Locale.US).startsWith("bit")) {
                 return new DatabaseDataType("BIT", getParameters());
             }
-            return new DatabaseDataType("TINYINT");
+            return database instanceof MariaDBDatabase ? new DatabaseDataType("TINYINT(1)") : new DatabaseDataType("TINYINT");
         } else if (database instanceof OracleDatabase) {
             try {
                 if (database.getDatabaseMajorVersion() >= OracleDatabase.ORACLE_23C_MAJOR_VERSION) {

--- a/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/AddColumnGeneratorTest.java
+++ b/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/AddColumnGeneratorTest.java
@@ -175,5 +175,16 @@ public class AddColumnGeneratorTest extends AbstractSqlGeneratorTest<AddColumnSt
         assertEquals("UPDATE schema_name.table_name SET column2 = 1", sql[2].toSql());
         assertEquals("ALTER TABLE schema_name.table_name MODIFY column1 BIGINT NOT NULL", sql[3].toSql());
         assertEquals("ALTER TABLE schema_name.table_name MODIFY column2 TINYINT NOT NULL", sql[4].toSql());
+
+        // repeat with MariaDBDatabase which shall result in TINYINT(1) for boolean column (instead of just TINYINT)
+        statements = change.generateStatements(new MariaDBDatabase());
+        sql = instance.generateSql(statements, new MariaDBDatabase());
+
+        assertEquals(5, sql.length);
+        assertEquals("ALTER TABLE schema_name.table_name ADD column1 BIGINT NULL, ADD column2 TINYINT(1) NULL", sql[0].toSql());
+        assertEquals("UPDATE schema_name.table_name SET column1 = 0", sql[1].toSql());
+        assertEquals("UPDATE schema_name.table_name SET column2 = 1", sql[2].toSql());
+        assertEquals("ALTER TABLE schema_name.table_name MODIFY column1 BIGINT NOT NULL", sql[3].toSql());
+        assertEquals("ALTER TABLE schema_name.table_name MODIFY column2 TINYINT(1) NOT NULL", sql[4].toSql());
     }
 }


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

For boolean columns on MariaDB, go back from `TINYINT` to `TINYINT(1)` like it was before 4.25.1. See #5489 for more details.

Fixes #5489

Test Harness PR: https://github.com/liquibase/liquibase-test-harness/pull/727