### PR TITLE
fix: EndDelimiter not working as expected since 4.29

### DIFF
--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/oracle/OracleIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/oracle/OracleIntegrationTest.java
@@ -239,7 +239,6 @@ public class OracleIntegrationTest extends AbstractIntegrationTest {
     @Test
     public void verifySlashReplacementOnStrictMode() throws DatabaseException {
         assumeNotNull(getDatabase());
-        clearDatabase();
         try {
             Scope.child(GlobalConfiguration.STRICT.getKey(), true, () -> {
                 Database database = getDatabase();
@@ -250,8 +249,6 @@ public class OracleIntegrationTest extends AbstractIntegrationTest {
             });
         } catch (Exception e) {
             Assert.fail("Should not fail. Reason: " + e.getMessage());
-        } finally {
-            clearDatabase();
         }
     }
 }

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/oracle/OracleIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/oracle/OracleIntegrationTest.java
@@ -23,6 +23,7 @@ import liquibase.sql.visitor.AbstractSqlVisitor;
 import liquibase.statement.core.RawParameterizedSqlStatement;
 import liquibase.structure.core.Index;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
@@ -230,7 +231,9 @@ public class OracleIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @Ignore
     public void verifySlashReplacementOnStrictMode() throws DatabaseException {
+        assumeNotNull(getDatabase());
         clearDatabase();
         try {
             Scope.child(GlobalConfiguration.STRICT.getKey(), true, () -> {

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/oracle/OracleIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/oracle/OracleIntegrationTest.java
@@ -23,7 +23,6 @@ import liquibase.sql.visitor.AbstractSqlVisitor;
 import liquibase.statement.core.RawParameterizedSqlStatement;
 import liquibase.structure.core.Index;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/oracle/OracleIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/oracle/OracleIntegrationTest.java
@@ -187,6 +187,12 @@ public class OracleIntegrationTest extends AbstractIntegrationTest {
         }
     }
 
+    @Override
+    @Test
+    public void testDiffExternalForeignKeys() throws Exception {
+        //cross-schema security for oracle is a bother, ignoring test for now
+    }
+
     @Test
     public void verifyIndexIsCreatedWhenAssociatedWithPropertyIsSetAsForeignKey() throws DatabaseException {
         clearDatabase();
@@ -231,7 +237,6 @@ public class OracleIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @Ignore
     public void verifySlashReplacementOnStrictMode() throws DatabaseException {
         assumeNotNull(getDatabase());
         clearDatabase();

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/oracle/OracleIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/oracle/OracleIntegrationTest.java
@@ -1,5 +1,6 @@
 package liquibase.dbtest.oracle;
 
+import liquibase.GlobalConfiguration;
 import liquibase.Liquibase;
 import liquibase.Scope;
 import liquibase.changelog.ChangeSet;
@@ -41,13 +42,15 @@ public class OracleIntegrationTest extends AbstractIntegrationTest {
     String viewOnSchemaChangeLog;
     String customExecutorChangeLog;
     String indexWithAssociatedWithChangeLog;
+    String strictChangelog;
 
     public OracleIntegrationTest() throws Exception {
         super("oracle", DatabaseFactory.getInstance().getDatabase("oracle"));
-         indexOnSchemaChangeLog = "changelogs/oracle/complete/indexOnSchema.xml";
-         viewOnSchemaChangeLog = "changelogs/oracle/complete/viewOnSchema.xml";
-         customExecutorChangeLog = "changelogs/oracle/complete/sqlplusExecutor.xml";
-         indexWithAssociatedWithChangeLog = "changelogs/common/index.with.associatedwith.changelog.xml";
+        indexOnSchemaChangeLog = "changelogs/oracle/complete/indexOnSchema.xml";
+        viewOnSchemaChangeLog = "changelogs/oracle/complete/viewOnSchema.xml";
+        customExecutorChangeLog = "changelogs/oracle/complete/sqlplusExecutor.xml";
+        indexWithAssociatedWithChangeLog = "changelogs/common/index.with.associatedwith.changelog.xml";
+        strictChangelog = "changelogs/oracle/complete/strict.changelog.xml";
         // Respect a user-defined location for sqlnet.ora, tnsnames.ora etc. stored in the environment
         // variable TNS_ADMIN. This allowes the use of TNSNAMES.
         if (System.getenv("TNS_ADMIN") != null)
@@ -125,10 +128,6 @@ public class OracleIntegrationTest extends AbstractIntegrationTest {
             e.printDescriptiveError(System.out);
             throw e;
         }
-
-
-
-
     }
 
     @Test
@@ -187,12 +186,6 @@ public class OracleIntegrationTest extends AbstractIntegrationTest {
         }
     }
 
-    @Override
-    @Test
-    public void testDiffExternalForeignKeys() throws Exception {
-        //cross-schema security for oracle is a bother, ignoring test for now
-    }
-
     @Test
     public void verifyIndexIsCreatedWhenAssociatedWithPropertyIsSetAsForeignKey() throws DatabaseException {
         clearDatabase();
@@ -215,7 +208,6 @@ public class OracleIntegrationTest extends AbstractIntegrationTest {
         } finally {
             clearDatabase();
         }
-
     }
 
     @Test
@@ -235,5 +227,23 @@ public class OracleIntegrationTest extends AbstractIntegrationTest {
 
         String generatedChangeLog = baos.toString();
         assertTrue("Text '" + textToTest + "' not found in generated change log: " + generatedChangeLog, generatedChangeLog.contains(textToTest));
+    }
+
+    @Test
+    public void verifySlashReplacementOnStrictMode() throws DatabaseException {
+        clearDatabase();
+        try {
+            Scope.child(GlobalConfiguration.STRICT.getKey(), true, () -> {
+                Database database = getDatabase();
+                CommandScope commandScope = new CommandScope(UpdateCommandStep.COMMAND_NAME);
+                commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.DATABASE_ARG, database);
+                commandScope.addArgumentValue(UpdateCommandStep.CHANGELOG_FILE_ARG, strictChangelog);
+                commandScope.execute();
+            });
+        } catch (Exception e) {
+            Assert.fail("Should not fail. Reason: " + e.getMessage());
+        } finally {
+            clearDatabase();
+        }
     }
 }

--- a/liquibase-integration-tests/src/test/resources/changelogs/oracle/complete/root.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/oracle/complete/root.changelog.xml
@@ -456,18 +456,6 @@ END testSP;
     <changeSet id="8" author="constraint-check">
         <dropNotNullConstraint tableName="unnamed_constraint" columnName="id"/>
     </changeSet>
-    <changeSet id="SlashEndDelimiterTest" author="mallod">
-        <sql endDelimiter="/" splitStatements="true" stripComments="false">
-            SELECT * FROM unnamed_constraint/
-            update liquibaseRunInfo set timesRan=timesRan+1/
-        </sql>
-    </changeSet>
-    <changeSet id="dividedAndSlashEndDelimiterTest" author="mallod">
-        <sql endDelimiter="/" splitStatements="true" stripComments="false">
-            SELECT 6 / 3 FROM unnamed_constraint/
-            update liquibaseRunInfo set timesRan=timesRan+1/
-        </sql>
-    </changeSet>
 
     <changeSet id="create-table-with-rowdependencies" author="matheusviegas">
         <createTable tableName="test_rowdeps" rowDependencies="true">

--- a/liquibase-integration-tests/src/test/resources/changelogs/oracle/complete/strict.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/oracle/complete/strict.changelog.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="14" author="nvoxland">
+        <createTable tableName="liquibaseRunInfo">
+            <column name="timesRan" type="int"/>
+        </createTable>
+        <insert tableName="liquibaseRunInfo">
+            <column name="timesRan" valueNumeric="1"/>
+        </insert>
+    </changeSet>
+
+        <changeSet id="SlashEndDelimiterTest" author="mallod">
+            <sql endDelimiter="/" splitStatements="true" stripComments="false">
+                SELECT * FROM DUAL/
+                update liquibaseRunInfo set timesRan=timesRan+1/
+            </sql>
+        </changeSet>
+        <changeSet id="dividedAndSlashEndDelimiterTest" author="mallod">
+            <sql endDelimiter="/" splitStatements="true" stripComments="false">
+                SELECT 6 / 3 FROM DUAL/
+                update liquibaseRunInfo set timesRan=timesRan+1/
+            </sql>
+        </changeSet>
+</databaseChangeLog>

--- a/liquibase-standard/src/main/java/liquibase/util/StringUtil.java
+++ b/liquibase-standard/src/main/java/liquibase/util/StringUtil.java
@@ -113,9 +113,9 @@ public class StringUtil {
                 String trimmedString;
                 if (Boolean.TRUE.equals(GlobalConfiguration.STRICT.getCurrentValue())) {
                     String sentenceWithoutDelimiter = removeEndDelimiterIfItsASlash(endDelimiter, currentString);
-                    trimmedString = sentenceWithoutDelimiter.isEmpty() ? StringUtil.trimToNull(currentString.toString()) : StringUtil.trimToNull(sentenceWithoutDelimiter);
+                    trimmedString = sentenceWithoutDelimiter.isEmpty() ? StringUtils.trimToNull(currentString.toString()) : StringUtils.trimToNull(sentenceWithoutDelimiter);
                 } else {
-                    trimmedString = StringUtil.trimToNull(currentString.toString());
+                    trimmedString = StringUtils.trimToNull(currentString.toString());
                 }
                 if (trimmedString != null) {
                     returnArray.add(trimmedString);
@@ -123,8 +123,8 @@ public class StringUtil {
                 currentString = new StringBuilder();
                 previousDelimiter = true;
             } else {
-                if (!previousDelimiter || (StringUtil.trimToNull((String) piece) != null)) { //don't include whitespace after a delimiter
-                    if ((currentString.length() > 0) || (StringUtil.trimToNull((String) piece) != null)) { //don't include whitespace before the statement
+                if (!previousDelimiter || (StringUtils.trimToNull((String) piece) != null)) { //don't include whitespace after a delimiter
+                    if ((currentString.length() > 0) || (StringUtils.trimToNull((String) piece) != null)) { //don't include whitespace before the statement
                         currentString.append(piece);
                     }
                 }
@@ -133,7 +133,7 @@ public class StringUtil {
             previousPiece = (String) piece;
         }
 
-        String trimmedString = StringUtil.trimToNull(currentString.toString());
+        String trimmedString = StringUtils.trimToNull(currentString.toString());
         if (trimmedString != null) {
             returnArray.add(trimmedString);
         }

--- a/liquibase-standard/src/main/java/liquibase/util/StringUtil.java
+++ b/liquibase-standard/src/main/java/liquibase/util/StringUtil.java
@@ -110,8 +110,13 @@ public class StringUtil {
             }
 
             if (isInClause == 0 && splitStatements && (piece instanceof String) && isDelimiter((String) piece, previousPiece, endDelimiter)) {
-                String sentenceWithoutDelimiter = removeEndDelimiterIfItsASlash(endDelimiter, currentString);
-                String trimmedString = sentenceWithoutDelimiter.isEmpty() ? StringUtil.trimToNull(currentString.toString()):StringUtil.trimToNull(sentenceWithoutDelimiter);
+                String trimmedString;
+                if (Boolean.TRUE.equals(GlobalConfiguration.STRICT.getCurrentValue())) {
+                    String sentenceWithoutDelimiter = removeEndDelimiterIfItsASlash(endDelimiter, currentString);
+                    trimmedString = sentenceWithoutDelimiter.isEmpty() ? StringUtil.trimToNull(currentString.toString()) : StringUtil.trimToNull(sentenceWithoutDelimiter);
+                } else {
+                    trimmedString = StringUtil.trimToNull(currentString.toString());
+                }
                 if (trimmedString != null) {
                     returnArray.add(trimmedString);
                 }
@@ -225,8 +230,13 @@ public class StringUtil {
         } else {
             if (endDelimiter.length() == 1) {
                 if ("/".equals(endDelimiter)) {
-                    if (previousPiece != null) {
-                        return previousPiece.contentEquals(endDelimiter) && piece.startsWith("\n");
+                    if (Boolean.TRUE.equals(GlobalConfiguration.STRICT.getCurrentValue())) {
+                        if (previousPiece != null) {
+                            return previousPiece.contentEquals(endDelimiter) && piece.startsWith("\n");
+                        }
+                    } else if (previousPiece != null && !previousPiece.endsWith("\n")) {
+                        //don't count /'s the are there for comments for division signs or any other use besides a / at the beginning of a line
+                        return false;
                     }
                 }
                 return StringUtils.equalsIgnoreCase(piece, endDelimiter);


### PR DESCRIPTION

## Description

Consider that you have sql endDelimiter = "/" , and the following SQL:
```
a = var1 / 
var2;
```

How Liquibase should handle it? Should we split or divide? It can be understood as:

```
a = var1 / var2; --  'division behavior'
```
or
```
a = var1 ;   
var2; -- 'strict behavior'
```

Historically, we had:

* Until v4.9.0 - Division behavior
* v4.9.0 (2022.03.17) - changed to Strict behavior - https://github.com/liquibase/liquibase/pull/2135
* v4.15.0 (2022.08.04) - rolled back to Division behavior - https://github.com/liquibase/liquibase/pull/3118
* v4.29.0 (2024-07-28) - changed to Strict behavior again! - https://github.com/liquibase/liquibase/pull/5704

Versions v4.9.0 to v4.14.x (only 5 months) were `strict` while all other versions are `division`. And with 4.29.0 we restored `strict`  because of issue https://github.com/liquibase/liquibase/issues/5359 (this is a case where an upgrade is being done from Liquibase 4.9.1).

As we have 2 different behaviors we decided to support both by using the `strict` flag. So: 

* Division behavior has been suported for longer and it's the default behavior
* Strict behavior is optional and can be enabled by using the `--scrict` parameter ( https://docs.liquibase.com/parameters/strict.html ) .

This is being documented so we don't change it again.

Fixes #6150