### PR TITLE
Fix BIT column type handling for Postgres

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/datatype/core/BooleanType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/BooleanType.java
@@ -67,7 +67,7 @@ public class BooleanType extends LiquibaseDataType {
             return new DatabaseDataType("BOOLEAN");
         } else if (database instanceof PostgresDatabase) {
             if (originalDefinition.toLowerCase(Locale.US).startsWith("bit")) {
-                return new DatabaseDataType("BIT", getParameters());
+               return new DatabaseDataType("BOOLEAN");
             }
         } else if (database instanceof H2Database && getParameters().length > 0) {
           return new DatabaseDataType("BOOLEAN");

--- a/liquibase-standard/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
@@ -244,6 +244,7 @@ class DataTypeFactoryTest extends Specification {
         "java.sql.Types.TIMESTAMP(6)"                  | new PostgresDatabase() | "TIMESTAMP(6) WITHOUT TIME ZONE"               | TimestampType | false
         "java.sql.Types.TIMESTAMP_WITH_TIMEZONE"       | new PostgresDatabase() | "TIMESTAMP WITH TIME ZONE"                     | TimestampType | false
         "java.sql.Types.TIMESTAMP_WITH_TIMEZONE(6)"    | new PostgresDatabase() | "TIMESTAMP(6) WITH TIME ZONE"                  | TimestampType | false
+        "bit"                                          | new PostgresDatabase() | "BOOLEAN"                                      | BooleanType   | false
         "BINARY(16)"                                   | new H2Database()       | "BINARY(16)"                                   | BlobType      | false
         "timestamp"                                    | new H2Database()       | "TIMESTAMP"                                    | TimestampType | false
         "timestamp(6)"                                 | new H2Database()       | "TIMESTAMP(6)"                                 | TimestampType | false

--- a/liquibase-standard/src/test/groovy/liquibase/datatype/core/BooleanTypeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/datatype/core/BooleanTypeTest.groovy
@@ -1,0 +1,27 @@
+package liquibase.datatype.core
+
+import liquibase.database.core.PostgresDatabase
+import liquibase.datatype.DataTypeFactory
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class BooleanTypeTest extends Specification {
+
+    @Unroll
+    def "verify type '#inputType' on #database.shortName is converted to #expectedType with #expectedValue value"() {
+
+        when:
+        def type = DataTypeFactory.getInstance().fromDescription(inputType, database)
+
+        then:
+        type instanceof BooleanType
+        type.toDatabaseDataType(database).toString() == expectedType
+        type.objectToSql(inputValue, database) == expectedValue
+
+        where:
+        inputType | inputValue | database                   | expectedType | expectedValue
+        "bit"     | 0          | new PostgresDatabase()     | "BOOLEAN"    | "FALSE"
+        "BOOLEAN" | "FALSE"    | new PostgresDatabase()     | "BOOLEAN"    | "FALSE"
+        "BIT(1)"  | "TRUE"     | new PostgresDatabase()     | "BOOLEAN"    | "TRUE"
+    }
+}


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

Fixes #4677 

For a changeset like the one below:

```xml
<createTable name="T">
  <column defaultValueNumeric="0" name="c" type="BIT"/>
</createTable>
```

The below invalid SQL was being generated:

```
"c" BIT DEFAULT FALSE...
```

But even though it was:

```
"c" BIT DEFAULT 0
```

This is not allowed for Postgres. So basically, this PR is making `BIT` be treated and converted into a `BOOLEAN` type and then assigning the expected value. 

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
- Add unit/integration tests (ask for support if not sure how to do it)
- Make sure tests all pass
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
