### PR TITLE
fix: top to bottom (globals first) changelog parameters search

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogParameters.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogParameters.java
@@ -14,6 +14,8 @@ import liquibase.structure.core.Schema;
 import liquibase.structure.core.Sequence;
 import liquibase.util.StringUtil;
 import lombok.Getter;
+import org.apache.commons.collections4.iterators.ReverseListIterator;
+import org.apache.commons.lang3.stream.Streams;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -29,7 +31,7 @@ import java.util.stream.Collectors;
  * <p>
  * Properties can be defined as "global" or "local". Global properties span all change logs.
  * A global setting configured in an included changelog is still available to all changesets
- * Local properties are  only available in the change log that they are defined in -- not even in changelogs "included" by the file that defines the property.
+ * Local properties are available in the change log that they are defined AND in included changelogs.
  */
 public class ChangeLogParameters {
 
@@ -307,34 +309,24 @@ public class ChangeLogParameters {
     }
 
     private ChangeLogParameter getChangelogParameter(String key, DatabaseChangeLog changeLog, Filter filter) {
-        List<ChangeLogParameter> localList = null;
         if (changeLog != null) {
             LiquibaseExecutionParameter executionParameter = LiquibaseExecutionParameter.findByName(key);
             if (executionParameter != null) {
                 return new ChangeLogParameter(executionParameter.name(), executionParameter.getValue(changeLog));
             }
-
-            localList = localParameters.get(getLocalKey(changeLog));
-            if (localList != null) {
-                localList = new ArrayList<>(localList); // make a copy as we don't want to reverse the original list
-                Collections.reverse(localList);
-            }
         }
 
-        for (List<ChangeLogParameter> paramList : Arrays.asList(globalParameters, localList)) {
-            if (paramList == null) {
-                continue;
-            }
-
-            for (ChangeLogParameter parameter : paramList) {
-                if (parameter.getKey().equalsIgnoreCase(key) && (filter == null || filter.matches(parameter))) {
-                    return parameter;
-                }
-            }
-
+        List<List<ChangeLogParameter>> parameters = new ArrayList<>();
+        for (DatabaseChangeLog cl = changeLog; cl != null; cl = cl.getParentChangeLog()) {
+            parameters.add(localParameters.get(getLocalKey(cl)));
         }
+        parameters.add(globalParameters);
 
-        return null;
+        return Streams.of(new ReverseListIterator<>(parameters))
+            .filter(Objects::nonNull)
+            .flatMap(List::stream)
+            .filter(parameter -> parameter.getKey().equalsIgnoreCase(key) && (filter == null || filter.matches(parameter)))
+            .findFirst().orElse(null);
     }
 
     /**

--- a/liquibase-standard/src/test/groovy/liquibase/parser/core/xml/XMLChangeLogSAXParser_RealFile_Test.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/parser/core/xml/XMLChangeLogSAXParser_RealFile_Test.groovy
@@ -393,7 +393,7 @@ class XMLChangeLogSAXParser_RealFile_Test extends Specification {
         changeLog.getChangeSets()[0].getLogicalFilePath() == "create_table_account_bank_enum.xml"
 
         and: "changeSet 2"
-        changeLog.getChangeSets()[1].getAuthor() == "Author2"
+        changeLog.getChangeSets()[1].getAuthor() == "unknown"
         changeLog.getChangeSets()[1].getId() == "createTable_financial_institution_enum"
         changeLog.getChangeSets()[1].getLogicalFilePath() == "create_table_financial_institution_enum.xml"
     }

--- a/liquibase-standard/src/test/resources/liquibase/parser/core/xml/localParameters/0000-BaseCreation.xml
+++ b/liquibase-standard/src/test/resources/liquibase/parser/core/xml/localParameters/0000-BaseCreation.xml
@@ -3,7 +3,11 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd" logicalFilePath="base.xml">
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+    <property name="table.schema" value="default" global="false"/>
+    <property name="table.name" value="default_table" global="false"/>
+    <property name="table.author" value="unknown" global="false"/>
 
     <changeSet author="${table.author}" logicalFilePath="create_table_${table.name}.xml"  id="createTable_${table.name}" >
         <createTable schemaName="${table.schema}" tableName="${table.name}">

--- a/liquibase-standard/src/test/resources/liquibase/parser/core/xml/localParameters/0001-account-bank-enum.xml
+++ b/liquibase-standard/src/test/resources/liquibase/parser/core/xml/localParameters/0001-account-bank-enum.xml
@@ -3,7 +3,7 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd" logicalFilePath="base.xml">
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
 
     <property name="table.schema" value="public" global="false"/>
     <property name="table.name" value="account_bank_enum" global="false"/>

--- a/liquibase-standard/src/test/resources/liquibase/parser/core/xml/localParameters/0002-financial-institution-enum.xml
+++ b/liquibase-standard/src/test/resources/liquibase/parser/core/xml/localParameters/0002-financial-institution-enum.xml
@@ -3,11 +3,10 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd" logicalFilePath="base.xml">
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
 
     <property name="table.schema" value="public" global="false"/>
     <property name="table.name" value="financial_institution_enum" global="false"/>
-    <property name="table.author" value="Author2" global="false"/>
 
     <include file="0000-BaseCreation.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/liquibase-standard/src/test/resources/liquibase/parser/core/xml/localParameters/changelog.xml
+++ b/liquibase-standard/src/test/resources/liquibase/parser/core/xml/localParameters/changelog.xml
@@ -7,5 +7,4 @@
     <include file="0001-account-bank-enum.xml" relativeToChangelogFile="true"/>
     <include file="0002-financial-institution-enum.xml" relativeToChangelogFile="true"/>
 
-
 </databaseChangeLog>


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

This PR fixes regression introduced in #4267 and #2656 making it possible to inherit local properties from included changelogs while keeping "first wins" behavior for property definitions. Property search starts from global properties and continues for local properties from root changelog down to the current.

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

It makes sense to check `globalProperties` first and then traverse changesets collecting local properties to list but I decided to collect local and global properties in single list and iterate in reverse order for simplicity.

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

Although it is considered as non-breaking change some expectations might be violated:
starting from v4.23.0 (#4267) local parameters behavior was changed to "last wins" making it possible to "inherit" properties in included changesets by assigning the same `logicalFilePath` for changesets.

**This is no longer possible** since properties in same `logicalFilePath` can't be changed once been set.

In order to inherit local properties they should be defined in distinct changesets as shown in the test changes.

cc @airon-assustadus

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

Some details provided in https://github.com/liquibase/liquibase/pull/4267#issuecomment-2380604946

<!--
Add any other context about the problem here.
-->
