### PR TITLE
Snapshot all configuration values for Oracle sequences

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
@@ -190,20 +190,14 @@ public class SequenceSnapshotGenerator extends JdbcSnapshotGenerator {
             if (catalogName == null || catalogName.isEmpty()) {
                 catalogName = database.getDefaultCatalogName();
             }
-            StringBuilder sql = new StringBuilder("SELECT sequence_name, \n")
-                    .append("CASE WHEN increment_by > 0 \n")
-                    .append("     THEN CASE WHEN min_value=1 THEN NULL ELSE min_value END\n")
-                    .append("     ELSE CASE WHEN min_value=(-999999999999999999999999999) THEN NULL else min_value END\n")
-                    .append("END AS min_value, \n")
-                    .append("CASE WHEN increment_by > 0 \n")
-                    .append("     THEN CASE WHEN max_value=999999999999999999999999999 THEN NULL ELSE max_value END\n")
-                    .append("     ELSE CASE WHEN max_value=last_number THEN NULL else max_value END \n")
-                    .append("END  AS max_value, \n")
-                    .append("CASE WHEN increment_by = 1 THEN NULL ELSE increment_by END AS increment_by, \n")
-                    .append("CASE WHEN cycle_flag = 'N' THEN NULL ELSE cycle_flag END AS will_cycle, \n")
-                    .append("CASE WHEN order_flag = 'N' THEN NULL ELSE order_flag END AS is_ordered, \n")
+            StringBuilder sql = new StringBuilder("SELECT SEQUENCE_NAME, \n")
+                    .append("MIN_VALUE, \n")
+                    .append("MAX_VALUE, \n")
+                    .append("INCREMENT_BY, \n")
+                    .append("CYCLE_FLAG AS WILL_CYCLE, \n")
+                    .append("ORDER_FLAG AS IS_ORDERED, \n")
                     .append("LAST_NUMBER as START_VALUE, \n")
-                    .append("CASE WHEN cache_size = 20 THEN NULL ELSE cache_size END AS cache_size \n")
+                    .append("CACHE_SIZE \n")
                     .append(String.format("FROM ALL_SEQUENCES WHERE SEQUENCE_OWNER = '%s'", catalogName));
             return new RawParameterizedSqlStatement(sql.toString());
         } else if (database instanceof PostgresDatabase) {


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

In commit 88beffd sequence configuration values with Oracle defaults have been converted to null to exclude them from the change log. Unfortunatelly this broke the ability to create correct diffs in the situation where the new state should be the default value (which is currently represented as null and therefore not included in the change log).

Restore capturing of all attributes like it is done for other databases and elements.

Fixes #6632

## Things to be aware of

Needs to be built and verified in the environment where we originally detected the issue.

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

No regression tests?

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
