### PR TITLE
Revert "Remove unneeded inclusion of commons-io in liquibase-core pom.xml"

### DIFF
--- a/liquibase-core/pom.xml
+++ b/liquibase-core/pom.xml
@@ -63,6 +63,11 @@
             <artifactId>commons-lang3</artifactId>
             <version>${commons-lang3.version}</version>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${commons-io.version}</version>
+        </dependency>
 
     </dependencies>
 


### PR DESCRIPTION
Reverts liquibase/liquibase#6117

The original MR leads to issue #6369.