### PR TITLE
Fixes #3763 tagDatabase tag allows for duplicate tag values

### DIFF
--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/core/TagIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/core/TagIntegrationTest.groovy
@@ -1,0 +1,73 @@
+package liquibase.command.core
+
+import liquibase.Scope
+import liquibase.command.CommandScope
+import liquibase.command.core.helpers.DbUrlConnectionArgumentsCommandStep
+import liquibase.command.util.CommandUtil
+import liquibase.extension.testing.testsystem.DatabaseTestSystem
+import liquibase.extension.testing.testsystem.TestSystemFactory
+import liquibase.extension.testing.testsystem.spock.LiquibaseIntegrationTest
+import spock.lang.Shared
+import spock.lang.Specification
+
+@LiquibaseIntegrationTest
+class TagIntegrationTest extends Specification {
+
+    @Shared
+    private DatabaseTestSystem h2 = (DatabaseTestSystem) Scope.getCurrentScope().getSingleton(TestSystemFactory.class).getTestSystem("h2")
+
+    def "validate update command with duplicated tag changes is successfully executed with only one tag applied"() {
+        when:
+        def updateCommand = new CommandScope(UpdateCommandStep.COMMAND_NAME)
+        updateCommand.addArgumentValue(DbUrlConnectionArgumentsCommandStep.URL_ARG, h2.getConnectionUrl())
+        updateCommand.addArgumentValue(DbUrlConnectionArgumentsCommandStep.USERNAME_ARG, h2.getUsername())
+        updateCommand.addArgumentValue(DbUrlConnectionArgumentsCommandStep.PASSWORD_ARG, h2.getPassword())
+        updateCommand.addArgumentValue(UpdateSqlCommandStep.CHANGELOG_FILE_ARG, "liquibase/tag-changelog.xml")
+        updateCommand.execute()
+
+        then:
+        def detailsResultSet1 = h2.getConnection().createStatement().executeQuery("select count(*) from databasechangelog where tag = 'release/1.0'")
+        def detailsResultSet2 = h2.getConnection().createStatement().executeQuery("select count(*) from databasechangelog where tag = 'release/0.1'")
+        detailsResultSet1.next();
+        detailsResultSet1.getInt(1) == 1
+        detailsResultSet2.next();
+        detailsResultSet2.getInt(1) == 1
+
+
+        cleanup:
+        CommandUtil.runDropAll(h2)
+    }
+
+    def "validate tag is successfully executed with clearing all existing tags"() {
+        when:
+        def updateCommand = new CommandScope(UpdateCommandStep.COMMAND_NAME)
+        updateCommand.addArgumentValue(DbUrlConnectionArgumentsCommandStep.URL_ARG, h2.getConnectionUrl())
+        updateCommand.addArgumentValue(DbUrlConnectionArgumentsCommandStep.USERNAME_ARG, h2.getUsername())
+        updateCommand.addArgumentValue(DbUrlConnectionArgumentsCommandStep.PASSWORD_ARG, h2.getPassword())
+        updateCommand.addArgumentValue(UpdateSqlCommandStep.CHANGELOG_FILE_ARG, "liquibase/tag-changelog.xml")
+        updateCommand.execute()
+
+        def tagCommand = new CommandScope(TagCommandStep.COMMAND_NAME)
+        tagCommand.addArgumentValue(TagCommandStep.TAG_ARG, "release/1.0")
+        tagCommand.addArgumentValue(DbUrlConnectionArgumentsCommandStep.URL_ARG, h2.getConnectionUrl())
+        tagCommand.addArgumentValue(DbUrlConnectionArgumentsCommandStep.USERNAME_ARG, h2.getUsername())
+        tagCommand.addArgumentValue(DbUrlConnectionArgumentsCommandStep.PASSWORD_ARG, h2.getPassword())
+        tagCommand.execute()
+
+        then:
+        def detailsResultSet1 = h2.getConnection().createStatement().executeQuery("select count(*) from databasechangelog where tag = 'release/1.0'")
+        def detailsResultSet2 = h2.getConnection().createStatement().executeQuery("select count(*) from databasechangelog where tag = 'release/1.0' and id = 'comment_change'")
+        def detailsResultSet3 = h2.getConnection().createStatement().executeQuery("select count(*) from databasechangelog where tag = 'release/0.1'")
+        detailsResultSet1.next()
+        detailsResultSet1.getInt(1) == 1
+        detailsResultSet2.next()
+        detailsResultSet2.getInt(1) == 1
+        detailsResultSet3.next()
+        detailsResultSet3.getInt(1) == 1
+
+        cleanup:
+        CommandUtil.runDropAll(h2)
+    }
+
+
+}

