### PR TITLE
Fix FormattedSqlChangeLogSerializer so it includes logicalFilePath in change-set info comments

### DIFF
--- a/liquibase-integration-tests/src/test/groovy/liquibase/diffchangelog/DiffChangelogIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/diffchangelog/DiffChangelogIntegrationTest.groovy
@@ -71,8 +71,8 @@ CREATE TABLE $tableName ( product_no varchar(20) DEFAULT nextval('$sequenceName'
         def generatedChangelogContents = FileUtil.getContents(generatedChangelog)
         generatedChangelogContents.contains("""CREATE SEQUENCE  IF NOT EXISTS "public"."${sequenceName.toLowerCase()}" AS bigint START WITH 100 INCREMENT BY 5 MINVALUE 1 MAXVALUE 9223372036854775807 CACHE 1;""")
         generatedChangelogContents.contains("""CREATE TABLE "public"."${tableName.toLowerCase()}" ("product_no" VARCHAR(20) DEFAULT 'nextval(''''${sequenceName.toLowerCase()}''''::regclass)');""")
-        generatedChangelogContents.contains(" labels: \"newlabels\"")
-        generatedChangelogContents.contains(" contextFilter: \"newContexts\"")
+        generatedChangelogContents.contains(" labels:\"newlabels\"")
+        generatedChangelogContents.contains(" contextFilter:\"newContexts\"")
 
         cleanup:
         try {

--- a/liquibase-standard/src/main/java/liquibase/serializer/core/formattedsql/FormattedSqlChangeLogSerializer.java
+++ b/liquibase-standard/src/main/java/liquibase/serializer/core/formattedsql/FormattedSqlChangeLogSerializer.java
@@ -77,15 +77,21 @@ public class FormattedSqlChangeLogSerializer  implements ChangeLogSerializer {
         Labels labels = changeSet.getLabels();
         if (labels != null && ! labels.isEmpty()) {
             String outputLabels = labels.toString();
-            builder.append(" labels: \"");
+            builder.append(" labels:\"");
             builder.append(outputLabels);
             builder.append("\"");
         }
         ContextExpression contexts = changeSet.getContextFilter();
         if (contexts != null && ! contexts.isEmpty()) {
             String outputContexts = contexts.toString();
-            builder.append(" contextFilter: \"");
+            builder.append(" contextFilter:\"");
             builder.append(outputContexts);
+            builder.append("\"");
+        }
+        String logicalFilePath = changeSet.getLogicalFilePath();
+        if (logicalFilePath != null && ! logicalFilePath.isEmpty()) {
+            builder.append(" logicalFilePath:\"");
+            builder.append(logicalFilePath);
             builder.append("\"");
         }
         builder.append("\n");

--- a/liquibase-standard/src/test/java/liquibase/serializer/core/formattedsql/FormattedSqlChangeLogSerializerTest.java
+++ b/liquibase-standard/src/test/java/liquibase/serializer/core/formattedsql/FormattedSqlChangeLogSerializerTest.java
@@ -40,7 +40,7 @@ public class FormattedSqlChangeLogSerializerTest {
         changeSetWithContextAndLabels.setLabels(new Labels("label1"));
         changeSetWithContextAndLabels.setContextFilter(new ContextExpression("context1"));
         String serialized = serializer.serialize(changeSetWithContextAndLabels, true);
-        assertEquals(serialized, ("-- changeset testAuthor:1 labels: \"label1\" contextFilter: \"context1\"\n"));
+        assertEquals(serialized, ("-- changeset testAuthor:1 labels:\"label1\" contextFilter:\"context1\"\n"));
     }
 
     @Test
@@ -80,6 +80,22 @@ public class FormattedSqlChangeLogSerializerTest {
         ChangeSet changeSetWithInvalidDb = new ChangeSet("1", "testAuthor",
                 false, false, "path/to/changeLogFile.LALALA.sql", null, null, null);
         serializer.serialize(changeSetWithInvalidDb, true);
+    }
+
+    @Test
+    public void serialize_changeSetWithLogicalFilePath() {
+        changeSet.setLogicalFilePath("foo/bar/baz.sql");
+
+        AddAutoIncrementChange statement = new AddAutoIncrementChange();
+        statement.setTableName("table_name");
+        statement.setColumnName("column_name");
+        statement.setColumnDataType("int");
+        changeSet.addChange(statement);
+        Sql[] sqls = SqlGeneratorFactory.getInstance().generateSql(statement, database);
+        String expectedSql = "-- changeset testAuthor:1 logicalFilePath:\"foo/bar/baz.sql\"\n" + sqls[0].toSql() + ";\n";
+
+        String serialized = serializer.serialize(changeSet, true);
+        assertEquals(expectedSql, serialized);
     }
 
 }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

This PR fixes an omission in `FormattedSqlChangeLogSerializer`, which today does not include `logicalFilePath` in the change-set info comment.  With this PR, it will include the logical file path if it is non-null and not empty.

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->

Fixes #6452