### PR TITLE
chore: invoke deprecated methods in default supports method for backwards compatibility

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/database/Database.java
+++ b/liquibase-standard/src/main/java/liquibase/database/Database.java
@@ -25,10 +25,7 @@ import liquibase.sqlgenerator.SqlGeneratorFactory;
 import liquibase.statement.DatabaseFunction;
 import liquibase.statement.SqlStatement;
 import liquibase.structure.DatabaseObject;
-import liquibase.structure.core.ForeignKey;
-import liquibase.structure.core.Index;
-import liquibase.structure.core.PrimaryKey;
-import liquibase.structure.core.UniqueConstraint;
+import liquibase.structure.core.*;
 import liquibase.util.StringUtil;
 
 import java.io.IOException;
@@ -372,6 +369,7 @@ public interface Database extends PrioritizedService, AutoCloseable {
      *
      * @deprecated Know if you should quote the name or not, and use {@link #escapeColumnName(String, String, String, String)} which will quote things that look like functions, or leave it along as you see fit. Don't rely on this function guessing.
      */
+    @Deprecated
     String escapeColumnName(String catalogName, String schemaName, String tableName, String columnName, boolean quoteNamesThatMayBeFunctions);
 
     /**
@@ -392,7 +390,22 @@ public interface Database extends PrioritizedService, AutoCloseable {
     @Deprecated
     boolean supportsCatalogs();
 
+    /**
+     * Whether this database supports the specified object type.
+     * It is invoking the deprecated methods to ensure that extensions are not broken, but
+     * once those are removed it will return only true
+     *
+     * @param object the object type to check
+     * @return true if the database supports the object type, false otherwise
+     */
     default boolean supports(Class<? extends DatabaseObject> object) {
+        if (Sequence.class.isAssignableFrom(object)) {
+            return supportsSequences();
+        } else if (Schema.class.isAssignableFrom(object)) {
+            return supportsSchemas();
+        } else if (Catalog.class.isAssignableFrom(object)) {
+            return supportsCatalogs();
+        }
         return true;
     }
 
@@ -500,6 +513,7 @@ public interface Database extends PrioritizedService, AutoCloseable {
      * removing set schema or catalog names if they are not supported
      * @deprecated use {@link liquibase.CatalogAndSchema#standardize(Database)}
      */
+    @Deprecated
     CatalogAndSchema correctSchema(CatalogAndSchema schema);
 
     /**


### PR DESCRIPTION

### TLDR: 
Invoke deprecated methods in default supports method to ensure that extensions are not broken, but one day when those are removed it will return only true

### Description
The new support `method` was introduced in PR https://github.com/liquibase/liquibase/pull/5619 so specially NoSQL databases can check for other supports as `Collections` without changing Database class and adding a `supportsCollections()` method.
In core all the locations were `supportsSequences()` existed were changed to supports(Sequence) , and all *Database classes had this new method implemented. But extensions don't have it, so they could return the wrong value. For instance, BigQuery doesn't support sequences but would start to return true to core.
With this fix we continue to return what is expected.

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 