### PR TITLE
 Do not show update summary when using update-sql via maven plugin (DAT-18323)

### DIFF
--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseUpdateSQL.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseUpdateSQL.java
@@ -39,9 +39,9 @@ public class LiquibaseUpdateSQL extends AbstractLiquibaseUpdateMojo {
 	@Override
 	protected void doUpdate(Liquibase liquibase) throws LiquibaseException {
 		if (changesToApply > 0) {
-			liquibase.update(changesToApply, new Contexts(contexts), new LabelExpression(getLabelFilter()), outputWriter);
+			liquibase.updateCountSql(changesToApply, new Contexts(contexts), new LabelExpression(getLabelFilter()), outputWriter);
 		} else {
-			liquibase.update(toTag, new Contexts(contexts), new LabelExpression(getLabelFilter()), outputWriter);
+			liquibase.updateToTagSql(toTag, new Contexts(contexts), new LabelExpression(getLabelFilter()), outputWriter);
 		}
 	}
 

--- a/liquibase-standard/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-standard/src/main/java/liquibase/Liquibase.java
@@ -320,7 +320,9 @@ public class Liquibase implements AutoCloseable {
             updateCommand.addArgumentValue(UpdateCountSqlCommandStep.LABEL_FILTER_ARG, labelExpression != null ? labelExpression.getOriginalString() : null);
             updateCommand.addArgumentValue(ChangeExecListenerCommandStep.CHANGE_EXEC_LISTENER_ARG, changeExecListener);
             updateCommand.addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_PARAMETERS, changeLogParameters);
-            updateCommand.setOutput(WriterOutputStream.builder().setWriter(output).setCharset(GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()).get());
+            updateCommand.setOutput(WriterOutputStream.builder()
+                    .setWriter(output)
+                    .setCharset(GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()).get());
             updateCommand.execute();
         });
     }

--- a/liquibase-standard/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-standard/src/main/java/liquibase/Liquibase.java
@@ -308,6 +308,23 @@ public class Liquibase implements AutoCloseable {
         });
     }
 
+    public void updateCountSql(int count, Contexts contexts, LabelExpression labelExpression, Writer output)
+            throws LiquibaseException {
+        runInScope(() -> {
+            CommandScope updateCommand = new CommandScope(UpdateCountSqlCommandStep.COMMAND_NAME);
+            updateCommand.addArgumentValue(UpdateCountSqlCommandStep.COUNT_ARG, count);
+            updateCommand.addArgumentValue(DbUrlConnectionArgumentsCommandStep.DATABASE_ARG, getDatabase());
+            updateCommand.addArgumentValue(UpdateCountSqlCommandStep.CHANGELOG_FILE_ARG, changeLogFile);
+            updateCommand.addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_ARG, databaseChangeLog);
+            updateCommand.addArgumentValue(UpdateCountSqlCommandStep.CONTEXTS_ARG, contexts != null ? contexts.toString() : null);
+            updateCommand.addArgumentValue(UpdateCountSqlCommandStep.LABEL_FILTER_ARG, labelExpression != null ? labelExpression.getOriginalString() : null);
+            updateCommand.addArgumentValue(ChangeExecListenerCommandStep.CHANGE_EXEC_LISTENER_ARG, changeExecListener);
+            updateCommand.addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_PARAMETERS, changeLogParameters);
+            updateCommand.setOutput(WriterOutputStream.builder().setWriter(output).setCharset(GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()).get());
+            updateCommand.execute();
+        });
+    }
+
     public void update(int changesToApply, String contexts) throws LiquibaseException {
         update(changesToApply, new Contexts(contexts), new LabelExpression());
     }
@@ -377,6 +394,26 @@ public class Liquibase implements AutoCloseable {
             updateCommand.execute();
         });
     }
+
+    public void updateToTagSql(String tag, Contexts contexts, LabelExpression labelExpression, Writer writer) throws LiquibaseException {
+        runInScope(() -> {
+            CommandScope updateCommand = new CommandScope(UpdateToTagSqlCommandStep.COMMAND_NAME);
+            updateCommand.addArgumentValue(DbUrlConnectionArgumentsCommandStep.DATABASE_ARG, getDatabase());
+            updateCommand.addArgumentValue(UpdateToTagSqlCommandStep.CHANGELOG_FILE_ARG, changeLogFile);
+            updateCommand.addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_ARG, databaseChangeLog);
+            updateCommand.addArgumentValue(UpdateToTagSqlCommandStep.CONTEXTS_ARG, contexts != null ? contexts.toString() : null);
+            updateCommand.addArgumentValue(UpdateToTagSqlCommandStep.LABEL_FILTER_ARG, labelExpression != null ? labelExpression.getOriginalString() : null);
+            updateCommand.addArgumentValue(ChangeExecListenerCommandStep.CHANGE_EXEC_LISTENER_ARG, changeExecListener);
+            updateCommand.addArgumentValue(UpdateToTagSqlCommandStep.TAG_ARG, tag);
+            updateCommand.addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_PARAMETERS, changeLogParameters);
+            updateCommand.setOutput(WriterOutputStream.builder()
+                    .setWriter(writer)
+                    .setCharset(GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()).get());
+            updateCommand.execute();
+        });
+    }
+
+
 
     public void update(int changesToApply, String contexts, Writer output) throws LiquibaseException {
         this.update(changesToApply, new Contexts(contexts), new LabelExpression(), output);

--- a/liquibase-standard/src/test/groovy/liquibase/util/NetUtilTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/util/NetUtilTest.groovy
@@ -1,9 +1,7 @@
 package liquibase.util
 
-import spock.lang.Ignore
 import spock.lang.Specification
 
-@Ignore
 class NetUtilTest extends Specification {
 
     def getLocalHostAddress() {

--- a/liquibase-standard/src/test/groovy/liquibase/util/NetUtilTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/util/NetUtilTest.groovy
@@ -1,7 +1,9 @@
 package liquibase.util
 
+import spock.lang.Ignore
 import spock.lang.Specification
 
+@Ignore
 class NetUtilTest extends Specification {
 
     def getLocalHostAddress() {


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description
Instead of replacing the executor with a logging executor, use `UpdateCountSqlCommandStep` and `UpdateToTagSqlCommandStep` in `liquibase:updateSql`. 
<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of
Adds two new methods to `Liquibase` class. We haven't ever actually called out `count` or `tag` in any of our update method names before on this class, but `update` has been overloaded ad nauseam so I decided to just label these exactly as to what they are doing.
<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
