### PR TITLE
Implement logic to selectively include/exclude columns in generate-changelog "data" export

### DIFF
--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/core/GenerateChangeLogPostgresqlIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/core/GenerateChangeLogPostgresqlIntegrationTest.groovy
@@ -1,0 +1,116 @@
+package liquibase.command.core
+
+import liquibase.Scope
+import liquibase.command.CommandScope
+import liquibase.command.core.helpers.DbUrlConnectionArgumentsCommandStep
+import liquibase.command.core.helpers.DiffOutputControlCommandStep
+import liquibase.command.core.helpers.PreCompareCommandStep
+import liquibase.command.util.CommandUtil
+import liquibase.extension.testing.testsystem.DatabaseTestSystem
+import liquibase.extension.testing.testsystem.TestSystemFactory
+import liquibase.extension.testing.testsystem.spock.LiquibaseIntegrationTest
+import liquibase.util.FileUtil
+
+import spock.lang.Shared
+import spock.lang.Specification
+
+@LiquibaseIntegrationTest
+class GenerateChangeLogPostgresqlIntegrationTest extends Specification {
+    @Shared
+    private DatabaseTestSystem db =
+            (DatabaseTestSystem) Scope.getCurrentScope().getSingleton(TestSystemFactory.class).getTestSystem("postgresql")
+
+    def "Should export database table TEST by applying includeObjects filter"() {
+        given:
+        db.executeSql("""
+CREATE TABLE "TEST" (
+    AFOO VARCHAR(4),
+    BFOO VARCHAR(4),
+    FOO  VARCHAR(4),
+    FOOL VARCHAR(4)
+);
+INSERT INTO "TEST" (AFOO, BFOO, FOO, FOOL) VALUES ('AFOO', 'BFOO', 'FOO', 'FOOL');
+COMMIT;
+""")
+
+        when:
+        def outputFileName = 'test/test-classes/output.postgresql.sql'
+        CommandScope commandScope = new CommandScope(GenerateChangelogCommandStep.COMMAND_NAME)
+        commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.URL_ARG, db.getConnectionUrl())
+        commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.USERNAME_ARG, db.getUsername())
+        commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.PASSWORD_ARG, db.getPassword())
+        commandScope.addArgumentValue(GenerateChangelogCommandStep.OVERWRITE_OUTPUT_FILE_ARG, true)
+        commandScope.addArgumentValue(GenerateChangelogCommandStep.CHANGELOG_FILE_ARG, outputFileName)
+        commandScope.addArgumentValue(PreCompareCommandStep.DIFF_TYPES_ARG, "data")
+        commandScope.addArgumentValue(DiffOutputControlCommandStep.INCLUDE_SCHEMA_ARG, true)
+        commandScope.addArgumentValue(DiffOutputControlCommandStep.INCLUDE_OBJECTS, "table:TEST, column:(?!foo\$).*") // skip only 'foo'
+        OutputStream outputStream = new ByteArrayOutputStream()
+        commandScope.setOutput(outputStream)
+        commandScope.execute()
+
+        then:
+        def outputFile = new File(outputFileName)
+        def contents = FileUtil.getContents(outputFile)
+        contents.contains("""
+INSERT INTO "public"."TEST" ("afoo", "bfoo", "fool") VALUES ('AFOO', 'BFOO', 'FOOL');
+"""
+)
+
+        when:
+        CommandUtil.runDropAll(db)
+
+        then:
+        noExceptionThrown()
+
+        cleanup:
+        CommandUtil.runDropAll(db)
+        outputFile.delete()
+    }
+
+    def "Should export database table TEST by applying excludeObjects filter"() {
+        given:
+        db.executeSql("""
+CREATE TABLE "TEST" (
+    AFOO VARCHAR(4),
+    BFOO VARCHAR(4),
+    FOO  VARCHAR(4),
+    FOOL VARCHAR(4)
+);
+INSERT INTO "TEST" (AFOO, BFOO, FOO, FOOL) VALUES ('AFOO', 'BFOO', 'FOO', 'FOOL');
+COMMIT;
+""")
+
+        when:
+        def outputFileName = 'test/test-classes/output.postgresql.sql'
+        CommandScope commandScope = new CommandScope(GenerateChangelogCommandStep.COMMAND_NAME)
+        commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.URL_ARG, db.getConnectionUrl())
+        commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.USERNAME_ARG, db.getUsername())
+        commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.PASSWORD_ARG, db.getPassword())
+        commandScope.addArgumentValue(GenerateChangelogCommandStep.OVERWRITE_OUTPUT_FILE_ARG, true)
+        commandScope.addArgumentValue(GenerateChangelogCommandStep.CHANGELOG_FILE_ARG, outputFileName)
+        commandScope.addArgumentValue(PreCompareCommandStep.DIFF_TYPES_ARG, "data")
+        commandScope.addArgumentValue(DiffOutputControlCommandStep.INCLUDE_SCHEMA_ARG, true)
+        commandScope.addArgumentValue(DiffOutputControlCommandStep.EXCLUDE_OBJECTS, 'column:.foo$') // skip 'afoo' and 'bfoo'
+        OutputStream outputStream = new ByteArrayOutputStream()
+        commandScope.setOutput(outputStream)
+        commandScope.execute()
+
+        then:
+        def outputFile = new File(outputFileName)
+        def contents = FileUtil.getContents(outputFile)
+        contents.contains("""
+INSERT INTO "public"."TEST" ("foo", "fool") VALUES ('FOO', 'FOOL');
+"""
+        )
+
+        when:
+        CommandUtil.runDropAll(db)
+
+        then:
+        noExceptionThrown()
+
+        cleanup:
+        CommandUtil.runDropAll(db)
+        outputFile.delete()
+    }
+}

