### PR TITLE
feat: add current java version to Banner

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/integration/commandline/Banner.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/commandline/Banner.java
@@ -3,10 +3,11 @@ package liquibase.integration.commandline;
 import liquibase.GlobalConfiguration;
 import liquibase.Scope;
 import liquibase.util.LiquibaseUtil;
-import liquibase.util.StringUtil;
+import liquibase.util.SystemUtil;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -23,6 +24,7 @@ public class Banner {
     private String version;
     private String build;
     private String built;
+    private String javaVersion;
     private String path;
     private String licensee;
     private String licenseEndDate;
@@ -31,6 +33,7 @@ public class Banner {
         version = LiquibaseUtil.getBuildVersionInfo();
         built = LiquibaseUtil.getBuildTime();
         build = LiquibaseUtil.getBuildNumber();
+        javaVersion = SystemUtil.getJavaVersion();
     }
 
     @Override
@@ -52,10 +55,10 @@ public class Banner {
         Calendar calendar = Calendar.getInstance();
         ResourceBundle coreBundle = getBundle("liquibase/i18n/liquibase-core");
         banner.append(String.format(
-                coreBundle.getString("starting.liquibase.at.timestamp"), dateFormat.format(calendar.getTime())
+                coreBundle.getString("starting.liquibase.at.timestamp"), dateFormat.format(calendar.getTime()), javaVersion
         ));
 
-        if (StringUtil.isNotEmpty(version) && StringUtil.isNotEmpty(built)) {
+        if (StringUtils.isNotEmpty(version) && StringUtils.isNotEmpty(built)) {
             version = version + " #" + build;
             banner.append(String.format(coreBundle.getString("liquibase.version.builddate"), version, built));
         }

--- a/liquibase-standard/src/main/resources/liquibase/i18n/liquibase-core.properties
+++ b/liquibase-standard/src/main/resources/liquibase/i18n/liquibase-core.properties
@@ -29,7 +29,7 @@ changeset.identifier.missing=ChangeSet identifier is missing.
 changeset.identifier.must.have.form.filepath.id.author=ChangeSet identifier must be of the form filepath::id::author.
 including.data.diffchangelog.has.no.effect=Including '%s=data' in the diffChangeLog command has no effect. This option should only be used with the '%s' command.
 starting.liquibase=Starting Liquibase.
-starting.liquibase.at.timestamp=Starting Liquibase at %s
+starting.liquibase.at.timestamp=Starting Liquibase at %s using Java %s
 parameter.unknown=Unknown parameter: '%s'
 parameter.ignored=The parameter '%s' was IGNORED.
 errors=Errors:

--- a/liquibase-standard/src/main/resources/liquibase/i18n/liquibase-core_de.properties
+++ b/liquibase-standard/src/main/resources/liquibase/i18n/liquibase-core_de.properties
@@ -22,7 +22,7 @@ changeset.identifier.missing=ChangeSet-ID fehlt.
 changeset.identifier.must.have.form.filepath.id.author=ChangeSet-IDs müssen die Form Dateipfad::Id::Autor haben.
 including.data.diffchangelog.has.no.effect=Die Option '%s=data' im Hauptbefehl 'diffChangeLog' ist wirkungslos. Diese Option sollte nur zusammen mit dem Hauptbefehl '%s' verwendet werden.
 starting.liquibase=Liquibase wird gestartet.
-starting.liquibase.at.timestamp=Starte Liquibase am %s
+starting.liquibase.at.timestamp=Starte Liquibase am %s mit Java %s
 parameter.unknown=Unbekannter Parameter: '%s'
 parameter.ignored=Der Parameter '%s' wurde IGNORIERT.
 errors=Fehler:

--- a/liquibase-standard/src/test/groovy/liquibase/integration/commandline/CommandLineUtilsTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/integration/commandline/CommandLineUtilsTest.groovy
@@ -18,7 +18,7 @@ class CommandLineUtilsTest extends Specification {
 
         then:
         banner.contains("Get documentation at docs.liquibase.com")
-        banner.contains(coreBundle.getString("starting.liquibase.at.timestamp").replace("%s", ""))
+        banner.contains(coreBundle.getString("starting.liquibase.at.timestamp").replace("%s using Java %s", ""))
         banner.contains(coreBundle.getString("liquibase.version.builddate").replaceFirst("%s.*", ""))
     }
 
@@ -30,7 +30,7 @@ class CommandLineUtilsTest extends Specification {
 
         then:
         !banner.contains("Get documentation at docs.liquibase.com")
-        banner.contains(coreBundle.getString("starting.liquibase.at.timestamp").replace("%s", ""))
+        banner.contains(coreBundle.getString("starting.liquibase.at.timestamp").replace("%s using Java %s", ""))
         banner.contains(coreBundle.getString("liquibase.version.builddate").replaceFirst("%s.*", ""))
     }
 }


### PR DESCRIPTION
## Impact

Adding current java version to Liquibase banner in a subtle manner so this information is available to help debug support issues.

Sample output:
![image](https://github.com/liquibase/liquibase/assets/13051282/4ffcb39e-ceaf-4d37-96f8-1192575af748)



