### PR TITLE
Clone system properties to prevent ConcurrentModificationException

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/configuration/core/ScopeValueProvider.java
+++ b/liquibase-standard/src/main/java/liquibase/configuration/core/ScopeValueProvider.java
@@ -34,8 +34,4 @@ public class ScopeValueProvider extends AbstractConfigurationValueProvider {
         return null;
     }
 
-    protected Properties getSystemProperties() {
-        return System.getProperties();
-    }
-
 }

--- a/liquibase-standard/src/main/java/liquibase/configuration/core/SystemPropertyValueProvider.java
+++ b/liquibase-standard/src/main/java/liquibase/configuration/core/SystemPropertyValueProvider.java
@@ -3,6 +3,7 @@ package liquibase.configuration.core;
 import liquibase.configuration.AbstractMapConfigurationValueProvider;
 
 import java.util.Map;
+import java.util.Properties;
 
 /**
  * Searches for the configuration values in the system properties {@link System#getProperties()}.
@@ -23,6 +24,6 @@ public class SystemPropertyValueProvider extends AbstractMapConfigurationValuePr
 
     @Override
     protected Map<?, ?> getMap() {
-        return System.getProperties();
+        return (Properties) System.getProperties().clone();
     }
 }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

If the system properties are modified while liquibase is iterating over them within the AbstractMapConfigurationValueProvider, a ConcurrentModificationException is thrown.
The fix is the same as the second fix of [CORE-2104](https://liquibase.jira.com/browse/CORE-2104) from [2015 (3.4.1)](https://github.com/liquibase/liquibase/commit/0c42dcd9fe89cbcd82594fc3bb6cfbf2ddbf1104), cloning the system properties. However, this code [no longer](https://github.com/liquibase/liquibase/blob/v4.28.0/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogParameters.java#L56) uses a for loop to iterate over the system properties.

This fixes #4908

## Things to be aware of

Seperating this test case/issue is not that easy. The changes are based on this reproduction project: https://github.com/Alf-Melmac/properties-iterator

The unused `getSystemProperties` method of `ScopeValueProvider` looks like a copy-paste error. To prevent further problems, I've removed it.

## Additional Context

This patch, but based on 4.21.1, is being tested and runs in production since the 26th of April.