### PR TITLE
High Level API (aka undeprecate Liquibase class)

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-standard/src/main/java/liquibase/Liquibase.java
@@ -3,10 +3,7 @@ package liquibase;
 import liquibase.change.CheckSum;
 import liquibase.changelog.*;
 import liquibase.changelog.filter.*;
-import liquibase.changelog.visitor.ChangeExecListener;
-import liquibase.changelog.visitor.DefaultChangeExecListener;
-import liquibase.changelog.visitor.ListVisitor;
-import liquibase.changelog.visitor.StatusVisitor;
+import liquibase.changelog.visitor.*;
 import liquibase.command.CommandResults;
 import liquibase.command.CommandScope;
 import liquibase.command.core.*;
@@ -35,8 +32,10 @@ import liquibase.resource.ResourceAccessor;
 import liquibase.serializer.ChangeLogSerializer;
 import liquibase.structure.DatabaseObject;
 import liquibase.util.LoggingExecutorTextUtil;
-import liquibase.util.StringUtil;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.io.output.WriterOutputStream;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.io.PrintStream;
@@ -48,7 +47,7 @@ import static java.util.ResourceBundle.getBundle;
 
 /**
  * Primary facade class for interacting with Liquibase.
- * The built in command line, Ant, Maven and other ways of running Liquibase are wrappers around methods in this class.
+ * The built-in command line, Ant, Maven and other ways of running Liquibase are wrappers around methods in this class.
  */
 public class Liquibase implements AutoCloseable {
 
@@ -56,16 +55,35 @@ public class Liquibase implements AutoCloseable {
     private static final ResourceBundle coreBundle = getBundle("liquibase/i18n/liquibase-core");
     public static final String MSG_COULD_NOT_RELEASE_LOCK = coreBundle.getString("could.not.release.lock");
 
+    /**
+     *  Returns the Database used by this Liquibase instance.
+     */
+    @Getter
     protected Database database;
     private DatabaseChangeLog databaseChangeLog;
+    /**
+     *  Return the change log file used by this Liquibase instance.
+     */
+    @Getter
     private String changeLogFile;
+    @Setter
     private UpdateSummaryOutputEnum showSummaryOutput;
+    @Setter
     private UpdateSummaryEnum showSummary;
+    /**
+     *  Return ResourceAccessor used by this Liquibase instance.
+     */
+    @Getter
     private final ResourceAccessor resourceAccessor;
+    /**
+     *  Returns the ChangeLogParameters container used by this Liquibase instance.
+     */
+    @Getter
     private final ChangeLogParameters changeLogParameters;
+    @Setter
     private ChangeExecListener changeExecListener;
+    @Getter
     private final DefaultChangeExecListener defaultChangeExecListener = new DefaultChangeExecListener();
-    private final Map<String, Boolean> upToDateFastCheck = new HashMap<>();
 
     /**
      * Creates a Liquibase instance for a given DatabaseConnection. The Database instance used will be found with {@link DatabaseFactory#findCorrectDatabaseImplementation(liquibase.database.DatabaseConnection)}
@@ -116,13 +134,6 @@ public class Liquibase implements AutoCloseable {
     }
 
     /**
-     * Return the change log file used by this Liquibase instance.
-     */
-    public String getChangeLogFile() {
-        return changeLogFile;
-    }
-
-    /**
      * Return the log used by this Liquibase instance.
      */
     public Logger getLog() {
@@ -130,36 +141,10 @@ public class Liquibase implements AutoCloseable {
     }
 
     /**
-     * Returns the ChangeLogParameters container used by this Liquibase instance.
-     */
-    public ChangeLogParameters getChangeLogParameters() {
-        return changeLogParameters;
-    }
-
-    /**
-     * Returns the Database used by this Liquibase instance.
-     */
-    public Database getDatabase() {
-        return database;
-    }
-
-    /**
-     * Return ResourceAccessor used by this Liquibase instance.
-     */
-    public ResourceAccessor getResourceAccessor() {
-        return resourceAccessor;
-    }
-
-    /**
      * Convenience method for {@link #update(Contexts)} that runs in "no context mode".
      *
      * @see <a href="https://docs.liquibase.com/concepts/changelogs/attributes/contexts.html" target="_top">contexts</a> in documentation
      */
-
-    /**
-     * @deprecated use {@link CommandScope}
-     **/
-    @Deprecated
     public void update() throws LiquibaseException {
         this.update(new Contexts());
     }
@@ -170,11 +155,6 @@ public class Liquibase implements AutoCloseable {
      *
      * @see <a href="https://docs.liquibase.com/concepts/changelogs/attributes/contexts.html" target="_top">contexts</a> in documentation
      */
-
-    /**
-     * @deprecated use {@link CommandScope}
-     **/
-    @Deprecated
     public void update(String contexts) throws LiquibaseException {
         this.update(new Contexts(contexts));
     }
@@ -185,11 +165,6 @@ public class Liquibase implements AutoCloseable {
      *
      * @see <a href="https://docs.liquibase.com/concepts/changelogs/attributes/contexts.html" target="_top">contexts</a> in documentation
      */
-
-    /**
-     * @deprecated use {@link CommandScope}
-     **/
-    @Deprecated
     public void update(Contexts contexts) throws LiquibaseException {
         update(contexts, new LabelExpression());
     }
@@ -203,11 +178,6 @@ public class Liquibase implements AutoCloseable {
      * @see <a href="https://docs.liquibase.com/concepts/changelogs/attributes/contexts.html" target="_top">Liquibase Contexts</a> in the Liquibase documentation
      * @see <a href="https://docs.liquibase.com/concepts/changelogs/attributes/labels.html" target="_top">Liquibase Labels</a> in the Liquibase documentation
      */
-
-    /**
-     * @deprecated use {@link CommandScope}
-     **/
-    @Deprecated
     public void update(Contexts contexts, LabelExpression labelExpression) throws LiquibaseException {
         update(contexts, labelExpression, true);
     }
@@ -225,11 +195,6 @@ public class Liquibase implements AutoCloseable {
      * @see <a href="https://docs.liquibase.com/concepts/changelogs/attributes/contexts.html" target="_top">Liquibase Contexts</a>
      * @see <a href="https://docs.liquibase.com/concepts/changelogs/attributes/labels.html" target="_top">Liquibase Labels</a>
      */
-
-    /**
-     * @deprecated use {@link CommandScope}
-     **/
-    @Deprecated
     public void update(Contexts contexts, LabelExpression labelExpression, boolean checkLiquibaseTables) throws LiquibaseException {
         runInScope(() -> {
             CommandScope updateCommand = new CommandScope(UpdateCommandStep.COMMAND_NAME);
@@ -255,7 +220,7 @@ public class Liquibase implements AutoCloseable {
      * But, if there are changelogs that might have to be ran and this returns <b>false</b>, you MUST get a lock and do a real check to know what changesets actually need to run.
      * <p>
      * NOTE: to reduce the number of queries to the databasehistory table, this method will cache the "fast check" results within this instance under the assumption that the total changesets will not change within this instance.
-     * @deprecated this method has been moved to {@link AbstractUpdateCommandStep}, use that one instead.
+     * @deprecated this method has been moved to {@link FastCheckService}, use that one instead.
      */
     @Deprecated
     protected boolean isUpToDateFastCheck(Contexts contexts, LabelExpression labelExpression) throws LiquibaseException {
@@ -280,7 +245,7 @@ public class Liquibase implements AutoCloseable {
             }
             databaseChangeLog = parser.parse(changeLogFile, changeLogParameters, resourceAccessor);
             Scope.getCurrentScope().getLog(Liquibase.class).info("Parsed changelog file '" + changeLogFile + "'");
-            if (StringUtil.isNotEmpty(databaseChangeLog.getLogicalFilePath())) {
+            if (StringUtils.isNotEmpty(databaseChangeLog.getLogicalFilePath())) {
                 Scope.getCurrentScope().addMdcValue(MdcKey.CHANGELOG_FILE, databaseChangeLog.getLogicalFilePath());
             } else {
                 Scope.getCurrentScope().addMdcValue(MdcKey.CHANGELOG_FILE, changeLogFile);
@@ -309,22 +274,18 @@ public class Liquibase implements AutoCloseable {
                 new IgnoreChangeSetFilter());
     }
 
-    @Deprecated
     public void update(String contexts, Writer output) throws LiquibaseException {
         this.update(new Contexts(contexts), output);
     }
 
-    @Deprecated
     public void update(Contexts contexts, Writer output) throws LiquibaseException {
         update(contexts, new LabelExpression(), output);
     }
 
-    @Deprecated
     public void update(Contexts contexts, LabelExpression labelExpression, Writer output) throws LiquibaseException {
         update(contexts, labelExpression, output, true);
     }
 
-    @Deprecated
     public void update(Contexts contexts, LabelExpression labelExpression, Writer output, boolean checkLiquibaseTables)
             throws LiquibaseException {
         runInScope(() -> {
@@ -336,12 +297,11 @@ public class Liquibase implements AutoCloseable {
             updateCommand.addArgumentValue(UpdateSqlCommandStep.LABEL_FILTER_ARG, labelExpression != null ? labelExpression.getOriginalString() : null);
             updateCommand.addArgumentValue(ChangeExecListenerCommandStep.CHANGE_EXEC_LISTENER_ARG, changeExecListener);
             updateCommand.addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_PARAMETERS, changeLogParameters);
-            updateCommand.setOutput(new WriterOutputStream(output, GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()));
+            updateCommand.setOutput(WriterOutputStream.builder().setWriter(output).setCharset(GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()).get());
             updateCommand.execute();
         });
     }
 
-    @Deprecated
     public void update(int changesToApply, String contexts) throws LiquibaseException {
         update(changesToApply, new Contexts(contexts), new LabelExpression());
     }
@@ -355,7 +315,6 @@ public class Liquibase implements AutoCloseable {
      * @param labelExpression the label expression used to filter the changesets.
      * @throws LiquibaseException if there is an error while updating the schema.
      */
-    @Deprecated
     public void update(int changesToApply, Contexts contexts, LabelExpression labelExpression)
             throws LiquibaseException {
         runInScope(() -> {
@@ -374,12 +333,10 @@ public class Liquibase implements AutoCloseable {
         });
     }
 
-    @Deprecated
     public void update(String tag, String contexts) throws LiquibaseException {
         update(tag, new Contexts(contexts), new LabelExpression());
     }
 
-    @Deprecated
     public void update(String tag, Contexts contexts) throws LiquibaseException {
         update(tag, contexts, new LabelExpression());
     }
@@ -393,7 +350,6 @@ public class Liquibase implements AutoCloseable {
      * @param labelExpression The label expression to execute with.
      * @throws LiquibaseException if there is an error updating the database.
      */
-    @Deprecated
     public void update(String tag, Contexts contexts, LabelExpression labelExpression) throws LiquibaseException {
         if (tag == null) {
             update(contexts, labelExpression);
@@ -416,12 +372,10 @@ public class Liquibase implements AutoCloseable {
         });
     }
 
-    @Deprecated
     public void update(int changesToApply, String contexts, Writer output) throws LiquibaseException {
         this.update(changesToApply, new Contexts(contexts), new LabelExpression(), output);
     }
 
-    @Deprecated
     public void update(int changesToApply, Contexts contexts, LabelExpression labelExpression, Writer output) throws LiquibaseException {
         changeLogParameters.setContexts(contexts);
         changeLogParameters.setLabels(labelExpression);
@@ -431,7 +385,7 @@ public class Liquibase implements AutoCloseable {
             /* We have no other choice than to save the current Executer here. */
             @SuppressWarnings("squid:S1941")
             Executor oldTemplate = getAndReplaceJdbcExecutor(output);
-            outputHeader("Update " + changesToApply + " Changesets Database Script");
+            LoggingExecutorTextUtil.outputHeader("Update " + changesToApply + " Changesets Database Script", database, changeLogFile);
 
             update(changesToApply, contexts, labelExpression);
 
@@ -443,17 +397,14 @@ public class Liquibase implements AutoCloseable {
 
     }
 
-    @Deprecated
     public void update(String tag, String contexts, Writer output) throws LiquibaseException {
         update(tag, new Contexts(contexts), new LabelExpression(), output);
     }
 
-    @Deprecated
     public void update(String tag, Contexts contexts, Writer output) throws LiquibaseException {
         update(tag, contexts, new LabelExpression(), output);
     }
 
-    @Deprecated
     public void update(String tag, Contexts contexts, LabelExpression labelExpression, Writer output)
             throws LiquibaseException {
         if (tag == null) {
@@ -469,7 +420,7 @@ public class Liquibase implements AutoCloseable {
             @SuppressWarnings("squid:S1941")
             Executor oldTemplate = getAndReplaceJdbcExecutor(output);
 
-            outputHeader("Update to '" + tag + "' Database Script");
+            LoggingExecutorTextUtil.outputHeader("Update to '" + tag + "' Database Script", database, changeLogFile);
 
             update(tag, contexts, labelExpression);
 
@@ -531,7 +482,7 @@ public class Liquibase implements AutoCloseable {
                 .addArgumentValue(RollbackCountCommandStep.COUNT_ARG, changesToRollback)
                 .addArgumentValue(AbstractRollbackCommandStep.ROLLBACK_SCRIPT_ARG, rollbackScript)
                 .addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_PARAMETERS, changeLogParameters)
-                .setOutput(new WriterOutputStream(output, GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()))
+                .setOutput(WriterOutputStream.builder().setWriter(output).setCharset(GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()).get())
                 .execute()
         );
     }
@@ -582,35 +533,29 @@ public class Liquibase implements AutoCloseable {
     // ---------- End RollbackCount Family of methods
 
     // ---------- RollbackSQL Family of methods
-    @Deprecated
     public void rollback(String tagToRollBackTo, String contexts, Writer output) throws LiquibaseException {
         rollback(tagToRollBackTo, null, contexts, output);
     }
 
-    @Deprecated
     public void rollback(String tagToRollBackTo, Contexts contexts, Writer output) throws LiquibaseException {
         rollback(tagToRollBackTo, null, contexts, output);
     }
 
-    @Deprecated
     public void rollback(String tagToRollBackTo, Contexts contexts, LabelExpression labelExpression, Writer output)
             throws LiquibaseException {
         rollback(tagToRollBackTo, null, contexts, labelExpression, output);
     }
 
-    @Deprecated
     public void rollback(String tagToRollBackTo, String rollbackScript, String contexts, Writer output)
             throws LiquibaseException {
         rollback(tagToRollBackTo, rollbackScript, new Contexts(contexts), output);
     }
 
-    @Deprecated
     public void rollback(String tagToRollBackTo, String rollbackScript, Contexts contexts, Writer output)
             throws LiquibaseException {
         rollback(tagToRollBackTo, rollbackScript, contexts, new LabelExpression(), output);
     }
 
-    @Deprecated
     public void rollback(String tagToRollBackTo, String rollbackScript, Contexts contexts,
                          LabelExpression labelExpression, Writer output) throws LiquibaseException {
         runInScope(() ->
@@ -624,35 +569,30 @@ public class Liquibase implements AutoCloseable {
                 .addArgumentValue(RollbackCommandStep.TAG_ARG, tagToRollBackTo)
                 .addArgumentValue(AbstractRollbackCommandStep.ROLLBACK_SCRIPT_ARG, rollbackScript)
                 .addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_PARAMETERS, changeLogParameters)
-                .setOutput(new WriterOutputStream(output, GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()))
+                .setOutput(WriterOutputStream.builder().setWriter(output).setCharset(GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()).get())
                 .execute()
         );
     }
     // ---------- End RollbackSQL Family of methods
 
     // ---------- Rollback (To Tag) Family of methods
-    @Deprecated
     public void rollback(String tagToRollBackTo, String contexts) throws LiquibaseException {
         rollback(tagToRollBackTo, null, contexts);
     }
 
-    @Deprecated
     public void rollback(String tagToRollBackTo, Contexts contexts) throws LiquibaseException {
         rollback(tagToRollBackTo, null, contexts);
     }
 
-    @Deprecated
     public void rollback(String tagToRollBackTo, Contexts contexts, LabelExpression labelExpression)
             throws LiquibaseException {
         rollback(tagToRollBackTo, null, contexts, labelExpression);
     }
 
-    @Deprecated
     public void rollback(String tagToRollBackTo, String rollbackScript, String contexts) throws LiquibaseException {
         rollback(tagToRollBackTo, rollbackScript, new Contexts(contexts));
     }
 
-    @Deprecated
     public void rollback(String tagToRollBackTo, String rollbackScript, Contexts contexts) throws LiquibaseException {
         rollback(tagToRollBackTo, rollbackScript, contexts, new LabelExpression());
     }
@@ -677,7 +617,7 @@ public class Liquibase implements AutoCloseable {
                 .addArgumentValue(DatabaseChangelogCommandStep.LABEL_FILTER_ARG, (labelExpression != null ? labelExpression.getOriginalString() : null))
                 .addArgumentValue(ChangeExecListenerCommandStep.CHANGE_EXEC_LISTENER_ARG, changeExecListener)
                 .addArgumentValue(RollbackCommandStep.TAG_ARG, tagToRollBackTo)
-                .addArgumentValue(RollbackCommandStep.ROLLBACK_SCRIPT_ARG, rollbackScript)
+                .addArgumentValue(AbstractRollbackCommandStep.ROLLBACK_SCRIPT_ARG, rollbackScript)
                 .addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_PARAMETERS, changeLogParameters)
                 .execute()
         );
@@ -712,7 +652,7 @@ public class Liquibase implements AutoCloseable {
                 .addArgumentValue(RollbackToDateCommandStep.DATE_ARG, dateToRollBackTo)
                 .addArgumentValue(AbstractRollbackCommandStep.ROLLBACK_SCRIPT_ARG, rollbackScript)
                 .addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_PARAMETERS, changeLogParameters)
-                .setOutput(new WriterOutputStream(output, GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()))
+                .setOutput(WriterOutputStream.builder().setWriter(output).setCharset(GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()).get())
                 .execute()
         );
     }
@@ -829,7 +769,7 @@ public class Liquibase implements AutoCloseable {
      * @throws LiquibaseException if an error occurs during the synchronization
      */
     public void changeLogSync(String tag, Contexts contexts, LabelExpression labelExpression) throws LiquibaseException {
-        String commandToRun = StringUtil.isEmpty(tag) ? ChangelogSyncCommandStep.COMMAND_NAME[0] : ChangelogSyncToTagCommandStep.COMMAND_NAME[0];
+        String commandToRun = StringUtils.isEmpty(tag) ? ChangelogSyncCommandStep.COMMAND_NAME[0] : ChangelogSyncToTagCommandStep.COMMAND_NAME[0];
         runInScope(() -> {
             new CommandScope(commandToRun)
                     .addArgumentValue(DbUrlConnectionArgumentsCommandStep.DATABASE_ARG, Liquibase.this.getDatabase())
@@ -854,23 +794,21 @@ public class Liquibase implements AutoCloseable {
 
     private void doChangeLogSyncSql(String tag, Contexts contexts, LabelExpression labelExpression, Writer output,
                                     Supplier<String> header) throws LiquibaseException {
-        String commandToRun = StringUtil.isEmpty(tag) ? ChangelogSyncSqlCommandStep.COMMAND_NAME[0] : ChangelogSyncToTagSqlCommandStep.COMMAND_NAME[0];
+        String commandToRun = StringUtils.isEmpty(tag) ? ChangelogSyncSqlCommandStep.COMMAND_NAME[0] : ChangelogSyncToTagSqlCommandStep.COMMAND_NAME[0];
         runInScope(() -> new CommandScope(commandToRun)
                 .addArgumentValue(DbUrlConnectionArgumentsCommandStep.DATABASE_ARG, Liquibase.this.getDatabase())
                 .addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_FILE_ARG, changeLogFile)
                 .addArgumentValue(DatabaseChangelogCommandStep.CONTEXTS_ARG, (contexts != null? contexts.toString() : null))
                 .addArgumentValue(DatabaseChangelogCommandStep.LABEL_FILTER_ARG, (labelExpression != null ? labelExpression.getOriginalString() : null))
                 .addArgumentValue(ChangelogSyncToTagSqlCommandStep.TAG_ARG, tag)
-                .setOutput(new WriterOutputStream(output, GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()))
+                .setOutput(WriterOutputStream.builder().setWriter(output).setCharset(GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()).get())
                 .execute());
     }
 
-    @Deprecated
     public void markNextChangeSetRan(String contexts, Writer output) throws LiquibaseException {
         markNextChangeSetRan(new Contexts(contexts), new LabelExpression(), output);
     }
 
-    @Deprecated
     public void markNextChangeSetRan(Contexts contexts, LabelExpression labelExpression, Writer output)
             throws LiquibaseException {
         runInScope(() -> new CommandScope(MarkNextChangesetRanSqlCommandStep.COMMAND_NAME)
@@ -879,16 +817,14 @@ public class Liquibase implements AutoCloseable {
                 .addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_PARAMETERS, changeLogParameters)
                 .addArgumentValue(DatabaseChangelogCommandStep.CONTEXTS_ARG, (contexts != null ? contexts.toString() : null))
                 .addArgumentValue(DatabaseChangelogCommandStep.LABEL_FILTER_ARG, (labelExpression != null ? labelExpression.getOriginalString() : null))
-                .setOutput(new WriterOutputStream(output, GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()))
+                .setOutput(WriterOutputStream.builder().setWriter(output).setCharset(GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()).get())
                 .execute());
     }
 
-    @Deprecated
     public void markNextChangeSetRan(String contexts) throws LiquibaseException {
         markNextChangeSetRan(new Contexts(contexts), new LabelExpression());
     }
 
-    @Deprecated
     public void markNextChangeSetRan(Contexts contexts, LabelExpression labelExpression) throws LiquibaseException {
         runInScope(() -> new CommandScope(MarkNextChangesetRanCommandStep.COMMAND_NAME)
                 .addArgumentValue(DbUrlConnectionArgumentsCommandStep.DATABASE_ARG, getDatabase())
@@ -899,64 +835,53 @@ public class Liquibase implements AutoCloseable {
                 .execute());
     }
 
-    @Deprecated
     public void futureRollbackSQL(String contexts, Writer output) throws LiquibaseException {
         futureRollbackSQL(null, contexts, output, true);
     }
 
-    @Deprecated
     public void futureRollbackSQL(Writer output) throws LiquibaseException {
         futureRollbackSQL(null, null, new Contexts(), new LabelExpression(), output);
     }
 
-    @Deprecated
     public void futureRollbackSQL(String contexts, Writer output, boolean checkLiquibaseTables)
             throws LiquibaseException {
         futureRollbackSQL(null, contexts, output, checkLiquibaseTables);
     }
 
-    @Deprecated
     public void futureRollbackSQL(Integer count, String contexts, Writer output) throws LiquibaseException {
         futureRollbackSQL(count, new Contexts(contexts), new LabelExpression(), output, true);
     }
 
-    @Deprecated
     public void futureRollbackSQL(Contexts contexts, LabelExpression labelExpression, Writer output)
             throws LiquibaseException {
         futureRollbackSQL(null, null, contexts, labelExpression, output);
     }
 
-    @Deprecated
     public void futureRollbackSQL(Integer count, String contexts, Writer output, boolean checkLiquibaseTables)
             throws LiquibaseException {
         futureRollbackSQL(count, new Contexts(contexts), new LabelExpression(), output, checkLiquibaseTables);
     }
 
-    @Deprecated
     public void futureRollbackSQL(Integer count, Contexts contexts, LabelExpression labelExpression, Writer output)
             throws LiquibaseException {
         futureRollbackSQL(count, contexts, labelExpression, output, true);
     }
 
-    @Deprecated
     public void futureRollbackSQL(Integer count, Contexts contexts, LabelExpression labelExpression, Writer output,
                                   boolean checkLiquibaseTables) throws LiquibaseException {
         futureRollbackSQL(count, null, contexts, labelExpression, output);
     }
 
-    @Deprecated
     public void futureRollbackSQL(String tag, Contexts contexts, LabelExpression labelExpression, Writer output)
             throws LiquibaseException {
         futureRollbackSQL(null, tag, contexts, labelExpression, output);
     }
 
-    @Deprecated
     protected void futureRollbackSQL(Integer count, String tag, Contexts contexts, LabelExpression labelExpression,
                                      Writer output) throws LiquibaseException {
         futureRollbackSQL(count, tag, contexts, labelExpression, output, true);
     }
 
-    @Deprecated
     protected void futureRollbackSQL(Integer count, String tag, Contexts contexts, LabelExpression labelExpression,
                                      Writer output, boolean checkLiquibaseTables) throws LiquibaseException {
         CommandScope commandScope;
@@ -1015,33 +940,29 @@ public class Liquibase implements AutoCloseable {
      */
     public final void dropAll(Boolean dropDbclhistory, CatalogAndSchema... schemas) throws DatabaseException {
 
-        CatalogAndSchema[] finalSchemas = schemas;
         try {
             CommandScope dropAll = new CommandScope("dropAll")
                     .addArgumentValue(DbUrlConnectionArgumentsCommandStep.DATABASE_ARG, Liquibase.this.getDatabase())
-                    .addArgumentValue(DropAllCommandStep.CATALOG_AND_SCHEMAS_ARG, finalSchemas)
+                    .addArgumentValue(DropAllCommandStep.CATALOG_AND_SCHEMAS_ARG, schemas)
                     .addArgumentValue("dropDbclhistory", dropDbclhistory);
 
-            try {
-                dropAll.execute();
-            } catch (CommandExecutionException e) {
-                throw new DatabaseException(e);
-            }
+            dropAllThrowingDatabaseException(dropAll);
         } catch (LiquibaseException e) {
-            if (e instanceof DatabaseException) {
-                throw (DatabaseException) e;
-            } else {
-                throw new DatabaseException(e);
-            }
+            throw (e instanceof DatabaseException) ? (DatabaseException) e : new DatabaseException(e);
+        }
+    }
+
+    private static void dropAllThrowingDatabaseException(CommandScope dropAll) throws DatabaseException {
+        try {
+            dropAll.execute();
+        } catch (CommandExecutionException e) {
+            throw new DatabaseException(e);
         }
     }
 
     /**
      * 'Tags' the database for future rollback
-     *
-     * @deprecated Use {@link CommandScope(String)} to tag instead of this method.
      */
-    @Deprecated
     public void tag(String tagString) throws LiquibaseException {
         new CommandScope("tag")
                 .addArgumentValue(DbUrlConnectionArgumentsCommandStep.DATABASE_ARG, database)
@@ -1051,10 +972,7 @@ public class Liquibase implements AutoCloseable {
 
     /**
      *  Verifies if a given tag exist in the database
-     *
-     * @deprecated Use {link {@link CommandScope(String)} to verify tag exist instead of this method.
      */
-    @Deprecated
     public boolean tagExists(String tagString) throws LiquibaseException {
         CommandResults commandResults = new CommandScope("tagExists")
                 .addArgumentValue(DbUrlConnectionArgumentsCommandStep.DATABASE_ARG, database)
@@ -1063,18 +981,15 @@ public class Liquibase implements AutoCloseable {
         return commandResults.getResult(TagExistsCommandStep.TAG_EXISTS_RESULT);
     }
 
-    @Deprecated
     public void updateTestingRollback(String contexts) throws LiquibaseException {
         updateTestingRollback(new Contexts(contexts), new LabelExpression());
     }
 
-    @Deprecated
     public void updateTestingRollback(Contexts contexts, LabelExpression labelExpression) throws LiquibaseException {
         updateTestingRollback(null, contexts, labelExpression);
 
     }
 
-    @Deprecated
     public void updateTestingRollback(String tag, Contexts contexts, LabelExpression labelExpression)
             throws LiquibaseException {
         runInScope(() -> {
@@ -1114,12 +1029,10 @@ public class Liquibase implements AutoCloseable {
     /**
      * Display change log lock information.
      */
-    @Deprecated
     public DatabaseChangeLogLock[] listLocks() throws LiquibaseException {
         return ListLocksCommandStep.listLocks(database);
     }
 
-    @Deprecated
     public void reportLocks(PrintStream out) throws LiquibaseException {
         runInScope(() -> {
             CommandScope listLocksCommand = new CommandScope(ListLocksCommandStep.COMMAND_NAME);
@@ -1143,32 +1056,15 @@ public class Liquibase implements AutoCloseable {
         return listUnrunChangeSets(contexts, new LabelExpression());
     }
 
-    @Deprecated
     public List<ChangeSet> listUnrunChangeSets(Contexts contexts, LabelExpression labels) throws LiquibaseException {
         return listUnrunChangeSets(contexts, labels, true);
     }
 
-    @Deprecated
     public List<ChangeSet> listUnrunChangeSets(Contexts contexts, LabelExpression labels, boolean checkLiquibaseTables) throws LiquibaseException {
         changeLogParameters.setContexts(contexts);
         changeLogParameters.setLabels(labels);
 
-        ListVisitor visitor = new ListVisitor();
-
-        runInScope(() -> {
-
-            DatabaseChangeLog changeLog = getDatabaseChangeLog();
-
-            if (checkLiquibaseTables) {
-                checkLiquibaseTables(false, changeLog, contexts, labels);
-            }
-
-            changeLog.validate(database, contexts, labels);
-
-            ChangeLogIterator logIterator = getStandardChangelogIterator(contexts, labels, changeLog);
-
-            logIterator.run(visitor, new RuntimeEnvironment(database, contexts, labels));
-        });
+        ListVisitor visitor = (ListVisitor) visitInScope(contexts, labels, checkLiquibaseTables, new ListVisitor());
         return visitor.getSeenChangeSets();
     }
 
@@ -1195,34 +1091,34 @@ public class Liquibase implements AutoCloseable {
         changeLogParameters.setLabels(labelExpression);
         StatusVisitor visitor = new StatusVisitor(database);
 
-        runInScope(() -> {
-
-            DatabaseChangeLog changeLog = getDatabaseChangeLog();
-
-            if (checkLiquibaseTables) {
-                checkLiquibaseTables(false, changeLog, contexts, labelExpression);
-            }
-
-            changeLog.validate(database, contexts, labelExpression);
-
-            ChangeLogIterator logIterator = getStandardChangelogIterator(contexts, labelExpression, changeLog);
-
-            logIterator.run(visitor, new RuntimeEnvironment(database, contexts, labelExpression));
-        });
+        visitInScope(contexts, labelExpression, checkLiquibaseTables, visitor);
         return visitor.getStatuses();
     }
 
-    @Deprecated
+    /**
+     * Populate a Visitor with the statuses of all changesets in the change log file and history in the order they appear
+     */
+    private ChangeSetVisitor visitInScope(Contexts contexts, LabelExpression labelExpression, boolean checkLiquibaseTables, ChangeSetVisitor visitor) throws LiquibaseException {
+        runInScope(() -> {
+            DatabaseChangeLog changeLog = getDatabaseChangeLog();
+            if (checkLiquibaseTables) {
+                checkLiquibaseTables(false, changeLog, contexts, labelExpression);
+            }
+            changeLog.validate(database, contexts, labelExpression);
+            ChangeLogIterator logIterator = getStandardChangelogIterator(contexts, labelExpression, changeLog);
+            logIterator.run(visitor, new RuntimeEnvironment(database, contexts, labelExpression));
+        });
+        return visitor;
+    }
+
     public void reportStatus(boolean verbose, String contexts, Writer out) throws LiquibaseException {
         reportStatus(verbose, new Contexts(contexts), new LabelExpression(), out);
     }
 
-    @Deprecated
     public void reportStatus(boolean verbose, Contexts contexts, Writer out) throws LiquibaseException {
         reportStatus(verbose, contexts, new LabelExpression(), out);
     }
 
-    @Deprecated
     public void reportStatus(boolean verbose, Contexts contexts, LabelExpression labels, Writer out)
             throws LiquibaseException {
         changeLogParameters.setContexts(contexts);
@@ -1233,28 +1129,24 @@ public class Liquibase implements AutoCloseable {
             statusCommand.addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_PARAMETERS, changeLogParameters);
             statusCommand.addArgumentValue(StatusCommandStep.VERBOSE_ARG, verbose);
             statusCommand.addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_FILE_ARG, changeLogFile);
-            statusCommand.setOutput(new WriterOutputStream(out, GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()));
+            statusCommand.setOutput(WriterOutputStream.builder().setWriter(out).setCharset(GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()).get());
             statusCommand.execute();
         });
     }
 
-    @Deprecated
     public Collection<RanChangeSet> listUnexpectedChangeSets(String contexts) throws LiquibaseException {
         return listUnexpectedChangeSets(new Contexts(contexts), new LabelExpression());
     }
 
-    @Deprecated
     public Collection<RanChangeSet> listUnexpectedChangeSets(Contexts contexts, LabelExpression labelExpression)
             throws LiquibaseException {
         return UnexpectedChangesetsCommandStep.listUnexpectedChangeSets(getDatabase(), getDatabaseChangeLog(), contexts, labelExpression);
     }
 
-    @Deprecated
     public void reportUnexpectedChangeSets(boolean verbose, String contexts, Writer out) throws LiquibaseException {
         reportUnexpectedChangeSets(verbose, new Contexts(contexts), new LabelExpression(), out);
     }
 
-    @Deprecated
     public void reportUnexpectedChangeSets(boolean verbose, Contexts contexts, LabelExpression labelExpression,
                                            Writer out) throws LiquibaseException {
         changeLogParameters.setContexts(contexts);
@@ -1267,19 +1159,16 @@ public class Liquibase implements AutoCloseable {
             unexpectedChangesetsCommand.addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_FILE_ARG, changeLogFile);
             unexpectedChangesetsCommand.addArgumentValue(DatabaseChangelogCommandStep.CONTEXTS_ARG, (contexts != null? contexts.toString() : null));
             unexpectedChangesetsCommand.addArgumentValue(DatabaseChangelogCommandStep.LABEL_FILTER_ARG, (labelExpression != null ? labelExpression.getOriginalString() : null));
-            unexpectedChangesetsCommand.setOutput(new WriterOutputStream(out, GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()));
+            unexpectedChangesetsCommand.setOutput(WriterOutputStream.builder().setWriter(out).setCharset(GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()).get());
             unexpectedChangesetsCommand.execute();
         });
     }
 
     /**
      * Sets checksums to null, so they will be repopulated next run
-     *
-     * @deprecated Use {@link CommandScope(String)}
      */
-    @Deprecated
     public void clearCheckSums() throws LiquibaseException {
-        CommandResults commandResults = new CommandScope(ClearChecksumsCommandStep.COMMAND_NAME)
+       new CommandScope(ClearChecksumsCommandStep.COMMAND_NAME)
                 .addArgumentValue(DbUrlConnectionArgumentsCommandStep.DATABASE_ARG, database)
                 .addArgumentValue(DbUrlConnectionArgumentsCommandStep.URL_ARG, database.getConnection().getURL())
                 .execute();
@@ -1287,12 +1176,9 @@ public class Liquibase implements AutoCloseable {
 
     /**
      * Calculate the checksum for a given identifier
-     *
-     * @deprecated Use {link {@link CommandScope(String)}.
      */
-    @Deprecated
     public final CheckSum calculateCheckSum(final String changeSetIdentifier) throws LiquibaseException {
-        String changeSetAttributes[] = changeSetIdentifier.split("::");
+        String[] changeSetAttributes = changeSetIdentifier.split("::");
         //validate changeSet parameters and return an error or removed/ignore any other '::' occurrence when processing either a path, id or author.
         return this.calculateCheckSum(changeSetAttributes[0], changeSetAttributes[1], changeSetAttributes[2]);
     }
@@ -1312,26 +1198,19 @@ public class Liquibase implements AutoCloseable {
         return commandResults.getResult(CalculateChecksumCommandStep.CHECKSUM_RESULT);
     }
 
-    @Deprecated
     public void generateDocumentation(String outputDirectory) throws LiquibaseException {
         // call without context
         generateDocumentation(outputDirectory, new Contexts(), new LabelExpression(), new CatalogAndSchema(null, null));
     }
 
-    @Deprecated
     public void generateDocumentation(String outputDirectory, String contexts) throws LiquibaseException {
         generateDocumentation(outputDirectory, new Contexts(contexts), new LabelExpression(), new CatalogAndSchema(null, null));
     }
 
-    @Deprecated
     public void generateDocumentation(String outputDirectory, String contexts, CatalogAndSchema... schemaList) throws LiquibaseException {
         generateDocumentation(outputDirectory, new Contexts(contexts), new LabelExpression(), schemaList);
     }
 
-    /**
-     * @deprecated Use {@link CommandScope} to generate dbDoc instead of this method.
-     */
-    @Deprecated
     public void generateDocumentation(String outputDirectory, Contexts contexts,
                                       LabelExpression labelExpression, CatalogAndSchema... schemaList) throws LiquibaseException {
         runInScope(() -> new CommandScope(DbDocCommandStep.COMMAND_NAME[0])
@@ -1345,10 +1224,6 @@ public class Liquibase implements AutoCloseable {
                 .execute());
     }
 
-    /**
-     * @deprecated Use {link {@link CommandScope(String)} to generate diff instead of this method.
-     */
-    @Deprecated
     public DiffResult diff(Database referenceDatabase, Database targetDatabase, CompareControl compareControl)
             throws LiquibaseException {
         return DiffGeneratorFactory.getInstance().compare(referenceDatabase, targetDatabase, compareControl);
@@ -1356,10 +1231,7 @@ public class Liquibase implements AutoCloseable {
 
     /**
      * Checks changelogs for bad MD5Sums and preconditions before attempting a migration
-     *
-     * @deprecated use {@link CommandScope}
      */
-    @Deprecated
     public void validate() throws LiquibaseException {
         runInScope(() ->
             new CommandScope("validate")
@@ -1374,26 +1246,6 @@ public class Liquibase implements AutoCloseable {
         this.changeLogParameters.set(key, value);
     }
 
-    public void setChangeExecListener(ChangeExecListener listener) {
-        this.changeExecListener = listener;
-    }
-
-    public DefaultChangeExecListener getDefaultChangeExecListener() {
-        return defaultChangeExecListener;
-    }
-
-    public void setShowSummary(UpdateSummaryEnum showSummary) {
-        this.showSummary = showSummary;
-    }
-
-    public void setShowSummaryOutput(UpdateSummaryOutputEnum showSummaryOutput) {
-        this.showSummaryOutput = showSummaryOutput;
-    }
-
-    /**
-     * @deprecated Use {link {@link CommandScope(String)} to generateChangelog instead of this method.
-     */
-    @Deprecated
     @SafeVarargs
     public final void generateChangeLog(CatalogAndSchema catalogAndSchema, DiffToChangeLog changeLogWriter,
                                         PrintStream outputStream, Class<? extends DatabaseObject>... snapshotTypes)
@@ -1401,10 +1253,6 @@ public class Liquibase implements AutoCloseable {
         generateChangeLog(catalogAndSchema, changeLogWriter, outputStream, null, snapshotTypes);
     }
 
-    /**
-     * @deprecated Use {link {@link CommandScope(String)} to generateChangelog instead of this method.
-     */
-    @Deprecated
     @SafeVarargs
     public final void generateChangeLog(CatalogAndSchema catalogAndSchema, DiffToChangeLog changeLogWriter,
                                         PrintStream outputStream, ChangeLogSerializer changeLogSerializer,
@@ -1427,7 +1275,7 @@ public class Liquibase implements AutoCloseable {
                 .execute();
     }
 
-    private void runInScope(Scope.ScopedRunner scopedRunner) throws LiquibaseException {
+    private void runInScope(Scope.ScopedRunner<?> scopedRunner) throws LiquibaseException {
         Map<String, Object> scopeObjects = new HashMap<>();
         scopeObjects.put(Scope.Attr.database.name(), getDatabase());
         scopeObjects.put(Scope.Attr.resourceAccessor.name(), getResourceAccessor());
@@ -1435,11 +1283,7 @@ public class Liquibase implements AutoCloseable {
         try {
             Scope.child(scopeObjects, scopedRunner);
         } catch (Exception e) {
-            if (e instanceof LiquibaseException) {
-                throw (LiquibaseException) e;
-            } else {
-                throw new LiquibaseException(e);
-            }
+            throw e instanceof LiquibaseException ? (LiquibaseException) e : new LiquibaseException(e);
         }
     }
 

--- a/liquibase-standard/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-standard/src/main/java/liquibase/Liquibase.java
@@ -46,8 +46,14 @@ import java.util.function.Supplier;
 import static java.util.ResourceBundle.getBundle;
 
 /**
- * Primary facade class for interacting with Liquibase.
- * The built-in command line, Ant, Maven and other ways of running Liquibase are wrappers around methods in this class.
+ * Primary facade class for interacting with Liquibase. The methods are in their majority wrappers around CommandScope instances
+ * that exists here to provide a simple and single point of entry for all Liquibase operations. If a method is not provided here,
+ * it can be accessed by creating the correspoding CommandScope instance and executing it.
+ * <p>
+ * As of Liquibase 4.* some of the built-in command line, Ant, Maven, tests and other ways of running Liquibase are wrappers around
+ * methods in this class, but this may change in future releases as we continue to refactor the codebase and move to CommandScope instances.
+ *
+ * @see <a href="https://contribute.liquibase.com/code/api/command-commandscope/"> CommandScope documentation</a>
  */
 public class Liquibase implements AutoCloseable {
 


### PR DESCRIPTION
## Impact

This PR undeprecates Liquibase class methods, improves javadocs and removes deprecated dependencies/sonar warnings as requested by community in #5663, #5066, forum and other locations.


Fixes #5663