### PR TITLE
Code review for extensions after 4.31.0 release

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/exception/PreconditionFailedException.java
+++ b/liquibase-standard/src/main/java/liquibase/exception/PreconditionFailedException.java
@@ -24,10 +24,6 @@ public class PreconditionFailedException extends Exception {
         this(new FailedPrecondition(message, changeLog, precondition), cause);
     }
 
-    /**
-     * @deprecated Use {@link #PreconditionFailedException(FailedPrecondition, Throwable)} instead
-     */
-    @Deprecated
     public PreconditionFailedException(FailedPrecondition failedPrecondition) {
         super("Preconditions Failed");
         this.failedPreconditions = new ArrayList<>();

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/RawParameterizedSqlGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/RawParameterizedSqlGenerator.java
@@ -13,7 +13,6 @@ public class RawParameterizedSqlGenerator extends AbstractSqlGenerator<RawParame
     public ValidationErrors validate(RawParameterizedSqlStatement statement, Database database, SqlGeneratorChain<RawParameterizedSqlStatement> sqlGeneratorChain) {
         ValidationErrors validationErrors = new ValidationErrors();
         validationErrors.checkRequiredField("sql", statement.getSql());
-        validationErrors.checkRequiredField("parameters", statement.getParameters(), true);
         return validationErrors;
     }
 


### PR DESCRIPTION
* undeprecate liquibase.exception.PreconditionFailedException#PreconditionFailedException(liquibase.precondition.FailedPrecondition) -> a community contributor added a new method that receives a throwable and deprecated this one, but for neo4j (and maybe other extensions) it still makes sense to have the old method.
* remove parameter validations in RawParameterizedSqlGenerator.java : we removed the validations from the executor class but they still exists in this generator. It`s interesting that they way we use RawParametrized in core don't trigger them, but Neo4j does.