### PR TITLE
Prevent spurious SET SEARCH_PATH SQL statements for Postgres during update-sql command. Fixes #5316

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/database/core/PostgresDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/PostgresDatabase.java
@@ -9,6 +9,8 @@ import liquibase.database.DatabaseConnection;
 import liquibase.database.ObjectQuotingStrategy;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
+import liquibase.executor.Executor;
+import liquibase.executor.ExecutorService;
 import liquibase.logging.Logger;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.RawCallStatement;
@@ -400,8 +402,13 @@ public class PostgresDatabase extends AbstractJdbcDatabase {
     public void rollback() throws DatabaseException {
         super.rollback();
 
-        //Rollback in postgresql resets the search path. Need to put it back to the defaults
-        DatabaseUtils.initializeDatabase(getDefaultCatalogName(), getDefaultSchemaName(), this);
+        // Rollback in postgresql resets the search path. Need to put it back to the defaults
+        // Prevent resetting the search path if we are running in a mode that does not update the database to avoid spurious 
+        // SET SEARCH_PATH SQL statements
+        final Executor executor = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", this);
+        if(executor.updatesDatabase()) {
+            DatabaseUtils.initializeDatabase(getDefaultCatalogName(), getDefaultSchemaName(), this);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

Prevent resetting the search path in Postgres after a rollback if we are running in a mode that does not update the database to avoid spurious SET SEARCH_PATH SQL statements.

The logic in `DatabaseUtils.initializeDatabase` for Postgres expects changes to the SEARCH_PATH to be persisted to detect when the SEARCH_PATH is already correct(ed). However in `update-sql` mode these changes are not executed, causing the detection mechanism to fail and resulting in extra SET SEARCH_PATH statements.

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

I'm aware of the other change in review that will fix this issue, but that is a bigger change and might take a long time to be merged. This could be a quick win.

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
