### PR TITLE
Don't add minValue change twice

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/diff/output/changelog/core/ChangedSequenceChangeGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/diff/output/changelog/core/ChangedSequenceChangeGenerator.java
@@ -60,7 +60,6 @@ public class ChangedSequenceChangeGenerator extends AbstractChangeGenerator impl
             change.setMinValue(sequence.getMinValue());
             accumulatedChange.setMinValue(sequence.getMinValue());
             changes.add(change);
-            changes.add(change);
         }
 
         if (differences.isDifferent("ordered")) {


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

If minValue of a sequence has changed the change was added twice. This was introduced in commit eddde5e1d0. Only add the change once to avoid duplicate output of the same change.

## Things to be aware of

There are more issues with default values for minValue for sequences in case of Oracle, but I'll analyse and report separately.

## Things to worry about

Test coverage

## Additional Context

