### PR TITLE
Check path validity before attempting to create a path

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/changelog/RanChangeSet.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/RanChangeSet.java
@@ -4,6 +4,7 @@ import liquibase.ChecksumVersion;
 import liquibase.ContextExpression;
 import liquibase.Labels;
 import liquibase.change.CheckSum;
+import liquibase.util.FilenameUtil;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -133,6 +134,6 @@ public class RanChangeSet {
     private boolean isSamePath(String filePath) {
         String normalizedFilePath = DatabaseChangeLog.normalizePath(this.getChangeLog());
         return normalizedFilePath.equalsIgnoreCase(DatabaseChangeLog.normalizePath(filePath))
-                || normalizedFilePath.equalsIgnoreCase(Paths.get(filePath).normalize().toString().replace("\\", "/"));
+                || (FilenameUtil.isValidPath(filePath) && normalizedFilePath.equalsIgnoreCase(Paths.get(filePath).normalize().toString().replace("\\", "/")));
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/util/FilenameUtil.java
+++ b/liquibase-standard/src/main/java/liquibase/util/FilenameUtil.java
@@ -132,4 +132,19 @@ public class FilenameUtil {
         }
         return fileName;
     }
+
+    /**
+     * Check if the given path is a valid path
+     *
+     * @param path to check
+     * @return true if the path is valid, false otherwise
+     */
+    public static boolean isValidPath(String path) {
+        try {
+            Paths.get(path);
+        } catch (InvalidPathException e) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/liquibase-standard/src/test/java/liquibase/changelog/RanChangeSetTest.java
+++ b/liquibase-standard/src/test/java/liquibase/changelog/RanChangeSetTest.java
@@ -2,6 +2,7 @@ package liquibase.changelog;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class RanChangeSetTest {
@@ -11,6 +12,13 @@ public class RanChangeSetTest {
         RanChangeSet ranChangeSet = new RanChangeSet("classpath:/db/file.log", "1", "author", null, null, null, null, null, null, null, null, null);
         ChangeSet incomingChangeSet = new ChangeSet("1", "author", false, false, "classpath:/db/file.log", null, null, null);
         assertTrue(ranChangeSet.isSameAs(incomingChangeSet));
+    }
+
+    @Test
+    public void is_not_same_when_changeset_has_classpath_prefix() {
+        RanChangeSet ranChangeSet = new RanChangeSet("db/ran-changeset.log", "1", "author", null, null, null, null, null, null, null, null, null);
+        ChangeSet incomingChangeSet = new ChangeSet("1", "author", false, false, "classpath:/db/file.log", null, null, null);
+        assertFalse(ranChangeSet.isSameAs(incomingChangeSet));
     }
 
     @Test


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

Checks for path validity before trying to create a path with `Paths.get`
This fixes #5681

## Things to worry about

I'm not really comfortable with spock tests. That why i didn't refactor the `RanChangeSetTest` and just added a new test case.
I don't think the new `FilenameUtil` method needs to be tested. Let me know if you have a different opinion.