--- a/liquibase-standard/src/main/java/liquibase/command/core/DiffToChangeLogCommand.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/DiffToChangeLogCommand.java
@@ -69,6 +69,8 @@ public class DiffToChangeLogCommand extends DiffCommand {
 
         commandScope.addArgumentValue(DiffChangelogCommandStep.CHANGELOG_FILE_ARG, getChangeLogFile());
         commandScope.addArgumentValue(DiffOutputControlCommandStep.INCLUDE_SCHEMA_ARG, getDiffOutputControl().getIncludeSchema());
+        commandScope.addArgumentValue(DiffOutputControlCommandStep.EXCLUDE_OBJECTS, getDiffOutputControl().getExcludeObjects());
+        commandScope.addArgumentValue(DiffOutputControlCommandStep.INCLUDE_OBJECTS, getDiffOutputControl().getIncludeObjects());
         commandScope.addArgumentValue(DiffOutputControlCommandStep.INCLUDE_CATALOG_ARG, getDiffOutputControl().getIncludeCatalog());
         commandScope.addArgumentValue(DiffOutputControlCommandStep.INCLUDE_TABLESPACE_ARG, getDiffOutputControl().getIncludeTablespace());
 

--- a/liquibase-standard/src/main/java/liquibase/command/core/GenerateChangeLogCommand.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/GenerateChangeLogCommand.java
@@ -57,6 +57,8 @@ public class GenerateChangeLogCommand extends DiffToChangeLogCommand {
         commandScope.addArgumentValue(DiffOutputControlCommandStep.INCLUDE_SCHEMA_ARG, getDiffOutputControl().getIncludeSchema());
         commandScope.addArgumentValue(DiffOutputControlCommandStep.INCLUDE_CATALOG_ARG, getDiffOutputControl().getIncludeCatalog());
         commandScope.addArgumentValue(DiffOutputControlCommandStep.INCLUDE_TABLESPACE_ARG, getDiffOutputControl().getIncludeTablespace());
+        commandScope.addArgumentValue(DiffOutputControlCommandStep.EXCLUDE_OBJECTS, getDiffOutputControl().getExcludeObjects());
+        commandScope.addArgumentValue(DiffOutputControlCommandStep.INCLUDE_OBJECTS, getDiffOutputControl().getIncludeObjects());
 
         commandScope.addArgumentValue(GenerateChangelogCommandStep.AUTHOR_ARG, getAuthor());
         commandScope.addArgumentValue(GenerateChangelogCommandStep.CONTEXT_ARG, getContext());

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/DiffOutputControlCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/DiffOutputControlCommandStep.java
@@ -21,6 +21,9 @@ public class DiffOutputControlCommandStep extends AbstractHelperCommandStep {
     public static final CommandArgumentDefinition<Boolean> INCLUDE_SCHEMA_ARG;
     public static final CommandArgumentDefinition<Boolean> INCLUDE_TABLESPACE_ARG;
 
+    public static final CommandArgumentDefinition<String> EXCLUDE_OBJECTS;
+    public static final CommandArgumentDefinition<String> INCLUDE_OBJECTS;
+
     public static final CommandResultDefinition<DiffOutputControl> DIFF_OUTPUT_CONTROL;
 
 
@@ -32,6 +35,11 @@ public class DiffOutputControlCommandStep extends AbstractHelperCommandStep {
                 .description("If true, the schema will be included in generated changeSets. Defaults to false.").build();
         INCLUDE_TABLESPACE_ARG = builder.argument("includeTablespace", Boolean.class).defaultValue(false)
                 .description("Include the tablespace attribute in the changelog. Defaults to false.").build();
+
+        EXCLUDE_OBJECTS = builder.argument("excludeObjects", String.class).defaultValue(null)
+                .description("Regular expression of columns to exclude. Defaults to null.").build();
+        INCLUDE_OBJECTS = builder.argument("includeObjects", String.class).defaultValue(null)
+                .description("Regular expression of columns to include. Defaults to null.").build();
 
         DIFF_OUTPUT_CONTROL = builder.result("diffOutputControl", DiffOutputControl.class).build();
     }
@@ -73,6 +81,8 @@ public class DiffOutputControlCommandStep extends AbstractHelperCommandStep {
         DiffOutputControl diffOutputControl = new DiffOutputControl(
                 includeCatalog, includeSchema,
                 includeTablespace, compareControl.getSchemaComparisons());
+        diffOutputControl.setExcludeObjects(commandScope.getArgumentValue(EXCLUDE_OBJECTS));
+        diffOutputControl.setIncludeObjects(commandScope.getArgumentValue(INCLUDE_OBJECTS));
         for (CompareControl.SchemaComparison schema : compareControl.getSchemaComparisons()) {
             diffOutputControl.addIncludedSchema(schema.getReferenceSchema());
             diffOutputControl.addIncludedSchema(schema.getComparisonSchema());

--- a/liquibase-standard/src/main/java/liquibase/diff/output/DiffOutputControl.java
+++ b/liquibase-standard/src/main/java/liquibase/diff/output/DiffOutputControl.java
@@ -32,6 +32,13 @@ public class DiffOutputControl {
     @Setter
     private boolean isReplaceIfExistsSet = false;
 
+    @Getter
+    @Setter
+    private String excludeObjects;
+    @Getter
+    @Setter
+    private String includeObjects;
+
     private CompareControl.SchemaComparison[] schemaComparisons;
 
     private final DatabaseObjectCollection alreadyHandledMissing= new DatabaseObjectCollection(new DatabaseForHash());

--- a/liquibase-standard/src/main/java/liquibase/integration/commandline/CommandLineUtils.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/commandline/CommandLineUtils.java
@@ -257,6 +257,8 @@ public class CommandLineUtils {
                 .addArgumentValue(DiffOutputControlCommandStep.INCLUDE_CATALOG_ARG, diffOutputControl.getIncludeCatalog())
                 .addArgumentValue(DiffOutputControlCommandStep.INCLUDE_SCHEMA_ARG, diffOutputControl.getIncludeSchema())
                 .addArgumentValue(DiffOutputControlCommandStep.INCLUDE_TABLESPACE_ARG, diffOutputControl.getIncludeTablespace())
+                .addArgumentValue(DiffOutputControlCommandStep.EXCLUDE_OBJECTS, diffOutputControl.getExcludeObjects())
+                .addArgumentValue(DiffOutputControlCommandStep.INCLUDE_OBJECTS, diffOutputControl.getIncludeObjects())
                 .addArgumentValue(DiffChangelogCommandStep.AUTHOR_ARG, author)
                 .addArgumentValue(DiffChangelogCommandStep.RUN_ON_CHANGE_TYPES_ARG, runOnChangeTypes)
                 .addArgumentValue(DiffChangelogCommandStep.REPLACE_IF_EXISTS_TYPES_ARG, replaceIfExistsTypes);
@@ -345,6 +347,8 @@ public class CommandLineUtils {
                 .addArgumentValue(DiffOutputControlCommandStep.INCLUDE_CATALOG_ARG, diffOutputControl.getIncludeCatalog())
                 .addArgumentValue(DiffOutputControlCommandStep.INCLUDE_SCHEMA_ARG, diffOutputControl.getIncludeSchema())
                 .addArgumentValue(DiffOutputControlCommandStep.INCLUDE_TABLESPACE_ARG, diffOutputControl.getIncludeTablespace())
+                .addArgumentValue(DiffOutputControlCommandStep.EXCLUDE_OBJECTS, diffOutputControl.getExcludeObjects())
+                .addArgumentValue(DiffOutputControlCommandStep.INCLUDE_OBJECTS, diffOutputControl.getIncludeObjects())
                 .addArgumentValue(GenerateChangelogCommandStep.AUTHOR_ARG, author)
                 .addArgumentValue(GenerateChangelogCommandStep.CONTEXT_ARG, context)
                 .addArgumentValue(GenerateChangelogCommandStep.OVERWRITE_OUTPUT_FILE_ARG, overwriteOutputFile)
@@ -352,7 +356,7 @@ public class CommandLineUtils {
                 .addArgumentValue(GenerateChangelogCommandStep.REPLACE_IF_EXISTS_TYPES_ARG, replaceIfExistsTypes);
 
 
-        if(diffOutputControl.isReplaceIfExistsSet()) {
+        if (diffOutputControl.isReplaceIfExistsSet()) {
             command.addArgumentValue(GenerateChangelogCommandStep.USE_OR_REPLACE_OPTION, true);
         }
         command.setOutput(System.out);

--- a/liquibase-standard/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/commandline/Main.java
@@ -1753,6 +1753,8 @@ public class Main {
                 .addArgumentValue(DiffOutputControlCommandStep.INCLUDE_CATALOG_ARG, includeCatalog)
                 .addArgumentValue(DiffOutputControlCommandStep.INCLUDE_SCHEMA_ARG, includeSchema)
                 .addArgumentValue(DiffOutputControlCommandStep.INCLUDE_TABLESPACE_ARG, includeTablespace)
+                .addArgumentValue(DiffOutputControlCommandStep.EXCLUDE_OBJECTS, excludeObjects)
+                .addArgumentValue(DiffOutputControlCommandStep.INCLUDE_OBJECTS, includeObjects)
                 .addArgumentValue(GenerateChangelogCommandStep.AUTHOR_ARG, StringUtil.trimToNull(changeSetAuthor))
                 .addArgumentValue(GenerateChangelogCommandStep.CONTEXT_ARG, StringUtil.trimToNull(changeSetContext))
                 .addArgumentValue(GenerateChangelogCommandStep.DATA_OUTPUT_DIR_ARG, StringUtil.trimToNull(dataOutputDirectory))
@@ -1769,6 +1771,8 @@ public class Main {
                 .addArgumentValue(DiffOutputControlCommandStep.INCLUDE_CATALOG_ARG, includeCatalog)
                 .addArgumentValue(DiffOutputControlCommandStep.INCLUDE_SCHEMA_ARG, includeSchema)
                 .addArgumentValue(DiffOutputControlCommandStep.INCLUDE_TABLESPACE_ARG, includeTablespace)
+                .addArgumentValue(DiffOutputControlCommandStep.EXCLUDE_OBJECTS, excludeObjects)
+                .addArgumentValue(DiffOutputControlCommandStep.INCLUDE_OBJECTS, includeObjects)
                 .addArgumentValue(DiffChangelogCommandStep.AUTHOR_ARG, StringUtil.trimToNull(changeSetAuthor))
                 .setOutput(getOutputStream());
 


### PR DESCRIPTION
Both variants are supported: either includeObjects or excludeObjects.

The columns are taken from "column:PATTERN" or, if both "table:" and "column:" are missing, then the entire includeObjects / excludeObjects is used to match the columns to export.

If neither includeObjects nor excludeObjects are provided, all columns are considered, which is the default case.  This corresponds to todays situation.

This PR addresses issues #3310 and #6310 - ey, exactly 3'000 issues apart.

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

This PR enhaces the generate-changelog for "data" export.
The current behaviour is to include all columns for this scenario.
This scenario is still support, so long no speficic "column:PATTERN" is provided in `--include-objects` or `--exclude-objects`.

However, sometimes an export must be provided that skip some columns.
In that case, you may want to express it via "column:PATTERN" in either the `--include-objects` or `--excludeObjects`.

This PR supports both cases, see the extra test case.

## Things to be aware of

This PR was tested against H2, PostgreSQL and Oracle.
