### PR TITLE
Use static final Pattern to avoid regexp compilation each time replaceAll is called

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/change/AbstractChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/AbstractChange.java
@@ -28,6 +28,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.*;
+import java.util.regex.Pattern;
 
 import static liquibase.statement.SqlStatement.EMPTY_SQL_STATEMENT;
 
@@ -42,6 +43,7 @@ import static liquibase.statement.SqlStatement.EMPTY_SQL_STATEMENT;
 public abstract class AbstractChange extends AbstractPlugin implements Change {
 
     protected static final String NODENAME_COLUMN = "column";
+    private static final Pattern ALPHABET = Pattern.compile("([A-Z])");
 
     private ChangeSet changeSet;
 
@@ -182,7 +184,7 @@ public abstract class AbstractChange extends AbstractPlugin implements Change {
     private ChangeParameterMetaData createChangeParameterMetadata(PropertyDescriptor property, Method readMethod) {
         try {
             String parameterName = property.getDisplayName();
-            String displayName = parameterName.replaceAll("([A-Z])", " $1");
+            String displayName = ALPHABET.matcher(parameterName).replaceAll(" $1");
             displayName = displayName.substring(0, 1).toUpperCase() + displayName.substring(1);
 
             Type type = readMethod.getGenericReturnType();


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Improve performance of `liquibase.Liquibase#getDatabaseChangeLog()` a bit. I've noticed that pattern compilation takes some time in my profile.

## Additional Context

String.replaceAll implementation:
https://github.com/openjdk/jdk/blob/fd8adf308357355bd33916ad80e2328c35434e5a/src/java.base/share/classes/java/lang/String.java#L3110
```
    public String replaceAll(String regex, String replacement) {
        return Pattern.compile(regex).matcher(this).replaceAll(replacement);
    }
```

![image](https://github.com/liquibase/liquibase/assets/741251/c19ca20b-4832-49f7-a55e-577422751138)
