### PR TITLE
✨ feat: DAT-19341:publish_assets_to_internal_nexus repo.liquibase.net

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -129,7 +129,7 @@ jobs:
         with:
           repository: "liquibase/liquibase"
           tag: "${{ needs.setup.outputs.tag }}"
-          filename: "*"
+          fileName: "*"
           out-file-path: "."
 
       - name: Set up Java for publishing to Maven Central Repository
@@ -229,7 +229,7 @@ jobs:
         with:
           repository: "liquibase/liquibase"
           tag: "${{ needs.setup.outputs.tag }}"
-          filename: "liquibase-additional*.zip"
+          fileName: "liquibase-additional*.zip"
           out-file-path: "."
 
       - name: Unpack javadoc files and upload to s3
@@ -488,7 +488,7 @@ jobs:
         with:
           repository: "liquibase/liquibase"
           releaseId: "${{ inputs.dry_run_release_id }}"
-          filename: "*"
+          fileName: "*"
           out-file-path: "."
 
       - name: Set up Java for publishing to Maven Central Repository
@@ -539,3 +539,35 @@ jobs:
           
           done
             
+  publish_assets_to_internal_nexus:
+    if: ${{ inputs.dry_run == false }}
+    name: Publish OSS released assets to repo.liquibase.net
+    needs: [ setup ]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download released assets
+        uses: robinraju/release-downloader@v1.11
+        with:
+          repository: "liquibase/liquibase"
+          latest: true          
+          fileName: "*"
+          out-file-path: "./${{ needs.setup.outputs.version }}-released-assets"
+
+      - name: Publish to internal Nexus (repo.liquibase.net)
+        env:
+          MAVEN_USERNAME: ${{ secrets.INTERNAL_NEXUS_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.INTERNAL_NEXUS_PASSWORD }}
+          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          version=${{ needs.setup.outputs.version }}
+          for file in ./${{ needs.setup.outputs.version }}-released-assets/*; do
+            mvn deploy:deploy-file \
+              -DrepositoryId=${version}-release-assets \
+              -Durl=https://repo.liquibase.net/repository/oss-release-assets \
+              -Dfile="$file" \
+              -DgroupId=org.liquibase \
+              -DartifactId=$(basename "$file" | rev | cut -d'.' -f2- | rev) \ 
+              -Dversion=${version} \
+              -Dpackaging=$(basename "$file" | cut -d'.' -f2-)
+          done
+          

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -544,7 +544,27 @@ jobs:
     name: Publish OSS released assets to repo.liquibase.net
     needs: [ setup ]
     runs-on: ubuntu-22.04
+    env:
+      MAVEN_USERNAME: ${{ secrets.INTERNAL_NEXUS_USERNAME }}
+      MAVEN_PASSWORD: ${{ secrets.INTERNAL_NEXUS_PASSWORD }}
+      GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
     steps:
+      # Check in nexus if the folder with the version already exists, if exists exit with error code
+      - name: Check if the version already exists in nexus
+        id: check_version
+        run: |
+          version=${{ needs.setup.outputs.version }}
+          response=$(curl -u "$MAVEN_USERNAME:$MAVEN_PASSWORD" -s -o /dev/null -w "%{http_code}" \
+            "https://repo.liquibase.net/repository/oss-release-assets/${version}-release-assets/")
+          
+          if [ "$response" -eq 200 ]; then
+            echo "folder_exists=true" >> $GITHUB_ENV
+            echo "Error: Release assets for version ${version} already exist in Nexus."
+            exit 1
+          else
+            echo "folder_exists=false" >> $GITHUB_ENV
+          fi
+
       - name: Download released assets
         uses: robinraju/release-downloader@v1.11
         with:
@@ -554,10 +574,7 @@ jobs:
           out-file-path: "./${{ needs.setup.outputs.version }}-released-assets"
 
       - name: Publish to internal Nexus (repo.liquibase.net)
-        env:
-          MAVEN_USERNAME: ${{ secrets.INTERNAL_NEXUS_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.INTERNAL_NEXUS_PASSWORD }}
-          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+        if: env.folder_exists == 'false'
         run: |
           version=${{ needs.setup.outputs.version }}
           for file in ./${{ needs.setup.outputs.version }}-released-assets/*; do


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/release-published.yml` file to correct a parameter name and add a new job for publishing assets to an internal Nexus repository.

Parameter name correction:

* Changed `filename` to `fileName` in multiple steps to ensure consistency and correctness. [[1]](diffhunk://#diff-f7ca0660afb7c5d6e7220dee8a6db81db251b3c98818f4d76a3e4441b85c7a6dL132-R132) [[2]](diffhunk://#diff-f7ca0660afb7c5d6e7220dee8a6db81db251b3c98818f4d76a3e4441b85c7a6dL232-R232) [[3]](diffhunk://#diff-f7ca0660afb7c5d6e7220dee8a6db81db251b3c98818f4d76a3e4441b85c7a6dL491-R491)

New job addition:

* Added a new job `publish_assets_to_internal_nexus` to publish OSS released assets to `repo.liquibase.net`, including steps to download released assets and publish them to the internal Nexus repository.