### PR TITLE
fix: restore public method in PreconditionFailedException

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/exception/PreconditionFailedException.java
+++ b/liquibase-standard/src/main/java/liquibase/exception/PreconditionFailedException.java
@@ -24,6 +24,16 @@ public class PreconditionFailedException extends Exception {
         this(new FailedPrecondition(message, changeLog, precondition), cause);
     }
 
+    /**
+     * @deprecated Use {@link #PreconditionFailedException(FailedPrecondition, Throwable)} instead
+     */
+    @Deprecated
+    public PreconditionFailedException(FailedPrecondition failedPrecondition) {
+        super("Preconditions Failed");
+        this.failedPreconditions = new ArrayList<>();
+        failedPreconditions.add(failedPrecondition);
+    }
+
     public PreconditionFailedException(FailedPrecondition failedPrecondition, Throwable cause) {
         super("Preconditions Failed", cause);
         this.failedPreconditions = new ArrayList<>();


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
Removal of this method is breaks extensions, such as https://github.com/liquibase/liquibase-neo4j/actions/runs/11139305021/job/30955764936 .

This method was changed by PR #6288 , so it's being restored as deprecated.
