### PR TITLE
Fix Sequence generator - cache size, data type - for various DBs

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/AlterSequenceGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/AlterSequenceGenerator.java
@@ -74,11 +74,22 @@ public class AlterSequenceGenerator extends AbstractSqlGenerator<AlterSequenceSt
             }
         }
 
-        if ((statement.getCacheSize() != null) && (database instanceof OracleDatabase || database instanceof PostgresDatabase || database instanceof MariaDBDatabase)) {
-            if (statement.getCacheSize().equals(BigInteger.ZERO)) {
-                buffer.append(" NOCACHE ");
-            } else {
-                buffer.append(" CACHE ").append(statement.getCacheSize());
+        if (statement.getCacheSize() != null) {
+            if (database instanceof OracleDatabase || database instanceof AbstractDb2Database || database instanceof PostgresDatabase
+                    || database instanceof MariaDBDatabase || database instanceof SybaseASADatabase || database instanceof MSSQLDatabase) {
+                if (BigInteger.ZERO.equals(statement.getCacheSize())) {
+                    if (database instanceof OracleDatabase) {
+                        buffer.append(" NOCACHE");
+                    } else if (database instanceof SybaseASADatabase || database instanceof AbstractDb2Database || database instanceof MSSQLDatabase) {
+                        buffer.append(" NO CACHE");
+                    } else if (database instanceof MariaDBDatabase) {
+                        buffer.append(" CACHE 0");
+                    } else if (database instanceof PostgresDatabase) {
+                        buffer.append(" CACHE 1");
+                    }
+                } else {
+                    buffer.append(" CACHE ").append(statement.getCacheSize());
+                }
             }
         }
 

--- a/liquibase-standard/src/test/resources/liquibase/change/ChangeDefinitionTest.yaml
+++ b/liquibase-standard/src/test/resources/liquibase/change/ChangeDefinitionTest.yaml
@@ -408,7 +408,7 @@ createSequence: |
     Supported: all
   dataType string 
     Description: Data type of the sequence
-    Supported: asany,cockroachdb,db2,db2z,derby,edb,h2,informix,postgresql
+    Supported: asany,cockroachdb,db2,db2z,derby,edb,h2,hsqldb,informix,mssql,postgresql
   incrementBy bigInteger 
     Description: Interval between sequence numbers
     Supported: asany,cockroachdb,db2,db2z,derby,edb,h2,hsqldb,informix,mariadb,mssql,oracle,postgresql

--- a/liquibase-standard/src/test/resources/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/createSequence/db2.sql
+++ b/liquibase-standard/src/test/resources/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/createSequence/db2.sql
@@ -1,3 +1,3 @@
 -- Database: db2
 -- Change Parameter: sequenceName=seq_id
-CREATE SEQUENCE seq_id;
+CREATE SEQUENCE seq_id AS BIGINT;

--- a/liquibase-standard/src/test/resources/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/createSequence/db2i.sql
+++ b/liquibase-standard/src/test/resources/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/createSequence/db2i.sql
@@ -1,3 +1,3 @@
 -- Database: db2i
 -- Change Parameter: sequenceName=seq_id
-CREATE SEQUENCE seq_id;
+CREATE SEQUENCE seq_id AS BIGINT;


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

Fixes #6421.
Updates database support for sequence parameters `data type` and `cache size`.

#### CreateSequenceGenerator

- No longer throw validation errors for HSQLDB and MSSQL when data-type is specified
- HSQLDB and DB2z are no longer forced to use BIGINT as data-types. However, they will default to it if none is specified. This is done to preserve the functionality which maintains consistent sequence data-types across database types, even those that default to INTEGER. The Db2zDatabase check has been changed to AbstractDb2Database, so DB2 is also covered by this.
- Allow cache-size to be used on all DB2 subtypes by checking instances of AbstractDb2Database
- Allow cache-size to be used on MSSQL
- Add no-cache (cache-size = 0) handling for PGSQL

#### AlterSequenceGenerator
- Replaced cache-size handling with a copy from CreateSequenceGenerator

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

DB2 (DB2i) will have `AS BIGINT` added to their `CREATE SEQUENCE` by default.
