### PR TITLE
Don't ignore logicalFilePath when including changelogs

### DIFF
--- a/liquibase-integration-tests/src/test/groovy/liquibase/changeType/ChangeLogIncludeTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/changeType/ChangeLogIncludeTest.groovy
@@ -1,0 +1,56 @@
+package liquibase.changeType
+
+import liquibase.Scope
+import liquibase.UpdateSummaryEnum
+import liquibase.UpdateSummaryOutputEnum
+import liquibase.command.CommandScope
+import liquibase.command.core.UpdateCommandStep
+import liquibase.command.core.helpers.DbUrlConnectionArgumentsCommandStep
+import liquibase.command.core.helpers.ShowSummaryArgument
+import liquibase.extension.testing.testsystem.DatabaseTestSystem
+import liquibase.extension.testing.testsystem.TestSystemFactory
+import liquibase.extension.testing.testsystem.spock.LiquibaseIntegrationTest
+import liquibase.logging.core.BufferedLogService
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.util.logging.Level
+
+@LiquibaseIntegrationTest
+class ChangeLogIncludeTest extends Specification {
+
+    @Shared
+    private DatabaseTestSystem db = (DatabaseTestSystem) Scope.getCurrentScope().getSingleton(TestSystemFactory.class).getTestSystem("h2")
+
+    def "make sure correct path is set according to each logicalFilePath set on the different levels"() {
+
+        given:
+        def logService = new BufferedLogService()
+        Map<String, Object> scopeValues = new HashMap<>()
+        scopeValues.put(Scope.Attr.logService.name(), logService)
+
+        Scope.child(scopeValues, new Scope.ScopedRunner() {
+            @Override
+            void run() throws Exception {
+                CommandScope commandScope = new CommandScope(UpdateCommandStep.COMMAND_NAME)
+                commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.URL_ARG, db.getConnectionUrl())
+                commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.USERNAME_ARG, db.getUsername())
+                commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.PASSWORD_ARG, db.getPassword())
+                commandScope.addArgumentValue(UpdateCommandStep.CHANGELOG_FILE_ARG, "changelogs/changeType/include/changelog.xml")
+                commandScope.addArgumentValue(ShowSummaryArgument.SHOW_SUMMARY, UpdateSummaryEnum.VERBOSE)
+                commandScope.addArgumentValue(ShowSummaryArgument.SHOW_SUMMARY_OUTPUT, UpdateSummaryOutputEnum.LOG)
+                commandScope.execute()
+            }
+        })
+
+        when:
+        def logContent = logService.getLogAsString(Level.INFO)
+
+        then:
+        logContent.contains("ChangeSet page-service-changelog::initial_db_setup::dev")
+        logContent.contains("ChangeSet mid::initial_db_setup::dev")
+        logContent.contains("ChangeSet app-changelog::initial_db_setup::dev")
+        logContent.contains("ChangeSet myownlfp::myown::dev")
+        logContent.contains("ChangeSet app-changelog::myown::dev")
+    }
+}

--- a/liquibase-integration-tests/src/test/resources/changelogs/changeType/include/changelog-level3.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/changeType/include/changelog-level3.xml
@@ -1,0 +1,22 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet author="dev" id="myown" logicalFilePath="myownlfp">
+        <createTable tableName="level31">
+            <column name="id" type="int" />
+            <column name="firstname" type="VARCHAR(255)"/>
+            <column name="lastname" type="VARCHAR(255)"/>
+        </createTable>
+    </changeSet>
+
+    <changeSet author="dev" id="myown">
+        <createTable tableName="level32">
+            <column name="id" type="int" />
+            <column name="firstname" type="VARCHAR(255)"/>
+            <column name="lastname" type="VARCHAR(255)"/>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/liquibase-integration-tests/src/test/resources/changelogs/changeType/include/changelog-mid.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/changeType/include/changelog-mid.xml
@@ -1,0 +1,11 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd"
+                   logicalFilePath="mid">
+
+    <include file="changelog-pages.xml" relativeToChangelogFile="true"/>
+    <include file="changelog-users.xml" relativeToChangelogFile="true"/>
+
+</databaseChangeLog>

--- a/liquibase-integration-tests/src/test/resources/changelogs/changeType/include/changelog-pages.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/changeType/include/changelog-pages.xml
@@ -1,0 +1,17 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd"
+                   logicalFilePath="page-service-changelog">
+
+
+    <changeSet author="dev" id="initial_db_setup">
+        <createTable tableName="pages">
+            <column name="id" type="int">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_authzPages_id"/>
+            </column>
+            <column name="title" type="VARCHAR(255)"/>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/liquibase-integration-tests/src/test/resources/changelogs/changeType/include/changelog-teams.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/changeType/include/changelog-teams.xml
@@ -1,0 +1,19 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet author="dev" id="initial_db_setup">
+        <createTable tableName="team">
+            <column name="id" type="int">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_teams_id"/>
+            </column>
+            <column name="name" type="VARCHAR(255)"/>
+            <column name="total_members" type="int"/>
+        </createTable>
+    </changeSet>
+
+    <include file="changelog-level3.xml" relativeToChangelogFile="true"/>
+
+</databaseChangeLog>

