### PR TITLE
Fix sqlite hsqldb and environment variable tests (DAT-18646)

### DIFF
--- a/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/EnvironmentVariableProviderForTest.groovy
+++ b/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/EnvironmentVariableProviderForTest.groovy
@@ -2,11 +2,9 @@ package liquibase.extension.testing
 
 import liquibase.configuration.core.EnvironmentValueProvider
 
-public class EnvironmentVariableProviderForTest extends EnvironmentValueProvider {
+class EnvironmentVariableProviderForTest extends EnvironmentValueProvider {
     private Map<?, ?> localMap = new HashMap<>()
-    public EnvironmentVariableProviderForTest(Map add, String[] remove) {
-//        Map<?, ?> map = super.getMap()
-//        localMap.putAll(map)
+    EnvironmentVariableProviderForTest(Map add, String[] remove) {
         add && add.each { it->
             localMap.put(it.key, it.value)
         }

--- a/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/EnvironmentVariableProviderForTest.groovy
+++ b/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/EnvironmentVariableProviderForTest.groovy
@@ -5,8 +5,8 @@ import liquibase.configuration.core.EnvironmentValueProvider
 public class EnvironmentVariableProviderForTest extends EnvironmentValueProvider {
     private Map<?, ?> localMap = new HashMap<>()
     public EnvironmentVariableProviderForTest(Map add, String[] remove) {
-        Map<?, ?> map = super.getMap()
-        localMap.putAll(map)
+//        Map<?, ?> map = super.getMap()
+//        localMap.putAll(map)
         add && add.each { it->
             localMap.put(it.key, it.value)
         }

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
@@ -294,6 +294,7 @@ public abstract class AbstractIntegrationTest {
             }
         }
         SnapshotGeneratorFactory.resetAll();
+        DatabaseObjectFactory.getInstance().reset();
     }
 
     protected boolean shouldRollBack() {

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/sqlite/SQLiteIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/sqlite/SQLiteIntegrationTest.java
@@ -6,6 +6,8 @@ import liquibase.database.DatabaseFactory;
 import liquibase.dbtest.AbstractIntegrationTest;
 import liquibase.exception.ValidationFailedException;
 import liquibase.snapshot.DatabaseSnapshot;
+import liquibase.snapshot.SnapshotGeneratorFactory;
+import liquibase.structure.core.DatabaseObjectFactory;
 import org.junit.Test;
 
 import java.io.File;
@@ -86,6 +88,7 @@ public class SQLiteIntegrationTest extends AbstractIntegrationTest {
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
+        DatabaseObjectFactory.getInstance().reset();
         try {
             String url = getDatabase().getConnection().getURL()
                     .replaceFirst("jdbc:sqlite:", ""); // remove the prefix of the URL jdbc:sqlite:C:\path\to\tmp\dir\liquibase.db

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/sqlite/SQLiteIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/sqlite/SQLiteIntegrationTest.java
@@ -88,7 +88,6 @@ public class SQLiteIntegrationTest extends AbstractIntegrationTest {
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
-        DatabaseObjectFactory.getInstance().reset();
         try {
             String url = getDatabase().getConnection().getURL()
                     .replaceFirst("jdbc:sqlite:", ""); // remove the prefix of the URL jdbc:sqlite:C:\path\to\tmp\dir\liquibase.db


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description
Issue 1: The test `StrictIntegrationTests` would fail if there were pro (or other extension related) environment variables set up outside of the scope of test execution. The change to `EnvironmentVariableProviderForTest` makes it so that we do not read the existing environment variables when utilizing this provider and enables us to successfully run the test without messing with existing environment variables.

Issue 2: When running sqlite integration tests before hsqldb integration tests, the databaseobjectfactory would carry over between test executions. Since sqlite does not support sequences, this would lead to sequences not being detected in hsqldb's integration tests causing them to fail. The change to the teardown method in the sqlite tests resets the factory, allowing sequences to be dropped in subsequent tests. 
<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
