### PR TITLE
DAT-19398 DevOps :: Fix Liquibase Checks versioning in the tarball to match the Liquibase Checks repository

### DIFF
--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -111,7 +111,7 @@ jobs:
       uses: liquibase/build-logic/.github/workflows/publish-for-liquibase.yml@main
       with:
           repository: liquibase/liquibase-checks
-          version: ${{ inputs.liquibase-version }}
+          version: ${{ needs.get-liquibase-checks-version.outputs.version }}
       secrets: inherit
 
   build-and-deploy-extensions:

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -102,8 +102,8 @@ jobs:
             name: Extract version from pom.xml
             shell: bash
             run: |
-              VERSION=$(grep -A1 '<artifactId>liquibase-checks</artifactId>' pom.xml | grep '<version>' | sed 's/.*<version>\(.*\)-SNAPSHOT<\/version>.*/\1/')
-              echo "version=$VERSION" >> $GITHUB_OUTPUT
+                VERSION=$(grep '<version>' pom.xml | head -n 1 | sed 's/.*<version>\(.*\)-SNAPSHOT<\/version>.*/\1/')
+                echo "version=$VERSION" >> $GITHUB_OUTPUT
 
   build-liquibase-checks:
       if: ${{ contains(inputs.extensions, 'liquibase-checks') }}

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -106,12 +106,9 @@ jobs:
                 echo "version=$VERSION" >> $GITHUB_OUTPUT
 
   delete-checks-packages:
-    needs: [ setup_matrix, get-liquibase-checks-version ]
+    needs: [ get-liquibase-checks-version ]
     runs-on: ubuntu-22.04
     continue-on-error: true
-    strategy:
-      matrix:
-        extensions: ${{ fromJson(needs.setup_matrix.outputs.extensions_matrix) }}
     steps:
       - uses: actions/delete-package-versions@v5
         with:

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -87,14 +87,32 @@ jobs:
           token: ${{ secrets.BOT_TOKEN }}
           ignore-versions: "^((?!${{ inputs.liquibase-version }}$).)*$"
 
+  get-liquibase-checks-version:
+      if: ${{ contains(inputs.extensions, 'liquibase-checks') }}
+      runs-on: ubuntu-latest
+      outputs:
+          version: ${{ steps.extract-version.outputs.version }}
+      steps:
+          - uses: actions/checkout@v4
+            with:
+              repository: liquibase/liquibase-checks
+              token: ${{ secrets.BOT_TOKEN }}
+
+          - id: extract-version
+            name: Extract version from pom.xml
+            shell: bash
+            run: |
+              VERSION=$(grep -A1 '<artifactId>liquibase-checks</artifactId>' pom.xml | grep '<version>' | sed 's/.*<version>\(.*\)-SNAPSHOT<\/version>.*/\1/')
+              echo "version=$VERSION" >> $GITHUB_OUTPUT
+
   build-liquibase-checks:
-    if: ${{ contains(inputs.extensions, 'liquibase-checks') }}
-    needs: [ delete-extension-packages ]
-    uses: liquibase/build-logic/.github/workflows/publish-for-liquibase.yml@main
-    with:
-      repository: liquibase/liquibase-checks
-      version: ${{ inputs.liquibase-version }}
-    secrets: inherit
+      if: ${{ contains(inputs.extensions, 'liquibase-checks') }}
+      needs: [ delete-extension-packages, get-liquibase-checks-version ]
+      uses: liquibase/build-logic/.github/workflows/publish-for-liquibase.yml@main
+      with:
+          repository: liquibase/liquibase-checks
+          version: ${{ inputs.liquibase-version }}
+      secrets: inherit
 
   build-and-deploy-extensions:
     needs: [delete-dependency-packages, delete-extension-packages]

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -105,9 +105,24 @@ jobs:
                 VERSION=$(grep '<version>' pom.xml | head -n 1 | sed 's/.*<version>\(.*\)-SNAPSHOT<\/version>.*/\1/')
                 echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+  delete-checks-packages:
