### PR TITLE
DAT-16264 DevOps :: liquibase build fails on Publish to Maven Central - Nexus

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -180,16 +180,24 @@ jobs:
 
           ## Release repository
           ## Have to find the stagingRepositoryId that was auto-generated
-          rcList=$(mvn -B org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8:rc-list -DnexusUrl=https://oss.sonatype.org/ -DserverId=sonatype-nexus-staging)
-          #echo $rcList
+          api_output=$(curl -s -u "${{ secrets.SONATYPE_USERNAME }}:${{ secrets.SONATYPE_TOKEN }}" "https://oss.sonatype.org/service/local/staging/profile_repositories")
+          # Extract ids of repositories-item containing the string "liquibase"
+          repositories=$(echo "$api_output" | grep -B 8 "liquibase" | grep "<repositoryId>" | awk -F"<|>" '{print $3}')
+          echo "Repository IDs containing 'liquibase': $repositories"
+          for repo_id in $repositories; do
+            echo "Check if $repo_id repository is an extension"
+            api_output=$(curl -s -u "${{ secrets.SONATYPE_USERNAME }}:${{ secrets.SONATYPE_TOKEN }}" "https://oss.sonatype.org/service/local/repositories/$repo_id/content/org/liquibase/")
+            relative_path=$(echo "$api_output" | grep -oP '<relativePath>\K[^<]+' | awk 'NR==1')
+            echo "Relative path: $relative_path"
+            if [[ "$relative_path" == *"/org/liquibase/ext/"* ]]; then
+                echo "Relative path contains '/org/liquibase/ext/'. It is an extension."
+            else
+                echo "Relative path does not contain '/org/liquibase/ext/'. It is not an extension."
+                stagingRepositoryId=$repo_id
+            fi
+          done
 
-          stagingRepositoryId=$(echo $rcList | grep -o "\[INFO\] orgliquibase-[0-9]*[ ]*OPEN" | grep -o "orgliquibase-[0-9]*")
           echo "Staging Repository Id: $stagingRepositoryId"
-
-          if [ "$(echo $stagingRepositoryId | grep -o "\-" | wc -l)" != "1" ]; then
-            echo "Did not find exactly one open repository"
-            exit 1
-          fi
 
           mvn org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8:rc-close \
             -DnexusUrl=https://oss.sonatype.org/ \

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -194,6 +194,7 @@ jobs:
             else
                 echo "Relative path does not contain '/org/liquibase/ext/'. It is not an extension."
                 stagingRepositoryId=$repo_id
+                break
             fi
           done
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

📝 (release-published.yml): improve logic to find the stagingRepositoryId for release repository by checking if a repository is an extension before assigning it as the staging repository.

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
