### PR TITLE
Add osgi.serverloader manifest header entries for liquibase.changelog.visitor.ValidatingVisitorGenerator #6040 fix

### DIFF
--- a/liquibase-standard/pom.xml
+++ b/liquibase-standard/pom.xml
@@ -270,7 +270,8 @@
                             osgi.serviceloader; osgi.serviceloader=liquibase.resource.PathHandler,
                             osgi.serviceloader; osgi.serviceloader=liquibase.report.ShowSummaryGenerator,
                             osgi.serviceloader; osgi.serviceloader=liquibase.parser.LiquibaseSqlParser,
-                            osgi.serviceloader; osgi.serviceloader=liquibase.changeset.ChangeSetService
+                            osgi.serviceloader; osgi.serviceloader=liquibase.changeset.ChangeSetService,
+                            osgi.serviceloader; osgi.serviceloader=liquibase.changelog.visitor.ValidatingVisitorGenerator
                         </Provide-Capability>
                         <Require-Capability>
                             osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)",
@@ -307,7 +308,8 @@
                             osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.resource.PathHandler)"; cardinality:=multiple,
                             osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.report.ShowSummaryGenerator)"; cardinality:=multiple,
                             osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.parser.LiquibaseSqlParser)"; cardinality:=multiple,
-                            osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.changeset.ChangeSetService)"; cardinality:=multiple
+                            osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.changeset.ChangeSetService)"; cardinality:=multiple,
+                            osgi.serviceloader; filter:="(osgi.serviceloader=liquibase.changelog.visitor.ValidatingVisitorGenerator)"; cardinality:=multiple
                         </Require-Capability>
                     </instructions>
                 </configuration>


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

Liquibase 4.28.0 failing under OSGi because the MANIFEST.MF of liquibase-core does not contain and for liquibase.changelog.visitor.ValidatingVisitorGenerator (similar to what was fixed in https://github.com/liquibase/liquibase/pull/5498 )

## Things to be aware of

The bug only takes place under OSGi (with the osgi.serviceloader loading SPI services).

The fix also only has any effect under OSGi.

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
