### PR TITLE
fix: uses ThreadLocal to prevent concurrent modification on ScopeManager

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/Scope.java
+++ b/liquibase-standard/src/main/java/liquibase/Scope.java
@@ -70,7 +70,7 @@ public class Scope {
 
     public static final String JAVA_PROPERTIES = "javaProperties";
 
-    private static ScopeManager scopeManager;
+    private static final ThreadLocal<ScopeManager> scopeManager = new ThreadLocal<>();
 
     private final Scope parent;
     private final SmartMap values = new SmartMap();
@@ -81,12 +81,12 @@ public class Scope {
     private LiquibaseListener listener;
 
     public static Scope getCurrentScope() {
-        if (scopeManager == null) {
-            scopeManager = new SingletonScopeManager();
+        if (scopeManager.get() == null) {
+            scopeManager.set(new SingletonScopeManager());
         }
-        if (scopeManager.getCurrentScope() == null) {
+        if (scopeManager.get().getCurrentScope() == null) {
             Scope rootScope = new Scope();
-            scopeManager.setCurrentScope(rootScope);
+            scopeManager.get().setCurrentScope(rootScope);
 
             rootScope.values.put(Attr.logService.name(), new JavaLogService());
             rootScope.values.put(Attr.serviceLocator.name(), new StandardServiceLocator());
@@ -114,11 +114,11 @@ public class Scope {
             rootScope.values.put(Attr.serviceLocator.name(), serviceLocator);
             rootScope.values.put(Attr.osgiPlatform.name(), ContainerChecker.isOsgiPlatform());
         }
-        return scopeManager.getCurrentScope();
+        return scopeManager.get().getCurrentScope();
     }
 
     public static void setScopeManager(ScopeManager scopeManager) {
-        Scope.scopeManager = scopeManager;
+        Scope.scopeManager.set(scopeManager);
     }
 
     /**
@@ -217,7 +217,7 @@ public class Scope {
         Scope originalScope = getCurrentScope();
         Scope child = new Scope(originalScope, scopeValues);
         child.listener = listener;
-        scopeManager.setCurrentScope(child);
+        scopeManager.get().setCurrentScope(child);
 
         return child.scopeId;
     }
@@ -239,7 +239,7 @@ public class Scope {
             mdcObject.close();
         }
 
-        scopeManager.setCurrentScope(currentScope.getParent());
+        scopeManager.get().setCurrentScope(currentScope.getParent());
     }
 
     /**

--- a/liquibase-standard/src/test/groovy/liquibase/ThreadLocalScopeManagerTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/ThreadLocalScopeManagerTest.groovy
@@ -24,7 +24,7 @@ class ThreadLocalScopeManagerTest extends Specification {
 
     def setup() {
         Scope.getCurrentScope()
-        originalScopeManager = Scope.scopeManager
+        originalScopeManager = Scope.scopeManager.get()
         Scope.setScopeManager(new ThreadLocalScopeManager())
     }
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 


## Description

Issues  #5426 #2433 #4173  #4314  presents the same error:  "Cannot end scope bsbacsmwja when currently at scope root" . 
The issue was narrowed down to Scope class handling of ScopeManager:

1. Thread "A" starts and creates a root scope. By doing so, Scope.getCurrentScope() returns "root"
2. Thread "A" starts a child scope "ABC". Now, Scope.getCurrentScope() returns "ABC", and parent is root (parent is saved in a non-static variable, while currentScope is static)
3. Thread "A"  is suspended and Thread "B" starts
4. Thread "B" starts.  By doing so, Scope.getCurrentScope() returns "ABC" (**hey! that's already wrong**)
5.  Thread "B" starts a child scope "DEF". Now, Scope.getCurrentScope() returns "DEF" and parent is "ABC"
6. Thread "B"  is suspended, "A"  resumes
7. Thread "A" does it's job and ends the scope.  The last step of exit is restoring the former Scope, so thread "A" sets currentScope to root (remember, parent is local and current is static) .
8. Thread "B" resumes - now working on curentScope "root" . It does it work and tries to finish. It tries to compare scopeId that was saved in a local variable,  but then "B" gets message "Cannot end scope DEF (local variable)  when currently at scope root (statically changed) " - RuntimeException 

We prevent this issue by using a ThreadLocal object that ensures that each thread will have it's own ScopeManager , so "A" won't break "B" as it cannot mess with it's ScopeManager. 

This issue has always been around, but seems it started to show up more as child scopes are being used for blocking tasks (that allows threads switching) such as database execution in ChangelogJdbcMdcListener . In the example above, A and B were suspended waiting for a database query to run.
