### PR TITLE
fix mysql uuid load data issue

### DIFF
--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/mysql/MySQLIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/mysql/MySQLIntegrationTest.java
@@ -1,11 +1,14 @@
 package liquibase.dbtest.mysql;
 
 import liquibase.CatalogAndSchema;
+import liquibase.Liquibase;
 import liquibase.Scope;
 import liquibase.database.DatabaseFactory;
+import liquibase.datatype.DataTypeFactory;
 import liquibase.dbtest.AbstractIntegrationTest;
 import liquibase.exception.DatabaseException;
 import liquibase.executor.ExecutorService;
+import liquibase.resource.Resource;
 import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.SnapshotControl;
 import liquibase.snapshot.SnapshotGeneratorFactory;
@@ -13,12 +16,20 @@ import liquibase.statement.core.RawParameterizedSqlStatement;
 import liquibase.structure.core.Column;
 import liquibase.structure.core.Schema;
 import liquibase.structure.core.Table;
+import liquibase.test.JUnitResourceAccessor;
 import org.junit.Test;
 
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.nio.ByteBuffer;
 import java.sql.SQLSyntaxErrorException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeNotNull;
 import static org.junit.Assume.assumeTrue;
 
 /**
@@ -43,8 +54,13 @@ import static org.junit.Assume.assumeTrue;
  */
 public class MySQLIntegrationTest extends AbstractIntegrationTest {
 
+    private final String uuidTableChangelog;
+    private final String uuidLoadDataCSV;
+
     public MySQLIntegrationTest() throws Exception {
         super("mysql", DatabaseFactory.getInstance().getDatabase("mysql"));
+        uuidTableChangelog = "changelogs/mysql/complete/uuid.changelog.xml";
+        uuidLoadDataCSV = "changelogs/mysql/complete/datafiles/uuid-data.csv";
     }
 
     @Test
@@ -85,6 +101,40 @@ public class MySQLIntegrationTest extends AbstractIntegrationTest {
         Object defaultValue = createdColumn.getDefaultValue();
         assertNotNull(defaultValue);
         assertEquals("0000-00-00 00:00:00", defaultValue);
+    }
+
+    @Test
+    public void testUUIDCreateLoadDataChangelog() throws Exception {
+        assumeNotNull(this.getDatabase());
+        clearDatabase();
+        // update database to create table
+        Liquibase liquibase = createLiquibase(uuidTableChangelog);
+        liquibase.update();
+        DatabaseSnapshot snapshot = SnapshotGeneratorFactory.getInstance().createSnapshot(CatalogAndSchema.DEFAULT, this.getDatabase(), new SnapshotControl(getDatabase()));
+
+        Table uuidTable = snapshot.get(Table.class).stream().filter(t -> t.getName().equals("uuidtest")).findFirst().orElse(null);
+
+        // assert created table and created 1 column
+        assertNotNull(uuidTable);
+        assertEquals(1, uuidTable.getColumns().size());
+
+        // assert created column is named uuid, and is of type BINARY(16) for MySQL UUID.
+        Column uuidColumn = uuidTable.getColumns().get(0);
+        assertEquals("uuid", uuidColumn.getName());
+        assertEquals(
+                DataTypeFactory.getInstance().fromDescription("char(36)", getDatabase()),
+                DataTypeFactory.getInstance().fromDescription(uuidColumn.getType().toString(), getDatabase()));
+
+        // assert that the UUID data was loaded correctly
+        List<Map<String, ?>> queryResult = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", getDatabase())
+                .queryForList(new RawParameterizedSqlStatement(String.format("select * from %s", uuidTable.getName())));
+
+        Resource fileOpener = new JUnitResourceAccessor().get(uuidLoadDataCSV);
+        BufferedReader br = new BufferedReader(new FileReader(fileOpener.getUri().getPath()));
+        br.readLine();
+        String expected = br.readLine();
+        String actual = (String) queryResult.get(0).get("uuid");
+        assertEquals(expected, actual);
     }
 
 }

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/mysql/MySQLIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/mysql/MySQLIntegrationTest.java
@@ -21,11 +21,9 @@ import org.junit.Test;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
-import java.nio.ByteBuffer;
 import java.sql.SQLSyntaxErrorException;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -118,7 +116,7 @@ public class MySQLIntegrationTest extends AbstractIntegrationTest {
         assertNotNull(uuidTable);
         assertEquals(1, uuidTable.getColumns().size());
 
-        // assert created column is named uuid, and is of type BINARY(16) for MySQL UUID.
+        // assert created column is named uuid, and is of type char(36) for MySQL UUID.
         Column uuidColumn = uuidTable.getColumns().get(0);
         assertEquals("uuid", uuidColumn.getName());
         assertEquals(

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/mysql/MySQLIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/mysql/MySQLIntegrationTest.java
@@ -129,12 +129,15 @@ public class MySQLIntegrationTest extends AbstractIntegrationTest {
         List<Map<String, ?>> queryResult = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", getDatabase())
                 .queryForList(new RawParameterizedSqlStatement(String.format("select * from %s", uuidTable.getName())));
 
-        Resource fileOpener = new JUnitResourceAccessor().get(uuidLoadDataCSV);
-        BufferedReader br = new BufferedReader(new FileReader(fileOpener.getUri().getPath()));
-        br.readLine();
-        String expected = br.readLine();
-        String actual = (String) queryResult.get(0).get("uuid");
-        assertEquals(expected, actual);
+        try (JUnitResourceAccessor jra = new JUnitResourceAccessor()) {
+            Resource fileOpener = jra.get(uuidLoadDataCSV);
+            try (BufferedReader br = new BufferedReader(new FileReader(fileOpener.getUri().getPath()))) {
+                br.readLine();
+                String expected = br.readLine();
+                String actual = (String) queryResult.get(0).get("uuid");
+                assertEquals(expected, actual);
+            }
+        }
     }
 
 }

--- a/liquibase-integration-tests/src/test/resources/changelogs/mysql/complete/datafiles/uuid-data.csv
+++ b/liquibase-integration-tests/src/test/resources/changelogs/mysql/complete/datafiles/uuid-data.csv
@@ -1,0 +1,2 @@
+uuid
+339a5f0c-d77f-45ba-b801-3325cf8f32ee

--- a/liquibase-integration-tests/src/test/resources/changelogs/mysql/complete/uuid.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/mysql/complete/uuid.changelog.xml
@@ -1,0 +1,17 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet id="uuid-1" author="qsevers">
+        <createTable tableName="uuidtest">
+            <column name="uuid" type="uuid">
+                <constraints primaryKey="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="uuid-2" author="qsevers">
+        <loadData tableName="uuidtest" file="changelogs/mysql/complete/datafiles/uuid-data.csv"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/liquibase-standard/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
+++ b/liquibase-standard/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
@@ -6,6 +6,8 @@ import liquibase.change.core.LoadDataChange;
 import liquibase.changelog.ChangeSet;
 import liquibase.database.Database;
 import liquibase.database.PreparedStatementFactory;
+import liquibase.database.core.MariaDBDatabase;
+import liquibase.database.core.MySQLDatabase;
 import liquibase.database.core.PostgresDatabase;
 import liquibase.database.core.SQLiteDatabase;
 import liquibase.datatype.DataTypeFactory;
@@ -32,6 +34,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.sql.*;
 import java.util.*;
 import java.util.logging.Level;
@@ -241,7 +244,11 @@ public abstract class ExecutablePreparedStatementBase implements ExecutablePrepa
         if (col.getValue() != null) {
             LOG.fine("value is string/UUID/blob = " + col.getValue());
             if (col.getType() != null && col.getType().equalsIgnoreCase(LoadDataChange.LOAD_DATA_TYPE.UUID.name())) {
-                stmt.setObject(i, UUID.fromString(col.getValue()));
+                if (database instanceof MySQLDatabase && !(database instanceof MariaDBDatabase))  {
+                    stmt.setString(i, col.getValue());
+                } else {
+                    stmt.setObject(i, UUID.fromString(col.getValue()));
+                }
             } else if (col.getType() != null && col.getType().equalsIgnoreCase(LoadDataChange.LOAD_DATA_TYPE.OTHER.name())) {
                 stmt.setObject(i, col.getValue(), Types.OTHER);
             } else if (LoadDataChange.LOAD_DATA_TYPE.BLOB.name().equalsIgnoreCase(col.getType())) {


### PR DESCRIPTION
## Impact


## Description

As UUID for Mysql is created as char(36), when loading UUID data we need to set it as String .

## Things to be aware of

Many sources in the internet suggest to create UUID columns as binary(16) in order to save space and provide better sorting , but Liquibase has been generating it as char(36) for a long time and it would be a breaking change for everyone already using it. So this PR just fixes data loading and add integration tests for Mysql UUID .

* https://dev.mysql.com/blog-archive/storing-uuid-values-in-mysql-tables/
* https://blogs.oracle.com/mysql/post/mysql-uuids
* https://dev.mysql.com/blog-archive/mysql-8-0-uuid-support/
* https://planetscale.com/blog/the-problem-with-using-a-uuid-primary-key-in-mysql
 
* https://dev.mysql.com/blog-archive/mysql-8-0-uuid-support/ - liquibase documentation stating that UUID is mapped to char


## Additional Context

Fixes #5145  .

This fix is based on the investigation and work from @qsevers23 in PR  https://github.com/liquibase/liquibase/pull/6212 .

