### PR TITLE
Add pg_stat_statements and pg_stat_statements_info views to the list of system tables and views to prevent them from being dropped

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/database/core/PostgresDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/PostgresDatabase.java
@@ -76,7 +76,6 @@ public class PostgresDatabase extends AbstractJdbcDatabase {
         super.unmodifiableDataTypes.addAll(Arrays.asList("bool", "int4", "int8", "float4", "float8", "bigserial", "serial", "oid", "bytea", "date", "timestamptz", "text", "int2[]", "int4[]", "int8[]", "float4[]", "float8[]", "bool[]", "varchar[]", "text[]", "numeric[]"));
         super.unquotedObjectsAreUppercased = false;
 
-        // Fix for issue 1451
         systemTablesAndViews.add("pg_stat_statements");
         systemTablesAndViews.add("pg_stat_statements_info");
     }

--- a/liquibase-standard/src/main/java/liquibase/database/core/PostgresDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/PostgresDatabase.java
@@ -75,6 +75,10 @@ public class PostgresDatabase extends AbstractJdbcDatabase {
         super.sequenceCurrentValueFunction = "currval('%s')";
         super.unmodifiableDataTypes.addAll(Arrays.asList("bool", "int4", "int8", "float4", "float8", "bigserial", "serial", "oid", "bytea", "date", "timestamptz", "text", "int2[]", "int4[]", "int8[]", "float4[]", "float8[]", "bool[]", "varchar[]", "text[]", "numeric[]"));
         super.unquotedObjectsAreUppercased = false;
+
+        // Fix for issue 1451
+        systemTablesAndViews.add("pg_stat_statements");
+        systemTablesAndViews.add("pg_stat_statements_info");
     }
 
     @Override


### PR DESCRIPTION

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Two view names - pg_stat_statements and pg_stat_statements_info (contributed by the pg_stat_statements Postgres db extension) - have been added to the systemTablesAndViews list so that they are identified as system objects in the PostgresDatabase class and thus are not dropped during the execution of the drop-all command (system objects are excluded from the change sets produced as part of taking the database snapshot for the purpose of dropping database objects). Fixes #1451 

## Things to be aware of

None.

## Things to worry about

None.

## Additional Context

None.
