### PR TITLE
DAT-18563 :: Unhide tag parameter for UpdateTestingRollback command

### DIFF
--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/core/UpdateTestingRollbackCommandsIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/core/UpdateTestingRollbackCommandsIntegrationTest.groovy
@@ -54,4 +54,23 @@ class UpdateTestingRollbackCommandsIntegrationTest extends Specification {
         cleanup:
         CommandUtil.runDropAll(h2)
     }
+
+    def "run UpdateTestingRollback specifying a tag with changelog parameter from Liquibase class"() {
+        when:
+        def testTag = "testTag"
+        def liquibase = new Liquibase("liquibase/update-tests.yml", new ClassLoaderResourceAccessor(), h2.getDatabaseFromFactory())
+        liquibase.updateTestingRollback(testTag, new Contexts(), new LabelExpression())
+
+        then:
+        def resultSet = h2.getConnection().createStatement().executeQuery("select count(1) from databasechangelog")
+        resultSet.next()
+        resultSet.getInt(1) == 1
+
+        def rsTableExist = h2.getConnection().createStatement().executeQuery("select count(1) from example_table")
+        rsTableExist.next()
+        rsTableExist.getInt(1) == 0
+
+        cleanup:
+        CommandUtil.runDropAll(h2)
+    }
 }

--- a/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/updateTestingRollback.test.groovy
+++ b/liquibase-integration-tests/src/test/resources/liquibase/extension/testing/command/updateTestingRollback.test.groovy
@@ -33,6 +33,8 @@ Optional Args:
   password (String) Password to use to connect to the database
     Default: null
     OBFUSCATED
+  tag (String) The tag to update to
+    Default: null
   username (String) Username to use to connect to the database
     Default: null
 """

--- a/liquibase-standard/src/main/java/liquibase/command/core/UpdateTestingRollbackCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/UpdateTestingRollbackCommandStep.java
@@ -20,7 +20,7 @@ public class UpdateTestingRollbackCommandStep extends AbstractCommandStep {
     static {
         CommandBuilder builder = new CommandBuilder(COMMAND_NAME);
         TAG_ARG = builder.argument("tag", String.class)
-                .hidden()
+                .description("The tag to update to")
                 .build();
     }
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description


> During testing, @James Bennett discovered that the updateTestingRollback command has a hidden argument for tag.  The argument has always been a part of the command, but was accidentally marked as hidden during command framework refactoring.  It appears to be working as designed but should be tested further after unhiding it.


With this PR, we just unhide `TAG` command argument and update the corresponding tests.

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
