### PR TITLE
Adressing issue #6331, small changes to pom.xml files to reduce warnings shown in building

### DIFF
--- a/liquibase-cli/pom.xml
+++ b/liquibase-cli/pom.xml
@@ -39,6 +39,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>3.4.2</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -174,7 +174,7 @@
                         </goals>
                         <configuration>
                             <target>
-                                <jar destfile="${project.build.directory}/${build.finalName}.jar"
+                                <jar destfile="${project.build.directory}/${project.build.finalName}.jar"
                                      update="true"
                                      basedir="${project.build.directory}/classes"
                                      includes="**/pom.xml"

--- a/pom.xml
+++ b/pom.xml
@@ -495,7 +495,7 @@
                 <configuration>
                     <attach>true</attach>
                     <author>false</author>
-                    <doctitle>Liquibase ${version} API</doctitle>
+                    <doctitle>Liquibase ${project.version} API</doctitle>
                     <quiet>true</quiet>
                     <doclint>none</doclint>
                     <encoding>UTF-8</encoding>


### PR DESCRIPTION
Use ${project.version} instead of ${version}; same goes for ${build.finalName}, which is recommended to switch to ${project.build.finalName}.

Finally, use version for `maven-jar-plugin` consistently.

## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`newContributors`    - New Contributors 

## Description

The project configuration in pom.xml uses two deprecated variables: ${version} and ${build.finalName}.
The warnings are issues with `mvn` version 3.9.x, possibly before.

Since the project has configured `mvn` version 3.9.5 in `.mvn/wrapper/maven-wrapper.properties`, a developer with no `mvn` installed is automatically using that version.

I am well aware that the project "only" mandates `mvn` version 3.6 as a minimum.

Fixes #6331 