### PR TITLE
Make the message be more accurate when an exception occurs during database close

### DIFF
--- a/liquibase-integration-tests/src/test/groovy/liquibase/snapshot/JdbcDatabaseConnectionCloseTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/snapshot/JdbcDatabaseConnectionCloseTest.groovy
@@ -1,0 +1,75 @@
+package liquibase.snapshot
+
+import liquibase.Scope
+import liquibase.database.AbstractJdbcDatabase
+import liquibase.database.Database
+import liquibase.database.jvm.JdbcConnection
+import liquibase.exception.DatabaseException
+import liquibase.extension.testing.testsystem.DatabaseTestSystem
+import liquibase.extension.testing.testsystem.TestSystemFactory
+import liquibase.extension.testing.testsystem.spock.LiquibaseIntegrationTest
+import liquibase.logging.core.BufferedLogService
+import liquibase.parser.ChangeLogParserConfiguration
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.sql.Connection
+import java.util.logging.Level
+
+@LiquibaseIntegrationTest
+class JdbcDatabaseConnectionCloseTest extends Specification {
+    @Shared
+    public DatabaseTestSystem h2 = Scope.currentScope.getSingleton(TestSystemFactory).getTestSystem("h2")
+
+    def "Test Exception"() {
+        when:
+        JdbcConnection connection = new TestJdbcConnection(h2.getConnection())
+        Database database = h2.getDatabaseFromFactory()
+        database.setConnection(connection)
+        database.close()
+
+        then:
+        thrown(DatabaseException)
+    }
+
+    def "Test Exception thrown during auto-commit"() {
+        when:
+        BufferedLogService bufferLog = new BufferedLogService()
+
+        Scope.child(Scope.Attr.logService.name(), bufferLog, () -> {
+            JdbcConnection connection = new TestJdbcConnectionAutoCommit(h2.getConnection())
+            Database database = h2.getDatabaseFromFactory()
+            ((AbstractJdbcDatabase)database).setPreviousAutoCommit(false)
+            database.setConnection(connection)
+            database.close()
+        })
+
+        then:
+        def dbe = thrown(DatabaseException)
+        assert dbe
+        assert bufferLog.getLogAsString(Level.WARNING).contains("WARNING Failed to restore the auto commit to false")
+    }
+
+    private class TestJdbcConnection extends JdbcConnection {
+        TestJdbcConnection(Connection sqlConnection) {
+            super(sqlConnection)
+        }
+
+        @Override
+        void close() throws DatabaseException {
+            throw new DatabaseException("This exception is for test")
+        }
+    }
+
+    private class TestJdbcConnectionAutoCommit extends JdbcConnection {
+        TestJdbcConnectionAutoCommit(Connection sqlConnection) {
+            super(sqlConnection)
+        }
+
+        @Override
+        void setAutoCommit(boolean autoCommit) throws DatabaseException {
+            throw new DatabaseException("This exception is for test")
+        }
+    }
+
+}

--- a/liquibase-integration-tests/src/test/java/liquibase/helper/DBTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/helper/DBTest.java
@@ -1,0 +1,74 @@
+package liquibase.helper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+import oracle.jdbc.OracleConnection;
+import oracle.jdbc.OracleDriver;
+import oracle.jdbc.OracleStatement;
+import oracle.jdbc.dcn.DatabaseChangeEvent;
+import oracle.jdbc.dcn.DatabaseChangeListener;
+import oracle.jdbc.dcn.DatabaseChangeRegistration;
+
+public class DBTest {
+    static final String USERNAME = "PROSCHEMA";
+    static final String PASSWORD = "PROSCHEMA";
+    static String URL = "jdbc:oracle:thin:@localhost:1521/BUCKET_01";
+
+    public static void main(String[] args) {
+        DBTest oracleDCN = new DBTest();
+        try {
+            oracleDCN.run();
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    private void run() throws Exception {
+        OracleConnection conn = connect();
+        Statement stmt= conn.createStatement();
+        ResultSet rs = stmt.executeQuery("select regid,callback from USER_CHANGE_NOTIFICATION_REGS");
+        while(rs.next()) {
+            long regid = rs.getLong(1);
+            String callback = rs.getString(2);
+            ((OracleConnection)conn).unregisterDatabaseChangeNotification(regid,callback);
+        }
+        stmt.close();
+        Properties prop = new Properties();
+        prop.setProperty(OracleConnection.DCN_NOTIFY_ROWIDS, "true");
+        DatabaseChangeRegistration dcr = conn.registerDatabaseChangeNotification(prop);
+
+        try {
+            dcr.addListener(new DatabaseChangeListener() {
+                public void onDatabaseChangeNotification(DatabaseChangeEvent dce) {
+                    System.out.println("GIVE ME SOMETHING!");
+                }
+            });
+            //conn.unregisterDatabaseChangeNotification(dcr);
+            stmt = conn.createStatement();
+            ((OracleStatement) stmt).setDatabaseChangeRegistration(dcr);
+            rs = stmt.executeQuery("select * from hello");
+            while (rs.next()) {
+            }
+            rs.close();
+            stmt.close();
+            conn.unregisterDatabaseChangeNotification(dcr);
+            conn.close();
+        } catch (SQLException ex) {
+            if (conn != null) {
+                conn.unregisterDatabaseChangeNotification(dcr);
+                conn.close();
+            }
+            throw ex;
+        }
+    }
+
+    OracleConnection connect() throws SQLException {
+        OracleDriver dr = new OracleDriver();
+        Properties prop = new Properties();
+        prop.setProperty("user", DBTest.USERNAME);
+        prop.setProperty("password", DBTest.PASSWORD);
+        return (OracleConnection) dr.connect(DBTest.URL, prop);
+    }
+}


### PR DESCRIPTION
I am unable to replicate the original issue or come up with a way to cause an exception on database close. I have added unit/integration tests to simulate the problem and fix.

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
