### PR TITLE
Skip harness and functional tests instead of failing workflow, one trigger for harness and functional to avoid multiple triggers

### DIFF
--- a/.github/workflows/run-functional-tests.yml
+++ b/.github/workflows/run-functional-tests.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   functional-tests-build:
     runs-on: ubuntu-latest
-    if: (github.event_name != 'pull_request' || github.event_name != 'pull_request_target') ||  github.event.label.name == 'runFunctional&HarnessTests'
+    if: (github.event_name != 'pull_request' || github.event_name != 'pull_request_target') || ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && contains(github.event.pull_request.labels.*.name, 'runFunctional&HarnessTests'))
     steps:
       
       - name: Check variables

--- a/.github/workflows/run-functional-tests.yml
+++ b/.github/workflows/run-functional-tests.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   functional-tests-build:
     runs-on: ubuntu-latest
-    if: (github.event_name != 'pull_request' || github.event_name != 'pull_request_target') || ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && contains(github.event.pull_request.labels.*.name, 'runFunctional&HarnessTests'))
+    if: contains(github.event.pull_request.labels.*.name, 'runFunctional&HarnessTests') || (github.event.pull_request.merged == true)
     steps:
       
       - name: Check variables

--- a/.github/workflows/run-functional-tests.yml
+++ b/.github/workflows/run-functional-tests.yml
@@ -19,6 +19,7 @@ on:
 jobs:
   functional-tests-build:
     runs-on: ubuntu-latest
+    if: (github.event_name != 'pull_request' || github.event_name != 'pull_request_target') || contains(github.event.pull_request.labels.*.name, 'runFunctional&HarnessTests')
     steps:
       
       - name: Check variables
@@ -29,12 +30,6 @@ jobs:
           echo "github.base_ref: ${{ github.base_ref }}"
           echo "github.event.pull_request.merged: ${{ github.event.pull_request.merged }}"
           echo "github.event_name: ${{ github.event_name }}"
-        
-      - name: Check runFunctionalTests label
-        if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && !contains(github.event.pull_request.labels.*.name, 'runFunctional&HarnessTests') && (github.event.pull_request.merged == false || github.base_ref != 'master')
-        run: |
-            echo "Add the runFunctionalTests label to the PR to trigger the Functional Tests workflow."
-            exit 0  
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/run-functional-tests.yml
+++ b/.github/workflows/run-functional-tests.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   functional-tests-build:
     runs-on: ubuntu-latest
-    if: (github.event_name != 'pull_request' || github.event_name != 'pull_request_target') || contains(github.event.pull_request.labels.*.name, 'runFunctional&HarnessTests')
+    if: (github.event_name != 'pull_request' || github.event_name != 'pull_request_target') ||  github.event.label.name == 'runFunctional&HarnessTests'
     steps:
       
       - name: Check variables

--- a/.github/workflows/run-functional-tests.yml
+++ b/.github/workflows/run-functional-tests.yml
@@ -31,10 +31,10 @@ jobs:
           echo "github.event_name: ${{ github.event_name }}"
         
       - name: Check runFunctionalTests label
-        if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && !contains(github.event.pull_request.labels.*.name, 'runFunctionalTests') && (github.event.pull_request.merged == false || github.base_ref != 'master')
+        if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && !contains(github.event.pull_request.labels.*.name, 'runFunctional&HarnessTests') && (github.event.pull_request.merged == false || github.base_ref != 'master')
         run: |
             echo "Add the runFunctionalTests label to the PR to trigger the Functional Tests workflow."
-            exit 1  
+            exit 0  
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   test-harness-build:
     runs-on: ubuntu-latest
-    if: (github.event_name != 'pull_request' || github.event_name != 'pull_request_target') || contains(github.event.pull_request.labels.*.name, 'runFunctional&HarnessTests')
+    if: (github.event_name != 'pull_request' || github.event_name != 'pull_request_target') ||  github.event.label.name == 'runFunctional&HarnessTests'
     steps:
       
       - name: Check variables

--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   test-harness-build:
     runs-on: ubuntu-latest
-    if: (github.event_name != 'pull_request' || github.event_name != 'pull_request_target') || ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && contains(github.event.pull_request.labels.*.name, 'runFunctional&HarnessTests'))
+    if: contains(github.event.pull_request.labels.*.name, 'runFunctional&HarnessTests') || (github.event.pull_request.merged == true)
     steps:
       
       - name: Check variables

--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -19,6 +19,7 @@ on:
 jobs:
   test-harness-build:
     runs-on: ubuntu-latest
+    if: (github.event_name != 'pull_request' || github.event_name != 'pull_request_target') || contains(github.event.pull_request.labels.*.name, 'runFunctional&HarnessTests')
     steps:
       
       - name: Check variables
@@ -29,12 +30,6 @@ jobs:
           echo "github.base_ref: ${{ github.base_ref }}"
           echo "github.event.pull_request.merged: ${{ github.event.pull_request.merged }}"
           echo "github.event_name: ${{ github.event_name }}"
-        
-      - name: Check runTestHarnessTests label
-        if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && !contains(github.event.pull_request.labels.*.name, 'runFunctional&HarnessTests') && (github.event.pull_request.merged == false || github.base_ref != 'master')
-        run: |
-          echo "Add the runTestHarnessTests label to the PR to trigger the Test Harness Tests workflow."
-          exit 0
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   test-harness-build:
     runs-on: ubuntu-latest
-    if: (github.event_name != 'pull_request' || github.event_name != 'pull_request_target') ||  github.event.label.name == 'runFunctional&HarnessTests'
+    if: (github.event_name != 'pull_request' || github.event_name != 'pull_request_target') || ((github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && contains(github.event.pull_request.labels.*.name, 'runFunctional&HarnessTests'))
     steps:
       
       - name: Check variables

--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -31,10 +31,10 @@ jobs:
           echo "github.event_name: ${{ github.event_name }}"
         
       - name: Check runTestHarnessTests label
-        if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && !contains(github.event.pull_request.labels.*.name, 'runTestHarnessTests') && (github.event.pull_request.merged == false || github.base_ref != 'master')
+        if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && !contains(github.event.pull_request.labels.*.name, 'runFunctional&HarnessTests') && (github.event.pull_request.merged == false || github.base_ref != 'master')
         run: |
           echo "Add the runTestHarnessTests label to the PR to trigger the Test Harness Tests workflow."
-          exit 1
+          exit 0
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

@wwillard7800 suggested not to fail the workflow but rather skip it, and I think he is right. Another change in the PR is to add one label, runFunctional&HarnessTests, because if we add separate labels like runFunctionalTests and runHarnessTests, the second added label will generate an extra test run for the first label. 

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
