### PR TITLE
DAT-18331 PRO: integrate checks extension into tarball/zip, not mac os dmg installer

### DIFF
--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -47,6 +47,7 @@ jobs:
     outputs:
       dependencies_matrix: ${{ steps.setup_dependencies_matrix.outputs.matrix_output }}
       extensions_matrix: ${{ steps.setup_extensions_matrix.outputs.matrix_output }}
+      extensions_list: ${{ steps.parse_extensions_matrix.outputs.matrix_output }}
     steps:
       - id: setup_dependencies_matrix
         uses: cschadewitz/dynamic-matrix-input@v1.0.0
@@ -239,7 +240,7 @@ jobs:
           scripts_branch=${{ inputs.branch }}
           git config --global credential.helper store
           echo "https://$GIT_USERNAME:$GIT_PASSWORD@github.com" > ~/.git-credentials
-          IFS=',' read -ra EXT_ARRAY <<< "${{ needs.setup_matrix.outputs.extensions_matrix }}"
+          IFS=',' read -ra EXT_ARRAY <<< "${{ needs.setup_matrix.outputs.extensions_list }}"
           for ext in "${EXT_ARRAY[@]}"; do
             ext=$(echo $ext | xargs)  # Remove leading and trailing whitespaces
             echo "Checking out and building $ext"

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -54,8 +54,9 @@ jobs:
           matrix_input: ${{ inputs.dependencies }}
       - id: parse_extensions_matrix
         run: |
-          echo "extensions=${{ inputs.extensions }}"
+          echo "${{ inputs.extensions }}"
           EXTENSIONS_LIST=$(echo "${{ inputs.extensions }}" | jq -r '.[].name' | tr '\n' ',' | sed 's/,$//')
+          echo "EXTENSIONS_LIST=$EXTENSIONS_LIST"
           echo "matrix_output=${EXTENSIONS_LIST}" >> $GITHUB_OUTPUT
       - id: setup_extensions_matrix
         uses: cschadewitz/dynamic-matrix-input@v1.0.0

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -93,7 +93,6 @@ jobs:
     with:
       repository: liquibase/liquibase-checks
       version: ${{ inputs.liquibase-version }}
-      source: liquibase
     secrets: inherit
 
   build-and-deploy-extensions:

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -106,16 +106,16 @@ jobs:
       GIT_PASSWORD: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
     steps:
 
-      # - uses: actions/checkout@v4
-      #   name: Checkout liquibase
+      - uses: actions/checkout@v4
+        name: Checkout liquibase
 
-      # - uses: actions/checkout@v4
-      #   name: Checkout liquibase-pro
-      #   with:
-      #     repository: liquibase/liquibase-pro
-      #     ref: "${{ inputs.branch }}"
-      #     path: liquibase-pro
-      #     token: ${{ secrets.BOT_TOKEN }}
+      - uses: actions/checkout@v4
+        name: Checkout liquibase-pro
+        with:
+          repository: liquibase/liquibase-pro
+          ref: "${{ inputs.branch }}"
+          path: liquibase-pro
+          token: ${{ secrets.BOT_TOKEN }}
 
       # - name: Checkout Dependencies
       #   run: |

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -187,14 +187,14 @@ jobs:
               }
             ]
 
-      # - name: Install liquibase 0-SNAPSHOT
-      #   run: mvn clean install -DskipTests
+      - name: Install liquibase 0-SNAPSHOT
+        run: mvn clean install -DskipTests
 
-      # - name: Install liquibase-commercial 0-SNAPSHOT
-      #   run: |
-      #     cd liquibase-pro
-      #     mvn clean install -DskipTests -P '!run-proguard'
-      #     cd ..
+      - name: Install liquibase-commercial 0-SNAPSHOT
+        run: |
+          cd liquibase-pro
+          mvn clean install -DskipTests -P '!run-proguard'
+          cd ..
 
       # - name: Re-version and build Dependencies
       #   env:
@@ -282,4 +282,4 @@ jobs:
         with:
           name: liquibase-checks-${{ matrix.os }}-${{ inputs.liquibase-version  }}-artifacts
           path: |
-            ./re-version/out/liquibase-checks-${{ inputs.liquibase-version }}.jar
+            ./re-version/out/liquibase-checks-*.jar

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -60,15 +60,6 @@ jobs:
           EXTENSIONS_LIST=$(cat extensions.json | jq -r '.[].name' | tr '\n' ',' | sed 's/,$//')
           echo "matrix_output=${EXTENSIONS_LIST}" >> $GITHUB_OUTPUT
 
-          artifact_path="."
-          printf "%s\n" ${{ inputs.extensions }} > extensions.json
-          cat extensions.json
-          EXT_ARTIFACT_PATH=$(cat extensions.json | jq -r --arg NAME "liquibase-checks" '.[] | select(.name==$NAME) | .artifact_path')
-          if [ -n "$EXT_ARTIFACT_PATH" ] && [ "$EXT_ARTIFACT_PATH" != "null" ]; then
-            artifact_path="$EXT_ARTIFACT_PATH"
-          fi
-          echo "Using artifact_path=$artifact_path"
-
       - id: setup_extensions_matrix
         uses: cschadewitz/dynamic-matrix-input@v1.0.0
         with:

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -244,6 +244,16 @@ jobs:
           for ext in "${EXT_ARRAY[@]}"; do
             ext=$(echo $ext | xargs)  # Remove leading and trailing whitespaces
             echo "Checking out and building $ext"
+
+            artifact_path="."
+            printf "%s\n" "${{ inputs.extensions }}" > extensions.json
+            cat extensions.json
+            EXT_ARTIFACT_PATH=$(cat extensions.json | jq -r --arg NAME "$ext" '.[] | select(.name==$NAME) | .artifact_path')
+            if [ -n "$EXT_ARTIFACT_PATH" ] && [ "$EXT_ARTIFACT_PATH" != "null" ]; then
+              artifact_path="$EXT_ARTIFACT_PATH"
+            fi
+            echo "Using artifact_path=$artifact_path"
+
             git clone https://github.com/liquibase/$ext.git $ext
             cd $ext
             sed -i "s/<liquibase.version>.*<\/liquibase.version>/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/" pom.xml
@@ -255,14 +265,6 @@ jobs:
             done
 
             mvn clean install -DskipTests
-
-            artifact_path="."
-            printf "%s\n" "${{ inputs.extensions }}" > extensions.json
-            EXT_ARTIFACT_PATH=$(cat extensions.json | jq -r --arg NAME "$ext" '.[] | select(.name==$NAME) | .artifact_path')
-            if [ -n "$EXT_ARTIFACT_PATH" ] && [ "$EXT_ARTIFACT_PATH" != "null" ]; then
-              artifact_path="$EXT_ARTIFACT_PATH"
-            fi
-            echo "Using artifact_path=$artifact_path"
 
             mkdir -p $PWD/.github/util/
             curl -o $PWD/.github/util/re-version.sh https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/re-version.sh

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -94,7 +94,7 @@ jobs:
           ignore-versions: '^((?!${{ inputs.liquibase-version }}$).)*$'
 
   build-and-deploy-extensions:
-    needs: [delete-dependency-packages, delete-extension-packages]
+    needs: [setup_matrix, delete-dependency-packages, delete-extension-packages]
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -239,7 +239,7 @@ jobs:
           scripts_branch=${{ inputs.branch }}
           git config --global credential.helper store
           echo "https://$GIT_USERNAME:$GIT_PASSWORD@github.com" > ~/.git-credentials
-          IFS=',' read -ra EXT_ARRAY <<< "${{ inputs.extensions }}"
+          IFS=',' read -ra EXT_ARRAY <<< "${{ needs.setup_matrix.outputs.extensions_matrix }}"
           for ext in "${EXT_ARRAY[@]}"; do
             ext=$(echo $ext | xargs)  # Remove leading and trailing whitespaces
             echo "Checking out and building $ext"

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -54,8 +54,8 @@ jobs:
           matrix_input: ${{ inputs.dependencies }}
       - id: parse_extensions_matrix
         run: |
-          echo "${{ inputs.extensions }}"
-          EXTENSIONS_LIST=$(echo "${{ inputs.extensions }}" | jq -r '.[].name' | tr '\n' ',' | sed 's/,$//')
+          echo "${{ inputs.extensions }}" > extensions.json
+          EXTENSIONS_LIST=$(cat extensions.json | jq -r '.[].name' | tr '\n' ',' | sed 's/,$//')
           echo "EXTENSIONS_LIST=$EXTENSIONS_LIST"
           echo "matrix_output=${EXTENSIONS_LIST}" >> $GITHUB_OUTPUT
       - id: setup_extensions_matrix

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -54,7 +54,7 @@ jobs:
           matrix_input: ${{ inputs.dependencies }}
       - id: parse_extensions_matrix
         run: |
-          EXTENSIONS_LIST=$(echo '${{ inputs.extensions }}' | jq -r '.[].name' | paste -sd ',')
+          EXTENSIONS_LIST=$(echo "${{ inputs.extensions }}" | jq -r '.[].name' | paste -sd ',')
           echo "matrix_output=${EXTENSIONS_LIST}" >> $GITHUB_OUTPUT
       - id: setup_extensions_matrix
         uses: cschadewitz/dynamic-matrix-input@v1.0.0

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -54,7 +54,8 @@ jobs:
           matrix_input: ${{ inputs.dependencies }}
       - id: parse_extensions_matrix
         run: |
-          EXTENSIONS_LIST=$(echo "${{ inputs.extensions }}" | jq -r '.[].name' | paste -sd ',')
+          echo "extensions=${{ inputs.extensions }}"
+          EXTENSIONS_LIST=$(echo "${{ inputs.extensions }}" | jq -r '.[].name' | tr '\n' ',' | sed 's/,$//')
           echo "matrix_output=${EXTENSIONS_LIST}" >> $GITHUB_OUTPUT
       - id: setup_extensions_matrix
         uses: cschadewitz/dynamic-matrix-input@v1.0.0

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -88,8 +88,9 @@ jobs:
           ignore-versions: "^((?!${{ inputs.liquibase-version }}$).)*$"
 
   build-liquibase-checks:
+    if: ${{ contains(inputs.extensions, 'liquibase-checks') }}
     needs: [ delete-extension-packages ]
-    uses: liquibase/build-logic/.github/workflows/publish-main-snapshots.yml@DAT-18331
+    uses: liquibase/build-logic/.github/workflows/publish-for-liquibase.yml@DAT-18331
     with:
       repository: liquibase/liquibase-checks
       version: ${{ inputs.liquibase-version }}
@@ -241,36 +242,38 @@ jobs:
           IFS=',' read -ra EXT_ARRAY <<< "${{ inputs.extensions }}"
           for ext in "${EXT_ARRAY[@]}"; do
             ext=$(echo $ext | xargs)  # Remove leading and trailing whitespaces
-            echo "Checking out and building $ext"
-            git clone https://github.com/liquibase/$ext.git $ext
-            cd $ext
-            sed -i "s/<liquibase.version>.*<\/liquibase.version>/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/" pom.xml
-            mvn versions:set -DnewVersion=0-SNAPSHOT
+            if [ "$ext" != "liquibase-checks" ]; then
+              echo "Checking out and building $ext"
+              git clone https://github.com/liquibase/$ext.git $ext
+              cd $ext
+              sed -i "s/<liquibase.version>.*<\/liquibase.version>/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/" pom.xml
+              mvn versions:set -DnewVersion=0-SNAPSHOT
 
-            for dep in "${DEP_ARRAY[@]}"; do
-              dep=$(echo $dep | xargs)
-              sed -i "/<artifactId>${dep//./\\.}<\/artifactId>/{N; s/<version>.*<\/version>/<version>${{ inputs.liquibase-version }}<\/version>/}" pom.xml || true
-            done
+              for dep in "${DEP_ARRAY[@]}"; do
+                dep=$(echo $dep | xargs)
+                sed -i "/<artifactId>${dep//./\\.}<\/artifactId>/{N; s/<version>.*<\/version>/<version>${{ inputs.liquibase-version }}<\/version>/}" pom.xml || true
+              done
 
-            mvn clean install -DskipTests
+              mvn clean install -DskipTests
 
-            mkdir -p $PWD/.github/util/
-            curl -o $PWD/.github/util/re-version.sh https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/re-version.sh
-            curl -o $PWD/.github/util/sign-artifacts.sh https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/sign-artifacts.sh
-            curl -o $PWD/.github/util/ManifestReversion.java https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/ManifestReversion.java
-            chmod +x $PWD/.github/util/re-version.sh
-            chmod +x $PWD/.github/util/sign-artifacts.sh
-            chmod +x $PWD/.github/util/ManifestReversion.java
-            $PWD/.github/util/re-version.sh ./target "${{ inputs.liquibase-version  }}" "${{ inputs.branch }}" ${ext}
-            $PWD/.github/util/sign-artifacts.sh ./target "${{ inputs.liquibase-version }}" "${{ inputs.branch }}"
-            mvn versions:set -DnewVersion=${{ inputs.liquibase-version }}
-            sed -i -e "s/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/<liquibase.version>${{ inputs.liquibase-version }}<\/liquibase.version>/g" pom.xml
-            # mvn deploy:deploy-file \
-            # -Dfile=./re-version/out/${ext}-${{ inputs.liquibase-version }}.jar \
-            # -Dsources=./re-version/out/${ext}-${{ inputs.liquibase-version }}-sources.jar \
-            # -Djavadoc=./re-version/out/${ext}-${{ inputs.liquibase-version }}-javadoc.jar \
-            # -DrepositoryId=liquibase \
-            # -Durl=https://maven.pkg.github.com/liquibase/$ext \
-            # -DpomFile=pom.xml
-            cd ..
+              mkdir -p $PWD/.github/util/
+              curl -o $PWD/.github/util/re-version.sh https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/re-version.sh
+              curl -o $PWD/.github/util/sign-artifacts.sh https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/sign-artifacts.sh
+              curl -o $PWD/.github/util/ManifestReversion.java https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/ManifestReversion.java
+              chmod +x $PWD/.github/util/re-version.sh
+              chmod +x $PWD/.github/util/sign-artifacts.sh
+              chmod +x $PWD/.github/util/ManifestReversion.java
+              $PWD/.github/util/re-version.sh ./target "${{ inputs.liquibase-version  }}" "${{ inputs.branch }}" ${ext}
+              $PWD/.github/util/sign-artifacts.sh ./target "${{ inputs.liquibase-version }}" "${{ inputs.branch }}"
+              mvn versions:set -DnewVersion=${{ inputs.liquibase-version }}
+              sed -i -e "s/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/<liquibase.version>${{ inputs.liquibase-version }}<\/liquibase.version>/g" pom.xml
+              # mvn deploy:deploy-file \
+              # -Dfile=./re-version/out/${ext}-${{ inputs.liquibase-version }}.jar \
+              # -Dsources=./re-version/out/${ext}-${{ inputs.liquibase-version }}-sources.jar \
+              # -Djavadoc=./re-version/out/${ext}-${{ inputs.liquibase-version }}-javadoc.jar \
+              # -DrepositoryId=liquibase \
+              # -Durl=https://maven.pkg.github.com/liquibase/$ext \
+              # -DpomFile=pom.xml
+              cd ..
+            fi
           done

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -55,7 +55,7 @@ jobs:
       - id: parse_extensions_matrix
         shell: bash
         run: |
-          printf "%s\n" "${{ inputs.extensions }}" > extensions.json
+          printf "%s\n" ${{ inputs.extensions }} > extensions.json
           EXTENSIONS_LIST=$(cat extensions.json | jq -r '.[].name' | tr '\n' ',' | sed 's/,$//')
           echo "matrix_output=${EXTENSIONS_LIST}" >> $GITHUB_OUTPUT
       - id: setup_extensions_matrix

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -239,7 +239,7 @@ jobs:
           scripts_branch=${{ inputs.branch }}
           git config --global credential.helper store
           echo "https://$GIT_USERNAME:$GIT_PASSWORD@github.com" > ~/.git-credentials
-          IFS=',' read -ra EXT_ARRAY <<< "${{ needs.setup_matrix.outputs.extensions_matrix }}"
+          IFS=',' read -ra EXT_ARRAY <<< "${{ fromJson(needs.setup_matrix.outputs.extensions_matrix) }}"
           for ext in "${EXT_ARRAY[@]}"; do
             ext=$(echo $ext | xargs)  # Remove leading and trailing whitespaces
             echo "Checking out and building $ext"

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -56,9 +56,7 @@ jobs:
         shell: bash
         run: |
           printf "%s\n" '[{"name":"liquibase-commercial-bigquery","combined_jars":"false"},{"name":"liquibase-checks","combined_jars":"true"}]' > extensions.json
-          cat extensions.json
           EXTENSIONS_LIST=$(cat extensions.json | jq -r '.[].name' | tr '\n' ',' | sed 's/,$//')
-          echo "EXTENSIONS_LIST=$EXTENSIONS_LIST"
           echo "matrix_output=${EXTENSIONS_LIST}" >> $GITHUB_OUTPUT
       - id: setup_extensions_matrix
         uses: cschadewitz/dynamic-matrix-input@v1.0.0
@@ -100,6 +98,8 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
+      matrix:
+        os: [ubuntu-latest,windows-latest,macos-latest]
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GIT_USERNAME: "liquibot"
@@ -275,3 +275,10 @@ jobs:
             # -DpomFile=pom.xml
             cd ..
           done
+
+      - name: Save Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: liquibase-checks-${{ matrix.os }}-${{ inputs.liquibase-version  }}-artifacts
+          path: |
+            ./re-version/out/liquibase-checks-${{ inputs.liquibase-version }}.jar

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -55,6 +55,7 @@ jobs:
       - id: parse_extensions_matrix
         run: |
           echo "${{ inputs.extensions }}" > extensions.json
+          cat extensions.json
           EXTENSIONS_LIST=$(cat extensions.json | jq -r '.[].name' | tr '\n' ',' | sed 's/,$//')
           echo "EXTENSIONS_LIST=$EXTENSIONS_LIST"
           echo "matrix_output=${EXTENSIONS_LIST}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -94,7 +94,7 @@ jobs:
   #         ignore-versions: '^((?!${{ inputs.liquibase-version }}$).)*$'
 
   build-and-deploy-extensions:
