### PR TITLE
[DAT-16135] add new scope flag for modifyChangeSet flow

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -31,6 +31,7 @@ import liquibase.resource.ResourceAccessor;
 import liquibase.servicelocator.LiquibaseService;
 import liquibase.util.FileUtil;
 import liquibase.util.StringUtil;
+import org.apache.commons.collections4.map.SingletonMap;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -235,9 +236,10 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
         return getFilePath().compareTo(o.getFilePath());
     }
 
-    public List<ChangeVisitor> getChangeVisitors(){
+    public List<ChangeVisitor> getChangeVisitors() {
         return changeVisitors;
     }
+
     public ChangeSet getChangeSet(String path, String author, String id) {
         final List<ChangeSet> possibleChangeSets = getChangeSets(path, author, id);
         if (possibleChangeSets.isEmpty()) {
@@ -352,14 +354,15 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
 
         if (!validatingVisitor.validationPassed()) {
             Scope.getCurrentScope().addMdcValue(MdcKey.DEPLOYMENT_OUTCOME, MdcValue.COMMAND_FAILED);
-            List<MdcChangeset> duplicateChangesetsMdc = validatingVisitor.getDuplicateChangeSets().stream().map(MdcChangeset::fromChangeset).collect(Collectors.toList());
+            List<MdcChangeset> duplicateChangesetsMdc =
+                    validatingVisitor.getDuplicateChangeSets().stream().map(MdcChangeset::fromChangeset).collect(Collectors.toList());
             Scope.getCurrentScope().addMdcValue(MdcKey.DUPLICATE_CHANGESETS, new DuplicateChangesets(duplicateChangesetsMdc));
             Scope.getCurrentScope().getLog(getClass()).info("Change failed validation!");
             throw new ValidationFailedException(validatingVisitor);
         }
     }
 
-    public ChangeSet  getChangeSet(RanChangeSet ranChangeSet) {
+    public ChangeSet getChangeSet(RanChangeSet ranChangeSet) {
         final ChangeSet changeSet = getChangeSet(ranChangeSet.getChangeLog(), ranChangeSet.getAuthor(), ranChangeSet.getId());
         if (changeSet != null) {
             changeSet.setStoredFilePath(ranChangeSet.getStoredChangeLog());
@@ -528,11 +531,11 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
             case "removeChangeSetProperty": {
                 List<ParsedNode> childNodes = node.getChildren();
                 Optional<ParsedNode> changeNode = childNodes.stream().filter(n -> n.getName().equalsIgnoreCase("change")).findFirst();
-                if(changeNode.isPresent()){
+                if (changeNode.isPresent()) {
                     ChangeVisitor changeVisitor = ChangeVisitorFactory.getInstance().create((String) changeNode.get().getValue());
-                    if(changeVisitor != null){
+                    if (changeVisitor != null) {
                         changeVisitor.load(node, resourceAccessor);
-                        if(DatabaseList.definitionMatches(changeVisitor.getDbms(), changeLogParameters.getDatabase(), false)) {
+                        if (DatabaseList.definitionMatches(changeVisitor.getDbms(), changeLogParameters.getDatabase(), false)) {
                             //add changeVisitor to this changeLog only if the running database matches with one of the removeChangeSetProperty's dbms
                             getChangeVisitors().add(changeVisitor);
                         }
@@ -699,7 +702,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                            int maxDepth)
             throws SetupException {
         includeAll(pathName, isRelativeToChangelogFile, resourceFilter, errorIfMissingOrEmpty, resourceComparator,
-                   resourceAccessor, includeContextFilter, labels, ignore, minDepth, maxDepth, "", new ModifyChangeSets(null, null));
+                resourceAccessor, includeContextFilter, labels, ignore, minDepth, maxDepth, "", new ModifyChangeSets(null, null));
     }
 
     @Deprecated
@@ -738,7 +741,8 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
             throw new SetupException("No path attribute for includeAll");
         }
         SortedSet<Resource> resources =
-                findResources(pathName, isRelativeToChangelogFile, resourceFilter, errorIfMissingOrEmpty, resourceComparator, resourceAccessor, minDepth, maxDepth, endsWithFilter);
+                findResources(pathName, isRelativeToChangelogFile, resourceFilter, errorIfMissingOrEmpty, resourceComparator, resourceAccessor, minDepth,
+                        maxDepth, endsWithFilter);
         if (resources.isEmpty() && errorIfMissingOrEmpty) {
             throw new SetupException(
                     "Could not find directory or directory was empty for includeAll '" + pathName + "'");
@@ -772,16 +776,16 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
     }
 
     public SortedSet<Resource> findResources(
-                               String pathName,
-                               boolean isRelativeToChangelogFile,
-                               IncludeAllFilter resourceFilter,
-                               boolean errorIfMissingOrEmpty,
-                               Comparator<String> resourceComparator,
-                               ResourceAccessor resourceAccessor,
-                               int minDepth,
-                               int maxDepth,
-                               String endsWithFilter
-                               ) throws SetupException {
+            String pathName,
+            boolean isRelativeToChangelogFile,
+            IncludeAllFilter resourceFilter,
+            boolean errorIfMissingOrEmpty,
+            Comparator<String> resourceComparator,
+            ResourceAccessor resourceAccessor,
+            int minDepth,
+            int maxDepth,
+            String endsWithFilter
+    ) throws SetupException {
         try {
             if (pathName == null) {
                 throw new SetupException("No path attribute for findResources");
@@ -826,7 +830,8 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
 
             if (resources.isEmpty() && errorIfMissingOrEmpty) {
                 throw new SetupException(
-                        "Could not find directory, directory was empty, or no changelogs matched the provided search criteria for includeAll '" + pathName + "'");
+                        "Could not find directory, directory was empty, or no changelogs matched the provided search criteria for includeAll '" + pathName +
+                                "'");
             }
             return resources;
         } catch (IOException e) {
@@ -843,7 +848,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
             path = normalizePath(path);
         }
 
-        if(path != null) {
+        if (path != null) {
             path = path.replace("\\", "/");
             if (StringUtil.isNotEmpty(path) && !(path.endsWith("/"))) {
                 path = path + '/';
@@ -892,7 +897,8 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                            Boolean ignore,
                            boolean logEveryUnknownFileFormat)
             throws LiquibaseException {
-        return include(fileName, isRelativePath, errorIfMissing, resourceAccessor, includeContextFilter, labels, ignore, logEveryUnknownFileFormat ? OnUnknownFileFormat.WARN : OnUnknownFileFormat.SKIP);
+        return include(fileName, isRelativePath, errorIfMissing, resourceAccessor, includeContextFilter, labels, ignore, logEveryUnknownFileFormat ?
+                OnUnknownFileFormat.WARN : OnUnknownFileFormat.SKIP);
     }
 
     public boolean include(String fileName,
@@ -904,7 +910,8 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                            Boolean ignore,
                            OnUnknownFileFormat onUnknownFileFormat)
             throws LiquibaseException {
-        return include(fileName, isRelativePath, errorIfMissing, resourceAccessor, includeContextFilter, labels, ignore, onUnknownFileFormat, new ModifyChangeSets(null, null));
+        return include(fileName, isRelativePath, errorIfMissing, resourceAccessor, includeContextFilter, labels, ignore, onUnknownFileFormat,
+                new ModifyChangeSets(null, null));
     }
 
     public boolean include(String fileName,
@@ -924,11 +931,12 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
         if (isRelativePath) {
             try {
                 fileName = resourceAccessor.get(this.getPhysicalFilePath()).resolveSibling(fileName).getPath();
-                fileName = normalizePath(Paths.get(fileName).toString());
             } catch (IOException e) {
                 throw new UnexpectedLiquibaseException(e);
             }
         }
+        final String normalizedFilePath = normalizePath(Paths.get(fileName).toString());
+
         DatabaseChangeLog changeLog;
         try {
             DatabaseChangeLog rootChangeLog = ROOT_CHANGE_LOG.get();
@@ -938,17 +946,23 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
             DatabaseChangeLog parentChangeLog = PARENT_CHANGE_LOG.get();
             PARENT_CHANGE_LOG.set(this);
             try {
-                if (!resourceAccessor.get(fileName).exists()) {
+                if (!resourceAccessor.get(normalizedFilePath).exists()) {
                     if (ChangeLogParserConfiguration.ON_MISSING_INCLUDE_CHANGELOG.getCurrentValue().equals(ChangeLogParserConfiguration.MissingIncludeConfiguration.WARN)
                             || !errorIfMissing) {
-                        Scope.getCurrentScope().getLog(getClass()).warning(FileUtil.getFileNotFoundMessage(fileName));
+                        Scope.getCurrentScope().getLog(getClass()).warning(FileUtil.getFileNotFoundMessage(normalizedFilePath));
                         return false;
                     } else {
-                        throw new ChangeLogParseException(FileUtil.getFileNotFoundMessage(fileName));
+                        throw new ChangeLogParseException(FileUtil.getFileNotFoundMessage(normalizedFilePath));
                     }
                 }
-                ChangeLogParser parser = ChangeLogParserFactory.getInstance().getParser(fileName, resourceAccessor);
-                changeLog = parser.parse(fileName, changeLogParameters, resourceAccessor);
+                ChangeLogParser parser = ChangeLogParserFactory.getInstance().getParser(normalizedFilePath, resourceAccessor);
+
+                if (modifyChangeSets != null) {
+                    changeLog = Scope.child(Collections.singletonMap("modifyChangeSets", true),
+                            () -> parser.parse(normalizedFilePath, changeLogParameters, resourceAccessor));
+                } else {
+                    changeLog = parser.parse(fileName, changeLogParameters, resourceAccessor);
+                }
                 changeLog.setIncludeContextFilter(includeContextFilter);
                 changeLog.setIncludeLabels(labels);
                 changeLog.setIncludeIgnore(ignore != null ? ignore.booleanValue() : false);
@@ -967,14 +981,14 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                 throw e;
             }
             // This matches only an extension, but filename can be a full path, too. Is it right?
-            boolean matchesFileExtension = StringUtil.trimToEmpty(fileName).matches("\\.\\w+$");
+            boolean matchesFileExtension = StringUtil.trimToEmpty(normalizedFilePath).matches("\\.\\w+$");
             if (matchesFileExtension || onUnknownFileFormat == OnUnknownFileFormat.WARN) {
                 Scope.getCurrentScope().getLog(getClass()).warning(
-                        "included file " + fileName + "/" + fileName + " is not a recognized file type"
+                        "included file " + normalizedFilePath + "/" + normalizedFilePath + " is not a recognized file type"
                 );
             }
             return false;
-        } catch (IOException e) {
+        } catch (Exception e) {
             throw new LiquibaseException(e.getMessage(), e);
         }
         PreconditionContainer preconditions = changeLog.getPreconditions();

--- a/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -31,7 +31,6 @@ import liquibase.resource.ResourceAccessor;
 import liquibase.servicelocator.LiquibaseService;
 import liquibase.util.FileUtil;
 import liquibase.util.StringUtil;
-import org.apache.commons.collections4.map.SingletonMap;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -236,10 +235,9 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
         return getFilePath().compareTo(o.getFilePath());
     }
 
-    public List<ChangeVisitor> getChangeVisitors() {
+    public List<ChangeVisitor> getChangeVisitors(){
         return changeVisitors;
     }
-
     public ChangeSet getChangeSet(String path, String author, String id) {
         final List<ChangeSet> possibleChangeSets = getChangeSets(path, author, id);
         if (possibleChangeSets.isEmpty()) {
@@ -354,15 +352,14 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
 
         if (!validatingVisitor.validationPassed()) {
             Scope.getCurrentScope().addMdcValue(MdcKey.DEPLOYMENT_OUTCOME, MdcValue.COMMAND_FAILED);
-            List<MdcChangeset> duplicateChangesetsMdc =
-                    validatingVisitor.getDuplicateChangeSets().stream().map(MdcChangeset::fromChangeset).collect(Collectors.toList());
+            List<MdcChangeset> duplicateChangesetsMdc = validatingVisitor.getDuplicateChangeSets().stream().map(MdcChangeset::fromChangeset).collect(Collectors.toList());
             Scope.getCurrentScope().addMdcValue(MdcKey.DUPLICATE_CHANGESETS, new DuplicateChangesets(duplicateChangesetsMdc));
             Scope.getCurrentScope().getLog(getClass()).info("Change failed validation!");
             throw new ValidationFailedException(validatingVisitor);
         }
     }
 
-    public ChangeSet getChangeSet(RanChangeSet ranChangeSet) {
+    public ChangeSet  getChangeSet(RanChangeSet ranChangeSet) {
         final ChangeSet changeSet = getChangeSet(ranChangeSet.getChangeLog(), ranChangeSet.getAuthor(), ranChangeSet.getId());
         if (changeSet != null) {
             changeSet.setStoredFilePath(ranChangeSet.getStoredChangeLog());
@@ -531,11 +528,11 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
             case "removeChangeSetProperty": {
                 List<ParsedNode> childNodes = node.getChildren();
                 Optional<ParsedNode> changeNode = childNodes.stream().filter(n -> n.getName().equalsIgnoreCase("change")).findFirst();
-                if (changeNode.isPresent()) {
+                if(changeNode.isPresent()){
                     ChangeVisitor changeVisitor = ChangeVisitorFactory.getInstance().create((String) changeNode.get().getValue());
-                    if (changeVisitor != null) {
+                    if(changeVisitor != null){
                         changeVisitor.load(node, resourceAccessor);
-                        if (DatabaseList.definitionMatches(changeVisitor.getDbms(), changeLogParameters.getDatabase(), false)) {
+                        if(DatabaseList.definitionMatches(changeVisitor.getDbms(), changeLogParameters.getDatabase(), false)) {
                             //add changeVisitor to this changeLog only if the running database matches with one of the removeChangeSetProperty's dbms
                             getChangeVisitors().add(changeVisitor);
                         }
@@ -702,7 +699,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                            int maxDepth)
             throws SetupException {
         includeAll(pathName, isRelativeToChangelogFile, resourceFilter, errorIfMissingOrEmpty, resourceComparator,
-                resourceAccessor, includeContextFilter, labels, ignore, minDepth, maxDepth, "", new ModifyChangeSets(null, null));
+                   resourceAccessor, includeContextFilter, labels, ignore, minDepth, maxDepth, "", new ModifyChangeSets(null, null));
     }
 
     @Deprecated
@@ -741,8 +738,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
             throw new SetupException("No path attribute for includeAll");
         }
         SortedSet<Resource> resources =
-                findResources(pathName, isRelativeToChangelogFile, resourceFilter, errorIfMissingOrEmpty, resourceComparator, resourceAccessor, minDepth,
-                        maxDepth, endsWithFilter);
+                findResources(pathName, isRelativeToChangelogFile, resourceFilter, errorIfMissingOrEmpty, resourceComparator, resourceAccessor, minDepth, maxDepth, endsWithFilter);
         if (resources.isEmpty() && errorIfMissingOrEmpty) {
             throw new SetupException(
                     "Could not find directory or directory was empty for includeAll '" + pathName + "'");
@@ -776,16 +772,16 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
     }
 
     public SortedSet<Resource> findResources(
-            String pathName,
-            boolean isRelativeToChangelogFile,
-            IncludeAllFilter resourceFilter,
-            boolean errorIfMissingOrEmpty,
-            Comparator<String> resourceComparator,
-            ResourceAccessor resourceAccessor,
-            int minDepth,
-            int maxDepth,
-            String endsWithFilter
-    ) throws SetupException {
+                               String pathName,
+                               boolean isRelativeToChangelogFile,
+                               IncludeAllFilter resourceFilter,
+                               boolean errorIfMissingOrEmpty,
+                               Comparator<String> resourceComparator,
+                               ResourceAccessor resourceAccessor,
+                               int minDepth,
+                               int maxDepth,
+                               String endsWithFilter
+                               ) throws SetupException {
         try {
             if (pathName == null) {
                 throw new SetupException("No path attribute for findResources");
@@ -830,8 +826,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
 
             if (resources.isEmpty() && errorIfMissingOrEmpty) {
                 throw new SetupException(
-                        "Could not find directory, directory was empty, or no changelogs matched the provided search criteria for includeAll '" + pathName +
-                                "'");
+                        "Could not find directory, directory was empty, or no changelogs matched the provided search criteria for includeAll '" + pathName + "'");
             }
             return resources;
         } catch (IOException e) {
@@ -848,7 +843,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
             path = normalizePath(path);
         }
 
-        if (path != null) {
+        if(path != null) {
             path = path.replace("\\", "/");
             if (StringUtil.isNotEmpty(path) && !(path.endsWith("/"))) {
                 path = path + '/';
@@ -897,8 +892,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                            Boolean ignore,
                            boolean logEveryUnknownFileFormat)
             throws LiquibaseException {
-        return include(fileName, isRelativePath, errorIfMissing, resourceAccessor, includeContextFilter, labels, ignore, logEveryUnknownFileFormat ?
-                OnUnknownFileFormat.WARN : OnUnknownFileFormat.SKIP);
+        return include(fileName, isRelativePath, errorIfMissing, resourceAccessor, includeContextFilter, labels, ignore, logEveryUnknownFileFormat ? OnUnknownFileFormat.WARN : OnUnknownFileFormat.SKIP);
     }
 
     public boolean include(String fileName,
@@ -910,8 +904,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                            Boolean ignore,
                            OnUnknownFileFormat onUnknownFileFormat)
             throws LiquibaseException {
-        return include(fileName, isRelativePath, errorIfMissing, resourceAccessor, includeContextFilter, labels, ignore, onUnknownFileFormat,
-                new ModifyChangeSets(null, null));
+        return include(fileName, isRelativePath, errorIfMissing, resourceAccessor, includeContextFilter, labels, ignore, onUnknownFileFormat, new ModifyChangeSets(null, null));
     }
 
     public boolean include(String fileName,
@@ -961,7 +954,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                     changeLog = Scope.child(Collections.singletonMap("modifyChangeSets", true),
                             () -> parser.parse(normalizedFilePath, changeLogParameters, resourceAccessor));
                 } else {
-                    changeLog = parser.parse(fileName, changeLogParameters, resourceAccessor);
+                    changeLog = parser.parse(normalizedFilePath, changeLogParameters, resourceAccessor);
                 }
                 changeLog.setIncludeContextFilter(includeContextFilter);
                 changeLog.setIncludeLabels(labels);

--- a/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -924,11 +924,12 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
         if (isRelativePath) {
             try {
                 fileName = resourceAccessor.get(this.getPhysicalFilePath()).resolveSibling(fileName).getPath();
+                fileName = normalizePath(Paths.get(fileName).toString());
             } catch (IOException e) {
                 throw new UnexpectedLiquibaseException(e);
             }
         }
-        final String normalizedFilePath = normalizePath(Paths.get(fileName).toString());
+        final String normalizedFilePath = fileName;
 
         DatabaseChangeLog changeLog;
         try {

--- a/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -951,6 +951,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                 ChangeLogParser parser = ChangeLogParserFactory.getInstance().getParser(normalizedFilePath, resourceAccessor);
 
                 if (modifyChangeSets != null) {
+                    // Some parser need to know it's not a top level changelog, in modifyChangeSets flow 'runWith' attributes are added later on
                     changeLog = Scope.child(Collections.singletonMap("modifyChangeSets", true),
                             () -> parser.parse(normalizedFilePath, changeLogParameters, resourceAccessor));
                 } else {


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
 

## Description
For some parsers, (like mongosh parsers) we need to know when modifyChangeSet flow is happening, as we can't run mongo instructions without native executor so `runWith` is required. But in modifyChangeSet flow `runWith` is added to the changeset later on, after parsing. 
Adding modifyChangeSets flag to the Scope allows parsers to read it and skip runWith validation knowing it's inner changeset and it gets 'runWith'  attribute later. 
