### PR TITLE
[ISSUE-#6611] Implement contextFilter (context) of include tag should also apply for property tags

### DIFF
--- a/liquibase-standard/src/test/groovy/liquibase/changelog/DatabaseChangeLogTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/changelog/DatabaseChangeLogTest.groovy
@@ -1,6 +1,7 @@
 package liquibase.changelog
 
 import liquibase.ContextExpression
+import liquibase.Contexts
 import liquibase.LabelExpression
 import liquibase.Labels
 import liquibase.Scope
@@ -646,6 +647,46 @@ http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbch
         then:
         rootChangeLog.getChangeLogParameters().hasValue("context", rootChangeLog)
         rootChangeLog.getChangeLogParameters().getValue("context", rootChangeLog) == "test"
+    }
+
+    def "properties values are correctly loaded and when contexts match include contextFilter"() {
+        when:
+        def propertiesResourceAccessor = new MockResourceAccessor(["com/example/file.properties": testProperties])
+
+        def rootChangeLog = new DatabaseChangeLog("com/example/root.xml")
+        rootChangeLog.setIncludeContextFilter(new ContextExpression("dev"))
+        rootChangeLog.setChangeLogParameters(new ChangeLogParameters())
+        rootChangeLog.getChangeLogParameters().setContexts(new Contexts("dev"))
+
+        rootChangeLog.load(new ParsedNode(null, "databaseChangeLog")
+                .addChildren([changeSet: [id: "1", author: "nvoxland", createTable: [tableName: "test_table", schemaName: "test_schema"]]])
+                .addChildren([property: [file: "file.properties", relativeToChangelogFile: "true", errorIfMissing: "true"]]),
+                propertiesResourceAccessor)
+
+        then:
+        rootChangeLog.getChangeLogParameters().hasValue("context", rootChangeLog)
+        rootChangeLog.getChangeLogParameters().getValue("context", rootChangeLog) == "test"
+    }
+
+    def "properties values should not be retrieved when contexts not matches include contextFilter"() {
+        when:
+        def propertiesResourceAccessor = new MockResourceAccessor(["com/example/file.properties": testProperties])
+
+        def rootChangeLog = new DatabaseChangeLog("com/example/root.xml")
+        rootChangeLog.setIncludeContextFilter(new ContextExpression("dev"))
+        rootChangeLog.setChangeLogParameters(new ChangeLogParameters())
+
+        //simulate that the context is not dev
+        rootChangeLog.getChangeLogParameters().setContexts(new Contexts("prod"))
+
+        rootChangeLog.load(new ParsedNode(null, "databaseChangeLog")
+                .addChildren([changeSet: [id: "1", author: "nvoxland", createTable: [tableName: "test_table", schemaName: "test_schema"]]])
+                .addChildren([property: [file: "file.properties", relativeToChangelogFile: "true", errorIfMissing: "true"]]),
+                propertiesResourceAccessor)
+
+        then:
+        !rootChangeLog.getChangeLogParameters().hasValue("context", rootChangeLog)
+        rootChangeLog.getChangeLogParameters().getValue("context", rootChangeLog) == null
     }
 
     def "properties values are not loaded and stored when file it's not relative to changelog"() {


### PR DESCRIPTION
## Impact

- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

If the <include /> tag has a contextFilter / context set, then before this change it would only apply to changeSets of the included changeLog. 

After this change, the same logic should apply to <property /> tags of the included changeLog.
Important Changes are in lines 487-492 of liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java

For more details on the problem description, see #6611.

## Things to be aware of

Minimal invasive: Applying the context already during property load of the changeLog. Existing functionality used for getting the included contexts by querying the `getIncludeContextFilter()` of the changeLog during parsing.

## Things to worry about

I ignore contexts from include when the property already has a context set. 
-> To be discussed, if it would make sense to append it if present.

## Additional Context

n/a
