### PR TITLE
fix: ClearChecksums in an empty database should not fail

### DIFF
--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/core/ClearCheckSumsIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/core/ClearCheckSumsIntegrationTest.groovy
@@ -18,6 +18,24 @@ class ClearCheckSumsIntegrationTest extends Specification {
     @Shared
     private DatabaseTestSystem h2 = (DatabaseTestSystem) Scope.currentScope.getSingleton(TestSystemFactory.class).getTestSystem("h2")
 
+    def "clearing checksums in an empty database does not throw an exception"() {
+        given:
+        CommandUtil.runDropAll(h2)
+
+        when:
+        def h2Database = h2.getDatabaseFromFactory()
+        def commandResults = new CommandScope("clearChecksums")
+                .addArgumentValue(DbUrlConnectionArgumentsCommandStep.URL_ARG, h2.getConnectionUrl())
+                .addArgumentValue(DbUrlConnectionArgumentsCommandStep.DATABASE_ARG, h2Database)
+                .execute()
+
+        then:
+        commandResults.results.size() == 0
+
+        cleanup:
+        CommandUtil.runDropAll(h2)
+    }
+
     def "validate checksums are cleared"() {
         given:
         def updateCommand = new CommandScope(UpdateCommandStep.COMMAND_NAME)

--- a/liquibase-standard/src/main/java/liquibase/command/core/ClearChecksumsCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/ClearChecksumsCommandStep.java
@@ -3,7 +3,10 @@ package liquibase.command.core;
 import liquibase.Scope;
 import liquibase.changelog.ChangeLogHistoryService;
 import liquibase.changelog.ChangeLogHistoryServiceFactory;
-import liquibase.command.*;
+import liquibase.command.AbstractCommandStep;
+import liquibase.command.CommandDefinition;
+import liquibase.command.CommandResultsBuilder;
+import liquibase.command.CommandScope;
 import liquibase.database.Database;
 import liquibase.lockservice.LockService;
 
@@ -31,9 +34,10 @@ public class ClearChecksumsCommandStep extends AbstractCommandStep {
         CommandScope commandScope = resultsBuilder.getCommandScope();
         final Database database = (Database) commandScope.getDependency(Database.class);
 
-        ChangeLogHistoryService changeLogService = ChangeLogHistoryServiceFactory.getInstance().getChangeLogService(database);
+        ChangeLogHistoryService changeLogHistoryService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database);
+        changeLogHistoryService.init();
         Scope.getCurrentScope().getLog(getClass()).info(String.format("Clearing database change log checksums for database %s", database.getShortName()));
-        changeLogService.clearAllCheckSums();
+        changeLogHistoryService.clearAllCheckSums();
     }
 
     @Override


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 

After https://github.com/liquibase/liquibase/pull/4628 clearChecksums started to raise exceptions in empty databases. This PR fixes this behavior.

Fixes #5319 
