### PR TITLE
Optimize parsing big xml files

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/util/ObjectMethods.java
+++ b/liquibase-standard/src/main/java/liquibase/util/ObjectMethods.java
@@ -1,0 +1,45 @@
+package liquibase.util;
+
+import static java.util.Locale.ROOT;
+import static java.util.stream.Collectors.toMap;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BinaryOperator;
+
+final class ObjectMethods {
+
+  private static final BinaryOperator<Method> ignoreMultipleMethodsWithSameName = (first, second) -> first;
+  private final Map<String, Method> writeMethods;
+  private final Map<String, Method> readMethods;
+
+  ObjectMethods(Method[] methods) {
+    readMethods = new HashMap<>(methods.length);
+    readMethods.putAll(find(methods, 0, "get"));
+    readMethods.putAll(find(methods, 0, "is"));
+    writeMethods = find(methods, 1, "set");
+  }
+
+  private Map<String, Method> find(Method[] methods, int parametersCount, String prefix) {
+    return Arrays.stream(methods)
+      .filter(m -> m.getParameterTypes().length == parametersCount)
+      .filter(m -> m.getName().startsWith(prefix))
+      .collect(toMap(m -> propertyName(m.getName(), prefix), m -> m, ignoreMultipleMethodsWithSameName));
+  }
+
+  private String propertyName(String methodName, String prefix) {
+    int length = prefix.length();
+    return methodName.substring(length, length + 1).toLowerCase(ROOT) + methodName.substring(length + 1);
+  }
+
+  Method getReadMethod(String propertyName) {
+    return readMethods.get(propertyName);
+  }
+
+  Method getWriteMethod(String propertyName) {
+    return writeMethods.get(propertyName);
+  }
+
+}

