### PR TITLE
feat: add new properties to Spring configuration (analytics Enabled and pro license)

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/integration/spring/MultiTenantSpringLiquibase.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/spring/MultiTenantSpringLiquibase.java
@@ -110,6 +110,14 @@ public class MultiTenantSpringLiquibase implements InitializingBean, ResourceLoa
 
     @Getter
     @Setter
+    protected String licenseKey;
+
+    @Getter
+    @Setter
+    protected boolean disableAnalytics;
+
+    @Getter
+    @Setter
     private boolean shouldRun = true;
 
     @Getter
@@ -203,6 +211,8 @@ public class MultiTenantSpringLiquibase implements InitializingBean, ResourceLoa
         liquibase.setLabelFilter(labelFilter);
         liquibase.setDropFirst(dropFirst);
         liquibase.setClearCheckSums(clearCheckSums);
+        liquibase.setLicenseKey(licenseKey);
+        liquibase.setDisableAnalytics(disableAnalytics);
         liquibase.setShouldRun(shouldRun);
         liquibase.setRollbackFile(rollbackFile);
         liquibase.setResourceLoader(resourceLoader);

--- a/liquibase-standard/src/main/java/liquibase/integration/spring/MultiTenantSpringLiquibase.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/spring/MultiTenantSpringLiquibase.java
@@ -114,7 +114,7 @@ public class MultiTenantSpringLiquibase implements InitializingBean, ResourceLoa
 
     @Getter
     @Setter
-    protected boolean disableAnalytics;
+    protected boolean analyticsEnabled;
 
     @Getter
     @Setter
@@ -212,7 +212,7 @@ public class MultiTenantSpringLiquibase implements InitializingBean, ResourceLoa
         liquibase.setDropFirst(dropFirst);
         liquibase.setClearCheckSums(clearCheckSums);
         liquibase.setLicenseKey(licenseKey);
-        liquibase.setDisableAnalytics(disableAnalytics);
+        liquibase.setAnalyticsEnabled(analyticsEnabled);
         liquibase.setShouldRun(shouldRun);
         liquibase.setRollbackFile(rollbackFile);
         liquibase.setResourceLoader(resourceLoader);

