### PR TITLE
#6264 append the cause of the problem to thrown exception

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -664,7 +664,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
             } catch (ReflectiveOperationException e) {
                 //take default comparator
                 Scope.getCurrentScope().getLog(getClass()).info("no resourceComparator defined - taking default " +
-                        "implementation");
+                        "implementation", e);
                 resourceComparator = getStandardChangeLogComparator();
             }
         }
@@ -868,7 +868,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                 unsortedResources = resourceAccessor.search(path, searchOptions);
             } catch (IOException e) {
                 if (errorIfMissingOrEmpty) {
-                    throw new IOException(String.format("Could not find/read changelogs from %s directory", pathName));
+                    throw new IOException(String.format("Could not find/read changelogs from %s directory", pathName), e);
                 }
             }
             SortedSet<Resource> resources = new TreeSet<>((o1, o2) -> resourceComparator.compare(o1.getPath(), o2.getPath()));
@@ -1035,7 +1035,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
             boolean matchesFileExtension = StringUtil.trimToEmpty(normalizedFilePath).matches("\\.\\w+$");
             if (matchesFileExtension || onUnknownFileFormat == OnUnknownFileFormat.WARN) {
                 Scope.getCurrentScope().getLog(getClass()).warning(
-                        "included file " + normalizedFilePath + "/" + normalizedFilePath + " is not a recognized file type"
+                        "included file " + normalizedFilePath + "/" + normalizedFilePath + " is not a recognized file type", e
                 );
             }
             return false;


### PR DESCRIPTION
The most important fix is line 271:
"Could not find/read changelogs from %s directory" - WHY???

## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

This PR fixes problem https://github.com/liquibase/liquibase/issues/6264

More exactly, it adds the error details to thrown exception (which was previously swallowed).