### PR TITLE
Fixes issue 6054: incorrect system table query on DB2 AS/400 platform

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -824,7 +824,7 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
 
                 if (database instanceof DB2Database) {
                     if (database.getDatabaseProductName().startsWith("DB2 UDB for AS/400")) {
-                        executeAndExtract(getDB2ForAs400Sql(jdbcSchemaName, tableName), database);
+                        return executeAndExtract(getDB2ForAs400Sql(jdbcSchemaName, tableName), database);
                     }
                     return querytDB2Luw(jdbcSchemaName, tableName);
                 } else if (database instanceof Db2zDatabase) {
@@ -863,7 +863,7 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                     CatalogAndSchema catalogAndSchema = new CatalogAndSchema(catalogName, schemaName).customize(database);
                     String jdbcSchemaName = ((AbstractJdbcDatabase) database).getJdbcSchemaName(catalogAndSchema);
                     if (database.getDatabaseProductName().startsWith("DB2 UDB for AS/400")) {
-                        executeAndExtract(getDB2ForAs400Sql(jdbcSchemaName, null), database);
+                        return executeAndExtract(getDB2ForAs400Sql(jdbcSchemaName, null), database);
                     }
                     return querytDB2Luw(jdbcSchemaName, null);
                 } else if (database instanceof Db2zDatabase) {


### PR DESCRIPTION
## Impact
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 
-->


## Description
Fixes #6054 incorrect system table queries being executed when running on the DB2i AS/400 platform by re-introducing two return statements.
