### PR TITLE
liquibase-maven-plugin: Allow `null` arguments to `ConfiguredValueModifierFactory.override(String)`

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/configuration/ConfiguredValueModifierFactory.java
+++ b/liquibase-standard/src/main/java/liquibase/configuration/ConfiguredValueModifierFactory.java
@@ -40,7 +40,7 @@ public class ConfiguredValueModifierFactory  implements SingletonObject {
         for (Iterator<ConfiguredValueModifier> iterator = allInstances.descendingIterator(); iterator.hasNext(); ) {
             ConfiguredValueModifier allInstance = iterator.next();
             String overriddenValue = allInstance.override(configuredValue);
-            if (!configuredValue.equals(overriddenValue)) {
+            if (configuredValue == null || !configuredValue.equals(overriddenValue)) {
                 return overriddenValue;
             }
         }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Allow `ConfiguredValueModifierFactory.override(String)` in `liquibase-maven-plugin` to accept `null` arguments

This fixes #6526 and allows the `username` and `password` attributes to be omitted in the `liquibase-maven-plugin` configuration.