### PR TITLE
fix: Locale test fix

### DIFF
--- a/liquibase-standard/src/test/groovy/liquibase/changelog/DatabaseChangeLogTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/changelog/DatabaseChangeLogTest.groovy
@@ -557,6 +557,9 @@ http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbch
     }
 
     def "include fails if XML file is empty"() {
+        given:
+        Locale.setDefault(Locale.ENGLISH)
+
         when:
         def resourceAccessor = new MockResourceAccessor(["com/example/test1.xml": ""])
 


### PR DESCRIPTION

## Things to be aware of

This test used to fail in Locales different than English as the expected message can be different if a translation is available