### PR TITLE
fix: addColumn changes are not respecting Datatypes definitions

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/diff/output/changelog/core/MissingColumnChangeGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/diff/output/changelog/core/MissingColumnChangeGenerator.java
@@ -5,6 +5,9 @@ import liquibase.change.Change;
 import liquibase.change.ConstraintsConfig;
 import liquibase.change.core.AddColumnChange;
 import liquibase.database.Database;
+import liquibase.datatype.DataTypeFactory;
+import liquibase.datatype.DatabaseDataType;
+import liquibase.datatype.LiquibaseDataType;
 import liquibase.diff.output.DiffOutputControl;
 import liquibase.diff.output.changelog.AbstractChangeGenerator;
 import liquibase.diff.output.changelog.ChangeGeneratorChain;
@@ -63,9 +66,10 @@ public class MissingColumnChangeGenerator extends AbstractChangeGenerator implem
         AddColumnConfig columnConfig = createAddColumnConfig();
         columnConfig.setName(column.getName());
 
-        String dataType = column.getType().toString();
-
-        columnConfig.setType(dataType);
+        LiquibaseDataType ldt = DataTypeFactory.getInstance().from(column.getType(), referenceDatabase);
+        DatabaseDataType ddt = ldt.toDatabaseDataType(comparisonDatabase);
+        String typeString = ddt.toString();
+        columnConfig.setType(typeString);
 
         MissingTableChangeGenerator.setDefaultValue(columnConfig, column, comparisonDatabase);
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

When running a diffChangelog, a create table the column uses the Datatypes classes to define the column types, but an addColumn change would simply dump the database text.

This PR fixes addColumn by making it behave as createTable.
