### PR TITLE
fix userId not finding license owner correctly, include license key in userId (DAT-18653)

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/analytics/SegmentBatch.java
+++ b/liquibase-standard/src/main/java/liquibase/analytics/SegmentBatch.java
@@ -16,7 +16,7 @@ public class SegmentBatch {
     private final String writeKey;
     private final Map<String, ?> context;
 
-    public static SegmentBatch fromLiquibaseEvent(Event event, String licenseIssuedTo) throws Exception {
+    public static SegmentBatch fromLiquibaseEvent(Event event, String userId) throws Exception {
         AnalyticsConfigurationFactory analyticsConfigurationFactory = Scope.getCurrentScope().getSingleton(AnalyticsConfigurationFactory.class);
         AnalyticsConfiguration analyticsConfiguration = analyticsConfigurationFactory.getPlugin();
         String writeKey = null;
@@ -24,7 +24,7 @@ public class SegmentBatch {
             writeKey = ((SegmentAnalyticsConfiguration) analyticsConfiguration).getWriteKey();
         }
         SegmentBatch segmentBatch = new SegmentBatch(writeKey, null);
-        segmentBatch.getBatch().add(SegmentTrackEvent.fromLiquibaseEvent(event, licenseIssuedTo));
+        segmentBatch.getBatch().add(SegmentTrackEvent.fromLiquibaseEvent(event, userId));
         return segmentBatch;
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/analytics/SegmentBatch.java
+++ b/liquibase-standard/src/main/java/liquibase/analytics/SegmentBatch.java
@@ -16,7 +16,7 @@ public class SegmentBatch {
     private final String writeKey;
     private final Map<String, ?> context;
 
-    public static SegmentBatch fromLiquibaseEvent(Event event) throws Exception {
+    public static SegmentBatch fromLiquibaseEvent(Event event, String licenseIssuedTo) throws Exception {
         AnalyticsConfigurationFactory analyticsConfigurationFactory = Scope.getCurrentScope().getSingleton(AnalyticsConfigurationFactory.class);
         AnalyticsConfiguration analyticsConfiguration = analyticsConfigurationFactory.getPlugin();
         String writeKey = null;
@@ -24,7 +24,7 @@ public class SegmentBatch {
             writeKey = ((SegmentAnalyticsConfiguration) analyticsConfiguration).getWriteKey();
         }
         SegmentBatch segmentBatch = new SegmentBatch(writeKey, null);
-        segmentBatch.getBatch().add(SegmentTrackEvent.fromLiquibaseEvent(event));
+        segmentBatch.getBatch().add(SegmentTrackEvent.fromLiquibaseEvent(event, licenseIssuedTo));
         return segmentBatch;
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/analytics/SegmentTrackEvent.java
+++ b/liquibase-standard/src/main/java/liquibase/analytics/SegmentTrackEvent.java
@@ -43,13 +43,9 @@ public class SegmentTrackEvent {
     private final Map<String, ?> context;
     private final String messageId = UUID.randomUUID().toString();
 
-    public static SegmentTrackEvent fromLiquibaseEvent(Event event) {
-        String userId = ExceptionUtil.doSilently(() -> {
-            LicenseService licenseService = Scope.getCurrentScope().getSingleton(LicenseServiceFactory.class).getLicenseService();
-            return licenseService.getLicenseInfoObject().getIssuedTo();
-        });
+    public static SegmentTrackEvent fromLiquibaseEvent(Event event, String licenseIssuedTo) {
         SegmentTrackEvent segmentTrackEvent = new SegmentTrackEvent(
-                userId,
+                licenseIssuedTo,
                 UUID.randomUUID().toString(), // todo this should be more sophisticated in the future
                 event.getPropertiesAsMap(),
                 null

--- a/liquibase-standard/src/main/java/liquibase/analytics/SegmentTrackEvent.java
+++ b/liquibase-standard/src/main/java/liquibase/analytics/SegmentTrackEvent.java
@@ -43,9 +43,9 @@ public class SegmentTrackEvent {
     private final Map<String, ?> context;
     private final String messageId = UUID.randomUUID().toString();
 
-    public static SegmentTrackEvent fromLiquibaseEvent(Event event, String licenseIssuedTo) {
+    public static SegmentTrackEvent fromLiquibaseEvent(Event event, String userId) {
         SegmentTrackEvent segmentTrackEvent = new SegmentTrackEvent(
-                licenseIssuedTo,
+                userId,
                 UUID.randomUUID().toString(), // todo this should be more sophisticated in the future
                 event.getPropertiesAsMap(),
                 null

--- a/liquibase-standard/src/main/java/liquibase/analytics/configuration/AnalyticsArgs.java
+++ b/liquibase-standard/src/main/java/liquibase/analytics/configuration/AnalyticsArgs.java
@@ -11,6 +11,7 @@ public class AnalyticsArgs implements AutoloadedConfigurations {
     private static final ConfigurationDefinition<Boolean> ENABLED;
     public static final ConfigurationDefinition<String> CONFIG_ENDPOINT_URL;
     public static final ConfigurationDefinition<Integer> CONFIG_ENDPOINT_TIMEOUT_MILLIS;
+    public static final ConfigurationDefinition<Integer> LICENSE_KEY_CHARS;
 
     static {
         ConfigurationDefinition.Builder builder = new ConfigurationDefinition.Builder("liquibase.analytics");
@@ -27,6 +28,12 @@ public class AnalyticsArgs implements AutoloadedConfigurations {
         CONFIG_ENDPOINT_TIMEOUT_MILLIS = builder.define("configEndpointTimeoutMillis", Integer.class)
                 .setDefaultValue(1500)
                 .setHidden(true)
+                .build();
+
+        LICENSE_KEY_CHARS = builder.define("licenseKeyChars", Integer.class)
+                .setDefaultValue(12)
+                .setHidden(true)
+                .setDescription("Number of characters of the license key that should be appended to the userId. This is used in the event that the same customer has multiple license keys associated with them.")
                 .build();
     }
 

--- a/liquibase-standard/src/main/java/liquibase/analytics/configuration/SegmentAnalyticsConfiguration.java
+++ b/liquibase-standard/src/main/java/liquibase/analytics/configuration/SegmentAnalyticsConfiguration.java
@@ -13,6 +13,10 @@ import java.util.concurrent.atomic.AtomicReference;
 @Data
 public class SegmentAnalyticsConfiguration implements AnalyticsConfiguration {
     private final static Cache<RemoteAnalyticsConfiguration> remoteAnalyticsConfiguration = new Cache<>(() -> {
+        /**
+         * It is important to obtain the URL here outside of the newly created thread. {@link Scope} stores its stuff
+         * in a ThreadLocal, so if you tried to get the value inside the thread, the value could be different.
+         */
         String url = AnalyticsArgs.CONFIG_ENDPOINT_URL.getCurrentValue();
         AtomicReference<RemoteAnalyticsConfiguration> remoteAnalyticsConfiguration = new AtomicReference<>();
         Thread thread = new Thread(() -> {

--- a/liquibase-standard/src/main/java/liquibase/license/LicenseService.java
+++ b/liquibase-standard/src/main/java/liquibase/license/LicenseService.java
@@ -1,5 +1,6 @@
 package liquibase.license; 
 
+import liquibase.configuration.ConfiguredValue;
 import liquibase.plugin.Plugin;
 
 import java.util.Date;
@@ -96,4 +97,7 @@ public interface LicenseService extends Plugin {
     return null;
   }
 
+  default ConfiguredValue<String> getLicenseKey() {
+    return null;
+  }
 }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

`Scope` is stored in a ThreadLocal, so we must get the owner of the license key outside of the newly created thread, because the thread has a different scope than the main Liquibase thread.

Additionally, include the last 12 characters of the license key in the userId transmitted to Segment, so that different keys for the same org can be differentiated.

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
