### PR TITLE
BugFix: Issue #6564: added a unique changelog history query in StandardChangeLogHistoryService

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/changelog/AbstractChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/AbstractChangeLogHistoryService.java
@@ -65,7 +65,7 @@ public abstract class AbstractChangeLogHistoryService implements ChangeLogHistor
     @Override
     public void upgradeChecksums(final DatabaseChangeLog databaseChangeLog, final Contexts contexts,
                                  LabelExpression labels) throws DatabaseException {
-        for (RanChangeSet ranChangeSet : this.getRanChangeSets()) {
+        for (RanChangeSet ranChangeSet : this.getUniqueRanChangeSets()) {
             if (ranChangeSet.getLastCheckSum() == null) {
                 List<ChangeSet> changeSets = databaseChangeLog.getChangeSets(ranChangeSet);
                 for (ChangeSet changeSet : changeSets) {

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryService.java
@@ -33,6 +33,8 @@ public interface ChangeLogHistoryService extends Plugin {
 
     List<RanChangeSet> getRanChangeSets() throws DatabaseException;
 
+    List<RanChangeSet> getUniqueRanChangeSets() throws DatabaseException;
+
     /**
      * This method was created to clear out MD5sum for upgrade purpose but after some refactoring the logic was moved to Update commands and it should have been removed
      * as everywhere it is called only with boolean false, so for core it is the same as getRanChangeSets().

--- a/liquibase-standard/src/main/java/liquibase/changelog/MockChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/MockChangeLogHistoryService.java
@@ -62,6 +62,12 @@ public class MockChangeLogHistoryService implements ChangeLogHistoryService {
     }
 
     @Override
+    public List<RanChangeSet> getUniqueRanChangeSets() throws DatabaseException
+    {
+        return ranChangeSets;
+    }
+
+    @Override
     public List<RanChangeSet> getRanChangeSets(boolean a) throws DatabaseException {
         return ranChangeSets;
     }

--- a/liquibase-standard/src/main/java/liquibase/changelog/OfflineChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/OfflineChangeLogHistoryService.java
@@ -144,6 +144,12 @@ public class OfflineChangeLogHistoryService extends AbstractChangeLogHistoryServ
     }
 
     @Override
+    public List<RanChangeSet> getUniqueRanChangeSets() throws DatabaseException
+    {
+        return getRanChangeSets();
+    }
+
+    @Override
     public List<RanChangeSet> getRanChangeSets() throws DatabaseException {
         try (
                 Reader reader = new InputStreamReader(Files.newInputStream(this.changeLogFile.toPath()), GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue())

--- a/liquibase-standard/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
@@ -367,7 +367,7 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
 
     public List<Map<String, ?>> queryDatabaseChangeLogTable(Database database) throws DatabaseException {
         SelectFromDatabaseChangeLogStatement select = new SelectFromDatabaseChangeLogStatement(new ColumnConfig()
-            .setName("*").setComputed(true)).setOrderBy("DATEEXECUTED ASC", "ORDEREXECUTED ASC");
+            .setName("DISTINCT *").setComputed(true)).setOrderBy("DATEEXECUTED ASC", "ORDEREXECUTED ASC");
         return ChangelogJdbcMdcListener.query(getDatabase(), executor -> executor.queryForList(select));
     }
 

--- a/liquibase-standard/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
@@ -354,14 +354,13 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
     @Override
     public List<RanChangeSet> getUniqueRanChangeSets() throws DatabaseException {
         if (this.ranChangeSetList == null) {
-            Database database = getDatabase();
             String databaseChangeLogTableName = getDatabase().escapeTableName(getLiquibaseCatalogName(),
                 getLiquibaseSchemaName(), getDatabaseChangeLogTableName());
             List<RanChangeSet> ranChangeSets = new ArrayList<>();
             if (hasDatabaseChangeLogTable()) {
                 Scope.getCurrentScope().getLog(getClass()).info("Reading from " + databaseChangeLogTableName);
-                List<Map<String, ?>> results = queryDatabaseChangeLogTableUnique(database);
-                for (Map rs : results) {
+                List<Map<String, ?>> results = queryDatabaseChangeLogTableUnique();
+                for (Map<String, ?> rs : results) {
                     String storedFileName = rs.get("FILENAME").toString();
                     String fileName = DatabaseChangeLog.normalizePath(storedFileName);
                     String author = rs.get("AUTHOR").toString();
@@ -415,7 +414,7 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
         return ChangelogJdbcMdcListener.query(getDatabase(), executor -> executor.queryForList(select));
     }
 
-    public List<Map<String, ?>> queryDatabaseChangeLogTableUnique(Database database) throws DatabaseException {
+    public List<Map<String, ?>> queryDatabaseChangeLogTableUnique() throws DatabaseException {
         SelectFromDatabaseChangeLogStatement select = new SelectFromDatabaseChangeLogStatement(
                 new SelectFromDatabaseChangeLogStatement.GroupByIdAuthorFilename(),
                 new ColumnConfig().setName("ID"), new ColumnConfig().setName("AUTHOR"), new ColumnConfig().setName("FILENAME"),

--- a/liquibase-standard/src/main/java/liquibase/statement/core/SelectFromDatabaseChangeLogStatement.java
+++ b/liquibase-standard/src/main/java/liquibase/statement/core/SelectFromDatabaseChangeLogStatement.java
@@ -102,12 +102,18 @@ public class SelectFromDatabaseChangeLogStatement extends AbstractSqlStatement {
     public static class GroupByIdAuthorFilename implements WhereClause {
         @Override
         public String generateSql(Database database) {
-            final String md5SUMColumnName = database.escapeColumnName(null, null, null, "MD5SUM");
             final String idColumnName = database.escapeColumnName(null, null, null, "ID");
             final String authorColumnName = database.escapeColumnName(null, null, null, "AUTHOR");
             final String fileNameColumnName = database.escapeColumnName(null, null, null, "FILENAME");
             final String exectype = database.escapeColumnName(null, null, null, "EXECTYPE");
-            return String.format(" WHERE %s is null GROUP BY %s, %s, %s, %s", md5SUMColumnName, idColumnName, authorColumnName, fileNameColumnName, exectype);
+            final String md5SUMColumnName = database.escapeColumnName(null, null, null, "MD5SUM");
+            final String descriptionColumnName = database.escapeColumnName(null, null, null, "DESCRIPTION");
+            final String commentsColumnName = database.escapeColumnName(null, null, null, "COMMENTS");
+            final String tagColumnName = database.escapeColumnName(null, null, null, "TAG");
+            final String contextsColumnName = database.escapeColumnName(null, null, null, "CONTEXTS");
+            final String labelsColumnName = database.escapeColumnName(null, null, null, "LABELS");
+            return String.format(" GROUP BY %s, %s, %s, %s, %s, %s, %s, %s, %s, %s", idColumnName, authorColumnName, fileNameColumnName, exectype,
+                    md5SUMColumnName, descriptionColumnName, commentsColumnName, tagColumnName, contextsColumnName, labelsColumnName);
         }
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/statement/core/SelectFromDatabaseChangeLogStatement.java
+++ b/liquibase-standard/src/main/java/liquibase/statement/core/SelectFromDatabaseChangeLogStatement.java
@@ -98,4 +98,16 @@ public class SelectFromDatabaseChangeLogStatement extends AbstractSqlStatement {
         }
     }
 
+    @Data
+    public static class GroupByIdAuthorFilename implements WhereClause {
+        @Override
+        public String generateSql(Database database) {
+            final String md5SUMColumnName = database.escapeColumnName(null, null, null, "MD5SUM");
+            final String idColumnName = database.escapeColumnName(null, null, null, "ID");
+            final String authorColumnName = database.escapeColumnName(null, null, null, "AUTHOR");
+            final String fileNameColumnName = database.escapeColumnName(null, null, null, "FILENAME");
+            final String exectype = database.escapeColumnName(null, null, null, "EXECTYPE");
+            return String.format(" WHERE %s is null GROUP BY %s, %s, %s, %s", md5SUMColumnName, idColumnName, authorColumnName, fileNameColumnName, exectype);
+        }
+    }
 }


### PR DESCRIPTION
Fixes #6564. 

Added the new method, StandardChangeLogHistoryService.getUniqueRanChangeSets(), to retrieve only one row for each unique changeSet from databasechangelog. This reduces redundant calculation of md5sums and updates to databasechangelog.

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description
I tracked the slow performance in recalculating checksums to the AbstractChangeLogHistoryService.upgradeChecksums() method. The outer loop driven by the result set from StandardChangeLogHistoryService.getRanChangeSets() method causes the loop to execute once for every row in databasechangelog, which is unnecessary for this purpose as there could be multiple rows in databasechangelog for the same changeset which would therefore have the same md5sum.

I created a new method, StandardChangeLogHistoryService.getUniqueRanChangeSets() with a corresponding new method in the ChangeLogHistoryService interface, and supporting methods for the where clause generation in SelectFromDatabaseChangeLogStatement.

The changes described above correspond to a SQL statement like:

select id, author, filename, exectype, count(*)
from databasechangelog
where 1 = 1
group by id, author, filename, exectype

This greatly reduces the number of iterations in AbstractChangeLogHistoryService.upgradeChecksums(), and eliminates the redundant calculation and update of checksums.

## Things to be aware of
The additional method in the ChangeLogHistoryService required adding that method to MockChangeLogHistoryService and OfflineChangeLogHistoryService. For those classes I just returned the same result as the getRanChangeSets() method. 

## Things to worry about
All unit tests pass, but I was unable to perform an integration test of the change to OfflineChangeLogHistoryService.

## Additional Context
The motivation for this fix is a specific use-case where I run a Liquibase changeLog repeatedly with several "run always" changeSets in order to create new partitions for two partitioned tables. This causes many rows in databasechangelog for the same changeSet, which caused a major performance problem as Liquibase was updating the md5sums once for every row in databasechangelog rather than just once per unique changeSet, with the problem getting worse over time.