### PR TITLE
Revert "Deployment ID enhancements and execution property" (DAT-19367)

### DIFF
--- a/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/setup/SetupChangeLogSync.groovy
+++ b/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/setup/SetupChangeLogSync.groovy
@@ -28,6 +28,7 @@ class SetupChangeLogSync extends TestSetup {
 
         final ChangeLogHistoryService changeLogService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database)
         changeLogService.init()
+        changeLogService.generateDeploymentId()
 
         changeLogService.reset()
         CompositeResourceAccessor fileOpener = new CompositeResourceAccessor(

--- a/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/setup/SetupChangelogHistory.groovy
+++ b/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/setup/SetupChangelogHistory.groovy
@@ -23,6 +23,7 @@ class SetupChangelogHistory extends TestSetup {
 
         final ChangeLogHistoryService changeLogService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database)
         changeLogService.init()
+        changeLogService.generateDeploymentId()
 
         List<RanChangeSet> toRemoveList = new ArrayList<>()
         for (RanChangeSet ranChangeSet : changeLogService.getRanChangeSets()) {

--- a/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/setup/SetupDatabaseStructure.groovy
+++ b/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/setup/SetupDatabaseStructure.groovy
@@ -25,6 +25,7 @@ class SetupDatabaseStructure extends TestSetup {
 
         final ChangeLogHistoryService changeLogService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database)
         changeLogService.init()
+        changeLogService.generateDeploymentId()
 
         changeLogService.reset()
 

--- a/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/setup/SetupRollbackCount.groovy
+++ b/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/setup/SetupRollbackCount.groovy
@@ -30,6 +30,7 @@ class SetupRollbackCount extends TestSetup {
 
         final ChangeLogHistoryService changeLogService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database)
         changeLogService.init()
+        changeLogService.generateDeploymentId()
 
         changeLogService.reset()
         CompositeResourceAccessor fileOpener = new CompositeResourceAccessor(

--- a/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/setup/SetupRunChangelog.groovy
+++ b/liquibase-extension-testing/src/main/groovy/liquibase/extension/testing/setup/SetupRunChangelog.groovy
@@ -50,6 +50,7 @@ class SetupRunChangelog extends TestSetup {
 
         final ChangeLogHistoryService changeLogService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database)
         changeLogService.init()
+        changeLogService.generateDeploymentId()
 
         changeLogService.reset()
         ResourceAccessor resourceAccessor;

--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/update/UpdateIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/update/UpdateIntegrationTest.groovy
@@ -25,7 +25,6 @@ class UpdateIntegrationTest extends Specification {
         given:
         CommandUtil.runDropAll(testDatabase)
         CommandUtil.runUpdate(testDatabase,"src/test/resources/changelogs/h2/update/execution-parameter.xml")
-        String expectedDeploymentId = Scope.getCurrentScope().getDeploymentId();
         String sql = "select * from parameter_value_tests order by id"
 
         when:
@@ -40,13 +39,13 @@ class UpdateIntegrationTest extends Specification {
 
         then:
         assert output == """Output of select * from parameter_value_tests order by id:
-ID | DEPLOYMENT_ID | CHANGELOG_FILE | CHANGESET_ID | CHANGESET_AUTHOR |
-1 | """ + expectedDeploymentId + """ | src/test/resources/changelogs/h2/update/execution-parameter/1.xml | 1.1 | jlyle | 
-2 | """ + expectedDeploymentId + """ | src/test/resources/changelogs/h2/update/execution-parameter/1.xml | 1.2 | not_jlyle | 
-3 | """ + expectedDeploymentId + """ | src/test/resources/changelogs/h2/update/execution-parameter/1.xml | 1.3 | jlyle | 
-4 | """ + expectedDeploymentId + """ | src/test/resources/changelogs/h2/update/execution-parameter/2.xml | 2.1 | jlyle | 
-5 | """ + expectedDeploymentId + """ | src/test/resources/changelogs/h2/update/execution-parameter/2.xml | 2.2 | not_jlyle | 
-6 | """ + expectedDeploymentId + """ | src/test/resources/changelogs/h2/update/execution-parameter/2.xml | 2.3 | jlyle | 
+ID | CHANGELOG_FILE | CHANGESET_ID | CHANGESET_AUTHOR |
+1 | src/test/resources/changelogs/h2/update/execution-parameter/1.xml | 1.1 | jlyle | 
+2 | src/test/resources/changelogs/h2/update/execution-parameter/1.xml | 1.2 | not_jlyle | 
+3 | src/test/resources/changelogs/h2/update/execution-parameter/1.xml | 1.3 | jlyle | 
+4 | src/test/resources/changelogs/h2/update/execution-parameter/2.xml | 2.1 | jlyle | 
+5 | src/test/resources/changelogs/h2/update/execution-parameter/2.xml | 2.2 | not_jlyle | 
+6 | src/test/resources/changelogs/h2/update/execution-parameter/2.xml | 2.3 | jlyle | 
 
 """
 

--- a/liquibase-integration-tests/src/test/java/liquibase/statementexecute/MarkChangeSetRanExecuteTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/statementexecute/MarkChangeSetRanExecuteTest.java
@@ -28,95 +28,94 @@ public class MarkChangeSetRanExecuteTest extends AbstractExecuteTest {
 
         this.statementUnderTest = new MarkChangeSetRanStatement(new ChangeSet("a", "b", false, false, "c", "e", "f",
                 null), ChangeSet.ExecType.EXECUTED);
-        String deploymentId = Scope.getCurrentScope().getDeploymentId();
         String version = StringUtil.limitSize(LiquibaseUtil.getBuildVersion()
                 .replaceAll("SNAPSHOT", "SNP")
                 .replaceAll("beta", "b")
                 .replaceAll("alpha", "a")
                 , 20);
-        assertCorrect(String.format("insert into [databasechangelog] ([id], [author], [filename], [dateexecuted], " +
+        assertCorrect("insert into [databasechangelog] ([id], [author], [filename], [dateexecuted], " +
                         "[orderexecuted], [md5sum], [description], [comments], [exectype], [contexts], [labels], " +
                         "[liquibase], [deployment_id]) values ('a', 'b', 'c', getdate(), 1, " +
                         "'9:d41d8cd98f00b204e9800998ecf8427e', 'empty', '', 'executed', 'e', null, '" + version + "'," +
-                        " '%s')", deploymentId),
+                        " null)",
                 MSSQLDatabase.class);
-        assertCorrect(String.format("insert into databasechangelog (id, author, filename, dateexecuted, orderexecuted, " +
+        assertCorrect("insert into databasechangelog (id, author, filename, dateexecuted, orderexecuted, " +
                         "md5sum, description, comments, exectype, contexts, labels, liquibase, deployment_id) values " +
                         "('a', 'b', 'c', systimestamp, 1, '9:d41d8cd98f00b204e9800998ecf8427e', 'empty', '', " +
-                        "'executed', 'e', null, '" + version + "', '%s')", deploymentId),
+                        "'executed', 'e', null, '" + version + "', null)",
                 OracleDatabase.class);
-        assertCorrect(String.format("insert into [databasechangelog] ([id], [author], [filename], [dateexecuted], " +
+        assertCorrect("insert into [databasechangelog] ([id], [author], [filename], [dateexecuted], " +
                         "[orderexecuted], [md5sum], [description], [comments], [exectype], [contexts], [labels], " +
                         "[liquibase], [deployment_id]) values ('a', 'b', 'c', getdate(), 1, " +
                         "'9:d41d8cd98f00b204e9800998ecf8427e', 'empty', '', 'executed', 'e', null, '" + version + "'," +
-                        " '%s')", deploymentId),
+                        " null)",
                 SybaseDatabase.class);
-        assertCorrect(String.format("insert into databasechangelog (id, author, filename, dateexecuted, orderexecuted, " +
+        assertCorrect("insert into databasechangelog (id, author, filename, dateexecuted, orderexecuted, " +
                         "md5sum, description, comments, exectype, contexts, labels, liquibase, deployment_id) values " +
                         "('a', 'b', 'c', " +
                         "current year to fraction(5), 1, '9:d41d8cd98f00b204e9800998ecf8427e', 'empty', '', " +
                         "'executed', " +
-                        "'e', null, '" + version + "', '%s')", deploymentId),
+                        "'e', null, '" + version + "', null)",
                 InformixDatabase.class);
-        assertCorrect(String.format("insert into databasechangelog (id, author, filename, dateexecuted, orderexecuted, " +
+        assertCorrect("insert into databasechangelog (id, author, filename, dateexecuted, orderexecuted, " +
                         "md5sum, description, comments, exectype, contexts, labels, liquibase, deployment_id) values " +
                         "('a', 'b', 'c', current timestamp, 1, " +
                         "'9:d41d8cd98f00b204e9800998ecf8427e', 'empty', '', 'executed', 'e', null, '" + version + "'," +
-                        " '%s')", deploymentId),
+                        " null)",
                 DB2Database.class);
-        assertCorrect(String.format("insert into databasechangelog (id, author, filename, dateexecuted, orderexecuted, " +
+        assertCorrect("insert into databasechangelog (id, author, filename, dateexecuted, orderexecuted, " +
                         "md5sum, description, comments, exectype, contexts, labels, liquibase, deployment_id) values " +
                         "('a', 'b', 'c', current_timestamp, 1, " +
                         "'9:d41d8cd98f00b204e9800998ecf8427e', 'empty', '', 'executed', 'e', null, '" + version + "'," +
-                        " '%s')", deploymentId),
+                        " null)",
                 FirebirdDatabase.class, DerbyDatabase.class);
-        assertCorrect(String.format("insert into databasechangelog (id, author, filename, dateexecuted, orderexecuted, " +
+        assertCorrect("insert into databasechangelog (id, author, filename, dateexecuted, orderexecuted, " +
                         "md5sum, description, comments, exectype, contexts, labels, liquibase, deployment_id) values " +
                         "('a', 'b', 'c', now, 1, " +
                         "'9:d41d8cd98f00b204e9800998ecf8427e', 'empty', '', 'executed', 'e', null, '" + version + "'," +
-                        " '%s')", deploymentId),
+                        " null)",
                 HsqlDatabase.class);
-        assertCorrect(String.format("insert into databasechangelog (id, author, filename, dateexecuted, orderexecuted, " +
+        assertCorrect("insert into databasechangelog (id, author, filename, dateexecuted, orderexecuted, " +
                         "md5sum, description, comments, exectype, contexts, labels, liquibase, deployment_id) values " +
                         "('a', 'b', 'c', now(), 1, " +
                         "'9:d41d8cd98f00b204e9800998ecf8427e', 'empty', '', 'executed', 'e', null, '" + version + "'," +
-                        " '%s')", deploymentId),
+                        " null)",
                 SybaseASADatabase.class);
-        assertCorrect(String.format("insert into databasechangelog (id, author, filename, dateexecuted, orderexecuted, " +
+        assertCorrect("insert into databasechangelog (id, author, filename, dateexecuted, orderexecuted, " +
                         "md5sum, `description`, comments, exectype, contexts, labels, liquibase, deployment_id) values " +
                         "('a', 'b', 'c', now(), 1, " +
                         "'9:d41d8cd98f00b204e9800998ecf8427e', 'empty', '', 'executed', 'e', null, '" + version + "'," +
-                        " '%s')", deploymentId),
+                        " null)",
                 MySQLDatabase.class);
-        assertCorrect(String.format("insert into databasechangelog (id, author, filename, dateexecuted, orderexecuted, " +
+        assertCorrect("insert into databasechangelog (id, author, filename, dateexecuted, orderexecuted, " +
                         "md5sum, `description`, comments, exectype, contexts, labels, liquibase, deployment_id) values " +
                         "('a', 'b', 'c', now(), 1, " +
                         "'9:d41d8cd98f00b204e9800998ecf8427e', 'empty', '', 'executed', 'e', null, '" + version + "'," +
-                        " '%s')", deploymentId),
+                        " null)",
                 MariaDBDatabase.class);
-        assertCorrect(String.format("insert into databasechangelog (id, author, filename, dateexecuted, orderexecuted, " +
+        assertCorrect("insert into databasechangelog (id, author, filename, dateexecuted, orderexecuted, " +
                         "md5sum, description, comments, exectype, contexts, labels, liquibase, deployment_id) values " +
                         "('a', 'b', 'c', now(), 1, " +
                         "'9:d41d8cd98f00b204e9800998ecf8427e', 'empty', '', 'executed', 'e', null, '" + version + "'," +
-                        " '%s')", deploymentId),
+                        " null)",
                 PostgresDatabase.class, H2Database.class, CockroachDatabase.class, EnterpriseDBDatabase.class);
-        assertCorrect(String.format("insert into databasechangelog (id, author, filename, dateexecuted, orderexecuted, " +
+        assertCorrect("insert into databasechangelog (id, author, filename, dateexecuted, orderexecuted, " +
                         "md5sum, description, comments, exectype, contexts, labels, liquibase, deployment_id) values " +
                         "('a', 'b', 'c', date('now'), 1, " +
                         "'9:d41d8cd98f00b204e9800998ecf8427e', 'empty', '', 'executed', 'e', null, '" + version + "'," +
-                        " '%s')", deploymentId),
+                        " null)",
                 Ingres9Database.class);
-        assertCorrect(String.format("insert into databasechangelog (id, author, filename, dateexecuted, orderexecuted, " +
+        assertCorrect("insert into databasechangelog (id, author, filename, dateexecuted, orderexecuted, " +
                         "md5sum, description, comments, exectype, contexts, labels, liquibase, deployment_id) values " +
                         "('a', 'b', 'c', current_timestamp::timestamp_ntz, 1," +
                         " '9:d41d8cd98f00b204e9800998ecf8427e', 'empty', '', 'executed', 'e', null, " +
-                        "'" + version + "', '%s')", deploymentId),
+                        "'" + version + "', null)",
                 SnowflakeDatabase.class);
-        assertCorrectOnRest(String.format("insert into databasechangelog (id, author, filename, dateexecuted, " +
+        assertCorrectOnRest("insert into databasechangelog (id, author, filename, dateexecuted, " +
                 "orderexecuted, md5sum, description, comments, exectype, contexts, labels, liquibase, deployment_id) " +
                 "values ('a', 'b', 'c', " +
                 "current timestamp, 1, '9:d41d8cd98f00b204e9800998ecf8427e', 'empty', '', 'executed', 'e', null, " +
-                "'" + version + "', '%s')", deploymentId));
+                "'" + version + "', null)");
     }
 
     @Test
@@ -125,42 +124,40 @@ public class MarkChangeSetRanExecuteTest extends AbstractExecuteTest {
 
         this.statementUnderTest = new MarkChangeSetRanStatement(new ChangeSet("a", "b", false, false, "c", "e", "f",
                 null), ChangeSet.ExecType.RERAN);
-
-        String deploymentId = Scope.getCurrentScope().getDeploymentId();
-
-        assertCorrect(String.format("update [databasechangelog] set [comments] = '', [contexts] = 'e', [dateexecuted] = getdate(), [deployment_id] = '%s', [description] = 'empty', [exectype] " +
+        assertCorrect("update [databasechangelog] set [comments] = '', [contexts] = 'e', [dateexecuted] = getdate(), [deployment_id] = null, [description] = 'empty', [exectype] " +
                         "= 'reran', [labels] = null, liquibase = 'dev', [md5sum] = '9:d41d8cd98f00b204e9800998ecf8427e', [orderexecuted] = 1 where [id] =" +
                         " 'a' and" +
-                        " [author] = 'b' and [filename] = 'c'", deploymentId),
+                        " [author] = 'b' and [filename] = 'c'",
                 MSSQLDatabase.class);
-        assertCorrect(String.format("update databasechangelog set comments = '', contexts = 'e', dateexecuted = systimestamp, deployment_id = '%s', [description] = 'empty', exectype = " +
+        assertCorrect("update databasechangelog set comments = '', contexts = 'e', dateexecuted = systimestamp, deployment_id = null, [description] = 'empty', exectype = " +
                         "'reran', labels = null, liquibase = 'dev', md5sum = '9:d41d8cd98f00b204e9800998ecf8427e', orderexecuted = 1 where id = 'a' and" +
                         " author " +
-                        "= 'b' and filename = 'c'", deploymentId),
+                        "= 'b' and filename = 'c'",
                 OracleDatabase.class);
-        assertCorrect(String.format("update [databasechangelog] set [comments] = '', [contexts] = 'e', [dateexecuted] = getdate(), [deployment_id] = '%s', [description] = 'empty', [exectype] " +
+        assertCorrect("update [databasechangelog] set [comments] = '', [contexts] = 'e', [dateexecuted] = getdate(), [deployment_id] = null, [description] = 'empty', [exectype] " +
                 "= 'reran', [labels] = null, liquibase = 'dev', [md5sum] = '9:d41d8cd98f00b204e9800998ecf8427e', [orderexecuted] = 1 where [id] = 'a' and" +
-                " [author] = 'b' and [filename] = 'c'", deploymentId), SybaseDatabase.class);
-        assertCorrect(String.format("update [databasechangelog] set [comments] = '', [contexts] = 'e', [dateexecuted] = current year to fraction(5), deployment_id = '%s', [description] = 'empty', exectype = 'reran', [labels] = null, liquibase = 'dev', md5sum = '9:d41d8cd98f00b204e9800998ecf8427e', orderexecuted = 1 where id " +
-                "= 'a' and author = 'b' and filename = 'c'", deploymentId), InformixDatabase.class);
-        assertCorrect(String.format("update [databasechangelog] set [comments] = '', [contexts] = 'e', [dateexecuted] = current timestamp, deployment_id = '%s', [description] = 'empty', " +
+                " [author] = 'b' and [filename] = 'c'", SybaseDatabase.class);
+        assertCorrect("update [databasechangelog] set [comments] = '', [contexts] = 'e', [dateexecuted] = current year to fraction(5), deployment_id = " +
+                "null, [description] = 'empty', exectype = 'reran', [labels] = null, liquibase = 'dev', md5sum = '9:d41d8cd98f00b204e9800998ecf8427e', orderexecuted = 1 where id " +
+                "= 'a' and author = 'b' and filename = 'c'", InformixDatabase.class);
+        assertCorrect("update [databasechangelog] set [comments] = '', [contexts] = 'e', [dateexecuted] = current timestamp, deployment_id = null, [description] = 'empty', " +
                         "exectype = 'reran', [labels] = null, liquibase = 'dev', md5sum = '9:d41d8cd98f00b204e9800998ecf8427e', orderexecuted = 1 where " +
-                        "id = 'a' and author = 'b' and filename = 'c'", deploymentId),
+                        "id = 'a' and author = 'b' and filename = 'c'",
                 DB2Database.class);
-        assertCorrect(String.format("update [databasechangelog] set [comments] = '', [contexts] = 'e', [dateexecuted] = current_timestamp, deployment_id = '%s', [description] = 'empty', " +
+        assertCorrect("update [databasechangelog] set [comments] = '', [contexts] = 'e', [dateexecuted] = current_timestamp, deployment_id = null, [description] = 'empty', " +
                         "exectype = 'reran', [labels] = null, liquibase = 'dev', md5sum = '9:d41d8cd98f00b204e9800998ecf8427e', orderexecuted = 1 where " +
-                        "id = 'a' and author = 'b' and filename = 'c'", deploymentId),
+                        "id = 'a' and author = 'b' and filename = 'c'",
                 FirebirdDatabase.class,
                 DerbyDatabase.class);
-        assertCorrect(String.format("update [databasechangelog] set [comments] = '', [contexts] = 'e', [dateexecuted] = NOW(), deployment_id = '%s', [description] = 'empty', exectype = " +
+        assertCorrect("update [databasechangelog] set [comments] = '', [contexts] = 'e', [dateexecuted] = NOW(), deployment_id = null, [description] = 'empty', exectype = " +
                         "'reran', [labels] = null, liquibase = 'dev', md5sum = '9:d41d8cd98f00b204e9800998ecf8427e', orderexecuted = 1 where id = 'a' and" +
-                        " author = 'b' and filename = 'c'", deploymentId),
+                        " author = 'b' and filename = 'c'",
                 SybaseASADatabase.class);
-        assertCorrect(String.format("update [databasechangelog] set [comments] = '', [contexts] = 'e', [dateexecuted] = NOW(), deployment_id = '%s', [description] = 'empty', exectype = " +
+        assertCorrect("update [databasechangelog] set [comments] = '', [contexts] = 'e', [dateexecuted] = NOW(), deployment_id = null, [description] = 'empty', exectype = " +
                         "'reran', [labels] = null, liquibase = 'dev', md5sum = '9:d41d8cd98f00b204e9800998ecf8427e', orderexecuted = 1 where id = 'a' and" +
-                        " author = 'b' and filename = 'c'", deploymentId),
+                        " author = 'b' and filename = 'c'",
                 MySQLDatabase.class, MariaDBDatabase.class, HsqlDatabase.class, PostgresDatabase.class, H2Database.class, CockroachDatabase.class);
-        assertCorrectOnRest(String.format("update [databasechangelog] set [comments] = '', [contexts] = 'e', [dateexecuted] = NOW(), [deployment_id] = '%s', [description] = 'empty', [exectype] = 'reran', [labels] = null, liquibase = 'dev', [md5sum] = " +
-                "'9:d41d8cd98f00b204e9800998ecf8427e', [orderexecuted] = 1 where id = 'a' and author = 'b' and filename = 'c'", deploymentId));
+        assertCorrectOnRest("update [databasechangelog] set [comments] = '', [contexts] = 'e', [dateexecuted] = NOW(), [deployment_id] = null, [description] = 'empty', [exectype] = 'reran', [labels] = null, liquibase = 'dev', [md5sum] = " +
+                "'9:d41d8cd98f00b204e9800998ecf8427e', [orderexecuted] = 1 where id = 'a' and author = 'b' and filename = 'c'");
     }
 }

--- a/liquibase-integration-tests/src/test/resources/changelogs/h2/update/execution-parameter.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/h2/update/execution-parameter.xml
@@ -8,7 +8,6 @@
     <changeSet id="1" author="jlyle">
         <createTable tableName="parameter_value_tests">
             <column name="id" type="number" autoIncrement="true" />
-            <column name="deployment_id" type="varchar2(36)" />
             <column name="changelog_file" type="varchar(4000)" />
             <column name="changeset_id" type="varchar(4000)" />
             <column name="changeset_author" type="varchar(4000)" />

--- a/liquibase-integration-tests/src/test/resources/changelogs/h2/update/execution-parameter/1.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/h2/update/execution-parameter/1.xml
@@ -7,7 +7,6 @@
 
     <changeSet author="jlyle" id="1.1">
         <insert tableName="parameter_value_tests">
-            <column name="deployment_id" value="${LIQUIBASE_EXECUTION_DEPLOYMENT_ID}" />
             <column name="changelog_file" value="${LIQUIBASE_EXECUTION_CHANGELOG_FILE}" />
             <column name="changeset_id" value="${LIQUIBASE_EXECUTION_CHANGESET_ID}" />
             <column name="changeset_author" value="${LIQUIBASE_EXECUTION_CHANGESET_AUTHOR}" />
@@ -16,7 +15,6 @@
 
     <changeSet author="not_jlyle" id="1.2">
         <insert tableName="parameter_value_tests">
-            <column name="deployment_id" value="${LIQUIBASE_EXECUTION_DEPLOYMENT_ID}" />
             <column name="changelog_file" value="${LIQUIBASE_EXECUTION_CHANGELOG_FILE}" />
             <column name="changeset_id" value="${LIQUIBASE_EXECUTION_CHANGESET_ID}" />
             <column name="changeset_author" value="${LIQUIBASE_EXECUTION_CHANGESET_AUTHOR}" />
@@ -25,7 +23,6 @@
 
     <changeSet author="jlyle" id="1.3">
         <insert tableName="parameter_value_tests">
-            <column name="deployment_id" value="${LIQUIBASE_EXECUTION_DEPLOYMENT_ID}" />
             <column name="changelog_file" value="${LIQUIBASE_EXECUTION_CHANGELOG_FILE}" />
             <column name="changeset_id" value="${LIQUIBASE_EXECUTION_CHANGESET_ID}" />
             <column name="changeset_author" value="${LIQUIBASE_EXECUTION_CHANGESET_AUTHOR}" />

--- a/liquibase-integration-tests/src/test/resources/changelogs/h2/update/execution-parameter/2.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/h2/update/execution-parameter/2.xml
@@ -7,7 +7,6 @@
 
     <changeSet author="jlyle" id="2.1">
         <insert tableName="parameter_value_tests">
-            <column name="deployment_id" value="${LIQUIBASE_EXECUTION_DEPLOYMENT_ID}" />
             <column name="changelog_file" value="${LIQUIBASE_EXECUTION_CHANGELOG_FILE}" />
             <column name="changeset_id" value="${LIQUIBASE_EXECUTION_CHANGESET_ID}" />
             <column name="changeset_author" value="${LIQUIBASE_EXECUTION_CHANGESET_AUTHOR}" />
@@ -16,7 +15,6 @@
 
     <changeSet author="not_jlyle" id="2.2">
         <insert tableName="parameter_value_tests">
-            <column name="deployment_id" value="${LIQUIBASE_EXECUTION_DEPLOYMENT_ID}" />
             <column name="changelog_file" value="${LIQUIBASE_EXECUTION_CHANGELOG_FILE}" />
             <column name="changeset_id" value="${LIQUIBASE_EXECUTION_CHANGESET_ID}" />
             <column name="changeset_author" value="${LIQUIBASE_EXECUTION_CHANGESET_AUTHOR}" />
@@ -25,7 +23,6 @@
 
     <changeSet author="jlyle" id="2.3">
         <insert tableName="parameter_value_tests">
-            <column name="deployment_id" value="${LIQUIBASE_EXECUTION_DEPLOYMENT_ID}" />
             <column name="changelog_file" value="${LIQUIBASE_EXECUTION_CHANGELOG_FILE}" />
             <column name="changeset_id" value="${LIQUIBASE_EXECUTION_CHANGESET_ID}" />
             <column name="changeset_author" value="${LIQUIBASE_EXECUTION_CHANGESET_AUTHOR}" />

--- a/liquibase-standard/src/main/java/liquibase/Scope.java
+++ b/liquibase-standard/src/main/java/liquibase/Scope.java
@@ -61,7 +61,6 @@ public class Scope {
         executeMode,
         lineSeparator,
         serviceLocator,
-        deploymentId,
 
         /**
          * @deprecated use {@link GlobalConfiguration#FILE_ENCODING}
@@ -126,7 +125,6 @@ public class Scope {
 
             rootScope.values.put(Attr.serviceLocator.name(), serviceLocator);
             rootScope.values.put(Attr.osgiPlatform.name(), ContainerChecker.isOsgiPlatform());
-            rootScope.values.put(Attr.deploymentId.name(), UUID.randomUUID().toString());
         }
         return scopeManager.get().getCurrentScope();
     }
@@ -373,8 +371,6 @@ public class Scope {
     public Database getDatabase() {
         return get(Attr.database, Database.class);
     }
-
-    public String getDeploymentId() { return get(Attr.deploymentId, String.class); }
 
     public ClassLoader getClassLoader() {
         return get(Attr.classLoader, Thread.currentThread().getContextClassLoader());

--- a/liquibase-standard/src/main/java/liquibase/changelog/AbstractChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/AbstractChangeLogHistoryService.java
@@ -1,18 +1,19 @@
 package liquibase.changelog;
 
-import liquibase.*;
+import liquibase.ChecksumVersion;
+import liquibase.Contexts;
+import liquibase.LabelExpression;
+import liquibase.Scope;
 import liquibase.changelog.filter.ContextChangeSetFilter;
 import liquibase.changelog.filter.DbmsChangeSetFilter;
 import liquibase.database.Database;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.DatabaseHistoryException;
 import liquibase.executor.ExecutorService;
-import liquibase.resource.ResourceAccessor;
 import liquibase.statement.core.UpdateChangeSetChecksumStatement;
 import lombok.Getter;
 
 import java.text.DecimalFormat;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 
@@ -20,6 +21,7 @@ public abstract class AbstractChangeLogHistoryService implements ChangeLogHistor
 
     @Getter
     private Database database;
+    private String deploymentId;
 
     @Override
     public void setDatabase(Database database) {
@@ -124,26 +126,26 @@ public abstract class AbstractChangeLogHistoryService implements ChangeLogHistor
         reset();
     }
 
-    /**
-     * @deprecated use {@link Scope#getDeploymentId()}
-     */
     @Override
-    @Deprecated
-    public String getDeploymentId() { return Scope.getCurrentScope().getDeploymentId(); }
+    public String getDeploymentId() {
+        return this.deploymentId;
+    }
 
-    /**
-     * @deprecated This is now handled automatically by the root scope
-     */
     @Override
-    @Deprecated
-    public void resetDeploymentId() {}
+    public void resetDeploymentId() {
+        this.deploymentId = null;
+    }
 
-    /**
-     * @deprecated This is now handled automatically by the root scope
-     */
     @Override
-    @Deprecated
-    public void generateDeploymentId() {}
+    public void generateDeploymentId() {
+        if (this.deploymentId == null) {
+            long time = (new Date()).getTime();
+            String dateString = String.valueOf(time);
+            DecimalFormat decimalFormat = new DecimalFormat("0000000000");
+            this.deploymentId = dateString.length() > 9 ? dateString.substring(dateString.length() - 10) :
+                    decimalFormat.format(time);
+        }
+    }
 
 
 }

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryService.java
@@ -2,7 +2,6 @@ package liquibase.changelog;
 
 import liquibase.Contexts;
 import liquibase.LabelExpression;
-import liquibase.Scope;
 import liquibase.database.Database;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.DatabaseHistoryException;
@@ -68,22 +67,10 @@ public interface ChangeLogHistoryService extends Plugin {
 
     void destroy() throws DatabaseException;
 
-    /**
-     * @deprecated use {@link Scope#getDeploymentId()}
-     */
-    @Deprecated
     String getDeploymentId();
 
-    /**
-     * @deprecated This is now handled automatically by the root scope
-     */
-    @Deprecated
     void resetDeploymentId();
 
-    /**
-     * @deprecated This is now handled automatically by the root scope
-     */
-    @Deprecated
     void generateDeploymentId();
 
     /**

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogParameters.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogParameters.java
@@ -48,12 +48,6 @@ public class ChangeLogParameters {
     private LabelExpression filterLabels;
 
     private enum LiquibaseExecutionParameter {
-        LIQUIBASE_EXECUTION_DEPLOYMENT_ID {
-            @Override
-            public String getValue(DatabaseChangeLog changeLog) {
-                return Scope.getCurrentScope().getDeploymentId();
-            }
-        },
         LIQUIBASE_EXECUTION_CHANGELOG_FILE {
             @Override
             public String getValue(DatabaseChangeLog changeLog) {

--- a/liquibase-standard/src/main/java/liquibase/changelog/MockChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/MockChangeLogHistoryService.java
@@ -1,6 +1,9 @@
 package liquibase.changelog;
 
-import liquibase.*;
+import liquibase.ContextExpression;
+import liquibase.Contexts;
+import liquibase.LabelExpression;
+import liquibase.Labels;
 import liquibase.change.CheckSum;
 import liquibase.database.Database;
 import liquibase.database.core.MockDatabase;
@@ -116,29 +119,17 @@ public class MockChangeLogHistoryService implements ChangeLogHistoryService {
 
     }
 
-    /**
-     * @deprecated use {@link Scope#getDeploymentId()}
-     */
     @Override
-    @Deprecated
     public String getDeploymentId() {
         return null;
     }
 
-    /**
-     * @deprecated This is now handled automatically by the root scope
-     */
     @Override
-    @Deprecated
     public void resetDeploymentId() {
 
     }
 
-    /**
-     * @deprecated This is now handled automatically by the root scope
-     */
     @Override
-    @Deprecated
     public void generateDeploymentId() {
 
     }

--- a/liquibase-standard/src/main/java/liquibase/changelog/OfflineChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/OfflineChangeLogHistoryService.java
@@ -265,7 +265,7 @@ public class OfflineChangeLogHistoryService extends AbstractChangeLogHistoryServ
             newLine[Columns.CONTEXTS.ordinal()] = (changeSet.getContextFilter() == null) ? null : changeSet.getContextFilter().toString();
             newLine[Columns.LABELS.ordinal()] = (changeSet.getLabels() == null) ? null : changeSet.getLabels().toString();
 
-            newLine[Columns.DEPLOYMENT_ID.ordinal()] = Scope.getCurrentScope().getDeploymentId();
+            newLine[Columns.DEPLOYMENT_ID.ordinal()] = getDeploymentId();
 
             csvWriter.writeNext(newLine);
 

--- a/liquibase-standard/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
@@ -143,7 +143,7 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
                     Integer columnSize = type.getColumnSize();
                     checksumNotRightSize = (columnSize != null) && (columnSize < 35);
                 } else {
-                    checksumNotRightSize = false;
+                    liquibaseColumnNotRightSize = false;
                 }
             }
             boolean hasExecTypeColumn = changeLogTable.getColumn("EXECTYPE") != null;
@@ -234,33 +234,14 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
                     getLabelsSize() + ")", null));
             }
 
-            boolean deploymentIdColumnNotRightSize = false;
             if (!hasDeploymentIdColumn) {
                 executor.comment("Adding missing databasechangelog.deployment_id column");
                 statementsToExecute.add(new AddColumnStatement(getLiquibaseCatalogName(), getLiquibaseSchemaName(),
-                    getDatabaseChangeLogTableName(), "DEPLOYMENT_ID", charTypeName + "(36)", null));
+                    getDatabaseChangeLogTableName(), "DEPLOYMENT_ID", "VARCHAR(10)", null));
                 if (database instanceof DB2Database) {
                     statementsToExecute.add(new ReorganizeTableStatement(getLiquibaseCatalogName(),
                         getLiquibaseSchemaName(), getDatabaseChangeLogTableName()));
                 }
-            }
-            else {
-                if (!(this.getDatabase() instanceof SQLiteDatabase)) {
-                    DataType type = changeLogTable.getColumn("DEPLOYMENT_ID").getType();
-                    if (type.getTypeName().toLowerCase().startsWith("varchar") || type.getTypeName().toLowerCase().startsWith("character varying")) {
-                        Integer columnSize = type.getColumnSize();
-                        deploymentIdColumnNotRightSize = (columnSize != null) && (columnSize < 36);
-                    } else {
-                        deploymentIdColumnNotRightSize = false;
-                    }
-                }
-            }
-
-            if (deploymentIdColumnNotRightSize) {
-                executor.comment("Modifying size of databasechangelog.deployment_id column");
-
-                statementsToExecute.add(new ModifyDataTypeStatement(getLiquibaseCatalogName(), getLiquibaseSchemaName(),
-                        getDatabaseChangeLogTableName(), "DEPLOYMENT_ID", charTypeName + "(36)"));
             }
 
             SqlStatement databaseChangeLogStatement = new SelectFromDatabaseChangeLogStatement(

--- a/liquibase-standard/src/main/java/liquibase/changelog/visitor/ChangeLogSyncVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/visitor/ChangeLogSyncVisitor.java
@@ -69,7 +69,7 @@ public class ChangeLogSyncVisitor implements ChangeSetVisitor {
     private void postRunMdc(ChangeSet changeSet) {
         try {
             ChangeLogHistoryServiceFactory instance = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class);
-            String deploymentId = Scope.getCurrentScope().getDeploymentId();
+            String deploymentId = instance.getChangeLogService(database).getDeploymentId();
             Scope.getCurrentScope().addMdcValue(MdcKey.DEPLOYMENT_ID, deploymentId);
         } catch (Exception e) {
             Scope.getCurrentScope().getLog(getClass()).fine("Failed to retrieve deployment ID for MDC", e);

--- a/liquibase-standard/src/main/java/liquibase/changelog/visitor/UpdateVisitor.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/visitor/UpdateVisitor.java
@@ -159,7 +159,9 @@ public class UpdateVisitor implements ChangeSetVisitor {
 
     private void addAttributesForMdc(ChangeSet changeSet, ExecType execType) {
         changeSet.setAttribute("updateExecType", execType);
-        changeSet.setAttribute("deploymentId", Scope.getCurrentScope().getDeploymentId());
+        ChangeLogHistoryService changelogService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database);
+        String deploymentId = changelogService.getDeploymentId();
+        changeSet.setAttribute("deploymentId", deploymentId);
     }
 }
 

--- a/liquibase-standard/src/main/java/liquibase/command/core/AbstractFutureRollbackCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/AbstractFutureRollbackCommandStep.java
@@ -69,6 +69,8 @@ public abstract class AbstractFutureRollbackCommandStep extends AbstractCommandS
         lockService.waitForLock();
 
         try {
+            Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database).generateDeploymentId();
+
             changeLog.validate(database, contexts, labelExpression);
 
             ChangeLogIterator logIterator;

--- a/liquibase-standard/src/main/java/liquibase/command/core/ChangelogSyncCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/ChangelogSyncCommandStep.java
@@ -60,6 +60,7 @@ public class ChangelogSyncCommandStep extends AbstractCommandStep {
         final ChangeLogParameters changeLogParameters = (ChangeLogParameters) commandScope.getDependency(ChangeLogParameters.class);
         final ChangeLogHistoryService changeLogHistoryService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database);
         changeLogHistoryService.init();
+        changeLogHistoryService.generateDeploymentId();
         try {
             ChangeLogIterator runChangeLogIterator = buildChangeLogIterator(tag, changeLog, changeLogParameters.getContexts(), changeLogParameters.getLabels(), database);
             AtomicInteger changesetCount = new AtomicInteger(0);

--- a/liquibase-standard/src/main/java/liquibase/command/core/MarkNextChangesetRanCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/MarkNextChangesetRanCommandStep.java
@@ -48,6 +48,8 @@ public class MarkNextChangesetRanCommandStep extends AbstractCommandStep {
             Contexts contexts = ((Contexts) commandScope.getDependency(Contexts.class));
             LabelExpression labelExpression = ((LabelExpression) commandScope.getDependency(LabelExpression.class));
 
+            Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database).generateDeploymentId();
+
             ChangeLogIterator logIterator = new ChangeLogIterator(changeLog,
                     new NotRanChangeSetFilter(database.getRanChangeSetList()),
                     new ContextChangeSetFilter(contexts),

--- a/liquibase-standard/src/main/java/liquibase/command/core/TagCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/TagCommandStep.java
@@ -32,6 +32,7 @@ public class TagCommandStep extends AbstractCommandStep {
         CommandScope commandScope = resultsBuilder.getCommandScope();
         Database database = (Database) commandScope.getDependency(Database.class);
         ChangeLogHistoryService changeLogService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database);
+        changeLogService.generateDeploymentId();
         changeLogService.init();
         LockServiceFactory.getInstance().getLockService(database).init();
         changeLogService.tag(commandScope.getArgumentValue(TagCommandStep.TAG_ARG));

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateDatabaseChangeLogTableGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateDatabaseChangeLogTableGenerator.java
@@ -44,7 +44,7 @@ public class CreateDatabaseChangeLogTableGenerator extends AbstractSqlGenerator<
                 .addColumn("LIQUIBASE", DataTypeFactory.getInstance().fromDescription(charTypeName + "(20)", database))
                 .addColumn("CONTEXTS", DataTypeFactory.getInstance().fromDescription(charTypeName + "("+getContextsSize()+")", database))
                 .addColumn("LABELS", DataTypeFactory.getInstance().fromDescription(charTypeName + "("+getLabelsSize()+")", database))
-                .addColumn("DEPLOYMENT_ID", DataTypeFactory.getInstance().fromDescription(charTypeName+"(36)", database));
+                .addColumn("DEPLOYMENT_ID", DataTypeFactory.getInstance().fromDescription(charTypeName+"(10)", database));
 
         // use LEGACY quoting since we're dealing with system objects
         ObjectQuotingStrategy currentStrategy = database.getObjectQuotingStrategy();

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateDatabaseChangeLogTableGeneratorSybase.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateDatabaseChangeLogTableGeneratorSybase.java
@@ -47,7 +47,7 @@ public class CreateDatabaseChangeLogTableGeneratorSybase extends AbstractSqlGene
                             "LIQUIBASE VARCHAR(20) NULL, " +
                             "CONTEXTS VARCHAR(255) NULL, " +
                             "LABELS VARCHAR(255) NULL, " +
-                            "DEPLOYMENT_ID VARCHAR(36) NULL, " +
+                            "DEPLOYMENT_ID VARCHAR(10) NULL, " +
                             "PRIMARY KEY(ID, AUTHOR, FILENAME))",
                             getAffectedTable(database))
             };

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/MarkChangeSetRanGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/MarkChangeSetRanGenerator.java
@@ -60,7 +60,7 @@ public class MarkChangeSetRanGenerator extends AbstractSqlGenerator<MarkChangeSe
                 final String description = StringUtil.limitSize(changeSet.getDescription(), 250);
                 final String md5Sum = changeSet.generateCheckSum(ChecksumVersion.latest()).toString();
 				final String execType = statement.getExecType().value;
-				final String deploymentId = Scope.getCurrentScope().getDeploymentId();
+				final String deploymentId = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database).getDeploymentId();
 
 				if (statement.getExecType().ranBefore) {
 	                runStatement = new UpdateStatement(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogTableName())

--- a/liquibase-standard/src/test/groovy/liquibase/ScopeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/ScopeTest.groovy
@@ -1,8 +1,5 @@
 package liquibase
 
-import liquibase.changelog.OfflineChangeLogHistoryService
-import liquibase.changelog.ChangeLogHistoryServiceFactory
-import liquibase.database.core.HsqlDatabase
 import liquibase.exception.UnexpectedLiquibaseException
 import liquibase.logging.mdc.CustomMdcObject
 import liquibase.logging.mdc.MdcManager
@@ -126,39 +123,6 @@ class ScopeTest extends Specification {
         then:
         def e = thrown(UnexpectedLiquibaseException)
         e.message == "Cannot pass a null parent to a new Scope. Use Scope.child to correctly create a nested scope"
-    }
-
-    def "scope generates deployment ID"() {
-        when:
-        def scope = Scope.getCurrentScope();
-        def deploymentId = scope.getDeploymentId();
-
-        then:
-        deploymentId != null && ! deploymentId.isBlank() && ! deploymentId.isEmpty();
-        scope.getDeploymentId() == deploymentId;
-    }
-
-    def "deprecated deployment id methods work correctly with scope deployment id"() {
-        when:
-        def database = new HsqlDatabase();
-        def scope = Scope.getCurrentScope();
-        def deploymentIdScope = scope.getDeploymentId();
-        def changeLogHistoryService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database);
-        def deploymentIdService1;
-        def deploymentIdService2;
-
-        changeLogHistoryService.generateDeploymentId();
-        deploymentIdService1 = changeLogHistoryService.getDeploymentId();
-        changeLogHistoryService.resetDeploymentId();
-        changeLogHistoryService.generateDeploymentId();
-        deploymentIdService2 = changeLogHistoryService.getDeploymentId();
-
-        then:
-        deploymentIdScope != null && ! deploymentIdScope.isBlank() && ! deploymentIdScope.isEmpty();
-        deploymentIdService1 != null && ! deploymentIdService1.isBlank() && ! deploymentIdService1.isEmpty();
-        deploymentIdService2 != null && ! deploymentIdService2.isBlank() && ! deploymentIdService2.isEmpty();
-        deploymentIdScope == deploymentIdService1;
-        deploymentIdScope == deploymentIdService2;
     }
 
     private class TestMdcManager implements MdcManager {

--- a/liquibase-standard/src/test/java/liquibase/changelog/OfflineChangeLogHistoryServiceTest.java
+++ b/liquibase-standard/src/test/java/liquibase/changelog/OfflineChangeLogHistoryServiceTest.java
@@ -94,6 +94,24 @@ public class OfflineChangeLogHistoryServiceTest {
         assertTrue(writer.toString().contains("INSERT INTO PUBLIC.DATABASECHANGELOG"));
     }
 
+    @Test
+    public void testGenerateDeploymentId() throws Exception{
+        StringWriter writer = new StringWriter();
+        OfflineChangeLogHistoryService service = createService(writer, "data_only");
+        ChangeSet changeSet = createChangeSet();
+        // When
+        service.init();
+        service.setExecType(changeSet, ChangeSet.ExecType.EXECUTED);
+        writer.close();
+
+        service.generateDeploymentId();
+        String deploymentId = service.getDeploymentId();
+
+        assertTrue(deploymentId.length() == 10);
+
+    }
+
+
     /**
      *
      * Create OfflineChangeLogHistoryService and register LoggingExecutor


### PR DESCRIPTION
Reverts liquibase/liquibase#5653

This has introduced a breaking change causing downstream effects to some database extensions. As a result we decided to remove this until we can get a handle on how to introduce this change in a measured way.