### PR TITLE
Support to generate a ChangeSetStatus with setting all its attributes when a changeset will be skipped 

### DIFF
--- a/liquibase-integration-tests/src/test/resources/changelogs/update.changelog.yaml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/update.changelog.yaml
@@ -1,0 +1,33 @@
+databaseChangeLog:
+  -  property:
+       name:  data_file
+       context: test1
+       value:  data-context1
+  -  property:
+       name:  data_file
+       context: test2
+       value:  data-context2
+
+  - changeSet:
+      id: 0 - Bug with file missing for non active context
+      author: Me
+      changes:
+        - createTable:
+            tableName: TEST
+            columns:
+              - column:
+                  name: ID
+                  type: int
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+  - changeSet:
+      id: 1 - Bug, without this context file should not have to exist
+      author: Me
+      context: "invalidcontext"
+      changes:
+        - loadData:
+            encoding: UTF-8
+            file: "changelog/yaml/data/${data_file}.csv"
+            separator: ","
+            tableName: TEST

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeSetStatus.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeSetStatus.java
@@ -4,6 +4,7 @@ import liquibase.ChecksumVersion;
 import liquibase.change.CheckSum;
 import liquibase.changelog.filter.ChangeSetFilter;
 import liquibase.changelog.filter.ChangeSetFilterResult;
+import liquibase.exception.LiquibaseException;
 import liquibase.integration.commandline.LiquibaseCommandLineConfiguration;
 
 import java.util.Date;
@@ -37,6 +38,18 @@ public class ChangeSetStatus {
         this.currentCheckSum = changeSet.generateCheckSum(version);
         this.description = changeSet.getDescription();
         this.comments = changeSet.getComments();
+    }
+
+    public ChangeSetStatus(ChangeSet changeSet, boolean skipChangeSetStatusGeneration) throws LiquibaseException {
+        if(skipChangeSetStatusGeneration) {
+            this.changeSet = changeSet;
+            this.currentCheckSum = null;
+            this.description = null;
+            this.comments = null;
+        }
+        else {
+            throw new LiquibaseException(String.format("ChangeSetStatus for ChangeSet %s cannot generated", changeSet.toString()));
+        }
     }
 
     public ChangeSet getChangeSet() {


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

We add support to be able to generate a ChangeSetStatus without for example having to generate a checksum when it's not needed because that given ChangeSet will be skipped.

Fixes #5430

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
