### PR TITLE
generated addPrimaryKey changes should not include column direction (DAT-17467)

### DIFF
--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/util/CommandUtil.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/util/CommandUtil.groovy
@@ -81,6 +81,7 @@ class CommandUtil {
         OutputStream outputStream = new FileOutputStream(new File(outputFile))
         commandScope.setOutput(outputStream)
         commandScope.execute()
+        outputStream.close()
     }
 
     static void runDiff(DatabaseTestSystem db, Database targetDatabase, Database referenceDatabase,

--- a/liquibase-integration-tests/src/test/groovy/liquibase/diffchangelog/DiffChangelogMssqlIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/diffchangelog/DiffChangelogMssqlIntegrationTest.groovy
@@ -1,0 +1,56 @@
+package liquibase.diffchangelog
+
+import liquibase.Scope
+import liquibase.command.CommandScope
+import liquibase.command.core.DiffChangelogCommandStep
+import liquibase.command.core.helpers.DbUrlConnectionCommandStep
+import liquibase.command.core.helpers.ReferenceDbUrlConnectionCommandStep
+import liquibase.command.util.CommandUtil
+import liquibase.extension.testing.testsystem.DatabaseTestSystem
+import liquibase.extension.testing.testsystem.TestSystemFactory
+import liquibase.extension.testing.testsystem.spock.LiquibaseIntegrationTest
+import liquibase.util.FileUtil
+import org.apache.commons.lang3.RandomStringUtils
+import spock.lang.Shared
+import spock.lang.Specification
+
+@LiquibaseIntegrationTest
+class DiffChangelogMssqlIntegrationTest extends Specification {
+
+    @Shared
+    private DatabaseTestSystem mssql =
+            (DatabaseTestSystem) Scope.getCurrentScope().getSingleton(TestSystemFactory.class).getTestSystem("mssql")
+
+    def "auto increment on varchar column" () {
+        def snapshotFilename = "target-${RandomStringUtils.randomAlphabetic(10)}.json"
+        def snapshotFilepath = "target/test-classes/" + snapshotFilename
+        def changelogFile = "target/test-classes/diffChangelog-${RandomStringUtils.randomAlphabetic(10)}.xml"
+        when:
+        mssql.executeSql("""
+CREATE TABLE MyTest (
+    ID INT not null,
+    Name VARCHAR(50),
+    Age INT);""")
+        CommandUtil.runSnapshot(mssql, snapshotFilepath)
+        mssql.executeSql("""
+ALTER TABLE MyTest
+ADD CONSTRAINT PK_MyTest PRIMARY KEY (ID DESC);""")
+        CommandScope commandScope = new CommandScope(DiffChangelogCommandStep.COMMAND_NAME)
+        commandScope.addArgumentValue(DiffChangelogCommandStep.CHANGELOG_FILE_ARG, changelogFile)
+        commandScope.addArgumentValue(ReferenceDbUrlConnectionCommandStep.REFERENCE_URL_ARG, mssql.getConnectionUrl())
+        commandScope.addArgumentValue(ReferenceDbUrlConnectionCommandStep.REFERENCE_USERNAME_ARG, mssql.getUsername())
+        commandScope.addArgumentValue(ReferenceDbUrlConnectionCommandStep.REFERENCE_PASSWORD_ARG, mssql.getPassword())
+        commandScope.addArgumentValue(DbUrlConnectionCommandStep.URL_ARG, "offline:mssql?snapshot=" + snapshotFilename)
+
+        then:
+        commandScope.execute()
+        def generatedChangelog = new File(changelogFile)
+        def generatedChangelogContents = FileUtil.getContents(generatedChangelog)
+        generatedChangelogContents.contains('<addPrimaryKey columnNames="ID" constraintName="PK_MyTest" tableName="MyTest"/>')
+
+        cleanup:
+        generatedChangelog.delete()
+        new File(snapshotFilename).delete()
+    }
+
+}

--- a/liquibase-integration-tests/src/test/groovy/liquibase/diffchangelog/DiffChangelogMssqlIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/diffchangelog/DiffChangelogMssqlIntegrationTest.groovy
@@ -10,6 +10,7 @@ import liquibase.extension.testing.testsystem.DatabaseTestSystem
 import liquibase.extension.testing.testsystem.TestSystemFactory
 import liquibase.extension.testing.testsystem.spock.LiquibaseIntegrationTest
 import liquibase.util.FileUtil
+import org.apache.commons.io.FileUtils
 import org.apache.commons.lang3.RandomStringUtils
 import spock.lang.Shared
 import spock.lang.Specification
@@ -21,7 +22,7 @@ class DiffChangelogMssqlIntegrationTest extends Specification {
     private DatabaseTestSystem mssql =
             (DatabaseTestSystem) Scope.getCurrentScope().getSingleton(TestSystemFactory.class).getTestSystem("mssql")
 
-    def "auto increment on varchar column" () {
+    def "column direction is not included in addPrimaryKey change" () {
         def snapshotFilename = "target-${RandomStringUtils.randomAlphabetic(10)}.json"
         def snapshotFilepath = "target/test-classes/" + snapshotFilename
         def changelogFile = "target/test-classes/diffChangelog-${RandomStringUtils.randomAlphabetic(10)}.xml"
@@ -50,7 +51,7 @@ ADD CONSTRAINT PK_MyTest PRIMARY KEY (ID DESC);""")
 
         cleanup:
         generatedChangelog.delete()
-        new File(snapshotFilename).delete()
+        FileUtils.forceDelete(new File(snapshotFilepath))
     }
 
 }

--- a/liquibase-standard/src/main/java/liquibase/structure/core/PrimaryKey.java
+++ b/liquibase-standard/src/main/java/liquibase/structure/core/PrimaryKey.java
@@ -58,7 +58,7 @@ public class PrimaryKey extends AbstractDatabaseObject {
     }
 
     public String getColumnNames() {
-        return StringUtil.join(getColumns(), ", ", obj -> ((Column) obj).toString(false));
+        return StringUtil.join(getColumns(), ", ", obj -> ((Column) obj).getName());
     }
 
     /**


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

Previously, diff-changelog would errorenously create addPrimaryKey changes which included the column direction:

```
        <addPrimaryKey columnNames="ID DESC" constraintName="PK_MyTest" tableName="MyTest"/>
```

This PR changes the generated change to:

```
        <addPrimaryKey columnNames="ID" constraintName="PK_MyTest" tableName="MyTest"/>
```

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