--- a/liquibase-standard/src/main/java/liquibase/util/ObjectMethods.java
+++ b/liquibase-standard/src/main/java/liquibase/util/ObjectMethods.java
@@ -15,6 +15,10 @@ final class ObjectMethods {
   private final Map<String, Method> writeMethods;
   private final Map<String, Method> readMethods;
 
+  ObjectMethods(Class klass) {
+    this(klass.getMethods());
+  }
+
   ObjectMethods(Method[] methods) {
     readMethods = new HashMap<>(methods.length);
     readMethods.putAll(find(methods, 0, "get"));

--- a/liquibase-standard/src/main/java/liquibase/util/ObjectUtil.java
+++ b/liquibase-standard/src/main/java/liquibase/util/ObjectUtil.java
@@ -29,11 +29,16 @@ import java.util.logging.Level;
 public class ObjectUtil {
 
     private static final List<BeanIntrospector> introspectors = new ArrayList<>(Arrays.asList(new DefaultBeanIntrospector(), new FluentPropertyBeanIntrospector()));
-    
+
     /**
      * Cache for the methods of classes that we have been queried about so far.
      */
     private static final Map<Class<?>, Method[]> methodCache = new ConcurrentHashMap<>();
+
+    private static final Map<String, String> getMethodCache = new ConcurrentHashMap<>();
+    private static final Map<String, String> isMethodCache = new ConcurrentHashMap<>();
+    private static final Map<String, String> setMethodCache = new ConcurrentHashMap<>();
+
     public static String ARGUMENT_KEY = "key";
 
     /**
@@ -206,10 +211,10 @@ public class ObjectUtil {
      * @return the {@link Method} if found, null in all other cases.
      */
     private static Method getReadMethod(Object object, String propertyName) {
-        String getMethodName = "get" + propertyName.substring(0, 1).toUpperCase(Locale.ENGLISH)
-            + propertyName.substring(1);
-        String isMethodName = "is" + propertyName.substring(0, 1).toUpperCase(Locale.ENGLISH)
-            + propertyName.substring(1);
+        String getMethodName = getMethodCache.computeIfAbsent(propertyName, (key) -> "get" + propertyName.substring(0, 1).toUpperCase(Locale.ENGLISH)
+            + propertyName.substring(1));
+        String isMethodName = isMethodCache.computeIfAbsent(propertyName, (key) -> "is" + propertyName.substring(0, 1).toUpperCase(Locale.ENGLISH)
+            + propertyName.substring(1));
 
         Method[] methods = getMethods(object);
 
@@ -229,8 +234,8 @@ public class ObjectUtil {
      * @return the {@link Method} if found, null in all other cases.
      */
     private static Method getWriteMethod(Object object, String propertyName) {
-        String methodName = "set"
-            + propertyName.substring(0, 1).toUpperCase(Locale.ENGLISH) + propertyName.substring(1);
+        String methodName = setMethodCache.computeIfAbsent(propertyName, (key) -> "set"
+          + propertyName.substring(0, 1).toUpperCase(Locale.ENGLISH) + propertyName.substring(1));
         Method[] methods = getMethods(object);
 
         for (Method method : methods) {

--- a/liquibase-standard/src/main/java/liquibase/util/ObjectUtil.java
+++ b/liquibase-standard/src/main/java/liquibase/util/ObjectUtil.java
@@ -1,5 +1,7 @@
 package liquibase.util;
 
+import static java.util.Locale.ENGLISH;
+
 import liquibase.Scope;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.statement.DatabaseFunction;
@@ -211,10 +213,8 @@ public class ObjectUtil {
      * @return the {@link Method} if found, null in all other cases.
      */
     private static Method getReadMethod(Object object, String propertyName) {
-        String getMethodName = getMethodCache.computeIfAbsent(propertyName, (key) -> "get" + propertyName.substring(0, 1).toUpperCase(Locale.ENGLISH)
-            + propertyName.substring(1));
-        String isMethodName = isMethodCache.computeIfAbsent(propertyName, (key) -> "is" + propertyName.substring(0, 1).toUpperCase(Locale.ENGLISH)
-            + propertyName.substring(1));
+        String getMethodName = getMethodCache.computeIfAbsent(propertyName, (key) -> methodName("get", propertyName));
+        String isMethodName = isMethodCache.computeIfAbsent(propertyName, (key) -> methodName("is", propertyName));
 
         Method[] methods = getMethods(object);
 
@@ -234,8 +234,7 @@ public class ObjectUtil {
      * @return the {@link Method} if found, null in all other cases.
      */
     private static Method getWriteMethod(Object object, String propertyName) {
-        String methodName = setMethodCache.computeIfAbsent(propertyName, (key) -> "set"
-          + propertyName.substring(0, 1).toUpperCase(Locale.ENGLISH) + propertyName.substring(1));
+        String methodName = setMethodCache.computeIfAbsent(propertyName, (key) -> methodName("set", propertyName));
         Method[] methods = getMethods(object);
 
         for (Method method : methods) {
@@ -244,6 +243,10 @@ public class ObjectUtil {
             }
         }
         return null;
+    }
+
+    private static String methodName(String prefix, String propertyName) {
+        return prefix + propertyName.substring(0, 1).toUpperCase(ENGLISH) + propertyName.substring(1);
     }
 
     /**

--- a/liquibase-standard/src/main/java/liquibase/util/ObjectUtil.java
+++ b/liquibase-standard/src/main/java/liquibase/util/ObjectUtil.java
@@ -227,7 +227,7 @@ public class ObjectUtil {
      * @return array of {@link Method} belonging to the class of the object
      */
     private static ObjectMethods getMethods(Object object) {
-        return methodCache.computeIfAbsent(object.getClass(), k -> new ObjectMethods(object.getClass().getMethods()));
+        return methodCache.computeIfAbsent(object.getClass(), k -> new ObjectMethods(object.getClass()));
     }
 
     /**

--- a/liquibase-standard/src/test/java/liquibase/util/ObjectMethodsTest.java
+++ b/liquibase-standard/src/test/java/liquibase/util/ObjectMethodsTest.java
@@ -1,0 +1,48 @@
+package liquibase.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ObjectMethodsTest {
+
+  @Test
+  void readMethods() {
+    ObjectMethods objectMethods = new ObjectMethods(User.class);
+    assertThat(objectMethods.getReadMethod("name").getName()).isEqualTo("getName");
+    assertThat(objectMethods.getReadMethod("age").getName()).isEqualTo("getAge");
+    assertThat(objectMethods.getReadMethod("human").getName()).isEqualTo("isHuman");
+    assertThat(objectMethods.getReadMethod("gender")).isNull();
+  }
+
+  @Test
+  void writeMethods() {
+    ObjectMethods objectMethods = new ObjectMethods(User.class);
+    assertThat(objectMethods.getWriteMethod("name")).isNull();
+    assertThat(objectMethods.getWriteMethod("age").getName()).isEqualTo("setAge");
+    assertThat(objectMethods.getWriteMethod("human")).isNull();
+  }
+
+  static class User {
+    private final String name;
+    private int age;
+
+    User(String name) {this.name = name;}
+
+    public String getName() {
+      return name;
+    }
+
+    public int getAge() {
+      return age;
+    }
+
+    public void setAge(int age) {
+      this.age = age;
+    }
+
+    public boolean isHuman() {
+      return true;
+    }
+  }
+}


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

When running a big integration test suite that runs LiquiBase multiple times, I realized that LB spends a lot of time on generating the same method names again and again (e.g. given property name `name`, LB generates Strings `isName`, `getName` and `setName` many-many times).

I suggest an optimization that computes them only once and holds in a Map. 
Should make parsing big XML files faster and consume less memory.

I believe this change doesn't affect any functionality (besides the above-mentioned performance improvement).
