### PR TITLE
DAT-18398 - Do not add version to shipped extensions + ignore current ones

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -172,7 +172,7 @@ jobs:
           rm -rf re-version/out/liquibase-${{ needs.setup.outputs.version }}.zip
           IFS=',' read -ra EXT <<< "${{ needs.setup.outputs.extensions }}"
           for i in "${EXT[@]}"; do
-            cp ~/.m2/repository/org/liquibase/ext/$i/${{ needs.setup.outputs.version }}/$i-${{ needs.setup.outputs.version }}.jar re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions/$i-${{ needs.setup.outputs.version }}.jar || echo "Failed to move $i artifact"
+            cp ~/.m2/repository/org/liquibase/ext/$i/${{ needs.setup.outputs.version }}/$i-${{ needs.setup.outputs.version }}.jar re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions/$i.jar || echo "Failed to move $i artifact"
           done
           (cd re-version/out/liquibase-${{ needs.setup.outputs.version }} && zip -r ../liquibase-${{ needs.setup.outputs.version }}.zip . && cd .. && rm -rf liquibase-${{ needs.setup.outputs.version }})
           
@@ -182,7 +182,7 @@ jobs:
           rm -rf re-version/out/liquibase-${{ needs.setup.outputs.version }}.tar.gz
           mkdir -p re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions
           for I in "${EXT[@]}"; do
-            cp ~/.m2/repository/org/liquibase/ext/$I/${{ needs.setup.outputs.version }}/$I-${{ needs.setup.outputs.version }}.jar re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions/$I-${{ needs.setup.outputs.version }}.jar || echo "Failed to move $I artifact"
+            cp ~/.m2/repository/org/liquibase/ext/$I/${{ needs.setup.outputs.version }}/$I-${{ needs.setup.outputs.version }}.jar re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions/$I.jar || echo "Failed to move $I artifact"
           done
           (cd re-version/out/liquibase-${{ needs.setup.outputs.version }} && tar -czvf ../liquibase-${{ needs.setup.outputs.version }}.tar.gz * && cd .. && rm -rf liquibase-${{ needs.setup.outputs.version }})
 

--- a/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseLauncher.java
+++ b/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseLauncher.java
@@ -173,6 +173,15 @@ public class LiquibaseLauncher {
                 new File(liquibaseHome, "internal/extensions"),
         };
 
+        // We released libraries containing the version in the file name,
+        // and we want to ignore them in the classpath as the installer/zip/tgz is
+        // not able to update them .
+        List<File> libsToIgnoreInClasspath = Arrays.asList(
+                new File(liquibaseHome, "internal/extensions/liquibase-bigquery-4.29.0.jar"),
+                new File(liquibaseHome, "internal/extensions/liquibase-bigquery-4.29.1.jar")
+        );
+
+
         for (File libDirFile : libDirs) {
             debug("Looking for libraries in " + libDirFile.getAbsolutePath());
 
@@ -189,6 +198,11 @@ public class LiquibaseLauncher {
             for (File lib : files) {
                 if (lib.getName().toLowerCase(Locale.US).endsWith(".jar") && !lib.getName().toLowerCase(Locale.US).equals("liquibase-core.jar")) {
                     try {
+                        if (libsToIgnoreInClasspath.stream().anyMatch(l -> l.getAbsoluteFile().equals(lib.getAbsoluteFile()))) {
+                            debug("Ignoring " + lib.getAbsolutePath() + " in classpath");
+                            continue; // skip the file if it is in the ignore list
+                        }
+
                         urls.add(lib.toURI().toURL());
                         debug("Added " + lib.getAbsolutePath() + " to classpath");
                     } catch (Exception e) {


### PR DESCRIPTION
chore: make sure that shipped extensions do not have the version number + ignore existing ones.