+    needs: [ setup_matrix, get-liquibase-checks-version ]
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    strategy:
+      matrix:
+        extensions: ${{ fromJson(needs.setup_matrix.outputs.extensions_matrix) }}
+    steps:
+      - uses: actions/delete-package-versions@v5
+        with:
+          package-name: org.liquibase.ext.liquibase-checks
+          package-type: "maven"
+          token: ${{ secrets.BOT_TOKEN }}
+          ignore-versions: "^((?!${{ needs.get-liquibase-checks-version.outputs.version }}$).)*$"
+
   build-liquibase-checks:
       if: ${{ contains(inputs.extensions, 'liquibase-checks') }}
-      needs: [ delete-extension-packages, get-liquibase-checks-version ]
+      needs: [ delete-extension-packages, get-liquibase-checks-version, delete-checks-packages ]
       uses: liquibase/build-logic/.github/workflows/publish-for-liquibase.yml@main
       with:
           repository: liquibase/liquibase-checks
@@ -115,7 +130,7 @@ jobs:
       secrets: inherit
 
   build-and-deploy-extensions:
-    needs: [delete-dependency-packages, delete-extension-packages]
+    needs: [delete-dependency-packages, delete-extension-packages, delete-checks-packages]
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -74,15 +74,15 @@ jobs:
       - run: |
           echo "Creating version ${{ inputs.version }} from ${{ inputs.branch }} with artifacts from build ${{ inputs.runId }} "
 
-  # owasp-scanner:
-  #   needs: [ setup ]
-  #   uses: liquibase/build-logic/.github/workflows/owasp-scanner.yml@main
-  #   with:
-  #     branch: ${{ needs.setup.outputs.branch }}
-  #   secrets: inherit
+  owasp-scanner:
+    needs: [ setup ]
+    uses: liquibase/build-logic/.github/workflows/owasp-scanner.yml@main
+    with:
+      branch: ${{ needs.setup.outputs.branch }}
+    secrets: inherit
 
   build-azure-uber-jar:
-   needs: [ setup ]
+   needs: [ setup, owasp-scanner ]
    uses: liquibase/liquibase/.github/workflows/build-azure-uber-jar.yml@master
    with:
      branch: ${{ needs.setup.outputs.branch }}
@@ -90,8 +90,8 @@ jobs:
    secrets: inherit
 
   build-extension-jars:
-   needs: [ setup ]
-   uses: liquibase/liquibase/.github/workflows/build-extension-jars.yml@DAT-19398
+   needs: [ setup, owasp-scanner ]
+   uses: liquibase/liquibase/.github/workflows/build-extension-jars.yml@master
    with:
      liquibase-version: ${{ needs.setup.outputs.version }}
      dependencies: ${{ needs.setup.outputs.dependencies }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -236,7 +236,11 @@ jobs:
           rm -rf re-version/out/liquibase-${{ needs.setup.outputs.version }}.tar.gz
           mkdir -p re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions
           for I in "${EXT[@]}"; do
-            cp ~/.m2/repository/org/liquibase/ext/$I/${{ needs.setup.outputs.version }}/$I-${{ needs.setup.outputs.version }}.jar re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions/$I.jar || echo "Failed to move $I artifact"
+            if [ "I" != "liquibase-checks" ]; then
+              cp ~/.m2/repository/org/liquibase/ext/$I/${{ needs.setup.outputs.version }}/$I-${{ needs.setup.outputs.version }}.jar re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions/$I.jar || echo "Failed to move $I artifact"
+            else
+              cp ~/.m2/repository/org/liquibase/ext/$I/${{ needs.get-liquibase-checks-version.outputs.version }}/$I-${{ needs.get-liquibase-checks-version.outputs.version }}.jar re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions/$I.jar || echo "Failed to move $I artifact"
+            fi
           done
           (cd re-version/out/liquibase-${{ needs.setup.outputs.version }} && tar -czvf ../liquibase-${{ needs.setup.outputs.version }}.tar.gz * && cd .. && rm -rf liquibase-${{ needs.setup.outputs.version }})
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -181,7 +181,6 @@ jobs:
           for extension in "${ADDR[@]}"; do
             if [ "$extension" != "liquibase-checks" ]; then
               mvn dependency:get -DgroupId=org.liquibase.ext -DartifactId=$extension -Dversion=${{ needs.setup.outputs.version }} -Dtransitive=false || echo "Failed to download $extension artifact"
-            fi
             else
               mvn dependency:get -DgroupId=org.liquibase.ext -DartifactId=$extension -Dversion=${{ needs.get-liquibase-checks-version.outputs.version }} -Dtransitive=false || echo "Failed to download $extension artifact"
             fi

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -195,6 +195,17 @@ jobs:
               }
             ]
 
