### PR TITLE
fix: only set Spring  analytics scope parameter if it's defined

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/integration/spring/MultiTenantSpringLiquibase.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/spring/MultiTenantSpringLiquibase.java
@@ -110,11 +110,11 @@ public class MultiTenantSpringLiquibase implements InitializingBean, ResourceLoa
 
     @Getter
     @Setter
-    protected String licenseKey;
+    protected String licenseKey = null;
 
     @Getter
     @Setter
-    protected boolean analyticsEnabled;
+    protected Boolean analyticsEnabled = null;
 
     @Getter
     @Setter

--- a/liquibase-standard/src/main/java/liquibase/integration/spring/SpringLiquibase.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/spring/SpringLiquibase.java
@@ -120,7 +120,7 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
 
     @Getter
     @Setter
-    protected boolean analyticsEnabled = true;
+    protected Boolean analyticsEnabled = null;
 
     @Setter
     protected boolean shouldRun = true;
@@ -259,7 +259,9 @@ public class SpringLiquibase implements InitializingBean, BeanNameAware, Resourc
             Map<String, Object> scopeVars = new HashMap<>();
             scopeVars.put(Scope.Attr.ui.name(), this.uiService.getUiServiceClass().getDeclaredConstructor().newInstance());
             scopeVars.put(Scope.Attr.integrationDetails.name(), new IntegrationDetails("spring"));
-            scopeVars.put(AnalyticsArgs.ENABLED.getKey(), analyticsEnabled);
+            if (this.analyticsEnabled != null) {
+                scopeVars.put(AnalyticsArgs.ENABLED.getKey(), this.analyticsEnabled);
+            }
 
             if (this.licenseKey != null) {
                 log.fine("Using PRO licenseKey.");


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Fix for https://github.com/liquibase/liquibase/pull/6516 . The way that it was implemented makes the environment variable LIQUIBASE_ANALYTICS_ENABLED and system property liquibase.analytics.enabled effectively ignored, and we don't want that.

Thanks to @mches for spotting this bug.