### PR TITLE
Default implementation of handleInvalidEmptyPreconditionCase added in AbtractFormattedChangeLogParser to avoid breaking extensions

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/parser/AbstractFormattedChangeLogParser.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/AbstractFormattedChangeLogParser.java
@@ -14,6 +14,7 @@ import liquibase.exception.ChangeLogParseException;
 import liquibase.resource.ResourceAccessor;
 import liquibase.util.StreamUtil;
 import liquibase.util.StringUtil;
+import org.apache.commons.lang3.NotImplementedException;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -609,20 +610,7 @@ public abstract class AbstractFormattedChangeLogParser implements ChangeLogParse
     }
 
     protected void handleInvalidEmptyPreconditionCase(ChangeLogParameters changeLogParameters, ChangeSet changeSet, Matcher preconditionMatcher) throws ChangeLogParseException {
-        if (preconditionMatcher.groupCount() == 1) {
-            String name = StringUtil.trimToNull(preconditionMatcher.group(1));
-            if (name != null) {
-                if ("sql-check".equals(name)) {
-                    throw new ChangeLogParseException("Precondition sql check failed because of missing required expectedResult and sql parameters.");
-                } else if ("table-exists".equals(name)) {
-                    throw new ChangeLogParseException("Precondition table exists failed because of missing required table name parameter.");
-                } else if ("view-exists".equals(name)) {
-                    throw new ChangeLogParseException("Precondition view exists failed because of missing required view name parameter.");
-                } else {
-                    throw new ChangeLogParseException("The '" + name + "' precondition type is not supported.");
-                }
-            }
-        }
+        throw new NotImplementedException();
     }
 
     private void handleRollbackSequence(String physicalChangeLogLocation, ChangeLogParameters changeLogParameters, DatabaseChangeLog changeLog, StringBuilder currentRollbackSequence, ChangeSet changeSet, Matcher rollbackSplitStatementsPatternMatcher, boolean rollbackSplitStatements, String rollbackEndDelimiter) throws ChangeLogParseException {

--- a/liquibase-standard/src/main/java/liquibase/parser/AbstractFormattedChangeLogParser.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/AbstractFormattedChangeLogParser.java
@@ -610,7 +610,7 @@ public abstract class AbstractFormattedChangeLogParser implements ChangeLogParse
     }
 
     protected void handleInvalidEmptyPreconditionCase(ChangeLogParameters changeLogParameters, ChangeSet changeSet, Matcher preconditionMatcher) throws ChangeLogParseException {
-        throw new NotImplementedException();
+        throw new NotImplementedException("Invalid empty precondition found");
     }
 
     private void handleRollbackSequence(String physicalChangeLogLocation, ChangeLogParameters changeLogParameters, DatabaseChangeLog changeLog, StringBuilder currentRollbackSequence, ChangeSet changeSet, Matcher rollbackSplitStatementsPatternMatcher, boolean rollbackSplitStatements, String rollbackEndDelimiter) throws ChangeLogParseException {

--- a/liquibase-standard/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
@@ -142,6 +142,24 @@ public class FormattedSqlChangeLogParser extends AbstractFormattedChangeLogParse
         change.setSql(changeLogParameters.expandExpressions(StringUtil.trimToNull(currentSequence.toString()), changeSet.getChangeLog()));
     }
 
+    @Override
+    protected void handleInvalidEmptyPreconditionCase(ChangeLogParameters changeLogParameters, ChangeSet changeSet, Matcher preconditionMatcher) throws ChangeLogParseException {
+        if (preconditionMatcher.groupCount() == 1) {
+            String name = StringUtil.trimToNull(preconditionMatcher.group(1));
+            if (name != null) {
+                if ("sql-check".equals(name)) {
+                    throw new ChangeLogParseException("Precondition sql check failed because of missing required expectedResult and sql parameters.");
+                } else if ("table-exists".equals(name)) {
+                    throw new ChangeLogParseException("Precondition table exists failed because of missing required table name parameter.");
+                } else if ("view-exists".equals(name)) {
+                    throw new ChangeLogParseException("Precondition view exists failed because of missing required view name parameter.");
+                } else {
+                    throw new ChangeLogParseException("The '" + name + "' precondition type is not supported.");
+                }
+            }
+        }
+    }
+
     private SqlPrecondition parseSqlCheckCondition(String body) throws ChangeLogParseException {
         for (Pattern pattern : WORD_AND_QUOTING_PATTERNS) {
             Matcher matcher = pattern.matcher(body);

--- a/liquibase-standard/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
@@ -81,24 +81,6 @@ public class FormattedSqlChangeLogParser extends AbstractFormattedChangeLogParse
     }
 
     @Override
-    protected void handleInvalidEmptyPreconditionCase(ChangeLogParameters changeLogParameters, ChangeSet changeSet, Matcher preconditionMatcher) throws ChangeLogParseException {
-        if (preconditionMatcher.groupCount() == 1) {
-            String name = StringUtil.trimToNull(preconditionMatcher.group(1));
-            if (name != null) {
-                if ("sql-check".equals(name)) {
-                    throw new ChangeLogParseException("Precondition sql check failed because of missing required expectedResult and sql parameters.");
-                } else if ("table-exists".equals(name)) {
-                    throw new ChangeLogParseException("Precondition table exists failed because of missing required table name parameter.");
-                } else if ("view-exists".equals(name)) {
-                    throw new ChangeLogParseException("Precondition view exists failed because of missing required view name parameter.");
-                } else {
-                    throw new ChangeLogParseException("The '" + name + "' precondition type is not supported.");
-                }
-            }
-        }
-    }
-
-    @Override
     protected void handlePreconditionCase(ChangeLogParameters changeLogParameters, ChangeSet changeSet, Matcher preconditionMatcher) throws ChangeLogParseException {
         if (changeSet.getPreconditions() == null) {
             // create the defaults


### PR DESCRIPTION


## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

Recently with the merge of this [PR](https://github.com/liquibase/liquibase/pull/5456/) the team has noticed this is breaking extensions, so just move the code implementation of `handleInvalidEmptyPreconditionCase` to the abstract class which should fix this issue if no extension overrides this method.

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