+      - name: Get extensions artifacts
+        run: |
+          IFS=',' read -ra ADDR <<< "${{ needs.setup.outputs.extensions }}"
+          for extension in "${ADDR[@]}"; do
+            if [ "$extension" != "liquibase-checks" ]; then
+              mvn dependency:get -DgroupId=org.liquibase.ext -DartifactId=$extension -Dversion=${{ needs.setup.outputs.version }} -Dtransitive=false || echo "Failed to download $extension artifact"
+            else
+              mvn dependency:get -DgroupId=org.liquibase.ext -DartifactId=$extension -Dversion=${{ needs.get-liquibase-checks-version.outputs.version }} -Dtransitive=false || echo "Failed to download $extension artifact"
+            fi
+          done
+
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -153,41 +153,47 @@ jobs:
           name: liquibase-pro-azure-artifacts
           path: liquibase-pro/liquibase-azure-deps
 
-      - name: Generate repositories and servers JSON
-        id: generate-json
-        run: |
-          IFS=',' read -ra EXT <<< "${{ needs.setup.outputs.extensions }}"
-          repositories=""
-          servers=""
-          for i in "${EXT[@]}"; do
-            repositories+="{\"id\": \"$i\",\"url\": \"https://maven.pkg.github.com/liquibase/$i\",\"releases\": {\"enabled\": \"true\"},\"snapshots\": {\"enabled\": \"true\",\"updatePolicy\": \"always\"}},"
-            servers+="{\"id\": \"$i\",\"username\": \"liquibot\",\"password\": \"${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}\"},"
-          done
-          # Remove trailing comma and wrap with brackets
-          repositories="["${repositories::-1}"]"
-          servers="["${servers::-1}"]"
-          echo "REPOSITORIES_JSON=$repositories" >> $GITHUB_ENV
-          echo "SERVERS_JSON=$servers" >> $GITHUB_ENV
-
       - name: maven-settings-xml-action
         uses: whelk-io/maven-settings-xml-action@v22
         with:
-          repositories: ${{ env.REPOSITORIES_JSON }}
-          servers: ${{ env.SERVERS_JSON }}
-
-      - name: Get extensions artifacts
-        run: |
-          IFS=',' read -ra ADDR <<< "${{ needs.setup.outputs.extensions }}"
-          for extension in "${ADDR[@]}"; do
-            if [ "$extension" != "liquibase-checks" ]; then
-              mvn dependency:get -DgroupId=org.liquibase.ext -DartifactId=$extension -Dversion=${{ needs.setup.outputs.version }} -Dtransitive=false || echo "Failed to download $extension artifact"
-              ls -ltr ~/.m2/repository/org/liquibase/ext/$extension/
-              ls -ltr ~/.m2/repository/org/liquibase/ext/$extension/${{ needs.setup.outputs.version }}
-              rm -rf ~/.m2/repository/org/liquibase/ext/$extension/${{ needs.setup.outputs.version }}/$extension-${{ needs.setup.outputs.version }}.jar
-            else
-              mvn dependency:get -DgroupId=org.liquibase.ext -DartifactId=$extension -Dversion=${{ needs.get-liquibase-checks-version.outputs.version }} -Dtransitive=false || echo "Failed to download $extension artifact"
-            fi
-          done
+          repositories: |
+            [
+              {
+                "id": "liquibase",
+                "url": "https://maven.pkg.github.com/liquibase/liquibase",
+                "releases": {
+                  "enabled": "true"
+                },
+                "snapshots": {
+                  "enabled": "true",
+                  "updatePolicy": "always"
+                }
+              },
+              {
+                "id": "liquibase-pro",
+                "url": "https://maven.pkg.github.com/liquibase/liquibase-pro",
+                "releases": {
+                  "enabled": "true"
+                },
+                "snapshots": {
+                  "enabled": "true",
+                  "updatePolicy": "always"
+                }
+              }
+            ]
+          servers: |
+            [
+              {
+                "id": "liquibase",
+                "username": "liquibot",
+                "password": "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
+              },
+              {
+                "id": "liquibase-pro",
+                "username": "liquibot",
+                "password": "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
+              }
+            ]
 
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -74,15 +74,15 @@ jobs:
       - run: |
           echo "Creating version ${{ inputs.version }} from ${{ inputs.branch }} with artifacts from build ${{ inputs.runId }} "
 
