### PR TITLE
feat: add commons-lang3 as a required dependency for core

### DIFF
--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -57,6 +57,11 @@
             <artifactId>liquibase-snowflake</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <trimStackTrace>false</trimStackTrace>
         <liquibase-pro.version>0-SNAPSHOT</liquibase-pro.version>
         <argLine></argLine>
+        <commons-lang3.version>3.14.0</commons-lang3.version>
         <ant.version>1.10.14</ant.version>
         <junit.version>4.13.2</junit.version>
         <junit-jupiter.version>5.10.2</junit-jupiter.version>


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

PR https://github.com/liquibase/liquibase/pull/5670/files that was just merged depends on commons-lang3. By verifying our zip & installer we can see that this library is shipped, as it is a dependency for Opencsv library. 

This library is also used in another place of the code but in an outlier case. 

So to prevent class not found issues it is being declared as a required dependency, otherwise it may brake cases where liquibase is used as a library such as Spring or Hibernate as now it will be called in every execution as per the changes on #5670.

Also adding this as a dependency allows to in remove a lot of code that is available in the library and we have been duplicating inside liquibase code.


