### PR TITLE
Add `LiquibaseCustomizer` for Spring.

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/integration/spring/LiquibaseCustomizer.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/spring/LiquibaseCustomizer.java
@@ -1,0 +1,19 @@
+package liquibase.integration.spring;
+
+import liquibase.Liquibase;
+
+/**
+ * Callback interface that can be implemented by beans wishing to further customize the
+ * {@link Liquibase}.
+ */
+@FunctionalInterface
+public interface LiquibaseCustomizer {
+
+    /**
+     * Customize the {@link Liquibase}.
+     *
+     * @param liquibase the Liquibase to customize
+     */
+    void customize(Liquibase liquibase);
+
+}

--- a/liquibase-standard/src/main/java/liquibase/integration/spring/SpringLiquibase.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/spring/SpringLiquibase.java
@@ -125,6 +125,10 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
     @Getter
     protected UIServiceEnum uiService = UIServiceEnum.LOGGER;
 
+    @Getter
+    @Setter
+    protected LiquibaseCustomizer customizer;
+
     public SpringLiquibase() {
         super();
     }
@@ -318,6 +322,10 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
 
         if (liquibase.getDatabase() instanceof DerbyDatabase) {
             ((DerbyDatabase) liquibase.getDatabase()).setShutdownEmbeddedDerby(false);
+        }
+
+        if (customizer != null) {
+            customizer.customize(liquibase);
         }
 
         return liquibase;

--- a/liquibase-standard/src/test/java/liquibase/integration/spring/SpringLiquibaseTest.java
+++ b/liquibase-standard/src/test/java/liquibase/integration/spring/SpringLiquibaseTest.java
@@ -1,6 +1,9 @@
 package liquibase.integration.spring;
 
 import liquibase.Liquibase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for {@link SpringLiquibase}
@@ -20,7 +23,7 @@ public class SpringLiquibaseTest {
 //    private ArgumentCaptor<String> stringCaptor ;
 
 //    @Before
-//    public void setUp(){
+//    public void setUp() {
 //        liquibase = mock(Liquibase.class);
 //        springLiquibase.setContexts(TEST_CONTEXT);
 //        springLiquibase.setLabels(TEST_LABELS);
@@ -73,4 +76,14 @@ public class SpringLiquibaseTest {
 //        assertTrue(labelCaptor.getValue().getLabels().contains(TEST_LABELS));
 //        assertSame(stringCaptor.getValue(),TEST_TAG);
 //    }
+
+    @Test
+    public void customizer() throws Exception {
+        LiquibaseCustomizer customizer = liquibase -> liquibase.setChangeLogParameter("some key", "some value");
+        springLiquibase.setCustomizer(customizer);
+        try (Liquibase liquibase = springLiquibase.createLiquibase(null)) {
+            Object value = liquibase.getChangeLogParameters().getValue("some key", null);
+            assertEquals("some value", value);
+        }
+    }
 }


### PR DESCRIPTION

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description
There is a need for Spring applications to configure the Liquibase created, for example to set `ChangeExecListener`.

In spring, there is a common pattern of Customizer, e.g. [Jackson2ObjectMapperBuilderCustomizer](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/jackson/Jackson2ObjectMapperBuilderCustomizer.html) to handle such situations.

This PR adds a `LiquibaseCustomizer`, which would be used by Spring after this is merged, so that it can be used in Spring application.

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

The class can be named `SpringLiquibaseCustomizer`, but I think `LiquibaseCustomizer` is more generic, and could possibly be moved into another package.

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->

Fixes #5128