### PR TITLE
Add CustomChangeChecksum interface

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/change/custom/CustomChangeChecksum.java
+++ b/liquibase-standard/src/main/java/liquibase/change/custom/CustomChangeChecksum.java
@@ -1,0 +1,21 @@
+package liquibase.change.custom;
+
+import liquibase.change.AbstractChange;
+import liquibase.change.CheckSum;
+
+/**
+ * Interface to implement that allows a custom change to generate its own checksum.
+ *
+ * @see liquibase.change.custom.CustomChange
+ * @see AbstractChange#generateCheckSum()
+ */
+public interface CustomChangeChecksum {
+
+    /**
+     * Generates a checksum for the current state of the change.
+     *
+     * @return the generated checksum
+     */
+    CheckSum generateChecksum();
+
+}

--- a/liquibase-standard/src/main/java/liquibase/change/custom/CustomChangeWrapper.java
+++ b/liquibase-standard/src/main/java/liquibase/change/custom/CustomChangeWrapper.java
@@ -209,9 +209,21 @@ public class CustomChangeWrapper extends AbstractChange {
             statements = SqlStatement.EMPTY_SQL_STATEMENT;
         }
         return statements;
-
     }
 
+    @Override
+    public CheckSum generateCheckSum() {
+        try {
+            configureCustomChange();
+            if (customChange instanceof CustomChangeChecksum) {
+                return ((CustomChangeChecksum) customChange).generateChecksum();
+            } else {
+                return super.generateCheckSum();
+            }
+        } catch (CustomChangeException e) {
+            throw new UnexpectedLiquibaseException(e);
+        }
+    }
 
     /**
      * Returns true if the customChange supports rolling back.

--- a/liquibase-standard/src/test/groovy/liquibase/change/custom/CustomChangeWrapperTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/custom/CustomChangeWrapperTest.groovy
@@ -1,5 +1,6 @@
 package liquibase.change.custom
 
+import liquibase.change.CheckSum
 import liquibase.database.Database
 import liquibase.exception.CustomChangeException
 import liquibase.exception.RollbackImpossibleException
@@ -322,5 +323,22 @@ class CustomChangeWrapperTest extends Specification {
         change.getParamValue("tableName") == "my_table"
         change.getParamValue("columnName") == "my_col"
         change.getParamValue("unusedParam") == null
+    }
+
+    def "custom checksum is used"() {
+        when:
+        def change1 = new CustomChangeWrapper()
+        change1.setClass(ExampleCustomSqlChangeWithChecksum.class.getName())
+        change1.setParam("tableName", "my_table")
+        def change2 = new CustomChangeWrapper()
+        change2.setClass(ExampleCustomSqlChangeWithChecksum.class.getName())
+        change2.setParam("tableName", "my_other_table_name")
+        def change3 = new CustomChangeWrapper()
+        change3.setClass(ExampleCustomSqlChange.class.getName())
+        change3.setParam("tableName", "my_table")
+
+        then: "The checksum not affected by parameters set"
+        change1.generateCheckSum() == change2.generateCheckSum()
+        change1.generateCheckSum() != change3.generateCheckSum()
     }
 }

--- a/liquibase-standard/src/test/java/liquibase/change/custom/ExampleCustomSqlChangeWithChecksum.java
+++ b/liquibase-standard/src/test/java/liquibase/change/custom/ExampleCustomSqlChangeWithChecksum.java
@@ -1,0 +1,19 @@
+package liquibase.change.custom;
+
+import liquibase.change.CheckSum;
+
+public class ExampleCustomSqlChangeWithChecksum extends ExampleCustomSqlChange implements CustomChangeChecksum {
+
+    // Some synthetic field to be used in our checksum calculation
+    private final Integer version = 5;
+
+    /**
+     * Generate a checksum based on the classname and the version number within.
+     * Does not care about any parameters set
+     * @return the calculated checksum
+     */
+    @Override
+    public CheckSum generateChecksum() {
+        return CheckSum.compute(getClass().getName() + ":" + version);
+    }
+}


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

Adds a new optional interface: CustomChangeChecksum, that you can implement on any CustomChange.

Will let you configure how the checksum for your specific change will be calculated, if you're not happy with the default.

See discussion in #5478

Closes #5478

## Things to be aware of

As previously stated, introduces the `CustomChangeChecksum` interface which you can add to your `CustomChange` implementation, in order to calculate your own checksum for your change. This will be a non-breaking change since the interface is completely optional.

The technical impact is that `CustomChangeWrapper` will look and see if the custom change implements the new interface, and then call the `generateChecksum` from that specific interface. If not, use the default one (via AbstractChange)

## Things to worry about

N/A

## Additional Context

N/A

Question: Who updates the documentation to include this new interface?