-  owasp-scanner:
-    needs: [ setup ]
-    uses: liquibase/build-logic/.github/workflows/owasp-scanner.yml@main
-    with:
-      branch: ${{ needs.setup.outputs.branch }}
-    secrets: inherit
+  # owasp-scanner:
+  #   needs: [ setup ]
+  #   uses: liquibase/build-logic/.github/workflows/owasp-scanner.yml@main
+  #   with:
+  #     branch: ${{ needs.setup.outputs.branch }}
+  #   secrets: inherit
 
   build-azure-uber-jar:
-   needs: [ setup, owasp-scanner ]
+   needs: [ setup ]
    uses: liquibase/liquibase/.github/workflows/build-azure-uber-jar.yml@master
    with:
      branch: ${{ needs.setup.outputs.branch }}
@@ -90,8 +90,8 @@ jobs:
    secrets: inherit
 
   build-extension-jars:
-   needs: [ setup, owasp-scanner ]
-   uses: liquibase/liquibase/.github/workflows/build-extension-jars.yml@master
+   needs: [ setup ]
+   uses: liquibase/liquibase/.github/workflows/build-extension-jars.yml@DAT-19398
    with:
      liquibase-version: ${{ needs.setup.outputs.version }}
      dependencies: ${{ needs.setup.outputs.dependencies }}
@@ -99,8 +99,27 @@ jobs:
      branch: ${{ needs.setup.outputs.branch }}
    secrets: inherit
 
+  get-liquibase-checks-version:
+    needs: [ setup ]
+    if: ${{ contains(needs.setup.outputs.extensions, 'liquibase-checks') }}
+    runs-on: ubuntu-latest
+    outputs:
+        version: ${{ steps.extract-version.outputs.version }}
+    steps:
+        - uses: actions/checkout@v4
+          with:
+            repository: liquibase/liquibase-checks
+            token: ${{ secrets.BOT_TOKEN }}
+
+        - id: extract-version
+          name: Extract version from pom.xml
+          shell: bash
+          run: |
+              VERSION=$(grep '<version>' pom.xml | head -n 1 | sed 's/.*<version>\(.*\)-SNAPSHOT<\/version>.*/\1/')
+              echo "version=$VERSION" >> $GITHUB_OUTPUT
+
   reversion:
-    needs: [ setup, build-azure-uber-jar, build-extension-jars ]
+    needs: [ setup, build-azure-uber-jar, build-extension-jars, get-liquibase-checks-version ]
     name: Re-version artifacts ${{ needs.setup.outputs.version }}
     runs-on: ubuntu-22.04
     steps:
@@ -160,7 +179,12 @@ jobs:
         run: |
           IFS=',' read -ra ADDR <<< "${{ needs.setup.outputs.extensions }}"
           for extension in "${ADDR[@]}"; do
-            mvn dependency:get -DgroupId=org.liquibase.ext -DartifactId=$extension -Dversion=${{ needs.setup.outputs.version }} -Dtransitive=false || echo "Failed to download $extension artifact"
+            if [ "$extension" != "liquibase-checks" ]; then
+              mvn dependency:get -DgroupId=org.liquibase.ext -DartifactId=$extension -Dversion=${{ needs.setup.outputs.version }} -Dtransitive=false || echo "Failed to download $extension artifact"
+            fi
+            else
+              mvn dependency:get -DgroupId=org.liquibase.ext -DartifactId=$extension -Dversion=${{ needs.get-liquibase-checks-version.outputs.version }} -Dtransitive=false || echo "Failed to download $extension artifact"
+            fi
           done
 
       - name: Set up JDK

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -246,7 +246,11 @@ jobs:
           rm -rf re-version/out/liquibase-${{ needs.setup.outputs.version }}.zip
           IFS=',' read -ra EXT <<< "${{ needs.setup.outputs.extensions }}"
           for i in "${EXT[@]}"; do
