### PR TITLE
Deprecate ThreadLocalScopeManager as it is no longer required

### DIFF
--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
@@ -3,7 +3,6 @@ package org.liquibase.maven.plugins;
 import liquibase.GlobalConfiguration;
 import liquibase.Liquibase;
 import liquibase.Scope;
-import liquibase.ThreadLocalScopeManager;
 import liquibase.changelog.visitor.ChangeExecListener;
 import liquibase.changelog.visitor.DefaultChangeExecListener;
 import liquibase.command.core.helpers.DbUrlConnectionCommandStep;
@@ -69,11 +68,6 @@ import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
  */
 @SuppressWarnings("java:S2583")
 public abstract class AbstractLiquibaseMojo extends AbstractMojo {
-
-    static {
-        // If maven is called with -T and a value larger than 1, it can get confused under heavy thread load
-        Scope.setScopeManager( new ThreadLocalScopeManager(null));
-    }
 
     /**
      * Suffix for fields that are representing a default value for a another field.

--- a/liquibase-standard/src/main/java/liquibase/ThreadLocalScopeManager.java
+++ b/liquibase-standard/src/main/java/liquibase/ThreadLocalScopeManager.java
@@ -6,7 +6,10 @@ package liquibase;
  * <br><br>
  * The value of Scope.getCurrentScope() at the time of the ThreadLocalScopeManger's creation will be the basis of all scopes created after setScopeManager() is changed,
  * so you will generally want to setScopeManager as soon as possible.
+ *
+ * @deprecated ScopeManager now uses ThreadLocal to prevent concurrent modification issues. This class is no longer needed.
  */
+@Deprecated
 @SuppressWarnings("java:S5164")
 public class ThreadLocalScopeManager extends ScopeManager {
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 

## Description

ScopeManager now uses ThreadLocal to prevent concurrent modification issues. ThreadLocalScopeManager class is no longer needed.


