### PR TITLE
fix: Allow skipping a missing custom change

### DIFF
--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
@@ -1364,6 +1364,18 @@ public abstract class AbstractIntegrationTest {
         }
     }
 
+    @Test
+    public void makeSureNoErrorIsReturnedWhenNonexistentCustomChangeIsRunWithFailOnErrorFalse() throws DatabaseException, CommandExecutionException {
+        clearDatabase();
+        runUpdate("changelogs/common/missingcustomchange/missing_custom_change_fail_on_error_false.changelog.xml");
+    }
+
+    @Test
+    public void makeSureNoErrorIsReturnedWhenNonexistentCustomChangeIsSkippedByPrecondition() throws DatabaseException, CommandExecutionException {
+        clearDatabase();
+        runUpdate("changelogs/common/missingcustomchange/missing_custom_change_precondition_failed.changelog.xml");
+    }
+
     private ProcessBuilder prepareExternalLiquibaseProcess() {
         String javaHome = System.getProperty("java.home");
         String javaBin = javaHome + File.separator + "bin" + File.separator + "java";

--- a/liquibase-integration-tests/src/test/resources/changelogs/common/missingcustomchange/missing_custom_change_fail_on_error_false.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/common/missingcustomchange/missing_custom_change_fail_on_error_false.changelog.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet id="missing_custom_change_fail_on_error_false" author="relliot" failOnError="false">
+        <customChange class="foo.ClassThatDoesNotExist">
+            <param name="tableName" value="person"/>
+            <param name="columnName" value="employer_id"/>
+            <param name="newValue" value="3"/>
+        </customChange>
+    </changeSet>
+</databaseChangeLog>

--- a/liquibase-integration-tests/src/test/resources/changelogs/common/missingcustomchange/missing_custom_change_precondition_failed.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/common/missingcustomchange/missing_custom_change_precondition_failed.changelog.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <property name="RUN_CUSTOM_CHANGE" value="false"/>
+    <changeSet id="missing_custom_change_precondition_failed" author="relliot">
+        <preConditions onFail="MARK_RAN">
+            <changeLogPropertyDefined property="RUN_CUSTOM_CHANGE" value="true"/>
+        </preConditions>
+
+        <customChange class="foo.ClassThatDoesNotExist">
+            <param name="tableName" value="person"/>
+            <param name="columnName" value="employer_id"/>
+            <param name="newValue" value="3"/>
+        </customChange>
+    </changeSet>
+</databaseChangeLog>

--- a/liquibase-standard/src/test/groovy/liquibase/util/NetUtilTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/util/NetUtilTest.groovy
@@ -1,9 +1,12 @@
 package liquibase.util
 
+import spock.lang.IgnoreIf
 import spock.lang.Specification
+import spock.util.environment.OperatingSystem
 
 class NetUtilTest extends Specification {
 
+    @IgnoreIf({ OperatingSystem.current.macOs })
     def getLocalHostAddress() {
         when:
         def address = NetUtil.getLocalHostAddress()


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

Prior to this a custom change with a class name that is not on the classpath would always fail the entire changelog.

Now `changeSet.failOnError: false` will be honoured if the cause of the failure is the failure to instantiate the change class.

In addition, a failing precondition for the changeset with onFail="MARK_RAN" will be honoured if the class is not on the classpath.

Fixes #6520

## Things to be aware of

N/A

## Things to worry about

N/A

## Additional Context

N/A
