### PR TITLE
fix: Checksum for SQL changes containing dbms attributes can get different values if md5sum column is null

### DIFF
--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/core/ClearCheckSumsIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/core/ClearCheckSumsIntegrationTest.groovy
@@ -3,14 +3,23 @@ package liquibase.command.core
 import liquibase.Scope
 import liquibase.changelog.ChangeLogHistoryService
 import liquibase.changelog.ChangeLogHistoryServiceFactory
+import liquibase.changelog.ChangeLogParameters
+import liquibase.changelog.ChangeSet
+import liquibase.changelog.DatabaseChangeLog
 import liquibase.command.CommandScope
+import liquibase.command.core.helpers.DatabaseChangelogCommandStep
 import liquibase.command.core.helpers.DbUrlConnectionArgumentsCommandStep
 import liquibase.command.util.CommandUtil
 import liquibase.extension.testing.testsystem.DatabaseTestSystem
 import liquibase.extension.testing.testsystem.TestSystemFactory
 import liquibase.extension.testing.testsystem.spock.LiquibaseIntegrationTest
+import liquibase.parser.core.ParsedNode
+import liquibase.resource.SearchPathResourceAccessor
+import liquibase.util.StringUtil
 import spock.lang.Shared
 import spock.lang.Specification
+
+import java.sql.ResultSet
 
 @LiquibaseIntegrationTest
 class ClearCheckSumsIntegrationTest extends Specification {
@@ -57,5 +66,40 @@ class ClearCheckSumsIntegrationTest extends Specification {
 
         cleanup:
         CommandUtil.runDropAll(h2)
+    }
+
+    def "validate generated CheckSum doesn't change after perform a clearCheckSum command and then a new update command"() {
+        given:
+        def changeLogFile = "changelogs/h2/complete/sqlchange.with.dbms.changelog.xml"
+        def id = "clearCheckSumTest"
+        def author = "mallod"
+        def filePath = "changelogs/h2/complete/sqlchange.with.dbms.changelog.xml"
+        CommandUtil.runUpdate(h2, changeLogFile, null, null, null)
+
+        def originalCheckSum = queryGeneratedCheckSum(id, author, filePath)
+
+        when:
+        CommandUtil.runClearCheckSum(h2)
+
+        then:
+        queryGeneratedCheckSum(id, author, filePath) == null
+
+        when:
+        CommandUtil.runUpdate(h2, changeLogFile, null, null, null)
+
+        then:
+        noExceptionThrown()
+        def newCheckSum = queryGeneratedCheckSum(id, author, filePath)
+        originalCheckSum == newCheckSum
+    }
+
+    private String queryGeneratedCheckSum(String id, String author, String filePath) {
+        ResultSet resultSet = h2.getConnection().createStatement().executeQuery(String.format("select md5sum from databasechangelog WHERE id='%s' AND author='%s' AND filename='%s'", id, author, filePath))
+        def originalCheckSum = ""
+        if (resultSet.next()) {
+            originalCheckSum = resultSet.getString("md5sum")
+        }
+
+        return originalCheckSum
     }
 }

--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/util/CommandUtil.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/util/CommandUtil.groovy
@@ -279,4 +279,12 @@ class CommandUtil {
             commandScope.execute()
         } as Scope.ScopedRunnerWithReturn<Void>)
     }
+
+    static void runClearCheckSum(DatabaseTestSystem db) {
+        CommandScope commandScope = new CommandScope(ClearChecksumsCommandStep.COMMAND_NAME)
+        commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.URL_ARG, db.getConnectionUrl())
+        commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.USERNAME_ARG, db.getUsername())
+        commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.PASSWORD_ARG, db.getPassword())
+        commandScope.execute()
+    }
 }

--- a/liquibase-integration-tests/src/test/resources/changelogs/h2/complete/sqlchange.with.dbms.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/h2/complete/sqlchange.with.dbms.changelog.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="mallod" id="clearCheckSumTest">
+        <sql  dbms="h2" splitStatements="false">
+            create table anydb(id boolean default true, status varchar(2));
+		</sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/DatabaseChangelogCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/DatabaseChangelogCommandStep.java
@@ -9,9 +9,6 @@ import liquibase.changelog.ChangeLogHistoryServiceFactory;
 import liquibase.changelog.ChangeLogParameters;
 import liquibase.changelog.DatabaseChangeLog;
 import liquibase.command.*;
-import liquibase.configuration.ConfigurationValueProvider;
-import liquibase.configuration.LiquibaseConfiguration;
-import liquibase.configuration.core.DefaultsFileValueProvider;
 import liquibase.database.Database;
 import liquibase.exception.LiquibaseException;
 import liquibase.lockservice.LockServiceFactory;
@@ -24,7 +21,6 @@ import liquibase.util.StringUtil;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -140,7 +136,12 @@ public class DatabaseChangelogCommandStep extends AbstractHelperCommandStep impl
         ChangeLogHistoryService changeLogHistoryService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database);
         changeLogHistoryService.init();
         if (updateExistingNullChecksums) {
-            changeLogHistoryService.upgradeChecksums(databaseChangeLog, contexts, labelExpression);
+            try {
+                Scope.child(Collections.singletonMap(Scope.Attr.database.name(), database),
+                    () ->changeLogHistoryService.upgradeChecksums(databaseChangeLog, contexts, labelExpression));
+            } catch (Exception e) {
+                throw new LiquibaseException(e);
+            }
         }
         LockServiceFactory.getInstance().getLockService(database).init();
     }


### PR DESCRIPTION
Database object needs to be present in scope when upgradingChecksums because of dbms tags in sql changes. This method is only triggered when md5sum column is null.

Fixes #5618 

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 