### PR TITLE
Fixed performance issue with valueBlobFile on Postgres databases introduced in v4.18.0

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
+++ b/liquibase-standard/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
@@ -16,6 +16,7 @@ import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.listener.SqlListener;
 import liquibase.logging.Logger;
 import liquibase.resource.ResourceAccessor;
+import liquibase.snapshot.SnapshotControl;
 import liquibase.snapshot.SnapshotGeneratorFactory;
 import liquibase.sql.SqlConfiguration;
 import liquibase.sql.visitor.SqlVisitor;
@@ -311,7 +312,8 @@ public abstract class ExecutablePreparedStatementBase implements ExecutablePrepa
                     Column snapshot = (Column) this.getScratchData(snapshotKeyName);
                     if (snapshot == null) {
                         snapshot = SnapshotGeneratorFactory.getInstance().createSnapshot(
-                                new Column(Table.class, getCatalogName(), getSchemaName(), getTableName(), col.getName()), database);
+                                new Column(Table.class, getCatalogName(), getSchemaName(), getTableName(), col.getName()),
+                                database, new SnapshotControl(database, false, Column.class));
                         this.setScratchData(snapshotKeyName, snapshot);
                     }
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

Fixes #6096

## Things to be aware of

This change avoids creating a snapshot of the entire database structure when we are only interested in a single column

Performance profiling (both before and after) were done on liquibase v4.20.0
<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

Before:
![348215223-5e5caf39-5a9a-4287-82ad-361b3bda3f5e](https://github.com/user-attachments/assets/f676ba4c-0d27-4bf9-bbbc-df3623e2b78d)

After:
![obraz](https://github.com/user-attachments/assets/08aeb990-c9c2-4886-b274-e49e9108ae2c)

<!--
Add any other context about the problem here.
-->
