### PR TITLE
Fix concurrency issues in multithread environments

### DIFF
--- a/liquibase-integration-tests/src/test/java/liquibase/threading/LiquibaseTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/threading/LiquibaseTest.java
@@ -1,0 +1,104 @@
+package liquibase.threading;
+
+import liquibase.Contexts;
+import liquibase.LabelExpression;
+import liquibase.Liquibase;
+import liquibase.Scope;
+import liquibase.changelog.ChangeSet;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.After;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+/**
+ * Simple test - create one database without spawning threads.
+ * <p>
+ *     This is done to provoke interference between tests spawning threads and
+ *     running on the test thread. See {@link Scope}.
+ * </p>
+ *
+ * @author github.com/bvremmeinfor
+ */
+public class LiquibaseTest {
+
+    private static final String DATABASE_NAME_PREFIX = "DB_SINGLE_";
+    private final Map<String, MemoryDatabase> liveConnections = new ConcurrentHashMap<>();
+
+    @After
+    public void tearDown() {
+        teardownLiveConnections();
+    }
+
+    @Test
+    public void itCanMaintainDatabase() {
+            final String dbName = DATABASE_NAME_PREFIX + "0";
+
+            createMemoryDatabase(dbName);
+            maintainDatabase(dbName);
+    }
+
+    private void maintainDatabase(final String dbName) {
+
+        System.out.println("-- maintaining database: " + dbName);
+
+        final MemoryDatabase db = getDatabase(dbName);
+
+        try (Connection con = db.getConnection()) {
+            final Liquibase liquibase = new Liquibase("/changelogs/threading/changelog.xml", new ClassLoaderResourceAccessor(), new JdbcConnection(con));
+
+            final List<ChangeSet> pending = liquibase.listUnrunChangeSets(new Contexts(), new LabelExpression());
+            if (pending.isEmpty()) {
+                fail("Expected pending database changesets");
+            }
+
+            liquibase.update(new Contexts(), new LabelExpression());
+
+            final List<String> tableNames = db.queryTables();
+
+            assertTrue("Expected to find table1 in " + tableNames, tableNames.contains("table1"));
+            assertTrue("Expected to find table2 in " + tableNames, tableNames.contains("table2"));
+
+            System.out.println("-- database maintenance OK for: " + dbName);
+
+        } catch (Exception e) {
+            System.out.println("-- database maintenance failed for: " + dbName);
+            throw new IllegalStateException(e.getMessage(), e);
+        }
+    }
+
+    private void createMemoryDatabase(final String dbName) {
+        System.out.println("-- creating memory database: " + dbName);
+        liveConnections.put(dbName, MemoryDatabase.create(dbName));
+        System.out.println("-- memory database created: " + dbName);
+    }
+
+    private MemoryDatabase getDatabase(final String dbName) {
+        final MemoryDatabase db = liveConnections.get(dbName);
+        assertNotNull("Memory database not created for " + dbName, db);
+        return db;
+    }
+
+
+    private void teardownLiveConnections() {
+        final Map<String, MemoryDatabase> all = new LinkedHashMap<>(liveConnections);
+        liveConnections.clear();
+
+        all.values().forEach(MemoryDatabase::close);
+
+        final List<String> notClosed = all.keySet().stream().filter(MemoryDatabase::databaseExists).collect(Collectors.toList());
+
+        if (!notClosed.isEmpty()) {
+            throw new IllegalStateException("Failed to close all databases, open: " + notClosed);
+        }
+    }
+
+}

