### PR TITLE
DAT-18191 and DAT-18192 - Fix classpath loading and incorrect configuration for addForeignKeyConstraint

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/change/core/AddForeignKeyConstraintChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/AddForeignKeyConstraintChange.java
@@ -2,7 +2,6 @@ package liquibase.change.core;
 
 import liquibase.change.*;
 import liquibase.database.Database;
-import liquibase.database.DatabaseFactory;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.snapshot.SnapshotGeneratorFactory;
 import liquibase.statement.SqlStatement;
@@ -12,9 +11,6 @@ import liquibase.structure.core.ForeignKey;
 import liquibase.structure.core.ForeignKeyConstraintType;
 import liquibase.structure.core.Table;
 import lombok.Setter;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Adds a foreign key constraint to an existing column.
@@ -54,25 +50,6 @@ public class AddForeignKeyConstraintChange extends AbstractChange {
 
     private String onUpdate;
     private String onDelete;
-
-
-    @Override
-    protected String[] createSupportedDatabasesMetaData(
-        String parameterName, DatabaseChangeProperty changePropertyAnnotation) {
-        if ("deferrable".equals(parameterName) || "initiallyDeferred".equals(parameterName)) {
-            List<String> supported = new ArrayList<>();
-            //FIXME we need another way to accomplish that, maybe by a static list
-//            for (Database database : DatabaseFactory.getInstance().getImplementedDatabases()) {
-//                if (database.supportsInitiallyDeferrableColumns()) {
-//                    supported.add(database.getShortName());
-//                }
-//            }
-            return supported.toArray(new String[0]);
-
-        } else {
-            return super.createSupportedDatabasesMetaData(parameterName, changePropertyAnnotation);
-        }
-    }
 
     @DatabaseChangeProperty(since = "3.0", mustEqualExisting ="column.relation.catalog",
         description = "Name of the database catalog of the base table")

--- a/liquibase-standard/src/main/java/liquibase/change/core/AddForeignKeyConstraintChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/AddForeignKeyConstraintChange.java
@@ -61,11 +61,12 @@ public class AddForeignKeyConstraintChange extends AbstractChange {
         String parameterName, DatabaseChangeProperty changePropertyAnnotation) {
         if ("deferrable".equals(parameterName) || "initiallyDeferred".equals(parameterName)) {
             List<String> supported = new ArrayList<>();
-            for (Database database : DatabaseFactory.getInstance().getImplementedDatabases()) {
-                if (database.supportsInitiallyDeferrableColumns()) {
-                    supported.add(database.getShortName());
-                }
-            }
+            //FIXME we need another way to accomplish that, maybe by a static list
+//            for (Database database : DatabaseFactory.getInstance().getImplementedDatabases()) {
+//                if (database.supportsInitiallyDeferrableColumns()) {
+//                    supported.add(database.getShortName());
+//                }
+//            }
             return supported.toArray(new String[0]);
 
         } else {

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/AbstractChangelogCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/AbstractChangelogCommandStep.java
@@ -33,7 +33,7 @@ public abstract class AbstractChangelogCommandStep extends AbstractCommandStep {
                 .defaultValue("none").description("Sets runOnChange=\"true\" for changesets containing solely changes of these types (e. g. createView, createProcedure, ...).").build();
         REPLACE_IF_EXISTS_TYPES_ARG = builder.argument("replaceIfExistsTypes", String.class)
                 .defaultValue("none")
-                .description(String.format("Sets replaceIfExists=\"true\" for changes of these types (supported types: %s)", StringUtils.join(REPLACE_IF_EXISTS_TYPES_NAMES, ","))).build();
+                .description(String.format("Sets replaceIfExists=\"true\" for changes of these types (supported types: %s)", StringUtils.join(REPLACE_IF_EXISTS_TYPES_NAMES, ", "))).build();
         SKIP_OBJECT_SORTING = builder.argument("skipObjectSorting", Boolean.class)
                 .defaultValue(false)
                 .description("When true will skip object sorting. This can be useful on databases that have a lot of packages/procedures that are " +

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/AbstractChangelogCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/AbstractChangelogCommandStep.java
@@ -8,10 +8,12 @@ import liquibase.command.CommandArgumentDefinition;
 import liquibase.command.CommandBuilder;
 import liquibase.command.CommandScope;
 import liquibase.exception.CommandValidationException;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -21,15 +23,15 @@ public abstract class AbstractChangelogCommandStep extends AbstractCommandStep {
     public static final CommandArgumentDefinition<String> RUN_ON_CHANGE_TYPES_ARG;
     public static final CommandArgumentDefinition<String> REPLACE_IF_EXISTS_TYPES_ARG;
     public static final CommandArgumentDefinition<Boolean> SKIP_OBJECT_SORTING;
+    private static final List<String> REPLACE_IF_EXISTS_TYPES_NAMES = Arrays.asList("createProcedure", "createView");
 
     static {
         final CommandBuilder builder = new CommandBuilder(COMMAND_NAME);
         RUN_ON_CHANGE_TYPES_ARG = builder.argument("runOnChangeTypes", String.class)
                 .defaultValue("none").description("Sets runOnChange=\"true\" for changesets containing solely changes of these types (e. g. createView, createProcedure, ...).").build();
-        final String replaceIfExistsTypeNames = supportedReplaceIfExistsTypes().collect(Collectors.joining(", "));
         REPLACE_IF_EXISTS_TYPES_ARG = builder.argument("replaceIfExistsTypes", String.class)
                 .defaultValue("none")
-                .description(String.format("Sets replaceIfExists=\"true\" for changes of these types (supported types: %s)", replaceIfExistsTypeNames)).build();
+                .description(String.format("Sets replaceIfExists=\"true\" for changes of these types (supported types: %s)", StringUtils.join(REPLACE_IF_EXISTS_TYPES_NAMES, ","))).build();
         SKIP_OBJECT_SORTING = builder.argument("skipObjectSorting", Boolean.class)
                 .defaultValue(false)
                 .description("When true will skip object sorting. This can be useful on databases that have a lot of packages/procedures that are " +

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/AbstractChangelogCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/AbstractChangelogCommandStep.java
@@ -23,6 +23,8 @@ public abstract class AbstractChangelogCommandStep extends AbstractCommandStep {
     public static final CommandArgumentDefinition<String> RUN_ON_CHANGE_TYPES_ARG;
     public static final CommandArgumentDefinition<String> REPLACE_IF_EXISTS_TYPES_ARG;
     public static final CommandArgumentDefinition<Boolean> SKIP_OBJECT_SORTING;
+    // besides we have ReplaceIfExists interface, we can't use it here because it will cause Liquibase to load libraries
+    // before classpath is fully setup, causing unexpected behaviors when using extensions outside of default Liquibase libraries directories
     private static final List<String> REPLACE_IF_EXISTS_TYPES_NAMES = Arrays.asList("createProcedure", "createView");
 
     static {
@@ -49,7 +51,8 @@ public abstract class AbstractChangelogCommandStep extends AbstractCommandStep {
 
     protected static void validateReplaceIfExistsTypes(final CommandScope commandScope) throws CommandValidationException {
         final Collection<String> replaceIfExistsTypes = new ArrayList(Arrays.asList(commandScope.getArgumentValue(REPLACE_IF_EXISTS_TYPES_ARG).split("\\s*,\\s*")));
-        final Collection<String> supportedReplaceIfExistsTypes = supportedReplaceIfExistsTypes().collect(Collectors.toList());
+        final ChangeFactory changeFactory = Scope.getCurrentScope().getSingleton(ChangeFactory.class);
+        final Collection<String> supportedReplaceIfExistsTypes = changeFactory.getDefinedChanges().stream().filter(changeType -> changeFactory.create(changeType) instanceof ReplaceIfExists).collect(Collectors.toList());
         supportedReplaceIfExistsTypes.add("none");
         replaceIfExistsTypes.removeAll(supportedReplaceIfExistsTypes);
         if (!replaceIfExistsTypes.isEmpty())
@@ -61,8 +64,4 @@ public abstract class AbstractChangelogCommandStep extends AbstractCommandStep {
         return changeFactory.getDefinedChanges().stream();
     }
 
-    protected static Stream<String> supportedReplaceIfExistsTypes() {
-        final ChangeFactory changeFactory = Scope.getCurrentScope().getSingleton(ChangeFactory.class);
-        return changeFactory.getDefinedChanges().stream().filter(changeType -> changeFactory.create(changeType) instanceof ReplaceIfExists);
-    }
 }

--- a/liquibase-standard/src/test/resources/liquibase/change/ChangeDefinitionTest.yaml
+++ b/liquibase-standard/src/test/resources/liquibase/change/ChangeDefinitionTest.yaml
@@ -108,13 +108,13 @@ addForeignKeyConstraint: |
     Required For: all
   deferrable boolean 
     Description: Defines whether the foreign key is deferrable
-    Supported: asany,edb,oracle,postgresql,sqlite
+    Supported: asany,edb,oracle,postgresql
   deleteCascade boolean 
     Description: Deprecated. This is true to set onDelete to Cascade, priority given to onDelete tag if one exists
     Supported: asany,cockroachdb,db2,db2z,derby,edb,firebird,h2,hsqldb,informix,ingres,mariadb,mssql,mysql,oracle,postgresql
   initiallyDeferred boolean 
     Description: Defines whether the foreign key is initially deferred
-    Supported: asany,edb,oracle,postgresql,sqlite
+    Supported: asany,edb,oracle,postgresql
   onDelete string 
     Description: ON DELETE functionality. Possible values: 'CASCADE', 'SET NULL', 'SET DEFAULT', 'RESTRICT', 'NO ACTION'
     Supported: asany,cockroachdb,db2,db2z,derby,edb,firebird,h2,hsqldb,informix,ingres,mariadb,mssql,mysql,oracle,postgresql


### PR DESCRIPTION
The calls being modified here should not be in those locations as they happen before all classloading is complete, thus causing incorrect evaluations of available classes.
 
To be more specific, DatabaseFactory is called before classpath parameter is evaluated by command line, causing extension that provide support to other databases that are pointed out by "classpath" parameter to not be loaded.

Fix https://github.com/liquibase/liquibase-docs/issues/105