### PR TITLE
Adds CommandOverrideProcessor to validate CommandOverride usage at compile time

### DIFF
--- a/liquibase-standard/pom.xml
+++ b/liquibase-standard/pom.xml
@@ -170,6 +170,25 @@
 
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.12.1</version>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <annotationProcessorPath>
+                            <groupId>org.liquibase</groupId>
+                            <artifactId>liquibase-standard</artifactId>
+                            <version>${project.version}</version>
+                        </annotationProcessorPath>
+                        <annotationProcessorPath>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.32</version>
+                        </annotationProcessorPath>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.javacc.plugin</groupId>
                 <artifactId>javacc-maven-plugin</artifactId>
                 <version>3.0.3</version>

--- a/liquibase-standard/src/main/java/liquibase/command/CommandOverrideProcessor.java
+++ b/liquibase-standard/src/main/java/liquibase/command/CommandOverrideProcessor.java
@@ -1,0 +1,66 @@
+package liquibase.command;
+
+import liquibase.util.StringUtil;
+import lombok.Getter;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.*;
+import javax.lang.model.util.Elements;
+import javax.tools.Diagnostic;
+import java.lang.annotation.Annotation;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Getter
+@SupportedAnnotationTypes({"liquibase.command.CommandOverride"})
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
+public class CommandOverrideProcessor extends AbstractProcessor {
+    private final Map<String, List<String>> overrides = new ConcurrentHashMap<>();
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        for (Element element : roundEnv.getElementsAnnotatedWith(CommandOverride.class)) {
+            Optional<? extends AnnotationMirror> maybeMirror = getAnnotationMirror(element, CommandOverride.class);
+            maybeMirror.ifPresent(mirror -> {
+                Optional<? extends AnnotationValue> maybeValue = getAnnotationValue(mirror, "override");
+                maybeValue.ifPresent(value -> {
+                    overrides.computeIfAbsent(value.getValue().toString(), val -> new ArrayList<>()).add(element.getSimpleName().toString());
+                });
+            });
+        }
+        Map<String, List<String>> invalidOverrides = new HashMap<>();
+        overrides.forEach((step, overrideSteps) -> {
+            if (overrideSteps.size() > 1) {
+                invalidOverrides.put(step, overrideSteps);
+            }
+        });
+
+        invalidOverrides.forEach((step, overrideSteps) -> {
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, String.format("Found multiple command steps overriding %s! A command may have at most one override. Invalid overrides include: %s",
+                    step,
+                    StringUtil.join(overrideSteps, ", ")));
+        });
+        return invalidOverrides.isEmpty();
+    }
+
+    public Optional<? extends AnnotationMirror> getAnnotationMirror(final Element element, final Class<? extends Annotation> annotationClass) {
+        final String annotationClassName = annotationClass.getName();
+        return element.getAnnotationMirrors().stream()
+                .filter(clazz -> clazz.getAnnotationType().toString().equals(annotationClassName))
+                .findFirst();
+    }
+
+    public Optional<? extends AnnotationValue> getAnnotationValue(final AnnotationMirror annotationMirror, final String name) {
+        final Elements elementUtils = this.processingEnv.getElementUtils();
+        final Map<? extends ExecutableElement, ? extends AnnotationValue> elementValues = elementUtils.getElementValuesWithDefaults(annotationMirror);
+        return elementValues.keySet().stream()
+                .filter(clazz -> clazz.getSimpleName().toString().equals(name))
+                .map(elementValues::get)
+                .findAny();
+    }
+}

--- a/liquibase-standard/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/liquibase-standard/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+liquibase.command.CommandOverrideProcessor


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description
Adds new annotation processor to detect invalid usage of the `@CommandOverride` annotation. 
TODO: 
- [ ] Do not print multiple messages, this means the annotation processor is running more than once
- [ ] Re-use code, this is currently duplicating the validation found in `CommandFactory`. 
- [ ] Validate that the new service file is actually needed
- [ ] Get this to build in the pipeline

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of
This will (intentionally) break builds. 
<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about
This can impact lombok. I don't think it does in its current form, but it can. 
<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