--- a/liquibase-integration-tests/src/test/java/liquibase/threading/LiquibaseThreadingTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/threading/LiquibaseThreadingTest.java
@@ -1,0 +1,180 @@
+package liquibase.threading;
+
+import liquibase.Contexts;
+import liquibase.LabelExpression;
+import liquibase.Liquibase;
+import liquibase.Scope;
+import liquibase.changelog.ChangeSet;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.After;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.*;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author github.com/bvremmeinfor
+ */
+public class LiquibaseThreadingTest {
+
+    private static final String DATABASE_NAME_PREFIX = "DB_MT_";
+    private final ExecutorService executor = Executors.newCachedThreadPool();
+    private final Map<String, MemoryDatabase> liveConnections = new ConcurrentHashMap<>();
+
+    @After
+    public void tearDown() {
+        teardownLiveConnections();
+        shutdownExecutorService();
+    }
+
+    @Test
+    public void itCanMaintainDatabasesInParallel() {
+        /*
+         * 4 threads seems to be sufficient to provoke most errors
+         */
+        final int threadCount = Math.min(16, Runtime.getRuntime().availableProcessors() * 2);
+
+        System.err.println("Liquibase threading test will use " + threadCount + " threads.");
+
+        assertMaintainDatabases(threadCount);
+    }
+
+
+    private void assertMaintainDatabases(final int threadCount) {
+        final List<Future<?>> maintainTasks = new ArrayList<>();
+
+        /*
+         * We want to stress initialization as much as possible, so we
+         * wait for all thread ready before we start.
+         */
+        final ThreadAligner threadAligner = new ThreadAligner(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            final String dbName = DATABASE_NAME_PREFIX + i;
+
+            createMemoryDatabase(dbName);
+
+            maintainTasks.add(executor.submit(() -> {
+                threadAligner.awaitAllReady();
+                maintainDatabase(dbName);
+            }));
+        }
+
+        maintainTasks.forEach(LiquibaseThreadingTest::assertResolved);
+    }
+
+    private void maintainDatabase(final String dbName) {
+
+        System.out.println("-- maintaining database: " + dbName);
+
+        final MemoryDatabase db = getDatabase(dbName);
+
+        try (Connection con = db.getConnection()) {
+
+            final Map<String, Object> liquibaseConfiguration = new LinkedHashMap<>();
+            liquibaseConfiguration.put("liquibase.analytics.devOverride", true);
+            liquibaseConfiguration.put("liquibase.analytics.configEndpointUrl", "http://localhost:5000");
+
+            Scope.child(liquibaseConfiguration, () -> {
+
+                final Liquibase liquibase = new Liquibase("/changelogs/threading/changelog.xml", new ClassLoaderResourceAccessor(), new JdbcConnection(con));
+
+                final List<ChangeSet> pending = liquibase.listUnrunChangeSets(new Contexts(), new LabelExpression());
+                if (pending.isEmpty()) {
+                    fail("Expected pending database changesets");
+                }
+
+                liquibase.update(new Contexts(), new LabelExpression());
+
+                final List<String> tableNames = db.queryTables();
+
+                assertTrue("Expected to find table1 in " + tableNames, tableNames.contains("table1"));
+                assertTrue("Expected to find table2 in " + tableNames, tableNames.contains("table2"));
+
+                System.out.println("-- database maintenance OK for: " + dbName);
+            });
+
+        } catch (Exception e) {
+            System.out.println("-- database maintenance failed for: " + dbName);
+            throw new IllegalStateException(e.getMessage(), e);
+        }
+    }
+
+    private void createMemoryDatabase(final String dbName) {
+        System.out.println("-- creating memory database: " + dbName);
+        liveConnections.put(dbName, MemoryDatabase.create(dbName));
+        System.out.println("-- memory database created: " + dbName);
+    }
+
+    private MemoryDatabase getDatabase(final String dbName) {
+        final MemoryDatabase db = liveConnections.get(dbName);
+        assertNotNull("Memory database not created for " + dbName, db);
+        return db;
+    }
+
+    private static <T> T assertResolved(Future<T> future) {
+        try {
+            return future.get(30, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Thread interrupted");
+        } catch (TimeoutException | ExecutionException e) {
+            throw new IllegalStateException(e.getMessage(), e);
+        }
+    }
+
+    private void shutdownExecutorService() {
+        executor.shutdownNow();
+
+        try {
+            if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("Failed to terminate all threads in a timely fashion");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting for all threads to terminate in a timely fashion");
+        }
+    }
+
+    private void teardownLiveConnections() {
+        final Map<String, MemoryDatabase> all = new LinkedHashMap<>(liveConnections);
+        liveConnections.clear();
+
+        all.values().forEach(MemoryDatabase::close);
+
+        final List<String> notClosed = all.keySet().stream().filter(MemoryDatabase::databaseExists).collect(Collectors.toList());
+
+        if (!notClosed.isEmpty()) {
+            throw new IllegalStateException("Failed to close all databases, open: " + notClosed);
+        }
+    }
+
+    private static class ThreadAligner {
+
+        private final CyclicBarrier barrier;
+
+        public ThreadAligner(int threads) {
+            this.barrier = new CyclicBarrier(threads);
+        }
+
+        void awaitAllReady() {
+            try {
+                barrier.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(e);
+            } catch (BrokenBarrierException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+
+}

--- a/liquibase-integration-tests/src/test/java/liquibase/threading/MemoryDatabase.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/threading/MemoryDatabase.java
@@ -1,0 +1,142 @@
+package liquibase.threading;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * @author github.com/bvremmeinfor
+ */
+public class MemoryDatabase implements AutoCloseable {
+
+    private static final String SENSING_TABLE = "_fake_lock";
+
+    private final String connectionUrl;
+    private final Connection mainConnection;
+
+    private boolean closed = false;
+
+    private MemoryDatabase(String connectionUrl, Connection mainConnection) {
+        this.connectionUrl = connectionUrl;
+        this.mainConnection = mainConnection;
+    }
+
+    public static synchronized MemoryDatabase create(String dbName) {
+        MemoryDatabase db = createUnvalidated(dbName);
+
+        if (db.hasSensingTable()) {
+            db.close();
+            throw new IllegalStateException("Database already exists: " + dbName);
+        }
+
+        db.createSensingTable();
+
+        return db;
+    }
+
+    public static boolean databaseExists(String dbName) {
+        try (MemoryDatabase db = createUnvalidated(dbName)) {
+            return db.hasSensingTable();
+        }
+    }
+
+    public synchronized boolean isClosed() {
+        return closed;
+    }
+
+    @Override
+    public synchronized void close() {
+        closed = true;
+        try {
+            mainConnection.close();
+        } catch (SQLException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public synchronized Connection getConnection() {
+        if (closed) {
+            throw new IllegalStateException("Fake connection factory is closed!");
+        }
+
+        try {
+            return createConnection(this.connectionUrl);
+        } catch (SQLException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public List<Map<String, String>> queryConnections() {
+        return query("select * from information_schema.sessions");
+    }
+
+    public boolean hasTable(String tableName) {
+        final String lowercaseTableName = tableName.toLowerCase();
+        return queryTables().stream().anyMatch(lowercaseTableName::equals);
+    }
+
+    public List<String> queryTables() {
+        return query("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA <> 'INFORMATION_SCHEMA'").stream()
+                .map(rec -> rec.get("table_name").toLowerCase())
+                .collect(Collectors.toList());
+    }
+
+    public List<Map<String, String>> query(final String sql) {
+        List<Map<String, String>> l = new ArrayList<>();
+
+        try (Statement stat = this.mainConnection.createStatement(); ResultSet rc = stat.executeQuery(sql)) {
+            final ResultSetMetaData m = rc.getMetaData();
+            while (rc.next()) {
+                Map<String, String> record = new LinkedHashMap<>();
+                for (int i = 1; i <= m.getColumnCount(); i++) {
+                    record.put(m.getColumnName(i).toLowerCase(), rc.getString(i));
+                }
+                l.add(record);
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException(e);
+        }
+
+        return l;
+    }
+
+    public int update(String sql) {
+        try (Statement stat = this.mainConnection.createStatement()) {
+            return stat.executeUpdate(sql);
+        } catch (SQLException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+
+    private static MemoryDatabase createUnvalidated(String dbName) {
+        try {
+            final String connectionUrl = "jdbc:h2:mem:" + dbName;
+            final Connection con = createConnection(connectionUrl);
+            return new MemoryDatabase(connectionUrl, con);
+        } catch (SQLException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private boolean hasSensingTable() {
+        return queryTables().stream().anyMatch(SENSING_TABLE::equals);
+    }
+
+    private void createSensingTable() {
+        final String sql = "CREATE TABLE " + SENSING_TABLE + " ( DUMMY VARCHAR(100), PRIMARY KEY (DUMMY))";
+        try (PreparedStatement stat = this.mainConnection.prepareStatement(sql)) {
+            stat.executeUpdate();
+        } catch (SQLException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static Connection createConnection(final String connectionUrl) throws SQLException {
+        return DriverManager.getConnection(connectionUrl, "sa", "");
+    }
+
+}

--- a/liquibase-integration-tests/src/test/resources/changelogs/threading/changelog-1.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/threading/changelog-1.xml
@@ -1,0 +1,132 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog
+	xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+	xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+	xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-3.8.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+	<changeSet author="system" id="step1" labels="1.0">
+		<createTable tableName="table1">
+			<column name="col1" type="VARCHAR(255)">
+				<constraints primaryKey="true"
+					primaryKeyName="table1_pk" />
+			</column>
+			<column name="col2" type="VARCHAR(255)" />
+			<column name="col3" type="VARCHAR(255)" />
+		</createTable>
+	</changeSet>
+
+
+	<changeSet author="system" id="step2" labels="1.0">
+		<createIndex indexName="ix_table1"
+					 tableName="table1">
+			<column name="col1" />
+			<column name="col2" />
+		</createIndex>
+	</changeSet>
+
+	<changeSet author="system" id="step3" labels="1.0">
+		<insert tableName="table1">
+			<column name="col1" value="a" />
+			<column name="col2" value="Some a" />
+			<column name="col3" value="Describe a" />
+		</insert>
+	</changeSet>
+
+	<changeSet author="system" id="step4" labels="1.0">
+		<insert tableName="table1">
+			<column name="col1" value="b" />
+			<column name="col2" value="Some b" />
+			<column name="col3" value="Describe b" />
+		</insert>
+	</changeSet>
+
+	<changeSet author="system" id="step5" labels="1.0">
+		<createTable tableName="table2">
+			<column name="col1" type="VARCHAR(255)">
+				<constraints primaryKey="true"
+							 primaryKeyName="table2_pk" />
+			</column>
+			<column name="col2" type="VARCHAR(255)" />
+			<column name="col3" type="VARCHAR(255)" />
+		</createTable>
+	</changeSet>
+
+	<changeSet author="system" id="step6" labels="1.0">
+		<insert tableName="table2">
+			<column name="col1" value="x" />
+			<column name="col2" value="Some x" />
+			<column name="col3" value="Describe x" />
+		</insert>
+	</changeSet>
+
+	<changeSet author="system" id="step7" labels="1.0">
+		<createIndex indexName="ix_table2"
+					 tableName="table2">
+			<column name="col1" />
+			<column name="col2" />
+		</createIndex>
+	</changeSet>
+
+	<changeSet author="system" id="step8" labels="1.0">
+		<insert tableName="table2">
+			<column name="col1" value="y" />
+			<column name="col2" value="Some y" />
+			<column name="col3" value="Describe y" />
+		</insert>
+	</changeSet>
+
+	<changeSet author="system" id="step9" labels="1.0">
+		<createTable tableName="xnode">
+			<column autoIncrement="true" name="node"
+					type="INTEGER" startWith="1" incrementBy="1">
+				<constraints primaryKey="true"
+							 primaryKeyName="xnode_pk" />
+			</column>
+			<column name="parent" type="INTEGER">
+				<constraints nullable="false" />
+			</column>
+		</createTable>
+
+		<insert tableName="xnode">
+			<column name="parent" valueNumeric="0" />
+		</insert>
+	</changeSet>
+
+	<changeSet author="system" id="step10" labels="1.0">
+		<createTable tableName="xnode_localization">
+			<column name="node" type="INTEGER">
+				<constraints primaryKey="true"
+							 primaryKeyName="xnode_localization_pk" />
+			</column>
+			<column name="locale" type="VARCHAR(20)">
+				<constraints primaryKey="true"
+							 primaryKeyName="xnode_localization_pk" />
+			</column>
+			<column name="fieldname" type="VARCHAR(255)">
+				<constraints primaryKey="true"
+							 primaryKeyName="xnode_localization_pk" />
+			</column>
+			<column name="fieldtext" type="VARCHAR(500)">
+				<constraints nullable="false" />
+			</column>
+		</createTable>
+
+		<addForeignKeyConstraint
+				baseColumnNames="node" baseTableName="xnode_localization"
+				constraintName="fk_xnode_localization_xnode" deferrable="false"
+				initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION"
+				referencedColumnNames="node" referencedTableName="xnode"
+				validate="true" />
+
+		<insert tableName="xnode_localization">
+			<column name="node" valueNumeric="1" />
+			<column name="locale" value="en" />
+			<column name="fieldname" value="name" />
+			<column name="fieldtext" value="Standard" />
+		</insert>
+	</changeSet>
+
+
+</databaseChangeLog>

--- a/liquibase-integration-tests/src/test/resources/changelogs/threading/changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/threading/changelog.xml
@@ -1,0 +1,25 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog
+	xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+	xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+	<!-- http://www.liquibase.org/databases.html -->
+
+	<property name="varchar.type" value="NVARCHAR" dbms="mssql" />
+	<property name="varchar.type" value="VARCHAR" dbms="!mssql" />
+
+	<property name="integer.type" value="INT" dbms="mssql" />
+	<property name="integer.type" value="INTEGER" dbms="!mssql" />
+
+	<property name="bigint.type" value="BIGINT" />
+
+	<property name="clob.type" value="NVARCHAR(MAX)" dbms="mssql" />
+	<property name="clob.type" value="LONGTEXT" dbms="h2" />
+	<property name="clob.type" value="CLOB" dbms="derby" />
+	<property name="clob.type" value="TEXT" dbms="postgresql" />
+	
+	<include file="changelogs/threading/changelog-1.xml"/>
+
+</databaseChangeLog>

--- a/liquibase-standard/src/main/java/liquibase/Scope.java
+++ b/liquibase-standard/src/main/java/liquibase/Scope.java
@@ -84,7 +84,7 @@ public class Scope {
 
     public static final String JAVA_PROPERTIES = "javaProperties";
 
-    private static final InheritableThreadLocal<ScopeManager> scopeManager = new InheritableThreadLocal<>();
+    private static final ThreadLocal<ScopeManager> scopeManager = new ThreadLocal<>();
 
     private final Scope parent;
     private final SmartMap values = new SmartMap();

--- a/liquibase-standard/src/main/java/liquibase/Scope.java
+++ b/liquibase-standard/src/main/java/liquibase/Scope.java
@@ -84,7 +84,14 @@ public class Scope {
 
     public static final String JAVA_PROPERTIES = "javaProperties";
 
-    private static final ThreadLocal<ScopeManager> scopeManager = new ThreadLocal<>();
+    private static final InheritableThreadLocal<ScopeManager> scopeManager = new InheritableThreadLocal<ScopeManager>() {
+        @Override
+        protected ScopeManager childValue(ScopeManager parentValue) {
+            ScopeManager sm = new SingletonScopeManager();
+            sm.setCurrentScope(parentValue.getCurrentScope());
+            return sm;
+        }
+    };
 
     private final Scope parent;
     private final SmartMap values = new SmartMap();


### PR DESCRIPTION
## Impact

fix InheritableThreadLocal inconsistent behavior in threadpool environments by just copying the required objects.


Fix #6588


We need to re-execute the tests from https://datical.atlassian.net/browse/DAT-18871 and make sure that it still works fine. 