--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/core/TagIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/core/TagIntegrationTest.groovy
@@ -16,7 +16,7 @@ class TagIntegrationTest extends Specification {
     @Shared
     private DatabaseTestSystem h2 = (DatabaseTestSystem) Scope.getCurrentScope().getSingleton(TestSystemFactory.class).getTestSystem("h2")
 
-    def "validate update command with duplicated tag changes is successfully executed with only one tag applied"() {
+    def "validate that only the last change populates the tag field when multiple changes with the same tag value are applied"() {
         when:
         def updateCommand = new CommandScope(UpdateCommandStep.COMMAND_NAME)
         updateCommand.addArgumentValue(DbUrlConnectionArgumentsCommandStep.URL_ARG, h2.getConnectionUrl())
@@ -26,8 +26,10 @@ class TagIntegrationTest extends Specification {
         updateCommand.execute()
 
         then:
-        def detailsResultSet1 = h2.getConnection().createStatement().executeQuery("select count(*) from databasechangelog where tag = 'release/1.0'")
-        def detailsResultSet2 = h2.getConnection().createStatement().executeQuery("select count(*) from databasechangelog where tag = 'release/0.1'")
+        def detailsResultSet1 = h2.getConnection().createStatement()
+                .executeQuery("select count(*) from databasechangelog where tag = 'release/1.0'")
+        def detailsResultSet2 = h2.getConnection().createStatement()
+                .executeQuery("select count(*) from databasechangelog where tag = 'release/0.1'")
         detailsResultSet1.next();
         detailsResultSet1.getInt(1) == 1
         detailsResultSet2.next();
@@ -38,7 +40,7 @@ class TagIntegrationTest extends Specification {
         CommandUtil.runDropAll(h2)
     }
 
-    def "validate tag is successfully executed with clearing all existing tags"() {
+    def "validate that the tag command clears tag fields for existing changes with the same tag value before applying"() {
         when:
         def updateCommand = new CommandScope(UpdateCommandStep.COMMAND_NAME)
         updateCommand.addArgumentValue(DbUrlConnectionArgumentsCommandStep.URL_ARG, h2.getConnectionUrl())
@@ -55,9 +57,12 @@ class TagIntegrationTest extends Specification {
         tagCommand.execute()
 
         then:
-        def detailsResultSet1 = h2.getConnection().createStatement().executeQuery("select count(*) from databasechangelog where tag = 'release/1.0'")
-        def detailsResultSet2 = h2.getConnection().createStatement().executeQuery("select count(*) from databasechangelog where tag = 'release/1.0' and id = 'comment_change'")
-        def detailsResultSet3 = h2.getConnection().createStatement().executeQuery("select count(*) from databasechangelog where tag = 'release/0.1'")
+        def detailsResultSet1 = h2.getConnection().createStatement()
+                .executeQuery("select count(*) from databasechangelog where tag = 'release/1.0'")
+        def detailsResultSet2 = h2.getConnection().createStatement()
+                .executeQuery("select count(*) from databasechangelog where tag = 'release/1.0' and id = 'comment_change'")
+        def detailsResultSet3 = h2.getConnection().createStatement()
+                .executeQuery("select count(*) from databasechangelog where tag = 'release/0.1'")
         detailsResultSet1.next()
         detailsResultSet1.getInt(1) == 1
         detailsResultSet2.next()

--- a/liquibase-integration-tests/src/test/resources/liquibase/tag-changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/liquibase/tag-changelog.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet id="TAG-0" author="dev1">
+        <tagDatabase tag="release/0.1"/>
+    </changeSet>
+    <changeSet id="TAG-1" author="dev1">
+        <tagDatabase tag="release/1.0"/>
+    </changeSet>
+    <changeSet id="TAG-1" author="dev2">
+        <tagDatabase tag="release/1.0"/>
+    </changeSet>
+    <changeSet id="comment_change" author="dev2">
+        <comment>Comment change</comment>
+    </changeSet>
+</databaseChangeLog>

--- a/liquibase-standard/src/main/java/liquibase/logging/mdc/NoOpMdcManager.java
+++ b/liquibase-standard/src/main/java/liquibase/logging/mdc/NoOpMdcManager.java
@@ -9,7 +9,7 @@ import java.util.Map;
 /**
  * Default MDC manager, which does nothing.
  */
-public class NoOpMdcManager implements MdcManager {
+    public class NoOpMdcManager implements MdcManager {
     @Override
     public MdcObject put(String key, String value) {
         return new MdcObject(key, value);

--- a/liquibase-standard/src/main/java/liquibase/logging/mdc/NoOpMdcManager.java
+++ b/liquibase-standard/src/main/java/liquibase/logging/mdc/NoOpMdcManager.java
@@ -9,7 +9,7 @@ import java.util.Map;
 /**
  * Default MDC manager, which does nothing.
  */
-    public class NoOpMdcManager implements MdcManager {
+public class NoOpMdcManager implements MdcManager {
     @Override
     public MdcObject put(String key, String value) {
         return new MdcObject(key, value);

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/ChainableAbstractSqlGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/ChainableAbstractSqlGenerator.java
@@ -1,0 +1,23 @@
+package liquibase.sqlgenerator.core;
+
+import liquibase.database.Database;
+import liquibase.sql.Sql;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.statement.SqlStatement;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public abstract class ChainableAbstractSqlGenerator<T extends SqlStatement> extends AbstractSqlGenerator<T> {
+
+    @Override
+    public Sql[] generateSql(final T statement, final Database database, final SqlGeneratorChain<T> sqlGeneratorChain) {
+        List<Sql> sqls = new ArrayList<>();
+        sqls.addAll(Arrays.asList(generateSql(statement, database)));
+        sqls.addAll(Arrays.asList(sqlGeneratorChain.generateSql(statement, database)));
+        return sqls.toArray(EMPTY_SQL);
+    }
+
+    public abstract Sql[] generateSql(final T statement, final Database database);
+}

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/ClearDuplicatedTagsBeforeMarkChangeStatementGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/ClearDuplicatedTagsBeforeMarkChangeStatementGenerator.java
@@ -1,0 +1,45 @@
+package liquibase.sqlgenerator.core;
+
+import liquibase.changelog.ChangeSet;
+import liquibase.database.Database;
+import liquibase.database.ObjectQuotingStrategy;
+import liquibase.exception.ValidationErrors;
+import liquibase.sql.Sql;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.statement.core.MarkChangeSetRanStatement;
+import liquibase.util.TagUtil;
+
+public class ClearDuplicatedTagsBeforeMarkChangeStatementGenerator extends ChainableAbstractSqlGenerator<MarkChangeSetRanStatement> {
+
+    @Override
+    public ValidationErrors validate(MarkChangeSetRanStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+        ValidationErrors validationErrors = new ValidationErrors();
+        validationErrors.checkRequiredField("changeSet", statement.getChangeSet());
+        return validationErrors;
+    }
+
+    @Override
+    public Sql[] generateSql(MarkChangeSetRanStatement statement, Database database) {
+        if (statement.getExecType().equals(ChangeSet.ExecType.FAILED)
+                || statement.getExecType().equals(ChangeSet.ExecType.SKIPPED)) {
+            return EMPTY_SQL;
+        }
+        String tag = TagUtil.getTagFromChangeset(statement.getChangeSet());
+        if (tag == null) {
+            return EMPTY_SQL;
+        }
+
+        ObjectQuotingStrategy currentStrategy = database.getObjectQuotingStrategy();
+        database.setObjectQuotingStrategy(ObjectQuotingStrategy.LEGACY);
+        try {
+            return TagUtil.buildClearDuplicatedTagSql(database, tag);
+        } finally {
+            database.setObjectQuotingStrategy(currentStrategy);
+        }
+    }
+
+    @Override
+    public int getPriority() {
+        return PRIORITY_DATABASE;
+    }
+}

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/ClearDuplicatedTagsBeforeTagStatementGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/ClearDuplicatedTagsBeforeTagStatementGenerator.java
@@ -23,10 +23,6 @@ public class ClearDuplicatedTagsBeforeTagStatementGenerator extends ChainableAbs
 
     @Override
     public Sql[] generateSql(TagDatabaseStatement statement, Database database) {
-        String tag = statement.getTag();
-        if (tag == null) {
-            return EMPTY_SQL;
-        }
-        return TagUtil.buildClearDuplicatedTagSql(database, tag);
+        return TagUtil.buildClearDuplicatedTagSql(database, statement.getTag());
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/ClearDuplicatedTagsBeforeTagStatementGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/ClearDuplicatedTagsBeforeTagStatementGenerator.java
@@ -1,0 +1,32 @@
+package liquibase.sqlgenerator.core;
+
+import liquibase.database.Database;
+import liquibase.exception.ValidationErrors;
+import liquibase.sql.Sql;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.statement.core.TagDatabaseStatement;
+import liquibase.util.TagUtil;
+
+public class ClearDuplicatedTagsBeforeTagStatementGenerator extends ChainableAbstractSqlGenerator<TagDatabaseStatement> {
+
+    @Override
+    public ValidationErrors validate(TagDatabaseStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+        ValidationErrors validationErrors = new ValidationErrors();
+        validationErrors.checkRequiredField("tag", statement.getTag());
+        return validationErrors;
+    }
+
+    @Override
+    public int getPriority() {
+        return PRIORITY_DATABASE;
+    }
+
+    @Override
+    public Sql[] generateSql(TagDatabaseStatement statement, Database database) {
+        String tag = statement.getTag();
+        if (tag == null) {
+            return EMPTY_SQL;
+        }
+        return TagUtil.buildClearDuplicatedTagSql(database, tag);
+    }
+}

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/MarkChangeSetRanGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/MarkChangeSetRanGenerator.java
@@ -22,6 +22,7 @@ import liquibase.statement.core.MarkChangeSetRanStatement;
 import liquibase.statement.core.UpdateStatement;
 import liquibase.util.LiquibaseUtil;
 import liquibase.util.StringUtil;
+import liquibase.util.TagUtil;
 
 public class MarkChangeSetRanGenerator extends AbstractSqlGenerator<MarkChangeSetRanStatement> {
 
@@ -53,7 +54,7 @@ public class MarkChangeSetRanGenerator extends AbstractSqlGenerator<MarkChangeSe
                     return EMPTY_SQL; //don't mark
                 }
 
-                final String tag = getTagFromChangeset(changeSet);
+                final String tag = TagUtil.getTagFromChangeset(changeSet);
                 final int orderExecuted = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database).getNextSequenceValue();
 	            final DatabaseFunction dateExecuted = new DatabaseFunction(dateValue);
                 final String liquibaseVersion = getLiquibaseBuildVersion();
@@ -110,18 +111,6 @@ public class MarkChangeSetRanGenerator extends AbstractSqlGenerator<MarkChangeSe
         } finally {
             database.setObjectQuotingStrategy(currentStrategy);
         }
-    }
-
-    public static String getTagFromChangeset(ChangeSet changeSet) {
-        if (changeSet != null) {
-            for (Change change : changeSet.getChanges()) {
-                if (change instanceof TagDatabaseChange) {
-                    TagDatabaseChange tagChange = (TagDatabaseChange) change;
-                    return tagChange.getTag();
-                }
-            }
-        }
-        return null;
     }
 
     public static String getLiquibaseBuildVersion() {

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/MarkChangeSetRanGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/MarkChangeSetRanGenerator.java
@@ -2,8 +2,6 @@ package liquibase.sqlgenerator.core;
 
 import liquibase.ChecksumVersion;
 import liquibase.Scope;
-import liquibase.change.Change;
-import liquibase.change.core.TagDatabaseChange;
 import liquibase.changelog.ChangeLogHistoryServiceFactory;
 import liquibase.changelog.ChangeSet;
 import liquibase.changelog.column.LiquibaseColumn;

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/TagDatabaseGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/TagDatabaseGenerator.java
@@ -33,6 +33,7 @@ public class TagDatabaseGenerator extends AbstractSqlGenerator<TagDatabaseStatem
             String dateColumnNameEscaped = database.escapeObjectName("DATEEXECUTED", Column.class);
             String tagColumnNameEscaped = database.escapeObjectName("TAG", Column.class);
             String tagEscaped = DataTypeFactory.getInstance().fromObject(statement.getTag(), database).objectToSql(statement.getTag(), database);
+
             if (database instanceof MySQLDatabase) {
                 return new Sql[]{
                         new UnparsedSql(
@@ -118,13 +119,13 @@ public class TagDatabaseGenerator extends AbstractSqlGenerator<TagDatabaseStatem
 
                 //Only uses dateexecuted as a default. Depending on the timestamp resolution, multiple rows may be tagged which normally works fine but can cause confusion and some issues.
                 //We cannot use orderexecuted alone because it is only guaranteed to be incrementing per update call.
-                //TODO: Better handle other databases to use dateexecuted desc, orderexecuted desc.
                 UpdateStatement updateStatement = new UpdateStatement(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogTableName())
                         .addNewColumnValue("TAG", statement.getTag())
                         .setWhereClause(
-                                dateColumnNameEscaped + " = (" +
-                                        "SELECT MAX(" + dateColumnNameEscaped + ") " +
-                                        "FROM " + tableNameEscaped +
+                                orderColumnNameEscaped + " = (" +
+                                        "SELECT MAX(" + orderColumnNameEscaped + ") FROM " + tableNameEscaped + " " +
+                                        "WHERE " + dateColumnNameEscaped + " = (" +
+                                          "SELECT MAX(" + dateColumnNameEscaped + ") FROM " + tableNameEscaped + ")" +
                                         ")");
 
                 return SqlGeneratorFactory.getInstance().generateSql(updateStatement, database);

--- a/liquibase-standard/src/main/java/liquibase/util/TagUtil.java
+++ b/liquibase-standard/src/main/java/liquibase/util/TagUtil.java
@@ -1,0 +1,33 @@
+package liquibase.util;
+
+import liquibase.change.Change;
+import liquibase.change.core.TagDatabaseChange;
+import liquibase.changelog.ChangeSet;
+import liquibase.changelog.column.LiquibaseColumn;
+import liquibase.database.Database;
+import liquibase.sql.Sql;
+import liquibase.sqlgenerator.SqlGeneratorFactory;
+import liquibase.statement.SqlStatement;
+import liquibase.statement.core.UpdateStatement;
+
+public class TagUtil {
+    public static Sql[] buildClearDuplicatedTagSql(Database database, String tag) {
+        SqlStatement runStatement = new UpdateStatement(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogTableName())
+                .addNewColumnValue("TAG", null)
+                .setWhereClause(database.escapeObjectName("TAG", LiquibaseColumn.class) + " = ?")
+                .addWhereParameters(tag);
+        return SqlGeneratorFactory.getInstance().generateSql(runStatement, database);
+    }
+
+    public static String getTagFromChangeset(ChangeSet changeSet) {
+        if (changeSet != null) {
+            for (Change change : changeSet.getChanges()) {
+                if (change instanceof TagDatabaseChange) {
+                    TagDatabaseChange tagChange = (TagDatabaseChange) change;
+                    return tagChange.getTag();
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/liquibase-standard/src/main/resources/META-INF/services/liquibase.sqlgenerator.SqlGenerator
+++ b/liquibase-standard/src/main/resources/META-INF/services/liquibase.sqlgenerator.SqlGenerator
@@ -79,6 +79,8 @@ liquibase.sqlgenerator.core.InsertOrUpdateGeneratorSybaseASA
 liquibase.sqlgenerator.core.InsertSetGenerator
 liquibase.sqlgenerator.core.LockDatabaseChangeLogGenerator
 liquibase.sqlgenerator.core.MarkChangeSetRanGenerator
+liquibase.sqlgenerator.core.ClearDuplicatedTagsBeforeMarkChangeStatementGenerator
+liquibase.sqlgenerator.core.ClearDuplicatedTagsBeforeTagStatementGenerator
 liquibase.sqlgenerator.core.ModifyDataTypeGenerator
 liquibase.sqlgenerator.core.RawParameterizedSqlGenerator
 liquibase.sqlgenerator.core.RawSqlGenerator

--- a/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/ChainableAbstractSqlGeneratorTest.java
+++ b/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/ChainableAbstractSqlGeneratorTest.java
@@ -55,7 +55,8 @@ public class ChainableAbstractSqlGeneratorTest {
         }
 
         @Override
-        public ValidationErrors validate(final TagDatabaseStatement statement, final Database database, final SqlGeneratorChain<TagDatabaseStatement> sqlGeneratorChain) {
+        public ValidationErrors validate(final TagDatabaseStatement statement, final Database database,
+                                         final SqlGeneratorChain<TagDatabaseStatement> sqlGeneratorChain) {
             return null;
         }
 

--- a/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/ChainableAbstractSqlGeneratorTest.java
+++ b/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/ChainableAbstractSqlGeneratorTest.java
@@ -1,0 +1,72 @@
+package liquibase.sqlgenerator.core;
+
+import liquibase.database.Database;
+import liquibase.database.core.PostgresDatabase;
+import liquibase.exception.ValidationErrors;
+import liquibase.servicelocator.LiquibaseService;
+import liquibase.sql.Sql;
+import liquibase.sql.UnparsedSql;
+import liquibase.sqlgenerator.SqlGenerator;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.statement.core.TagDatabaseStatement;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import static org.junit.Assert.assertEquals;
+
+public class ChainableAbstractSqlGeneratorTest {
+
+    @Test
+    public void generateSqlInChainableGenerator_returnAllSqlsFromAllGenerators() {
+        // given
+        SortedSet<SqlGenerator> generators = new TreeSet<>((o1, o2) -> -1 * Integer.compare(o1.getPriority(), o2.getPriority()));
+        generators.add(new ChainableGeneratorTest(5, "SELECT * FROM TABLE1", "SELECT * FROM TABLE2"));
+        generators.add(new ChainableGeneratorTest(1,"SELECT * FROM TABLE3"));
+        SqlGeneratorChain sqlGeneratorChain = new SqlGeneratorChain(generators);
+
+        // when
+        Sql[] sqls = sqlGeneratorChain.generateSql(new TagDatabaseStatement("tag1"), new PostgresDatabase());
+
+        // then
+        assertEquals("SELECT * FROM TABLE1", sqls[0].toSql());
+        assertEquals("SELECT * FROM TABLE2", sqls[1].toSql());
+        assertEquals("SELECT * FROM TABLE3", sqls[2].toSql());
+
+    }
+
+    @LiquibaseService(skip = true)
+    private static class ChainableGeneratorTest extends ChainableAbstractSqlGenerator<TagDatabaseStatement> {
+
+        private String[] returnSql;
+        private int priority;
+
+        public ChainableGeneratorTest(int priority,String... returnSql) {
+            this.priority = priority;
+            this.returnSql = returnSql;
+        }
+
+        @Override
+        public int getPriority() {
+            return this.priority;
+        }
+
+        @Override
+        public ValidationErrors validate(final TagDatabaseStatement statement, final Database database, final SqlGeneratorChain<TagDatabaseStatement> sqlGeneratorChain) {
+            return null;
+        }
+
+        @Override
+        public Sql[] generateSql(final TagDatabaseStatement statement, final Database database) {
+            List<Sql> sql = new ArrayList<Sql>();
+            for (String returnSql  : this.returnSql) {
+                sql.add(new UnparsedSql(returnSql));
+            }
+            return sql.toArray(EMPTY_SQL);
+        }
+    }
+
+}

--- a/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/ClearDuplicatedTagsBeforeMarkChangeStatementGeneratorTest.java
+++ b/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/ClearDuplicatedTagsBeforeMarkChangeStatementGeneratorTest.java
@@ -1,0 +1,92 @@
+package liquibase.sqlgenerator.core;
+
+import liquibase.change.core.InsertDataChange;
+import liquibase.change.core.TagDatabaseChange;
+import liquibase.changelog.ChangeSet;
+import liquibase.changelog.DatabaseChangeLog;
+import liquibase.database.Database;
+import liquibase.database.core.PostgresDatabase;
+import liquibase.sql.Sql;
+import liquibase.statement.core.MarkChangeSetRanStatement;
+import org.junit.Test;
+
+import static liquibase.sqlgenerator.SqlGenerator.EMPTY_SQL;
+import static org.junit.Assert.assertEquals;
+
+public class ClearDuplicatedTagsBeforeMarkChangeStatementGeneratorTest {
+
+    @Test
+    public void whenTagChange_returnClearingStatement() {
+        // given
+        ClearDuplicatedTagsBeforeMarkChangeStatementGenerator generator = new ClearDuplicatedTagsBeforeMarkChangeStatementGenerator();
+        MarkChangeSetRanStatement statement = new MarkChangeSetRanStatement(createChangeSetWithTag(), ChangeSet.ExecType.EXECUTED);
+        Database database = new PostgresDatabase();
+
+        // when
+        Sql[] sqls = generator.generateSql(statement, database);
+
+        // then
+        assertEquals("UPDATE databasechangelog SET TAG = NULL WHERE TAG = 'tag1.0'", sqls[0].toSql());
+    }
+
+    @Test
+    public void whenNullTag_returnEmptyStatement() {
+        // given
+        ClearDuplicatedTagsBeforeMarkChangeStatementGenerator generator = new ClearDuplicatedTagsBeforeMarkChangeStatementGenerator();
+        MarkChangeSetRanStatement statement = new MarkChangeSetRanStatement(createChangeSetWithoutTag(), ChangeSet.ExecType.EXECUTED);
+        Database database = new PostgresDatabase();
+
+        // when
+        Sql[] sqls = generator.generateSql(statement, database);
+
+        // then
+        assertEquals(EMPTY_SQL, sqls);
+    }
+
+    @Test
+    public void whenChangeSetFailed_returnEmptyStatement() {
+        // given
+        ClearDuplicatedTagsBeforeMarkChangeStatementGenerator generator = new ClearDuplicatedTagsBeforeMarkChangeStatementGenerator();
+        MarkChangeSetRanStatement statement = new MarkChangeSetRanStatement(createChangeSetWithoutTag(), ChangeSet.ExecType.FAILED);
+        Database database = new PostgresDatabase();
+
+        // when
+        Sql[] sqls = generator.generateSql(statement, database);
+
+        // then
+        assertEquals(EMPTY_SQL, sqls);
+    }
+
+    @Test
+    public void whenChangeSetSkipped_returnEmptyStatement() {
+        // given
+        ClearDuplicatedTagsBeforeMarkChangeStatementGenerator generator = new ClearDuplicatedTagsBeforeMarkChangeStatementGenerator();
+        MarkChangeSetRanStatement statement = new MarkChangeSetRanStatement(createChangeSetWithoutTag(), ChangeSet.ExecType.SKIPPED);
+        Database database = new PostgresDatabase();
+
+        // when
+        Sql[] sqls = generator.generateSql(statement, database);
+
+        // then
+        assertEquals(EMPTY_SQL, sqls);
+    }
+
+    private ChangeSet createChangeSetWithTag() {
+        DatabaseChangeLog databaseChangeLog = new DatabaseChangeLog("/patch/changeLog.xml");
+        ChangeSet changeSet = new ChangeSet("id", "author", false, false, "/path/changeSet.xml", "", "", databaseChangeLog);
+        TagDatabaseChange tagDatabaseChange = new TagDatabaseChange();
+        tagDatabaseChange.setTag("tag1.0");
+        changeSet.addChange(tagDatabaseChange);
+        databaseChangeLog.addChangeSet(changeSet);
+        return changeSet;
+    }
+
+    private ChangeSet createChangeSetWithoutTag() {
+        DatabaseChangeLog databaseChangeLog = new DatabaseChangeLog("/patch/changeLog.xml");
+        ChangeSet changeSet = new ChangeSet("id", "author", false, false, "/path/changeSet.xml", "", "", databaseChangeLog);
+        changeSet.addChange(new InsertDataChange());
+        databaseChangeLog.addChangeSet(changeSet);
+        return changeSet;
+    }
+
+}

--- a/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/ClearDuplicatedTagsBeforeMarkChangeStatementGeneratorTest.java
+++ b/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/ClearDuplicatedTagsBeforeMarkChangeStatementGeneratorTest.java
@@ -6,6 +6,7 @@ import liquibase.changelog.ChangeSet;
 import liquibase.changelog.DatabaseChangeLog;
 import liquibase.database.Database;
 import liquibase.database.core.PostgresDatabase;
+import liquibase.exception.ValidationErrors;
 import liquibase.sql.Sql;
 import liquibase.statement.core.MarkChangeSetRanStatement;
 import org.junit.Test;
@@ -41,6 +42,19 @@ public class ClearDuplicatedTagsBeforeMarkChangeStatementGeneratorTest {
 
         // then
         assertEquals(EMPTY_SQL, sqls);
+    }
+
+    @Test
+    public void whenChangeSetEmptyInStatement_validationFails() {
+        // given
+        ClearDuplicatedTagsBeforeMarkChangeStatementGenerator generator = new ClearDuplicatedTagsBeforeMarkChangeStatementGenerator();
+        MarkChangeSetRanStatement statement = new MarkChangeSetRanStatement(null, ChangeSet.ExecType.EXECUTED);
+
+        // when
+        ValidationErrors validate = generator.validate(statement, new PostgresDatabase(), null);
+
+        // then
+        assertEquals(1, validate.getErrorMessages().size());
     }
 
     @Test

--- a/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/ClearDuplicatedTagsBeforeTagStatementGeneratorTest.java
+++ b/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/ClearDuplicatedTagsBeforeTagStatementGeneratorTest.java
@@ -2,11 +2,11 @@ package liquibase.sqlgenerator.core;
 
 import liquibase.database.Database;
 import liquibase.database.core.PostgresDatabase;
+import liquibase.exception.ValidationErrors;
 import liquibase.sql.Sql;
 import liquibase.statement.core.TagDatabaseStatement;
 import org.junit.Test;
 
-import static liquibase.sqlgenerator.SqlGenerator.EMPTY_SQL;
 import static org.junit.Assert.assertEquals;
 
 public class ClearDuplicatedTagsBeforeTagStatementGeneratorTest {
@@ -26,17 +26,17 @@ public class ClearDuplicatedTagsBeforeTagStatementGeneratorTest {
     }
 
     @Test
-    public void whenNullTag_returnEmptyStatement() {
+    public void whenNullTagInStatement_validationFails() {
         // given
         ClearDuplicatedTagsBeforeTagStatementGenerator generator = new ClearDuplicatedTagsBeforeTagStatementGenerator();
         TagDatabaseStatement statement = new TagDatabaseStatement(null);
         Database database = new PostgresDatabase();
 
         // when
-        Sql[] sqls = generator.generateSql(statement, database);
+        ValidationErrors validate = generator.validate(statement, database, null);
 
         // then
-        assertEquals(EMPTY_SQL, sqls);
+        assertEquals(1, validate.getErrorMessages().size());
     }
 
 }

--- a/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/ClearDuplicatedTagsBeforeTagStatementGeneratorTest.java
+++ b/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/ClearDuplicatedTagsBeforeTagStatementGeneratorTest.java
@@ -1,0 +1,42 @@
+package liquibase.sqlgenerator.core;
+
+import liquibase.database.Database;
+import liquibase.database.core.PostgresDatabase;
+import liquibase.sql.Sql;
+import liquibase.statement.core.TagDatabaseStatement;
+import org.junit.Test;
+
+import static liquibase.sqlgenerator.SqlGenerator.EMPTY_SQL;
+import static org.junit.Assert.assertEquals;
+
+public class ClearDuplicatedTagsBeforeTagStatementGeneratorTest {
+
+    @Test
+    public void whenTagStatement_returnClearingStatement() {
+        // given
+        ClearDuplicatedTagsBeforeTagStatementGenerator generator = new ClearDuplicatedTagsBeforeTagStatementGenerator();
+        TagDatabaseStatement statement = new TagDatabaseStatement("tag1.0");
+        Database database = new PostgresDatabase();
+
+        // when
+        Sql[] sqls = generator.generateSql(statement, database);
+
+        // then
+        assertEquals("UPDATE databasechangelog SET TAG = NULL WHERE TAG = 'tag1.0'", sqls[0].toSql());
+    }
+
+    @Test
+    public void whenNullTag_returnEmptyStatement() {
+        // given
+        ClearDuplicatedTagsBeforeTagStatementGenerator generator = new ClearDuplicatedTagsBeforeTagStatementGenerator();
+        TagDatabaseStatement statement = new TagDatabaseStatement(null);
+        Database database = new PostgresDatabase();
+
+        // when
+        Sql[] sqls = generator.generateSql(statement, database);
+
+        // then
+        assertEquals(EMPTY_SQL, sqls);
+    }
+
+}

--- a/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/TagDatabaseGeneratorTest.java
+++ b/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/TagDatabaseGeneratorTest.java
@@ -1,6 +1,7 @@
 package liquibase.sqlgenerator.core;
 
-import liquibase.database.core.HsqlDatabase;
+import liquibase.database.AbstractJdbcDatabase;
+import liquibase.database.DatabaseConnection;
 import liquibase.database.core.MSSQLDatabase;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.SqlGeneratorFactory;
@@ -60,18 +61,64 @@ public class TagDatabaseGeneratorTest {
     }
 
     @Test
-    public void testHsql() throws Exception {
+    public void testOtherDb() {
         TagDatabaseStatement statement = new TagDatabaseStatement("v1.0");
-        Sql[] sql = SqlGeneratorFactory.getInstance().generateSql(statement, new HsqlDatabase());
+
+        Sql[] sql = SqlGeneratorFactory.getInstance().generateSql(statement, new OtherDb());
 
         assertEquals(1, sql.length);
         assertEquals(
                 "UPDATE DATABASECHANGELOG " +
                 "SET TAG = 'v1.0' " +
-                "WHERE DATEEXECUTED = (" +
-                    "SELECT MAX(DATEEXECUTED) " +
-                    "FROM DATABASECHANGELOG" +
+                "WHERE ORDEREXECUTED = (" +
+                  "SELECT MAX(ORDEREXECUTED) FROM DATABASECHANGELOG " +
+                  "WHERE DATEEXECUTED = (" +
+                    "SELECT MAX(DATEEXECUTED) FROM DATABASECHANGELOG" +
+                  ")" +
                 ")",
                 sql[0].toSql());
+    }
+
+    private static class OtherDb extends AbstractJdbcDatabase {
+
+        @Override
+        protected String getDefaultDatabaseProductName() {
+            return null;
+        }
+
+        @Override
+        public boolean isCorrectDatabaseImplementation(final DatabaseConnection conn) {
+            return false;
+        }
+
+        @Override
+        public String getDefaultDriver(final String url) {
+            return null;
+        }
+
+        @Override
+        public String getShortName() {
+            return "OtherDb";
+        }
+
+        @Override
+        public Integer getDefaultPort() {
+            return null;
+        }
+
+        @Override
+        public boolean supportsInitiallyDeferrableColumns() {
+            return false;
+        }
+
+        @Override
+        public boolean supportsTablespaces() {
+            return false;
+        }
+
+        @Override
+        public int getPriority() {
+            return 0;
+        }
     }
 }

--- a/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/TagDatabaseGeneratorTest.java
+++ b/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/TagDatabaseGeneratorTest.java
@@ -40,7 +40,7 @@ public class TagDatabaseGeneratorTest {
 //    }
 
     @Test
-    public void testMSSQL() throws Exception {
+    public void testMSSQL() {
         TagDatabaseStatement statement = new TagDatabaseStatement("v1.0");
         Sql[] sql = SqlGeneratorFactory.getInstance().generateSql(statement, new MSSQLDatabase());
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

Fixed duplicate tags in the **databasechangelog** table per recommendations from issue #3763:

- For the **update** command: Before applying a tag changeset, the system checks **databasechangelog** for any existing rows with the same tag. If found, the existing tag value is cleared.
- For the **tag** command: Before setting a tag on the last row, the system checks **databasechangelog** for any existing rows with the same tag. If found, the existing tag value is cleared.
- Updated tagging logic **TagDatabaseGenerator** for default databases: Rows are now selected based on the highest **DATEEXECUTED** and, subsequently, the highest **ORDEREXECUTED**.

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->


## Things to be aware of
If we have to changesets, for example:

    <changeSet id="TAG-1" author="dev1">
        <tagDatabase tag="release/1.0"/>
    </changeSet>
    <changeSet id="TAG-1" author="dev2">
        <tagDatabase tag="release/1.0"/>
    </changeSet>

We will get two records in databasechangelog, but only one will have the tag field filled. In other words, one tagChangeset record will be without a tag

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about
I've implemented **ChainableAbstractSqlGenerator** to handle the responsibility of advancing in the SqlGeneratorChain. Maybe it's an overhead.
<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
