### PR TITLE
Improve diffChangelog error message

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/command/core/DiffChangelogCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/DiffChangelogCommandStep.java
@@ -117,7 +117,7 @@ public class DiffChangelogCommandStep extends AbstractChangelogCommandStep {
             }
         } catch (Exception e) {
             try (MdcObject diffChangelogOutcome = Scope.getCurrentScope().addMdcValue(MdcKey.DIFF_CHANGELOG_OUTCOME, MdcValue.COMMAND_FAILED)) {
-                Scope.getCurrentScope().getLog(getClass()).warning("Diff changelog command failed");
+                Scope.getCurrentScope().getLog(getClass()).warning("Diff changelog command failed: " + e.getMessage());
             }
         }
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

When diffchangelog fails we should share with the users at least a short description of the error, so instead of:

```
Diff changelog command failed
```

you get

```
 iff changelog command failed: Cannot parse resource location: 'src/main/resources/db/changelog/2024-04-19T17:55:17Z_changelog.xml'

```