-            cp ~/.m2/repository/org/liquibase/ext/$i/${{ needs.setup.outputs.version }}/$i-${{ needs.setup.outputs.version }}.jar re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions/$i.jar || echo "Failed to move $i artifact"
+            if [ "$i" != "liquibase-checks" ]; then
+              cp ~/.m2/repository/org/liquibase/ext/$i/${{ needs.setup.outputs.version }}/$i-${{ needs.setup.outputs.version }}.jar re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions/$i.jar || echo "Failed to move $i artifact"
+            else
+              cp ~/.m2/repository/org/liquibase/ext/$i/${{ needs.get-liquibase-checks-version.outputs.version }}/$i-${{ needs.get-liquibase-checks-version.outputs.version }}.jar re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions/$i.jar || echo "Failed to move $i artifact"
+            fi
           done
           (cd re-version/out/liquibase-${{ needs.setup.outputs.version }} && zip -r ../liquibase-${{ needs.setup.outputs.version }}.zip . && cd .. && rm -rf liquibase-${{ needs.setup.outputs.version }})
 
@@ -256,7 +260,7 @@ jobs:
           rm -rf re-version/out/liquibase-${{ needs.setup.outputs.version }}.tar.gz
           mkdir -p re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions
           for I in "${EXT[@]}"; do
-            if [ "I" != "liquibase-checks" ]; then
+            if [ "$I" != "liquibase-checks" ]; then
               cp ~/.m2/repository/org/liquibase/ext/$I/${{ needs.setup.outputs.version }}/$I-${{ needs.setup.outputs.version }}.jar re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions/$I.jar || echo "Failed to move $I artifact"
             else
               cp ~/.m2/repository/org/liquibase/ext/$I/${{ needs.get-liquibase-checks-version.outputs.version }}/$I-${{ needs.get-liquibase-checks-version.outputs.version }}.jar re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions/$I.jar || echo "Failed to move $I artifact"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -17,7 +17,7 @@ on:
         required: false
         type: boolean
         default: false
-      dry_run: 
+      dry_run:
         description: 'Flag to indicate if the workflow is triggered to create a dry-run release'
         required: false
         type: boolean
@@ -42,7 +42,7 @@ on:
         required: true
         type: boolean
         default: false
-      dry_run: 
+      dry_run:
         description: 'Flag to indicate if the workflow is triggered to create a dry-run release'
         required: true
         type: boolean
@@ -73,7 +73,7 @@ jobs:
     steps:
       - run: |
           echo "Creating version ${{ inputs.version }} from ${{ inputs.branch }} with artifacts from build ${{ inputs.runId }} "
-          
+
   owasp-scanner:
     needs: [ setup ]
     uses: liquibase/build-logic/.github/workflows/owasp-scanner.yml@main
@@ -88,10 +88,10 @@ jobs:
      branch: ${{ needs.setup.outputs.branch }}
      liquibase-version: ${{ needs.setup.outputs.version }}
    secrets: inherit
-  
+
   build-extension-jars:
    needs: [ setup, owasp-scanner ]
-   uses: liquibase/liquibase/.github/workflows/build-extension-jars.yml@master
+   uses: liquibase/liquibase/.github/workflows/build-extension-jars.yml@DAT-19398
    with:
      liquibase-version: ${{ needs.setup.outputs.version }}
      dependencies: ${{ needs.setup.outputs.dependencies }}
@@ -130,7 +130,7 @@ jobs:
 
       - name: Download liquibase-pro-azure-artifacts
         uses: actions/download-artifact@v4
-        with: 
+        with:
           name: liquibase-pro-azure-artifacts
           path: liquibase-pro/liquibase-azure-deps
 