--- a/liquibase-integration-tests/src/test/resources/changelogs/changeType/include/changelog-users.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/changeType/include/changelog-users.xml
@@ -1,0 +1,16 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet author="dev" id="initial_db_setup">
+        <createTable tableName="users">
+            <column name="id" type="int">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_Users_id"/>
+            </column>
+            <column name="firstname" type="VARCHAR(255)"/>
+            <column name="lastname" type="VARCHAR(255)"/>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/liquibase-integration-tests/src/test/resources/changelogs/changeType/include/changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/changeType/include/changelog.xml
@@ -1,0 +1,11 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd"
+                   logicalFilePath="app-changelog">
+
+    <include file="changelog-mid.xml" relativeToChangelogFile="true"/>
+    <include file="changelog-teams.xml" relativeToChangelogFile="true"/>
+
+</databaseChangeLog>

--- a/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -1131,8 +1131,8 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
             }
         } while ((currentChangeLog = currentChangeLog.getParentChangeLog()) != null);
 
-        if (actualLogicalFilePath == null && StringUtils.isNotBlank(this.getLogicalFilePath())) {
-            actualLogicalFilePath = this.getLogicalFilePath();
+        if (actualLogicalFilePath == null && StringUtils.isNotBlank(this.getRawLogicalFilePath())) {
+            actualLogicalFilePath = this.getRawLogicalFilePath();
         } else {
             actualLogicalFilePath = logicalFilePath;
         }

--- a/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -1131,10 +1131,12 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
             }
         } while ((currentChangeLog = currentChangeLog.getParentChangeLog()) != null);
 
-        if (actualLogicalFilePath == null && StringUtils.isNotBlank(this.getRawLogicalFilePath())) {
+        if (actualLogicalFilePath == null) {
+            if (StringUtils.isNotBlank(this.getRawLogicalFilePath())) {
             actualLogicalFilePath = this.getRawLogicalFilePath();
-        } else {
-            actualLogicalFilePath = logicalFilePath;
+            } else {
+                actualLogicalFilePath = logicalFilePath;
+            }
         }
 
         for (ChangeSet changeSet : changeLog.getChangeSets()) {

--- a/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -1122,22 +1122,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
             ranChangeSets = database.getRanChangeSetList();
         }
 
-        DatabaseChangeLog currentChangeLog = changeLog;
-        String actualLogicalFilePath = null;
-        do {
-            if (StringUtils.isNotBlank(currentChangeLog.getRawLogicalFilePath())) {
-                actualLogicalFilePath = currentChangeLog.getRawLogicalFilePath();
-                break;
-            }
-        } while ((currentChangeLog = currentChangeLog.getParentChangeLog()) != null);
-
-        if (actualLogicalFilePath == null) {
-            if (StringUtils.isNotBlank(this.getRawLogicalFilePath())) {
-            actualLogicalFilePath = this.getRawLogicalFilePath();
-            } else {
-                actualLogicalFilePath = logicalFilePath;
-            }
-        }
+        String actualLogicalFilePath = getActualLogicalFilePath(logicalFilePath, changeLog);
 
         for (ChangeSet changeSet : changeLog.getChangeSets()) {
             if (modifyChangeSets != null) {
@@ -1162,6 +1147,23 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
         skippedChangeSets.addAll(changeLog.getSkippedChangeSets());
 
         return true;
+    }
+
+    /**
+     * Search for the closest logicalfilePath for this changelog
+     */
+    private String getActualLogicalFilePath(String logicalFilePath, DatabaseChangeLog changeLog) {
+        DatabaseChangeLog currentChangeLog = changeLog;
+        do {
+            if (StringUtils.isNotBlank(currentChangeLog.getRawLogicalFilePath())) {
+                return currentChangeLog.getRawLogicalFilePath();
+            }
+        } while ((currentChangeLog = currentChangeLog.getParentChangeLog()) != null);
+
+        if (StringUtils.isNotBlank(this.getRawLogicalFilePath())) {
+            return this.getRawLogicalFilePath();
+        }
+        return logicalFilePath;
     }
 
     /**


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 

## Description

Don't ignore logicalFilePath & parent tree cascading when including changelogs. 


## Things to be aware of

Right now this kind of including fails:

```
parent, using logicalFilePath = bla
    child1 -> with change named = change, logicalFilePath = child1
    child2 -> with change named = change, logicalFilePath = child2
```
    
As it produces th following changeset id, ignoring the child logicalFilePath:
```
bla:change
bla:change
```

This fix makes it produces the expected changeset ids:
```
child1:change
child2:change
```

This fix also accounts for more levels, so you can have:
```
parent, using logicalFilePath = bla
     mid, using logicalFilePath = mid
       child1 -> with change named = change, logicalFilePath = child1
       child2 -> with change named = change, logicalFilePath = child2
    mid2, no logicalFilePath
       child3 -> with change named = change, no logicalPath
```
      
It produces:
```
mid:child1
mid:child2
bla:child3  (we skipped mid2 level but found bla on top)
```


## Additional Context

Fixes #6656