--- a/liquibase-standard/src/main/java/liquibase/integration/spring/SpringLiquibase.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/spring/SpringLiquibase.java
@@ -265,8 +265,8 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
             scopeVars.put(AnalyticsArgs.ENABLED.getKey(), !disableAnalytics);
 
             if (this.licenseKey != null) {
-                log.info("Using liquibase PRO licenseKey");
-                scopeVars.put("licenseKey", licenseKey);
+                log.info("Using PRO licenseKey defined in Spring configuration files.");
+                scopeVars.put("liquibase.licenseKey", licenseKey);
             }
             Scope.child(scopeVars,
                     () -> {

--- a/liquibase-standard/src/main/java/liquibase/integration/spring/SpringLiquibase.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/spring/SpringLiquibase.java
@@ -259,8 +259,13 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
             Map<String, Object> scopeVars = new HashMap<>();
             scopeVars.put(Scope.Attr.ui.name(), this.uiService.getUiServiceClass().getDeclaredConstructor().newInstance());
             scopeVars.put(Scope.Attr.integrationDetails.name(), new IntegrationDetails("spring"));
+            if (disableAnalytics) {
+                log.info("Disabling Liquibase analytics.");
+            }
             scopeVars.put(AnalyticsArgs.ENABLED.getKey(), !disableAnalytics);
+
             if (this.licenseKey != null) {
+                log.info("Using liquibase PRO licenseKey");
                 scopeVars.put("licenseKey", licenseKey);
             }
             Scope.child(scopeVars,

--- a/liquibase-standard/src/main/java/liquibase/integration/spring/SpringLiquibase.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/spring/SpringLiquibase.java
@@ -1,6 +1,7 @@
 package liquibase.integration.spring;
 
 import liquibase.*;
+import liquibase.analytics.configuration.AnalyticsArgs;
 import liquibase.configuration.ConfiguredValue;
 import liquibase.database.Database;
 import liquibase.database.DatabaseConnection;
@@ -10,7 +11,6 @@ import liquibase.database.core.DerbyDatabase;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.LiquibaseException;
-import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.integration.IntegrationDetails;
 import liquibase.integration.commandline.LiquibaseCommandLineConfiguration;
 import liquibase.logging.Logger;
@@ -31,7 +31,6 @@ import java.io.*;
 import java.nio.file.Files;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -114,6 +113,14 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
     @Getter
     @Setter
     protected boolean clearCheckSums;
+
+    @Getter
+    @Setter
+    protected String licenseKey = null;
+
+    @Getter
+    @Setter
+    protected boolean disableAnalytics = false;
 
     @Setter
     protected boolean shouldRun = true;
@@ -252,6 +259,10 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
             Map<String, Object> scopeVars = new HashMap<>();
             scopeVars.put(Scope.Attr.ui.name(), this.uiService.getUiServiceClass().getDeclaredConstructor().newInstance());
             scopeVars.put(Scope.Attr.integrationDetails.name(), new IntegrationDetails("spring"));
+            scopeVars.put(AnalyticsArgs.ENABLED.getKey(), !disableAnalytics);
+            if (this.licenseKey != null) {
+                scopeVars.put("licenseKey", licenseKey);
+            }
             Scope.child(scopeVars,
                     () -> {
                         Liquibase liquibase = null;

--- a/liquibase-standard/src/main/java/liquibase/integration/spring/SpringLiquibase.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/spring/SpringLiquibase.java
@@ -120,7 +120,7 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
 
     @Getter
     @Setter
-    protected boolean disableAnalytics = false;
+    protected boolean analyticsEnabled = true;
 
     @Setter
     protected boolean shouldRun = true;
@@ -259,10 +259,10 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
             Map<String, Object> scopeVars = new HashMap<>();
             scopeVars.put(Scope.Attr.ui.name(), this.uiService.getUiServiceClass().getDeclaredConstructor().newInstance());
             scopeVars.put(Scope.Attr.integrationDetails.name(), new IntegrationDetails("spring"));
-            if (disableAnalytics) {
+            if (!analyticsEnabled) {
                 log.info("Disabling Liquibase analytics.");
             }
-            scopeVars.put(AnalyticsArgs.ENABLED.getKey(), !disableAnalytics);
+            scopeVars.put(AnalyticsArgs.ENABLED.getKey(), analyticsEnabled);
 
             if (this.licenseKey != null) {
                 log.info("Using PRO licenseKey defined in Spring configuration files.");

--- a/liquibase-standard/src/main/java/liquibase/integration/spring/SpringLiquibase.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/spring/SpringLiquibase.java
@@ -259,15 +259,13 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
             Map<String, Object> scopeVars = new HashMap<>();
             scopeVars.put(Scope.Attr.ui.name(), this.uiService.getUiServiceClass().getDeclaredConstructor().newInstance());
             scopeVars.put(Scope.Attr.integrationDetails.name(), new IntegrationDetails("spring"));
-            if (!analyticsEnabled) {
-                log.info("Disabling Liquibase analytics.");
-            }
             scopeVars.put(AnalyticsArgs.ENABLED.getKey(), analyticsEnabled);
 
             if (this.licenseKey != null) {
-                log.info("Using PRO licenseKey defined in Spring configuration files.");
+                log.fine("Using PRO licenseKey.");
                 scopeVars.put("liquibase.licenseKey", licenseKey);
             }
+
             Scope.child(scopeVars,
                     () -> {
                         Liquibase liquibase = null;


### PR DESCRIPTION
Adding properties licenseKey and analyticsEnabled to Spring configuration.

## Steps to get it supported in Spring:
* Review & merge this PR to Liquibase
* Release Liquibase (probably 4.30.1 or 4.31.0)
* In the following PR, fix Liquibase version and change base to Spring repo: https://github.com/filipelautert/spring-boot/pull/1/files

### application.properties:
```
spring.liquibase.licenseKey=Mybase64KeyHere
spring.liquibase.analyticsEnabled=false
...
```
### Execution Log - changes:
```
... liquibase.integration                    : Disabling Liquibase analytics.
... liquibase.integration                    : Using PRO licenseKey specified in Spring configuration files.
```
### Full log
```
08:14:12.419 [main] INFO org.springframework.test.context.support.AnnotationConfigContextLoaderUtils -- Could not detect default configuration classes for test class [com.example.demo.DemoApplicationTests]: DemoApplicationTests does not declare any static, non-private, non-final, nested classes annotated with @Configuration.
08:14:12.533 [main] INFO org.springframework.boot.test.context.SpringBootTestContextBootstrapper -- Found @SpringBootConfiguration com.example.demo.DemoApplication for test class com.example.demo.DemoApplicationTests

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::       (v3.4.0-SNAPSHOT)

2024-11-14T08:14:12.972-03:00  INFO 16096 --- [demo] [           main] com.example.demo.DemoApplicationTests    : Starting DemoApplicationTests using Java 21.0.5 with PID 16096 (started by filip in C:\liquibase\demos\demo)
2024-11-14T08:14:12.974-03:00  INFO 16096 --- [demo] [           main] com.example.demo.DemoApplicationTests    : No active profile set, falling back to 1 default profile: "default"
2024-11-14T08:14:13.402-03:00  INFO 16096 --- [demo] [           main] .s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data JPA repositories in DEFAULT mode.
2024-11-14T08:14:13.424-03:00  INFO 16096 --- [demo] [           main] .s.d.r.c.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 11 ms. Found 0 JPA repository interfaces.
2024-11-14T08:14:13.867-03:00  INFO 16096 --- [demo] [           main] liquibase.integration                    : Disabling Liquibase analytics.
2024-11-14T08:14:13.867-03:00  INFO 16096 --- [demo] [           main] liquibase.integration                    : Using PRO licenseKey specified in Spring configuration files.
2024-11-14T08:14:13.868-03:00  INFO 16096 --- [demo] [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Starting...
2024-11-14T08:14:14.108-03:00  INFO 16096 --- [demo] [           main] com.zaxxer.hikari.pool.HikariPool        : HikariPool-1 - Added connection org.postgresql.jdbc.PgConnection@4fdca00a
2024-11-14T08:14:14.110-03:00  INFO 16096 --- [demo] [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Start completed.
2024-11-14T08:14:14.245-03:00  INFO 16096 --- [demo] [           main] liquibase.database                       : Set default schema name to public
2024-11-14T08:14:14.709-03:00  INFO 16096 --- [demo] [           main] liquibase.license                        : Successfully installed license from Base64 string starting with 'ABwwGgQUsw' (Scoped value 'liquibase.licenseKey').

2024-11-14T08:14:15.131-03:00  INFO 16096 --- [demo] [           main] liquibase.changelog                      : Creating database history table with name: public.databasechangelog
2024-11-14T08:14:15.176-03:00  INFO 16096 --- [demo] [           main] liquibase.changelog                      : Reading from public.databasechangelog
2024-11-14T08:14:15.198-03:00  INFO 16096 --- [demo] [           main] liquibase.snapshot                       : Creating snapshot
2024-11-14T08:14:15.282-03:00  INFO 16096 --- [demo] [           main] liquibase.lockservice                    : Successfully acquired change log lock
2024-11-14T08:14:15.284-03:00  INFO 16096 --- [demo] [           main] liquibase.command                        : Using deploymentId: 1582855283
2024-11-14T08:14:15.286-03:00  INFO 16096 --- [demo] [           main] liquibase.changelog                      : Reading from public.databasechangelog
2024-11-14T08:14:15.298-03:00  INFO 16096 --- [demo] [           main] liquibase.ui                             : Running Changeset: db/changelog/db.changelog-master.xml::1::my_name
2024-11-14T08:14:15.307-03:00  INFO 16096 --- [demo] [           main] liquibase.changelog                      : Table test_table created
2024-11-14T08:14:15.309-03:00  INFO 16096 --- [demo] [           main] liquibase.changelog                      : ChangeSet db/changelog/db.changelog-master.xml::1::my_name ran successfully in 9ms
2024-11-14T08:14:15.316-03:00  INFO 16096 --- [demo] [           main] liquibase.ui                             : Running Changeset: db/changelog/db.changelog-master.xml::createFunction::Liquibase Pro User
2024-11-14T08:14:15.322-03:00  INFO 16096 --- [demo] [           main] liquibase.changelog                      : Function FUNCTION1 created
2024-11-14T08:14:15.324-03:00  INFO 16096 --- [demo] [           main] liquibase.changelog                      : ChangeSet db/changelog/db.changelog-master.xml::createFunction::Liquibase Pro User ran successfully in 8ms
2024-11-14T08:14:15.334-03:00  INFO 16096 --- [demo] [           main] liquibase.util                           : UPDATE SUMMARY
2024-11-14T08:14:15.335-03:00  INFO 16096 --- [demo] [           main] liquibase.util                           : Run:                          2
2024-11-14T08:14:15.335-03:00  INFO 16096 --- [demo] [           main] liquibase.util                           : Previously run:               0
2024-11-14T08:14:15.335-03:00  INFO 16096 --- [demo] [           main] liquibase.util                           : Filtered out:                 0
2024-11-14T08:14:15.335-03:00  INFO 16096 --- [demo] [           main] liquibase.util                           : Failed deployment:            0
2024-11-14T08:14:15.335-03:00  INFO 16096 --- [demo] [           main] liquibase.util                           : -------------------------------
2024-11-14T08:14:15.335-03:00  INFO 16096 --- [demo] [           main] liquibase.util                           : Total change sets:            2
2024-11-14T08:14:15.337-03:00  INFO 16096 --- [demo] [           main] liquibase.util                           : Update summary generated
2024-11-14T08:14:15.341-03:00  INFO 16096 --- [demo] [           main] liquibase.command                        : Update command completed successfully.
2024-11-14T08:14:15.341-03:00  INFO 16096 --- [demo] [           main] liquibase.ui                             : Liquibase: Update has been successful. Rows affected: 2
2024-11-14T08:14:15.346-03:00  INFO 16096 --- [demo] [           main] liquibase.lockservice                    : Successfully released change log lock
2024-11-14T08:14:15.402-03:00  INFO 16096 --- [demo] [           main] liquibase                                : Pro Update Report created!
* File 'resourceaccessor:./Update-report-14-nov.-2024-081415.html' was created.
** To suppress Update reports add command arg 'liquibase update --report-enabled=false'
** To suppress all Pro Reports set liquibase.reports.enabled=false, or LIQUIBASE_REPORTS_ENABLED=false
2024-11-14T08:14:15.402-03:00  INFO 16096 --- [demo] [           main] liquibase.ui                             : Pro Update Report created!
* File 'resourceaccessor:./Update-report-14-nov.-2024-081415.html' was created.
** To suppress Update reports add command arg 'liquibase update --report-enabled=false'
** To suppress all Pro Reports set liquibase.reports.enabled=false, or LIQUIBASE_REPORTS_ENABLED=false
2024-11-14T08:14:15.443-03:00  INFO 16096 --- [demo] [           main] liquibase.command                        : Command execution complete
2024-11-14T08:14:15.444-03:00 ERROR 16096 --- [demo] [           main] liquibase.analytics                      : Analytics is disabled because this is not a release build and the user has not provided a value for the liquibase.analytics.devOverride option.
2024-11-14T08:14:15.552-03:00  INFO 16096 --- [demo] [           main] o.hibernate.jpa.internal.util.LogHelper  : HHH000204: Processing PersistenceUnitInfo [name: default]
2024-11-14T08:14:15.643-03:00  INFO 16096 --- [demo] [           main] org.hibernate.Version                    : HHH000412: Hibernate ORM core version 6.6.2.Final
2024-11-14T08:14:15.683-03:00  INFO 16096 --- [demo] [           main] o.h.c.internal.RegionFactoryInitiator    : HHH000026: Second-level cache disabled
2024-11-14T08:14:15.999-03:00  INFO 16096 --- [demo] [           main] o.s.o.j.p.SpringPersistenceUnitInfo      : No LoadTimeWeaver setup: ignoring JPA class transformer
2024-11-14T08:14:16.084-03:00  INFO 16096 --- [demo] [           main] org.hibernate.orm.connections.pooling    : HHH10001005: Database info:
	Database JDBC URL [Connecting through datasource 'HikariDataSource (HikariPool-1)']
	Database driver: undefined/unknown
	Database version: 14.13
	Autocommit mode: undefined/unknown
	Isolation level: undefined/unknown
	Minimum pool size: undefined/unknown
	Maximum pool size: undefined/unknown
2024-11-14T08:14:16.407-03:00  INFO 16096 --- [demo] [           main] o.h.e.t.j.p.i.JtaPlatformInitiator       : HHH000489: No JTA platform available (set 'hibernate.transaction.jta.platform' to enable JTA platform integration)
2024-11-14T08:14:16.411-03:00  INFO 16096 --- [demo] [           main] j.LocalContainerEntityManagerFactoryBean : Initialized JPA EntityManagerFactory for persistence unit 'default'
2024-11-14T08:14:16.608-03:00  INFO 16096 --- [demo] [           main] com.example.demo.DemoApplicationTests    : Started DemoApplicationTests in 3.933 seconds (process running for 4.897)
Mockito is currently self-attaching to enable the inline-mock-maker. This will no longer work in future releases of the JDK. Please add Mockito as an agent to your build what is described in Mockito's documentation: https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#0.3
WARNING: A Java agent has been loaded dynamically (C:\Users\filip\.m2\repository\net\bytebuddy\byte-buddy-agent\1.15.10\byte-buddy-agent-1.15.10.jar)
WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
WARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information
WARNING: Dynamic loading of agents will be disallowed by default in a future release
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
2024-11-14T08:14:17.163-03:00  INFO 16096 --- [demo] [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2024-11-14T08:14:17.164-03:00  INFO 16096 --- [demo] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown initiated...
2024-11-14T08:14:17.169-03:00  INFO 16096 --- [demo] [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown completed.

Process finished with exit code 0
```


Fixe #6501
