### PR TITLE
Append included labels to the changeset labels when matching DAT-16636

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/changelog/filter/LabelChangeSetFilter.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/filter/LabelChangeSetFilter.java
@@ -34,8 +34,8 @@ public class LabelChangeSetFilter implements ChangeSetFilter {
             labelExpression = new LabelExpression();
         }
 
-        Collection<Labels> inheritableLabels = changeSet.getInheritableLabels();
-        if (labelExpression.matches(changeSet.getLabels()) && LabelExpression.matchesAll(inheritableLabels, labelExpression)) {
+        String allLabels = changeSet.buildFullLabels();
+        if (labelExpression.matches(new Labels(allLabels))) {
             return new ChangeSetFilterResult(true, "Labels matches '" + labelExpression.toString() + "'", this.getClass(), getMdcName(), getDisplayName());
         }
         else {

--- a/liquibase-standard/src/test/java/liquibase/changelog/filter/LabelChangeSetFilterTest.java
+++ b/liquibase-standard/src/test/java/liquibase/changelog/filter/LabelChangeSetFilterTest.java
@@ -3,6 +3,7 @@ package liquibase.changelog.filter;
 import liquibase.LabelExpression;
 import liquibase.Labels;
 import liquibase.changelog.ChangeSet;
+import liquibase.changelog.DatabaseChangeLog;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -214,6 +215,81 @@ public class LabelChangeSetFilterTest {
 
         filter = new LabelChangeSetFilter(new LabelExpression("@test1", "@test2"));
         assertTrue(filter.accepts(testChangeSet).isAccepted());
+    }
+
+    @Test
+    public void inheritableLabels() {
+        LabelChangeSetFilter filter;
+
+        //
+        // Command line argument equivalent
+        //
+        filter = new LabelChangeSetFilter(new LabelExpression("test1"));
+
+        //
+        // Changeset with no labels
+        //
+        ChangeSet testChangeSet = createTestChangeSet("test1");
+        assertTrue(filter.accepts(testChangeSet).isAccepted());
+
+        //
+        // Changeset with a label of "test2"
+        //
+        testChangeSet = createTestChangeSet("test1");
+        testChangeSet.setLabels(new Labels("test2"));
+        assertTrue(filter.accepts(testChangeSet).isAccepted());
+
+        //
+        // Command line argument equivalent
+        //
+        filter = new LabelChangeSetFilter(new LabelExpression("test2"));
+
+        //
+        // Changeset with no labels
+        //
+        testChangeSet = createTestChangeSet("test1");
+        assertFalse(filter.accepts(testChangeSet).isAccepted());
+
+        //
+        // Changeset with a label of "test2"
+        //
+        testChangeSet = createTestChangeSet("test1");
+        testChangeSet.setLabels(new Labels("test2"));
+        assertTrue(filter.accepts(testChangeSet).isAccepted());
+
+        //
+        // Changeset with no labels and no included labels
+        //
+        testChangeSet = createTestChangeSet(null);
+        assertTrue(filter.accepts(testChangeSet).isAccepted());
+
+        //
+        // Changeset with label of "test2" and no included labels
+        //
+        testChangeSet = createTestChangeSet(null);
+        testChangeSet.setLabels(new Labels("test2"));
+        assertTrue(filter.accepts(testChangeSet).isAccepted());
+
+        //
+        // Changeset with label of "test1" and no included labels
+        //
+        testChangeSet = createTestChangeSet(null);
+        testChangeSet.setLabels(new Labels("test1"));
+        assertFalse(filter.accepts(testChangeSet).isAccepted());
+    }
+
+    //
+    // Create the changeset and add an include label
+    //
+    private ChangeSet createTestChangeSet(String label) {
+        DatabaseChangeLog changeLog = new DatabaseChangeLog();
+        ChangeSet testChangeSet = new ChangeSet(changeLog);
+        if (label != null) {
+            testChangeSet.getChangeLog().setIncludeLabels(new Labels(label));
+        }
+        changeLog.addChangeSet(testChangeSet);
+
+        return testChangeSet;
     }
 
     @Test


### PR DESCRIPTION
Previously, the matching required a label expression to match both the change set labels AND the included labels

All the tests passed, but this change probably needs some discussion, since the code has been this way since 2018.

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
