### PR TITLE
Always add database information to MDC and analytics when running via maven (DAT-18630)

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/DbUrlConnectionCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/DbUrlConnectionCommandStep.java
@@ -100,24 +100,23 @@ public class DbUrlConnectionCommandStep extends AbstractDatabaseConnectionComman
      * @throws DatabaseException Thrown when there is a connection error
      */
     public Database obtainDatabase(CommandScope commandScope) throws DatabaseException {
-        if (commandScope.getArgumentValue(DATABASE_ARG) == null) {
+        Database database = commandScope.getArgumentValue(DATABASE_ARG);
+        if (database == null) {
             String url = commandScope.getArgumentValue(URL_ARG);
-            String username = commandScope.getArgumentValue(USERNAME_ARG);
-            String password = commandScope.getArgumentValue(PASSWORD_ARG);
-            String defaultSchemaName = commandScope.getArgumentValue(DbUrlConnectionArgumentsCommandStep.DEFAULT_SCHEMA_NAME_ARG);
-            String defaultCatalogName = commandScope.getArgumentValue(DbUrlConnectionArgumentsCommandStep.DEFAULT_CATALOG_NAME_ARG);
-            String driver = getDriver(commandScope);
-            String driverPropertiesFile = commandScope.getArgumentValue(DbUrlConnectionArgumentsCommandStep.DRIVER_PROPERTIES_FILE_ARG);
-            Database database = createDatabaseObject(url, username, password, defaultSchemaName, defaultCatalogName, driver, driverPropertiesFile,
-                    StringUtil.trimToNull(GlobalConfiguration.LIQUIBASE_CATALOG_NAME.getCurrentValue()),
-                    StringUtil.trimToNull(GlobalConfiguration.LIQUIBASE_SCHEMA_NAME.getCurrentValue()));
-            logMdc(url, database);
-            return database;
-        } else {
-            Database database = commandScope.getArgumentValue(DATABASE_ARG);
-            logMdc(database.getConnection().getURL(), database);
-            return database;
+            database = createDatabaseObject(
+                url,
+                commandScope.getArgumentValue(USERNAME_ARG),
+                commandScope.getArgumentValue(PASSWORD_ARG),
+                commandScope.getArgumentValue(DbUrlConnectionArgumentsCommandStep.DEFAULT_SCHEMA_NAME_ARG),
+                commandScope.getArgumentValue(DbUrlConnectionArgumentsCommandStep.DEFAULT_CATALOG_NAME_ARG),
+                getDriver(commandScope),
+                commandScope.getArgumentValue(DbUrlConnectionArgumentsCommandStep.DRIVER_PROPERTIES_FILE_ARG),
+                StringUtil.trimToNull(GlobalConfiguration.LIQUIBASE_CATALOG_NAME.getCurrentValue()),
+                StringUtil.trimToNull(GlobalConfiguration.LIQUIBASE_SCHEMA_NAME.getCurrentValue())
+            );
         }
+        logMdc(database.getConnection().getURL(), database);
+        return database;
     }
 
     private static String getDriver(CommandScope commandScope) {

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/DbUrlConnectionCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/DbUrlConnectionCommandStep.java
@@ -101,8 +101,8 @@ public class DbUrlConnectionCommandStep extends AbstractDatabaseConnectionComman
      */
     public Database obtainDatabase(CommandScope commandScope) throws DatabaseException {
         Database database = commandScope.getArgumentValue(DATABASE_ARG);
+        String url = commandScope.getArgumentValue(URL_ARG);
         if (database == null) {
-            String url = commandScope.getArgumentValue(URL_ARG);
             database = createDatabaseObject(
                 url,
                 commandScope.getArgumentValue(USERNAME_ARG),
@@ -115,7 +115,7 @@ public class DbUrlConnectionCommandStep extends AbstractDatabaseConnectionComman
                 StringUtil.trimToNull(GlobalConfiguration.LIQUIBASE_SCHEMA_NAME.getCurrentValue())
             );
         }
-        logMdc(database.getConnection().getURL(), database);
+        logMdc(url == null ? database.getConnection().getURL() : url, database);
         return database;
     }
 

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/DbUrlConnectionCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/DbUrlConnectionCommandStep.java
@@ -114,7 +114,9 @@ public class DbUrlConnectionCommandStep extends AbstractDatabaseConnectionComman
             logMdc(url, database);
             return database;
         } else {
-            return commandScope.getArgumentValue(DATABASE_ARG);
+            Database database = commandScope.getArgumentValue(DATABASE_ARG);
+            logMdc(database.getConnection().getURL(), database);
+            return database;
         }
     }
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description
When executing a maven goal the database command scope argument is set up before the DbUrlConnectionCommandStep is executed. This meant that occasionally we didn't actually log all of the relevant database platform information in MDC and analytics. This change logs the mdc information regardless of whether the database was set up in the command step or elsewhere. 
<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of
This change removes an if/else that caused the bug and refactors the code to be a bit more compact, but functionally nothing should change.
<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