-    needs: [delete-dependency-packages, delete-extension-packages]
+    #needs: [delete-dependency-packages, delete-extension-packages]
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -256,6 +256,14 @@ jobs:
 
             mvn clean install -DskipTests
 
+            artifact_path="."
+            # 'ext' here is the extension name we're currently building
+            EXT_ARTIFACT_PATH=$(echo "${{ inputs.extensions }}" | jq -r --arg NAME "$ext" '.[] | select(.name==$NAME) | .artifact_path')
+            if [ -n "$EXT_ARTIFACT_PATH" ] && [ "$EXT_ARTIFACT_PATH" != "null" ]; then
+              artifact_path="$EXT_ARTIFACT_PATH"
+            fi
+            echo "Using artifact_path=$artifact_path"
+
             mkdir -p $PWD/.github/util/
             curl -o $PWD/.github/util/re-version.sh https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/re-version.sh
             curl -o $PWD/.github/util/sign-artifacts.sh https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/sign-artifacts.sh
@@ -263,8 +271,8 @@ jobs:
             chmod +x $PWD/.github/util/re-version.sh
             chmod +x $PWD/.github/util/sign-artifacts.sh
             chmod +x $PWD/.github/util/ManifestReversion.java
-            $PWD/.github/util/re-version.sh ./target "${{ inputs.liquibase-version  }}" "${{ inputs.branch }}" ${ext}
-            $PWD/.github/util/sign-artifacts.sh ./target "${{ inputs.liquibase-version }}" "${{ inputs.branch }}"
+            $PWD/.github/util/re-version.sh $artifact_path/target "${{ inputs.liquibase-version  }}" "${{ inputs.branch }}" ${ext}
+            $PWD/.github/util/sign-artifacts.sh $artifact_path/target "${{ inputs.liquibase-version }}" "${{ inputs.branch }}"
             mvn versions:set -DnewVersion=${{ inputs.liquibase-version }}
             sed -i -e "s/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/<liquibase.version>${{ inputs.liquibase-version }}<\/liquibase.version>/g" pom.xml
             # mvn deploy:deploy-file \
@@ -283,3 +291,56 @@ jobs:
           name: liquibase-checks-${{ matrix.os }}-${{ inputs.liquibase-version  }}-artifacts
           path: |
             ./re-version/out/liquibase-checks-*.jar
