### PR TITLE
feat: improve snapshot generation for NOSQL databases

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotGeneratorChain.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotGeneratorChain.java
@@ -32,13 +32,8 @@ public class SnapshotGeneratorChain {
 
     /**
      * This calls all the non-replaced {@link SnapshotGenerator} in the chain, by comparison order
-     * Only the first generator in the chain is allowed to create a new instance of T
-     * Subsequent generators must modify the instance or call the chain if the provided object is not handled,
-     * otherwise a {@link DatabaseException} is thrown
      *
      * @return snapshot object
-     * @throws DatabaseException if any of the subsequent generators return an instance different from the first generator's
-     *                           invocation result
      * @see SnapshotGenerator#replaces() to skip generators that do not comply to the above requireemnts
      */
     public <T extends DatabaseObject> T snapshot(T example, DatabaseSnapshot snapshot)
@@ -59,39 +54,18 @@ public class SnapshotGeneratorChain {
             return null;
         }
 
-        boolean firstRoundDone = false;
-        SnapshotGenerator lastGenerator = null;
-        T lastObject = example;
+        T objectToSnapshot = example;
         while (snapshotGenerators.hasNext()) {
             SnapshotGenerator generator = snapshotGenerators.next();
             if (replacedGenerators.contains(generator.getClass())) {
                 continue;
             }
-            T object = generator.snapshot(lastObject, snapshot, this);
+            T object = generator.snapshot(objectToSnapshot, snapshot, this);
             if ((object != null) && (object.getSnapshotId() == null)) {
                 object.setSnapshotId(snapshotIdService.generateId());
             }
-            // only first generator in the chain is allowed to create new instances - subsequent ones are not
-            if (firstRoundDone && object != lastObject) {
-                throw new DatabaseException(String.format("Snapshot generator %s has returned a different reference from the previous generator %s.\n" +
-                                "\tSnapshot object was: %s, it is now: %s.\n" +
-                                "\tConsider declaring %1$s as being replaced by one the generator in the chain via liquibase.snapshot.SnapshotGenerator#replaces.",
-                        generator.getClass().getName(),
-                        lastGenerator.getClass().getName(),
-                        identity(lastObject),
-                        identity(object)));
-            }
-            lastObject = object;
-            lastGenerator = generator;
-            firstRoundDone = true;
+            objectToSnapshot = object;
         }
-        return lastObject;
-    }
-
-    private static String identity(Object object) {
-        if (object == null) {
-            return "null";
-        }
-        return String.format("%s@%s", object.getClass(), System.identityHashCode(object));
+        return objectToSnapshot;
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotGeneratorChain.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotGeneratorChain.java
@@ -31,7 +31,15 @@ public class SnapshotGeneratorChain {
     }
 
     /**
-     * This calls all the non-replaced {@link SnapshotGenerator} in the chain, by comparison order
+     * This calls all the non-replaced {@link SnapshotGenerator} in the chain, by comparison order.
+     * <p>
+     * During the chain processing, the snapshot method returns an object that will be passed to the next generator in the chain.
+     * The object can be the same object that was passed to the generator, or a new object, given that:
+     * - the generator copies the attributes of the provided object to a new object and returns the new object (liquibase-hibernate extension does this in https://github.com/liquibase/liquibase-hibernate/blob/main/src/main/java/liquibase/ext/hibernate/snapshot/IndexSnapshotGenerator.java#L31 )
+     * - the generator returns the existing instance (they can e.g. set new attributes to it)
+     * <p>
+     * Snapshot generators that do not abide by the previous rules must be the first to be called for a given object type and there are not more than one of these per object type.
+     * Note that this can get tricky as extensions can bring their own snapshot generators to the mix breaking core generators.
      *
      * @return snapshot object
      * @see SnapshotGenerator#replaces() to skip generators that do not comply to the above requireemnts

--- a/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotGeneratorChain.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotGeneratorChain.java
@@ -72,7 +72,9 @@ public class SnapshotGeneratorChain {
             if ((object != null) && (object.getSnapshotId() == null)) {
                 object.setSnapshotId(snapshotIdService.generateId());
             }
-            objectToSnapshot = object;
+            if (object != null) {
+                objectToSnapshot = object;
+            }
         }
         return objectToSnapshot;
     }

--- a/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotGeneratorChain.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotGeneratorChain.java
@@ -72,9 +72,7 @@ public class SnapshotGeneratorChain {
             if ((object != null) && (object.getSnapshotId() == null)) {
                 object.setSnapshotId(snapshotIdService.generateId());
             }
-            if (object != null) {
-                objectToSnapshot = object;
-            }
+            objectToSnapshot = object;
         }
         return objectToSnapshot;
     }

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/JdbcSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/JdbcSnapshotGenerator.java
@@ -61,7 +61,7 @@ public abstract class JdbcSnapshotGenerator implements SnapshotGenerator {
 
     @Override
     public DatabaseObject snapshot(DatabaseObject example, DatabaseSnapshot snapshot, SnapshotGeneratorChain chain) throws DatabaseException, InvalidExampleException {
-        if ((defaultFor != null) && defaultFor.isAssignableFrom(example.getClass())) {
+        if (defaultFor != null && example != null && defaultFor.isAssignableFrom(example.getClass())) {
             return snapshotObject(example, snapshot);
         }
 

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/JdbcSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/JdbcSnapshotGenerator.java
@@ -70,14 +70,10 @@ public abstract class JdbcSnapshotGenerator implements SnapshotGenerator {
             return null;
         }
 
-        if (shouldAddTo(example.getClass(), snapshot)) {
-            if (addsTo() != null) {
-                for (Class<? extends DatabaseObject> addType : addsTo()) {
-                    if (addType.isAssignableFrom(example.getClass())) {
-                        if (chainResponse != null) {
-                            addTo(chainResponse, snapshot);
-                        }
-                    }
+        if (example != null && shouldAddTo(example.getClass(), snapshot) && addsTo() != null) {
+            for (Class<? extends DatabaseObject> addType : addsTo()) {
+                if (addType.isAssignableFrom(example.getClass())) {
+                    addTo(chainResponse, snapshot);
                 }
             }
         }

--- a/liquibase-standard/src/test/groovy/liquibase/snapshot/SnapshotGeneratorChainTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/snapshot/SnapshotGeneratorChainTest.groovy
@@ -90,24 +90,6 @@ class SnapshotGeneratorChainTest extends Specification {
         snapshot.getAttribute("visited", Boolean.class) == expectedTable.getAttribute("visited", Boolean.class)
     }
 
-    def "snapshotting fails if subsequent generator returns a different instance"() {
-        given:
-        def chain = new SnapshotGeneratorChain(sortedSetOf(visitingGenerator, badGenerator))
-        def object = new Table()
-        database.isSystemObject(object) >> false
-        snapshotControl.shouldInclude(object.class) >> true
-        def expectedTable = new Table()
-        expectedTable.setAttribute("visited", true)
-
-
-        when:
-        chain.snapshot(object, snapshotContext)
-
-        then:
-        def exception = thrown(DatabaseException)
-        exception.message.startsWith("Snapshot generator liquibase.snapshot.BadSnapshotGenerator has returned a different reference from the previous generator liquibase.snapshot.VisitedSnapshotGenerator.")
-    }
-
     def "snapshotting works even if first generator returns a different instance"() {
         given:
         def chain = new SnapshotGeneratorChain(sortedSetOf(badGenerator))
@@ -257,7 +239,7 @@ class BadSnapshotGenerator implements SnapshotGenerator, Comparable<SnapshotGene
     <T extends DatabaseObject> T snapshot(T example, DatabaseSnapshot snapshot, SnapshotGeneratorChain chain) throws DatabaseException, InvalidExampleException {
         // generators are expected to add nested attributes, ... to the provided example or delegate if the example type does not match
         // they are NOT expected to create new instances of the same type
-        return acceptedType.newInstance() as T
+        return acceptedType.getDeclaredConstructor().newInstance() as T
     }
 
     @Override


### PR DESCRIPTION
Brings back what had to be rolledback from PR #5619 to be tested again and fix what is required.

The original code allowed only one Generator as top level for the chain. This PR improves chain handler to make sure that all subscribed generators are called.


Pro PR companion: https://github.com/liquibase/liquibase-pro/pull/1650