### PR TITLE
Fix ChangelogHistoryService NPE when running concurrently

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryServiceFactory.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryServiceFactory.java
@@ -48,7 +48,7 @@ public class ChangeLogHistoryServiceFactory extends AbstractPluginFactory<Change
     }
 
 
-    public ChangeLogHistoryService getChangeLogService(Database database) {
+    public synchronized ChangeLogHistoryService getChangeLogService(Database database) {
             if (services.containsKey(database)) {
                 return services.get(database);
             }

--- a/liquibase-standard/src/test/groovy/liquibase/ThreadLocalScopeManagerTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/ThreadLocalScopeManagerTest.groovy
@@ -4,6 +4,7 @@ import liquibase.changelog.ChangeSet
 import liquibase.database.jvm.JdbcConnection
 import liquibase.exception.LiquibaseException
 import liquibase.resource.ClassLoaderResourceAccessor
+import liquibase.util.StringUtil
 import spock.lang.Ignore
 import spock.lang.Specification
 
@@ -53,7 +54,7 @@ class ThreadLocalScopeManagerTest extends Specification {
         final ThreadAligner threadAligner = new ThreadAligner(threadCount)
 
         for (int i = 0; i < threadCount; i++) {
-            final String dbName = DATABASE_NAME_PREFIX + i
+            final String dbName = DATABASE_NAME_PREFIX + StringUtil.randomIdentifer(5) + i
 
             liveConnections.put(dbName, MemoryDatabase.create(dbName))
 

--- a/liquibase-standard/src/test/groovy/liquibase/ThreadLocalScopeManagerTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/ThreadLocalScopeManagerTest.groovy
@@ -54,7 +54,7 @@ class ThreadLocalScopeManagerTest extends Specification {
         final ThreadAligner threadAligner = new ThreadAligner(threadCount)
 
         for (int i = 0; i < threadCount; i++) {
-            final String dbName = DATABASE_NAME_PREFIX + StringUtil.randomIdentifer(5) + i
+            final String dbName = DATABASE_NAME_PREFIX + StringUtil.randomIdentifer(10) + i
 
             liveConnections.put(dbName, MemoryDatabase.create(dbName))
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description
Make ChangelogHistoryServiceFactory#getChangeLogService synchronized to avoid concurrency issues when retreiving the ChangelogService. This problem was revealed in [these](https://github.com/liquibase/liquibase/actions/runs/7786641501/attempts/1) [previous](https://github.com/liquibase/liquibase/actions/runs/7786641501/job/21232934858) runs.

Resolves the error: 
```java.util.concurrent.ExecutionException: java.lang.IllegalStateException: liquibase.exception.LiquibaseException: liquibase.exception.DatabaseException: java.lang.NullPointerException: Cannot invoke "liquibase.changelog.ChangeLogHistoryService.getNextSequenceValue()" because the return value of "liquibase.changelog.ChangeLogHistoryServiceFactory.getChangeLogService(liquibase.database.Database)" is null```
<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of
This method has existed since 2022. 
This does not count as breaking backwards compatibility from what I can tell.
<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about
<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
