### PR TITLE
New methods to obtain raw dbcl and dbcll table names

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -659,6 +659,13 @@ public abstract class AbstractJdbcDatabase implements Database {
         this.databaseChangeLogTableName = tableName;
     }
 
+    /**
+     * Method used by extensions to get raw dbcl table name
+     */
+    protected String getRawDatabaseChangeLogTableName() {
+        return databaseChangeLogTableName;
+    }
+
     @Override
     public String getDatabaseChangeLogLockTableName() {
         if (databaseChangeLogLockTableName != null) {
@@ -671,6 +678,13 @@ public abstract class AbstractJdbcDatabase implements Database {
     @Override
     public void setDatabaseChangeLogLockTableName(final String tableName) {
         this.databaseChangeLogLockTableName = tableName;
+    }
+
+    /**
+     * Method used by extensions to get raw dbcll table name
+     */
+    protected String getRawDatabaseChangeLogLockTableName() {
+        return databaseChangeLogLockTableName;
     }
 
     @Override


### PR DESCRIPTION
Provide methods that return raw dbcl and dbcll table names so database extensions can manipulate them as required.

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 

New methods will be used to fix #5034 in BigQuery extension PR  #TBC .