@@ -155,7 +155,7 @@ jobs:
         with:
           repositories: ${{ env.REPOSITORIES_JSON }}
           servers: ${{ env.SERVERS_JSON }}
-              
+
       - name: Get extensions artifacts
         run: |
           IFS=',' read -ra ADDR <<< "${{ needs.setup.outputs.extensions }}"
@@ -181,7 +181,7 @@ jobs:
           mkdir -p $PWD/.github/util/
           # Download a script (re-version.sh) from a URL and save it to the specified directory
           curl -o $PWD/.github/util/re-version.sh https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/re-version.sh
-          
+
           # Download another script (sign-artifacts.sh) from a URL and save it to the specified directory
           curl -o $PWD/.github/util/sign-artifacts.sh https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/sign-artifacts.sh
           curl -o $PWD/.github/util/ManifestReversion.java https://raw.githubusercontent.com/liquibase/liquibase/$scripts_branch/.github/util/ManifestReversion.java
@@ -192,11 +192,11 @@ jobs:
 
           # Execute the sign-artifacts.sh script with specific arguments
           $PWD/.github/util/sign-artifacts.sh download/liquibase-artifacts "${{ needs.setup.outputs.version }}" "${{ needs.setup.outputs.branch }}"
-          
+
           ## Sign Files
           ## liquibase-azure-deps and liquibase extensions are already on its correct version. Check reusable workflow: build-azure-uber-jar.yml and build-extension-jars.yml
           mv liquibase-pro/liquibase-azure-deps/* re-version/out
-          
+
           # Modify the zip file
           unzip re-version/out/liquibase-${{ needs.setup.outputs.version }}.zip -d re-version/out/liquibase-${{ needs.setup.outputs.version }}
           mkdir -p re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions
@@ -206,7 +206,7 @@ jobs:
             cp ~/.m2/repository/org/liquibase/ext/$i/${{ needs.setup.outputs.version }}/$i-${{ needs.setup.outputs.version }}.jar re-version/out/liquibase-${{ needs.setup.outputs.version }}/internal/extensions/$i.jar || echo "Failed to move $i artifact"
           done
           (cd re-version/out/liquibase-${{ needs.setup.outputs.version }} && zip -r ../liquibase-${{ needs.setup.outputs.version }}.zip . && cd .. && rm -rf liquibase-${{ needs.setup.outputs.version }})
-          
+
           # Modify the tar.gz file
           mkdir -p re-version/out/liquibase-${{ needs.setup.outputs.version }}
           tar -xzvf re-version/out/liquibase-${{ needs.setup.outputs.version }}.tar.gz -C re-version/out/liquibase-${{ needs.setup.outputs.version }}
@@ -218,7 +218,7 @@ jobs:
           (cd re-version/out/liquibase-${{ needs.setup.outputs.version }} && tar -czvf ../liquibase-${{ needs.setup.outputs.version }}.tar.gz * && cd .. && rm -rf liquibase-${{ needs.setup.outputs.version }})
 
           $PWD/.github/util/sign-artifacts.sh re-version/out
-   
+
           # Move files to a specific directory
           mkdir re-version/final
           mv re-version/out/liquibase-core-${{ needs.setup.outputs.version }}.jar re-version/final
@@ -253,7 +253,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     outputs:
       dry_run_zip_url: ${{ steps.extract-dry-run-url.outputs.dry_run_zip_url }}
-      dry_run_tar_gz_url: ${{ steps.extract-dry-run-url.outputs.dry_run_tar_gz_url }} 
+      dry_run_tar_gz_url: ${{ steps.extract-dry-run-url.outputs.dry_run_tar_gz_url }}
     steps:
       - uses: actions/checkout@v4
 
@@ -291,19 +291,19 @@ jobs:
           echo "Saving windows key"
           echo "$INSTALL4J_WINDOWS_KEY" | base64 -d > liquibase-dist/target/keys/datical_windows.pfx
           version="${{ needs.setup.outputs.version }}"
-          
+
           ##### Rebuild installers
           tarFile=$(pwd)/re-version/final/liquibase-$version.tar.gz
           scriptDir=$(pwd)/.github/util/
-          
+
           mkdir -p liquibase-dist/target/liquibase-$version
           (cd liquibase-dist/target/liquibase-$version && tar xfz $tarFile)
           (cd liquibase-dist && $scriptDir/package-install4j.sh $version)
           mv liquibase-dist/target/liquibase-*-installer-* re-version/final
-          
+
           ##Sign Files
           $PWD/.github/util/sign-artifacts.sh re-version/final
-          
+
           (cd re-version/final && zip liquibase-additional-$version.zip *.asc *.md5 *.sha1)
           rm re-version/final/*.asc
           rm re-version/final/*.md5
@@ -348,11 +348,10 @@ jobs:
           echo $zip_url
           echo "dry_run_tar_gz_url=$tar_gz_url" >> $GITHUB_OUTPUT
           echo "dry_run_zip_url=$zip_url" >> $GITHUB_OUTPUT
-        
+
       - name: Attach standalone zip to Build
         if: ${{ inputs.standalone_zip == true && inputs.dry_run == false }}
         uses: actions/upload-artifact@v4
         with:
             name: liquibase-installers-${{ needs.setup.outputs.version }}
             path: re-version/final/*
-    

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -74,15 +74,15 @@ jobs:
       - run: |
           echo "Creating version ${{ inputs.version }} from ${{ inputs.branch }} with artifacts from build ${{ inputs.runId }} "
 
-  owasp-scanner:
-    needs: [ setup ]
-    uses: liquibase/build-logic/.github/workflows/owasp-scanner.yml@main
-    with:
-      branch: ${{ needs.setup.outputs.branch }}
-    secrets: inherit
+  # owasp-scanner:
+  #   needs: [ setup ]
+  #   uses: liquibase/build-logic/.github/workflows/owasp-scanner.yml@main
+  #   with:
+  #     branch: ${{ needs.setup.outputs.branch }}
+  #   secrets: inherit
 
   build-azure-uber-jar:
-   needs: [ setup, owasp-scanner ]
+   needs: [ setup ]
    uses: liquibase/liquibase/.github/workflows/build-azure-uber-jar.yml@master
    with:
      branch: ${{ needs.setup.outputs.branch }}
@@ -90,7 +90,7 @@ jobs:
    secrets: inherit
 
   build-extension-jars:
-   needs: [ setup, owasp-scanner ]
+   needs: [ setup ]
    uses: liquibase/liquibase/.github/workflows/build-extension-jars.yml@DAT-19398
    with:
      liquibase-version: ${{ needs.setup.outputs.version }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -181,6 +181,9 @@ jobs:
           for extension in "${ADDR[@]}"; do
             if [ "$extension" != "liquibase-checks" ]; then
               mvn dependency:get -DgroupId=org.liquibase.ext -DartifactId=$extension -Dversion=${{ needs.setup.outputs.version }} -Dtransitive=false || echo "Failed to download $extension artifact"
+              ls -ltr ~/.m2/repository/org/liquibase/ext/$extension/
+              ls -ltr ~/.m2/repository/org/liquibase/ext/$extension/${{ needs.setup.outputs.version }}
+              rm -rf ~/.m2/repository/org/liquibase/ext/$extension/${{ needs.setup.outputs.version }}/$extension-${{ needs.setup.outputs.version }}.jar
             else
               mvn dependency:get -DgroupId=org.liquibase.ext -DartifactId=$extension -Dversion=${{ needs.get-liquibase-checks-version.outputs.version }} -Dtransitive=false || echo "Failed to download $extension artifact"
             fi


### PR DESCRIPTION
This pull request includes a new job to extract the version of `liquibase-checks` from its `pom.xml` and updates the existing build job to depend on this new job.

Changes to the `.github/workflows/build-extension-jars.yml` file:

* Added a new job `get-liquibase-checks-version` to extract the version of `liquibase-checks` from its `pom.xml` file. This job runs only if `liquibase-checks` is included in the inputs and sets an output variable `version` with the extracted version.
* Updated the `build-liquibase-checks` job to depend on the new `get-liquibase-checks-version` job. This ensures that the version is extracted before the build process begins.