+
+  combineJars:
+    needs: [ build-and-deploy-extensions ]
+    name: Combine Jars
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        extension: ${{ fromJson(inputs.extensions) }}
+    steps:
+
+      - name: Download Ubuntu Artifacts
+        if: ${{ matrix.extension.combined_jars == 'true' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.extension.name }}-ubuntu-latest-${{ inputs.liquibase-version }}-artifacts
+          path: /tmp/ubuntu
+
+      - name: Download macOS Artifacts
+        if: ${{ matrix.extension.combined_jars == 'true' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.extension.name }}-macos-latest-${{ inputs.liquibase-version }}-artifacts
+          path: /tmp/macos
+
+      - name: Download Windows Artifacts
+        if: ${{ matrix.extension.combined_jars == 'true' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.extension.name }}-windows-latest-${{ inputs.liquibase-version }}-artifacts
+          path: /tmp/windows
+
+      - name: Create multiplatform jar
+        if: ${{ matrix.extension.combined_jars == 'true' }}
+        run: |
+          rm -rf /tmp/combined/ubuntu /tmp/combined/windows /tmp/combined/macos
+          mkdir -p /tmp/combined/ubuntu /tmp/combined/windows /tmp/combined/macos
+          unzip -d /tmp/combined/ubuntu /tmp/ubuntu/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}.jar
+          unzip -d /tmp/combined/windows /tmp/windows/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}.jar
+          unzip -d /tmp/combined/macos /tmp/macos/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}.jar
+          rm -r -f /tmp/combined/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}
+          mkdir /tmp/combined/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}
+          cp -a /tmp/combined/ubuntu/* /tmp/combined/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}/
+          cp -a /tmp/combined/windows/* /tmp/combined/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}/
+          cp -a /tmp/combined/macos/* /tmp/combined/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}/
+          rm /tmp/combined/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}/org.graalvm.python.vfs/fileslist.txt
+          cat /tmp/combined/ubuntu/org.graalvm.python.vfs/fileslist.txt /tmp/combined/windows/org.graalvm.python.vfs/fileslist.txt /tmp/combined/macos/org.graalvm.python.vfs/fileslist.txt > /tmp/combined/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}/org.graalvm.python.vfs/fileslist.txt
+          rm -f /tmp/combined/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}.jar
+          cd /tmp/combined/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}/
+          zip -r ../${{ matrix.extension.name }}-${{ inputs.liquibase-version }}.jar *
+          cd ..
+          cp /tmp/ubuntu/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}-sources.jar /tmp/combined/
+          cp /tmp/ubuntu/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}-javadoc.jar /tmp/combined/
+          cp /tmp/ubuntu/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}.pom /tmp/combined/

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -246,7 +246,7 @@ jobs:
             echo "Checking out and building $ext"
 
             artifact_path="."
-            printf "%s\n" "${{ inputs.extensions }}" > extensions.json
+            printf "%s\n" ${{ inputs.extensions }} > extensions.json
             cat extensions.json
             EXT_ARTIFACT_PATH=$(cat extensions.json | jq -r --arg NAME "$ext" '.[] | select(.name==$NAME) | .artifact_path')
             if [ -n "$EXT_ARTIFACT_PATH" ] && [ "$EXT_ARTIFACT_PATH" != "null" ]; then

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -53,8 +53,9 @@ jobs:
         with:
           matrix_input: ${{ inputs.dependencies }}
       - id: parse_extensions_matrix
+        shell: bash
         run: |
-          echo "${{ inputs.extensions }}" > extensions.json
+          printf "%s\n" "${{ inputs.extensions }}" > extensions.json
           cat extensions.json
           EXTENSIONS_LIST=$(cat extensions.json | jq -r '.[].name' | tr '\n' ',' | sed 's/,$//')
           echo "EXTENSIONS_LIST=$EXTENSIONS_LIST"

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -217,13 +217,13 @@ jobs:
             $PWD/.github/util/sign-artifacts.sh ./target "${{ inputs.liquibase-version }}" "${{ inputs.branch }}"
             mvn versions:set -DnewVersion=${{ inputs.liquibase-version }}
             sed -i -e "s/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/<liquibase.version>${{ inputs.liquibase-version }}<\/liquibase.version>/g" pom.xml
-            mvn deploy:deploy-file \
-            -Dfile=./re-version/out/${dep}-${{ inputs.liquibase-version }}.jar \
-            -Dsources=./re-version/out/${dep}-${{ inputs.liquibase-version }}-sources.jar \
-            -Djavadoc=./re-version/out/${dep}-${{ inputs.liquibase-version }}-javadoc.jar \
-            -DrepositoryId=liquibase \
-            -Durl=https://maven.pkg.github.com/liquibase/$dep \
-            -DpomFile=pom.xml
+            # mvn deploy:deploy-file \
+            # -Dfile=./re-version/out/${dep}-${{ inputs.liquibase-version }}.jar \
+            # -Dsources=./re-version/out/${dep}-${{ inputs.liquibase-version }}-sources.jar \
+            # -Djavadoc=./re-version/out/${dep}-${{ inputs.liquibase-version }}-javadoc.jar \
+            # -DrepositoryId=liquibase \
+            # -Durl=https://maven.pkg.github.com/liquibase/$dep \
+            # -DpomFile=pom.xml
             cd ..
           done
 
@@ -262,12 +262,12 @@ jobs:
             $PWD/.github/util/sign-artifacts.sh ./target "${{ inputs.liquibase-version }}" "${{ inputs.branch }}"
             mvn versions:set -DnewVersion=${{ inputs.liquibase-version }}
             sed -i -e "s/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/<liquibase.version>${{ inputs.liquibase-version }}<\/liquibase.version>/g" pom.xml
-            mvn deploy:deploy-file \
-            -Dfile=./re-version/out/${ext}-${{ inputs.liquibase-version }}.jar \
-            -Dsources=./re-version/out/${ext}-${{ inputs.liquibase-version }}-sources.jar \
-            -Djavadoc=./re-version/out/${ext}-${{ inputs.liquibase-version }}-javadoc.jar \
-            -DrepositoryId=liquibase \
-            -Durl=https://maven.pkg.github.com/liquibase/$ext \
-            -DpomFile=pom.xml
+            # mvn deploy:deploy-file \
+            # -Dfile=./re-version/out/${ext}-${{ inputs.liquibase-version }}.jar \
+            # -Dsources=./re-version/out/${ext}-${{ inputs.liquibase-version }}-sources.jar \
+            # -Djavadoc=./re-version/out/${ext}-${{ inputs.liquibase-version }}-javadoc.jar \
+            # -DrepositoryId=liquibase \
+            # -Durl=https://maven.pkg.github.com/liquibase/$ext \
+            # -DpomFile=pom.xml
             cd ..
           done

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -257,8 +257,8 @@ jobs:
             mvn clean install -DskipTests
 
             artifact_path="."
-            # 'ext' here is the extension name we're currently building
-            EXT_ARTIFACT_PATH=$(echo "${{ inputs.extensions }}" | jq -r --arg NAME "$ext" '.[] | select(.name==$NAME) | .artifact_path')
+            printf "%s\n" "${{ inputs.extensions }}" > extensions.json
+            EXT_ARTIFACT_PATH=$(cat extensions.json | jq -r --arg NAME "$ext" '.[] | select(.name==$NAME) | .artifact_path')
             if [ -n "$EXT_ARTIFACT_PATH" ] && [ "$EXT_ARTIFACT_PATH" != "null" ]; then
               artifact_path="$EXT_ARTIFACT_PATH"
             fi

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -93,6 +93,7 @@ jobs:
     with:
       repository: liquibase/liquibase-checks
       version: ${{ inputs.liquibase-version }}
+      source: liquibase
     secrets: inherit
 
   build-and-deploy-extensions:

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -4,42 +4,42 @@ on:
   workflow_call:
     inputs:
       liquibase-version:
-        description: 'liquibase version'
+        description: "liquibase version"
         required: true
         type: string
       dependencies:
-        description: 'Comma separated list of needed dependencies to release the extensions list'
+        description: "Comma separated list of needed dependencies to release the extensions list"
         required: false
         type: string
       extensions:
-        description: 'Comma separated list of extensions to release to GPM'
+        description: "Comma separated list of extensions to release to GPM"
         required: true
         type: string
       branch:
-        description: 'branch to check out'
+        description: "branch to check out"
         required: true
         type: string
   workflow_dispatch:
     inputs:
       liquibase-version:
-        description: 'liquibase version'
+        description: "liquibase version"
         required: true
         type: string
       dependencies:
-        description: 'Comma separated list of needed dependencies to release the extensions list'
+        description: "Comma separated list of needed dependencies to release the extensions list"
         required: false
         type: string
       extensions:
-        description: 'Comma separated list of extensions to release to GPM'
+        description: "Comma separated list of extensions to release to GPM"
         required: true
         type: string
       branch:
-        description: 'branch to check out'
+        description: "branch to check out"
         required: true
         type: string
 
 env:
-  MAVEN_VERSION: '3.9.2'
+  MAVEN_VERSION: "3.9.2"
 
 jobs:
   setup_matrix:
@@ -47,23 +47,15 @@ jobs:
     outputs:
       dependencies_matrix: ${{ steps.setup_dependencies_matrix.outputs.matrix_output }}
       extensions_matrix: ${{ steps.setup_extensions_matrix.outputs.matrix_output }}
-      extensions_list: ${{ steps.parse_extensions_matrix.outputs.matrix_output }}
     steps:
       - id: setup_dependencies_matrix
         uses: cschadewitz/dynamic-matrix-input@v1.0.0
         with:
           matrix_input: ${{ inputs.dependencies }}
-      - id: parse_extensions_matrix
-        shell: bash
-        run: |
-          printf "%s\n" ${{ inputs.extensions }} > extensions.json
-          EXTENSIONS_LIST=$(cat extensions.json | jq -r '.[].name' | tr '\n' ',' | sed 's/,$//')
-          echo "matrix_output=${EXTENSIONS_LIST}" >> $GITHUB_OUTPUT
-
       - id: setup_extensions_matrix
         uses: cschadewitz/dynamic-matrix-input@v1.0.0
         with:
-          matrix_input: ${{ steps.parse_extensions_matrix.outputs.matrix_output }}
+          matrix_input: ${{ inputs.extensions }}
 
   delete-dependency-packages:
     needs: setup_matrix
@@ -76,10 +68,10 @@ jobs:
       - uses: actions/delete-package-versions@v5
         with:
           package-name: org.liquibase.ext.${{ matrix.dependencies }}
-          package-type: 'maven'
+          package-type: "maven"
           token: ${{ secrets.BOT_TOKEN }}
-          ignore-versions: '^((?!${{ inputs.liquibase-version }}$).)*$'
-        
+          ignore-versions: "^((?!${{ inputs.liquibase-version }}$).)*$"
+
   delete-extension-packages:
     needs: setup_matrix
     runs-on: ubuntu-22.04
@@ -91,23 +83,27 @@ jobs:
       - uses: actions/delete-package-versions@v5
         with:
           package-name: org.liquibase.ext.${{ matrix.extensions }}
-          package-type: 'maven'
+          package-type: "maven"
           token: ${{ secrets.BOT_TOKEN }}
-          ignore-versions: '^((?!${{ inputs.liquibase-version }}$).)*$'
+          ignore-versions: "^((?!${{ inputs.liquibase-version }}$).)*$"
+
+  build-liquibase-checks:
+    needs: [ delete-extension-packages ]
+    uses: liquibase/liquibase-checks/.github/workflows/publish-main-snapshots.yml@DAT-18331
+    with:
+      version: ${{ inputs.liquibase-version }}
+    secrets: inherit
 
   build-and-deploy-extensions:
-    needs: [setup_matrix, delete-dependency-packages, delete-extension-packages]
+    needs: [delete-dependency-packages, delete-extension-packages]
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
-      matrix:
-        os: [ubuntu-latest,windows-latest,macos-latest]
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GIT_USERNAME: "liquibot"
       GIT_PASSWORD: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
     steps:
-
       - uses: actions/checkout@v4
         name: Checkout liquibase
 
@@ -119,27 +115,27 @@ jobs:
           path: liquibase-pro
           token: ${{ secrets.BOT_TOKEN }}
 
-      # - name: Checkout Dependencies
-      #   run: |
-      #       git config --global credential.helper store
-      #       echo "https://$GIT_USERNAME:$GIT_PASSWORD@github.com" > ~/.git-credentials
-      #       IFS=',' read -ra DEP_ARRAY <<< "${{ inputs.dependencies }}"
-      #       for dep in "${DEP_ARRAY[@]}"; do
-      #           dep=$(echo $dep | xargs)  # Remove leading and trailing whitespaces
-      #           echo "Checking out $dep"
-      #           git clone https://github.com/liquibase/$dep.git $dep
-      #       done
+      - name: Checkout Dependencies
+        run: |
+          git config --global credential.helper store
+          echo "https://$GIT_USERNAME:$GIT_PASSWORD@github.com" > ~/.git-credentials
+          IFS=',' read -ra DEP_ARRAY <<< "${{ inputs.dependencies }}"
+          for dep in "${DEP_ARRAY[@]}"; do
+              dep=$(echo $dep | xargs)  # Remove leading and trailing whitespaces
+              echo "Checking out $dep"
+              git clone https://github.com/liquibase/$dep.git $dep
+          done
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           java-version: 21
-          distribution: 'temurin'
-          cache: 'maven'
+          distribution: "temurin"
+          cache: "maven"
           gpg-private-key: ${{ secrets.GPG_SECRET }}
           gpg-passphrase: GPG_PASSPHRASE
         env:
-           GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Set up Maven
         uses: stCarolas/setup-maven@v5
@@ -197,41 +193,41 @@ jobs:
           mvn clean install -DskipTests -P '!run-proguard'
           cd ..
 
-      # - name: Re-version and build Dependencies
-      #   env:
-      #      GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
-      #   if: ${{ inputs.dependencies != '' }}
-      #   continue-on-error: true
-      #   run: |
-      #     scripts_branch=${{ inputs.branch }}
-      #     IFS=',' read -ra DEP_ARRAY <<< "${{ inputs.dependencies }}"
-      #     for dep in "${DEP_ARRAY[@]}"; do
-      #       dep=$(echo $dep | xargs)  # Remove leading and trailing whitespaces
-      #       echo "Re-versioning $dep"
-      #       cd $dep
-      #       sed -i "s/<liquibase.version>.*<\/liquibase.version>/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/" pom.xml
-      #       mvn versions:set -DnewVersion=0-SNAPSHOT
-      #       mvn clean install -DskipTests
-      #       mkdir -p $PWD/.github/util/
-      #       curl -o $PWD/.github/util/re-version.sh https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/re-version.sh
-      #       curl -o $PWD/.github/util/sign-artifacts.sh https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/sign-artifacts.sh
-      #       curl -o $PWD/.github/util/ManifestReversion.java https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/ManifestReversion.java
-      #       chmod +x $PWD/.github/util/re-version.sh
-      #       chmod +x $PWD/.github/util/sign-artifacts.sh
-      #       chmod +x $PWD/.github/util/ManifestReversion.java
-      #       $PWD/.github/util/re-version.sh ./target "${{ inputs.liquibase-version  }}" "${{ inputs.branch }}" ${dep}
-      #       $PWD/.github/util/sign-artifacts.sh ./target "${{ inputs.liquibase-version }}" "${{ inputs.branch }}"
-      #       mvn versions:set -DnewVersion=${{ inputs.liquibase-version }}
-      #       sed -i -e "s/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/<liquibase.version>${{ inputs.liquibase-version }}<\/liquibase.version>/g" pom.xml
-      #       # mvn deploy:deploy-file \
-      #       # -Dfile=./re-version/out/${dep}-${{ inputs.liquibase-version }}.jar \
-      #       # -Dsources=./re-version/out/${dep}-${{ inputs.liquibase-version }}-sources.jar \
-      #       # -Djavadoc=./re-version/out/${dep}-${{ inputs.liquibase-version }}-javadoc.jar \
-      #       # -DrepositoryId=liquibase \
-      #       # -Durl=https://maven.pkg.github.com/liquibase/$dep \
-      #       # -DpomFile=pom.xml
-      #       cd ..
-      #     done
+      - name: Re-version and build Dependencies
+        env:
+          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+        if: ${{ inputs.dependencies != '' }}
+        continue-on-error: true
+        run: |
+          scripts_branch=${{ inputs.branch }}
+          IFS=',' read -ra DEP_ARRAY <<< "${{ inputs.dependencies }}"
+          for dep in "${DEP_ARRAY[@]}"; do
+            dep=$(echo $dep | xargs)  # Remove leading and trailing whitespaces
+            echo "Re-versioning $dep"
+            cd $dep
+            sed -i "s/<liquibase.version>.*<\/liquibase.version>/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/" pom.xml
+            mvn versions:set -DnewVersion=0-SNAPSHOT
+            mvn clean install -DskipTests
+            mkdir -p $PWD/.github/util/
+            curl -o $PWD/.github/util/re-version.sh https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/re-version.sh
+            curl -o $PWD/.github/util/sign-artifacts.sh https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/sign-artifacts.sh
+            curl -o $PWD/.github/util/ManifestReversion.java https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/ManifestReversion.java
+            chmod +x $PWD/.github/util/re-version.sh
+            chmod +x $PWD/.github/util/sign-artifacts.sh
+            chmod +x $PWD/.github/util/ManifestReversion.java
+            $PWD/.github/util/re-version.sh ./target "${{ inputs.liquibase-version  }}" "${{ inputs.branch }}" ${dep}
+            $PWD/.github/util/sign-artifacts.sh ./target "${{ inputs.liquibase-version }}" "${{ inputs.branch }}"
+            mvn versions:set -DnewVersion=${{ inputs.liquibase-version }}
+            sed -i -e "s/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/<liquibase.version>${{ inputs.liquibase-version }}<\/liquibase.version>/g" pom.xml
+            # mvn deploy:deploy-file \
+            # -Dfile=./re-version/out/${dep}-${{ inputs.liquibase-version }}.jar \
+            # -Dsources=./re-version/out/${dep}-${{ inputs.liquibase-version }}-sources.jar \
+            # -Djavadoc=./re-version/out/${dep}-${{ inputs.liquibase-version }}-javadoc.jar \
+            # -DrepositoryId=liquibase \
+            # -Durl=https://maven.pkg.github.com/liquibase/$dep \
+            # -DpomFile=pom.xml
+            cd ..
+          done
 
       - name: Checkout and build Extensions
         env:
@@ -241,28 +237,14 @@ jobs:
           scripts_branch=${{ inputs.branch }}
           git config --global credential.helper store
           echo "https://$GIT_USERNAME:$GIT_PASSWORD@github.com" > ~/.git-credentials
-          IFS=',' read -ra EXT_ARRAY <<< "${{ needs.setup_matrix.outputs.extensions_list }}"
+          IFS=',' read -ra EXT_ARRAY <<< "${{ inputs.extensions }}"
           for ext in "${EXT_ARRAY[@]}"; do
             ext=$(echo $ext | xargs)  # Remove leading and trailing whitespaces
             echo "Checking out and building $ext"
-
             git clone https://github.com/liquibase/$ext.git $ext
             cd $ext
             sed -i "s/<liquibase.version>.*<\/liquibase.version>/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/" pom.xml
             mvn versions:set -DnewVersion=0-SNAPSHOT
-
-            artifact_path="."
-            printf "%s\n" ${{ inputs.extensions }} > extensions.json
-            cat extensions.json
-            EXT_ARTIFACT_PATH=$(cat extensions.json | jq -r --arg NAME "$ext" '.[] | select(.name==$NAME) | .artifact_path')
-            if [ -n "$EXT_ARTIFACT_PATH" ] && [ "$EXT_ARTIFACT_PATH" != "null" ]; then
-              artifact_path="$EXT_ARTIFACT_PATH"
-              cd $artifact_path
-              sed -i "s/<liquibase.version>.*<\/liquibase.version>/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/" pom.xml
-              mvn versions:set -DnewVersion=0-SNAPSHOT
-              cd ..
-            fi
-            echo "Using artifact_path=$artifact_path"
 
             for dep in "${DEP_ARRAY[@]}"; do
               dep=$(echo $dep | xargs)
@@ -278,8 +260,8 @@ jobs:
             chmod +x $PWD/.github/util/re-version.sh
             chmod +x $PWD/.github/util/sign-artifacts.sh
             chmod +x $PWD/.github/util/ManifestReversion.java
-            $PWD/.github/util/re-version.sh $artifact_path/target "${{ inputs.liquibase-version  }}" "${{ inputs.branch }}" ${ext}
-            $PWD/.github/util/sign-artifacts.sh $artifact_path/target "${{ inputs.liquibase-version }}" "${{ inputs.branch }}"
+            $PWD/.github/util/re-version.sh ./target "${{ inputs.liquibase-version  }}" "${{ inputs.branch }}" ${ext}
+            $PWD/.github/util/sign-artifacts.sh ./target "${{ inputs.liquibase-version }}" "${{ inputs.branch }}"
             mvn versions:set -DnewVersion=${{ inputs.liquibase-version }}
             sed -i -e "s/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/<liquibase.version>${{ inputs.liquibase-version }}<\/liquibase.version>/g" pom.xml
             # mvn deploy:deploy-file \
@@ -291,63 +273,3 @@ jobs:
             # -DpomFile=pom.xml
             cd ..
           done
-
-      - name: Save Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: liquibase-checks-${{ matrix.os }}-${{ inputs.liquibase-version  }}-artifacts
-          path: |
-            ./liquibase-checks/re-version/out/liquibase-checks-*.jar
-
-  combineJars:
-    needs: [ build-and-deploy-extensions ]
-    name: Combine Jars
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        extension: ${{ fromJson(inputs.extensions) }}
-    steps:
-
-      - name: Download Ubuntu Artifacts
-        if: ${{ matrix.extension.combined_jars == 'true' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ matrix.extension.name }}-ubuntu-latest-${{ inputs.liquibase-version }}-artifacts
-          path: /tmp/ubuntu
-
-      - name: Download macOS Artifacts
-        if: ${{ matrix.extension.combined_jars == 'true' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ matrix.extension.name }}-macos-latest-${{ inputs.liquibase-version }}-artifacts
-          path: /tmp/macos
-
-      - name: Download Windows Artifacts
-        if: ${{ matrix.extension.combined_jars == 'true' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ matrix.extension.name }}-windows-latest-${{ inputs.liquibase-version }}-artifacts
-          path: /tmp/windows
-
-      - name: Create multiplatform jar
-        if: ${{ matrix.extension.combined_jars == 'true' }}
-        run: |
-          rm -rf /tmp/combined/ubuntu /tmp/combined/windows /tmp/combined/macos
-          mkdir -p /tmp/combined/ubuntu /tmp/combined/windows /tmp/combined/macos
-          unzip -d /tmp/combined/ubuntu /tmp/ubuntu/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}.jar
-          unzip -d /tmp/combined/windows /tmp/windows/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}.jar
-          unzip -d /tmp/combined/macos /tmp/macos/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}.jar
-          rm -r -f /tmp/combined/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}
-          mkdir /tmp/combined/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}
-          cp -a /tmp/combined/ubuntu/* /tmp/combined/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}/
-          cp -a /tmp/combined/windows/* /tmp/combined/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}/
-          cp -a /tmp/combined/macos/* /tmp/combined/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}/
-          rm /tmp/combined/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}/org.graalvm.python.vfs/fileslist.txt
-          cat /tmp/combined/ubuntu/org.graalvm.python.vfs/fileslist.txt /tmp/combined/windows/org.graalvm.python.vfs/fileslist.txt /tmp/combined/macos/org.graalvm.python.vfs/fileslist.txt > /tmp/combined/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}/org.graalvm.python.vfs/fileslist.txt
-          rm -f /tmp/combined/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}.jar
-          cd /tmp/combined/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}/
-          zip -r ../${{ matrix.extension.name }}-${{ inputs.liquibase-version }}.jar *
-          cd ..
-          cp /tmp/ubuntu/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}-sources.jar /tmp/combined/
-          cp /tmp/ubuntu/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}-javadoc.jar /tmp/combined/
-          cp /tmp/ubuntu/${{ matrix.extension.name }}-${{ inputs.liquibase-version }}.pom /tmp/combined/

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -52,10 +52,14 @@ jobs:
         uses: cschadewitz/dynamic-matrix-input@v1.0.0
         with:
           matrix_input: ${{ inputs.dependencies }}
+      - id: parse_extensions_matrix
+        run: |
+          EXTENSIONS_LIST=$(echo '${{ inputs.extensions }}' | jq -r '.[].name' | paste -sd ',')
+          echo "matrix_output=${EXTENSIONS_LIST}" >> $GITHUB_OUTPUT
       - id: setup_extensions_matrix
         uses: cschadewitz/dynamic-matrix-input@v1.0.0
         with:
-          matrix_input: ${{ inputs.extensions }}
+          matrix_input: ${{ steps.parse_extensions_matrix.outputs.matrix_output }}
 
   delete-dependency-packages:
     needs: setup_matrix

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -59,6 +59,16 @@ jobs:
           printf "%s\n" ${{ inputs.extensions }} > extensions.json
           EXTENSIONS_LIST=$(cat extensions.json | jq -r '.[].name' | tr '\n' ',' | sed 's/,$//')
           echo "matrix_output=${EXTENSIONS_LIST}" >> $GITHUB_OUTPUT
+
+          artifact_path="."
+          printf "%s\n" ${{ inputs.extensions }} > extensions.json
+          cat extensions.json
+          EXT_ARTIFACT_PATH=$(cat extensions.json | jq -r --arg NAME "liquibase-checks" '.[] | select(.name==$NAME) | .artifact_path')
+          if [ -n "$EXT_ARTIFACT_PATH" ] && [ "$EXT_ARTIFACT_PATH" != "null" ]; then
+            artifact_path="$EXT_ARTIFACT_PATH"
+          fi
+          echo "Using artifact_path=$artifact_path"
+
       - id: setup_extensions_matrix
         uses: cschadewitz/dynamic-matrix-input@v1.0.0
         with:

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -89,8 +89,9 @@ jobs:
 
   build-liquibase-checks:
     needs: [ delete-extension-packages ]
-    uses: liquibase/liquibase-checks/.github/workflows/publish-main-snapshots.yml@DAT-18331
+    uses: liquibase/build-logic/.github/workflows/publish-main-snapshots.yml@DAT-18331
     with:
+      repository: liquibase/liquibase-checks
       version: ${{ inputs.liquibase-version }}
     secrets: inherit
 

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -297,7 +297,7 @@ jobs:
         with:
           name: liquibase-checks-${{ matrix.os }}-${{ inputs.liquibase-version  }}-artifacts
           path: |
-            ./re-version/out/liquibase-checks-*.jar
+            ./liquibase-checks/re-version/out/liquibase-checks-*.jar
 
   combineJars:
     needs: [ build-and-deploy-extensions ]

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -55,7 +55,7 @@ jobs:
       - id: parse_extensions_matrix
         shell: bash
         run: |
-          printf "%s\n" '[{"name":"liquibase-commercial-bigquery","combined_jars":"false"},{"name":"liquibase-checks","combined_jars":"true"}]' > extensions.json
+          printf "%s\n" "${{ inputs.extensions }}" > extensions.json
           EXTENSIONS_LIST=$(cat extensions.json | jq -r '.[].name' | tr '\n' ',' | sed 's/,$//')
           echo "matrix_output=${EXTENSIONS_LIST}" >> $GITHUB_OUTPUT
       - id: setup_extensions_matrix
@@ -63,38 +63,38 @@ jobs:
         with:
           matrix_input: ${{ steps.parse_extensions_matrix.outputs.matrix_output }}
 
-  delete-dependency-packages:
-    needs: setup_matrix
-    runs-on: ubuntu-22.04
-    continue-on-error: true
-    strategy:
-      matrix:
-        dependencies: ${{ fromJson(needs.setup_matrix.outputs.dependencies_matrix) }}
-    steps:
-      - uses: actions/delete-package-versions@v5
-        with:
-          package-name: org.liquibase.ext.${{ matrix.dependencies }}
-          package-type: 'maven'
-          token: ${{ secrets.BOT_TOKEN }}
-          ignore-versions: '^((?!${{ inputs.liquibase-version }}$).)*$'
+  # delete-dependency-packages:
+  #   needs: setup_matrix
+  #   runs-on: ubuntu-22.04
+  #   continue-on-error: true
+  #   strategy:
+  #     matrix:
+  #       dependencies: ${{ fromJson(needs.setup_matrix.outputs.dependencies_matrix) }}
+  #   steps:
+  #     - uses: actions/delete-package-versions@v5
+  #       with:
+  #         package-name: org.liquibase.ext.${{ matrix.dependencies }}
+  #         package-type: 'maven'
+  #         token: ${{ secrets.BOT_TOKEN }}
+  #         ignore-versions: '^((?!${{ inputs.liquibase-version }}$).)*$'
         
-  delete-extension-packages:
-    needs: setup_matrix
-    runs-on: ubuntu-22.04
-    continue-on-error: true
-    strategy:
-      matrix:
-        extensions: ${{ fromJson(needs.setup_matrix.outputs.extensions_matrix) }}
-    steps:
-      - uses: actions/delete-package-versions@v5
-        with:
-          package-name: org.liquibase.ext.${{ matrix.extensions }}
-          package-type: 'maven'
-          token: ${{ secrets.BOT_TOKEN }}
-          ignore-versions: '^((?!${{ inputs.liquibase-version }}$).)*$'
+  # delete-extension-packages:
+  #   needs: setup_matrix
+  #   runs-on: ubuntu-22.04
+  #   continue-on-error: true
+  #   strategy:
+  #     matrix:
+  #       extensions: ${{ fromJson(needs.setup_matrix.outputs.extensions_matrix) }}
+  #   steps:
+  #     - uses: actions/delete-package-versions@v5
+  #       with:
+  #         package-name: org.liquibase.ext.${{ matrix.extensions }}
+  #         package-type: 'maven'
+  #         token: ${{ secrets.BOT_TOKEN }}
+  #         ignore-versions: '^((?!${{ inputs.liquibase-version }}$).)*$'
 
   build-and-deploy-extensions:
-    needs: [setup_matrix, delete-dependency-packages, delete-extension-packages]
+    needs: [delete-dependency-packages, delete-extension-packages]
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -106,27 +106,27 @@ jobs:
       GIT_PASSWORD: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
     steps:
 
-      - uses: actions/checkout@v4
-        name: Checkout liquibase
+      # - uses: actions/checkout@v4
+      #   name: Checkout liquibase
 
-      - uses: actions/checkout@v4
-        name: Checkout liquibase-pro
-        with:
-          repository: liquibase/liquibase-pro
-          ref: "${{ inputs.branch }}"
-          path: liquibase-pro
-          token: ${{ secrets.BOT_TOKEN }}
+      # - uses: actions/checkout@v4
+      #   name: Checkout liquibase-pro
+      #   with:
+      #     repository: liquibase/liquibase-pro
+      #     ref: "${{ inputs.branch }}"
+      #     path: liquibase-pro
+      #     token: ${{ secrets.BOT_TOKEN }}
 
-      - name: Checkout Dependencies
-        run: |
-            git config --global credential.helper store
-            echo "https://$GIT_USERNAME:$GIT_PASSWORD@github.com" > ~/.git-credentials
-            IFS=',' read -ra DEP_ARRAY <<< "${{ inputs.dependencies }}"
-            for dep in "${DEP_ARRAY[@]}"; do
-                dep=$(echo $dep | xargs)  # Remove leading and trailing whitespaces
-                echo "Checking out $dep"
-                git clone https://github.com/liquibase/$dep.git $dep
-            done
+      # - name: Checkout Dependencies
+      #   run: |
+      #       git config --global credential.helper store
+      #       echo "https://$GIT_USERNAME:$GIT_PASSWORD@github.com" > ~/.git-credentials
+      #       IFS=',' read -ra DEP_ARRAY <<< "${{ inputs.dependencies }}"
+      #       for dep in "${DEP_ARRAY[@]}"; do
+      #           dep=$(echo $dep | xargs)  # Remove leading and trailing whitespaces
+      #           echo "Checking out $dep"
+      #           git clone https://github.com/liquibase/$dep.git $dep
+      #       done
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -186,50 +186,50 @@ jobs:
               }
             ]
 
-      - name: Install liquibase 0-SNAPSHOT
-        run: mvn clean install -DskipTests
+      # - name: Install liquibase 0-SNAPSHOT
+      #   run: mvn clean install -DskipTests
 
-      - name: Install liquibase-commercial 0-SNAPSHOT
-        run: |
-          cd liquibase-pro
-          mvn clean install -DskipTests -P '!run-proguard'
-          cd ..
+      # - name: Install liquibase-commercial 0-SNAPSHOT
+      #   run: |
+      #     cd liquibase-pro
+      #     mvn clean install -DskipTests -P '!run-proguard'
+      #     cd ..
 
-      - name: Re-version and build Dependencies
-        env:
-           GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
-        if: ${{ inputs.dependencies != '' }}
-        continue-on-error: true
-        run: |
-          scripts_branch=${{ inputs.branch }}
-          IFS=',' read -ra DEP_ARRAY <<< "${{ inputs.dependencies }}"
-          for dep in "${DEP_ARRAY[@]}"; do
-            dep=$(echo $dep | xargs)  # Remove leading and trailing whitespaces
-            echo "Re-versioning $dep"
-            cd $dep
-            sed -i "s/<liquibase.version>.*<\/liquibase.version>/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/" pom.xml
-            mvn versions:set -DnewVersion=0-SNAPSHOT
-            mvn clean install -DskipTests
-            mkdir -p $PWD/.github/util/
-            curl -o $PWD/.github/util/re-version.sh https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/re-version.sh
-            curl -o $PWD/.github/util/sign-artifacts.sh https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/sign-artifacts.sh
-            curl -o $PWD/.github/util/ManifestReversion.java https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/ManifestReversion.java
-            chmod +x $PWD/.github/util/re-version.sh
-            chmod +x $PWD/.github/util/sign-artifacts.sh
-            chmod +x $PWD/.github/util/ManifestReversion.java
-            $PWD/.github/util/re-version.sh ./target "${{ inputs.liquibase-version  }}" "${{ inputs.branch }}" ${dep}
-            $PWD/.github/util/sign-artifacts.sh ./target "${{ inputs.liquibase-version }}" "${{ inputs.branch }}"
-            mvn versions:set -DnewVersion=${{ inputs.liquibase-version }}
-            sed -i -e "s/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/<liquibase.version>${{ inputs.liquibase-version }}<\/liquibase.version>/g" pom.xml
-            # mvn deploy:deploy-file \
-            # -Dfile=./re-version/out/${dep}-${{ inputs.liquibase-version }}.jar \
-            # -Dsources=./re-version/out/${dep}-${{ inputs.liquibase-version }}-sources.jar \
-            # -Djavadoc=./re-version/out/${dep}-${{ inputs.liquibase-version }}-javadoc.jar \
-            # -DrepositoryId=liquibase \
-            # -Durl=https://maven.pkg.github.com/liquibase/$dep \
-            # -DpomFile=pom.xml
-            cd ..
-          done
+      # - name: Re-version and build Dependencies
+      #   env:
+      #      GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+      #   if: ${{ inputs.dependencies != '' }}
+      #   continue-on-error: true
+      #   run: |
+      #     scripts_branch=${{ inputs.branch }}
+      #     IFS=',' read -ra DEP_ARRAY <<< "${{ inputs.dependencies }}"
+      #     for dep in "${DEP_ARRAY[@]}"; do
+      #       dep=$(echo $dep | xargs)  # Remove leading and trailing whitespaces
+      #       echo "Re-versioning $dep"
+      #       cd $dep
+      #       sed -i "s/<liquibase.version>.*<\/liquibase.version>/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/" pom.xml
+      #       mvn versions:set -DnewVersion=0-SNAPSHOT
+      #       mvn clean install -DskipTests
+      #       mkdir -p $PWD/.github/util/
+      #       curl -o $PWD/.github/util/re-version.sh https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/re-version.sh
+      #       curl -o $PWD/.github/util/sign-artifacts.sh https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/sign-artifacts.sh
+      #       curl -o $PWD/.github/util/ManifestReversion.java https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/ManifestReversion.java
+      #       chmod +x $PWD/.github/util/re-version.sh
+      #       chmod +x $PWD/.github/util/sign-artifacts.sh
+      #       chmod +x $PWD/.github/util/ManifestReversion.java
+      #       $PWD/.github/util/re-version.sh ./target "${{ inputs.liquibase-version  }}" "${{ inputs.branch }}" ${dep}
+      #       $PWD/.github/util/sign-artifacts.sh ./target "${{ inputs.liquibase-version }}" "${{ inputs.branch }}"
+      #       mvn versions:set -DnewVersion=${{ inputs.liquibase-version }}
+      #       sed -i -e "s/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/<liquibase.version>${{ inputs.liquibase-version }}<\/liquibase.version>/g" pom.xml
+      #       # mvn deploy:deploy-file \
+      #       # -Dfile=./re-version/out/${dep}-${{ inputs.liquibase-version }}.jar \
+      #       # -Dsources=./re-version/out/${dep}-${{ inputs.liquibase-version }}-sources.jar \
+      #       # -Djavadoc=./re-version/out/${dep}-${{ inputs.liquibase-version }}-javadoc.jar \
+      #       # -DrepositoryId=liquibase \
+      #       # -Durl=https://maven.pkg.github.com/liquibase/$dep \
+      #       # -DpomFile=pom.xml
+      #       cd ..
+      #     done
 
       - name: Checkout and build Extensions
         env:
@@ -239,7 +239,7 @@ jobs:
           scripts_branch=${{ inputs.branch }}
           git config --global credential.helper store
           echo "https://$GIT_USERNAME:$GIT_PASSWORD@github.com" > ~/.git-credentials
-          IFS=',' read -ra EXT_ARRAY <<< "${{ fromJson(needs.setup_matrix.outputs.extensions_matrix) }}"
+          IFS=',' read -ra EXT_ARRAY <<< "${{ inputs.extensions }}"
           for ext in "${EXT_ARRAY[@]}"; do
             ext=$(echo $ext | xargs)  # Remove leading and trailing whitespaces
             echo "Checking out and building $ext"

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -246,6 +246,11 @@ jobs:
             ext=$(echo $ext | xargs)  # Remove leading and trailing whitespaces
             echo "Checking out and building $ext"
 
+            git clone https://github.com/liquibase/$ext.git $ext
+            cd $ext
+            sed -i "s/<liquibase.version>.*<\/liquibase.version>/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/" pom.xml
+            mvn versions:set -DnewVersion=0-SNAPSHOT
+
             artifact_path="."
             printf "%s\n" ${{ inputs.extensions }} > extensions.json
             cat extensions.json
@@ -258,11 +263,6 @@ jobs:
               cd ..
             fi
             echo "Using artifact_path=$artifact_path"
-
-            git clone https://github.com/liquibase/$ext.git $ext
-            cd $ext
-            sed -i "s/<liquibase.version>.*<\/liquibase.version>/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/" pom.xml
-            mvn versions:set -DnewVersion=0-SNAPSHOT
 
             for dep in "${DEP_ARRAY[@]}"; do
               dep=$(echo $dep | xargs)

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -221,13 +221,13 @@ jobs:
             $PWD/.github/util/sign-artifacts.sh ./target "${{ inputs.liquibase-version }}" "${{ inputs.branch }}"
             mvn versions:set -DnewVersion=${{ inputs.liquibase-version }}
             sed -i -e "s/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/<liquibase.version>${{ inputs.liquibase-version }}<\/liquibase.version>/g" pom.xml
-            # mvn deploy:deploy-file \
-            # -Dfile=./re-version/out/${dep}-${{ inputs.liquibase-version }}.jar \
-            # -Dsources=./re-version/out/${dep}-${{ inputs.liquibase-version }}-sources.jar \
-            # -Djavadoc=./re-version/out/${dep}-${{ inputs.liquibase-version }}-javadoc.jar \
-            # -DrepositoryId=liquibase \
-            # -Durl=https://maven.pkg.github.com/liquibase/$dep \
-            # -DpomFile=pom.xml
+            mvn deploy:deploy-file \
+            -Dfile=./re-version/out/${dep}-${{ inputs.liquibase-version }}.jar \
+            -Dsources=./re-version/out/${dep}-${{ inputs.liquibase-version }}-sources.jar \
+            -Djavadoc=./re-version/out/${dep}-${{ inputs.liquibase-version }}-javadoc.jar \
+            -DrepositoryId=liquibase \
+            -Durl=https://maven.pkg.github.com/liquibase/$dep \
+            -DpomFile=pom.xml
             cd ..
           done
 
@@ -267,13 +267,13 @@ jobs:
               $PWD/.github/util/sign-artifacts.sh ./target "${{ inputs.liquibase-version }}" "${{ inputs.branch }}"
               mvn versions:set -DnewVersion=${{ inputs.liquibase-version }}
               sed -i -e "s/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/<liquibase.version>${{ inputs.liquibase-version }}<\/liquibase.version>/g" pom.xml
-              # mvn deploy:deploy-file \
-              # -Dfile=./re-version/out/${ext}-${{ inputs.liquibase-version }}.jar \
-              # -Dsources=./re-version/out/${ext}-${{ inputs.liquibase-version }}-sources.jar \
-              # -Djavadoc=./re-version/out/${ext}-${{ inputs.liquibase-version }}-javadoc.jar \
-              # -DrepositoryId=liquibase \
-              # -Durl=https://maven.pkg.github.com/liquibase/$ext \
-              # -DpomFile=pom.xml
+              mvn deploy:deploy-file \
+              -Dfile=./re-version/out/${ext}-${{ inputs.liquibase-version }}.jar \
+              -Dsources=./re-version/out/${ext}-${{ inputs.liquibase-version }}-sources.jar \
+              -Djavadoc=./re-version/out/${ext}-${{ inputs.liquibase-version }}-javadoc.jar \
+              -DrepositoryId=liquibase \
+              -Durl=https://maven.pkg.github.com/liquibase/$ext \
+              -DpomFile=pom.xml
               cd ..
             fi
           done

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -90,7 +90,7 @@ jobs:
   build-liquibase-checks:
     if: ${{ contains(inputs.extensions, 'liquibase-checks') }}
     needs: [ delete-extension-packages ]
-    uses: liquibase/build-logic/.github/workflows/publish-for-liquibase.yml@DAT-18331
+    uses: liquibase/build-logic/.github/workflows/publish-for-liquibase.yml@main
     with:
       repository: liquibase/liquibase-checks
       version: ${{ inputs.liquibase-version }}

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -63,38 +63,38 @@ jobs:
         with:
           matrix_input: ${{ steps.parse_extensions_matrix.outputs.matrix_output }}
 
-  # delete-dependency-packages:
-  #   needs: setup_matrix
-  #   runs-on: ubuntu-22.04
-  #   continue-on-error: true
-  #   strategy:
-  #     matrix:
-  #       dependencies: ${{ fromJson(needs.setup_matrix.outputs.dependencies_matrix) }}
-  #   steps:
-  #     - uses: actions/delete-package-versions@v5
-  #       with:
-  #         package-name: org.liquibase.ext.${{ matrix.dependencies }}
-  #         package-type: 'maven'
-  #         token: ${{ secrets.BOT_TOKEN }}
-  #         ignore-versions: '^((?!${{ inputs.liquibase-version }}$).)*$'
+  delete-dependency-packages:
+    needs: setup_matrix
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    strategy:
+      matrix:
+        dependencies: ${{ fromJson(needs.setup_matrix.outputs.dependencies_matrix) }}
+    steps:
+      - uses: actions/delete-package-versions@v5
+        with:
+          package-name: org.liquibase.ext.${{ matrix.dependencies }}
+          package-type: 'maven'
+          token: ${{ secrets.BOT_TOKEN }}
+          ignore-versions: '^((?!${{ inputs.liquibase-version }}$).)*$'
         
-  # delete-extension-packages:
-  #   needs: setup_matrix
-  #   runs-on: ubuntu-22.04
-  #   continue-on-error: true
-  #   strategy:
-  #     matrix:
-  #       extensions: ${{ fromJson(needs.setup_matrix.outputs.extensions_matrix) }}
-  #   steps:
-  #     - uses: actions/delete-package-versions@v5
-  #       with:
-  #         package-name: org.liquibase.ext.${{ matrix.extensions }}
-  #         package-type: 'maven'
-  #         token: ${{ secrets.BOT_TOKEN }}
-  #         ignore-versions: '^((?!${{ inputs.liquibase-version }}$).)*$'
+  delete-extension-packages:
+    needs: setup_matrix
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    strategy:
+      matrix:
+        extensions: ${{ fromJson(needs.setup_matrix.outputs.extensions_matrix) }}
+    steps:
+      - uses: actions/delete-package-versions@v5
+        with:
+          package-name: org.liquibase.ext.${{ matrix.extensions }}
+          package-type: 'maven'
+          token: ${{ secrets.BOT_TOKEN }}
+          ignore-versions: '^((?!${{ inputs.liquibase-version }}$).)*$'
 
   build-and-deploy-extensions:
-    #needs: [delete-dependency-packages, delete-extension-packages]
+    needs: [delete-dependency-packages, delete-extension-packages]
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -55,7 +55,7 @@ jobs:
       - id: parse_extensions_matrix
         shell: bash
         run: |
-          printf "%s\n" "${{ inputs.extensions }}" > extensions.json
+          printf "%s\n" '[{"name":"liquibase-commercial-bigquery","combined_jars":"false"},{"name":"liquibase-checks","combined_jars":"true"}]' > extensions.json
           cat extensions.json
           EXTENSIONS_LIST=$(cat extensions.json | jq -r '.[].name' | tr '\n' ',' | sed 's/,$//')
           echo "EXTENSIONS_LIST=$EXTENSIONS_LIST"

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -252,6 +252,10 @@ jobs:
             EXT_ARTIFACT_PATH=$(cat extensions.json | jq -r --arg NAME "$ext" '.[] | select(.name==$NAME) | .artifact_path')
             if [ -n "$EXT_ARTIFACT_PATH" ] && [ "$EXT_ARTIFACT_PATH" != "null" ]; then
               artifact_path="$EXT_ARTIFACT_PATH"
+              cd $artifact_path
+              sed -i "s/<liquibase.version>.*<\/liquibase.version>/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/" pom.xml
+              mvn versions:set -DnewVersion=0-SNAPSHOT
+              cd ..
             fi
             echo "Using artifact_path=$artifact_path"
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -57,10 +57,10 @@ on:
 
 env:
   DEPENDENCIES: "liquibase-bigquery"
-  EXTENSIONS:  |
+  EXTENSIONS: |
     [
-      {"name": "liquibase-commercial-bigquery", "combined_jars": false},
-      {"name": "liquibase-checks", "combined_jars": true}
+      {"name": "liquibase-commercial-bigquery", "combined_jars": "false"},
+      {"name": "liquibase-checks", "combined_jars": "true"}
     ]
 
 jobs:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -95,7 +95,7 @@ jobs:
   
   build-extension-jars:
    needs: [ setup ]
-   uses: liquibase/liquibase/.github/workflows/build-extension-jars.yml@master
+   uses: liquibase/liquibase/.github/workflows/build-extension-jars.yml@DAT-18331
    with:
      liquibase-version: ${{ needs.setup.outputs.version }}
      dependencies: ${{ needs.setup.outputs.dependencies }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -101,7 +101,7 @@ jobs:
      dependencies: ${{ needs.setup.outputs.dependencies }}
      extensions: ${{ needs.setup.outputs.extensions }}
      branch: ${{ needs.setup.outputs.branch }}
-  #  secrets: inherit
+     secrets: inherit
 
   # reversion:
   #   needs: [ setup, build-extension-jars ]

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -57,7 +57,8 @@ on:
 
 env:
   DEPENDENCIES: "liquibase-bigquery"
-  EXTENSIONS: '[{"name":"liquibase-commercial-bigquery","combined_jars":"false"},{"name":"liquibase-checks","combined_jars":"true"}]'
+  EXTENSIONS: |
+    [{"name":"liquibase-commercial-bigquery","combined_jars":"false"},{"name":"liquibase-checks","combined_jars":"true"}]
 
 jobs:
   setup:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -101,7 +101,7 @@ jobs:
      dependencies: ${{ needs.setup.outputs.dependencies }}
      extensions: ${{ needs.setup.outputs.extensions }}
      branch: ${{ needs.setup.outputs.branch }}
-     secrets: inherit
+   secrets: inherit
 
   # reversion:
   #   needs: [ setup, build-extension-jars ]

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -81,27 +81,26 @@ jobs:
   #     branch: ${{ needs.setup.outputs.branch }}
   #   secrets: inherit
 
-  # build-azure-uber-jar:
-  #  needs: [ setup ]
-  #  uses: liquibase/liquibase/.github/workflows/build-azure-uber-jar.yml@master
-  #  with:
-  #    branch: ${{ needs.setup.outputs.branch }}
-  #    liquibase-version: ${{ needs.setup.outputs.version }}
-  #  secrets: inherit
+  build-azure-uber-jar:
+   needs: [ setup ]
+   uses: liquibase/liquibase/.github/workflows/build-azure-uber-jar.yml@master
+   with:
+     branch: ${{ needs.setup.outputs.branch }}
+     liquibase-version: ${{ needs.setup.outputs.version }}
+   secrets: inherit
   
-  # build-extension-jars:
-  #  needs: [ setup ]
-  #  uses: liquibase/liquibase/.github/workflows/build-extension-jars.yml@DAT-18331
-  #  with:
-  #    liquibase-version: ${{ needs.setup.outputs.version }}
-  #    dependencies: ${{ needs.setup.outputs.dependencies }}
-  #    extensions: ${{ needs.setup.outputs.extensions }}
-  #    branch: ${{ needs.setup.outputs.branch }}
-  #  secrets: inherit
+  build-extension-jars:
+   needs: [ setup ]
+   uses: liquibase/liquibase/.github/workflows/build-extension-jars.yml@DAT-18331
+   with:
+     liquibase-version: ${{ needs.setup.outputs.version }}
+     dependencies: ${{ needs.setup.outputs.dependencies }}
+     extensions: ${{ needs.setup.outputs.extensions }}
+     branch: ${{ needs.setup.outputs.branch }}
+   secrets: inherit
 
   reversion:
-    needs: [ setup ]
-    #needs: [ setup, build-azure-uber-jar, build-extension-jars ]
+    needs: [ setup, build-azure-uber-jar, build-extension-jars ]
     name: Re-version artifacts ${{ needs.setup.outputs.version }}
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -57,11 +57,7 @@ on:
 
 env:
   DEPENDENCIES: "liquibase-bigquery"
-  EXTENSIONS: |
-    [
-      {"name": "liquibase-commercial-bigquery", "combined_jars": "false"},
-      {"name": "liquibase-checks", "combined_jars": "true"}
-    ]
+  EXTENSIONS: '[{"name":"liquibase-commercial-bigquery","combined_jars":"false"},{"name":"liquibase-checks","combined_jars":"true"}]'
 
 jobs:
   setup:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -74,15 +74,15 @@ jobs:
       - run: |
           echo "Creating version ${{ inputs.version }} from ${{ inputs.branch }} with artifacts from build ${{ inputs.runId }} "
           
-  owasp-scanner:
-    needs: [ setup ]
-    uses: liquibase/build-logic/.github/workflows/owasp-scanner.yml@main
-    with:
-      branch: ${{ needs.setup.outputs.branch }}
-    secrets: inherit
+  # owasp-scanner:
+  #   needs: [ setup ]
+  #   uses: liquibase/build-logic/.github/workflows/owasp-scanner.yml@main
+  #   with:
+  #     branch: ${{ needs.setup.outputs.branch }}
+  #   secrets: inherit
 
   build-azure-uber-jar:
-   needs: [ setup, owasp-scanner ]
+   needs: [ setup ]
    uses: liquibase/liquibase/.github/workflows/build-azure-uber-jar.yml@master
    with:
      branch: ${{ needs.setup.outputs.branch }}
@@ -90,7 +90,7 @@ jobs:
    secrets: inherit
   
   build-extension-jars:
-   needs: [ setup, owasp-scanner ]
+   needs: [ setup ]
    uses: liquibase/liquibase/.github/workflows/build-extension-jars.yml@DAT-18331
    with:
      liquibase-version: ${{ needs.setup.outputs.version }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -56,8 +56,12 @@ on:
         value: ${{ jobs.build-installers.outputs.dry_run_tar_gz_url }}
 
 env:
-  DEPENDENCIES: "liquibase-bigquery" # Comma separated list of dependencies to release the extensions list
-  EXTENSIONS: "liquibase-commercial-bigquery" # Comma separated list of extensions to release to GPM
+  DEPENDENCIES: "liquibase-bigquery"
+  EXTENSIONS:  |
+    [
+      {"name": "liquibase-commercial-bigquery", "combined_jars": false},
+      {"name": "liquibase-checks", "combined_jars": true}
+    ]
 
 jobs:
   setup:
@@ -74,285 +78,285 @@ jobs:
       - run: |
           echo "Creating version ${{ inputs.version }} from ${{ inputs.branch }} with artifacts from build ${{ inputs.runId }} "
           
-  owasp-scanner:
-    needs: [ setup ]
-    uses: liquibase/build-logic/.github/workflows/owasp-scanner.yml@main
-    with:
-      branch: ${{ needs.setup.outputs.branch }}
-    secrets: inherit
+  # owasp-scanner:
+  #   needs: [ setup ]
+  #   uses: liquibase/build-logic/.github/workflows/owasp-scanner.yml@main
+  #   with:
+  #     branch: ${{ needs.setup.outputs.branch }}
+  #   secrets: inherit
 
-  build-azure-uber-jar:
-   needs: [ setup, owasp-scanner ]
-   uses: liquibase/liquibase/.github/workflows/build-azure-uber-jar.yml@master
-   with:
-     branch: ${{ needs.setup.outputs.branch }}
-     liquibase-version: ${{ needs.setup.outputs.version }}
-   secrets: inherit
+  # build-azure-uber-jar:
+  #  needs: [ setup, owasp-scanner ]
+  #  uses: liquibase/liquibase/.github/workflows/build-azure-uber-jar.yml@master
+  #  with:
+  #    branch: ${{ needs.setup.outputs.branch }}
+  #    liquibase-version: ${{ needs.setup.outputs.version }}
+  #  secrets: inherit
   
   build-extension-jars:
-   needs: [ setup, owasp-scanner ]
+   needs: [ setup ]
    uses: liquibase/liquibase/.github/workflows/build-extension-jars.yml@master
    with:
      liquibase-version: ${{ needs.setup.outputs.version }}
      dependencies: ${{ needs.setup.outputs.dependencies }}
      extensions: ${{ needs.setup.outputs.extensions }}
      branch: ${{ needs.setup.outputs.branch }}
-   secrets: inherit
+  #  secrets: inherit
 
-  reversion:
-    needs: [ setup, build-azure-uber-jar, build-extension-jars ]
-    name: Re-version artifacts ${{ needs.setup.outputs.version }}
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
+  # reversion:
+  #   needs: [ setup, build-extension-jars ]
+  #   name: Re-version artifacts ${{ needs.setup.outputs.version }}
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - uses: actions/checkout@v4
-        name: Checkout liquibase-pro
-        with:
-          repository: liquibase/liquibase-pro
-          ref: "${{ needs.setup.outputs.branch }}"
-          path: download/repo/liquibase-pro
-          token: ${{ secrets.BOT_TOKEN }}
+  #     - uses: actions/checkout@v4
+  #       name: Checkout liquibase-pro
+  #       with:
+  #         repository: liquibase/liquibase-pro
+  #         ref: "${{ needs.setup.outputs.branch }}"
+  #         path: download/repo/liquibase-pro
+  #         token: ${{ secrets.BOT_TOKEN }}
 
-      - name: Download liquibase-artifacts
-        uses: liquibase/action-download-artifact@v2-liquibase
-        with:
-          workflow: run-tests.yml
-          run_id: ${{ needs.setup.outputs.runId }}
-          name: liquibase-artifacts
-          path: download/liquibase-artifacts
+  #     - name: Download liquibase-artifacts
+  #       uses: liquibase/action-download-artifact@v2-liquibase
+  #       with:
+  #         workflow: run-tests.yml
+  #         run_id: ${{ needs.setup.outputs.runId }}
+  #         name: liquibase-artifacts
+  #         path: download/liquibase-artifacts
 
-      - name: Get Current Run ID
-        id: get_run_id
-        run: |
-          run_id=${{ github.run_id }}
-          echo "uber_jar_runId=${run_id}" >> $GITHUB_OUTPUT
+  #     - name: Get Current Run ID
+  #       id: get_run_id
+  #       run: |
+  #         run_id=${{ github.run_id }}
+  #         echo "uber_jar_runId=${run_id}" >> $GITHUB_OUTPUT
 
-      - name: Download liquibase-pro-azure-artifacts
-        uses: actions/download-artifact@v4
-        with: 
-          name: liquibase-pro-azure-artifacts
-          path: liquibase-pro/liquibase-azure-deps
+  #     - name: Download liquibase-pro-azure-artifacts
+  #       uses: actions/download-artifact@v4
+  #       with: 
+  #         name: liquibase-pro-azure-artifacts
+  #         path: liquibase-pro/liquibase-azure-deps
 
-      - name: Generate repositories and servers JSON
-        id: generate-json
-        run: |
-          IFS=',' read -ra EXT <<< "${{ needs.setup.outputs.extensions }}"
-          repositories=""
-          servers=""
-          for i in "${EXT[@]}"; do
-            repositories+="{\"id\": \"$i\",\"url\": \"https://maven.pkg.github.com/liquibase/$i\",\"releases\": {\"enabled\": \"true\"},\"snapshots\": {\"enabled\": \"true\",\"updatePolicy\": \"always\"}},"
-            servers+="{\"id\": \"$i\",\"username\": \"liquibot\",\"password\": \"${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}\"},"
-          done
-          # Remove trailing comma and wrap with brackets
-          repositories="["${repositories::-1}"]"
-          servers="["${servers::-1}"]"
-          echo "REPOSITORIES_JSON=$repositories" >> $GITHUB_ENV
-          echo "SERVERS_JSON=$servers" >> $GITHUB_ENV
+  #     - name: Generate repositories and servers JSON
+  #       id: generate-json
+  #       run: |
+  #         IFS=',' read -ra EXT <<< "${{ needs.setup.outputs.extensions }}"
+  #         repositories=""
+  #         servers=""
+  #         for i in "${EXT[@]}"; do
+  #           repositories+="{\"id\": \"$i\",\"url\": \"https://maven.pkg.github.com/liquibase/$i\",\"releases\": {\"enabled\": \"true\"},\"snapshots\": {\"enabled\": \"true\",\"updatePolicy\": \"always\"}},"
+  #           servers+="{\"id\": \"$i\",\"username\": \"liquibot\",\"password\": \"${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}\"},"
+  #         done
+  #         # Remove trailing comma and wrap with brackets
+  #         repositories="["${repositories::-1}"]"
+  #         servers="["${servers::-1}"]"
+  #         echo "REPOSITORIES_JSON=$repositories" >> $GITHUB_ENV
+  #         echo "SERVERS_JSON=$servers" >> $GITHUB_ENV
 
-      - name: maven-settings-xml-action
-        uses: whelk-io/maven-settings-xml-action@v22
-        with:
-          repositories: ${{ env.REPOSITORIES_JSON }}
-          servers: ${{ env.SERVERS_JSON }}
+  #     - name: maven-settings-xml-action
+  #       uses: whelk-io/maven-settings-xml-action@v22
+  #       with:
+  #         repositories: ${{ env.REPOSITORIES_JSON }}
+  #         servers: ${{ env.SERVERS_JSON }}
               
-      - name: Get extensions artifacts
-        run: |
-          IFS=',' read -ra ADDR <<< "${{ needs.setup.outputs.extensions }}"
-          for extension in "${ADDR[@]}"; do
-            mvn dependency:get -DgroupId=org.liquibase.ext -DartifactId=$extension -Dversion=${{ needs.setup.outputs.version }} -Dtransitive=false || echo "Failed to download $extension artifact"
-          done
+  #     - name: Get extensions artifacts
+  #       run: |
+  #         IFS=',' read -ra ADDR <<< "${{ needs.setup.outputs.extensions }}"
+  #         for extension in "${ADDR[@]}"; do
+  #           mvn dependency:get -DgroupId=org.liquibase.ext -DartifactId=$extension -Dversion=${{ needs.setup.outputs.version }} -Dtransitive=false || echo "Failed to download $extension artifact"
+  #         done
 
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          java-version: '8'
-          distribution: 'adopt'
-          gpg-private-key: ${{ secrets.GPG_SECRET }}
-          gpg-passphrase: GPG_PASSPHRASE
-        env:
-          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+  #     - name: Set up JDK
+  #       uses: actions/setup-java@v4
+  #       with:
+  #         java-version: '8'
+  #         distribution: 'adopt'
+  #         gpg-private-key: ${{ secrets.GPG_SECRET }}
+  #         gpg-passphrase: GPG_PASSPHRASE
+  #       env:
+  #         GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Re-version Artifacts
-        env:
-          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
-        run: |
-          scripts_branch=${{ github.ref }}
-          mkdir -p $PWD/.github/util/
-          # Download a script (re-version.sh) from a URL and save it to the specified directory
-          curl -o $PWD/.github/util/re-version.sh https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/re-version.sh
+  #     - name: Re-version Artifacts
+  #       env:
+  #         GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+  #       run: |
+  #         scripts_branch=${{ github.ref }}
+  #         mkdir -p $PWD/.github/util/
+  #         # Download a script (re-version.sh) from a URL and save it to the specified directory
+  #         curl -o $PWD/.github/util/re-version.sh https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/re-version.sh
           
-          # Download another script (sign-artifacts.sh) from a URL and save it to the specified directory
-          curl -o $PWD/.github/util/sign-artifacts.sh https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/sign-artifacts.sh
-          curl -o $PWD/.github/util/ManifestReversion.java https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/ManifestReversion.java
-          chmod +x $PWD/.github/util/re-version.sh
-          chmod +x $PWD/.github/util/ManifestReversion.java
-          chmod +x $PWD/.github/util/sign-artifacts.sh
-          $PWD/.github/util/re-version.sh download/liquibase-artifacts "${{ needs.setup.outputs.version }}" "${{ needs.setup.outputs.branch }}"
+  #         # Download another script (sign-artifacts.sh) from a URL and save it to the specified directory
+  #         curl -o $PWD/.github/util/sign-artifacts.sh https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/sign-artifacts.sh
+  #         curl -o $PWD/.github/util/ManifestReversion.java https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/ManifestReversion.java
+  #         chmod +x $PWD/.github/util/re-version.sh
+  #         chmod +x $PWD/.github/util/ManifestReversion.java
+  #         chmod +x $PWD/.github/util/sign-artifacts.sh
+  #         $PWD/.github/util/re-version.sh download/liquibase-artifacts "${{ needs.setup.outputs.version }}" "${{ needs.setup.outputs.branch }}"
 
-          # Execute the sign-artifacts.sh script with specific arguments
-          $PWD/.github/util/sign-artifacts.sh download/liquibase-artifacts "${{ needs.setup.outputs.version }}" "${{ needs.setup.outputs.branch }}"
+  #         # Execute the sign-artifacts.sh script with specific arguments
+  #         $PWD/.github/util/sign-artifacts.sh download/liquibase-artifacts "${{ needs.setup.outputs.version }}" "${{ needs.setup.outputs.branch }}"
           
-          ## Sign Files
-          ## liquibase-azure-deps and liquibase extensions are already on its correct version. Check reusable workflow: build-azure-uber-jar.yml and build-extension-jars.yml
-          mv liquibase-pro/liquibase-azure-deps/* re-version/out
+  #         ## Sign Files
+  #         ## liquibase-azure-deps and liquibase extensions are already on its correct version. Check reusable workflow: build-azure-uber-jar.yml and build-extension-jars.yml
+  #         mv liquibase-pro/liquibase-azure-deps/* re-version/out
           
-          # Modify the zip file
-          unzip re-version/out/liquibase-${{ needs.setup.outputs.version }}.zip -d re-version/out/liquibase-${{ needs.setup.outputs.version }}
-          mkdir -p re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions
-          rm -rf re-version/out/liquibase-${{ needs.setup.outputs.version }}.zip
-          IFS=',' read -ra EXT <<< "${{ needs.setup.outputs.extensions }}"
-          for i in "${EXT[@]}"; do
-            cp ~/.m2/repository/org/liquibase/ext/$i/${{ needs.setup.outputs.version }}/$i-${{ needs.setup.outputs.version }}.jar re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions/$i.jar || echo "Failed to move $i artifact"
-          done
-          (cd re-version/out/liquibase-${{ needs.setup.outputs.version }} && zip -r ../liquibase-${{ needs.setup.outputs.version }}.zip . && cd .. && rm -rf liquibase-${{ needs.setup.outputs.version }})
+  #         # Modify the zip file
+  #         unzip re-version/out/liquibase-${{ needs.setup.outputs.version }}.zip -d re-version/out/liquibase-${{ needs.setup.outputs.version }}
+  #         mkdir -p re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions
+  #         rm -rf re-version/out/liquibase-${{ needs.setup.outputs.version }}.zip
+  #         IFS=',' read -ra EXT <<< "${{ needs.setup.outputs.extensions }}"
+  #         for i in "${EXT[@]}"; do
+  #           cp ~/.m2/repository/org/liquibase/ext/$i/${{ needs.setup.outputs.version }}/$i-${{ needs.setup.outputs.version }}.jar re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions/$i.jar || echo "Failed to move $i artifact"
+  #         done
+  #         (cd re-version/out/liquibase-${{ needs.setup.outputs.version }} && zip -r ../liquibase-${{ needs.setup.outputs.version }}.zip . && cd .. && rm -rf liquibase-${{ needs.setup.outputs.version }})
           
-          # Modify the tar.gz file
-          mkdir -p re-version/out/liquibase-${{ needs.setup.outputs.version }}
-          tar -xzvf re-version/out/liquibase-${{ needs.setup.outputs.version }}.tar.gz -C re-version/out/liquibase-${{ needs.setup.outputs.version }}
-          rm -rf re-version/out/liquibase-${{ needs.setup.outputs.version }}.tar.gz
-          mkdir -p re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions
-          for I in "${EXT[@]}"; do
-            cp ~/.m2/repository/org/liquibase/ext/$I/${{ needs.setup.outputs.version }}/$I-${{ needs.setup.outputs.version }}.jar re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions/$I.jar || echo "Failed to move $I artifact"
-          done
-          (cd re-version/out/liquibase-${{ needs.setup.outputs.version }} && tar -czvf ../liquibase-${{ needs.setup.outputs.version }}.tar.gz * && cd .. && rm -rf liquibase-${{ needs.setup.outputs.version }})
+  #         # Modify the tar.gz file
+  #         mkdir -p re-version/out/liquibase-${{ needs.setup.outputs.version }}
+  #         tar -xzvf re-version/out/liquibase-${{ needs.setup.outputs.version }}.tar.gz -C re-version/out/liquibase-${{ needs.setup.outputs.version }}
+  #         rm -rf re-version/out/liquibase-${{ needs.setup.outputs.version }}.tar.gz
+  #         mkdir -p re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions
+  #         for I in "${EXT[@]}"; do
+  #           cp ~/.m2/repository/org/liquibase/ext/$I/${{ needs.setup.outputs.version }}/$I-${{ needs.setup.outputs.version }}.jar re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions/$I.jar || echo "Failed to move $I artifact"
+  #         done
+  #         (cd re-version/out/liquibase-${{ needs.setup.outputs.version }} && tar -czvf ../liquibase-${{ needs.setup.outputs.version }}.tar.gz * && cd .. && rm -rf liquibase-${{ needs.setup.outputs.version }})
 
-          $PWD/.github/util/sign-artifacts.sh re-version/out
+  #         $PWD/.github/util/sign-artifacts.sh re-version/out
    
-          # Move files to a specific directory
-          mkdir re-version/final
-          mv re-version/out/liquibase-core-${{ needs.setup.outputs.version }}.jar re-version/final
-          mv re-version/out/liquibase-commercial-${{ needs.setup.outputs.version }}.jar re-version/final
-          mv re-version/out/liquibase-${{ needs.setup.outputs.version }}.tar.gz re-version/final
-          mv re-version/out/liquibase-${{ needs.setup.outputs.version }}.zip re-version/final
-          mv re-version/out/liquibase-azure-deps-${{ needs.setup.outputs.version }}.jar re-version/final/liquibase-azure-deps-${{ needs.setup.outputs.version }}.jar
-          (cd re-version/out/ && zip liquibase-additional-${{ needs.setup.outputs.version }}.zip *)
-          mv re-version/out/liquibase-additional-${{ needs.setup.outputs.version }}.zip re-version/final
+  #         # Move files to a specific directory
+  #         mkdir re-version/final
+  #         mv re-version/out/liquibase-core-${{ needs.setup.outputs.version }}.jar re-version/final
+  #         mv re-version/out/liquibase-commercial-${{ needs.setup.outputs.version }}.jar re-version/final
+  #         mv re-version/out/liquibase-${{ needs.setup.outputs.version }}.tar.gz re-version/final
+  #         mv re-version/out/liquibase-${{ needs.setup.outputs.version }}.zip re-version/final
+  #         mv re-version/out/liquibase-azure-deps-${{ needs.setup.outputs.version }}.jar re-version/final/liquibase-azure-deps-${{ needs.setup.outputs.version }}.jar
+  #         (cd re-version/out/ && zip liquibase-additional-${{ needs.setup.outputs.version }}.zip *)
+  #         mv re-version/out/liquibase-additional-${{ needs.setup.outputs.version }}.zip re-version/final
 
-      - name: Cache Completed Artifacts
-        uses: actions/cache@v4.1.2
-        with:
-          key: completed-artifacts-${{ github.run_number }}-${{ github.run_attempt }}
-          path: re-version/final
+  #     - name: Cache Completed Artifacts
+  #       uses: actions/cache@v4.1.2
+  #       with:
+  #         key: completed-artifacts-${{ github.run_number }}-${{ github.run_attempt }}
+  #         path: re-version/final
 
-      - name: Set repository tags
-        if: ${{ inputs.standalone_zip == false && inputs.dry_run == false }}
-        run: |
-          git tag -f v${{ needs.setup.outputs.version }}
-          git push -f origin v${{ needs.setup.outputs.version }}
-          (cd download/repo/liquibase-pro && git tag -f v${{ needs.setup.outputs.version }})
-          (cd download/repo/liquibase-pro && git push -f origin v${{ needs.setup.outputs.version }})
+  #     - name: Set repository tags
+  #       if: ${{ inputs.standalone_zip == false && inputs.dry_run == false }}
+  #       run: |
+  #         git tag -f v${{ needs.setup.outputs.version }}
+  #         git push -f origin v${{ needs.setup.outputs.version }}
+  #         (cd download/repo/liquibase-pro && git tag -f v${{ needs.setup.outputs.version }})
+  #         (cd download/repo/liquibase-pro && git push -f origin v${{ needs.setup.outputs.version }})
 
-  build-installers:
-    permissions:
-      contents: write  # for softprops/action-gh-release to create GitHub release
-    needs: [ setup, reversion ]
-    name: Build Installers
-    runs-on: macos-13 #needs macos for apple notarization
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    outputs:
-      dry_run_zip_url: ${{ steps.extract-dry-run-url.outputs.dry_run_zip_url }}
-      dry_run_tar_gz_url: ${{ steps.extract-dry-run-url.outputs.dry_run_tar_gz_url }} 
-    steps:
-      - uses: actions/checkout@v4
+  # build-installers:
+  #   permissions:
+  #     contents: write  # for softprops/action-gh-release to create GitHub release
+  #   needs: [ setup, reversion ]
+  #   name: Build Installers
+  #   runs-on: macos-13 #needs macos for apple notarization
+  #   env:
+  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #   outputs:
+  #     dry_run_zip_url: ${{ steps.extract-dry-run-url.outputs.dry_run_zip_url }}
+  #     dry_run_tar_gz_url: ${{ steps.extract-dry-run-url.outputs.dry_run_tar_gz_url }} 
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - name: Restore Completed Artifacts
-        uses: actions/cache@v4.1.2
-        with:
-          key: completed-artifacts-${{ github.run_number }}-${{ github.run_attempt }}
-          path: re-version/final
+  #     - name: Restore Completed Artifacts
+  #       uses: actions/cache@v4.1.2
+  #       with:
+  #         key: completed-artifacts-${{ github.run_number }}-${{ github.run_attempt }}
+  #         path: re-version/final
 
-      - name: Set up JDK for GPG
-        uses: actions/setup-java@v4
-        with:
-          java-version: '8'
-          distribution: 'adopt'
-          gpg-private-key: ${{ secrets.GPG_SECRET }}
-          gpg-passphrase: GPG_PASSPHRASE
-        env:
-          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+  #     - name: Set up JDK for GPG
+  #       uses: actions/setup-java@v4
+  #       with:
+  #         java-version: '8'
+  #         distribution: 'adopt'
+  #         gpg-private-key: ${{ secrets.GPG_SECRET }}
+  #         gpg-passphrase: GPG_PASSPHRASE
+  #       env:
+  #         GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
 
 
-      - name: Re-version Installers
-        env:
-          INSTALL4J_10_LICENSE: ${{ secrets.INSTALL4J_10_LICENSE }}
-          INSTALL4J_APPLE_KEY: ${{ secrets.INSTALL4J_APPLE_KEY }}
-          INSTALL4J_APPLE_KEY_PASSWORD: ${{ secrets.INSTALL4J_APPLE_KEY_PASSWORD }}
-          INSTALL4J_APPLE_ID: ${{ secrets.INSTALL4J_APPLE_ID }}
-          INSTALL4J_APPLE_ID_PASSWORD: ${{ secrets.INSTALL4J_APPLE_ID_PASSWORD }}
-          INSTALL4J_WINDOWS_KEY: ${{ secrets.INSTALL4J_WINDOWS_KEY }}
-          INSTALL4J_WINDOWS_KEY_PASSWORD: ${{ secrets.INSTALL4J_WINDOWS_KEY_PASSWORD }}
-          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
-        run: |
-          mkdir -p liquibase-dist/target/keys
-          echo "Saving apple key"
-          echo "$INSTALL4J_APPLE_KEY" | base64 -d > liquibase-dist/target/keys/datical_apple.p12
-          echo "Saving windows key"
-          echo "$INSTALL4J_WINDOWS_KEY" | base64 -d > liquibase-dist/target/keys/datical_windows.pfx
-          version="${{ needs.setup.outputs.version }}"
+  #     - name: Re-version Installers
+  #       env:
+  #         INSTALL4J_10_LICENSE: ${{ secrets.INSTALL4J_10_LICENSE }}
+  #         INSTALL4J_APPLE_KEY: ${{ secrets.INSTALL4J_APPLE_KEY }}
+  #         INSTALL4J_APPLE_KEY_PASSWORD: ${{ secrets.INSTALL4J_APPLE_KEY_PASSWORD }}
+  #         INSTALL4J_APPLE_ID: ${{ secrets.INSTALL4J_APPLE_ID }}
+  #         INSTALL4J_APPLE_ID_PASSWORD: ${{ secrets.INSTALL4J_APPLE_ID_PASSWORD }}
+  #         INSTALL4J_WINDOWS_KEY: ${{ secrets.INSTALL4J_WINDOWS_KEY }}
+  #         INSTALL4J_WINDOWS_KEY_PASSWORD: ${{ secrets.INSTALL4J_WINDOWS_KEY_PASSWORD }}
+  #         GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+  #       run: |
+  #         mkdir -p liquibase-dist/target/keys
+  #         echo "Saving apple key"
+  #         echo "$INSTALL4J_APPLE_KEY" | base64 -d > liquibase-dist/target/keys/datical_apple.p12
+  #         echo "Saving windows key"
+  #         echo "$INSTALL4J_WINDOWS_KEY" | base64 -d > liquibase-dist/target/keys/datical_windows.pfx
+  #         version="${{ needs.setup.outputs.version }}"
           
-          ##### Rebuild installers
-          tarFile=$(pwd)/re-version/final/liquibase-$version.tar.gz
-          scriptDir=$(pwd)/.github/util/
+  #         ##### Rebuild installers
+  #         tarFile=$(pwd)/re-version/final/liquibase-$version.tar.gz
+  #         scriptDir=$(pwd)/.github/util/
           
-          mkdir -p liquibase-dist/target/liquibase-$version
-          (cd liquibase-dist/target/liquibase-$version && tar xfz $tarFile)
-          (cd liquibase-dist && $scriptDir/package-install4j.sh $version)
-          mv liquibase-dist/target/liquibase-*-installer-* re-version/final
+  #         mkdir -p liquibase-dist/target/liquibase-$version
+  #         (cd liquibase-dist/target/liquibase-$version && tar xfz $tarFile)
+  #         (cd liquibase-dist && $scriptDir/package-install4j.sh $version)
+  #         mv liquibase-dist/target/liquibase-*-installer-* re-version/final
           
-          ##Sign Files
-          $PWD/.github/util/sign-artifacts.sh re-version/final
+  #         ##Sign Files
+  #         $PWD/.github/util/sign-artifacts.sh re-version/final
           
-          (cd re-version/final && zip liquibase-additional-$version.zip *.asc *.md5 *.sha1)
-          rm re-version/final/*.asc
-          rm re-version/final/*.md5
-          rm re-version/final/*.sha1
+  #         (cd re-version/final && zip liquibase-additional-$version.zip *.asc *.md5 *.sha1)
+  #         rm re-version/final/*.asc
+  #         rm re-version/final/*.md5
+  #         rm re-version/final/*.sha1
 
-      - name: Attach Files to Draft Release
-        if: ${{ inputs.standalone_zip == false && inputs.dry_run == false }}
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: v${{ needs.setup.outputs.version }}
-          fail_on_unmatched_files: true
-          body: Liquibase ${{ needs.setup.outputs.version }}
-          generate_release_notes: true
-          draft: true
-          files: re-version/final/*
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Attach Files to Draft Release
+  #       if: ${{ inputs.standalone_zip == false && inputs.dry_run == false }}
+  #       uses: softprops/action-gh-release@v2
+  #       with:
+  #         tag_name: v${{ needs.setup.outputs.version }}
+  #         fail_on_unmatched_files: true
+  #         body: Liquibase ${{ needs.setup.outputs.version }}
+  #         generate_release_notes: true
+  #         draft: true
+  #         files: re-version/final/*
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Attach Files to Dry-Run Draft Release
-        id: attach-files-dry-run
-        if: ${{ inputs.standalone_zip == false && inputs.dry_run == true }}
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: v${{ needs.setup.outputs.version }}
-          fail_on_unmatched_files: true
-          body: Liquibase ${{ needs.setup.outputs.version }} (Dry-Run)
-          generate_release_notes: true
-          draft: true
-          files: re-version/final/*
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Attach Files to Dry-Run Draft Release
+  #       id: attach-files-dry-run
+  #       if: ${{ inputs.standalone_zip == false && inputs.dry_run == true }}
+  #       uses: softprops/action-gh-release@v2
+  #       with:
+  #         tag_name: v${{ needs.setup.outputs.version }}
+  #         fail_on_unmatched_files: true
+  #         body: Liquibase ${{ needs.setup.outputs.version }} (Dry-Run)
+  #         generate_release_notes: true
+  #         draft: true
+  #         files: re-version/final/*
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract dry-run release URL
-        if: ${{ inputs.standalone_zip == false && inputs.dry_run == true }}
-        id: extract-dry-run-url
-        shell: bash
-        run: |
-          assets_json=$(echo '${{ toJson(steps.attach-files-dry-run.outputs) }}' | jq -r '.assets | fromjson')
-          tar_gz_url=$(echo "$assets_json" | jq -r '.[] | select(.name | test("^liquibase-dry-run-.*\\.tar\\.gz$")) | .url')
-          zip_url=$(echo "$assets_json" | jq -r '.[] | select(.name | test("^liquibase-dry-run-.*\\.zip$")) | .url')
-          echo $tar_gz_url
-          echo $zip_url
-          echo "dry_run_tar_gz_url=$tar_gz_url" >> $GITHUB_OUTPUT
-          echo "dry_run_zip_url=$zip_url" >> $GITHUB_OUTPUT
+  #     - name: Extract dry-run release URL
+  #       if: ${{ inputs.standalone_zip == false && inputs.dry_run == true }}
+  #       id: extract-dry-run-url
+  #       shell: bash
+  #       run: |
+  #         assets_json=$(echo '${{ toJson(steps.attach-files-dry-run.outputs) }}' | jq -r '.assets | fromjson')
+  #         tar_gz_url=$(echo "$assets_json" | jq -r '.[] | select(.name | test("^liquibase-dry-run-.*\\.tar\\.gz$")) | .url')
+  #         zip_url=$(echo "$assets_json" | jq -r '.[] | select(.name | test("^liquibase-dry-run-.*\\.zip$")) | .url')
+  #         echo $tar_gz_url
+  #         echo $zip_url
+  #         echo "dry_run_tar_gz_url=$tar_gz_url" >> $GITHUB_OUTPUT
+  #         echo "dry_run_zip_url=$zip_url" >> $GITHUB_OUTPUT
         
-      - name: Attach standalone zip to Build
-        if: ${{ inputs.standalone_zip == true && inputs.dry_run == false }}
-        uses: actions/upload-artifact@v4
-        with:
-            name: liquibase-installers-${{ needs.setup.outputs.version }}
-            path: re-version/final/*
+  #     - name: Attach standalone zip to Build
+  #       if: ${{ inputs.standalone_zip == true && inputs.dry_run == false }}
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #           name: liquibase-installers-${{ needs.setup.outputs.version }}
+  #           path: re-version/final/*
     

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -74,15 +74,15 @@ jobs:
       - run: |
           echo "Creating version ${{ inputs.version }} from ${{ inputs.branch }} with artifacts from build ${{ inputs.runId }} "
           
-  # owasp-scanner:
-  #   needs: [ setup ]
-  #   uses: liquibase/build-logic/.github/workflows/owasp-scanner.yml@main
-  #   with:
-  #     branch: ${{ needs.setup.outputs.branch }}
-  #   secrets: inherit
+  owasp-scanner:
+    needs: [ setup ]
+    uses: liquibase/build-logic/.github/workflows/owasp-scanner.yml@main
+    with:
+      branch: ${{ needs.setup.outputs.branch }}
+    secrets: inherit
 
   build-azure-uber-jar:
-   needs: [ setup ]
+   needs: [ setup, owasp-scanner ]
    uses: liquibase/liquibase/.github/workflows/build-azure-uber-jar.yml@master
    with:
      branch: ${{ needs.setup.outputs.branch }}
@@ -90,8 +90,8 @@ jobs:
    secrets: inherit
   
   build-extension-jars:
-   needs: [ setup ]
-   uses: liquibase/liquibase/.github/workflows/build-extension-jars.yml@DAT-18331
+   needs: [ setup, owasp-scanner ]
+   uses: liquibase/liquibase/.github/workflows/build-extension-jars.yml@master
    with:
      liquibase-version: ${{ needs.setup.outputs.version }}
      dependencies: ${{ needs.setup.outputs.dependencies }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -81,26 +81,27 @@ jobs:
   #     branch: ${{ needs.setup.outputs.branch }}
   #   secrets: inherit
 
-  build-azure-uber-jar:
-   needs: [ setup ]
-   uses: liquibase/liquibase/.github/workflows/build-azure-uber-jar.yml@master
-   with:
-     branch: ${{ needs.setup.outputs.branch }}
-     liquibase-version: ${{ needs.setup.outputs.version }}
-   secrets: inherit
+  # build-azure-uber-jar:
+  #  needs: [ setup ]
+  #  uses: liquibase/liquibase/.github/workflows/build-azure-uber-jar.yml@master
+  #  with:
+  #    branch: ${{ needs.setup.outputs.branch }}
+  #    liquibase-version: ${{ needs.setup.outputs.version }}
+  #  secrets: inherit
   
-  build-extension-jars:
-   needs: [ setup ]
-   uses: liquibase/liquibase/.github/workflows/build-extension-jars.yml@DAT-18331
-   with:
-     liquibase-version: ${{ needs.setup.outputs.version }}
-     dependencies: ${{ needs.setup.outputs.dependencies }}
-     extensions: ${{ needs.setup.outputs.extensions }}
-     branch: ${{ needs.setup.outputs.branch }}
-   secrets: inherit
+  # build-extension-jars:
+  #  needs: [ setup ]
+  #  uses: liquibase/liquibase/.github/workflows/build-extension-jars.yml@DAT-18331
+  #  with:
+  #    liquibase-version: ${{ needs.setup.outputs.version }}
+  #    dependencies: ${{ needs.setup.outputs.dependencies }}
+  #    extensions: ${{ needs.setup.outputs.extensions }}
+  #    branch: ${{ needs.setup.outputs.branch }}
+  #  secrets: inherit
 
   reversion:
-    needs: [ setup, build-azure-uber-jar, build-extension-jars ]
+    needs: [ setup ]
+    #needs: [ setup, build-azure-uber-jar, build-extension-jars ]
     name: Re-version artifacts ${{ needs.setup.outputs.version }}
     runs-on: ubuntu-22.04
     steps:
@@ -115,7 +116,7 @@ jobs:
           token: ${{ secrets.BOT_TOKEN }}
 
       - name: Download liquibase-artifacts
-        uses: liquibase/action-download-artifact@v2-liquibase
+        uses: dawidd6/action-download-artifact@v7
         with:
           workflow: run-tests.yml
           run_id: ${{ needs.setup.outputs.runId }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -309,45 +309,45 @@ jobs:
           rm re-version/final/*.md5
           rm re-version/final/*.sha1
 
-      # - name: Attach Files to Draft Release
-      #   if: ${{ inputs.standalone_zip == false && inputs.dry_run == false }}
-      #   uses: softprops/action-gh-release@v2
-      #   with:
-      #     tag_name: v${{ needs.setup.outputs.version }}
-      #     fail_on_unmatched_files: true
-      #     body: Liquibase ${{ needs.setup.outputs.version }}
-      #     generate_release_notes: true
-      #     draft: true
-      #     files: re-version/final/*
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Attach Files to Draft Release
+        if: ${{ inputs.standalone_zip == false && inputs.dry_run == false }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ needs.setup.outputs.version }}
+          fail_on_unmatched_files: true
+          body: Liquibase ${{ needs.setup.outputs.version }}
+          generate_release_notes: true
+          draft: true
+          files: re-version/final/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Attach Files to Dry-Run Draft Release
-      #   id: attach-files-dry-run
-      #   if: ${{ inputs.standalone_zip == false && inputs.dry_run == true }}
-      #   uses: softprops/action-gh-release@v2
-      #   with:
-      #     tag_name: v${{ needs.setup.outputs.version }}
-      #     fail_on_unmatched_files: true
-      #     body: Liquibase ${{ needs.setup.outputs.version }} (Dry-Run)
-      #     generate_release_notes: true
-      #     draft: true
-      #     files: re-version/final/*
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Attach Files to Dry-Run Draft Release
+        id: attach-files-dry-run
+        if: ${{ inputs.standalone_zip == false && inputs.dry_run == true }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ needs.setup.outputs.version }}
+          fail_on_unmatched_files: true
+          body: Liquibase ${{ needs.setup.outputs.version }} (Dry-Run)
+          generate_release_notes: true
+          draft: true
+          files: re-version/final/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Extract dry-run release URL
-      #   if: ${{ inputs.standalone_zip == false && inputs.dry_run == true }}
-      #   id: extract-dry-run-url
-      #   shell: bash
-      #   run: |
-      #     assets_json=$(echo '${{ toJson(steps.attach-files-dry-run.outputs) }}' | jq -r '.assets | fromjson')
-      #     tar_gz_url=$(echo "$assets_json" | jq -r '.[] | select(.name | test("^liquibase-dry-run-.*\\.tar\\.gz$")) | .url')
-      #     zip_url=$(echo "$assets_json" | jq -r '.[] | select(.name | test("^liquibase-dry-run-.*\\.zip$")) | .url')
-      #     echo $tar_gz_url
-      #     echo $zip_url
-      #     echo "dry_run_tar_gz_url=$tar_gz_url" >> $GITHUB_OUTPUT
-      #     echo "dry_run_zip_url=$zip_url" >> $GITHUB_OUTPUT
+      - name: Extract dry-run release URL
+        if: ${{ inputs.standalone_zip == false && inputs.dry_run == true }}
+        id: extract-dry-run-url
+        shell: bash
+        run: |
+          assets_json=$(echo '${{ toJson(steps.attach-files-dry-run.outputs) }}' | jq -r '.assets | fromjson')
+          tar_gz_url=$(echo "$assets_json" | jq -r '.[] | select(.name | test("^liquibase-dry-run-.*\\.tar\\.gz$")) | .url')
+          zip_url=$(echo "$assets_json" | jq -r '.[] | select(.name | test("^liquibase-dry-run-.*\\.zip$")) | .url')
+          echo $tar_gz_url
+          echo $zip_url
+          echo "dry_run_tar_gz_url=$tar_gz_url" >> $GITHUB_OUTPUT
+          echo "dry_run_zip_url=$zip_url" >> $GITHUB_OUTPUT
         
       - name: Attach standalone zip to Build
         if: ${{ inputs.standalone_zip == true && inputs.dry_run == false }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -56,11 +56,8 @@ on:
         value: ${{ jobs.build-installers.outputs.dry_run_tar_gz_url }}
 
 env:
-  DEPENDENCIES: "liquibase-bigquery"
-  EXTENSIONS: >-
-    '[{"name":"liquibase-checks","combined_jars":"true","artifact_path":"liquibase-checks"}]'
-  # EXTENSIONS: >-
-  #   '[{"name":"liquibase-commercial-bigquery","combined_jars":"false"},{"name":"liquibase-checks","combined_jars":"true"}]'
+  DEPENDENCIES: "liquibase-bigquery" # Comma separated list of dependencies to release the extensions list
+  EXTENSIONS: "liquibase-commercial-bigquery,liquibase-checks" # Comma separated list of extensions to release to GPM
 
 jobs:
   setup:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -74,23 +74,23 @@ jobs:
       - run: |
           echo "Creating version ${{ inputs.version }} from ${{ inputs.branch }} with artifacts from build ${{ inputs.runId }} "
           
-  # owasp-scanner:
-  #   needs: [ setup ]
-  #   uses: liquibase/build-logic/.github/workflows/owasp-scanner.yml@main
-  #   with:
-  #     branch: ${{ needs.setup.outputs.branch }}
-  #   secrets: inherit
+  owasp-scanner:
+    needs: [ setup ]
+    uses: liquibase/build-logic/.github/workflows/owasp-scanner.yml@main
+    with:
+      branch: ${{ needs.setup.outputs.branch }}
+    secrets: inherit
 
-  # build-azure-uber-jar:
-  #  needs: [ setup, owasp-scanner ]
-  #  uses: liquibase/liquibase/.github/workflows/build-azure-uber-jar.yml@master
-  #  with:
-  #    branch: ${{ needs.setup.outputs.branch }}
-  #    liquibase-version: ${{ needs.setup.outputs.version }}
-  #  secrets: inherit
+  build-azure-uber-jar:
+   needs: [ setup, owasp-scanner ]
+   uses: liquibase/liquibase/.github/workflows/build-azure-uber-jar.yml@master
+   with:
+     branch: ${{ needs.setup.outputs.branch }}
+     liquibase-version: ${{ needs.setup.outputs.version }}
+   secrets: inherit
   
   build-extension-jars:
-   needs: [ setup ]
+   needs: [ setup, owasp-scanner ]
    uses: liquibase/liquibase/.github/workflows/build-extension-jars.yml@DAT-18331
    with:
      liquibase-version: ${{ needs.setup.outputs.version }}
@@ -99,260 +99,260 @@ jobs:
      branch: ${{ needs.setup.outputs.branch }}
    secrets: inherit
 
-  # reversion:
-  #   needs: [ setup, build-extension-jars ]
-  #   name: Re-version artifacts ${{ needs.setup.outputs.version }}
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - uses: actions/checkout@v4
+  reversion:
+    needs: [ setup, build-azure-uber-jar, build-extension-jars ]
+    name: Re-version artifacts ${{ needs.setup.outputs.version }}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - uses: actions/checkout@v4
-  #       name: Checkout liquibase-pro
-  #       with:
-  #         repository: liquibase/liquibase-pro
-  #         ref: "${{ needs.setup.outputs.branch }}"
-  #         path: download/repo/liquibase-pro
-  #         token: ${{ secrets.BOT_TOKEN }}
+      - uses: actions/checkout@v4
+        name: Checkout liquibase-pro
+        with:
+          repository: liquibase/liquibase-pro
+          ref: "${{ needs.setup.outputs.branch }}"
+          path: download/repo/liquibase-pro
+          token: ${{ secrets.BOT_TOKEN }}
 
-  #     - name: Download liquibase-artifacts
-  #       uses: liquibase/action-download-artifact@v2-liquibase
-  #       with:
-  #         workflow: run-tests.yml
-  #         run_id: ${{ needs.setup.outputs.runId }}
-  #         name: liquibase-artifacts
-  #         path: download/liquibase-artifacts
+      - name: Download liquibase-artifacts
+        uses: liquibase/action-download-artifact@v2-liquibase
+        with:
+          workflow: run-tests.yml
+          run_id: ${{ needs.setup.outputs.runId }}
+          name: liquibase-artifacts
+          path: download/liquibase-artifacts
 
-  #     - name: Get Current Run ID
-  #       id: get_run_id
-  #       run: |
-  #         run_id=${{ github.run_id }}
-  #         echo "uber_jar_runId=${run_id}" >> $GITHUB_OUTPUT
+      - name: Get Current Run ID
+        id: get_run_id
+        run: |
+          run_id=${{ github.run_id }}
+          echo "uber_jar_runId=${run_id}" >> $GITHUB_OUTPUT
 
-  #     - name: Download liquibase-pro-azure-artifacts
-  #       uses: actions/download-artifact@v4
-  #       with: 
-  #         name: liquibase-pro-azure-artifacts
-  #         path: liquibase-pro/liquibase-azure-deps
+      - name: Download liquibase-pro-azure-artifacts
+        uses: actions/download-artifact@v4
+        with: 
+          name: liquibase-pro-azure-artifacts
+          path: liquibase-pro/liquibase-azure-deps
 
-  #     - name: Generate repositories and servers JSON
-  #       id: generate-json
-  #       run: |
-  #         IFS=',' read -ra EXT <<< "${{ needs.setup.outputs.extensions }}"
-  #         repositories=""
-  #         servers=""
-  #         for i in "${EXT[@]}"; do
-  #           repositories+="{\"id\": \"$i\",\"url\": \"https://maven.pkg.github.com/liquibase/$i\",\"releases\": {\"enabled\": \"true\"},\"snapshots\": {\"enabled\": \"true\",\"updatePolicy\": \"always\"}},"
-  #           servers+="{\"id\": \"$i\",\"username\": \"liquibot\",\"password\": \"${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}\"},"
-  #         done
-  #         # Remove trailing comma and wrap with brackets
-  #         repositories="["${repositories::-1}"]"
-  #         servers="["${servers::-1}"]"
-  #         echo "REPOSITORIES_JSON=$repositories" >> $GITHUB_ENV
-  #         echo "SERVERS_JSON=$servers" >> $GITHUB_ENV
+      - name: Generate repositories and servers JSON
+        id: generate-json
+        run: |
+          IFS=',' read -ra EXT <<< "${{ needs.setup.outputs.extensions }}"
+          repositories=""
+          servers=""
+          for i in "${EXT[@]}"; do
+            repositories+="{\"id\": \"$i\",\"url\": \"https://maven.pkg.github.com/liquibase/$i\",\"releases\": {\"enabled\": \"true\"},\"snapshots\": {\"enabled\": \"true\",\"updatePolicy\": \"always\"}},"
+            servers+="{\"id\": \"$i\",\"username\": \"liquibot\",\"password\": \"${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}\"},"
+          done
+          # Remove trailing comma and wrap with brackets
+          repositories="["${repositories::-1}"]"
+          servers="["${servers::-1}"]"
+          echo "REPOSITORIES_JSON=$repositories" >> $GITHUB_ENV
+          echo "SERVERS_JSON=$servers" >> $GITHUB_ENV
 
-  #     - name: maven-settings-xml-action
-  #       uses: whelk-io/maven-settings-xml-action@v22
-  #       with:
-  #         repositories: ${{ env.REPOSITORIES_JSON }}
-  #         servers: ${{ env.SERVERS_JSON }}
+      - name: maven-settings-xml-action
+        uses: whelk-io/maven-settings-xml-action@v22
+        with:
+          repositories: ${{ env.REPOSITORIES_JSON }}
+          servers: ${{ env.SERVERS_JSON }}
               
-  #     - name: Get extensions artifacts
-  #       run: |
-  #         IFS=',' read -ra ADDR <<< "${{ needs.setup.outputs.extensions }}"
-  #         for extension in "${ADDR[@]}"; do
-  #           mvn dependency:get -DgroupId=org.liquibase.ext -DartifactId=$extension -Dversion=${{ needs.setup.outputs.version }} -Dtransitive=false || echo "Failed to download $extension artifact"
-  #         done
+      - name: Get extensions artifacts
+        run: |
+          IFS=',' read -ra ADDR <<< "${{ needs.setup.outputs.extensions }}"
+          for extension in "${ADDR[@]}"; do
+            mvn dependency:get -DgroupId=org.liquibase.ext -DartifactId=$extension -Dversion=${{ needs.setup.outputs.version }} -Dtransitive=false || echo "Failed to download $extension artifact"
+          done
 
-  #     - name: Set up JDK
-  #       uses: actions/setup-java@v4
-  #       with:
-  #         java-version: '8'
-  #         distribution: 'adopt'
-  #         gpg-private-key: ${{ secrets.GPG_SECRET }}
-  #         gpg-passphrase: GPG_PASSPHRASE
-  #       env:
-  #         GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+          gpg-private-key: ${{ secrets.GPG_SECRET }}
+          gpg-passphrase: GPG_PASSPHRASE
+        env:
+          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
 
-  #     - name: Re-version Artifacts
-  #       env:
-  #         GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
-  #       run: |
-  #         scripts_branch=${{ github.ref }}
-  #         mkdir -p $PWD/.github/util/
-  #         # Download a script (re-version.sh) from a URL and save it to the specified directory
-  #         curl -o $PWD/.github/util/re-version.sh https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/re-version.sh
+      - name: Re-version Artifacts
+        env:
+          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          scripts_branch=${{ github.ref }}
+          mkdir -p $PWD/.github/util/
+          # Download a script (re-version.sh) from a URL and save it to the specified directory
+          curl -o $PWD/.github/util/re-version.sh https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/re-version.sh
           
-  #         # Download another script (sign-artifacts.sh) from a URL and save it to the specified directory
-  #         curl -o $PWD/.github/util/sign-artifacts.sh https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/sign-artifacts.sh
-  #         curl -o $PWD/.github/util/ManifestReversion.java https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/ManifestReversion.java
-  #         chmod +x $PWD/.github/util/re-version.sh
-  #         chmod +x $PWD/.github/util/ManifestReversion.java
-  #         chmod +x $PWD/.github/util/sign-artifacts.sh
-  #         $PWD/.github/util/re-version.sh download/liquibase-artifacts "${{ needs.setup.outputs.version }}" "${{ needs.setup.outputs.branch }}"
+          # Download another script (sign-artifacts.sh) from a URL and save it to the specified directory
+          curl -o $PWD/.github/util/sign-artifacts.sh https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/sign-artifacts.sh
+          curl -o $PWD/.github/util/ManifestReversion.java https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/ManifestReversion.java
+          chmod +x $PWD/.github/util/re-version.sh
+          chmod +x $PWD/.github/util/ManifestReversion.java
+          chmod +x $PWD/.github/util/sign-artifacts.sh
+          $PWD/.github/util/re-version.sh download/liquibase-artifacts "${{ needs.setup.outputs.version }}" "${{ needs.setup.outputs.branch }}"
 
-  #         # Execute the sign-artifacts.sh script with specific arguments
-  #         $PWD/.github/util/sign-artifacts.sh download/liquibase-artifacts "${{ needs.setup.outputs.version }}" "${{ needs.setup.outputs.branch }}"
+          # Execute the sign-artifacts.sh script with specific arguments
+          $PWD/.github/util/sign-artifacts.sh download/liquibase-artifacts "${{ needs.setup.outputs.version }}" "${{ needs.setup.outputs.branch }}"
           
-  #         ## Sign Files
-  #         ## liquibase-azure-deps and liquibase extensions are already on its correct version. Check reusable workflow: build-azure-uber-jar.yml and build-extension-jars.yml
-  #         mv liquibase-pro/liquibase-azure-deps/* re-version/out
+          ## Sign Files
+          ## liquibase-azure-deps and liquibase extensions are already on its correct version. Check reusable workflow: build-azure-uber-jar.yml and build-extension-jars.yml
+          mv liquibase-pro/liquibase-azure-deps/* re-version/out
           
-  #         # Modify the zip file
-  #         unzip re-version/out/liquibase-${{ needs.setup.outputs.version }}.zip -d re-version/out/liquibase-${{ needs.setup.outputs.version }}
-  #         mkdir -p re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions
-  #         rm -rf re-version/out/liquibase-${{ needs.setup.outputs.version }}.zip
-  #         IFS=',' read -ra EXT <<< "${{ needs.setup.outputs.extensions }}"
-  #         for i in "${EXT[@]}"; do
-  #           cp ~/.m2/repository/org/liquibase/ext/$i/${{ needs.setup.outputs.version }}/$i-${{ needs.setup.outputs.version }}.jar re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions/$i.jar || echo "Failed to move $i artifact"
-  #         done
-  #         (cd re-version/out/liquibase-${{ needs.setup.outputs.version }} && zip -r ../liquibase-${{ needs.setup.outputs.version }}.zip . && cd .. && rm -rf liquibase-${{ needs.setup.outputs.version }})
+          # Modify the zip file
+          unzip re-version/out/liquibase-${{ needs.setup.outputs.version }}.zip -d re-version/out/liquibase-${{ needs.setup.outputs.version }}
+          mkdir -p re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions
+          rm -rf re-version/out/liquibase-${{ needs.setup.outputs.version }}.zip
+          IFS=',' read -ra EXT <<< "${{ needs.setup.outputs.extensions }}"
+          for i in "${EXT[@]}"; do
+            cp ~/.m2/repository/org/liquibase/ext/$i/${{ needs.setup.outputs.version }}/$i-${{ needs.setup.outputs.version }}.jar re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions/$i.jar || echo "Failed to move $i artifact"
+          done
+          (cd re-version/out/liquibase-${{ needs.setup.outputs.version }} && zip -r ../liquibase-${{ needs.setup.outputs.version }}.zip . && cd .. && rm -rf liquibase-${{ needs.setup.outputs.version }})
           
-  #         # Modify the tar.gz file
-  #         mkdir -p re-version/out/liquibase-${{ needs.setup.outputs.version }}
-  #         tar -xzvf re-version/out/liquibase-${{ needs.setup.outputs.version }}.tar.gz -C re-version/out/liquibase-${{ needs.setup.outputs.version }}
-  #         rm -rf re-version/out/liquibase-${{ needs.setup.outputs.version }}.tar.gz
-  #         mkdir -p re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions
-  #         for I in "${EXT[@]}"; do
-  #           cp ~/.m2/repository/org/liquibase/ext/$I/${{ needs.setup.outputs.version }}/$I-${{ needs.setup.outputs.version }}.jar re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions/$I.jar || echo "Failed to move $I artifact"
-  #         done
-  #         (cd re-version/out/liquibase-${{ needs.setup.outputs.version }} && tar -czvf ../liquibase-${{ needs.setup.outputs.version }}.tar.gz * && cd .. && rm -rf liquibase-${{ needs.setup.outputs.version }})
+          # Modify the tar.gz file
+          mkdir -p re-version/out/liquibase-${{ needs.setup.outputs.version }}
+          tar -xzvf re-version/out/liquibase-${{ needs.setup.outputs.version }}.tar.gz -C re-version/out/liquibase-${{ needs.setup.outputs.version }}
+          rm -rf re-version/out/liquibase-${{ needs.setup.outputs.version }}.tar.gz
+          mkdir -p re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions
+          for I in "${EXT[@]}"; do
+            cp ~/.m2/repository/org/liquibase/ext/$I/${{ needs.setup.outputs.version }}/$I-${{ needs.setup.outputs.version }}.jar re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions/$I.jar || echo "Failed to move $I artifact"
+          done
+          (cd re-version/out/liquibase-${{ needs.setup.outputs.version }} && tar -czvf ../liquibase-${{ needs.setup.outputs.version }}.tar.gz * && cd .. && rm -rf liquibase-${{ needs.setup.outputs.version }})
 
-  #         $PWD/.github/util/sign-artifacts.sh re-version/out
+          $PWD/.github/util/sign-artifacts.sh re-version/out
    
-  #         # Move files to a specific directory
-  #         mkdir re-version/final
-  #         mv re-version/out/liquibase-core-${{ needs.setup.outputs.version }}.jar re-version/final
-  #         mv re-version/out/liquibase-commercial-${{ needs.setup.outputs.version }}.jar re-version/final
-  #         mv re-version/out/liquibase-${{ needs.setup.outputs.version }}.tar.gz re-version/final
-  #         mv re-version/out/liquibase-${{ needs.setup.outputs.version }}.zip re-version/final
-  #         mv re-version/out/liquibase-azure-deps-${{ needs.setup.outputs.version }}.jar re-version/final/liquibase-azure-deps-${{ needs.setup.outputs.version }}.jar
-  #         (cd re-version/out/ && zip liquibase-additional-${{ needs.setup.outputs.version }}.zip *)
-  #         mv re-version/out/liquibase-additional-${{ needs.setup.outputs.version }}.zip re-version/final
+          # Move files to a specific directory
+          mkdir re-version/final
+          mv re-version/out/liquibase-core-${{ needs.setup.outputs.version }}.jar re-version/final
+          mv re-version/out/liquibase-commercial-${{ needs.setup.outputs.version }}.jar re-version/final
+          mv re-version/out/liquibase-${{ needs.setup.outputs.version }}.tar.gz re-version/final
+          mv re-version/out/liquibase-${{ needs.setup.outputs.version }}.zip re-version/final
+          mv re-version/out/liquibase-azure-deps-${{ needs.setup.outputs.version }}.jar re-version/final/liquibase-azure-deps-${{ needs.setup.outputs.version }}.jar
+          (cd re-version/out/ && zip liquibase-additional-${{ needs.setup.outputs.version }}.zip *)
+          mv re-version/out/liquibase-additional-${{ needs.setup.outputs.version }}.zip re-version/final
 
-  #     - name: Cache Completed Artifacts
-  #       uses: actions/cache@v4.1.2
-  #       with:
-  #         key: completed-artifacts-${{ github.run_number }}-${{ github.run_attempt }}
-  #         path: re-version/final
+      - name: Cache Completed Artifacts
+        uses: actions/cache@v4.1.2
+        with:
+          key: completed-artifacts-${{ github.run_number }}-${{ github.run_attempt }}
+          path: re-version/final
 
-  #     - name: Set repository tags
-  #       if: ${{ inputs.standalone_zip == false && inputs.dry_run == false }}
-  #       run: |
-  #         git tag -f v${{ needs.setup.outputs.version }}
-  #         git push -f origin v${{ needs.setup.outputs.version }}
-  #         (cd download/repo/liquibase-pro && git tag -f v${{ needs.setup.outputs.version }})
-  #         (cd download/repo/liquibase-pro && git push -f origin v${{ needs.setup.outputs.version }})
+      - name: Set repository tags
+        if: ${{ inputs.standalone_zip == false && inputs.dry_run == false }}
+        run: |
+          git tag -f v${{ needs.setup.outputs.version }}
+          git push -f origin v${{ needs.setup.outputs.version }}
+          (cd download/repo/liquibase-pro && git tag -f v${{ needs.setup.outputs.version }})
+          (cd download/repo/liquibase-pro && git push -f origin v${{ needs.setup.outputs.version }})
 
-  # build-installers:
-  #   permissions:
-  #     contents: write  # for softprops/action-gh-release to create GitHub release
-  #   needs: [ setup, reversion ]
-  #   name: Build Installers
-  #   runs-on: macos-13 #needs macos for apple notarization
-  #   env:
-  #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #   outputs:
-  #     dry_run_zip_url: ${{ steps.extract-dry-run-url.outputs.dry_run_zip_url }}
-  #     dry_run_tar_gz_url: ${{ steps.extract-dry-run-url.outputs.dry_run_tar_gz_url }} 
-  #   steps:
-  #     - uses: actions/checkout@v4
+  build-installers:
+    permissions:
+      contents: write  # for softprops/action-gh-release to create GitHub release
+    needs: [ setup, reversion ]
+    name: Build Installers
+    runs-on: macos-13 #needs macos for apple notarization
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    outputs:
+      dry_run_zip_url: ${{ steps.extract-dry-run-url.outputs.dry_run_zip_url }}
+      dry_run_tar_gz_url: ${{ steps.extract-dry-run-url.outputs.dry_run_tar_gz_url }} 
+    steps:
+      - uses: actions/checkout@v4
 
-  #     - name: Restore Completed Artifacts
-  #       uses: actions/cache@v4.1.2
-  #       with:
-  #         key: completed-artifacts-${{ github.run_number }}-${{ github.run_attempt }}
-  #         path: re-version/final
+      - name: Restore Completed Artifacts
+        uses: actions/cache@v4.1.2
+        with:
+          key: completed-artifacts-${{ github.run_number }}-${{ github.run_attempt }}
+          path: re-version/final
 
-  #     - name: Set up JDK for GPG
-  #       uses: actions/setup-java@v4
-  #       with:
-  #         java-version: '8'
-  #         distribution: 'adopt'
-  #         gpg-private-key: ${{ secrets.GPG_SECRET }}
-  #         gpg-passphrase: GPG_PASSPHRASE
-  #       env:
-  #         GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Set up JDK for GPG
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+          gpg-private-key: ${{ secrets.GPG_SECRET }}
+          gpg-passphrase: GPG_PASSPHRASE
+        env:
+          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
 
 
-  #     - name: Re-version Installers
-  #       env:
-  #         INSTALL4J_10_LICENSE: ${{ secrets.INSTALL4J_10_LICENSE }}
-  #         INSTALL4J_APPLE_KEY: ${{ secrets.INSTALL4J_APPLE_KEY }}
-  #         INSTALL4J_APPLE_KEY_PASSWORD: ${{ secrets.INSTALL4J_APPLE_KEY_PASSWORD }}
-  #         INSTALL4J_APPLE_ID: ${{ secrets.INSTALL4J_APPLE_ID }}
-  #         INSTALL4J_APPLE_ID_PASSWORD: ${{ secrets.INSTALL4J_APPLE_ID_PASSWORD }}
-  #         INSTALL4J_WINDOWS_KEY: ${{ secrets.INSTALL4J_WINDOWS_KEY }}
-  #         INSTALL4J_WINDOWS_KEY_PASSWORD: ${{ secrets.INSTALL4J_WINDOWS_KEY_PASSWORD }}
-  #         GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
-  #       run: |
-  #         mkdir -p liquibase-dist/target/keys
-  #         echo "Saving apple key"
-  #         echo "$INSTALL4J_APPLE_KEY" | base64 -d > liquibase-dist/target/keys/datical_apple.p12
-  #         echo "Saving windows key"
-  #         echo "$INSTALL4J_WINDOWS_KEY" | base64 -d > liquibase-dist/target/keys/datical_windows.pfx
-  #         version="${{ needs.setup.outputs.version }}"
+      - name: Re-version Installers
+        env:
+          INSTALL4J_10_LICENSE: ${{ secrets.INSTALL4J_10_LICENSE }}
+          INSTALL4J_APPLE_KEY: ${{ secrets.INSTALL4J_APPLE_KEY }}
+          INSTALL4J_APPLE_KEY_PASSWORD: ${{ secrets.INSTALL4J_APPLE_KEY_PASSWORD }}
+          INSTALL4J_APPLE_ID: ${{ secrets.INSTALL4J_APPLE_ID }}
+          INSTALL4J_APPLE_ID_PASSWORD: ${{ secrets.INSTALL4J_APPLE_ID_PASSWORD }}
+          INSTALL4J_WINDOWS_KEY: ${{ secrets.INSTALL4J_WINDOWS_KEY }}
+          INSTALL4J_WINDOWS_KEY_PASSWORD: ${{ secrets.INSTALL4J_WINDOWS_KEY_PASSWORD }}
+          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          mkdir -p liquibase-dist/target/keys
+          echo "Saving apple key"
+          echo "$INSTALL4J_APPLE_KEY" | base64 -d > liquibase-dist/target/keys/datical_apple.p12
+          echo "Saving windows key"
+          echo "$INSTALL4J_WINDOWS_KEY" | base64 -d > liquibase-dist/target/keys/datical_windows.pfx
+          version="${{ needs.setup.outputs.version }}"
           
-  #         ##### Rebuild installers
-  #         tarFile=$(pwd)/re-version/final/liquibase-$version.tar.gz
-  #         scriptDir=$(pwd)/.github/util/
+          ##### Rebuild installers
+          tarFile=$(pwd)/re-version/final/liquibase-$version.tar.gz
+          scriptDir=$(pwd)/.github/util/
           
-  #         mkdir -p liquibase-dist/target/liquibase-$version
-  #         (cd liquibase-dist/target/liquibase-$version && tar xfz $tarFile)
-  #         (cd liquibase-dist && $scriptDir/package-install4j.sh $version)
-  #         mv liquibase-dist/target/liquibase-*-installer-* re-version/final
+          mkdir -p liquibase-dist/target/liquibase-$version
+          (cd liquibase-dist/target/liquibase-$version && tar xfz $tarFile)
+          (cd liquibase-dist && $scriptDir/package-install4j.sh $version)
+          mv liquibase-dist/target/liquibase-*-installer-* re-version/final
           
-  #         ##Sign Files
-  #         $PWD/.github/util/sign-artifacts.sh re-version/final
+          ##Sign Files
+          $PWD/.github/util/sign-artifacts.sh re-version/final
           
-  #         (cd re-version/final && zip liquibase-additional-$version.zip *.asc *.md5 *.sha1)
-  #         rm re-version/final/*.asc
-  #         rm re-version/final/*.md5
-  #         rm re-version/final/*.sha1
+          (cd re-version/final && zip liquibase-additional-$version.zip *.asc *.md5 *.sha1)
+          rm re-version/final/*.asc
+          rm re-version/final/*.md5
+          rm re-version/final/*.sha1
 
-  #     - name: Attach Files to Draft Release
-  #       if: ${{ inputs.standalone_zip == false && inputs.dry_run == false }}
-  #       uses: softprops/action-gh-release@v2
-  #       with:
-  #         tag_name: v${{ needs.setup.outputs.version }}
-  #         fail_on_unmatched_files: true
-  #         body: Liquibase ${{ needs.setup.outputs.version }}
-  #         generate_release_notes: true
-  #         draft: true
-  #         files: re-version/final/*
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Attach Files to Draft Release
+      #   if: ${{ inputs.standalone_zip == false && inputs.dry_run == false }}
+      #   uses: softprops/action-gh-release@v2
+      #   with:
+      #     tag_name: v${{ needs.setup.outputs.version }}
+      #     fail_on_unmatched_files: true
+      #     body: Liquibase ${{ needs.setup.outputs.version }}
+      #     generate_release_notes: true
+      #     draft: true
+      #     files: re-version/final/*
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - name: Attach Files to Dry-Run Draft Release
-  #       id: attach-files-dry-run
-  #       if: ${{ inputs.standalone_zip == false && inputs.dry_run == true }}
-  #       uses: softprops/action-gh-release@v2
-  #       with:
-  #         tag_name: v${{ needs.setup.outputs.version }}
-  #         fail_on_unmatched_files: true
-  #         body: Liquibase ${{ needs.setup.outputs.version }} (Dry-Run)
-  #         generate_release_notes: true
-  #         draft: true
-  #         files: re-version/final/*
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Attach Files to Dry-Run Draft Release
+      #   id: attach-files-dry-run
+      #   if: ${{ inputs.standalone_zip == false && inputs.dry_run == true }}
+      #   uses: softprops/action-gh-release@v2
+      #   with:
+      #     tag_name: v${{ needs.setup.outputs.version }}
+      #     fail_on_unmatched_files: true
+      #     body: Liquibase ${{ needs.setup.outputs.version }} (Dry-Run)
+      #     generate_release_notes: true
+      #     draft: true
+      #     files: re-version/final/*
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  #     - name: Extract dry-run release URL
-  #       if: ${{ inputs.standalone_zip == false && inputs.dry_run == true }}
-  #       id: extract-dry-run-url
-  #       shell: bash
-  #       run: |
-  #         assets_json=$(echo '${{ toJson(steps.attach-files-dry-run.outputs) }}' | jq -r '.assets | fromjson')
-  #         tar_gz_url=$(echo "$assets_json" | jq -r '.[] | select(.name | test("^liquibase-dry-run-.*\\.tar\\.gz$")) | .url')
-  #         zip_url=$(echo "$assets_json" | jq -r '.[] | select(.name | test("^liquibase-dry-run-.*\\.zip$")) | .url')
-  #         echo $tar_gz_url
-  #         echo $zip_url
-  #         echo "dry_run_tar_gz_url=$tar_gz_url" >> $GITHUB_OUTPUT
-  #         echo "dry_run_zip_url=$zip_url" >> $GITHUB_OUTPUT
+      # - name: Extract dry-run release URL
+      #   if: ${{ inputs.standalone_zip == false && inputs.dry_run == true }}
+      #   id: extract-dry-run-url
+      #   shell: bash
+      #   run: |
+      #     assets_json=$(echo '${{ toJson(steps.attach-files-dry-run.outputs) }}' | jq -r '.assets | fromjson')
+      #     tar_gz_url=$(echo "$assets_json" | jq -r '.[] | select(.name | test("^liquibase-dry-run-.*\\.tar\\.gz$")) | .url')
+      #     zip_url=$(echo "$assets_json" | jq -r '.[] | select(.name | test("^liquibase-dry-run-.*\\.zip$")) | .url')
+      #     echo $tar_gz_url
+      #     echo $zip_url
+      #     echo "dry_run_tar_gz_url=$tar_gz_url" >> $GITHUB_OUTPUT
+      #     echo "dry_run_zip_url=$zip_url" >> $GITHUB_OUTPUT
         
-  #     - name: Attach standalone zip to Build
-  #       if: ${{ inputs.standalone_zip == true && inputs.dry_run == false }}
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #           name: liquibase-installers-${{ needs.setup.outputs.version }}
-  #           path: re-version/final/*
+      - name: Attach standalone zip to Build
+        if: ${{ inputs.standalone_zip == true && inputs.dry_run == false }}
+        uses: actions/upload-artifact@v4
+        with:
+            name: liquibase-installers-${{ needs.setup.outputs.version }}
+            path: re-version/final/*
     

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -57,8 +57,8 @@ on:
 
 env:
   DEPENDENCIES: "liquibase-bigquery"
-  EXTENSIONS: |
-    [{"name":"liquibase-commercial-bigquery","combined_jars":"false"},{"name":"liquibase-checks","combined_jars":"true"}]
+  EXTENSIONS: >-
+    '[{"name":"liquibase-commercial-bigquery","combined_jars":"false"},{"name":"liquibase-checks","combined_jars":"true"}]'
 
 jobs:
   setup:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -58,7 +58,7 @@ on:
 env:
   DEPENDENCIES: "liquibase-bigquery"
   EXTENSIONS: >-
-    '[{"name":"liquibase-checks","combined_jars":"true"}]'
+    '[{"name":"liquibase-checks","combined_jars":"true","artifact_path":"liquibase-checks"}]'
   # EXTENSIONS: >-
   #   '[{"name":"liquibase-commercial-bigquery","combined_jars":"false"},{"name":"liquibase-checks","combined_jars":"true"}]'
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -58,7 +58,9 @@ on:
 env:
   DEPENDENCIES: "liquibase-bigquery"
   EXTENSIONS: >-
-    '[{"name":"liquibase-commercial-bigquery","combined_jars":"false"},{"name":"liquibase-checks","combined_jars":"true"}]'
+    '[{"name":"liquibase-checks","combined_jars":"true"}]'
+  # EXTENSIONS: >-
+  #   '[{"name":"liquibase-commercial-bigquery","combined_jars":"false"},{"name":"liquibase-checks","combined_jars":"true"}]'
 
 jobs:
   setup:


### PR DESCRIPTION
This pull request includes several changes to the GitHub Actions workflows for building and releasing Liquibase extensions. The most significant updates involve standardizing string quotes, adding new build steps for `liquibase-checks`, and commenting out the OWASP scanner and file attachment steps in the release workflow.

### Standardization and Formatting:
* [`.github/workflows/build-extension-jars.yml`](diffhunk://#diff-dc83207379251c4eeafe63714db8ce416c176c525edf14a8bd6ad57ca0e9027bL7-R42): Changed single quotes to double quotes for consistency in the description fields and other string values. [[1]](diffhunk://#diff-dc83207379251c4eeafe63714db8ce416c176c525edf14a8bd6ad57ca0e9027bL7-R42) [[2]](diffhunk://#diff-dc83207379251c4eeafe63714db8ce416c176c525edf14a8bd6ad57ca0e9027bL71-R73) [[3]](diffhunk://#diff-dc83207379251c4eeafe63714db8ce416c176c525edf14a8bd6ad57ca0e9027bL86-R97) [[4]](diffhunk://#diff-dc83207379251c4eeafe63714db8ce416c176c525edf14a8bd6ad57ca0e9027bL127-R136)

### New Build Steps:
* [`.github/workflows/build-extension-jars.yml`](diffhunk://#diff-dc83207379251c4eeafe63714db8ce416c176c525edf14a8bd6ad57ca0e9027bL86-R97): Added a new job `build-liquibase-checks` to handle the build process for `liquibase-checks` if it is included in the inputs.
* [`.github/workflows/build-extension-jars.yml`](diffhunk://#diff-dc83207379251c4eeafe63714db8ce416c176c525edf14a8bd6ad57ca0e9027bR245): Updated the extension build steps to skip `liquibase-checks` during the checkout and build process. [[1]](diffhunk://#diff-dc83207379251c4eeafe63714db8ce416c176c525edf14a8bd6ad57ca0e9027bR245) [[2]](diffhunk://#diff-dc83207379251c4eeafe63714db8ce416c176c525edf14a8bd6ad57ca0e9027bR278)

### Workflow Dispatch Changes:
* [`.github/workflows/create-release.yml`](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79L60-R60): Added `liquibase-checks` to the list of extensions to be released.

### Commented Out Steps:
* [`.github/workflows/create-release.yml`](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79L77-R94): Commented out the OWASP scanner job and the steps for attaching files to draft releases and extracting URLs for dry-run releases. [[1]](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79L77-R94) [[2]](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79L312-R350)

These changes aim to improve the build and release processes by ensuring consistency in string formatting, adding support for new extensions, and temporarily disabling certain steps to streamline the workflow.