### PR TITLE
#6281 fix NPE when default value is null

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/snapshot/CachedRow.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/CachedRow.java
@@ -3,29 +3,27 @@ package liquibase.snapshot;
 import java.util.Map;
 
 public class CachedRow {
-    private final Map row;
+    private final Map<String, Object> row;
 
-    public CachedRow(Map row) {
+    public CachedRow(Map<String, Object> row) {
         this.row = row;
     }
 
-
-
-    public Object get(String columnName) {
-        return row.get(columnName);
+    @SuppressWarnings("unchecked")
+    public <T> T get(String columnName) {
+        return (T) row.get(columnName);
     }
 
     public void set(String columnName, Object value) {
         row.put(columnName, value);
     }
 
-
     public boolean containsColumn(String columnName) {
         return row.containsKey(columnName);
     }
 
     public String getString(String columnName) {
-        return (String) row.get(columnName);
+        return get(columnName);
     }
 
     public Integer getInt(String columnName) {

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
@@ -580,19 +580,19 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
 
         if (database instanceof SybaseASADatabase) {
             String defaultValue = (String) columnMetadataResultSet.get(COLUMN_DEF_COL);
+            if (defaultValue != null) {
+                // SQL Anywhere returns `CURRENT DATE` (without underscore), which no other RDBMS would understand
+               defaultValue = defaultValue.replaceAll("(?i)\\bCURRENT\\s+DATE\\b", "{fn CURDATE()}");
 
-           // SQL Anywhere returns `CURRENT DATE` (without underscore), which no other RDBMS would understand
-           defaultValue = defaultValue.replaceAll("(?i)\\bCURRENT\\s+DATE\\b", "{fn CURDATE()}");
+               // SQL Anywhere returns `CURRENT TIME` (without underscore), which no other RDBMS would understand
+               defaultValue = defaultValue.replaceAll("(?i)\\bCURRENT\\s+TIME\\b", "{fn CURTIME()}");
 
-           // SQL Anywhere returns `CURRENT TIME` (without underscore), which no other RDBMS would understand
-           defaultValue = defaultValue.replaceAll("(?i)\\bCURRENT\\s+TIME\\b", "{fn CURTIME()}");
+               // SQL Anywhere returns `CURRENT TIMESTAMP` (without underscore), which no other RDBMS would understand
+               defaultValue = defaultValue.replaceAll("(?i)\\bCURRENT\\s+TIMESTAMP\\b", "{fn NOW()}");
 
-           // SQL Anywhere returns `CURRENT TIMESTAMP` (without underscore), which no other RDBMS would understand
-           defaultValue = defaultValue.replaceAll("(?i)\\bCURRENT\\s+TIMESTAMP\\b", "{fn NOW()}");
-
-           // SQL Anywhere returns `CURRENT USER` (without underscore), which no other RDBMS would understand
-           defaultValue = defaultValue.replaceAll("(?i)\\bCURRENT\\s+USER\\b", "{fn USER()}");
-
+               // SQL Anywhere returns `CURRENT USER` (without underscore), which no other RDBMS would understand
+               defaultValue = defaultValue.replaceAll("(?i)\\bCURRENT\\s+USER\\b", "{fn USER()}");
+           }
            columnMetadataResultSet.set(COLUMN_DEF_COL, defaultValue);
 
            if (YES_VALUE.equals(columnMetadataResultSet.get(IS_GENERATED_COLUMN))) {


### PR DESCRIPTION
Sample:
```java
java.lang.NullPointerException: Cannot invoke "String.replaceAll(String, String)" because "defaultValue" is null
	at liquibase.snapshot.jvm.ColumnSnapshotGenerator.readDefaultValue(ColumnSnapshotGenerator.java:571)
	at liquibase.snapshot.jvm.ColumnSnapshotGenerator.readColumn(ColumnSnapshotGenerator.java:291)
	at liquibase.snapshot.jvm.ColumnSnapshotGenerator.addTo(ColumnSnapshotGenerator.java:204)
	at liquibase.snapshot.jvm.JdbcSnapshotGenerator.snapshot(JdbcSnapshotGenerator.java:78)
	at liquibase.snapshot.SnapshotGeneratorChain.snapshot(SnapshotGeneratorChain.java:49)
```

## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

This PR fixes bug https://github.com/liquibase/liquibase/issues/6281
