### PR TITLE
Make Scope ID RNG no longer use SecureRandom (fix #6178)

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/util/StringUtil.java
+++ b/liquibase-standard/src/main/java/liquibase/util/StringUtil.java
@@ -8,12 +8,12 @@ import liquibase.parser.LiquibaseSqlParser;
 import liquibase.parser.SqlParserFactory;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.CharUtils;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -768,7 +768,12 @@ public class StringUtil {
      * @return an identifier of the desired length
      */
     public static String randomIdentifier(int len) {
-        return RandomStringUtils.random(len, true, false);
+        final String AB = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+        StringBuilder sb = new StringBuilder(len);
+        for (int i = 0; i < len; i++)
+            sb.append(AB.charAt(ThreadLocalRandom.current().nextInt(AB.length())));
+        return sb.toString();
     }
 
     /**


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->

## Description
SecureRandom is a robust RNG for use in security-sensitive scenarios (like generating cryptographic/private keys). For something like a random Scope ID, it is overkill, as it's slower, and becomes a potentially blocking call if the machine hasn't been on for long or have enough entropy.

~~I've looked into the original change (in commit 3daa688c6a99ed131687036ba4e40cd743c4b3c8) and it seems to have been done to improve the performance of the Scope ID generation. While it clearly did improve things, it's much better to just use a normal ThreadLocalRandom instance, that will not experience contention issues even under high traffic, and will not have the problem with depending on system entropy.~~

The original change (in commit 3daa688c6a99ed131687036ba4e40cd743c4b3c8) already did this change implicitly, since RandomStringUtils up to version 3.14 was using ThreadLocalRandom. So from Liquibase's perspective, this maintains the improved performance profile without making it subject to the whims of Apache Commons Lang3.

Fixes #6178. I built a local `liquibase-core` JAR and linked into my CLI tool, and the changeset deployment no longer hangs.

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of
~~This makes the Scope ID generation not use a SecureRandom instance anymore, but it should really not be a problem as it should not require cryptographic-level randomness.~~
This is just setting your Scope ID generation to use ThreadLocalRandom again, more explicitly, and in a way that cannot be arbitrarily changed by myopic library maintainers :)

## Things to worry about
~~I think that the performance should actually be much better than the previous implemented fix (using Apache Commons), but I have not tested your use-case. I would recommend that you test it and see what the actual performance impact is.~~

Actually, you did the change initially, to move away from `SecureRandom` to `ThreadLocalRandom`, and the Apache Commons Lang3 team just changed that out from under you in v3.15, not just back to `SecureRandom` but all the way to `SecureRandom.getInstanceStrong()` which will make this block/take forever. So I see nothing more to worry about :)