### PR TITLE
Improve snapshot extensibility for NoSQL databases

### DIFF
--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
@@ -203,11 +203,11 @@ public abstract class AbstractIntegrationTest {
             String altSchema = testSystem.getAltSchema();
             String altCatalog = testSystem.getAltCatalog();
 
-            if (database.supportsSchemas()) {
+            if (database.supports(Schema.class)) {
                 emptyTestSchema(null, altSchema, database);
             }
             if (supportsAltCatalogTests()) {
-                if (database.supportsSchemas() && database.supportsCatalogs()) {
+                if (database.supports(Schema.class) && database.supports(Catalog.class)) {
                     emptyTestSchema(altCatalog, altSchema, database);
                 }
             }
@@ -264,7 +264,7 @@ public abstract class AbstractIntegrationTest {
     }
 
     protected boolean supportsAltCatalogTests() {
-        return database.supportsCatalogs();
+        return database.supports(Catalog.class);
     }
 
     protected Properties createProperties() {
@@ -756,7 +756,7 @@ public abstract class AbstractIntegrationTest {
         if (database.getShortName().equalsIgnoreCase("mssql")) {
             return; // not possible on MSSQL.
         }
-        if (!database.supportsSchemas()) {
+        if (!database.supports(Schema.class)) {
             return;
         }
 

--- a/liquibase-integration-tests/src/test/java/liquibase/statementexecute/AbstractExecuteTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/statementexecute/AbstractExecuteTest.java
@@ -22,6 +22,7 @@ import liquibase.snapshot.SnapshotGeneratorFactory;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.SqlGeneratorFactory;
 import liquibase.statement.SqlStatement;
+import liquibase.structure.core.Schema;
 import liquibase.structure.core.Table;
 import liquibase.test.TestContext;
 import org.junit.After;
@@ -231,7 +232,7 @@ public abstract class AbstractExecuteTest {
             }
             connection.commit();
 
-            if (database.supportsSchemas()) {
+            if (database.supports(Schema.class)) {
                 try {
                 database.dropDatabaseObjects(new CatalogAndSchema(null, testSystem.getAltSchema()));
                 } catch (DatabaseException e) {

--- a/liquibase-snowflake/src/test/java/liquibase/database/core/SnowflakeDatabaseTest.java
+++ b/liquibase-snowflake/src/test/java/liquibase/database/core/SnowflakeDatabaseTest.java
@@ -2,6 +2,9 @@ package liquibase.database.core;
 
 import liquibase.CatalogAndSchema;
 import liquibase.database.jvm.JdbcConnection;
+import liquibase.structure.core.Catalog;
+import liquibase.structure.core.Schema;
+import liquibase.structure.core.Sequence;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -72,11 +75,13 @@ public class SnowflakeDatabaseTest {
     @Test
     public void testSupportsSchemas() {
         assertTrue(database.supportsSchemas());
+        assertTrue(database.supports(Schema.class));
     }
 
     @Test
     public void testSupportsCatalogs() {
         assertTrue(database.supportsCatalogs());
+        assertTrue(database.supports(Catalog.class));
     }
 
     @Test
@@ -87,6 +92,7 @@ public class SnowflakeDatabaseTest {
     @Test
     public void testSupportsSequences() {
         assertTrue(database.supportsSequences());
+        assertTrue(database.supports(Sequence.class));
     }
 
     @Test

--- a/liquibase-standard/src/main/java/liquibase/CatalogAndSchema.java
+++ b/liquibase-standard/src/main/java/liquibase/CatalogAndSchema.java
@@ -36,7 +36,7 @@ public class CatalogAndSchema {
     }
 
     public boolean equals(CatalogAndSchema catalogAndSchema, Database accordingTo) {
-        if (!accordingTo.supportsCatalogs()) {
+        if (!accordingTo.supports(Catalog.class)) {
             return true;
         }
 
@@ -53,7 +53,7 @@ public class CatalogAndSchema {
             return false;
         }
 
-        if (accordingTo.supportsSchemas()) {
+        if (accordingTo.supports(Schema.class)) {
             if (workCatalogAndSchema.getSchemaName() == null) {
                 return thisCatalogAndSchema.getSchemaName() == null;
             } else {
@@ -79,11 +79,11 @@ public class CatalogAndSchema {
         String workCatalogName = StringUtil.trimToNull(getCatalogName());
         String workSchemaName = StringUtil.trimToNull(getSchemaName());
 
-        if (!accordingTo.supportsCatalogs()) {
+        if (!accordingTo.supports(Catalog.class)) {
             return new CatalogAndSchema(null, null);
         }
 
-        if (accordingTo.supportsSchemas()) {
+        if (accordingTo.supports(Schema.class)) {
             if ((workSchemaName != null) && workSchemaName.equalsIgnoreCase(accordingTo.getDefaultSchemaName())) {
                 workSchemaName = null;
             }
@@ -100,7 +100,7 @@ public class CatalogAndSchema {
         if (workSchemaName != null && equals(accordingTo, workSchemaName, accordingTo.getDefaultSchemaName())) {
             workSchemaName = null;
         }
-        if (!accordingTo.supportsSchemas() && (workCatalogName != null) && (workSchemaName != null) &&
+        if (!accordingTo.supports(Schema.class) && (workCatalogName != null) && (workSchemaName != null) &&
             !workCatalogName.equals(workSchemaName)) {
             workSchemaName = null;
         }
@@ -143,7 +143,7 @@ public class CatalogAndSchema {
         String workSchemaName = standard.getSchemaName();
 
         if (workCatalogName == null) {
-            if (!accordingTo.supportsSchemas() && (workSchemaName != null)) {
+            if (!accordingTo.supports(Schema.class) && (workSchemaName != null)) {
                 return new CatalogAndSchema(accordingTo.correctObjectName(workSchemaName, Catalog.class), null);
             }
             workCatalogName = accordingTo.getDefaultCatalogName();

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogParameters.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogParameters.java
@@ -8,6 +8,8 @@ import liquibase.database.Database;
 import liquibase.database.DatabaseList;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.UnknownChangeLogParameterException;
+import liquibase.structure.core.Schema;
+import liquibase.structure.core.Sequence;
 import liquibase.util.StringUtil;
 
 import java.util.*;
@@ -87,8 +89,8 @@ public class ChangeLogParameters {
             this.set("database.supportsForeignKeyDisable", database.supportsForeignKeyDisable());
             this.set("database.supportsInitiallyDeferrableColumns", database.supportsInitiallyDeferrableColumns());
             this.set("database.supportsRestrictForeignKeys", database.supportsRestrictForeignKeys());
-            this.set("database.supportsSchemas", database.supportsSchemas());
-            this.set("database.supportsSequences", database.supportsSequences());
+            this.set("database.supportsSchemas", database.supports(Schema.class));
+            this.set("database.supportsSequences", database.supports(Sequence.class));
             this.set("database.supportsTablespaces", database.supportsTablespaces());
             this.set("database.supportsNotNullConstraintNames", database.supportsNotNullConstraintNames());
 

--- a/liquibase-standard/src/main/java/liquibase/command/core/DiffCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/DiffCommandStep.java
@@ -18,6 +18,7 @@ import liquibase.logging.mdc.MdcValue;
 import liquibase.snapshot.*;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.DatabaseObjectFactory;
+import liquibase.structure.core.Schema;
 import liquibase.util.StringUtil;
 
 import java.io.PrintStream;
@@ -134,7 +135,7 @@ public class DiffCommandStep extends AbstractCommandStep {
             int i = 0;
             for (CompareControl.SchemaComparison comparison : compareControl.getSchemaComparisons()) {
                 CatalogAndSchema schema;
-                if (targetDatabase.supportsSchemas()) {
+                if (targetDatabase.supports(Schema.class)) {
                     schema = new CatalogAndSchema(targetDatabase.getDefaultCatalogName(), comparison.getComparisonSchema().getSchemaName());
                 } else {
                     schema = new CatalogAndSchema(comparison.getComparisonSchema().getSchemaName(), comparison.getComparisonSchema().getSchemaName());
@@ -175,7 +176,7 @@ public class DiffCommandStep extends AbstractCommandStep {
             int i = 0;
             for (CompareControl.SchemaComparison comparison : compareControl.getSchemaComparisons()) {
                 CatalogAndSchema schema;
-                if (referenceDatabase.supportsSchemas()) {
+                if (referenceDatabase.supports(Schema.class)) {
                     schema = new CatalogAndSchema(referenceDatabase.getDefaultCatalogName(), comparison.getReferenceSchema().getSchemaName());
                 } else {
                     schema = new CatalogAndSchema(comparison.getReferenceSchema().getSchemaName(), comparison.getReferenceSchema().getSchemaName());

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/AbstractDatabaseConnectionCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/AbstractDatabaseConnectionCommandStep.java
@@ -10,6 +10,7 @@ import liquibase.database.core.DatabaseUtils;
 import liquibase.exception.DatabaseException;
 import liquibase.integration.commandline.LiquibaseCommandLineConfiguration;
 import liquibase.resource.ResourceAccessor;
+import liquibase.structure.core.Schema;
 import liquibase.util.StringUtil;
 
 import java.util.ResourceBundle;
@@ -73,7 +74,7 @@ public abstract class AbstractDatabaseConnectionCommandStep extends AbstractHelp
             database = DatabaseFactory.getInstance().openDatabase(url, username, password, driver,
                     databaseClassName, driverPropertiesFile, propertyProviderClass, resourceAccessor);
 
-            if (!database.supportsSchemas()) {
+            if (!database.supports(Schema.class)) {
                 if ((defaultSchemaName != null) && (defaultCatalogName == null)) {
                     defaultCatalogName = defaultSchemaName;
                 }

--- a/liquibase-standard/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -229,7 +229,7 @@ public abstract class AbstractJdbcDatabase implements Database {
     @Override
     public String getDefaultCatalogName() {
         if (defaultCatalogName == null) {
-            if ((defaultSchemaName != null) && !this.supportsSchemas()) {
+            if ((defaultSchemaName != null) && !this.supports(Schema.class)) {
                 return defaultSchemaName;
             }
 
@@ -303,7 +303,7 @@ public abstract class AbstractJdbcDatabase implements Database {
 
     @Override
     public String getDefaultSchemaName() {
-        if (!supportsSchemas()) {
+        if (!supports(Schema.class)) {
             return getDefaultCatalogName();
         }
 
@@ -326,7 +326,7 @@ public abstract class AbstractJdbcDatabase implements Database {
     @Override
     public void setDefaultSchemaName(final String schemaName) {
         this.defaultSchemaName = correctObjectName(schemaName, Schema.class);
-        if (!supportsSchemas()) {
+        if (!supports(Schema.class)) {
             defaultCatalogSet = schemaName != null;
         }
     }
@@ -841,7 +841,7 @@ public abstract class AbstractJdbcDatabase implements Database {
     @Override
     public String escapeObjectName(String catalogName, String schemaName, final String objectName,
                                    final Class<? extends DatabaseObject> objectType) {
-        if (supportsSchemas()) {
+        if (supports(Schema.class)) {
             catalogName = StringUtil.trimToNull(catalogName);
             schemaName = StringUtil.trimToNull(schemaName);
 
@@ -873,7 +873,7 @@ public abstract class AbstractJdbcDatabase implements Database {
                     return escapeObjectName(catalogName, Catalog.class) + "." + escapeObjectName(schemaName, Schema.class) + "." + escapeObjectName(objectName, objectType);
                 }
             }
-        } else if (supportsCatalogs()) {
+        } else if (supports(Catalog.class)) {
             catalogName = StringUtil.trimToNull(catalogName);
             schemaName = StringUtil.trimToNull(schemaName);
 
@@ -1415,7 +1415,7 @@ public abstract class AbstractJdbcDatabase implements Database {
 
     @Override
     public boolean isDefaultSchema(final String catalog, final String schema) {
-        if (!supportsSchemas()) {
+        if (!supports(Schema.class)) {
             return true;
         }
 
@@ -1427,7 +1427,7 @@ public abstract class AbstractJdbcDatabase implements Database {
 
     @Override
     public boolean isDefaultCatalog(final String catalog) {
-        if (!supportsCatalogs()) {
+        if (!supports(Catalog.class)) {
             return true;
         }
 

--- a/liquibase-standard/src/main/java/liquibase/database/Database.java
+++ b/liquibase-standard/src/main/java/liquibase/database/Database.java
@@ -140,6 +140,11 @@ public interface Database extends PrioritizedService, AutoCloseable {
      */
     boolean supportsInitiallyDeferrableColumns();
 
+    /**
+     * Whether this database supports sequences
+     * @deprecated please call {@link Database#supports(Class)} with the {@link liquibase.structure.core.Sequence} type instead
+     */
+    @Deprecated
     boolean supportsSequences();
 
     boolean supportsDropTableCascadeConstraints();
@@ -380,10 +385,25 @@ public interface Database extends PrioritizedService, AutoCloseable {
 
     boolean supportsTablespaces();
 
+    /**
+     * Whether this database supports catalogs
+     * @deprecated please call {@link Database#supports(Class)} with the {@link liquibase.structure.core.Catalog} type instead
+     */
+    @Deprecated
     boolean supportsCatalogs();
+
+    default boolean supports(Class<? extends DatabaseObject> object) {
+        return true;
+    }
+
 
     CatalogAndSchema.CatalogAndSchemaCase getSchemaAndCatalogCase();
 
+    /**
+     * Whether this database supports schemas
+     * @deprecated please call {@link Database#supports(Class)} with the {@link liquibase.structure.core.Schema} type instead
+     */
+    @Deprecated
     boolean supportsSchemas();
 
     boolean supportsCatalogInObjectName(Class<? extends DatabaseObject> type);

--- a/liquibase-standard/src/main/java/liquibase/database/core/AbstractDb2Database.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/AbstractDb2Database.java
@@ -52,6 +52,14 @@ public abstract class AbstractDb2Database extends AbstractJdbcDatabase {
     }
 
     @Override
+    public boolean supports(Class<? extends DatabaseObject> object) {
+        if (Schema.class.isAssignableFrom(object)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
     public boolean supportsSchemas() {
         return false;
     }

--- a/liquibase-standard/src/main/java/liquibase/database/core/DerbyDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/DerbyDatabase.java
@@ -10,6 +10,8 @@ import liquibase.exception.DatabaseException;
 import liquibase.executor.ExecutorService;
 import liquibase.statement.core.RawSqlStatement;
 import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.Schema;
+import liquibase.structure.core.Sequence;
 
 import java.sql.Driver;
 import java.sql.DriverManager;
@@ -71,6 +73,18 @@ public class DerbyDatabase extends AbstractJdbcDatabase {
     @Override
     public int getPriority() {
         return PRIORITY_DEFAULT;
+    }
+
+
+    @Override
+    public boolean supports(Class<? extends DatabaseObject> object) {
+        if (Schema.class.isAssignableFrom(object)) {
+            return false;
+        }
+        if (Sequence.class.isAssignableFrom(object)) {
+            return ((driverVersionMajor == 10) && (driverVersionMinor >= 6)) || (driverVersionMajor >= 11);
+        }
+        return super.supports(object);
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/database/core/FirebirdDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/FirebirdDatabase.java
@@ -4,6 +4,8 @@ import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.DatabaseConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.Catalog;
+import liquibase.structure.core.Schema;
 import liquibase.structure.core.Table;
 
 import java.util.Locale;
@@ -84,6 +86,17 @@ public class FirebirdDatabase extends AbstractJdbcDatabase {
     @Override
     public boolean supportsAutoIncrement() {
         return false;
+    }
+
+    @Override
+    public boolean supports(Class<? extends DatabaseObject> object) {
+        if (Schema.class.isAssignableFrom(object)) {
+            return false;
+        }
+        if (Catalog.class.isAssignableFrom(object)) {
+            return false;
+        }
+        return super.supports(object);
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/database/core/HsqlDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/HsqlDatabase.java
@@ -6,6 +6,8 @@ import liquibase.database.ObjectQuotingStrategy;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.DateParseException;
 import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.Catalog;
+import liquibase.structure.core.Schema;
 import liquibase.structure.core.Table;
 import liquibase.util.ISODateFormat;
 
@@ -381,6 +383,21 @@ public class HsqlDatabase extends AbstractJdbcDatabase {
     }
 
     @Override
+    public boolean supports(Class<? extends DatabaseObject> object) {
+        if (Schema.class.isAssignableFrom(object)) {
+            return false;
+        }
+        if (Catalog.class.isAssignableFrom(object)) {
+            try {
+                return getDatabaseMajorVersion() >= 2;
+            } catch (DatabaseException e) {
+                return true;
+            }
+        }
+        return super.supports(object);
+    }
+
+    @Override
     public boolean supportsCatalogs() {
         try {
             return getDatabaseMajorVersion() >= 2;
@@ -391,7 +408,7 @@ public class HsqlDatabase extends AbstractJdbcDatabase {
 
     @Override
     protected String getConnectionCatalogName() throws DatabaseException {
-        if (supportsCatalogs()) {
+        if (supports(Catalog.class)) {
             return "PUBLIC";
         } else {
             return null;

--- a/liquibase-standard/src/main/java/liquibase/database/core/HsqlDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/HsqlDatabase.java
@@ -384,9 +384,6 @@ public class HsqlDatabase extends AbstractJdbcDatabase {
 
     @Override
     public boolean supports(Class<? extends DatabaseObject> object) {
-        if (Schema.class.isAssignableFrom(object)) {
-            return false;
-        }
         if (Catalog.class.isAssignableFrom(object)) {
             try {
                 return getDatabaseMajorVersion() >= 2;

--- a/liquibase-standard/src/main/java/liquibase/database/core/Ingres9Database.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/Ingres9Database.java
@@ -7,6 +7,7 @@ import liquibase.database.OfflineConnection;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.Sequence;
 import liquibase.structure.core.Table;
 import liquibase.util.JdbcUtil;
 
@@ -115,6 +116,14 @@ public class Ingres9Database extends AbstractJdbcDatabase {
             }
         }
         return super.isSystemObject(example);
+    }
+
+    @Override
+    public boolean supports(Class<? extends DatabaseObject> object) {
+        if (Sequence.class.isAssignableFrom(object)) {
+            return false;
+        }
+        return super.supports(object);
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/database/core/MSSQLDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/MSSQLDatabase.java
@@ -185,15 +185,24 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
     }
 
     @Override
+    public boolean supports(Class<? extends DatabaseObject> object) {
+        if (Sequence.class.isAssignableFrom(object)) {
+            try {
+                return isAzureDb() || this.getDatabaseMajorVersion() >= MSSQL_SERVER_VERSIONS.MSSQL2012;
+            } catch (DatabaseException e) {
+                throw new UnexpectedLiquibaseException(e);
+            }
+        }
+        return super.supports(object);
+    }
+
+    @Override
     public boolean supportsSequences() {
         try {
-            if (isAzureDb() || this.getDatabaseMajorVersion() >= MSSQL_SERVER_VERSIONS.MSSQL2012) {
-                return true;
-            }
+            return isAzureDb() || this.getDatabaseMajorVersion() >= MSSQL_SERVER_VERSIONS.MSSQL2012;
         } catch (DatabaseException e) {
             throw new UnexpectedLiquibaseException(e);
         }
-        return false;
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/database/core/MockDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/MockDatabase.java
@@ -17,7 +17,9 @@ import liquibase.sql.visitor.SqlVisitor;
 import liquibase.statement.DatabaseFunction;
 import liquibase.statement.SqlStatement;
 import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.Catalog;
 import liquibase.structure.core.Schema;
+import liquibase.structure.core.Sequence;
 
 import java.io.Writer;
 import java.math.BigInteger;
@@ -426,6 +428,22 @@ public class MockDatabase implements Database, InternalDatabase {
 
     public String convertRequestedSchemaToCatalog(final String requestedSchema) {
         return null;
+    }
+
+
+
+    @Override
+    public boolean supports(Class<? extends DatabaseObject> object) {
+        if (Schema.class.isAssignableFrom(object)) {
+            return supportsSchemas;
+        }
+        if (Catalog.class.isAssignableFrom(object)) {
+            return supportsCatalogs;
+        }
+        if (Sequence.class.isAssignableFrom(object)) {
+            return supportsSequences;
+        }
+        return true;
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/database/core/MySQLDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/MySQLDatabase.java
@@ -12,6 +12,8 @@ import liquibase.statement.core.RawSqlStatement;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.Index;
 import liquibase.structure.core.PrimaryKey;
+import liquibase.structure.core.Schema;
+import liquibase.structure.core.Sequence;
 import liquibase.structure.core.Table;
 import liquibase.util.StringUtil;
 
@@ -113,7 +115,6 @@ public class MySQLDatabase extends AbstractJdbcDatabase {
 
     @Override
     public boolean supportsSequences() {
-
         return false;
     }
 
@@ -183,6 +184,19 @@ public class MySQLDatabase extends AbstractJdbcDatabase {
     @Override
     public boolean supportsTablespaces() {
         return false;
+    }
+
+
+
+    @Override
+    public boolean supports(Class<? extends DatabaseObject> object) {
+        if (Schema.class.isAssignableFrom(object)) {
+            return false;
+        }
+        if (Sequence.class.isAssignableFrom(object)) {
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/database/core/MySQLDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/MySQLDatabase.java
@@ -196,7 +196,7 @@ public class MySQLDatabase extends AbstractJdbcDatabase {
         if (Sequence.class.isAssignableFrom(object)) {
             return false;
         }
-        return true;
+        return super.supports(object);
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/database/core/OracleDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/OracleDatabase.java
@@ -287,7 +287,7 @@ public class OracleDatabase extends AbstractJdbcDatabase {
         if (Schema.class.isAssignableFrom(object)) {
             return false;
         }
-        return true;
+        return super.supports(object);
     }
 
     /**

--- a/liquibase-standard/src/main/java/liquibase/database/core/OracleDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/OracleDatabase.java
@@ -282,6 +282,14 @@ public class OracleDatabase extends AbstractJdbcDatabase {
         return true;
     }
 
+    @Override
+    public boolean supports(Class<? extends DatabaseObject> object) {
+        if (Schema.class.isAssignableFrom(object)) {
+            return false;
+        }
+        return true;
+    }
+
     /**
      * Oracle supports catalogs in liquibase terms
      *

--- a/liquibase-standard/src/main/java/liquibase/database/core/SQLiteDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/SQLiteDatabase.java
@@ -215,6 +215,19 @@ public class SQLiteDatabase extends AbstractJdbcDatabase {
         return false;
     }
 
+
+
+    @Override
+    public boolean supports(Class<? extends DatabaseObject> object) {
+        if (Schema.class.isAssignableFrom(object)) {
+            return false;
+        }
+        if (Sequence.class.isAssignableFrom(object)) {
+            return false;
+        }
+        return true;
+    }
+
     @Override
     public boolean supportsSchemas() {
         return false;

--- a/liquibase-standard/src/main/java/liquibase/database/core/SQLiteDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/SQLiteDatabase.java
@@ -225,7 +225,7 @@ public class SQLiteDatabase extends AbstractJdbcDatabase {
         if (Sequence.class.isAssignableFrom(object)) {
             return false;
         }
-        return true;
+        return super.supports(object);
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/database/core/SybaseDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/SybaseDatabase.java
@@ -12,6 +12,7 @@ import liquibase.statement.core.GetViewDefinitionStatement;
 import liquibase.statement.core.RawSqlStatement;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.Column;
+import liquibase.structure.core.Sequence;
 import liquibase.structure.core.Table;
 import liquibase.structure.core.View;
 import liquibase.util.StringUtil;
@@ -92,6 +93,14 @@ public class SybaseDatabase extends AbstractJdbcDatabase {
     @Override
     public boolean supportsInitiallyDeferrableColumns() {
         return false;
+    }
+
+    @Override
+    public boolean supports(Class<? extends DatabaseObject> object) {
+        if (Sequence.class.isAssignableFrom(object)) {
+            return false;
+        }
+        return super.supports(object);
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/database/core/UnsupportedDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/UnsupportedDatabase.java
@@ -3,6 +3,8 @@ package liquibase.database.core;
 import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.DatabaseConnection;
 import liquibase.exception.DatabaseException;
+import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.Sequence;
 
 public class UnsupportedDatabase extends AbstractJdbcDatabase {
 
@@ -69,6 +71,14 @@ public class UnsupportedDatabase extends AbstractJdbcDatabase {
     @Override
     public boolean supportsTablespaces() {
         return false;
+    }
+
+    @Override
+    public boolean supports(Class<? extends DatabaseObject> object) {
+        if (Sequence.class.isAssignableFrom(object)) {
+            return false;
+        }
+        return super.supports(object);
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/diff/DiffResult.java
+++ b/liquibase-standard/src/main/java/liquibase/diff/DiffResult.java
@@ -173,7 +173,7 @@ public class DiffResult {
         if ((obj instanceof Catalog) || (obj instanceof Schema)) {
             if ((differences.getSchemaComparisons() != null) && (differences.getDifferences().size() == 1) &&
                 (differences.getDifference("name") != null)) {
-                if ((obj instanceof Catalog) && this.getReferenceSnapshot().getDatabase().supportsSchemas()) { //still save name
+                if ((obj instanceof Catalog) && this.getReferenceSnapshot().getDatabase().supports(Schema.class)) { //still save name
                     changedObjects.put(obj, differences);
                     return;
                 } else {

--- a/liquibase-standard/src/main/java/liquibase/diff/compare/core/CatalogComparator.java
+++ b/liquibase-standard/src/main/java/liquibase/diff/compare/core/CatalogComparator.java
@@ -33,7 +33,7 @@ public class CatalogComparator extends CommonCatalogSchemaComparator {
             return false;
         }
 
-        if (!accordingTo.supportsCatalogs()) {
+        if (!accordingTo.supports(Catalog.class)) {
             return true;
         }
 

--- a/liquibase-standard/src/main/java/liquibase/diff/compare/core/CommonCatalogSchemaComparator.java
+++ b/liquibase-standard/src/main/java/liquibase/diff/compare/core/CommonCatalogSchemaComparator.java
@@ -4,6 +4,8 @@ import liquibase.CatalogAndSchema;
 import liquibase.database.Database;
 import liquibase.diff.compare.CompareControl;
 import liquibase.diff.compare.DatabaseObjectComparator;
+import liquibase.structure.core.Catalog;
+import liquibase.structure.core.Schema;
 import liquibase.util.StringUtil;
 
 /**
@@ -19,18 +21,18 @@ public abstract class CommonCatalogSchemaComparator implements DatabaseObjectCom
     }
 
     protected String getComparisonSchemaOrCatalog(Database accordingTo, CompareControl.SchemaComparison comparison) {
-        if (accordingTo.supportsSchemas()) {
+        if (accordingTo.supports(Schema.class)) {
             return comparison.getComparisonSchema().getSchemaName();
-        } else if (accordingTo.supportsCatalogs()) {
+        } else if (accordingTo.supports(Catalog.class)) {
             return comparison.getComparisonSchema().getCatalogName();
         }
         return null;
     }
 
     protected String getReferenceSchemaOrCatalog(Database accordingTo, CompareControl.SchemaComparison comparison) {
-        if (accordingTo.supportsSchemas()) {
+        if (accordingTo.supports(Schema.class)) {
             return comparison.getReferenceSchema().getSchemaName();
-        } else if (accordingTo.supportsCatalogs()) {
+        } else if (accordingTo.supports(Catalog.class)) {
             return comparison.getReferenceSchema().getCatalogName();
         }
 

--- a/liquibase-standard/src/main/java/liquibase/diff/compare/core/SchemaComparator.java
+++ b/liquibase-standard/src/main/java/liquibase/diff/compare/core/SchemaComparator.java
@@ -45,11 +45,11 @@ public class SchemaComparator extends CommonCatalogSchemaComparator {
                 return false;
             }
         }
-        if (accordingTo.supportsSchemas()) {
+        if (accordingTo.supports(Schema.class)) {
             schemaName1 = databaseObject1.getName();
             schemaName2 = databaseObject2.getName();
 
-        } else if (accordingTo.supportsCatalogs()) {
+        } else if (accordingTo.supports(Catalog.class)) {
             schemaName1 = ((Schema) databaseObject1).getCatalogName();
             schemaName2 = ((Schema) databaseObject2).getCatalogName();
         }
@@ -94,9 +94,9 @@ public class SchemaComparator extends CommonCatalogSchemaComparator {
 
     private String getSchemaAfterComparison(Database accordingTo, String schemaName1) {
         if (schemaName1 == null) {
-            if (accordingTo.supportsSchemas()) {
+            if (accordingTo.supports(Schema.class)) {
                 schemaName1 = accordingTo.getDefaultSchemaName();
-            } else if (accordingTo.supportsCatalogs()) {
+            } else if (accordingTo.supports(Catalog.class)) {
                 schemaName1 = accordingTo.getDefaultCatalogName();
             }
         }

--- a/liquibase-standard/src/main/java/liquibase/diff/output/changelog/core/MissingForeignKeyChangeGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/diff/output/changelog/core/MissingForeignKeyChangeGenerator.java
@@ -53,7 +53,7 @@ public class MissingForeignKeyChangeGenerator extends AbstractChangeGenerator im
         change.setReferencedTableName(fk.getPrimaryKeyTable().getName());
 
         String missingPrimaryKeyCatalogName = StringUtil.trimToEmpty(fk.getPrimaryKeyTable().getSchema().getCatalogName());
-        if (referenceDatabase.supportsCatalogs()) {
+        if (referenceDatabase.supports(Catalog.class)) {
             if (control.getIncludeCatalog() || control.considerCatalogsAsSchemas()) {
                 change.setReferencedTableCatalogName(fk.getPrimaryKeyTable().getSchema().getCatalogName());
                 includedCatalog = true;
@@ -66,7 +66,7 @@ public class MissingForeignKeyChangeGenerator extends AbstractChangeGenerator im
         }
 
         String missingPrimaryKeySchemaName = StringUtil.trimToEmpty(fk.getPrimaryKeyTable().getSchema().getName());
-        if (referenceDatabase.supportsSchemas()) {
+        if (referenceDatabase.supports(Schema.class)) {
             if (includedCatalog || control.getIncludeSchema()) {
                 change.setReferencedTableSchemaName(fk.getPrimaryKeyTable().getSchema().getName());
             } else if (!defaultSchemaName.equalsIgnoreCase(missingPrimaryKeySchemaName)) {

--- a/liquibase-standard/src/main/java/liquibase/diff/output/report/DiffToReport.java
+++ b/liquibase-standard/src/main/java/liquibase/diff/output/report/DiffToReport.java
@@ -9,6 +9,7 @@ import liquibase.diff.compare.CompareControl;
 import liquibase.diff.compare.DatabaseObjectCollectionComparator;
 import liquibase.exception.DatabaseException;
 import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.Catalog;
 import liquibase.structure.core.Schema;
 import liquibase.util.StringUtil;
 
@@ -41,12 +42,12 @@ public class DiffToReport {
                 Database referenceDatabase = diffResult.getReferenceSnapshot().getDatabase();
                 Database comparisonDatabase = diffResult.getComparisonSnapshot().getDatabase();
 
-                if (referenceDatabase.supportsSchemas()) {
+                if (referenceDatabase.supports(Schema.class)) {
                     referenceName = obj.getReferenceSchema().getSchemaName();
                     if (referenceName == null) {
                         referenceName = referenceDatabase.getDefaultSchemaName();
                     }
-                } else if (referenceDatabase.supportsCatalogs()) {
+                } else if (referenceDatabase.supports(Catalog.class)) {
                     referenceName = obj.getReferenceSchema().getCatalogName();
                     if (referenceName == null) {
                         referenceName = referenceDatabase.getDefaultCatalogName();
@@ -55,12 +56,12 @@ public class DiffToReport {
                     return "";
                 }
 
-                if (comparisonDatabase.supportsSchemas()) {
+                if (comparisonDatabase.supports(Schema.class)) {
                     comparisonName = obj.getComparisonSchema().getSchemaName();
                     if (comparisonName == null) {
                         comparisonName = comparisonDatabase.getDefaultSchemaName();
                     }
-                } else if (comparisonDatabase.supportsCatalogs()) {
+                } else if (comparisonDatabase.supports(Catalog.class)) {
                     comparisonName = obj.getComparisonSchema().getCatalogName();
                     if (comparisonName == null) {
                         comparisonName = comparisonDatabase.getDefaultCatalogName();
@@ -92,7 +93,7 @@ public class DiffToReport {
         TreeSet<Class<? extends DatabaseObject>> types = new TreeSet<>(Comparator.comparing(Class::getSimpleName));
         types.addAll(diffResult.getCompareControl().getComparedTypes());
         for (Class<? extends DatabaseObject> type : types) {
-            if (type.equals(Schema.class) && !diffResult.getComparisonSnapshot().getDatabase().supportsSchemas()) {
+            if (type.equals(Schema.class) && !diffResult.getComparisonSnapshot().getDatabase().supports(Schema.class)) {
                 continue;
             }
             printSetComparison("Missing " + getTypeName(type), diffResult.getMissingObjects(type, comparator), out);
@@ -208,12 +209,12 @@ public class DiffToReport {
                     Database referenceDatabase = diffResult.getReferenceSnapshot().getDatabase();
                     Database comparisonDatabase = diffResult.getComparisonSnapshot().getDatabase();
 
-                    if (referenceDatabase.supportsSchemas()) {
+                    if (referenceDatabase.supports(Schema.class)) {
                         referenceName = obj.getReferenceSchema().getSchemaName();
                         if (referenceName == null) {
                             referenceName = referenceDatabase.getDefaultSchemaName();
                         }
-                    } else if (referenceDatabase.supportsCatalogs()) {
+                    } else if (referenceDatabase.supports(Catalog.class)) {
                         referenceName = obj.getReferenceSchema().getCatalogName();
                         if (referenceName == null) {
                             referenceName = referenceDatabase.getDefaultCatalogName();
@@ -222,12 +223,12 @@ public class DiffToReport {
                         return "";
                     }
 
-                    if (comparisonDatabase.supportsSchemas()) {
+                    if (comparisonDatabase.supports(Schema.class)) {
                         comparisonName = obj.getComparisonSchema().getSchemaName();
                         if (comparisonName == null) {
                             comparisonName = comparisonDatabase.getDefaultSchemaName();
                         }
-                    } else if (comparisonDatabase.supportsCatalogs()) {
+                    } else if (comparisonDatabase.supports(Catalog.class)) {
                         comparisonName = obj.getComparisonSchema().getCatalogName();
                         if (comparisonName == null) {
                             comparisonName = comparisonDatabase.getDefaultCatalogName();

--- a/liquibase-standard/src/main/java/liquibase/integration/commandline/CommandLineUtils.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/commandline/CommandLineUtils.java
@@ -20,6 +20,7 @@ import liquibase.exception.DatabaseException;
 import liquibase.exception.LiquibaseException;
 import liquibase.resource.ClassLoaderResourceAccessor;
 import liquibase.resource.ResourceAccessor;
+import liquibase.structure.core.Schema;
 import liquibase.util.StringUtil;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -93,7 +94,7 @@ public class CommandLineUtils {
             Database database = DatabaseFactory.getInstance().openDatabase(url, username, password, driver,
                     databaseClass, driverPropertiesFile, propertyProviderClass, resourceAccessor);
 
-            if (!database.supportsSchemas()) {
+            if (!database.supports(Schema.class)) {
                 if ((defaultSchemaName != null) && (defaultCatalogName == null)) {
                     defaultCatalogName = defaultSchemaName;
                 }

--- a/liquibase-standard/src/main/java/liquibase/integration/spring/SpringLiquibase.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/spring/SpringLiquibase.java
@@ -14,6 +14,8 @@ import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.integration.commandline.LiquibaseCommandLineConfiguration;
 import liquibase.logging.Logger;
 import liquibase.resource.ResourceAccessor;
+import liquibase.structure.core.Catalog;
+import liquibase.structure.core.Schema;
 import liquibase.ui.UIServiceEnum;
 import liquibase.util.StringUtil;
 import lombok.Getter;
@@ -342,17 +344,17 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
         }
 
         Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(liquibaseConnection);
-        if (StringUtil.trimToNull(this.defaultSchema) != null) {
-            if (database.supportsSchemas()) {
+		if (StringUtil.trimToNull(this.defaultSchema) != null) {
+            if (database.supports(Schema.class)) {
                 database.setDefaultSchemaName(this.defaultSchema);
-            } else if (database.supportsCatalogs()) {
+            } else if (database.supports(Catalog.class)) {
                 database.setDefaultCatalogName(this.defaultSchema);
             }
         }
         if (StringUtil.trimToNull(this.liquibaseSchema) != null) {
-            if (database.supportsSchemas()) {
+            if (database.supports(Schema.class)) {
                 database.setLiquibaseSchemaName(this.liquibaseSchema);
-            } else if (database.supportsCatalogs()) {
+            } else if (database.supports(Catalog.class)) {
                 database.setLiquibaseCatalogName(this.liquibaseSchema);
             }
         }

--- a/liquibase-standard/src/main/java/liquibase/serializer/core/string/StringSnapshotSerializerReadable.java
+++ b/liquibase-standard/src/main/java/liquibase/serializer/core/string/StringSnapshotSerializerReadable.java
@@ -48,7 +48,7 @@ public class StringSnapshotSerializerReadable implements SnapshotSerializer {
             List<Schema> schemas = sort(snapshot.get(Schema.class), Comparator.comparing(Schema::toString));
 
             for (Schema schema : schemas) {
-                if (database.supportsSchemas()) {
+                if (database.supports(Schema.class)) {
                     buffer.append("\nCatalog & Schema: ").append(schema.getCatalogName()).append(" / ").append(schema.getName()).append("\n");
                 } else {
                     buffer.append("\nCatalog: ").append(schema.getCatalogName()).append("\n");

--- a/liquibase-standard/src/main/java/liquibase/snapshot/DatabaseSnapshot.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/DatabaseSnapshot.java
@@ -311,7 +311,6 @@ public abstract class DatabaseSnapshot implements LiquibaseSerializable {
         }
 
         T object = chain.snapshot(example, this);
-
         if (object == null) {
             Set<DatabaseObject> collection = knownNull.computeIfAbsent(example.getClass(), k -> new HashSet<>());
             collection.add(example);

--- a/liquibase-standard/src/main/java/liquibase/snapshot/DatabaseSnapshot.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/DatabaseSnapshot.java
@@ -94,7 +94,7 @@ public abstract class DatabaseSnapshot implements LiquibaseSerializable {
                 }
             }
 
-            if (getDatabase().supportsCatalogs()) {
+            if (getDatabase().supports(Catalog.class)) {
                 for (Catalog catalog : catalogs) {
                     this.snapshotControl.addType(catalog.getClass(), database);
                     include(catalog);

--- a/liquibase-standard/src/main/java/liquibase/snapshot/ResultSetCache.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/ResultSetCache.java
@@ -8,6 +8,8 @@ import liquibase.exception.DatabaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.executor.jvm.ColumnMapRowMapper;
 import liquibase.executor.jvm.RowMapperResultSetExtractor;
+import liquibase.structure.core.Catalog;
+import liquibase.structure.core.Schema;
 import liquibase.util.JdbcUtil;
 import liquibase.util.StringUtil;
 
@@ -162,9 +164,9 @@ public class ResultSetCache {
         }
 
         public String createSchemaKey(Database database) {
-            if (!database.supportsCatalogs() && !database.supportsSchemas()) {
+            if (!database.supports(Catalog.class) && !database.supports(Schema.class)) {
                 return "all";
-            } else if (database.supportsCatalogs() && database.supportsSchemas()) {
+            } else if (database.supports(Catalog.class) && database.supports(Schema.class)) {
                 if (CatalogAndSchema.CatalogAndSchemaCase.ORIGINAL_CASE.
                         equals(database.getSchemaAndCatalogCase())) {
                     return (catalog + "." + schema);

--- a/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotControl.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotControl.java
@@ -123,9 +123,9 @@ public class SnapshotControl implements LiquibaseSerializable {
 
     private void setTypes(Set<Class<? extends DatabaseObject>> types, Database database) {
         this.types = new HashSet<>();
-        for (Class<? extends DatabaseObject> type : types) {
-            addType(type, database);
-        }
+        types.stream()
+                .filter(database::supports)
+                .forEach(type -> addType(type, database));
     }
     
     /**

--- a/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotControl.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotControl.java
@@ -11,6 +11,7 @@ import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.DatabaseObjectFactory;
 
 import java.util.*;
+import java.util.stream.Stream;
 
 /**
  * Allows the class user to influence various aspects of the database object snapshot generation, e.g.
@@ -123,9 +124,11 @@ public class SnapshotControl implements LiquibaseSerializable {
 
     private void setTypes(Set<Class<? extends DatabaseObject>> types, Database database) {
         this.types = new HashSet<>();
-        types.stream()
-                .filter(database::supports)
-                .forEach(type -> addType(type, database));
+        Stream<Class<? extends DatabaseObject>> objectStream = types.stream();
+        if (database != null) {
+            objectStream = objectStream.filter(database::supports);
+        }
+        objectStream.forEach(type -> addType(type, database));
     }
     
     /**

--- a/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotControl.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotControl.java
@@ -1,6 +1,7 @@
 package liquibase.snapshot;
 
 import liquibase.database.Database;
+import liquibase.database.core.FirebirdDatabase;
 import liquibase.diff.output.ObjectChangeFilter;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.parser.core.ParsedNode;
@@ -8,6 +9,7 @@ import liquibase.parser.core.ParsedNodeException;
 import liquibase.resource.ResourceAccessor;
 import liquibase.serializer.LiquibaseSerializable;
 import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.Catalog;
 import liquibase.structure.core.DatabaseObjectFactory;
 
 import java.util.*;
@@ -93,11 +95,11 @@ public class SnapshotControl implements LiquibaseSerializable {
     @Override
     public Object getSerializableFieldValue(String field) {
         if ("includedType".equals(field)) {
-            SortedSet<String> types = new TreeSet<>();
+            SortedSet<String> typesNames = new TreeSet<>();
             for (Class type : this.getTypesToInclude()) {
-                types.add(type.getName());
+                typesNames.add(type.getName());
             }
-            return types;
+            return typesNames;
         } else {
             throw new UnexpectedLiquibaseException("Unknown field "+field);
         }
@@ -126,7 +128,9 @@ public class SnapshotControl implements LiquibaseSerializable {
         this.types = new HashSet<>();
         Stream<Class<? extends DatabaseObject>> objectStream = types.stream();
         if (database != null) {
-            objectStream = objectStream.filter(database::supports);
+            // Firebird does not support catalogs, but we need to include them in the snapshot for it as it has a catalog name
+            // Something incorrectly implemented in the FirebirdDatabase class that we work around here
+            objectStream = objectStream.filter(t -> (database.supports(t) || (database instanceof FirebirdDatabase && t.equals(Catalog.class))));
         }
         objectStream.forEach(type -> addType(type, database));
     }

--- a/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotGeneratorChain.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotGeneratorChain.java
@@ -59,8 +59,6 @@ public class SnapshotGeneratorChain {
             return null;
         }
 
-        boolean firstRoundDone = false;
-        SnapshotGenerator lastGenerator = null;
         T lastObject = example;
         while (snapshotGenerators.hasNext()) {
             SnapshotGenerator generator = snapshotGenerators.next();
@@ -71,27 +69,8 @@ public class SnapshotGeneratorChain {
             if ((object != null) && (object.getSnapshotId() == null)) {
                 object.setSnapshotId(snapshotIdService.generateId());
             }
-            // only first generator in the chain is allowed to create new instances - subsequent ones are not
-            if (firstRoundDone && object != lastObject) {
-                throw new DatabaseException(String.format("Snapshot generator %s has returned a different reference from the previous generator %s.\n" +
-                                                          "\tSnapshot object was: %s, it is now: %s.\n" +
-                                                          "\tConsider declaring %1$s as being replaced by one the generator in the chain via liquibase.snapshot.SnapshotGenerator#replaces.",
-                        generator.getClass().getName(),
-                        lastGenerator.getClass().getName(),
-                        identity(lastObject),
-                        identity(object)));
-            }
             lastObject = object;
-            lastGenerator = generator;
-            firstRoundDone = true;
         }
         return lastObject;
-    }
-
-    private static String identity(Object object) {
-        if (object == null) {
-            return "null";
-        }
-        return String.format("%s@%s", object.getClass(), System.identityHashCode(object));
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotGeneratorChain.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotGeneratorChain.java
@@ -59,6 +59,8 @@ public class SnapshotGeneratorChain {
             return null;
         }
 
+        boolean firstRoundDone = false;
+        SnapshotGenerator lastGenerator = null;
         T lastObject = example;
         while (snapshotGenerators.hasNext()) {
             SnapshotGenerator generator = snapshotGenerators.next();
@@ -69,8 +71,27 @@ public class SnapshotGeneratorChain {
             if ((object != null) && (object.getSnapshotId() == null)) {
                 object.setSnapshotId(snapshotIdService.generateId());
             }
+            // only first generator in the chain is allowed to create new instances - subsequent ones are not
+            if (firstRoundDone && object != lastObject) {
+                throw new DatabaseException(String.format("Snapshot generator %s has returned a different reference from the previous generator %s.\n" +
+                                                          "\tSnapshot object was: %s, it is now: %s.\n" +
+                                                          "\tConsider declaring %1$s as being replaced by one the generator in the chain via liquibase.snapshot.SnapshotGenerator#replaces.",
+                        generator.getClass().getName(),
+                        lastGenerator.getClass().getName(),
+                        identity(lastObject),
+                        identity(object)));
+            }
             lastObject = object;
+            lastGenerator = generator;
+            firstRoundDone = true;
         }
         return lastObject;
+    }
+
+    private static String identity(Object object) {
+        if (object == null) {
+            return "null";
+        }
+        return String.format("%s@%s", object.getClass(), System.identityHashCode(object));
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/CatalogSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/CatalogSnapshotGenerator.java
@@ -26,7 +26,7 @@ public class CatalogSnapshotGenerator extends JdbcSnapshotGenerator {
         Database database = snapshot.getDatabase();
         Catalog match = null;
         String catalogName = example.getName();
-        if ((catalogName == null) && database.supportsCatalogs()) {
+        if ((catalogName == null) && database.supports(Catalog.class)) {
             catalogName = database.getDefaultCatalogName();
         }
         example = new Catalog(catalogName);

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
@@ -148,7 +148,7 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
 
     @Override
     protected void addTo(DatabaseObject foundObject, DatabaseSnapshot snapshot) throws DatabaseException {
-        if (!snapshot.getSnapshotControl().shouldInclude(Column.class)) {
+        if (!snapshot.getSnapshotControl().shouldInclude(Column.class) || !snapshot.getDatabase().supports(Column.class)) {
             return;
         }
         if (foundObject instanceof Relation) {

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/DataSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/DataSnapshotGenerator.java
@@ -20,7 +20,7 @@ public class DataSnapshotGenerator extends JdbcSnapshotGenerator {
 
     @Override
     protected void addTo(DatabaseObject foundObject, DatabaseSnapshot snapshot) throws DatabaseException, InvalidExampleException {
-        if (!snapshot.getSnapshotControl().shouldInclude(Data.class)) {
+        if (!snapshot.getSnapshotControl().shouldInclude(Data.class) || !snapshot.getDatabase().supports(Table.class)) {
             return;
         }
         if (foundObject instanceof Table) {

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ForeignKeySnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ForeignKeySnapshotGenerator.java
@@ -47,7 +47,7 @@ public class ForeignKeySnapshotGenerator extends JdbcSnapshotGenerator {
 
     @Override
     protected void addTo(DatabaseObject foundObject, DatabaseSnapshot snapshot) throws DatabaseException, InvalidExampleException {
-        if (!snapshot.getSnapshotControl().shouldInclude(ForeignKey.class)) {
+        if (!snapshot.getSnapshotControl().shouldInclude(ForeignKey.class) || !snapshot.getDatabase().supports(ForeignKey.class)) {
             return;
         }
 

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/IndexSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/IndexSnapshotGenerator.java
@@ -30,7 +30,7 @@ public class IndexSnapshotGenerator extends JdbcSnapshotGenerator {
 
     @Override
     protected void addTo(DatabaseObject foundObject, DatabaseSnapshot snapshot) throws DatabaseException, InvalidExampleException {
-        if (!snapshot.getSnapshotControl().shouldInclude(Index.class)) {
+        if (!snapshot.getSnapshotControl().shouldInclude(Index.class) || !snapshot.getDatabase().supports(Index.class)) {
             return;
         }
 

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/PrimaryKeySnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/PrimaryKeySnapshotGenerator.java
@@ -105,7 +105,7 @@ public class PrimaryKeySnapshotGenerator extends JdbcSnapshotGenerator {
 
     @Override
     protected void addTo(DatabaseObject foundObject, DatabaseSnapshot snapshot) throws DatabaseException {
-        if (!snapshot.getSnapshotControl().shouldInclude(PrimaryKey.class)) {
+        if (!snapshot.getSnapshotControl().shouldInclude(PrimaryKey.class) || !snapshot.getDatabase().supports(PrimaryKey.class)) {
             return;
         }
 

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/SchemaSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/SchemaSnapshotGenerator.java
@@ -34,7 +34,7 @@ public class SchemaSnapshotGenerator extends JdbcSnapshotGenerator {
 
         String catalogName = ((Schema) example).getCatalogName();
         String schemaName = example.getName();
-        if (database.supportsSchemas()) {
+        if (database.supports(Schema.class)) {
             if (catalogName == null) {
                 catalogName = database.getDefaultCatalogName();
             }
@@ -42,7 +42,7 @@ public class SchemaSnapshotGenerator extends JdbcSnapshotGenerator {
                 schemaName = database.getDefaultSchemaName();
             }
         } else {
-            if (database.supportsCatalogs()) {
+            if (database.supports(Catalog.class)) {
                 if ((catalogName == null) && (schemaName != null)) {
                     catalogName = schemaName;
                     schemaName = null;
@@ -59,7 +59,7 @@ public class SchemaSnapshotGenerator extends JdbcSnapshotGenerator {
         ObjectQuotingStrategy currentStrategy = database.getObjectQuotingStrategy();
         database.setObjectQuotingStrategy(ObjectQuotingStrategy.LEGACY);
         try {
-            if (database.supportsSchemas()) {
+            if (database.supports(Schema.class)) {
                 for (String tableSchema : getDatabaseSchemaNames(database)) {
                     CatalogAndSchema schemaFromJdbcInfo = toCatalogAndSchema(tableSchema, database);
 

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
@@ -47,7 +47,7 @@ public class SequenceSnapshotGenerator extends JdbcSnapshotGenerator {
 
     @Override
     protected void addTo(DatabaseObject foundObject, DatabaseSnapshot snapshot) throws DatabaseException, InvalidExampleException {
-        if (!(foundObject instanceof Schema) || !snapshot.getDatabase().supportsSequences()) {
+        if (!(foundObject instanceof Schema) || !snapshot.getDatabase().supports(Sequence.class)) {
             return;
         }
         Schema schema = (Schema) foundObject;
@@ -82,7 +82,7 @@ public class SequenceSnapshotGenerator extends JdbcSnapshotGenerator {
                 return example;
             }
 
-            if (!database.supportsSequences()) {
+            if (!database.supports(Sequence.class)) {
                 return null;
             }
 

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
@@ -82,10 +82,6 @@ public class SequenceSnapshotGenerator extends JdbcSnapshotGenerator {
                 return example;
             }
 
-            if (!database.supports(Sequence.class)) {
-                return null;
-            }
-
             sequences = Scope.getCurrentScope().getSingleton(ExecutorService.class)
                     .getExecutor("jdbc", database)
                     .queryForList(getSelectSequenceStatement(example.getSchema(), database));

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
@@ -82,6 +82,9 @@ public class SequenceSnapshotGenerator extends JdbcSnapshotGenerator {
                 return example;
             }
 
+            if (!database.supports(Sequence.class)) {
+                return null;
+            }
             sequences = Scope.getCurrentScope().getSingleton(ExecutorService.class)
                     .getExecutor("jdbc", database)
                     .queryForList(getSelectSequenceStatement(example.getSchema(), database));

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/TableSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/TableSnapshotGenerator.java
@@ -48,7 +48,7 @@ public class TableSnapshotGenerator extends JdbcSnapshotGenerator {
 
     @Override
     protected void addTo(DatabaseObject foundObject, DatabaseSnapshot snapshot) throws DatabaseException, InvalidExampleException {
-        if (!snapshot.getSnapshotControl().shouldInclude(Table.class)) {
+        if (!snapshot.getSnapshotControl().shouldInclude(Table.class) || !snapshot.getDatabase().supports(Table.class)) {
             return;
         }
 

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
@@ -101,7 +101,7 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
     @Override
     protected void addTo(DatabaseObject foundObject, DatabaseSnapshot snapshot) throws DatabaseException {
 
-        if (!snapshot.getSnapshotControl().shouldInclude(UniqueConstraint.class)) {
+        if (!snapshot.getSnapshotControl().shouldInclude(UniqueConstraint.class) || !snapshot.getDatabase().supports(UniqueConstraint.class)) {
             return;
         }
 

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ViewSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ViewSnapshotGenerator.java
@@ -123,15 +123,12 @@ public class ViewSnapshotGenerator extends JdbcSnapshotGenerator {
 
     @Override
     protected void addTo(DatabaseObject foundObject, DatabaseSnapshot snapshot) throws DatabaseException, InvalidExampleException {
-        if (!snapshot.getSnapshotControl().shouldInclude(View.class)) {
+        Database database = snapshot.getDatabase();
+        if (!snapshot.getSnapshotControl().shouldInclude(View.class) || !database.supports(View.class)) {
             return;
         }
 
         if (!(foundObject instanceof Schema)) {
-            return;
-        }
-        Database database = snapshot.getDatabase();
-        if (!database.supports(View.class)) {
             return;
         }
         Schema schema = (Schema) foundObject;

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/AddDefaultValueGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/AddDefaultValueGenerator.java
@@ -17,6 +17,7 @@ import liquibase.statement.SequenceNextValueFunction;
 import liquibase.statement.core.AddDefaultValueStatement;
 import liquibase.structure.core.Column;
 import liquibase.structure.core.Schema;
+import liquibase.structure.core.Sequence;
 import liquibase.structure.core.Table;
 
 public class AddDefaultValueGenerator extends AbstractSqlGenerator<AddDefaultValueStatement> {
@@ -29,7 +30,7 @@ public class AddDefaultValueGenerator extends AbstractSqlGenerator<AddDefaultVal
         validationErrors.checkRequiredField("defaultValue", defaultValue, true);
         validationErrors.checkRequiredField("columnName", addDefaultValueStatement.getColumnName());
         validationErrors.checkRequiredField("tableName", addDefaultValueStatement.getTableName());
-        if (!database.supportsSequences() && (defaultValue instanceof SequenceNextValueFunction)) {
+        if (!database.supports(Sequence.class) && (defaultValue instanceof SequenceNextValueFunction)) {
             validationErrors.addError("Database "+database.getShortName()+" does not support sequences");
         }
         if (database instanceof HsqlDatabase) {

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/AlterSequenceGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/AlterSequenceGenerator.java
@@ -15,7 +15,7 @@ public class AlterSequenceGenerator extends AbstractSqlGenerator<AlterSequenceSt
 
     @Override
     public boolean supports(AlterSequenceStatement statement, Database database) {
-        return database.supportsSequences();
+        return database.supports(Sequence.class);
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateSequenceGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateSequenceGenerator.java
@@ -16,7 +16,7 @@ public class CreateSequenceGenerator extends AbstractSqlGenerator<CreateSequence
 
     @Override
     public boolean supports(CreateSequenceStatement statement, Database database) {
-        return database.supportsSequences();
+        return database.supports(Sequence.class);
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateTableGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateTableGenerator.java
@@ -20,6 +20,7 @@ import liquibase.sql.UnparsedSql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.statement.*;
 import liquibase.statement.core.CreateTableStatement;
+import liquibase.structure.core.Catalog;
 import liquibase.structure.core.ForeignKey;
 import liquibase.structure.core.Relation;
 import liquibase.structure.core.Schema;
@@ -294,7 +295,7 @@ public class CreateTableGenerator extends AbstractSqlGenerator<CreateTableStatem
                     .append(") REFERENCES ");
             if (referencesString != null) {
                 if (!referencesString.contains(".") && (database.getDefaultSchemaName() != null) && database
-                        .getOutputDefaultSchema() && (database.supportsSchemas() || database.supportsCatalogs())) {
+                        .getOutputDefaultSchema() && (database.supports(Schema.class) || database.supports(Catalog.class))) {
                     referencesString = database.escapeObjectName(database.getDefaultSchemaName(), Schema.class) + "." + referencesString;
                 }
                 buffer.append(referencesString);

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/DropSequenceGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/DropSequenceGenerator.java
@@ -14,7 +14,7 @@ public class DropSequenceGenerator extends AbstractSqlGenerator<DropSequenceStat
 
     @Override
     public boolean supports(DropSequenceStatement statement, Database database) {
-        return database.supportsSequences();
+        return database.supports(Sequence.class);
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/GetViewDefinitionGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/GetViewDefinitionGenerator.java
@@ -9,6 +9,8 @@ import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.statement.core.GetViewDefinitionStatement;
+import liquibase.structure.core.Catalog;
+import liquibase.structure.core.Schema;
 import liquibase.structure.core.View;
 
 public class GetViewDefinitionGenerator extends AbstractSqlGenerator<GetViewDefinitionStatement> {
@@ -34,7 +36,7 @@ public class GetViewDefinitionGenerator extends AbstractSqlGenerator<GetViewDefi
             sql += " and table_schema='" + schema.getCatalogName() + "'";
         } else {
 
-            if (database.supportsSchemas()) {
+            if (database.supports(Schema.class)) {
                 String schemaName = schema.getSchemaName();
                 if (schemaName != null) {
                 	if (database instanceof MSSQLDatabase)
@@ -44,7 +46,7 @@ public class GetViewDefinitionGenerator extends AbstractSqlGenerator<GetViewDefi
                 }
             }
 
-            if (database.supportsCatalogs()) {
+            if (database.supports(Catalog.class)) {
                 String catalogName = schema.getCatalogName();
                 if (catalogName != null) {
                 	if (database instanceof MSSQLDatabase)

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/RenameSequenceGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/RenameSequenceGenerator.java
@@ -13,7 +13,7 @@ public class RenameSequenceGenerator extends AbstractSqlGenerator<RenameSequence
 
     @Override
     public boolean supports(RenameSequenceStatement statement, Database database) {
-        return database.supportsSequences() 
+        return database.supports(Sequence.class)
             // TODO: following are not implemented/tested currently
             && !(database instanceof AbstractDb2Database)
             && !(database instanceof FirebirdDatabase)

--- a/liquibase-standard/src/test/groovy/liquibase/snapshot/SnapshotGeneratorChainTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/snapshot/SnapshotGeneratorChainTest.groovy
@@ -90,24 +90,6 @@ class SnapshotGeneratorChainTest extends Specification {
         snapshot.getAttribute("visited", Boolean.class) == expectedTable.getAttribute("visited", Boolean.class)
     }
 
-    def "snapshotting fails if subsequent generator returns a different instance"() {
-        given:
-        def chain = new SnapshotGeneratorChain(sortedSetOf(visitingGenerator, badGenerator))
-        def object = new Table()
-        database.isSystemObject(object) >> false
-        snapshotControl.shouldInclude(object.class) >> true
-        def expectedTable = new Table()
-        expectedTable.setAttribute("visited", true)
-
-
-        when:
-        chain.snapshot(object, snapshotContext)
-
-        then:
-        def exception = thrown(DatabaseException)
-        exception.message.startsWith("Snapshot generator liquibase.snapshot.BadSnapshotGenerator has returned a different reference from the previous generator liquibase.snapshot.VisitedSnapshotGenerator.")
-    }
-
     def "snapshotting works even if first generator returns a different instance"() {
         given:
         def chain = new SnapshotGeneratorChain(sortedSetOf(badGenerator))

--- a/liquibase-standard/src/test/groovy/liquibase/snapshot/SnapshotGeneratorChainTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/snapshot/SnapshotGeneratorChainTest.groovy
@@ -1,0 +1,280 @@
+package liquibase.snapshot
+
+import liquibase.database.Database
+import liquibase.exception.DatabaseException
+import liquibase.structure.DatabaseObject
+import liquibase.structure.core.Table
+import spock.lang.Specification
+
+class SnapshotGeneratorChainTest extends Specification {
+
+    private def database = Stub(Database.class)
+    private def snapshotControl = Stub(SnapshotControl.class)
+    private def snapshotContext = Stub(DatabaseSnapshot.class) {
+        getDatabase() >> database
+        getSnapshotControl() >> snapshotControl
+    }
+    private def object = new Table()
+    private def visitingGenerator = new VisitedSnapshotGenerator(object.class)
+    private def badGenerator = new BadSnapshotGenerator(object.class)
+    private def replacementForBadGenerator = new ReplacingSnapshotGenerator(object.class, badGenerator.class)
+
+
+    def "snapshotting null yields null"() {
+        given:
+        database.isSystemObject(_ as DatabaseObject) >> false
+        snapshotControl.shouldInclude(_ as Class<? extends DatabaseObject>) >> true
+
+        when:
+        def snapshot = new SnapshotGeneratorChain(null).snapshot(null, snapshotContext)
+
+        then:
+        snapshot == null
+    }
+
+    def "snapshotting system object yields null"() {
+        given:
+        def chain = new SnapshotGeneratorChain(sortedSetOf(visitingGenerator))
+        database.isSystemObject(object) >> true
+        snapshotControl.shouldInclude(object.class) >> true
+
+        when:
+        def snapshot = chain.snapshot(object, snapshotContext)
+
+        then:
+        snapshot == null
+    }
+
+    def "snapshotting excluded object yields null"() {
+        given:
+        def chain = new SnapshotGeneratorChain(sortedSetOf(visitingGenerator))
+        def object = new Table()
+        database.isSystemObject(object) >> false
+        snapshotControl.shouldInclude(object.class) >> false
+
+        when:
+        def snapshot = chain.snapshot(object, snapshotContext)
+
+        then:
+        snapshot == null
+    }
+
+    def "snapshotting with null generators yields null"() {
+        given:
+        def chain = new SnapshotGeneratorChain(null)
+        def object = new Table()
+        database.isSystemObject(object) >> false
+        snapshotControl.shouldInclude(object.class) >> true
+
+        when:
+        def snapshot = chain.snapshot(object, snapshotContext)
+
+        then:
+        snapshot == null
+    }
+
+    def "snapshotting delegates to generators"() {
+        given:
+        def chain = new SnapshotGeneratorChain(sortedSetOf(visitingGenerator))
+        def object = new Table()
+        database.isSystemObject(object) >> false
+        snapshotControl.shouldInclude(object.class) >> true
+        def expectedTable = new Table()
+        expectedTable.setAttribute("visited", true)
+
+
+        when:
+        def snapshot = chain.snapshot(object, snapshotContext)
+
+        then:
+        snapshot.getAttribute("visited", Boolean.class) == expectedTable.getAttribute("visited", Boolean.class)
+    }
+
+    def "snapshotting fails if subsequent generator returns a different instance"() {
+        given:
+        def chain = new SnapshotGeneratorChain(sortedSetOf(visitingGenerator, badGenerator))
+        def object = new Table()
+        database.isSystemObject(object) >> false
+        snapshotControl.shouldInclude(object.class) >> true
+        def expectedTable = new Table()
+        expectedTable.setAttribute("visited", true)
+
+
+        when:
+        chain.snapshot(object, snapshotContext)
+
+        then:
+        def exception = thrown(DatabaseException)
+        exception.message.startsWith("Snapshot generator liquibase.snapshot.BadSnapshotGenerator has returned a different reference from the previous generator liquibase.snapshot.VisitedSnapshotGenerator.")
+    }
+
+    def "snapshotting works even if first generator returns a different instance"() {
+        given:
+        def chain = new SnapshotGeneratorChain(sortedSetOf(badGenerator))
+        def object = new Table()
+        database.isSystemObject(object) >> false
+        snapshotControl.shouldInclude(object.class) >> true
+        def expectedTable = new Table()
+        expectedTable.setAttribute("visited", true)
+
+
+        when:
+        def result = chain.snapshot(object, snapshotContext)
+
+        then:
+        result != null
+    }
+
+    def "snapshotting works if bad generator is replaced in the chain"() {
+        given:
+        def chain = new SnapshotGeneratorChain(sortedSetOf(visitingGenerator, badGenerator, replacementForBadGenerator))
+        def object = new Table()
+        database.isSystemObject(object) >> false
+        snapshotControl.shouldInclude(object.class) >> true
+        def expectedTable = new Table()
+        expectedTable.setAttribute("visited", true)
+        expectedTable.setAttribute("replacement", "done")
+
+
+        when:
+        def snapshot = chain.snapshot(object, snapshotContext)
+
+        then:
+        snapshot.getAttribute("visited", Boolean.class) == expectedTable.getAttribute("visited", Boolean.class)
+        snapshot.getAttribute("replacement", String.class) == expectedTable.getAttribute("replacement", String.class)
+    }
+
+    private static SortedSet<SnapshotGenerator> sortedSetOf(SnapshotGenerator... generators) {
+        def result = new TreeSet<SnapshotGenerator>()
+        result.addAll(generators)
+        result
+    }
+}
+
+class VisitedSnapshotGenerator implements SnapshotGenerator, Comparable<SnapshotGenerator> {
+
+    private final Class<? extends DatabaseObject> acceptedType
+
+    VisitedSnapshotGenerator(Class<? extends DatabaseObject> acceptedType) {
+        this.acceptedType = acceptedType
+    }
+
+    @Override
+    int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
+        if (objectType == acceptedType) {
+            return PRIORITY_DATABASE
+        }
+        return PRIORITY_NONE
+    }
+
+    @Override
+    def <T extends DatabaseObject> T snapshot(T example, DatabaseSnapshot snapshot, SnapshotGeneratorChain chain) throws DatabaseException, InvalidExampleException {
+        example.setAttribute("visited", true)
+        return example
+    }
+
+    @Override
+    Class<? extends DatabaseObject>[] addsTo() {
+        return [acceptedType]
+    }
+
+    @Override
+    Class<? extends SnapshotGenerator>[] replaces() {
+        return new Class[0]
+    }
+
+    @Override
+    int compareTo(SnapshotGenerator o) {
+        if (System.identityHashCode(this) == System.identityHashCode(o)) {
+            return 0;
+        }
+        return 1; // smaller than == most priority
+    }
+}
+
+class ReplacingSnapshotGenerator implements SnapshotGenerator, Comparable<SnapshotGenerator> {
+
+    private final Class<? extends SnapshotGenerator> replacedGenerator
+    private final Class<? extends DatabaseObject> acceptedType
+
+    ReplacingSnapshotGenerator(Class<? extends DatabaseObject> acceptedType,
+                               Class<? extends SnapshotGenerator> replacedGenerator) {
+
+        this.acceptedType = acceptedType
+        this.replacedGenerator = replacedGenerator
+    }
+
+    @Override
+    int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
+        if (objectType == acceptedType) {
+            return PRIORITY_DATABASE
+        }
+        return PRIORITY_NONE
+    }
+
+    @Override
+    def <T extends DatabaseObject> T snapshot(T example, DatabaseSnapshot snapshot, SnapshotGeneratorChain chain) throws DatabaseException, InvalidExampleException {
+        example.setAttribute("replacement", "done")
+        return example
+    }
+
+    @Override
+    Class<? extends DatabaseObject>[] addsTo() {
+        return [acceptedType]
+    }
+
+    @Override
+    Class<? extends SnapshotGenerator>[] replaces() {
+        return [replacedGenerator]
+    }
+
+    @Override
+    int compareTo(SnapshotGenerator o) {
+        if (System.identityHashCode(this) == System.identityHashCode(o)) {
+            return 0;
+        }
+        return 1; // greater than == least priority
+    }
+}
+
+class BadSnapshotGenerator implements SnapshotGenerator, Comparable<SnapshotGenerator> {
+
+    private final Class<? extends DatabaseObject> acceptedType
+
+    BadSnapshotGenerator(Class<? extends DatabaseObject> acceptedType) {
+        this.acceptedType = acceptedType
+    }
+
+    @Override
+    int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
+        if (objectType == acceptedType) {
+            return PRIORITY_DATABASE
+        }
+        return PRIORITY_NONE
+    }
+
+    @Override
+    def <T extends DatabaseObject> T snapshot(T example, DatabaseSnapshot snapshot, SnapshotGeneratorChain chain) throws DatabaseException, InvalidExampleException {
+        // generators are expected to add nested attributes, ... to the provided example or delegate if the example type does not match
+        // they are NOT expected to create new instances of the same type
+        return acceptedType.newInstance() as T
+    }
+
+    @Override
+    Class<? extends DatabaseObject>[] addsTo() {
+        return [acceptedType]
+    }
+
+    @Override
+    Class<? extends SnapshotGenerator>[] replaces() {
+        return new Class[0]
+    }
+
+    @Override
+    int compareTo(SnapshotGenerator o) {
+        if (System.identityHashCode(this) == System.identityHashCode(o)) {
+            return 0;
+        }
+        return 1; // greater than == least priority
+    }
+}

--- a/liquibase-standard/src/test/groovy/liquibase/snapshot/SnapshotGeneratorChainTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/snapshot/SnapshotGeneratorChainTest.groovy
@@ -90,6 +90,24 @@ class SnapshotGeneratorChainTest extends Specification {
         snapshot.getAttribute("visited", Boolean.class) == expectedTable.getAttribute("visited", Boolean.class)
     }
 
+    def "snapshotting fails if subsequent generator returns a different instance"() {
+        given:
+        def chain = new SnapshotGeneratorChain(sortedSetOf(visitingGenerator, badGenerator))
+        def object = new Table()
+        database.isSystemObject(object) >> false
+        snapshotControl.shouldInclude(object.class) >> true
+        def expectedTable = new Table()
+        expectedTable.setAttribute("visited", true)
+
+
+        when:
+        chain.snapshot(object, snapshotContext)
+
+        then:
+        def exception = thrown(DatabaseException)
+        exception.message.startsWith("Snapshot generator liquibase.snapshot.BadSnapshotGenerator has returned a different reference from the previous generator liquibase.snapshot.VisitedSnapshotGenerator.")
+    }
+
     def "snapshotting works even if first generator returns a different instance"() {
         given:
         def chain = new SnapshotGeneratorChain(sortedSetOf(badGenerator))

--- a/liquibase-standard/src/test/groovy/liquibase/snapshot/jvm/ViewSnapshotGeneratorTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/snapshot/jvm/ViewSnapshotGeneratorTest.groovy
@@ -1,0 +1,29 @@
+package liquibase.snapshot.jvm
+
+import liquibase.database.Database
+import liquibase.snapshot.DatabaseSnapshot
+import liquibase.snapshot.SnapshotControl
+import liquibase.structure.core.Schema
+import liquibase.structure.core.View
+import spock.lang.Specification
+
+class ViewSnapshotGeneratorTest extends Specification {
+
+    def "does not add any views to snapshot if database does not support views"() {
+        given:
+        def database = Stub(Database.class)
+        database.supportsViews() >> false
+        def snapshotControl = Stub(SnapshotControl.class)
+        snapshotControl.shouldInclude(View.class) >> true
+        def snapshot = Stub(DatabaseSnapshot.class)
+        snapshot.getDatabase() >> database
+        snapshot.getSnapshotControl() >> snapshotControl
+        def schema = Mock(Schema.class)
+
+        when:
+        new ViewSnapshotGenerator().addTo(schema, snapshot)
+
+        then:
+        0 * _
+    }
+}

--- a/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/AlterSequenceGeneratorTest.java
+++ b/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/AlterSequenceGeneratorTest.java
@@ -7,6 +7,7 @@ import liquibase.database.core.PostgresDatabase;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.AbstractSqlGeneratorTest;
 import liquibase.statement.core.AlterSequenceStatement;
+import liquibase.structure.core.Sequence;
 import liquibase.test.TestContext;
 import org.junit.Test;
 
@@ -122,6 +123,6 @@ public class AlterSequenceGeneratorTest extends AbstractSqlGeneratorTest<AlterSe
 
     @Override
     protected boolean shouldBeImplementation(Database database) {
-        return database.supportsSequences();
+        return database.supports(Sequence.class);
     }
 }

--- a/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/CreateSequenceGeneratorTest.java
+++ b/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/CreateSequenceGeneratorTest.java
@@ -11,6 +11,7 @@ import liquibase.sql.Sql;
 import liquibase.sqlgenerator.AbstractSqlGeneratorTest;
 import liquibase.sqlgenerator.MockSqlGeneratorChain;
 import liquibase.statement.core.CreateSequenceStatement;
+import liquibase.structure.core.Sequence;
 import org.junit.Test;
 
 import java.math.BigInteger;
@@ -237,7 +238,7 @@ public class CreateSequenceGeneratorTest extends AbstractSqlGeneratorTest<Create
     @Override
     protected boolean shouldBeImplementation(Database database) {
 
-        return database.supportsSequences();
+        return database.supports(Sequence.class);
     }
 
 //    //    @Test


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Pro companion PR: https://github.com/liquibase/liquibase-pro/pull/1605
Pro-tests companion PR: https://github.com/liquibase/liquibase-pro-tests/pull/1322
 
## Things to be aware of

* Fixes SnapshotGeneratorChain
* Improves Database.supports methods

Having a generic method as 
```
 default boolean supports(Class<? extends DatabaseObject> object) {
```

allows extensions (specially NoSql ones) to implement validations as 

```
supports(Table.class) && supports(Catalog.class) 
```

without changing core to add a new "supportsTables" method.


## Things to worry about
TODO
