### PR TITLE
[DAT-17403] resolved priorities for Datatypes and ModifyDatatype generator

### DIFF
--- a/liquibase-bigquery/src/main/java/liquibase/datatype/core/BignumericDataTypeBigQuery.java
+++ b/liquibase-bigquery/src/main/java/liquibase/datatype/core/BignumericDataTypeBigQuery.java
@@ -12,7 +12,7 @@ import liquibase.datatype.LiquibaseDataType;
         name = "bignumeric",
         minParameters = 0,
         maxParameters = 0,
-        priority = 1
+        priority = LiquibaseDataType.PRIORITY_DATABASE
 )
 public class BignumericDataTypeBigQuery extends LiquibaseDataType {
 

--- a/liquibase-bigquery/src/main/java/liquibase/datatype/core/BoolDataTypeBigQuery.java
+++ b/liquibase-bigquery/src/main/java/liquibase/datatype/core/BoolDataTypeBigQuery.java
@@ -12,7 +12,7 @@ import liquibase.datatype.LiquibaseDataType;
         name = "boolean",
         minParameters = 0,
         maxParameters = 0,
-        priority = BigQueryDatabase.BIGQUERY_PRIORITY_DATABASE
+        priority = LiquibaseDataType.PRIORITY_DATABASE
 )
 public class BoolDataTypeBigQuery extends LiquibaseDataType {
     public BoolDataTypeBigQuery() {

--- a/liquibase-bigquery/src/main/java/liquibase/datatype/core/Float64DataTypeBigQuery.java
+++ b/liquibase-bigquery/src/main/java/liquibase/datatype/core/Float64DataTypeBigQuery.java
@@ -11,7 +11,7 @@ import liquibase.datatype.LiquibaseDataType;
         name = "float64",
         minParameters = 0,
         maxParameters = 0,
-        priority = BigQueryDatabase.BIGQUERY_PRIORITY_DATABASE
+        priority = LiquibaseDataType.PRIORITY_DATABASE
 )
 public class Float64DataTypeBigQuery extends LiquibaseDataType {
     public Float64DataTypeBigQuery() {

--- a/liquibase-bigquery/src/main/java/liquibase/datatype/core/GeographyDataTypeBigQuery.java
+++ b/liquibase-bigquery/src/main/java/liquibase/datatype/core/GeographyDataTypeBigQuery.java
@@ -12,7 +12,7 @@ import liquibase.datatype.LiquibaseDataType;
         name = "geography",
         minParameters = 0,
         maxParameters = 0,
-        priority = BigQueryDatabase.BIGQUERY_PRIORITY_DATABASE
+        priority = LiquibaseDataType.PRIORITY_DATABASE
 )
 public class GeographyDataTypeBigQuery extends LiquibaseDataType {
     public GeographyDataTypeBigQuery() {

--- a/liquibase-bigquery/src/main/java/liquibase/datatype/core/Int64DataTypeBigQuery.java
+++ b/liquibase-bigquery/src/main/java/liquibase/datatype/core/Int64DataTypeBigQuery.java
@@ -12,7 +12,7 @@ import liquibase.datatype.LiquibaseDataType;
         name = "int64",
         minParameters = 0,
         maxParameters = 0,
-        priority = 1
+        priority = LiquibaseDataType.PRIORITY_DATABASE
 )
 public class Int64DataTypeBigQuery extends LiquibaseDataType {
     public Int64DataTypeBigQuery() {

--- a/liquibase-bigquery/src/main/java/liquibase/datatype/core/NumericDataTypeBigQuery.java
+++ b/liquibase-bigquery/src/main/java/liquibase/datatype/core/NumericDataTypeBigQuery.java
@@ -12,10 +12,10 @@ import liquibase.datatype.LiquibaseDataType;
         name = "numeric",
         minParameters = 0,
         maxParameters = 0,
-        priority = 1
+        priority = LiquibaseDataType.PRIORITY_DATABASE
 )
-public class NumberDataTypeBigQuery extends LiquibaseDataType {
-    public NumberDataTypeBigQuery() {
+public class NumericDataTypeBigQuery extends LiquibaseDataType {
+    public NumericDataTypeBigQuery() {
     }
 
     @Override

--- a/liquibase-bigquery/src/main/java/liquibase/datatype/core/StringDataTypeBigQuery.java
+++ b/liquibase-bigquery/src/main/java/liquibase/datatype/core/StringDataTypeBigQuery.java
@@ -5,13 +5,14 @@ import liquibase.database.BigQueryDatabase;
 import liquibase.database.Database;
 import liquibase.datatype.DataTypeInfo;
 import liquibase.datatype.DatabaseDataType;
+import liquibase.datatype.LiquibaseDataType;
 
 
 @DataTypeInfo(
         name = "string",
         minParameters = 0,
         maxParameters = 0,
-        priority = BigQueryDatabase.BIGQUERY_PRIORITY_DATABASE,
+        priority = LiquibaseDataType.PRIORITY_DATABASE,
         aliases = { "varchar", "clob", "java.lang.String" }
 )
 public class StringDataTypeBigQuery extends VarcharType {

--- a/liquibase-bigquery/src/main/java/liquibase/sqlgenerator/BigQueryModifyDataTypeGenerator.java
+++ b/liquibase-bigquery/src/main/java/liquibase/sqlgenerator/BigQueryModifyDataTypeGenerator.java
@@ -16,6 +16,11 @@ public class BigQueryModifyDataTypeGenerator extends ModifyDataTypeGenerator {
     }
 
     @Override
+    public int getPriority() {
+        return SqlGenerator.PRIORITY_DATABASE;
+    }
+
+    @Override
     public Sql[] generateSql(ModifyDataTypeStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
         String alterTable;
 

--- a/liquibase-bigquery/src/main/resources/META-INF/services/liquibase.datatype.LiquibaseDataType
+++ b/liquibase-bigquery/src/main/resources/META-INF/services/liquibase.datatype.LiquibaseDataType
@@ -3,5 +3,5 @@ liquibase.datatype.core.GeographyDataTypeBigQuery
 liquibase.datatype.core.Float64DataTypeBigQuery
 liquibase.datatype.core.BoolDataTypeBigQuery
 liquibase.datatype.core.Int64DataTypeBigQuery
-liquibase.datatype.core.NumberDataTypeBigQuery
+liquibase.datatype.core.NumericDataTypeBigQuery
 liquibase.datatype.core.BignumericDataTypeBigQuery

--- a/liquibase-bigquery/src/test/java/liquibase/datatype/core/NumericDataTypeBigQueryTest.java
+++ b/liquibase-bigquery/src/test/java/liquibase/datatype/core/NumericDataTypeBigQueryTest.java
@@ -7,12 +7,12 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-class NumberDataTypeBigQueryTest {
+class NumericDataTypeBigQueryTest {
 
     @Test
     void toDatabaseDataType() {
-        NumberDataTypeBigQuery numberDataTypeBigQuery = new NumberDataTypeBigQuery();
-        DatabaseDataType databaseDataType = numberDataTypeBigQuery.toDatabaseDataType(new BigQueryDatabase());
+        NumericDataTypeBigQuery numericDataTypeBigQuery = new NumericDataTypeBigQuery();
+        DatabaseDataType databaseDataType = numericDataTypeBigQuery.toDatabaseDataType(new BigQueryDatabase());
         assertNotNull(databaseDataType);
         assertEquals("NUMERIC", databaseDataType.getType());
     }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description
2 issues here
- Added priority method to BigQueryModifyDataTypeGenerator - as it had default priority is was suppressed by other extensions in classpath. This resolved query to have `SET DATA TYPE` instead of just `TYPE`
- Fixed priorities for datatypes as NumericDataTypeBigQuery was never used and we had `NUMBER` in the query instead of `NUMERIC`
