### PR TITLE
Implement Watchdog Mechanism for Changelog Lock Refresh (#6538)

### DIFF
--- a/liquibase-core/src/main/java/liquibase/GlobalConfiguration.java
+++ b/liquibase-core/src/main/java/liquibase/GlobalConfiguration.java
@@ -19,6 +19,7 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
     public static final ConfigurationDefinition<String> OUTPUT_LINE_SEPARATOR;
     public static final ConfigurationDefinition<String> OUTPUT_FILE_ENCODING;
     public static final ConfigurationDefinition<Charset> FILE_ENCODING;
+    public static final ConfigurationDefinition<Long> CHANGELOGLOCK_TIMEOUT_WITH_WATCHDOG;
     public static final ConfigurationDefinition<Long> CHANGELOGLOCK_WAIT_TIME;
     public static final ConfigurationDefinition<Long> CHANGELOGLOCK_POLL_RATE;
     public static final ConfigurationDefinition<Boolean> CONVERT_DATA_TYPES;
@@ -48,6 +49,12 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
                 .addAliasKey("liquibase.databaseChangeLogLockTableName")
                 .setDescription("Name of table to use for tracking concurrent Liquibase usage")
                 .setDefaultValue("DATABASECHANGELOGLOCK")
+                .build();
+
+        CHANGELOGLOCK_TIMEOUT_WITH_WATCHDOG = builder.define("changelogLockTimeoutWithWatchdogInSeconds", Long.class)
+                .addAliasKey("liquibase.changelogLockTimeoutWithWatchdogInSeconds")
+                .setDescription("The maximum amount of time (in seconds) to wait before forcibly releasing a lock with watchdog.")
+                .setDefaultValue(60L)
                 .build();
 
         CHANGELOGLOCK_WAIT_TIME = builder.define("changelogLockWaitTimeInMinutes", Long.class)

--- a/liquibase-core/src/main/java/liquibase/sqlgenerator/core/RefreshLockDatabaseChangeLogGenerator.java
+++ b/liquibase-core/src/main/java/liquibase/sqlgenerator/core/RefreshLockDatabaseChangeLogGenerator.java
@@ -1,0 +1,55 @@
+package liquibase.sqlgenerator.core;
+
+import liquibase.database.Database;
+import liquibase.database.core.MSSQLDatabase;
+import liquibase.datatype.DataTypeFactory;
+import liquibase.exception.UnexpectedLiquibaseException;
+import liquibase.exception.ValidationErrors;
+import liquibase.sql.Sql;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.sqlgenerator.SqlGeneratorFactory;
+import liquibase.statement.core.LockDatabaseChangeLogStatement;
+import liquibase.statement.core.RefreshLockDatabaseChangeLogStatement;
+import liquibase.statement.core.UpdateStatement;
+import liquibase.util.NetUtil;
+import org.apache.tools.ant.util.StringUtils;
+
+import java.sql.Timestamp;
+import java.util.UUID;
+
+public class RefreshLockDatabaseChangeLogGenerator extends AbstractSqlGenerator<RefreshLockDatabaseChangeLogStatement> {
+
+    @Override
+    public ValidationErrors validate(RefreshLockDatabaseChangeLogStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+        return new ValidationErrors();
+    }
+
+
+    protected String getCharTypeName(Database database) {
+        if (database instanceof MSSQLDatabase && ((MSSQLDatabase) database).sendsStringParametersAsUnicode()) {
+            return "nvarchar";
+        }
+        return "varchar";
+    }
+
+    @Override
+    public Sql[] generateSql(RefreshLockDatabaseChangeLogStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+    	String liquibaseSchema = database.getLiquibaseSchemaName();
+        String liquibaseCatalog = database.getLiquibaseCatalogName();
+        String charTypeName = getCharTypeName(database);
+
+        UpdateStatement updateStatement = new UpdateStatement(liquibaseCatalog, liquibaseSchema, database.getDatabaseChangeLogLockTableName());
+        updateStatement.addNewColumnValue("LOCKED", true);
+        updateStatement.addNewColumnValue("LOCKGRANTED", new Timestamp(new java.util.Date().getTime()));
+        updateStatement.addNewColumnValue("LOCKEDBY", LockDatabaseChangeLogGenerator.getLockedBy());
+        updateStatement.setWhereClause(database.escapeColumnName(liquibaseCatalog, liquibaseSchema, database.getDatabaseChangeLogTableName(), "ID")
+                + " = 1 AND " + database.escapeColumnName(liquibaseCatalog, liquibaseSchema, database.getDatabaseChangeLogTableName(), "LOCKED")
+                + " = " + DataTypeFactory.getInstance().fromDescription("boolean", database).objectToSql(true, database)
+                + " AND " + database.escapeColumnName(liquibaseCatalog, liquibaseSchema, database.getDatabaseChangeLogTableName(), "LOCKEDBY")
+                + " = " + DataTypeFactory.getInstance().fromDescription(charTypeName + "(255)", database).objectToSql(LockDatabaseChangeLogGenerator.getLockedBy(), database)
+        );
+
+        return SqlGeneratorFactory.getInstance().generateSql(updateStatement, database);
+
+    }
+}

--- a/liquibase-core/src/main/java/liquibase/statement/core/RefreshLockDatabaseChangeLogStatement.java
+++ b/liquibase-core/src/main/java/liquibase/statement/core/RefreshLockDatabaseChangeLogStatement.java
@@ -1,0 +1,7 @@
+package liquibase.statement.core;
+
+import liquibase.statement.AbstractSqlStatement;
+
+public class RefreshLockDatabaseChangeLogStatement extends AbstractSqlStatement {
+    
+}

--- a/liquibase-core/src/main/resources/META-INF/services/liquibase.sqlgenerator.SqlGenerator
+++ b/liquibase-core/src/main/resources/META-INF/services/liquibase.sqlgenerator.SqlGenerator
@@ -78,6 +78,7 @@ liquibase.sqlgenerator.core.InsertOrUpdateGeneratorSQLite
 liquibase.sqlgenerator.core.InsertOrUpdateGeneratorSybaseASA
 liquibase.sqlgenerator.core.InsertSetGenerator
 liquibase.sqlgenerator.core.LockDatabaseChangeLogGenerator
+liquibase.sqlgenerator.core.RefreshLockDatabaseChangeLogGenerator
 liquibase.sqlgenerator.core.MarkChangeSetRanGenerator
 liquibase.sqlgenerator.core.ModifyDataTypeGenerator
 liquibase.sqlgenerator.core.RawSqlGenerator


### PR DESCRIPTION
Description
This pull request implements a Watchdog Mechanism for refreshing or forcibly unlocking expired changelog locks, addressing the issue described in [#6538](https://github.com/org/repo/issues/6538).

The feature was originally developed based on version 4.9.1 and has been verified to work as intended in that context. However, during the merge with the latest version (4.30.1), a crash was identified in the following file:
liquibase/Scope.java at line 230

Key Changes:
Introduced a Watchdog mechanism to:
Periodically refresh locks.
Handle force unlock for expired locks.
Added new configurations to control the watchdog behavior (e.g., refresh intervals, timeout thresholds).
Ensured backward compatibility with existing lock management.
Known Issue:
The current implementation causes a crash when integrated with version 4.30.1, specifically in the Scope.java file at line 230. Further investigation is required to identify the root cause and adapt the feature for the latest version.

Testing
Environment:
Verified functionality on version 4.9.1.
Test Cases:
Ensured locks are refreshed at regular intervals.
Validated force unlock for expired locks.
Confirmed no regression in existing lock management behavior.
Steps to Reproduce Crash in 4.30.1:
Merge the branch with version 4.30.1.
Execute lock-related operations that trigger the Watchdog mechanism.
Observe the crash at liquibase/Scope.java:230.