### PR TITLE
🛠️ DAT-19292: fix Attach Artifacts to Draft Release failures

### DIFF
--- a/.github/util/re-version.sh
+++ b/.github/util/re-version.sh
@@ -177,8 +177,6 @@ if [ -z "$extension_name" ]; then
   ## Extract tar.gz and rebuild it back into the tar.gz and zip
   mkdir $workdir/tgz-repackage
   tar -xzf $workdir/liquibase-$MODIFIED_BRANCH_NAME-SNAPSHOT.tar.gz -C $workdir/tgz-repackage
-  ls $workdir/tgz-repackage
-  tree $workdir/tgz-repackage
   cp $workdir/internal/lib/liquibase-core.jar $workdir/tgz-repackage/internal/lib/liquibase-core.jar
   cp $workdir/internal/lib/liquibase-commercial.jar $workdir/tgz-repackage/internal/lib/liquibase-commercial.jar
   find $workdir/tgz-repackage -name "*.txt" -exec sed -i -e "s/\(0\|release\|master\)-SNAPSHOT/$version/" {} \;

--- a/.github/util/re-version.sh
+++ b/.github/util/re-version.sh
@@ -177,6 +177,8 @@ if [ -z "$extension_name" ]; then
   ## Extract tar.gz and rebuild it back into the tar.gz and zip
   mkdir $workdir/tgz-repackage
   tar -xzf $workdir/liquibase-$MODIFIED_BRANCH_NAME-SNAPSHOT.tar.gz -C $workdir/tgz-repackage --strip-components=1
+  ls $workdir/tgz-repackage
+  tree $workdir/tgz-repackage
   cp $workdir/internal/lib/liquibase-core.jar $workdir/tgz-repackage/internal/lib/liquibase-core.jar
   cp $workdir/internal/lib/liquibase-commercial.jar $workdir/tgz-repackage/internal/lib/liquibase-commercial.jar
   find $workdir/tgz-repackage -name "*.txt" -exec sed -i -e "s/\(0\|release\|master\)-SNAPSHOT/$version/" {} \;

--- a/.github/util/re-version.sh
+++ b/.github/util/re-version.sh
@@ -176,7 +176,7 @@ if [ -z "$extension_name" ]; then
 
   ## Extract tar.gz and rebuild it back into the tar.gz and zip
   mkdir $workdir/tgz-repackage
-  tar -xzf $workdir/liquibase-$MODIFIED_BRANCH_NAME-SNAPSHOT.tar.gz -C $workdir/tgz-repackage --strip-components=1
+  tar -xzf $workdir/liquibase-$MODIFIED_BRANCH_NAME-SNAPSHOT.tar.gz -C $workdir/tgz-repackage
   ls $workdir/tgz-repackage
   tree $workdir/tgz-repackage
   cp $workdir/internal/lib/liquibase-core.jar $workdir/tgz-repackage/internal/lib/liquibase-core.jar


### PR DESCRIPTION
This pull request includes a small change to the `.github/util/re-version.sh` file. The change involves modifying the `tar` command to no longer use the `--strip-components=1` option when extracting the `tar.gz` file. 

* [`.github/util/re-version.sh`](diffhunk://#diff-05532236ce14388a53050c18c36e556c73805595c14236636f93936059581289L179-R179): Removed the `--strip-components=1` option from the `tar` command to ensure the directory structure is preserved during extraction.