### PR TITLE
Allow for scopemanager to be shared between threads created by liquibase (DAT-18871)

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/Scope.java
+++ b/liquibase-standard/src/main/java/liquibase/Scope.java
@@ -78,7 +78,7 @@ public class Scope {
 
     public static final String JAVA_PROPERTIES = "javaProperties";
 
-    private static final ThreadLocal<ScopeManager> scopeManager = new ThreadLocal<>();
+    private static final InheritableThreadLocal<ScopeManager> scopeManager = new InheritableThreadLocal<>();
 
     private final Scope parent;
     private final SmartMap values = new SmartMap();


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description
When sending analytics we create a new thread to easily time out the thread in case processing takes too long. This works fine for normal use cases, but in the event we are say, redirecting the logs to a file or using structured logging with our pro extension, we need to check the liquibase configuration and grab information via the scope. This can result in unexpected errors from inside a new thread as the `scopeManager` has not been set up in this new thread. By swapping to a `InheritableThreadLocal`, we automatically transfer this scopevalue into the child thread without having to muck with copying the scope values. 
<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about
As far as I can tell this should work the same as a normal `ThreadLocal` but allow us to not need to reconfigure our scope when spawning child threads. That said, changing something this fundamental to Liquibase is always a risk. 

When chatting with the development team we came to the conclusion that the only way this change should be noticed is if a user creates a thread within the thread they are running liquibase on and then runs liquibase again. This form of usage seems unlikely.
<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
