### PR TITLE
🔧 DAT-19374

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -83,7 +83,7 @@ jobs:
 
   build-azure-uber-jar:
    needs: [ setup, owasp-scanner ]
-   uses: liquibase/liquibase/.github/workflows/build-azure-uber-jar.yml@master
+   uses: ./.github/workflows/build-azure-uber-jar.yml
    with:
      branch: ${{ needs.setup.outputs.branch }}
      liquibase-version: ${{ needs.setup.outputs.version }}
@@ -91,7 +91,7 @@ jobs:
 
   build-extension-jars:
    needs: [ setup, owasp-scanner ]
-   uses: liquibase/liquibase/.github/workflows/build-extension-jars.yml@master
+   uses: ./.github/workflows/build-extension-jars.yml
    with:
      liquibase-version: ${{ needs.setup.outputs.version }}
      dependencies: ${{ needs.setup.outputs.dependencies }}

--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -29,7 +29,7 @@ jobs:
 
   dry-run-create-release:
     needs: [ setup ]
-    uses: liquibase/liquibase/.github/workflows/create-release.yml@master
+    uses: ./.github/workflows/create-release.yml@master
     with:
       version: "dry-run-${{ github.run_id }}"
       runId: ${{ needs.setup.outputs.dry_run_id }}
@@ -62,7 +62,7 @@ jobs:
 
   dry-run-release-published:
     needs: [ setup, dry-run-create-release, dry-run-get-draft-release ]
-    uses: liquibase/liquibase/.github/workflows/release-published.yml@master
+    uses: ./.github/workflows/release-published.yml@master
     with:
       tag: "vdry-run-${{ github.run_id }}"
       dry_run_release_id: ${{ needs.dry-run-get-draft-release.outputs.dry_run_release_id }}

--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -29,7 +29,7 @@ jobs:
 
   dry-run-create-release:
     needs: [ setup ]
-    uses: ./.github/workflows/create-release.yml@master
+    uses: ./.github/workflows/create-release.yml
     with:
       version: "dry-run-${{ github.run_id }}"
       runId: ${{ needs.setup.outputs.dry_run_id }}
@@ -62,7 +62,7 @@ jobs:
 
   dry-run-release-published:
     needs: [ setup, dry-run-create-release, dry-run-get-draft-release ]
-    uses: ./.github/workflows/release-published.yml@master
+    uses: ./.github/workflows/release-published.yml
     with:
       tag: "vdry-run-${{ github.run_id }}"
       dry_run_release_id: ${{ needs.dry-run-get-draft-release.outputs.dry_run_release_id }}


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/dry-run-release.yml` file to update the references for the `jobs:` section. The most important changes involve modifying the `uses` attribute for two jobs to use local workflow files instead of the ones from the `liquibase/liquibase` repository.

Changes to workflow file references:

* [`.github/workflows/dry-run-release.yml`](diffhunk://#diff-da505eba40e5178912154d1d165e17f3353098ba24e44bd62d23ad028700e42aL32-R32): Updated the `uses` attribute for the `dry-run-create-release` job to reference the local `create-release.yml` file.
* [`.github/workflows/dry-run-release.yml`](diffhunk://#diff-da505eba40e5178912154d1d165e17f3353098ba24e44bd62d23ad028700e42aL65-R65): Updated the `uses` attribute for the `dry-run-release-published` job to reference the local `release-published.yml` file.