### PR TITLE
[6022] Keep original schema and catalog case

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/database/core/H2Database.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/H2Database.java
@@ -411,6 +411,11 @@ public class H2Database extends AbstractJdbcDatabase {
     }
 
     @Override
+    public CatalogAndSchema.CatalogAndSchemaCase getSchemaAndCatalogCase() {
+        return CatalogAndSchema.CatalogAndSchemaCase.ORIGINAL_CASE;
+    }
+
+    @Override
     public String escapeObjectName(String objectName, final Class<? extends DatabaseObject> objectType) {
         if (objectName == null) {
             return null;

--- a/liquibase-standard/src/test/java/liquibase/database/core/H2DatabaseTest.java
+++ b/liquibase-standard/src/test/java/liquibase/database/core/H2DatabaseTest.java
@@ -54,8 +54,6 @@ public class H2DatabaseTest extends AbstractJdbcDatabaseTest {
         assertEquals("schemaName.tableName", database.escapeTableName("catalogName", "schemaName", "tableName"));
     }
 
-
-
 //    @Test
 //    public void versionBeforeMinMaxSequenceIntroductionShouldReturnFalse() throws DatabaseException {
 //

--- a/liquibase-standard/src/test/java/liquibase/database/core/H2DatabaseTest.java
+++ b/liquibase-standard/src/test/java/liquibase/database/core/H2DatabaseTest.java
@@ -54,6 +54,8 @@ public class H2DatabaseTest extends AbstractJdbcDatabaseTest {
         assertEquals("schemaName.tableName", database.escapeTableName("catalogName", "schemaName", "tableName"));
     }
 
+
+
 //    @Test
 //    public void versionBeforeMinMaxSequenceIntroductionShouldReturnFalse() throws DatabaseException {
 //


### PR DESCRIPTION
H2 allows users to specify the behavior for casing. This is important when certain databases are mimicked. If the schema and catalog always are rewritten to UPPER_CASE, as it is the default Database.java behavior, situations may occur in which the schema and/or catalog name no longer match the actual database object.

To handle this schema and catalog are now always returned in the original case.

## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

- Fix for https://github.com/liquibase/liquibase/issues/6122
- Handle H2s ability to adapt the casing for schemas and catalogs
- Changed H2 to always  use original case for catalog and schema

