### PR TITLE
Changelog for 4.29.2 + revert snowflake driver + slf4j versions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,87 @@
 Liquibase Core Changelog
 ===========================================
 
+Changes in version 4.29.2 (2024.09.03)
+
+### Liquibase 4.29.2 is a patch release
+
+> Liquibase 4.29.2 patches minor issues found in Liquibase 4.29.1 release.
+
+## Notable Changes
+### [PRO]
+
+#### Custom Policy Checks updates: Create and run Python-based checks which fit your specific needs.
+* Liquibase checks have been opened to the world of Python development! This release fixes some minor issues so you can use your custom Python scripts as policy checks to solve your nuanced and techstack specific conditions for better risk mitigation, compliance, code quality, security, and more.
+* Learn more https://docs.liquibase.com/custom-policy-checks
+* Get the Checks extension to enable this capability: https://docs.liquibase.com/pro-extensions
+
+## Deprecation Notice
+
+#### MacOS .dmg Installer to be removed in next release.
+* This is the final Liquibase release in which the MacOS installer will be shipped. Both the tarball (the liquibase-x.y.z.tar.gz) and the .zip (liquibase-x.y.x.zip) are the preferred replaced options for MacOS users.
+* Questions or comments? https://www.liquibase.com/contact-us
+
+### [PRO] Changelog
+
+## Changes
+
+* DAT-18013: optionally suppress Liquibase SQL for *-sql commands in https://github.com/liquibase/liquibase-pro/pull/1877 by @StevenMassaro
+* DAT-17659: tagDatabase changes in formatted sql files in https://github.com/liquibase/liquibase-pro/pull/1833 by @StevenMassaro
+* DAT-18310: update CustomCheckDefaultValuesTest to check all parameters in https://github.com/liquibase/liquibase-pro/pull/1887 by @StevenMassaro
+* Now that report files are enabled by default, suppress them with git in https://github.com/liquibase/liquibase-pro/pull/1886 by @wwillard7800
+* DAT-17390: global setting for stripComments option in https://github.com/liquibase/liquibase-pro/pull/1879 by @StevenMassaro
+* DAT-18111: add "Report" word to title of update reports in https://github.com/liquibase/liquibase-pro/pull/1890 by @StevenMassaro
+* DAT-18182: show correct message when license expires on same day in https://github.com/liquibase/liquibase-pro/pull/1885 by @StevenMassaro
+* DAT-18342: Store Pro License Key in AWS Secrets Manager in https://github.com/liquibase/liquibase-pro/pull/1896 by @sayaliM0412
+* DAT-18063 Release lock after SQLPLUS timeout error in https://github.com/liquibase/liquibase-pro/pull/1892 by @wwillard7800
+* DAT-18360: only show expiration date message in checks run if expiration date is not null in https://github.com/liquibase/liquibase-pro/pull/1895 by @StevenMassaro
+* DAT-18396 - fix scripts resource caching in https://github.com/liquibase/liquibase-pro/pull/1899 by @filipelautert
+* DAT-18420 Change check that controls database checks to make sure they don't run just because we took a snapshot for a custom check in https://github.com/liquibase/liquibase-pro/pull/1902 by @wwillard7800
+* DAT-18440 Handle strict mode setting when doing auto rollback in https://github.com/liquibase/liquibase-pro/pull/1909 by @wwillard7800
+* DAT-18196: add method to LicenseService to allow custom invalid license message in https://github.com/liquibase/liquibase-pro/pull/1917 by @StevenMassaro
+* DAT-18389 Changing Quality Checks -> Policy Checks in https://github.com/liquibase/liquibase-pro/pull/1906 by @wwillard7800
+
+
+### [OSS] Changelog
+
+## Changes
+
+* Make Scope ID RNG no longer use SecureRandom (fix #6178 in https://github.com/liquibase/liquibase/pull/6179 by @danielthegray
+* optionally suppress Liquibase SQL for *-sql commands (DAT-18013) in https://github.com/liquibase/liquibase/pull/6132 by @StevenMassaro
+* changes in support of globally setting stripComments option (DAT-1739) in https://github.com/liquibase/liquibase/pull/6137 by @StevenMassaro
+* Handle reporting of changes which are skipped due to license issues (DAT-17659) in https://github.com/liquibase/liquibase/pull/6114 by @wwillard7800
+* [DAT-17993] Improve diffChangelog between MSSQL and Oracle in https://github.com/liquibase/liquibase/pull/6094 by @filipelautert
+* DAT-18250 DevOps :: Clean up branch build not working in https://github.com/liquibase/liquibase/pull/6162 by @jandroav
+* compare contents of zip file against baseline (DAT-18324) in https://github.com/liquibase/liquibase/pull/6166 by @StevenMassaro
+* maven flag for suppressLiquibaseSql (DAT-18273) in https://github.com/liquibase/liquibase/pull/6163 by @StevenMassaro
+* Append included labels to the changeset labels when matching (DAT-16636) in https://github.com/liquibase/liquibase/pull/6159 by @wwillard7800
+* chore: upgrade installer jdk version to 21.0.4+7 in https://github.com/liquibase/liquibase/pull/6119 by @filipelautert
+* Fix serialization of DatabaseChangeLog with 'preConditions' for yaml in https://github.com/liquibase/liquibase/pull/6118 by @MalloD12
+* Add additional duplicateFileMode options in https://github.com/liquibase/liquibase/pull/6067 by @k4pran
+* Do not show update summary when using update-sql via maven plugin (DAT-18323) in https://github.com/liquibase/liquibase/pull/6168 by @abrackx
+* Bump org.mariadb.jdbc:mariadb-java-client from 3.3.3 to 3.4.1 in https://github.com/liquibase/liquibase/pull/6113 by @dependabot
+* fix case where expiration date is null in --version output (DAT-18360) in https://github.com/liquibase/liquibase/pull/6170 by @StevenMassaro
+* Use correct method for Maven updateSQL * DAT-18142 in https://github.com/liquibase/liquibase/pull/6198 by @wwillard7800
+* DAT-18398 - Do not add version to shipped extensions + ignore current ones in https://github.com/liquibase/liquibase/pull/6197 by @filipelautert
+* Fixes issue 6054: incorrect system table query on DB2 AS/400 platform in https://github.com/liquibase/liquibase/pull/6185 by @AlexCoolen
+* Do not throw exception if data type is not supported by database in https://github.com/liquibase/liquibase/pull/6226 by @wwillard7800
+* Do not release lock if not locked by this update * DAT-18370 in https://github.com/liquibase/liquibase/pull/6218 by @wwillard7800
+* add method to LicenseService to allow custom invalid license message( DAT-18196) in https://github.com/liquibase/liquibase/pull/6232 by @StevenMassaro
+* fix: EndDelimiter not working as expected since 4.29 in https://github.com/liquibase/liquibase/pull/6157 by @filipelautert
+* Changing Quality Checks -> Policy Checks in https://github.com/liquibase/liquibase/pull/6204 by @wwillard7800
+* fix release workflows in https://github.com/liquibase/liquibase/pull/6260 by @jandroav
+
+## Security, Driver and Other Updates
+
+* Bump slf4j.version from 1.7.36 to 2.0.13 in https://github.com/liquibase/liquibase/pull/6106 by @dependabot
+* Bump org.testcontainers:testcontainers-bom from 1.19.8 to 1.20.1 in https://github.com/liquibase/liquibase/pull/6155 by @dependabot
+* Bump org.apache.commons:commons-lang3 from 3.14.0 to 3.15.0 in https://github.com/liquibase/liquibase/pull/6112 by @dependabot
+* Bump org.apache.maven.plugins:maven-javadoc-plugin from 3.7.0 to 3.8.0 in https://github.com/liquibase/liquibase/pull/6116 by @dependabot
+
+
+**Full Changelog**: https://github.com/liquibase/liquibase/compare/v4.29.1...v4.29.2
+
+
 Changes in version 4.29.1 (2024.07.31)
 
 ### Liquibase 4.29.1 is a patch release

--- a/liquibase-dist/pom.xml
+++ b/liquibase-dist/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-jdbc</artifactId>
-            <version>3.18.0</version>
+            <version>3.16.1</version>
         </dependency>
 
         <!--        CANNOT INCLUDE MYSQL FOR LICENSING REASONS -->

--- a/liquibase-dist/pom.xml
+++ b/liquibase-dist/pom.xml
@@ -26,7 +26,7 @@
         <sqlite.version>3.46.0.0</sqlite.version>
         <db2.version>11.5.9.0</db2.version>
         <firebird.version>5.0.5.java8</firebird.version>
-        <slf4j.version>2.0.13</slf4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <liquibase-pro.version>master-SNAPSHOT</liquibase-pro.version>
         <liquibase-checks.version>0-SNAPSHOT</liquibase-checks.version>
         <assemblyConfigFile>src/main/assembly/assembly-bin.xml</assemblyConfigFile>

--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-jdbc</artifactId>
-            <version>3.18.0</version>
+            <version>3.16.1</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION

Changelog for 4.29.2 + revert snowflakke driver version to 3.16.1 (same as 4.29.1 ) and slf4j back to 1.x - thos ehould not have been bumped for a patch version.. 