### PR TITLE
fix: do not release a lock when lock is being held by another instance. Fixes #5438.

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/command/core/UpdateCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/UpdateCommandStep.java
@@ -99,9 +99,4 @@ public class UpdateCommandStep extends AbstractUpdateCommandStep implements Clea
         return deps;
     }
 
-    @Override
-    public void run(CommandResultsBuilder resultsBuilder) throws Exception {
-        setDBLock(false);
-        super.run(resultsBuilder);
-    }
 }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

When liquibase is unable to acquire a lock because the lock is being held by another instance it forcibly removes this lock allowing others to acquire it again and proceed with migration set. This is causing multiple instances to run the same migration set and conflict with each other. 

Steps To Reproduce
1. Make DB locked.
2. Run some liquibase migration.
3. Wait until liquibase give up trying to acquire a lock.
4. Check the lock still exists in DB.

Expected Behavior
4. liquibase removes the lock when giving up.

Actual Behavior
4. liquibase leave the lock held by another instance in place

```
2024-08-23T18:08:36.281+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.changelog                      : Reading from liquibaselock.DATABASECHANGELOG
2024-08-23T18:08:36.342+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:08:46.362+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:08:56.382+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:09:06.401+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:09:16.421+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:09:26.443+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:09:36.462+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:09:46.482+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:09:56.503+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:10:06.521+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:10:16.548+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:10:26.569+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:10:36.589+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:10:46.608+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:10:56.629+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:11:06.649+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:11:16.668+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:11:26.695+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:11:36.714+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:11:46.734+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:11:56.753+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:12:06.772+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:12:16.791+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:12:26.809+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:12:36.829+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:12:46.851+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:12:56.871+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:13:06.889+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:13:16.912+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:13:26.931+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Waiting for changelog lock....
2024-08-23T18:13:36.957+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.command                        : Update command encountered an exception.
2024-08-23T18:13:36.992+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.lockservice                    : Successfully released change log lock
2024-08-23T18:13:36.997+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.command                        : Logging exception.
2024-08-23T18:13:36.997+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.ui                             : ERROR: Exception Details
2024-08-23T18:13:36.997+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.ui                             : ERROR: Exception Primary Class:  LockException
2024-08-23T18:13:36.997+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.ui                             : ERROR: Exception Primary Reason:  Could not acquire change log lock.  Currently locked by Locked by another instance since 8/23/24, 6:08 PM
2024-08-23T18:13:36.997+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.ui                             : ERROR: Exception Primary Source:  4.27.0
2024-08-23T18:13:36.998+02:00  INFO 28699 --- [liquibase-lock] [           main] liquibase.command                        : Command execution complete
```


<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
