### PR TITLE
fix: prefix table name with schema name when adding column constraint

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/AddColumnGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/AddColumnGenerator.java
@@ -269,11 +269,12 @@ public class AddColumnGenerator extends AbstractSqlGenerator<AddColumnStatement>
                     refTableName = referencesMatcher.group(1);
                     refColName = referencesMatcher.group(2);
                 } else {
+                    refSchemaName = ((ForeignKeyConstraint) constraint).getReferencedTableSchemaName();
                     refTableName = ((ForeignKeyConstraint) constraint).getReferencedTableName();
                     refColName = ((ForeignKeyConstraint) constraint).getReferencedColumnNames();
                 }
 
-                if (refTableName.indexOf(".") > 0) {
+                if (refSchemaName == null && refTableName.indexOf(".") > 0) {
                     refSchemaName = refTableName.split("\\.")[0];
                     refTableName = refTableName.split("\\.")[1];
                 }

--- a/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/AddColumnGeneratorTest.java
+++ b/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/AddColumnGeneratorTest.java
@@ -195,4 +195,16 @@ public class AddColumnGeneratorTest extends AbstractSqlGeneratorTest<AddColumnSt
         Sql[] sql = instance.generateSql(statement, new PostgresDatabase());
         assertEquals("ALTER TABLE table_name ADD column_name COLUMN_TYPE GENERATED ALWAYS AS (value->>'foo') STORED", sql[0].toSql());
     }
+
+    @Test
+    public void testAddColumnWithForeignKeyConstraintReferencedWithSchemaName(){
+        MSSQLDatabase database = new MSSQLDatabase();
+        AddColumnGenerator generator = new AddColumnGenerator();
+        ForeignKeyConstraint constraint = new ForeignKeyConstraint("fk_book_category", null, "categories", "id");
+        constraint.setReferencedTableSchemaName("app");
+        AddColumnStatement statement = new AddColumnStatement(null, "app", "books", "id_category", "bigint", null, constraint);
+        Sql[] sql = generator.generateSql(statement, database,  null);
+        String theSql = sql[1].toSql();
+        assertTrue("ensure references has schema name prefix", theSql.contains("ALTER TABLE app.books ADD CONSTRAINT fk_book_category FOREIGN KEY (id_category) REFERENCES app.categories (id)"));
+    }
 }


### PR DESCRIPTION
Fixes: #3313

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description
As described in #3313, using `referencedTableSchemaName` on `ForeignKeyConstraint` didn't have any effect on the generated sql statement.
Instead, it was possible to pass a schema name prefixing `referencedTableName` with `my_schema.`

The change made on this PR ensure `referencedTableSchemaName` is used as a priority, but fallback on prefix syntax on `referencedTableName` if `null`.

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

I kept the current behavior (prefix syntax) while fixing the issue : `referencedTableSchemaName` being simply ignored.

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->
It's my first contribution, Liquibase is a huge codebase so please ensure it's made correctly and do not hesistate to provide geedback.

## Additional Context

<!--
Add any other context about the problem here.
-->
