### PR TITLE
add default constructor + setters to `DatabaseChangeLogLock`

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/lockservice/DatabaseChangeLogLock.java
+++ b/liquibase-standard/src/main/java/liquibase/lockservice/DatabaseChangeLogLock.java
@@ -1,15 +1,24 @@
 package liquibase.lockservice;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import java.util.Date;
 
 /**
  * Information about the database changelog lock which allows only one instance of Liquibase to attempt to
  * update a database at a time. Immutable class
  */
+@NoArgsConstructor
 public class DatabaseChangeLogLock {
-    private final int id;
-    private final Date lockGranted;
-    private final String lockedBy;
+    @Getter
+    @Setter
+    private int id;
+    private Date lockGranted;
+    @Getter
+    @Setter
+    private String lockedBy;
 
     public DatabaseChangeLogLock(int id, Date lockGranted, String lockedBy) {
         this.id = id;
@@ -17,15 +26,12 @@ public class DatabaseChangeLogLock {
         this.lockedBy = lockedBy;
     }
 
-    public int getId() {
-        return id;
-    }
-
     public Date getLockGranted() {
         return (Date) lockGranted.clone();
     }
 
-    public String getLockedBy() {
-        return lockedBy;
+    public void setLockGranted(final Date lockGranted) {
+        this.lockGranted = new Date(lockGranted.getTime());
     }
+
 }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

this is needed to be able to de-serialise it using [jackson] which relies on the default constructor & setters.
in the upcoming [liquibase-opensearch] implementation [opensearch-java] is used, which underneath is using jackson for the (de-)serialisation of classes.

specifically, this is used in the implementation of `LockService#listLocks` which needs to load `DatabaseChangeLogLock`s from the DB.

also do some minor cleanups by removing manually implemented getters & setters where lombok annotations can do the job instead (no functional impact).
this could be cleaned up even further if `Date` were replaced with `LocalTime` (which is immutable), but that'd be a bigger (breaking) change.

note that this is the same pattern as was previously done in #5336 (commit b4726a0) for `RanChangeSet` & other classes.

[jackson]: https://github.com/FasterXML/jackson
[opensearch-java]: https://github.com/opensearch-project/opensearch-java/
[liquibase-opensearch]: https://github.com/liquibase/liquibase-opensearch/

## Things to be aware of

n/a

## Things to worry about

n/a

## Additional Context

see above