### PR TITLE
fix: introduce new class ParserSupportedFileExtension to remove hard dependency on snakeyaml for core

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/parser/core/ParserSupportedFileExtension.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/core/ParserSupportedFileExtension.java
@@ -1,0 +1,22 @@
+package liquibase.parser.core;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Liquibase supported file extensions for parsing
+ */
+public class ParserSupportedFileExtension {
+
+    private ParserSupportedFileExtension() {
+        // Prevent instantiation
+    }
+
+    public static final Set<String> XML_SUPPORTED_EXTENSIONS = Collections.singleton("xml");
+    public static final Set<String> JSON_SUPPORTED_EXTENSIONS = Collections.singleton("json");
+    public static final Set<String> YAML_SUPPORTED_EXTENSIONS = new HashSet<>(Arrays.asList("yaml", "yml"));
+
+
+}

--- a/liquibase-standard/src/main/java/liquibase/parser/core/json/JsonChangeLogParser.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/core/json/JsonChangeLogParser.java
@@ -1,16 +1,12 @@
 package liquibase.parser.core.json;
 
+import liquibase.parser.core.ParserSupportedFileExtension;
 import liquibase.parser.core.yaml.YamlChangeLogParser;
-
-import java.util.Collections;
-import java.util.Set;
 
 public class JsonChangeLogParser extends YamlChangeLogParser {
 
-    public static final Set<String> SUPPORTED_EXTENSIONS = Collections.singleton("json");
-
     @Override
     protected String[] getSupportedFileExtensions() {
-        return SUPPORTED_EXTENSIONS.toArray(new String[0]);
+        return ParserSupportedFileExtension.JSON_SUPPORTED_EXTENSIONS.toArray(new String[0]);
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/parser/core/xml/XMLChangeLogSAXParser.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/core/xml/XMLChangeLogSAXParser.java
@@ -5,6 +5,7 @@ import liquibase.Scope;
 import liquibase.changelog.ChangeLogParameters;
 import liquibase.exception.ChangeLogParseException;
 import liquibase.parser.core.ParsedNode;
+import liquibase.parser.core.ParserSupportedFileExtension;
 import liquibase.resource.Resource;
 import liquibase.resource.ResourceAccessor;
 import liquibase.util.BomAwareInputStream;
@@ -17,14 +18,11 @@ import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collections;
-import java.util.Set;
 
 public class XMLChangeLogSAXParser extends AbstractChangeLogParser {
 
     public static final String LIQUIBASE_SCHEMA_VERSION;
     private final SAXParserFactory saxParserFactory;
-    public static final Set<String> SUPPORTED_EXTENSIONS = Collections.singleton("xml");
 
     static {
         LIQUIBASE_SCHEMA_VERSION = computeSchemaVersion(LiquibaseUtil.getBuildVersion());
@@ -56,7 +54,7 @@ public class XMLChangeLogSAXParser extends AbstractChangeLogParser {
 
     @Override
     public boolean supports(String changeLogFile, ResourceAccessor resourceAccessor) {
-        return SUPPORTED_EXTENSIONS.stream().anyMatch(ext -> changeLogFile.toLowerCase().endsWith(ext));
+        return ParserSupportedFileExtension.XML_SUPPORTED_EXTENSIONS.stream().anyMatch(ext -> changeLogFile.toLowerCase().endsWith(ext));
     }
 
     protected SAXParserFactory getSaxParserFactory() {

--- a/liquibase-standard/src/main/java/liquibase/parser/core/yaml/YamlParser.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/core/yaml/YamlParser.java
@@ -3,18 +3,14 @@ package liquibase.parser.core.yaml;
 import liquibase.Scope;
 import liquibase.logging.Logger;
 import liquibase.parser.LiquibaseParser;
+import liquibase.parser.core.ParserSupportedFileExtension;
 import liquibase.resource.ResourceAccessor;
 import liquibase.util.SnakeYamlUtil;
 import org.yaml.snakeyaml.LoaderOptions;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-
 public abstract class YamlParser implements LiquibaseParser {
 
     protected Logger log = Scope.getCurrentScope().getLog(getClass());
-    public static final Set<String> SUPPORTED_EXTENSIONS = new HashSet<>(Arrays.asList("yaml", "yml"));
 
     public static LoaderOptions createLoaderOptions() {
         LoaderOptions options = new LoaderOptions();
@@ -36,7 +32,7 @@ public abstract class YamlParser implements LiquibaseParser {
     }
 
     protected String[] getSupportedFileExtensions() {
-        return SUPPORTED_EXTENSIONS.toArray(new String[0]);
+        return ParserSupportedFileExtension.YAML_SUPPORTED_EXTENSIONS.toArray(new String[0]);
     }
 
     @Override


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 

## Description

Fixes #6491

This PR removes a indirect dependency on snakeyaml, so people not using yaml/json files can safely exclude snakeyaml from their dependencies.


## Things to be aware of

Analytics also needs to be disabled in order for this fix to work (property `liquibase.analytics.enabled` set to false).

## Things to worry about

We don't have automated tests for it, and creating them would be complicated. 
