### PR TITLE
Use insecure RNG for generating scope IDs

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/util/StringUtil.java
+++ b/liquibase-standard/src/main/java/liquibase/util/StringUtil.java
@@ -768,7 +768,7 @@ public class StringUtil {
      * @return an identifier of the desired length
      */
     public static String randomIdentifier(int len) {
-        return RandomStringUtils.random(len, true, false);
+        return RandomStringUtils.insecure().next(len, true, false);
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <trimStackTrace>false</trimStackTrace>
         <liquibase-pro.version>0-SNAPSHOT</liquibase-pro.version>
         <argLine></argLine>
-        <commons-lang3.version>3.15.0</commons-lang3.version>
+        <commons-lang3.version>3.16.0</commons-lang3.version>
         <commons-io.version>2.16.1</commons-io.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <commons-text.version>1.12.0</commons-text.version>


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->

## Description
Apache Commons Lang3 3.15 changed to using SecureRandom instead of ThreadLocalRandom, and due to the various hanging issues that have been reported, a secure()/insecure() API was created to make the choice more explicit.

This would revert the performance improvement that was obtained by moving to RandomStringUtils a few weeks ago.

## Things to be aware of
This involved a version increase to 3.16 of Apache Commons Lang3. It is insane that they published such a breaking behavioral change with a minor version bump, but it is what it is.
<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about
I can see a risk of people taking a dependency on Liquibase not being on Apache Commons Lang3 3.16 having some errors since the new API to select the insecure RNG is not API-compatible, but just having hard-to-debug random hangs is worse.

## Additional Context

<!--
Add any other context about the problem here.
-->
