### PR TITLE
Do not check for nested database objects when using foreignKeyConstraintExists precondition (DAT-18624)

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/precondition/core/ForeignKeyExistsPrecondition.java
+++ b/liquibase-standard/src/main/java/liquibase/precondition/core/ForeignKeyExistsPrecondition.java
@@ -13,7 +13,6 @@ import liquibase.snapshot.SnapshotGeneratorFactory;
 import liquibase.structure.core.ForeignKey;
 import liquibase.structure.core.Schema;
 import liquibase.structure.core.Table;
-import liquibase.util.StringUtil;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
@@ -54,7 +53,7 @@ public class ForeignKeyExistsPrecondition extends AbstractPrecondition {
             String schemaName = getSchemaName() != null ? getSchemaName() : database.getDefaultSchemaName();
             example.getForeignKeyTable().setSchema(new Schema(catalogName, schemaName));
 
-            if (!SnapshotGeneratorFactory.getInstance().has(example, database, false)) {
+            if (!SnapshotGeneratorFactory.getInstance().hasIgnoreNested(example, database)) {
                 throw new PreconditionFailedException("Foreign Key " +
                     database.escapeIndexName(catalogName, schemaName, foreignKeyName) + " does not exist",
                     changeLog,

--- a/liquibase-standard/src/main/java/liquibase/precondition/core/ForeignKeyExistsPrecondition.java
+++ b/liquibase-standard/src/main/java/liquibase/precondition/core/ForeignKeyExistsPrecondition.java
@@ -50,7 +50,9 @@ public class ForeignKeyExistsPrecondition extends AbstractPrecondition {
             if (StringUtils.trimToNull(getForeignKeyTableName()) != null) {
                 example.getForeignKeyTable().setName(getForeignKeyTableName());
             }
-            example.getForeignKeyTable().setSchema(new Schema(getCatalogName(), getSchemaName()));
+            String catalogName = getCatalogName() != null ? getCatalogName() : database.getDefaultCatalogName();
+            String schemaName = getSchemaName() != null ? getSchemaName() : database.getDefaultSchemaName();
+            example.getForeignKeyTable().setSchema(new Schema(catalogName, schemaName));
 
             if (!SnapshotGeneratorFactory.getInstance().has(example, database, false)) {
                 throw new PreconditionFailedException("Foreign Key " +

--- a/liquibase-standard/src/main/java/liquibase/precondition/core/ForeignKeyExistsPrecondition.java
+++ b/liquibase-standard/src/main/java/liquibase/precondition/core/ForeignKeyExistsPrecondition.java
@@ -14,7 +14,12 @@ import liquibase.structure.core.ForeignKey;
 import liquibase.structure.core.Schema;
 import liquibase.structure.core.Table;
 import liquibase.util.StringUtil;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
 
+@Setter
+@Getter
 public class ForeignKeyExistsPrecondition extends AbstractPrecondition {
     private String catalogName;
     private String schemaName;
@@ -24,38 +29,6 @@ public class ForeignKeyExistsPrecondition extends AbstractPrecondition {
     @Override
     public String getSerializedObjectNamespace() {
         return STANDARD_CHANGELOG_NAMESPACE;
-    }
-
-    public String getCatalogName() {
-        return catalogName;
-    }
-
-    public void setCatalogName(String catalogName) {
-        this.catalogName = catalogName;
-    }
-
-    public String getSchemaName() {
-        return schemaName;
-    }
-
-    public void setSchemaName(String schemaName) {
-        this.schemaName = schemaName;
-    }
-
-    public String getForeignKeyTableName() {
-        return foreignKeyTableName;
-    }
-
-    public void setForeignKeyTableName(String foreignKeyTableName) {
-        this.foreignKeyTableName = foreignKeyTableName;
-    }
-
-    public String getForeignKeyName() {
-        return foreignKeyName;
-    }
-
-    public void setForeignKeyName(String foreignKeyName) {
-        this.foreignKeyName = foreignKeyName;
     }
 
     @Override
@@ -74,12 +47,12 @@ public class ForeignKeyExistsPrecondition extends AbstractPrecondition {
             ForeignKey example = new ForeignKey();
             example.setName(getForeignKeyName());
             example.setForeignKeyTable(new Table());
-            if (StringUtil.trimToNull(getForeignKeyTableName()) != null) {
+            if (StringUtils.trimToNull(getForeignKeyTableName()) != null) {
                 example.getForeignKeyTable().setName(getForeignKeyTableName());
             }
             example.getForeignKeyTable().setSchema(new Schema(getCatalogName(), getSchemaName()));
 
-            if (!SnapshotGeneratorFactory.getInstance().has(example, database)) {
+            if (!SnapshotGeneratorFactory.getInstance().has(example, database, false)) {
                 throw new PreconditionFailedException("Foreign Key " +
                     database.escapeIndexName(catalogName, schemaName, foreignKeyName) + " does not exist",
                     changeLog,

--- a/liquibase-standard/src/main/java/liquibase/snapshot/DatabaseSnapshot.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/DatabaseSnapshot.java
@@ -22,6 +22,8 @@ import liquibase.util.BooleanUtil;
 import liquibase.util.ISODateFormat;
 import liquibase.util.ObjectUtil;
 import liquibase.util.StringUtil;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.sql.Timestamp;
 import java.util.*;
@@ -44,8 +46,12 @@ public abstract class DatabaseSnapshot implements LiquibaseSerializable {
     private final Map<String, Object> snapshotScratchPad = new ConcurrentHashMap<>();
 
     private final Map<String, ResultSetCache> resultSetCaches = new ConcurrentHashMap<>();
+    @Setter
+    @Getter
     private CompareControl.SchemaComparison[] schemaComparisons;
 
+    @Setter
+    @Getter
     private Map<String, Object> metadata = new ConcurrentHashMap<>();
 
     DatabaseSnapshot(DatabaseObject[] examples, Database database, SnapshotControl snapshotControl) throws DatabaseException, InvalidExampleException {
@@ -326,11 +332,12 @@ public abstract class DatabaseSnapshot implements LiquibaseSerializable {
 
         } else {
             allFound.add(object);
-
-            try {
-                includeNestedObjects(object);
-            } catch (ReflectiveOperationException e) {
-                throw new UnexpectedLiquibaseException(e);
+            if (snapshotControl.shouldSearchNestedObjects()) {
+                try {
+                    includeNestedObjects(object);
+                } catch (ReflectiveOperationException e) {
+                    throw new UnexpectedLiquibaseException(e);
+                }
             }
         }
 
@@ -692,21 +699,5 @@ public abstract class DatabaseSnapshot implements LiquibaseSerializable {
 
     public Object setScratchData(String key, Object data) {
         return snapshotScratchPad.put(key, data);
-    }
-
-    public CompareControl.SchemaComparison[] getSchemaComparisons() {
-        return schemaComparisons;
-    }
-
-    public void setSchemaComparisons(CompareControl.SchemaComparison[] schemaComparisons) {
-        this.schemaComparisons = schemaComparisons;
-    }
-
-    public Map<String, Object> getMetadata() {
-        return metadata;
-    }
-
-    public void setMetadata(Map<String, Object> metadata) {
-        this.metadata = metadata;
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotControl.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotControl.java
@@ -11,6 +11,8 @@ import liquibase.serializer.LiquibaseSerializable;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.Catalog;
 import liquibase.structure.core.DatabaseObjectFactory;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.util.*;
 import java.util.stream.Stream;
@@ -25,6 +27,8 @@ public class SnapshotControl implements LiquibaseSerializable {
     private ObjectChangeFilter objectChangeFilter;
     private SnapshotListener snapshotListener;
     private boolean warnIfObjectNotFound = true;
+    @Setter
+    private boolean searchNestedObjects = true;
     
     
     /**
@@ -184,6 +188,15 @@ public class SnapshotControl implements LiquibaseSerializable {
      */
     public boolean isWarnIfObjectNotFound() {
         return warnIfObjectNotFound;
+    }
+
+    /**
+     * When searchNestedObjects is false this indicates to stop searching the snapshot the moment
+     * an example object has been found. With this disabled we will not search for nested objects.
+     * @return the search nested objects configuration
+     */
+    public boolean shouldSearchNestedObjects() {
+        return searchNestedObjects;
     }
     
     /**

--- a/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotGeneratorFactory.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotGeneratorFactory.java
@@ -87,70 +87,74 @@ public class SnapshotGeneratorFactory {
     }
 
     /**
-     * Checks if a specific object is present in a database
-     * @param example The DatabaseObject to check for existence
-     * @param database The DBMS in which the object might exist
-     * @return true if object existence can be confirmed, false otherwise
-     * @throws DatabaseException If a problem occurs in the DBMS-specific code
-     * @throws InvalidExampleException If the object cannot be checked properly, e.g. if the object name is ambiguous
+     * Initialize the types to use for the snapshot
+     *
+     * @param example the example object to search for
+     * @param database the database to snapshot
+     * @return the Database Object types to search for
      */
-    public boolean has(DatabaseObject example, Database database) throws DatabaseException, InvalidExampleException {
-        // @todo I have seen duplicates in types - maybe convert the List into a Set? Need to understand it more thoroughly.
-        List<Class<? extends DatabaseObject>> types = new ArrayList<>(getContainerTypes(example.getClass(), database));
+    private Set<Class<? extends DatabaseObject>> initializeSnapshotTypes(DatabaseObject example, Database database) {
+        Set<Class<? extends DatabaseObject>> types = new HashSet<>(getContainerTypes(example.getClass(), database));
         types.add(example.getClass());
+        return types;
+    }
 
-        /*
-         * Does the query concern the DATABASECHANGELOG / DATABASECHANGELOGLOCK table? If so, we do a quick & dirty
-         * SELECT COUNT(*) on that table. If that works, we count that as confirmation of existence.
-         */
-        // @todo Actually, there may be extreme cases (distorted table statistics etc.) where a COUNT(*) might not be so cheap. Maybe SELECT a dummy constant is the better way?
-        LiquibaseTableNamesFactory liquibaseTableNamesFactory = Scope.getCurrentScope().getSingleton(LiquibaseTableNamesFactory.class);
-        List<String> liquibaseTableNames = liquibaseTableNamesFactory.getLiquibaseTableNames(database);
-        if ((example instanceof Table) && (liquibaseTableNames.stream().anyMatch(tableName -> example.getName().equals(tableName)))) {
+    /**
+     * Check if the example object is a liquibase managed table
+     *
+     * @param example the database object to search for
+     * @param database the database to search
+     * @param liquibaseTableNames the list of liquibase table names
+     * @return true if the table exists, false otherwise
+     * @throws DatabaseException if there was an exception encountered when rolling back the postgres database
+     */
+    private boolean checkLiquibaseTablesExistence(DatabaseObject example, Database database, List<String> liquibaseTableNames) throws DatabaseException {
+        if (example instanceof Table && liquibaseTableNames.contains(example.getName())) {
             try {
-                //
-                // Handle MariaDB differently to avoid the
-                // Error: 1146-42S02: Table 'intuser_db.DATABASECHANGELOGLOCK' doesn't exist
-                //
                 if (database instanceof MariaDBDatabase) {
+                    // Handle MariaDB differently to avoid the
+                    // Error: 1146-42S02: Table 'intuser_db.DATABASECHANGELOGLOCK' doesn't exist
                     String sql = "select table_name from information_schema.TABLES where TABLE_SCHEMA = ? and TABLE_NAME = ?;";
                     List<Map<String, ?>> res = Scope.getCurrentScope().getSingleton(ExecutorService.class)
                             .getExecutor("jdbc", database)
                             .queryForList(new RawParameterizedSqlStatement(sql, database.getLiquibaseCatalogName(), example.getName()));
                     return !res.isEmpty();
                 }
+                // Does the query concern the DATABASECHANGELOG / DATABASECHANGELOGLOCK table? If so, we do a quick & dirty
+                // SELECT COUNT(*) on that table. If that works, we count that as confirmation of existence.
+                // @todo Actually, there may be extreme cases (distorted table statistics etc.) where a COUNT(*) might not be so cheap. Maybe SELECT a dummy constant is the better way?
                 Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database).queryForInt(
-                    new RawParameterizedSqlStatement(String.format("SELECT COUNT(*) FROM %s",
-                        database.escapeObjectName(database.getLiquibaseCatalogName(),
-                        database.getLiquibaseSchemaName(), example.getName(), Table.class))));
+                        new RawParameterizedSqlStatement(String.format("SELECT COUNT(*) FROM %s",
+                                database.escapeObjectName(database.getLiquibaseCatalogName(),
+                                        database.getLiquibaseSchemaName(), example.getName(), Table.class))));
                 return true;
             } catch (DatabaseException e) {
-                if (database instanceof PostgresDatabase) { // throws "current transaction is aborted" unless we roll back the connection
-                    database.rollback();
+                if (database instanceof PostgresDatabase) {
+                    database.rollback(); // throws "current transaction is aborted" unless we roll back the connection
                 }
                 return false;
             }
         }
+        return false;
+    }
 
-        /*
-          * If the query is about another object, try to create a snapshot of the of the object (or used the cached
-          * snapshot. If that works, we count that as confirmation of existence.
-          */
-
-        SnapshotControl snapshotControl = (new SnapshotControl(database, false, types.toArray(new Class[0])));
-        snapshotControl.setWarnIfObjectNotFound(false);
-
-        if (createSnapshot(example, database,snapshotControl) != null) {
+    /**
+     * Create and search the database snapshot for the example object.
+     *
+     * @param example The DatabaseObject to check for existence
+     * @param database The DBMS in which the object might exist
+     * @param snapshotControl the snapshot configuration to use
+     * @return true if the example object exists, false otherwise
+     * @throws DatabaseException if there was a problem searching the DBMS
+     * @throws InvalidExampleException if provided an invalid example DatabaseObject
+     */
+    private boolean createAndCheckSnapshot(DatabaseObject example, Database database, SnapshotControl snapshotControl) throws DatabaseException, InvalidExampleException {
+        if (createSnapshot(example, database, snapshotControl) != null) {
             return true;
         }
-        CatalogAndSchema catalogAndSchema;
-        if (example.getSchema() == null) {
-            catalogAndSchema = database.getDefaultSchema();
-        } else {
-            catalogAndSchema = example.getSchema().toCatalogAndSchema();
-        }
+        CatalogAndSchema catalogAndSchema = example.getSchema() == null ? database.getDefaultSchema() : example.getSchema().toCatalogAndSchema();
         DatabaseSnapshot snapshot = createSnapshot(catalogAndSchema, database,
-            new SnapshotControl(database, false, example.getClass()).setWarnIfObjectNotFound(false)
+                new SnapshotControl(database, false, example.getClass()).setWarnIfObjectNotFound(false)
         );
 
         for (DatabaseObject obj : snapshot.get(example.getClass())) {
@@ -159,6 +163,59 @@ public class SnapshotGeneratorFactory {
             }
         }
         return false;
+    }
+
+    /**
+     * Checks if a specific object is present in a database
+     *
+     * @param example  The DatabaseObject to check for existence
+     * @param database The DBMS in which the object might exist
+     * @return true if object exists, false otherwise
+     * @throws DatabaseException       If a problem occurs in the DBMS-specific code
+     * @throws InvalidExampleException If the object cannot be checked properly, e.g. if the object name is ambiguous
+     */
+    public boolean has(DatabaseObject example, Database database) throws DatabaseException, InvalidExampleException {
+        return checkExistence(example, database, true);
+    }
+
+    /**
+     * Checks if a specific object is present in a database. Enable or disable searching nested objects.
+     *
+     * @param example  The DatabaseObject to check for existence
+     * @param database The DBMS in which the object might exist
+     * @param searchNestedObjects whether to search nested objects, if true this is equivalent to calling {@link SnapshotGeneratorFactory#has(DatabaseObject, Database)}
+     * @return true if object exists, false otherwise
+     * @throws DatabaseException       If a problem occurs in the DBMS-specific code
+     * @throws InvalidExampleException If the object cannot be checked properly, e.g. if the object name is ambiguous
+     */
+    public boolean has(DatabaseObject example, Database database, boolean searchNestedObjects) throws DatabaseException, InvalidExampleException {
+        return checkExistence(example, database, searchNestedObjects);
+    }
+
+    /**
+     * Common method to check if a specific object is present in a database
+     *
+     * @param example   The DatabaseObject to check for existence
+     * @param database  The DBMS in which the object might exist
+     * @param searchNestedObjects Whether to use fast check
+     * @return true if object existence can be confirmed, false otherwise
+     * @throws DatabaseException       If a problem occurs in the DBMS-specific code
+     * @throws InvalidExampleException If the object cannot be checked properly, e.g. if the object name is ambiguous
+     */
+    private boolean checkExistence(DatabaseObject example, Database database, boolean searchNestedObjects) throws DatabaseException, InvalidExampleException {
+        Set<Class<? extends DatabaseObject>> types = initializeSnapshotTypes(example, database);
+        LiquibaseTableNamesFactory liquibaseTableNamesFactory = Scope.getCurrentScope().getSingleton(LiquibaseTableNamesFactory.class);
+        List<String> liquibaseTableNames = liquibaseTableNamesFactory.getLiquibaseTableNames(database);
+
+        if (checkLiquibaseTablesExistence(example, database, liquibaseTableNames)) {
+            return true;
+        }
+
+        SnapshotControl snapshotControl = new SnapshotControl(database, false, types.toArray(new Class[0]));
+        snapshotControl.setWarnIfObjectNotFound(false);
+        snapshotControl.setSearchNestedObjects(searchNestedObjects);
+
+        return createAndCheckSnapshot(example, database, snapshotControl);
     }
 
     public DatabaseSnapshot createSnapshot(CatalogAndSchema example, Database database, SnapshotControl snapshotControl) throws DatabaseException, InvalidExampleException {

--- a/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotGeneratorFactory.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotGeneratorFactory.java
@@ -179,17 +179,17 @@ public class SnapshotGeneratorFactory {
     }
 
     /**
-     * Checks if a specific object is present in a database. Enable or disable searching nested objects.
+     * Checks if a specific object is present in a database. When using this method the database snapshot will
+     * NOT search through nested objects.
      *
      * @param example  The DatabaseObject to check for existence
      * @param database The DBMS in which the object might exist
-     * @param searchNestedObjects whether to search nested objects, if true this is equivalent to calling {@link SnapshotGeneratorFactory#has(DatabaseObject, Database)}
      * @return true if object exists, false otherwise
      * @throws DatabaseException       If a problem occurs in the DBMS-specific code
      * @throws InvalidExampleException If the object cannot be checked properly, e.g. if the object name is ambiguous
      */
-    public boolean has(DatabaseObject example, Database database, boolean searchNestedObjects) throws DatabaseException, InvalidExampleException {
-        return checkExistence(example, database, searchNestedObjects);
+    public boolean hasIgnoreNested(DatabaseObject example, Database database) throws DatabaseException, InvalidExampleException {
+        return checkExistence(example, database, false);
     }
 
     /**

--- a/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotGeneratorFactory.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotGeneratorFactory.java
@@ -153,10 +153,10 @@ public class SnapshotGeneratorFactory {
             return true;
         }
         CatalogAndSchema catalogAndSchema = example.getSchema() == null ? database.getDefaultSchema() : example.getSchema().toCatalogAndSchema();
-        DatabaseSnapshot snapshot = createSnapshot(catalogAndSchema, database,
-                new SnapshotControl(database, false, example.getClass()).setWarnIfObjectNotFound(false)
-        );
-
+        SnapshotControl replacedSnapshotControl = new SnapshotControl(database, false, example.getClass());
+        replacedSnapshotControl.setWarnIfObjectNotFound(false);
+        replacedSnapshotControl.setSearchNestedObjects(snapshotControl.shouldSearchNestedObjects());
+        DatabaseSnapshot snapshot = createSnapshot(catalogAndSchema, database, snapshotControl);
         for (DatabaseObject obj : snapshot.get(example.getClass())) {
             if (DatabaseObjectComparatorFactory.getInstance().isSameObject(example, obj, null, database)) {
                 return true;


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description
When using a foreignKeyConstraintExists precondition do not check for nested database objects. 

Refactors SnapshotGeneratorFactory to allow for disabling the nested search behavior by introducing a new flag searchNestedObjects to SnapshotControl. Respect this flag in DatabaseSnapshot.
<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of
The changes to the catalog/schema setup in `ForeignKeyExistsPrecondition` were necessary to fix Oracle integration tests. In the case of Oracle the schema was not found immediately, was set up to use `DEFAULT.DEFAULT`, and we were forced to iterate through objects until we reached the `includeNestedObjects` and `replaceObject` methods in `DatabaseSnapshot`. Once we reached this point the foreign key table from the example databaseObject would be updated to use the proper schema/catalog (the default schema/catalog) and the foreign key would be found. With this change we do not need to enter into the `includeNestedObjects` method at all when searching for foreign keys.
<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about
This change in behavior impacts all supported dbms.
<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
