### PR TITLE
fix: do not throw an unchecked exception for SpringBoot 

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/integration/spring/SpringLiquibase.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/spring/SpringLiquibase.java
@@ -264,7 +264,7 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
                         }
                     });
         } catch (Exception e) {
-            throw new UnexpectedLiquibaseException(e);
+            throw new LiquibaseException(e);
         }
     }
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

PR #4584 added an unchecked  exception when it should be a checked one. This PR fixes it. 

Fixes #6196 
