### PR TITLE
[DRAFT] Enable selection of Checksum hashing algorithm

### DIFF
--- a/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineTest.groovy
+++ b/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineTest.groovy
@@ -109,6 +109,14 @@ Global Options
                                environment variable:
                                'LIQUIBASE_CHANGELOG_PARSE_MODE')
 
+      --checksum-algorithm=PARAM
+                             Changes the hashing algorithm that Liquibase uses
+                               to calculate checksums.
+                             DEFAULT: MD5
+                             (defaults file: 'liquibase.checksumAlgorithm',
+                               environment variable:
+                               'LIQUIBASE_CHECKSUM_ALGORITHM')
+
       --classpath=PARAM      Additional classpath entries to use
                              (defaults file: 'liquibase.classpath', environment
                                variable: 'LIQUIBASE_CLASSPATH')

--- a/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineThreadingTest.groovy
+++ b/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineThreadingTest.groovy
@@ -32,3 +32,5 @@ class LiquibaseCommandLineThreadingTest extends Specification {
     }
 
 }
+
+

--- a/liquibase-standard/src/main/java/liquibase/ChecksumVersion.java
+++ b/liquibase-standard/src/main/java/liquibase/ChecksumVersion.java
@@ -11,7 +11,8 @@ import java.util.Arrays;
 @Getter
 public enum ChecksumVersion {
 
-    V9(9, "Version used from Liquibase 4.22.0 till now", "4.22.0"),
+    V10(10, "Liquibase 5.0.0 supporting multiple checksum algorythims", "5.0.0"),
+    V9(9, "Version used from Liquibase 4.22.0 and remaining of 4.x series", "4.22.0"),
     V8(8, "Version used from Liquibase 3.5.0 until 4.21.1", "3.5.0"),
     V7(7, "Old version", "?"),
     V6(6, "Old version", "?"),

--- a/liquibase-standard/src/main/java/liquibase/ChecksumVersion.java
+++ b/liquibase-standard/src/main/java/liquibase/ChecksumVersion.java
@@ -11,8 +11,7 @@ import java.util.Arrays;
 @Getter
 public enum ChecksumVersion {
 
-    V10(10, "Liquibase 5.0.0 supporting multiple checksum algorythims", "5.0.0"),
-    V9(9, "Version used from Liquibase 4.22.0 and remaining of 4.x series", "4.22.0"),
+    V9(9, "Version used from Liquibase 4.22.0 till now", "4.22.0"),
     V8(8, "Version used from Liquibase 3.5.0 until 4.21.1", "3.5.0"),
     V7(7, "Old version", "?"),
     V6(6, "Old version", "?"),

--- a/liquibase-standard/src/main/java/liquibase/GlobalConfiguration.java
+++ b/liquibase-standard/src/main/java/liquibase/GlobalConfiguration.java
@@ -1,5 +1,6 @@
 package liquibase;
 
+import liquibase.checksums.ChecksumAlgorithm;
 import liquibase.command.core.DiffCommandStep;
 import liquibase.configuration.AutoloadedConfigurations;
 import liquibase.configuration.ConfigurationDefinition;
@@ -60,6 +61,8 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
 
     public static final ConfigurationDefinition<Boolean> PRESERVE_CLASSPATH_PREFIX_IN_NORMALIZED_PATHS;
     public static final ConfigurationDefinition<Boolean> ALLOW_INHERIT_LOGICAL_FILE_PATH;
+
+    public static final ConfigurationDefinition<ChecksumAlgorithm> CHECKSUM_ALGORITHM;
 
     static {
         ConfigurationDefinition.Builder builder = new ConfigurationDefinition.Builder("liquibase");
@@ -279,6 +282,11 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
         ALLOW_INHERIT_LOGICAL_FILE_PATH = builder.define("allowInheritLogicalFilePath", Boolean.class)
                 .setDescription("If true, included changelogs without an explicit logicalFilePath will inherit their parent changelog's logicalFilePath, and explicit logicalFilePath attributes on include statements are honored (Liquibase 4.31.0+ behavior). If false, included changelogs use their physical file paths, ignoring both implicit inheritance and explicit logicalFilePath attributes on include statements. Only logicalFilePath set directly on the changelog itself is respected. Defaults to true for backward compatibility.")
                 .setDefaultValue(true)
+                .build();
+
+        CHECKSUM_ALGORITHM = builder.define("checksumAlgorithm", ChecksumAlgorithm.class)
+                .setDescription("Changes the hashing algorithm that Liquibase uses to calculate checksums.")
+                .setDefaultValue(ChecksumAlgorithm.MD5)
                 .build();
     }
 

--- a/liquibase-standard/src/main/java/liquibase/Scope.java
+++ b/liquibase-standard/src/main/java/liquibase/Scope.java
@@ -74,6 +74,7 @@ public class Scope {
         osgiPlatform,
         checksumVersion,
         latestChecksumVersion,
+        checksumAlgorithm,
         /**
          * A <code>Map<String, String></code> of arguments/configuration properties used in the maven invocation of Liquibase.
          */
@@ -143,7 +144,8 @@ public class Scope {
             rootScope.values.put(Attr.logService.name(), new JavaLogService());
             rootScope.values.put(Attr.serviceLocator.name(), new StandardServiceLocator());
             rootScope.values.put(Attr.resourceAccessor.name(), new ClassLoaderResourceAccessor());
-            rootScope.values.put(Attr.latestChecksumVersion.name(), ChecksumVersion.V9);
+            rootScope.values.put(Attr.checksumAlgorithm.name(), GlobalConfiguration.CHECKSUM_ALGORITHM.getCurrentValue().getAlgorithm());
+            rootScope.values.put(Attr.latestChecksumVersion.name(), ChecksumVersion.V10);
             rootScope.values.put(Attr.checksumVersion.name(), ChecksumVersion.latest());
 
             rootScope.values.put(Attr.ui.name(), new ConsoleUIService());

--- a/liquibase-standard/src/main/java/liquibase/Scope.java
+++ b/liquibase-standard/src/main/java/liquibase/Scope.java
@@ -143,7 +143,7 @@ public class Scope {
             rootScope.values.put(Attr.logService.name(), new JavaLogService());
             rootScope.values.put(Attr.serviceLocator.name(), new StandardServiceLocator());
             rootScope.values.put(Attr.resourceAccessor.name(), new ClassLoaderResourceAccessor());
-            rootScope.values.put(Attr.latestChecksumVersion.name(), ChecksumVersion.V10);
+            rootScope.values.put(Attr.latestChecksumVersion.name(), ChecksumVersion.V9);
             rootScope.values.put(Attr.checksumVersion.name(), ChecksumVersion.latest());
 
             rootScope.values.put(Attr.ui.name(), new ConsoleUIService());

--- a/liquibase-standard/src/main/java/liquibase/Scope.java
+++ b/liquibase-standard/src/main/java/liquibase/Scope.java
@@ -74,6 +74,7 @@ public class Scope {
         osgiPlatform,
         checksumVersion,
         latestChecksumVersion,
+        checksumAlgorithm,
         /**
          * A <code>Map<String, String></code> of arguments/configuration properties used in the maven invocation of Liquibase.
          */
@@ -143,6 +144,7 @@ public class Scope {
             rootScope.values.put(Attr.logService.name(), new JavaLogService());
             rootScope.values.put(Attr.serviceLocator.name(), new StandardServiceLocator());
             rootScope.values.put(Attr.resourceAccessor.name(), new ClassLoaderResourceAccessor());
+            rootScope.values.put(Attr.checksumAlgorithm.name(), GlobalConfiguration.CHECKSUM_ALGORITHM.getCurrentValue().getAlgorithm());
             rootScope.values.put(Attr.latestChecksumVersion.name(), ChecksumVersion.V10);
             rootScope.values.put(Attr.checksumVersion.name(), ChecksumVersion.latest());
 

--- a/liquibase-standard/src/main/java/liquibase/Scope.java
+++ b/liquibase-standard/src/main/java/liquibase/Scope.java
@@ -74,7 +74,6 @@ public class Scope {
         osgiPlatform,
         checksumVersion,
         latestChecksumVersion,
-        checksumAlgorithm,
         /**
          * A <code>Map<String, String></code> of arguments/configuration properties used in the maven invocation of Liquibase.
          */
@@ -144,7 +143,6 @@ public class Scope {
             rootScope.values.put(Attr.logService.name(), new JavaLogService());
             rootScope.values.put(Attr.serviceLocator.name(), new StandardServiceLocator());
             rootScope.values.put(Attr.resourceAccessor.name(), new ClassLoaderResourceAccessor());
-            rootScope.values.put(Attr.checksumAlgorithm.name(), GlobalConfiguration.CHECKSUM_ALGORITHM.getCurrentValue().getAlgorithm());
             rootScope.values.put(Attr.latestChecksumVersion.name(), ChecksumVersion.V10);
             rootScope.values.put(Attr.checksumVersion.name(), ChecksumVersion.latest());
 

--- a/liquibase-standard/src/main/java/liquibase/change/CheckSum.java
+++ b/liquibase-standard/src/main/java/liquibase/change/CheckSum.java
@@ -1,8 +1,8 @@
 package liquibase.change;
 
-import liquibase.ChecksumVersion;
 import liquibase.Scope;
-import liquibase.util.MD5Util;
+import liquibase.ChecksumVersion;
+import liquibase.checksums.ComputeChecksumService;
 import liquibase.util.StringUtil;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -83,7 +83,7 @@ public final class CheckSum {
      * Compute a storedCheckSum of the given string.
      */
     public static CheckSum compute(String valueToChecksum) {
-        return new CheckSum(MD5Util.computeMD5(
+        return new CheckSum(ComputeChecksumService.getInstance().compute(
                 //remove "Unknown" unicode char 65533
                 Normalizer.normalize(StringUtil.standardizeLineEndings(valueToChecksum)
                         .replace("\uFFFD", ""), Normalizer.Form.NFC)
@@ -117,7 +117,7 @@ public final class CheckSum {
             };
         }
 
-        return new CheckSum(MD5Util.computeMD5(newStream), Scope.getCurrentScope().getChecksumVersion().getVersion());
+        return new CheckSum(ComputeChecksumService.getInstance().compute(newStream), Scope.getCurrentScope().getChecksumVersion().getVersion());
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/change/CheckSum.java
+++ b/liquibase-standard/src/main/java/liquibase/change/CheckSum.java
@@ -83,7 +83,7 @@ public final class CheckSum {
      * Compute a storedCheckSum of the given string.
      */
     public static CheckSum compute(String valueToChecksum) {
-        return new CheckSum(ComputeChecksumService.getInstance().compute(
+        return new CheckSum(ComputeChecksumService.compute(
                 //remove "Unknown" unicode char 65533
                 Normalizer.normalize(StringUtil.standardizeLineEndings(valueToChecksum)
                         .replace("\uFFFD", ""), Normalizer.Form.NFC)
@@ -117,7 +117,7 @@ public final class CheckSum {
             };
         }
 
-        return new CheckSum(ComputeChecksumService.getInstance().compute(newStream), Scope.getCurrentScope().getChecksumVersion().getVersion());
+        return new CheckSum(ComputeChecksumService.compute(newStream), Scope.getCurrentScope().getChecksumVersion().getVersion());
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryService.java
@@ -3,6 +3,7 @@ package liquibase.changelog;
 import liquibase.Beta;
 import liquibase.Contexts;
 import liquibase.LabelExpression;
+import liquibase.ChecksumVersion;
 import liquibase.Scope;
 import liquibase.database.Database;
 import liquibase.exception.DatabaseException;
@@ -88,11 +89,11 @@ public interface ChangeLogHistoryService extends Plugin {
     void generateDeploymentId();
 
     /**
-     *  This method should return true if all checksums in dbcl table have the same version as {@link liquibase.ChecksumVersion#latest().getVersion()}.
+     *  This method should return true if all checksums in dbcl table have the same version as {@link ChecksumVersion#latest().getVersion()}.
      *  This method is used by Update command family in order to know if there are old checksum versions in the database that should be updated or if it can proceed with fast checksum update process.
      *  IF your implementation does not validate dbcl table then return false.
      *
-     * @return false if we have checksums different from  {@link liquibase.ChecksumVersion#latest().getVersion()} in the dbcl table.
+     * @return false if we have checksums different from  {@link ChecksumVersion#latest().getVersion()} in the dbcl table.
      */
     boolean isDatabaseChecksumsCompatible();
 

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeSetStatus.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeSetStatus.java
@@ -5,7 +5,6 @@ import liquibase.change.CheckSum;
 import liquibase.changelog.filter.ChangeSetFilter;
 import liquibase.changelog.filter.ChangeSetFilterResult;
 import liquibase.exception.LiquibaseException;
-import liquibase.integration.commandline.LiquibaseCommandLineConfiguration;
 
 import java.util.Date;
 import java.util.Set;

--- a/liquibase-standard/src/main/java/liquibase/changelog/RanChangeSet.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/RanChangeSet.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.nio.file.Paths;
 import java.util.Date;
 
 /**

--- a/liquibase-standard/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
@@ -49,6 +49,8 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
     protected static final String LABELS_SIZE = "255";
     protected static final String CONTEXTS_SIZE = "255";
 
+    public static final String MD5_COLUMN_SIZE = "68";
+
     @Override
     public int getPriority() {
         return PRIORITY_DEFAULT;
@@ -130,6 +132,7 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
             boolean hasLiquibase = changeLogTable.getColumn("LIQUIBASE") != null;
             boolean hasContexts = changeLogTable.getColumn("CONTEXTS") != null;
             boolean hasLabels = changeLogTable.getColumn("LABELS") != null;
+            boolean hasSmallChecksum = changeLogTable.getColumn("MD5SUM").getType().getColumnSize() < Integer.parseInt(MD5_COLUMN_SIZE);
             boolean liquibaseColumnNotRightSize = false;
             if (!(this.getDatabase() instanceof SQLiteDatabase)) {
                 DataType type = changeLogTable.getColumn("LIQUIBASE").getType();
@@ -248,6 +251,19 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
                         getLiquibaseSchemaName(), getDatabaseChangeLogTableName()));
                 }
             }
+
+            if (hasSmallChecksum) {
+                executor.comment("Modifying size of databasechangelog.md5sum column");
+                statementsToExecute.add(new ModifyDataTypeStatement(getLiquibaseCatalogName(),
+                        getLiquibaseSchemaName(), getDatabaseChangeLogTableName(), "MD5SUM",
+                        charTypeName + "(" + MD5_COLUMN_SIZE + ")"));
+
+            }
+
+            SqlStatement databaseChangeLogStatement = new SelectFromDatabaseChangeLogStatement(
+                    new SelectFromDatabaseChangeLogStatement.ByCheckSumNotNullAndNotLike(ChecksumVersion.latest().getVersion()),
+                    new ColumnConfig().setName("MD5SUM"));
+            List<Map<String, ?>> md5sumRS = ChangelogJdbcMdcListener.query(getDatabase(), ex -> ex.queryForList(databaseChangeLogStatement));
 
             //check if any checksum is not using the current version
             databaseChecksumsCompatible = getIncompatibleDatabaseChangeLogs().isEmpty();

--- a/liquibase-standard/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
@@ -132,7 +132,7 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
             boolean hasLiquibase = changeLogTable.getColumn("LIQUIBASE") != null;
             boolean hasContexts = changeLogTable.getColumn("CONTEXTS") != null;
             boolean hasLabels = changeLogTable.getColumn("LABELS") != null;
-            boolean hasSmallChecksum = changeLogTable.getColumn("MD5SUM").getType().getColumnSize() < Integer.parseInt(MD5_COLUMN_SIZE);
+            boolean hasShortChecksum = changeLogTable.getColumn("MD5SUM").getType().getColumnSize() < Integer.parseInt(MD5_COLUMN_SIZE);
             boolean liquibaseColumnNotRightSize = false;
             if (!(this.getDatabase() instanceof SQLiteDatabase)) {
                 DataType type = changeLogTable.getColumn("LIQUIBASE").getType();
@@ -252,7 +252,7 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
                 }
             }
 
-            if (hasSmallChecksum) {
+            if (hasShortChecksum) {
                 executor.comment("Modifying size of databasechangelog.md5sum column");
                 statementsToExecute.add(new ModifyDataTypeStatement(getLiquibaseCatalogName(),
                         getLiquibaseSchemaName(), getDatabaseChangeLogTableName(), "MD5SUM",

--- a/liquibase-standard/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/visitor/ValidatingVisitor.java
@@ -6,6 +6,7 @@ import liquibase.Scope;
 import liquibase.change.Change;
 import liquibase.changelog.*;
 import liquibase.changelog.filter.ChangeSetFilterResult;
+import liquibase.checksums.ChecksumAlgorithm;
 import liquibase.database.Database;
 import liquibase.database.DatabaseList;
 import liquibase.exception.*;
@@ -128,14 +129,38 @@ public class ValidatingVisitor implements ChangeSetVisitor {
                     !ValidatingVisitorUtil.isChecksumIssue(changeSet, ranChangeSet, databaseChangeLog, database) &&
                     !changeSet.shouldRunOnChange() &&
                     !changeSet.shouldAlwaysRun()) {
-                invalidMD5Sums.add(changeSet.toString(false) + " was: " + ranChangeSet.getLastCheckSum().toString()
-                        + " but is now: " + changeSet.generateCheckSum(ChecksumVersion.enumFromChecksumVersion(ranChangeSet.getLastCheckSum().getVersion())).toString());
+                invalidMD5Sums.add(generateInvalidChecksumMessage(changeSet, ranChangeSet));
             }
         }
 
         // Did we already see this ChangeSet?
         String changeSetString = changeSet.toString(false);
         checkForDuplicatesFromDifferentFiles(changeSet, changeSetString);
+    }
+
+    private String generateInvalidChecksumMessage(ChangeSet changeSet, RanChangeSet ranChangeSet) {
+        String newChecksum = changeSet.generateCheckSum(ChecksumVersion.enumFromChecksumVersion(ranChangeSet.getLastCheckSum().getVersion())).toString();
+        String oldChecksum = ranChangeSet.getLastCheckSum().toString();
+        int oldChecksumSize = oldChecksum.contains(":") ? oldChecksum.split(":")[1].length() : -1;
+
+        String algorithmFailure = "";
+        if (oldChecksumSize == ChecksumAlgorithm.MD5.getSize() && isNotCurrentAlgorithm(ChecksumAlgorithm.MD5)) {
+            algorithmFailure = generateAlgorithmFailureMessage("MD5");
+        } else if (oldChecksumSize == ChecksumAlgorithm.SHA1.getSize() && isNotCurrentAlgorithm(ChecksumAlgorithm.SHA1)) {
+            algorithmFailure = generateAlgorithmFailureMessage("SHA-1");
+        } else if (oldChecksumSize == ChecksumAlgorithm.SHA256.getSize() && isNotCurrentAlgorithm(ChecksumAlgorithm.SHA256)) {
+            algorithmFailure = generateAlgorithmFailureMessage("SHA-256");
+        }
+
+        return changeSet.toString(false) + " was: " + oldChecksum + " but is now: " + newChecksum + algorithmFailure;
+    }
+
+    private boolean isNotCurrentAlgorithm(ChecksumAlgorithm algorithm) {
+        return !GlobalConfiguration.CHECKSUM_ALGORITHM.getCurrentValue().equals(algorithm);
+    }
+
+    private String generateAlgorithmFailureMessage(String algorithmName) {
+        return " (Note: you are using checksumAlgorithm " + GlobalConfiguration.CHECKSUM_ALGORITHM.getCurrentValue().getAlgorithm() + ", but the checksum in database looks like " + algorithmName + ")";
     }
 
     /**

--- a/liquibase-standard/src/main/java/liquibase/checksums/ChecksumAlgorithm.java
+++ b/liquibase-standard/src/main/java/liquibase/checksums/ChecksumAlgorithm.java
@@ -1,10 +1,12 @@
 package liquibase.checksums;
 
+import lombok.Getter;
+
+@Getter
 public enum ChecksumAlgorithm {
     MD5("MD5"),
     SHA1("SHA-1"),
-    SHA256("SHA-256"),
-    SHA512("SHA-512");
+    SHA256("SHA-256");
 
     private final String algorithm;
 
@@ -12,7 +14,4 @@ public enum ChecksumAlgorithm {
         this.algorithm = algorithm;
     }
 
-    public String getAlgorithm() {
-        return algorithm;
-    }
 }

--- a/liquibase-standard/src/main/java/liquibase/checksums/ChecksumAlgorithm.java
+++ b/liquibase-standard/src/main/java/liquibase/checksums/ChecksumAlgorithm.java
@@ -1,7 +1,9 @@
 package liquibase.checksums;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@AllArgsConstructor
 @Getter
 public enum ChecksumAlgorithm {
     MD5("MD5"),
@@ -9,9 +11,5 @@ public enum ChecksumAlgorithm {
     SHA256("SHA-256");
 
     private final String algorithm;
-
-    ChecksumAlgorithm(String algorithm) {
-        this.algorithm = algorithm;
-    }
 
 }

--- a/liquibase-standard/src/main/java/liquibase/checksums/ChecksumAlgorithm.java
+++ b/liquibase-standard/src/main/java/liquibase/checksums/ChecksumAlgorithm.java
@@ -1,0 +1,18 @@
+package liquibase.checksums;
+
+public enum ChecksumAlgorithm {
+    MD5("MD5"),
+    SHA1("SHA-1"),
+    SHA256("SHA-256"),
+    SHA512("SHA-512");
+
+    private final String algorithm;
+
+    ChecksumAlgorithm(String algorithm) {
+        this.algorithm = algorithm;
+    }
+
+    public String getAlgorithm() {
+        return algorithm;
+    }
+}

--- a/liquibase-standard/src/main/java/liquibase/checksums/ChecksumAlgorithm.java
+++ b/liquibase-standard/src/main/java/liquibase/checksums/ChecksumAlgorithm.java
@@ -6,10 +6,12 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum ChecksumAlgorithm {
-    MD5("MD5"),
-    SHA1("SHA-1"),
-    SHA256("SHA-256");
+    MD5("MD5", 32),
+    SHA1("SHA-1", 40),
+    SHA256("SHA-256", 64);
 
     private final String algorithm;
+
+    private final int size;
 
 }

--- a/liquibase-standard/src/main/java/liquibase/checksums/ComputeChecksumService.java
+++ b/liquibase-standard/src/main/java/liquibase/checksums/ComputeChecksumService.java
@@ -1,0 +1,20 @@
+package liquibase.checksums;
+
+import liquibase.GlobalConfiguration;
+import lombok.Getter;
+
+import java.io.InputStream;
+
+public class ComputeChecksumService {
+
+    @Getter
+    private static final ComputeChecksumService instance = new ComputeChecksumService();
+
+    public String compute(String input) {
+        return HashingUtil.compute(input, GlobalConfiguration.CHECKSUM_ALGORITHM.getCurrentValue().getAlgorithm());
+    }
+
+    public String compute(InputStream stream) {
+        return HashingUtil.compute(stream, GlobalConfiguration.CHECKSUM_ALGORITHM.getCurrentValue().getAlgorithm());
+    }
+}

--- a/liquibase-standard/src/main/java/liquibase/checksums/ComputeChecksumService.java
+++ b/liquibase-standard/src/main/java/liquibase/checksums/ComputeChecksumService.java
@@ -3,24 +3,29 @@ package liquibase.checksums;
 import liquibase.ChecksumVersion;
 import liquibase.GlobalConfiguration;
 import liquibase.Scope;
-import lombok.Getter;
 
 import java.io.InputStream;
 
+/**
+ * Utility class for computing checksums based on Liquibase Global configuration parameter
+ */
 public class ComputeChecksumService {
 
-    @Getter
-    private static final ComputeChecksumService instance = new ComputeChecksumService();
+    private ComputeChecksumService() {
+        // prevent instantiation
+    }
 
-    public String compute(String input) {
-        if (Scope.getCurrentScope().getChecksumVersion().lowerOrEqualThan(ChecksumVersion.V9)) {
+    public static String compute(String input) {
+        // If the checksum version is lower or equal to V8, use MD5 algorithm as this option wasn't present back then
+        if (Scope.getCurrentScope().getChecksumVersion().lowerOrEqualThan(ChecksumVersion.V8) ) {
             return HashingUtil.compute(input, ChecksumAlgorithm.MD5.getAlgorithm());
         }
         return HashingUtil.compute(input, GlobalConfiguration.CHECKSUM_ALGORITHM.getCurrentValue().getAlgorithm());
     }
 
-    public String compute(InputStream stream) {
-        if (Scope.getCurrentScope().getChecksumVersion().lowerOrEqualThan(ChecksumVersion.V9)) {
+    public static String compute(InputStream stream) {
+        // If the checksum version is lower or equal to V8, use MD5 algorithm as this option wasn't present back then
+        if (Scope.getCurrentScope().getChecksumVersion().lowerOrEqualThan(ChecksumVersion.V8)) {
             return HashingUtil.compute(stream, ChecksumAlgorithm.MD5.getAlgorithm());
         }
         return HashingUtil.compute(stream, GlobalConfiguration.CHECKSUM_ALGORITHM.getCurrentValue().getAlgorithm());

--- a/liquibase-standard/src/main/java/liquibase/checksums/ComputeChecksumService.java
+++ b/liquibase-standard/src/main/java/liquibase/checksums/ComputeChecksumService.java
@@ -1,6 +1,8 @@
 package liquibase.checksums;
 
+import liquibase.ChecksumVersion;
 import liquibase.GlobalConfiguration;
+import liquibase.Scope;
 import lombok.Getter;
 
 import java.io.InputStream;
@@ -11,10 +13,16 @@ public class ComputeChecksumService {
     private static final ComputeChecksumService instance = new ComputeChecksumService();
 
     public String compute(String input) {
+        if (Scope.getCurrentScope().getChecksumVersion().lowerOrEqualThan(ChecksumVersion.V9)) {
+            return HashingUtil.compute(input, ChecksumAlgorithm.MD5.getAlgorithm());
+        }
         return HashingUtil.compute(input, GlobalConfiguration.CHECKSUM_ALGORITHM.getCurrentValue().getAlgorithm());
     }
 
     public String compute(InputStream stream) {
+        if (Scope.getCurrentScope().getChecksumVersion().lowerOrEqualThan(ChecksumVersion.V9)) {
+            return HashingUtil.compute(stream, ChecksumAlgorithm.MD5.getAlgorithm());
+        }
         return HashingUtil.compute(stream, GlobalConfiguration.CHECKSUM_ALGORITHM.getCurrentValue().getAlgorithm());
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/checksums/HashingUtil.java
+++ b/liquibase-standard/src/main/java/liquibase/checksums/HashingUtil.java
@@ -59,13 +59,14 @@ public class HashingUtil {
         try {
             digest = MessageDigest.getInstance(algorithm);
 
-            DigestInputStream digestStream = new DigestInputStream(stream, digest);
-            byte[] buf = new byte[20480];
-            while (digestStream.read(buf) != -1) {
-                //digest is updating
+            try (DigestInputStream digestStream = new DigestInputStream(stream, digest)) {
+                byte[] buf = new byte[20480];
+                while (digestStream.read(buf) != -1) {
+                    //digest is updating
+                }
             }
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new UnexpectedLiquibaseException(e);
         }
         byte[] digestBytes = digest.digest();
 

--- a/liquibase-standard/src/main/java/liquibase/checksums/HashingUtil.java
+++ b/liquibase-standard/src/main/java/liquibase/checksums/HashingUtil.java
@@ -1,0 +1,95 @@
+package liquibase.checksums;
+
+import liquibase.GlobalConfiguration;
+import liquibase.Scope;
+import liquibase.exception.UnexpectedLiquibaseException;
+
+import java.io.InputStream;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+
+public class HashingUtil {
+
+    /**
+     * Used to build output as Hex
+     */
+    private static final char[] DIGITS_LOWER = {
+            '0', '1', '2', '3', '4', '5', '6', '7',
+            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
+    };
+
+    public static String compute(String input, String algorithm) {
+        if (input == null) {
+            return null;
+        }
+        MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance(algorithm);
+            digest.update(input.getBytes(GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()));
+        } catch (Exception e) {
+            throw new UnexpectedLiquibaseException(e);
+        }
+        byte[] digestBytes = digest.digest();
+
+        String returnString = new String(encodeHex(digestBytes));
+
+        String inputToLog = input;
+        if (inputToLog.length() > 500) {
+            inputToLog = inputToLog.substring(0, 500)+"... [truncated in log]";
+        }
+
+        Scope.getCurrentScope().getLog(HashingUtil.class).fine(String.format("Computed %s hash for %s as %s", algorithm, inputToLog, returnString));
+        return returnString;
+
+    }
+
+    public static String compute(InputStream stream, String algorithm) {
+        if (stream == null) {
+            return null;
+        }
+
+        MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance(algorithm);
+
+            DigestInputStream digestStream = new DigestInputStream(stream, digest);
+            byte[] buf = new byte[20480];
+            while (digestStream.read(buf) != -1) {
+                //digest is updating
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        byte[] digestBytes = digest.digest();
+
+        String returnString = new String(encodeHex(digestBytes));
+
+        Scope.getCurrentScope().getLog(HashingUtil.class).fine(String.format("Computed %s hash for inputStream as %s", algorithm, returnString));
+        return returnString;
+    }
+
+    /**
+     * Converts an array of bytes into an array of characters representing the hexadecimal values of each byte in order.
+     * The returned array will be double the length of the passed array, as it takes two characters to represent any
+     * given byte.
+     *
+     * @param data
+     *            a byte[] to convert to Hex characters
+     * @return A char[] containing hexadecimal characters
+     */
+    private static char[] encodeHex(byte[] data) {
+
+        int l = data.length;
+
+        char[] out = new char[l << 1];
+
+        // two characters form the hex value.
+        for (int i = 0, j = 0; i < l; i++) {
+            out[j++] = DIGITS_LOWER[(0xF0 & data[i]) >>> 4];
+            out[j++] = DIGITS_LOWER[0x0F & data[i]];
+        }
+
+        return out;
+    }
+
+}

--- a/liquibase-standard/src/main/java/liquibase/checksums/HashingUtil.java
+++ b/liquibase-standard/src/main/java/liquibase/checksums/HashingUtil.java
@@ -8,7 +8,14 @@ import java.io.InputStream;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 
+/**
+ * Utility class for hashing
+ */
 public class HashingUtil {
+
+    private HashingUtil() {
+        // prevent instantiation
+    }
 
     /**
      * Used to build output as Hex

--- a/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotIdService.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotIdService.java
@@ -1,13 +1,13 @@
 package liquibase.snapshot;
 
-import liquibase.util.MD5Util;
+import liquibase.checksums.ComputeChecksumService;
 
 import java.util.Date;
 
 public class SnapshotIdService {
     private static final SnapshotIdService instance = new SnapshotIdService();
     private int nextId = 100;
-    private final String base = MD5Util.computeMD5(Long.toString(new Date().getTime())).substring(0, 4);
+    private final String base = ComputeChecksumService.getInstance().compute(Long.toString(new Date().getTime())).substring(0, 4);
 
     public static SnapshotIdService getInstance() {
         return instance;

--- a/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotIdService.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotIdService.java
@@ -1,20 +1,17 @@
 package liquibase.snapshot;
 
 import liquibase.checksums.ComputeChecksumService;
+import lombok.Getter;
 
 import java.util.Date;
 
 public class SnapshotIdService {
+    @Getter
     private static final SnapshotIdService instance = new SnapshotIdService();
     private int nextId = 100;
-    private final String base = ComputeChecksumService.getInstance().compute(Long.toString(new Date().getTime())).substring(0, 4);
-
-    public static SnapshotIdService getInstance() {
-        return instance;
-    }
+    private final String base = ComputeChecksumService.compute(Long.toString(new Date().getTime())).substring(0, 4);
 
     private SnapshotIdService() {
-
     }
 
     public String generateId() {

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateDatabaseChangeLogTableGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateDatabaseChangeLogTableGenerator.java
@@ -55,7 +55,7 @@ public class CreateDatabaseChangeLogTableGenerator extends AbstractSqlGenerator<
                 .addColumn("DATEEXECUTED", DataTypeFactory.getInstance().fromDescription(dateTimeTypeString, database), null, null, new NotNullConstraint())
                 .addColumn("ORDEREXECUTED", DataTypeFactory.getInstance().fromDescription("int", database), null, null, new NotNullConstraint())
                 .addColumn("EXECTYPE", DataTypeFactory.getInstance().fromDescription(charTypeName + "(10)", database), null, null, new NotNullConstraint())
-                .addColumn("MD5SUM", DataTypeFactory.getInstance().fromDescription(charTypeName + "(35)", database))
+                .addColumn("MD5SUM", DataTypeFactory.getInstance().fromDescription(charTypeName + "(68)", database))
                 .addColumn("DESCRIPTION", DataTypeFactory.getInstance().fromDescription(charTypeName + "(255)", database))
                 .addColumn("COMMENTS", DataTypeFactory.getInstance().fromDescription(charTypeName + "(255)", database))
                 .addColumn("TAG", DataTypeFactory.getInstance().fromDescription(charTypeName + "(255)", database))

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateDatabaseChangeLogTableGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateDatabaseChangeLogTableGenerator.java
@@ -1,5 +1,6 @@
 package liquibase.sqlgenerator.core;
 
+import liquibase.changelog.StandardChangeLogHistoryService;
 import liquibase.database.Database;
 import liquibase.database.ObjectQuotingStrategy;
 import liquibase.database.core.MSSQLDatabase;
@@ -55,7 +56,7 @@ public class CreateDatabaseChangeLogTableGenerator extends AbstractSqlGenerator<
                 .addColumn("DATEEXECUTED", DataTypeFactory.getInstance().fromDescription(dateTimeTypeString, database), null, null, new NotNullConstraint())
                 .addColumn("ORDEREXECUTED", DataTypeFactory.getInstance().fromDescription("int", database), null, null, new NotNullConstraint())
                 .addColumn("EXECTYPE", DataTypeFactory.getInstance().fromDescription(charTypeName + "(10)", database), null, null, new NotNullConstraint())
-                .addColumn("MD5SUM", DataTypeFactory.getInstance().fromDescription(charTypeName + "(68)", database))
+                .addColumn("MD5SUM", DataTypeFactory.getInstance().fromDescription(charTypeName + "(" + StandardChangeLogHistoryService.MD5_COLUMN_SIZE + ")", database))
                 .addColumn("DESCRIPTION", DataTypeFactory.getInstance().fromDescription(charTypeName + "(255)", database))
                 .addColumn("COMMENTS", DataTypeFactory.getInstance().fromDescription(charTypeName + "(255)", database))
                 .addColumn("TAG", DataTypeFactory.getInstance().fromDescription(charTypeName + "(255)", database))

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateDatabaseChangeLogTableGeneratorSybase.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateDatabaseChangeLogTableGeneratorSybase.java
@@ -1,5 +1,6 @@
 package liquibase.sqlgenerator.core;
 
+import liquibase.changelog.StandardChangeLogHistoryService;
 import liquibase.database.Database;
 import liquibase.database.ObjectQuotingStrategy;
 import liquibase.database.core.SybaseDatabase;
@@ -40,7 +41,7 @@ public class CreateDatabaseChangeLogTableGeneratorSybase extends AbstractSqlGene
                             "DATEEXECUTED " + DataTypeFactory.getInstance().fromDescription("datetime", database).toDatabaseDataType(database) + " NOT NULL, " +
                             "ORDEREXECUTED INT NOT NULL, " +
                             "EXECTYPE VARCHAR(10) NOT NULL, " +
-                            "MD5SUM VARCHAR(35) NULL, " +
+                            "MD5SUM VARCHAR(" + StandardChangeLogHistoryService.MD5_COLUMN_SIZE + ") NULL, " +
                             "DESCRIPTION VARCHAR(255) NULL, " +
                             "COMMENTS VARCHAR(255) NULL, " +
                             "TAG VARCHAR(255) NULL, " +

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/UpdateChangeSetChecksumGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/UpdateChangeSetChecksumGenerator.java
@@ -6,7 +6,6 @@ import liquibase.changelog.column.LiquibaseColumn;
 import liquibase.database.Database;
 import liquibase.database.ObjectQuotingStrategy;
 import liquibase.exception.ValidationErrors;
-import liquibase.integration.commandline.LiquibaseCommandLineConfiguration;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.SqlGeneratorFactory;

--- a/liquibase-standard/src/main/java/liquibase/util/MD5Util.java
+++ b/liquibase-standard/src/main/java/liquibase/util/MD5Util.java
@@ -1,5 +1,6 @@
 package liquibase.util;
 
+import liquibase.checksums.ChecksumAlgorithm;
 import liquibase.checksums.HashingUtil;
 
 import java.io.InputStream;
@@ -12,12 +13,12 @@ import java.io.InputStream;
 public class MD5Util {
 
     public static String computeMD5(String input) {
-        return HashingUtil.compute(input, "MD5");
+        return HashingUtil.compute(input, ChecksumAlgorithm.MD5.getAlgorithm());
 
     }
 
     public static String computeMD5(InputStream stream) {
-        return HashingUtil.compute(stream, "MD5");
+        return HashingUtil.compute(stream, ChecksumAlgorithm.MD5.getAlgorithm());
     }
 
 }

--- a/liquibase-standard/src/main/java/liquibase/util/MD5Util.java
+++ b/liquibase-standard/src/main/java/liquibase/util/MD5Util.java
@@ -1,97 +1,23 @@
 package liquibase.util;
 
-import liquibase.Scope;
-import liquibase.GlobalConfiguration;
-import liquibase.exception.UnexpectedLiquibaseException;
+import liquibase.checksums.HashingUtil;
 
 import java.io.InputStream;
-import java.security.DigestInputStream;
-import java.security.MessageDigest;
 
 /**
  * Generates md5-sums based on a string.
+ * @deprecated Use {@link HashingUtil} instead
  */
+@Deprecated
 public class MD5Util {
 
-    /**
-     * Used to build output as Hex
-     */
-    private static final char[] DIGITS_LOWER = {
-        '0', '1', '2', '3', '4', '5', '6', '7',
-           '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
-    };
-
     public static String computeMD5(String input) {
-        if (input == null) {
-            return null;
-        }
-        MessageDigest digest;
-        try {
-            digest = MessageDigest.getInstance("MD5");
-            digest.update(input.getBytes(GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()));
-        } catch (Exception e) {
-            throw new UnexpectedLiquibaseException(e);
-        }
-        byte[] digestBytes = digest.digest();
-
-        String returnString = new String(encodeHex(digestBytes));
-
-        String inputToLog = input;
-        if (inputToLog.length() > 500) {
-            inputToLog = inputToLog.substring(0, 500)+"... [truncated in log]";
-        }
-        Scope.getCurrentScope().getLog(MD5Util.class).fine("Computed checksum for "+inputToLog+" as "+returnString);
-        return returnString;
+        return HashingUtil.compute(input, "MD5");
 
     }
 
     public static String computeMD5(InputStream stream) {
-        if (stream == null) {
-            return null;
-        }
-
-        MessageDigest digest;
-        try {
-            digest = MessageDigest.getInstance("MD5");
-
-            DigestInputStream digestStream = new DigestInputStream(stream, digest);
-            byte[] buf = new byte[20480];
-            while (digestStream.read(buf) != -1) {
-                //digest is updating
-            }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-        byte[] digestBytes = digest.digest();
-
-        String returnString = new String(encodeHex(digestBytes));
-
-        Scope.getCurrentScope().getLog(MD5Util.class).fine("Computed checksum for inputStream as "+returnString);
-        return returnString;
-    }
-
-    /**
-     * Converts an array of bytes into an array of characters representing the hexadecimal values of each byte in order.
-     * The returned array will be double the length of the passed array, as it takes two characters to represent any
-     * given byte.
-     *
-     * @param data
-     *            a byte[] to convert to Hex characters
-     * @return A char[] containing hexadecimal characters
-     */
-    private static char[] encodeHex(byte[] data) {
-
-        int l = data.length;
-
-        char[] out = new char[l << 1];
-
-        // two characters form the hex value.
-        for (int i = 0, j = 0; i < l; i++) {
-            out[j++] = DIGITS_LOWER[(0xF0 & data[i]) >>> 4];
-            out[j++] = DIGITS_LOWER[0x0F & data[i]];
-        }
-
-        return out;
+        return HashingUtil.compute(stream, "MD5");
     }
 
 }

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/CreateViewChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/CreateViewChangeTest.groovy
@@ -9,7 +9,6 @@ import liquibase.changelog.ChangeSet
 import liquibase.changelog.DatabaseChangeLog
 import liquibase.database.core.MockDatabase
 import liquibase.exception.SetupException
-import liquibase.integration.commandline.LiquibaseCommandLineConfiguration
 import liquibase.parser.core.ParsedNodeException
 import liquibase.sdk.resource.MockResourceAccessor
 import liquibase.snapshot.MockSnapshotGeneratorFactory

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/LoadUpdateDataChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/LoadUpdateDataChangeTest.groovy
@@ -5,7 +5,6 @@ import liquibase.Scope
 import liquibase.change.ChangeStatus
 import liquibase.database.core.PostgresDatabase
 import liquibase.database.DatabaseConnection
-import liquibase.integration.commandline.LiquibaseCommandLineConfiguration
 import liquibase.snapshot.MockSnapshotGeneratorFactory
 import liquibase.snapshot.SnapshotGeneratorFactory
 import liquibase.change.StandardChangeTest;

--- a/liquibase-standard/src/test/java/liquibase/change/AbstractSQLChangeTest.java
+++ b/liquibase-standard/src/test/java/liquibase/change/AbstractSQLChangeTest.java
@@ -4,7 +4,6 @@ import liquibase.ChecksumVersion;
 import liquibase.Scope;
 import liquibase.database.core.MSSQLDatabase;
 import liquibase.statement.SqlStatement;
-import liquibase.statement.core.RawParameterizedSqlStatement;
 import liquibase.statement.core.RawSqlStatement;
 import liquibase.util.StreamUtil;
 import org.junit.Test;

--- a/liquibase-standard/src/test/java/liquibase/change/CheckSumTest.java
+++ b/liquibase-standard/src/test/java/liquibase/change/CheckSumTest.java
@@ -1,7 +1,6 @@
 package liquibase.change;
 
 import liquibase.ChecksumVersion;
-import liquibase.integration.commandline.LiquibaseCommandLineConfiguration;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;

--- a/liquibase-standard/src/test/java/liquibase/change/CheckSumTest.java
+++ b/liquibase-standard/src/test/java/liquibase/change/CheckSumTest.java
@@ -1,6 +1,9 @@
 package liquibase.change;
 
 import liquibase.ChecksumVersion;
+import liquibase.GlobalConfiguration;
+import liquibase.Scope;
+import liquibase.checksums.ChecksumAlgorithm;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -15,6 +18,29 @@ public class CheckSumTest {
         CheckSum checkSum = CheckSum.parse(checksumString);
         assertEquals(3, checkSum.getVersion());
         assertEquals(checksumString, checkSum.toString());
+    }
+
+    @Test
+    public void getDefaultAlgorithmIsMd5() {
+        assertEquals(GlobalConfiguration.CHECKSUM_ALGORITHM.getDefaultValue(), ChecksumAlgorithm.MD5);
+    }
+
+    @Test
+    public void sha1Checksum() throws Exception {
+        Scope.child(GlobalConfiguration.CHECKSUM_ALGORITHM.getKey(), ChecksumAlgorithm.SHA1, () -> {
+            CheckSum checkSum = CheckSum.compute("asdf");
+            assertEquals(ChecksumVersion.V9.getVersion(), checkSum.getVersion());
+            assertEquals("3da541559918a808c2402bba5012f6c60b27661c", checkSum.getStoredCheckSum());
+        });
+    }
+
+    @Test
+    public void sha256Checksum() throws Exception {
+        Scope.child(GlobalConfiguration.CHECKSUM_ALGORITHM.getKey(), ChecksumAlgorithm.SHA256, () -> {
+            CheckSum checkSum = CheckSum.compute("asdf");
+            assertEquals(ChecksumVersion.V9.getVersion(), checkSum.getVersion());
+            assertEquals("f0e4c2f76c58916ec258f246851bea091d14d4247a2fc3e18694461b1816e13b", checkSum.getStoredCheckSum());
+        });
     }
 
     @Test

--- a/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/UpdateChangeSetChecksumGeneratorTest.java
+++ b/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/UpdateChangeSetChecksumGeneratorTest.java
@@ -4,7 +4,6 @@ import liquibase.ChecksumVersion;
 import liquibase.change.CheckSum;
 import liquibase.changelog.ChangeSet;
 import liquibase.database.Database;
-import liquibase.integration.commandline.LiquibaseCommandLineConfiguration;
 import liquibase.sqlgenerator.SqlGeneratorFactory;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.UpdateChangeSetChecksumStatement;


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Reasoning from source issue: There are some companies, that believe MD5 is an agent of evil and even mentioning it in a codebase will instantly cause all security to fail. Regardless if it is only being used in a way to provide a general hash value to avoid collisions in non-cryptographically-security situations. Having a config value to indicate that SHA256 should be used in preference to MD5 would mean not having to jump through hoops.

What this PR does:
- Introduces a new Global Flag , CHECKSUM_ALGORITHM, that allows to switch from default MD5 to SHA1 or SHA256
- Increase the MD5 column from databasechangelog table  to support those new hash sizes
- Refactorings and tests

## Things to be aware of
So far, this PR is not handling migrations. So if an user wants to go from` MD5 to SHAX`, he first needs to run `clearchecksums` **THEN** run an `update`. Same logic to rollback.

Should we add a new `changeCheckSums` command to handle this migration smoothly? Should it be done under the hood?

## Things to worry about

We are not storing the algorithm used to calculate checksum anywhere. So if someone runs liquibase using` -checksumAlgorithm=SHA256 `, and in the next run forgets the parameter there will be a checksum error message. 

Should we improve our current checksum from **VERSION:CHECKSUM** to **VERSION:ALGORITHM:CHECKSUM** , or add a new column to dbcl, or do nothing? some thoughts: 
* adding the algorithm we can have mixed checksum algorithms, so the user can switch from MD5 to SHAX without changing the existing values. 
* But this would be against the whole point of changing the checksum, right?
* This would be mostly useful if the user forgot which algorithm he used, or to remove the requirement of keeping the global flag after migrating everything - but who does it?
* Changing the checksum string would break backwards compatibility, and it means that we would need to bump checksums version again, impacting _everyone_ - even people that is not migrating
* Adding a new column would be less intrusive is this case, as we don't need to bump checksum version
* Doing nothing is already implement, works like a charm

## Additional Context

* Fixes #6062 
* Still need to verify if there is any impact to liquibase-commercial (hopefully not)