### PR TITLE
🔧 DAT-19341: Add check for existing OSS release tag to prevent duplicate artifacts

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -363,12 +363,13 @@ jobs:
         # Check if the tag already exists in OSS repository, if it does, exit with error. This is to prevent the artifacts from being attached to the already released tag.
       - name: Check OSS release tag existence, if tag exists, exit with error
         run: |
-          tag=v${{ needs.setup.outputs.version }}
-          if git rev-parse $tag >/dev/null 2>&1
+          tag="v${{ needs.setup.outputs.version }}"
+          if git show-ref --tags --quiet --verify -- "refs/tags/$tag"
           then
-            echo "Tag $tag already exists"
-            exit 1
+              echo "Tag $tag already exists"
+              exit 1
           fi
+
 
       - name: Attach Files to Draft Release
         if: ${{ inputs.standalone_zip == false && inputs.dry_run == false }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -360,6 +360,16 @@ jobs:
           rm re-version/final/*.md5
           rm re-version/final/*.sha1
 
+        # Check if the tag already exists in OSS repository, if it does, exit with error. This is to prevent the artifacts from being attached to the already released tag.
+      - name: Check OSS release tag existence, if tag exists, exit with error
+        run: |
+          tag=v${{ needs.setup.outputs.version }}
+          if git rev-parse $tag >/dev/null 2>&1
+          then
+            echo "Tag $tag already exists"
+            exit 1
+          fi
+
       - name: Attach Files to Draft Release
         if: ${{ inputs.standalone_zip == false && inputs.dry_run == false }}
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/create-release.yml` file to add a check for the existence of a release tag in the OSS repository before proceeding with attaching files to the draft release.

Key change:

* Added a new step to check if the tag already exists in the OSS repository and exit with an error if it does, to prevent attaching artifacts to an already released tag. (`.github/workflows/create-release.yml`)