### PR TITLE
🔧 fix cleanup branch builds

### DIFF
--- a/.github/workflows/cleanup-branch-builds.yml
+++ b/.github/workflows/cleanup-branch-builds.yml
@@ -28,6 +28,7 @@ jobs:
 
   delete-dat-package:
     name: Delete DAT-SNAPSHOT Github Package for Branch
+    if: always()
     needs: extract-branch-info
     runs-on: ubuntu-22.04
 
@@ -54,6 +55,7 @@ jobs:
         
   delete-sha-package:
     name: Delete SHA-SNAPSHOT Github Package for Branch
+    if: always()
     needs: [ delete-dat-package, extract-branch-info ]
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/cleanup-branch-builds.yml
+++ b/.github/workflows/cleanup-branch-builds.yml
@@ -51,8 +51,6 @@ jobs:
         
         # on branch id's deletion we only want to delete that particular branch version
         package-version-ids: "${{ steps.version.outputs.ids }}"
-        delete-only-pre-release-versions: false
-        delete-only-untagged-versions: false
         
   delete-sha-package:
     name: Delete SHA-SNAPSHOT Github Package for Branch

--- a/.github/workflows/cleanup-branch-builds.yml
+++ b/.github/workflows/cleanup-branch-builds.yml
@@ -46,16 +46,14 @@ jobs:
     - uses: actions/delete-package-versions@v5
       if: ${{ steps.version.outputs.ids != '' }}
       with:
+        # Delete all deletable versions
         package-type: maven
-        # The number of latest versions to keep.
-        # This cannot be specified with `num-old-versions-to-delete`. By default, `num-old-versions-to-delete` takes precedence over `min-versions-to-keep`.
-        # When set to 0, all deletable versions will be deleted.
-        # When set greater than 0, all deletable package versions except the specified number will be deleted.
-        min-versions-to-keep: 0
         
         # on branch id's deletion we only want to delete that particular branch version
         package-version-ids: "${{ steps.version.outputs.ids }}"
-
+        delete-only-pre-release-versions: false
+        delete-only-untagged-versions: false
+        
   delete-sha-package:
     name: Delete SHA-SNAPSHOT Github Package for Branch
     needs: [ delete-dat-package, extract-branch-info ]

--- a/.github/workflows/cleanup-branch-builds.yml
+++ b/.github/workflows/cleanup-branch-builds.yml
@@ -28,7 +28,6 @@ jobs:
 
   delete-dat-package:
     name: Delete DAT-SNAPSHOT Github Package for Branch
-    if: always()
     needs: extract-branch-info
     runs-on: ubuntu-22.04
 
@@ -55,7 +54,6 @@ jobs:
         
   delete-sha-package:
     name: Delete SHA-SNAPSHOT Github Package for Branch
-    if: always()
     needs: [ delete-dat-package, extract-branch-info ]
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/cleanup-master-builds.yml
+++ b/.github/workflows/cleanup-master-builds.yml
@@ -22,12 +22,6 @@ jobs:
         package-name: ${{ matrix.packages_to_delete }}
         package-type: maven
 
-        # The number of latest versions to keep.
-        # This cannot be specified with `num-old-versions-to-delete`. By default, `num-old-versions-to-delete` takes precedence over `min-versions-to-keep`.
-        # When set to 0, all deletable versions will be deleted.
-        # When set greater than 0, all deletable package versions except the specified number will be deleted.
-        min-versions-to-keep: 0
-
         # The package versions to exclude from deletion.
         # Takes regex for the version name as input.
         # By default nothing is ignored.

--- a/.github/workflows/cleanup-master-builds.yml
+++ b/.github/workflows/cleanup-master-builds.yml
@@ -22,6 +22,12 @@ jobs:
         package-name: ${{ matrix.packages_to_delete }}
         package-type: maven
 
+        # The number of latest versions to keep.
+        # This cannot be specified with `num-old-versions-to-delete`. By default, `num-old-versions-to-delete` takes precedence over `min-versions-to-keep`.
+        # When set to 0, all deletable versions will be deleted.
+        # When set greater than 0, all deletable package versions except the specified number will be deleted.
+        min-versions-to-keep: 0
+
         # The package versions to exclude from deletion.
         # Takes regex for the version name as input.
         # By default nothing is ignored.


### PR DESCRIPTION
This pull request includes a change to the .github/workflows/cleanup-branch-builds.yml file to simplify the deletion of package versions in the jobs: section. It removes the usage of min-versions-to-keep that is not a [Valid Input Combination](https://github.com/marketplace/actions/delete-package-versions#valid-input-combinations) but we can use the combination of this PR based on [Delete a specific version of a package](https://github.com/marketplace/actions/delete-package-versions#delete-a-specific-version-of-a-package)