### PR TITLE
Prevent silent failures when two "databaseChangeLog" tags are present (fixes #5963)

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/parser/core/yaml/YamlChangeLogParser.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/core/yaml/YamlChangeLogParser.java
@@ -99,10 +99,77 @@ public class YamlChangeLogParser extends YamlParser implements ChangeLogParser {
         }
     }
 
+    /**
+     * A simple "interceptor" InputStream to ensure that the YAML stream doesn't contain two "databaseChangeLog" tags,
+     * which would otherwise cause silent omissions if something is copy/pasted wrongly into the file.
+     */
+    static class DoubleChangelogCheckerInputStream extends FilterInputStream {
+
+        byte[] databaseChangeLog = "databaseChangeLog".getBytes(StandardCharsets.UTF_8);
+        int scanPos;
+        boolean databaseChangeLogSeen;
+
+        DoubleChangelogCheckerInputStream(InputStream in) {
+            super(in);
+            scanPos = 0;
+            databaseChangeLogSeen = false;
+        }
+
+        private void processByte(int nextByte) {
+            // scanPos will be -1 if we aren't in a position where "databaseChangeLog" would cause a problem
+            // i.e. the beginning of a file or of a line
+            if (nextByte == 10) {
+                // a new line means we should expect to see it again
+                scanPos = 0;
+            } else if (scanPos > -1 && nextByte == databaseChangeLog[scanPos]) {
+                scanPos++;
+                if (scanPos == databaseChangeLog.length) {
+                    if (databaseChangeLogSeen) {
+                        throw new IllegalStateException("Two 'databaseChangeLog' tags found in a single file!");
+                    } else {
+                        databaseChangeLogSeen = true;
+                        scanPos = -1;
+                    }
+                }
+            } else {
+                // no point in scanning since the string was not found
+                scanPos = -1;
+            }
+        }
+
+        @Override
+        public int read() throws IOException {
+            int nextByte = super.read();
+            processByte(nextByte);
+            return nextByte;
+        }
+
+        @Override
+        public int read(byte[] b) throws IOException {
+            int numBytes = super.read(b);
+
+            for (int i=0; i<numBytes; i++) {
+                processByte(b[i]);
+            }
+
+            return numBytes;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            int numBytes = super.read(b, off, len);
+
+            for (int i=off; i < off + numBytes; i++) {
+                processByte(b[i]);
+            }
+            return numBytes;
+        }
+    }
+
     private Map parseYamlStream(String physicalChangeLogLocation, Yaml yaml, InputStream changeLogStream) throws ChangeLogParseException {
         Map parsedYaml;
         try {
-            parsedYaml = yaml.load(changeLogStream);
+            parsedYaml = yaml.load(new DoubleChangelogCheckerInputStream(changeLogStream));
         } catch (Exception e) {
             throw new ChangeLogParseException("Syntax error in file " + physicalChangeLogLocation + ": " + e.getMessage(), e);
         }

--- a/liquibase-standard/src/main/java/liquibase/parser/core/yaml/YamlParser.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/core/yaml/YamlParser.java
@@ -15,8 +15,6 @@ public abstract class YamlParser implements LiquibaseParser {
         LoaderOptions options = new LoaderOptions();
         SnakeYamlUtil.setCodePointLimitSafely(options, Integer.MAX_VALUE);
         SnakeYamlUtil.setProcessCommentsSafely(options, false);
-        // TODO: remove the below line when we have a general fix for the not allowed duplicated databaseChangelog and sql tags
-        //        options.setAllowDuplicateKeys(false);
         options.setAllowRecursiveKeys(false);
         return options;
     }

--- a/liquibase-standard/src/test/groovy/liquibase/parser/core/yaml/YamlChangeLogParser_RealFile_Test.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/parser/core/yaml/YamlChangeLogParser_RealFile_Test.groovy
@@ -46,7 +46,6 @@ import liquibase.sql.visitor.AppendSqlVisitor
 import liquibase.sql.visitor.ReplaceSqlVisitor
 import liquibase.test.JUnitResourceAccessor
 import liquibase.util.ISODateFormat
-import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -300,7 +299,6 @@ public class YamlChangeLogParser_RealFile_Test extends Specification {
         assert e.message.startsWith("Syntax error in file liquibase/parser/core/yaml/malformedChangeLog.yaml")
     }
 
-    @Ignore
     def "ChangeLogParseException thrown if changelog has two databaseChangeLog tags"() throws Exception {
         when:
         new YamlChangeLogParser().parse("liquibase/parser/core/yaml/malformedDoubleChangeLog.yaml", new ChangeLogParameters(), new JUnitResourceAccessor())


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description
If someone makes a mistake and copy/pastes a databaseChangeLog block in, and makes the file have two tags, the SnakeYAML parser silently covers up the first instance with the second one, which will cause the first block of changes to be silently omitted.

This can be very problematic and cause hard-to-debug errors, which is why I have added a small FilterInputStream interceptor to check the stream as it is fed into the YAML parser, for a duplicate tag. Doing it with the FilterInputStream like this prevents the efficiency losses of opening the file twice.

I've removed the `@Ignore` flag from the test, which should now validate that the invalid file correctly throws a syntax error.

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

I did it with a InputStream interceptor to not need to fully load the changeset into memory for parsing, but just check it "on-the-fly" as it flows by. This way no additional memory limitation is imposed on Liquibase and the performance profile should be the same as before.

## Things to worry about

I'm guessing it could have some breaking impact if there was a Liquibase script that was silently failing before but is now throwing the syntax error... maybe we want to disable the syntax check for already processed Liquibase changesets?

## Additional Context

I previously did this change in PR #1826 but it was suggested that I change it to just disallow duplicate keys, which has clearly not worked. I am re-submitting my initial change. Yes, it is a bit less elegant, but it will catch the duplicate databaseChangeLog case and give a warning instead of silently failing. This should fix the follow-up issue #5963.
