### PR TITLE
🔧 DAT-19341: publish oss released assets to s3

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -539,32 +539,12 @@ jobs:
           
   #         done
             
-  publish_assets_to_internal_nexus:
+  publish_assets_to_s3_bucket:
     if: ${{ inputs.dry_run == false }}
-    name: Publish OSS released assets to repo.liquibase.net
+    name: Publish OSS released assets to s3 bucket liquibaseorg-origin
     needs: [ setup ]
     runs-on: ubuntu-22.04
-    env:
-      MAVEN_USERNAME: ${{ secrets.INTERNAL_NEXUS_USERNAME }}
-      MAVEN_PASSWORD: ${{ secrets.INTERNAL_NEXUS_PASSWORD }}
-      GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
     steps:
-      # Check in nexus if the folder with the version already exists, if exists exit with error code
-      - name: Check if the version already exists in nexus
-        id: check_version
-        run: |
-          version=${{ needs.setup.outputs.version }}
-          response=$(curl -u "$MAVEN_USERNAME:$MAVEN_PASSWORD" -s -o /dev/null -w "%{http_code}" \
-            "https://repo.liquibase.net/repository/oss-release-assets/${version}-release-assets/")
-          
-          if [ "$response" -eq 200 ]; then
-            echo "folder_exists=true" >> $GITHUB_ENV
-            echo "Error: Release assets for version ${version} already exist in Nexus."
-            exit 1
-          else
-            echo "folder_exists=false" >> $GITHUB_ENV
-          fi
-
       - name: Download released assets
         uses: robinraju/release-downloader@v1.11
         with:
@@ -573,18 +553,11 @@ jobs:
           fileName: "*"
           out-file-path: "./${{ needs.setup.outputs.version }}-released-assets"
 
-      - name: Publish to internal Nexus (repo.liquibase.net)
-        if: env.folder_exists == 'false'
+      - name: Publish to s3 bucket
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.LIQUIBASEORIGIN_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.LIQUIBASEORIGIN_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
         run: |
-          version=${{ needs.setup.outputs.version }}
-          for file in ./${{ needs.setup.outputs.version }}-released-assets/*; do
-            mvn deploy:deploy-file \
-              -DrepositoryId=${version}-release-assets \
-              -Durl=https://repo.liquibase.net/repository/oss-release-assets \
-              -Dfile="$file" \
-              -DgroupId=org.liquibase \
-              -DartifactId=liquibase \ 
-              -Dversion=${version} \
-              -Dpackaging=$(basename "$file" | cut -d'.' -f2-)
-          done
+          aws s3 sync "./${{ needs.setup.outputs.version }}-released-assets" s3://liquibaseorg-origin/${{ needs.setup.outputs.version }}-released-assets/ --only-show-errors
           

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -101,443 +101,443 @@ jobs:
             echo "branch=${{ inputs.dry_run_branch_name }}" >> $GITHUB_OUTPUT
           fi
 
-  manual_trigger_deployment:
-    if: ${{ inputs.dry_run == false }}
-    name: Manually trigger deployment
-    needs: [ setup ]
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Get Version to deploy
-        uses: trstringer/manual-approval@v1
-        with:
-          secret: ${{ secrets.GITHUB_TOKEN }}
-          approvers: suryaaki2,rberezen,jnewton03,kristyldatical,sayaliM0412
-          minimum-approvals: 2
-          issue-title: "Deploying ${{ needs.setup.outputs.version }} to sonatype"
-          issue-body: "Please approve or deny the deployment of version ${{ needs.setup.outputs.version }}"
-          additional-approved-words: 'lgtm,✅,👍,proceed,shipit,:shipit:'
-          additional-denied-words: 'stop,error,failed,fail,broken,:x:,👎'
+  # manual_trigger_deployment:
+  #   if: ${{ inputs.dry_run == false }}
+  #   name: Manually trigger deployment
+  #   needs: [ setup ]
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - name: Get Version to deploy
+  #       uses: trstringer/manual-approval@v1
+  #       with:
+  #         secret: ${{ secrets.GITHUB_TOKEN }}
+  #         approvers: suryaaki2,rberezen,jnewton03,kristyldatical,sayaliM0412
+  #         minimum-approvals: 2
+  #         issue-title: "Deploying ${{ needs.setup.outputs.version }} to sonatype"
+  #         issue-body: "Please approve or deny the deployment of version ${{ needs.setup.outputs.version }}"
+  #         additional-approved-words: 'lgtm,✅,👍,proceed,shipit,:shipit:'
+  #         additional-denied-words: 'stop,error,failed,fail,broken,:x:,👎'
 
-  deploy_maven:
-    if: ${{ inputs.dry_run == false }}
-    name: Deploy to Maven
-    needs: [ setup, manual_trigger_deployment, deploy_javadocs, publish_to_github_packages, deploy_xsd, release-docker ]
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Download release assets
-        uses: robinraju/release-downloader@v1.11
-        with:
-          repository: "liquibase/liquibase"
-          tag: "${{ needs.setup.outputs.tag }}"
-          fileName: "*"
-          out-file-path: "."
+  # deploy_maven:
+  #   if: ${{ inputs.dry_run == false }}
+  #   name: Deploy to Maven
+  #   needs: [ setup, manual_trigger_deployment, deploy_javadocs, publish_to_github_packages, deploy_xsd, release-docker ]
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - name: Download release assets
+  #       uses: robinraju/release-downloader@v1.11
+  #       with:
+  #         repository: "liquibase/liquibase"
+  #         tag: "${{ needs.setup.outputs.tag }}"
+  #         fileName: "*"
+  #         out-file-path: "."
 
-      - name: Set up Java for publishing to Maven Central Repository
-        uses: actions/setup-java@v4
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-          server-id: sonatype-nexus-staging
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-          gpg-private-key: ${{ secrets.GPG_SECRET }}
-          gpg-passphrase: GPG_PASSPHRASE
-        env:
-          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+  #     - name: Set up Java for publishing to Maven Central Repository
+  #       uses: actions/setup-java@v4
+  #       with:
+  #         java-version: '11'
+  #         distribution: 'adopt'
+  #         server-id: sonatype-nexus-staging
+  #         server-username: MAVEN_USERNAME
+  #         server-password: MAVEN_PASSWORD
+  #         gpg-private-key: ${{ secrets.GPG_SECRET }}
+  #         gpg-passphrase: GPG_PASSPHRASE
+  #       env:
+  #         GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Publish to Maven Central
-        env:
-          MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.SONATYPE_TOKEN }}
-          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
-        run: |
-          version=${{ needs.setup.outputs.version }}
+  #     - name: Publish to Maven Central
+  #       env:
+  #         MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+  #         MAVEN_PASSWORD: ${{ secrets.SONATYPE_TOKEN }}
+  #         GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+  #       run: |
+  #         version=${{ needs.setup.outputs.version }}
 
-          unzip -j liquibase-additional-*.zip
+  #         unzip -j liquibase-additional-*.zip
 
-          ##extracts and sign poms
-          for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-cdi' 'liquibase-cdi-jakarta' 'liquibase-commercial'; do
-            unzip -j $i-${version}.jar META-INF/maven/org.liquibase/$i/pom.xml
-            sed -i -e "s/<version>\(release\|master\)-SNAPSHOT<\/version>/<version>${version}<\/version>/" pom.xml
-            mv pom.xml $i-${version}.pom
-            if test 'liquibase-commercial' == $i; then
-              sed -i -e "s/<\/licenses>/<\/licenses><scm><connection>private<\/connection><developerConnection>private<\/developerConnection><url>private<\/url><\/scm>/" $i-${version}.pom   ## scm info not in the pom
-            fi
+  #         ##extracts and sign poms
+  #         for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-cdi' 'liquibase-cdi-jakarta' 'liquibase-commercial'; do
+  #           unzip -j $i-${version}.jar META-INF/maven/org.liquibase/$i/pom.xml
+  #           sed -i -e "s/<version>\(release\|master\)-SNAPSHOT<\/version>/<version>${version}<\/version>/" pom.xml
+  #           mv pom.xml $i-${version}.pom
+  #           if test 'liquibase-commercial' == $i; then
+  #             sed -i -e "s/<\/licenses>/<\/licenses><scm><connection>private<\/connection><developerConnection>private<\/developerConnection><url>private<\/url><\/scm>/" $i-${version}.pom   ## scm info not in the pom
+  #           fi
           
-            gpg --batch --pinentry-mode=loopback --passphrase "$GPG_PASSWORD" -ab $i-${version}.pom
+  #           gpg --batch --pinentry-mode=loopback --passphrase "$GPG_PASSWORD" -ab $i-${version}.pom
           
-            mvn -B org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1:deploy-file \
-              -Durl=https://oss.sonatype.org/service/local/staging/deploy/maven2/ \
-              -DrepositoryId=sonatype-nexus-staging \
-              -DpomFile=$i-${version}.pom \
-              -DgeneratePom=false \
-              -Dfile=$i-${version}.jar \
-              -Dsources=$i-${version}-sources.jar \
-              -Djavadoc=$i-${version}-javadoc.jar \
-              -Dfiles=$i-${version}.jar.asc,$i-${version}-sources.jar.asc,$i-${version}-javadoc.jar.asc,$i-${version}.pom.asc \
-              -Dtypes=jar.asc,jar.asc,jar.asc,pom.asc \
-              -Dclassifiers=,sources,javadoc,
-          done
+  #           mvn -B org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1:deploy-file \
+  #             -Durl=https://oss.sonatype.org/service/local/staging/deploy/maven2/ \
+  #             -DrepositoryId=sonatype-nexus-staging \
+  #             -DpomFile=$i-${version}.pom \
+  #             -DgeneratePom=false \
+  #             -Dfile=$i-${version}.jar \
+  #             -Dsources=$i-${version}-sources.jar \
+  #             -Djavadoc=$i-${version}-javadoc.jar \
+  #             -Dfiles=$i-${version}.jar.asc,$i-${version}-sources.jar.asc,$i-${version}-javadoc.jar.asc,$i-${version}.pom.asc \
+  #             -Dtypes=jar.asc,jar.asc,jar.asc,pom.asc \
+  #             -Dclassifiers=,sources,javadoc,
+  #         done
 
-          ## Release repository
-          ## Have to find the stagingRepositoryId that was auto-generated
-          api_output=$(curl -s -u "${{ secrets.SONATYPE_USERNAME }}:${{ secrets.SONATYPE_TOKEN }}" "https://oss.sonatype.org/service/local/staging/profile_repositories")
-          # Extract ids of repositories-item containing the string "liquibase"
-          repositories=$(echo "$api_output" | grep -B 8 "liquibase" | grep "<repositoryId>" | awk -F"<|>" '{print $3}')
-          echo "Repository IDs containing 'liquibase': $repositories"
-          for repo_id in $repositories; do
-            echo "Check if $repo_id repository is an extension"
-            api_output=$(curl -s -u "${{ secrets.SONATYPE_USERNAME }}:${{ secrets.SONATYPE_TOKEN }}" "https://oss.sonatype.org/service/local/repositories/$repo_id/content/org/liquibase/")
-            relative_path=$(echo "$api_output" | grep -oP '<relativePath>\K[^<]+' | awk 'NR==1')
-            echo "Relative path: $relative_path"
-            if [[ "$relative_path" == *"/org/liquibase/ext/"* ]]; then
-                echo "Relative path contains '/org/liquibase/ext/'. It is an extension."
-            else
-                echo "Relative path does not contain '/org/liquibase/ext/'. It is not an extension."
-                stagingRepositoryId=$repo_id
-                break
-            fi
-          done
+  #         ## Release repository
+  #         ## Have to find the stagingRepositoryId that was auto-generated
+  #         api_output=$(curl -s -u "${{ secrets.SONATYPE_USERNAME }}:${{ secrets.SONATYPE_TOKEN }}" "https://oss.sonatype.org/service/local/staging/profile_repositories")
+  #         # Extract ids of repositories-item containing the string "liquibase"
+  #         repositories=$(echo "$api_output" | grep -B 8 "liquibase" | grep "<repositoryId>" | awk -F"<|>" '{print $3}')
+  #         echo "Repository IDs containing 'liquibase': $repositories"
+  #         for repo_id in $repositories; do
+  #           echo "Check if $repo_id repository is an extension"
+  #           api_output=$(curl -s -u "${{ secrets.SONATYPE_USERNAME }}:${{ secrets.SONATYPE_TOKEN }}" "https://oss.sonatype.org/service/local/repositories/$repo_id/content/org/liquibase/")
+  #           relative_path=$(echo "$api_output" | grep -oP '<relativePath>\K[^<]+' | awk 'NR==1')
+  #           echo "Relative path: $relative_path"
+  #           if [[ "$relative_path" == *"/org/liquibase/ext/"* ]]; then
+  #               echo "Relative path contains '/org/liquibase/ext/'. It is an extension."
+  #           else
+  #               echo "Relative path does not contain '/org/liquibase/ext/'. It is not an extension."
+  #               stagingRepositoryId=$repo_id
+  #               break
+  #           fi
+  #         done
 
-          echo "Staging Repository Id: $stagingRepositoryId"
+  #         echo "Staging Repository Id: $stagingRepositoryId"
 
-          mvn org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8:rc-close \
-            -DnexusUrl=https://oss.sonatype.org/ \
-            -DserverId=sonatype-nexus-staging \
-            -DstagingRepositoryId=$stagingRepositoryId \
-            -DstagingProgressTimeoutMinutes=10
+  #         mvn org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8:rc-close \
+  #           -DnexusUrl=https://oss.sonatype.org/ \
+  #           -DserverId=sonatype-nexus-staging \
+  #           -DstagingRepositoryId=$stagingRepositoryId \
+  #           -DstagingProgressTimeoutMinutes=10
 
-          mvn org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8:rc-release \
-            -DautoDropAfterRelease=true \
-            -DnexusUrl=https://oss.sonatype.org/ \
-            -DserverId=sonatype-nexus-staging \
-            -DstagingRepositoryId=$stagingRepositoryId \
-            -DstagingProgressTimeoutMinutes=10
+  #         mvn org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8:rc-release \
+  #           -DautoDropAfterRelease=true \
+  #           -DnexusUrl=https://oss.sonatype.org/ \
+  #           -DserverId=sonatype-nexus-staging \
+  #           -DstagingRepositoryId=$stagingRepositoryId \
+  #           -DstagingProgressTimeoutMinutes=10
 
-  deploy_javadocs:
-    if: ${{ inputs.dry_run == false }}
-    name: Upload Javadocs
-    needs: [ setup, manual_trigger_deployment ]
-    runs-on: ubuntu-22.04
-    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Download release javadocs
-        uses: robinraju/release-downloader@v1.11
-        with:
-          repository: "liquibase/liquibase"
-          tag: "${{ needs.setup.outputs.tag }}"
-          fileName: "liquibase-additional*.zip"
-          out-file-path: "."
+  # deploy_javadocs:
+  #   if: ${{ inputs.dry_run == false }}
+  #   name: Upload Javadocs
+  #   needs: [ setup, manual_trigger_deployment ]
+  #   runs-on: ubuntu-22.04
+  #   # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #     - name: Download release javadocs
+  #       uses: robinraju/release-downloader@v1.11
+  #       with:
+  #         repository: "liquibase/liquibase"
+  #         tag: "${{ needs.setup.outputs.tag }}"
+  #         fileName: "liquibase-additional*.zip"
+  #         out-file-path: "."
 
-      - name: Unpack javadoc files and upload to s3
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.JAVADOCS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.JAVADOCS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: us-east-1
-        # unzip archives, create directory for each jar, and extract jar contents to directory.  Then delete the jar and zip files.  Then upload to s3.
-        run: |
-          unzip -j '*.zip' '*javadoc*.jar' 
+  #     - name: Unpack javadoc files and upload to s3
+  #       env:
+  #         AWS_ACCESS_KEY_ID: ${{ secrets.JAVADOCS_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.JAVADOCS_SECRET_ACCESS_KEY }}
+  #         AWS_DEFAULT_REGION: us-east-1
+  #       # unzip archives, create directory for each jar, and extract jar contents to directory.  Then delete the jar and zip files.  Then upload to s3.
+  #       run: |
+  #         unzip -j '*.zip' '*javadoc*.jar' 
           
-          for jar in *liquibase*.jar; do
-            dir_name=$(basename "$jar" .jar)
-            dir_name=$(echo "$dir_name" | sed -E 's/(-[0-9]+(\.[0-9]+)*(-javadoc)?)//')
-            mkdir -p "$dir_name"
-            unzip -o "$jar" -d "$dir_name"
-          done
+  #         for jar in *liquibase*.jar; do
+  #           dir_name=$(basename "$jar" .jar)
+  #           dir_name=$(echo "$dir_name" | sed -E 's/(-[0-9]+(\.[0-9]+)*(-javadoc)?)//')
+  #           mkdir -p "$dir_name"
+  #           unzip -o "$jar" -d "$dir_name"
+  #         done
           
-          rm -rf *.jar *.zip
-          aws s3 sync . s3://javadocsliquibasecom-origin --only-show-errors
+  #         rm -rf *.jar *.zip
+  #         aws s3 sync . s3://javadocsliquibasecom-origin --only-show-errors
 
-  publish_to_github_packages:
-    if: ${{ inputs.dry_run == false }}
-    name: Publish artifacts to Github Packages
-    runs-on: ubuntu-22.04
-    needs: [ setup, manual_trigger_deployment ]
-    permissions:
-      contents: read
-      packages: write
+  # publish_to_github_packages:
+  #   if: ${{ inputs.dry_run == false }}
+  #   name: Publish artifacts to Github Packages
+  #   runs-on: ubuntu-22.04
+  #   needs: [ setup, manual_trigger_deployment ]
+  #   permissions:
+  #     contents: read
+  #     packages: write
 
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Java for publishing to GitHub Repository
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'maven'
-          server-id: liquibase
-      - name: Set up Maven
-        uses: stCarolas/setup-maven@v5
-        with:
-          maven-version: ${{ env.MAVEN_VERSION }}
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Set up Java for publishing to GitHub Repository
+  #       uses: actions/setup-java@v4
+  #       with:
+  #         java-version: '17'
+  #         distribution: 'temurin'
+  #         cache: 'maven'
+  #         server-id: liquibase
+  #     - name: Set up Maven
+  #       uses: stCarolas/setup-maven@v5
+  #       with:
+  #         maven-version: ${{ env.MAVEN_VERSION }}
 
-      - name: Version artifact
-        run: mvn versions:set -DnewVersion="${{ needs.setup.outputs.version }}"
+  #     - name: Version artifact
+  #       run: mvn versions:set -DnewVersion="${{ needs.setup.outputs.version }}"
 
-      # Publish to GitHub Packages
-      - name: Publish package to Github
-        run: mvn -B clean deploy -DskipTests=true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TARGET_ARTIFACT_REPOSITORY: liquibase
+  #     # Publish to GitHub Packages
+  #     - name: Publish package to Github
+  #       run: mvn -B clean deploy -DskipTests=true
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         TARGET_ARTIFACT_REPOSITORY: liquibase
 
-  deploy_xsd:
-    if: ${{ inputs.dry_run == false }}
-    name: Upload xsds
-    needs: [ setup, manual_trigger_deployment]
-    runs-on: ubuntu-22.04
-    outputs:
-      tag: ${{ steps.collect-data.outputs.tag }}
-      version: ${{ needs.setup.outputs.version }}
-    steps:
-      - name: Download liquibase xsd
-        uses: actions/checkout@v4
-        with:
-          # Relative path under $GITHUB_WORKSPACE to place the repository
-          path: liquibase-core-repo
-          repository: "liquibase/liquibase"
+  # deploy_xsd:
+  #   if: ${{ inputs.dry_run == false }}
+  #   name: Upload xsds
+  #   needs: [ setup, manual_trigger_deployment]
+  #   runs-on: ubuntu-22.04
+  #   outputs:
+  #     tag: ${{ steps.collect-data.outputs.tag }}
+  #     version: ${{ needs.setup.outputs.version }}
+  #   steps:
+  #     - name: Download liquibase xsd
+  #       uses: actions/checkout@v4
+  #       with:
+  #         # Relative path under $GITHUB_WORKSPACE to place the repository
+  #         path: liquibase-core-repo
+  #         repository: "liquibase/liquibase"
 
-      - name: Download liquibase-pro xsd
-        uses: actions/checkout@v4
-        with:
-          ref: "${{ needs.setup.outputs.ref_branch }}"
-          token: ${{ secrets.BOT_TOKEN }}
-          # Relative path under $GITHUB_WORKSPACE to place the repository
-          path: liquibase-pro-repo
-          repository: "liquibase/liquibase-pro"
+  #     - name: Download liquibase-pro xsd
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: "${{ needs.setup.outputs.ref_branch }}"
+  #         token: ${{ secrets.BOT_TOKEN }}
+  #         # Relative path under $GITHUB_WORKSPACE to place the repository
+  #         path: liquibase-pro-repo
+  #         repository: "liquibase/liquibase-pro"
 
-      - name: Upload to s3
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.LIQUIBASEORIGIN_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.LIQUIBASEORIGIN_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: us-east-1
-        # aws s3 sync syncs directories and S3 prefixes.
-        run: |
-          aws s3 sync liquibase-pro-repo/pro/src/main/resources/www.liquibase.org/xml/ns/pro/ s3://liquibaseorg-origin/xml/ns/pro/ --content-type application/octet-stream --only-show-errors
-          aws s3 sync liquibase-core-repo/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/ s3://liquibaseorg-origin/xml/ns/dbchangelog/ --content-type application/octet-stream --only-show-errors
-          aws s3 sync liquibase-pro-repo/pro/src/main/resources/schemas/ s3://liquibaseorg-origin/json/schema/ --content-type application/octet-stream --only-show-errors
+  #     - name: Upload to s3
+  #       env:
+  #         AWS_ACCESS_KEY_ID: ${{ secrets.LIQUIBASEORIGIN_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.LIQUIBASEORIGIN_SECRET_ACCESS_KEY }}
+  #         AWS_DEFAULT_REGION: us-east-1
+  #       # aws s3 sync syncs directories and S3 prefixes.
+  #       run: |
+  #         aws s3 sync liquibase-pro-repo/pro/src/main/resources/www.liquibase.org/xml/ns/pro/ s3://liquibaseorg-origin/xml/ns/pro/ --content-type application/octet-stream --only-show-errors
+  #         aws s3 sync liquibase-core-repo/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/ s3://liquibaseorg-origin/xml/ns/dbchangelog/ --content-type application/octet-stream --only-show-errors
+  #         aws s3 sync liquibase-pro-repo/pro/src/main/resources/schemas/ s3://liquibaseorg-origin/json/schema/ --content-type application/octet-stream --only-show-errors
 
-      - name: Index.htm file upload
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.LIQUIBASEORIGIN_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.LIQUIBASEORIGIN_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: us-east-1
-        # get the major.minor xsd version. grab the index.htm from s3, add the new verison of xsd and sync with the s3 again
-        run: |
-          version=${{ needs.setup.outputs.version }}
-          arr=(${version//./ })
-          xsd_version=${arr[0]}"."${arr[1]}
-          mkdir index-file
-          aws s3 cp s3://liquibaseorg-origin/xml/ns/dbchangelog/index.htm index-file
-          if ! grep -q ${xsd_version} index-file/index.htm ; then
-            sed -ie "s/<\/ul>/  <li><a href=\"\/xml\/ns\/dbchangelog\/dbchangelog-${xsd_version}.xsd\">dbchangelog-${xsd_version}.xsd<\/a><\/li>\n<\/ul>/" index-file/index.htm
-            aws s3 sync index-file s3://liquibaseorg-origin/xml/ns/dbchangelog/ --only-show-errors
-          fi
+  #     - name: Index.htm file upload
+  #       env:
+  #         AWS_ACCESS_KEY_ID: ${{ secrets.LIQUIBASEORIGIN_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.LIQUIBASEORIGIN_SECRET_ACCESS_KEY }}
+  #         AWS_DEFAULT_REGION: us-east-1
+  #       # get the major.minor xsd version. grab the index.htm from s3, add the new verison of xsd and sync with the s3 again
+  #       run: |
+  #         version=${{ needs.setup.outputs.version }}
+  #         arr=(${version//./ })
+  #         xsd_version=${arr[0]}"."${arr[1]}
+  #         mkdir index-file
+  #         aws s3 cp s3://liquibaseorg-origin/xml/ns/dbchangelog/index.htm index-file
+  #         if ! grep -q ${xsd_version} index-file/index.htm ; then
+  #           sed -ie "s/<\/ul>/  <li><a href=\"\/xml\/ns\/dbchangelog\/dbchangelog-${xsd_version}.xsd\">dbchangelog-${xsd_version}.xsd<\/a><\/li>\n<\/ul>/" index-file/index.htm
+  #           aws s3 sync index-file s3://liquibaseorg-origin/xml/ns/dbchangelog/ --only-show-errors
+  #         fi
 
-      - name: Liquibase xsds SFTP upload
-        uses: wangyucode/sftp-upload-action@v2.0.4
-        with:
-          host: ${{ secrets.WPENGINE_SFTP_HOST }}
-          port: ${{ secrets.WPENGINE_SFTP_PORT }}
-          username: ${{ secrets.WPENGINE_SFTP_USER }}
-          password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
-          compress: true
-          forceUpload: true
-          localDir: 'liquibase-core-repo/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/'
-          remoteDir: '/xml/ns/dbchangelog/'
+  #     - name: Liquibase xsds SFTP upload
+  #       uses: wangyucode/sftp-upload-action@v2.0.4
+  #       with:
+  #         host: ${{ secrets.WPENGINE_SFTP_HOST }}
+  #         port: ${{ secrets.WPENGINE_SFTP_PORT }}
+  #         username: ${{ secrets.WPENGINE_SFTP_USER }}
+  #         password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
+  #         compress: true
+  #         forceUpload: true
+  #         localDir: 'liquibase-core-repo/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/'
+  #         remoteDir: '/xml/ns/dbchangelog/'
 
-      - name: Liquibase PRO xsds SFTP upload
-        uses: wangyucode/sftp-upload-action@v2.0.4
-        with:
-          host: ${{ secrets.WPENGINE_SFTP_HOST }}
-          port: ${{ secrets.WPENGINE_SFTP_PORT }}
-          username: ${{ secrets.WPENGINE_SFTP_USER }}
-          password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
-          compress: false
-          forceUpload: true
-          localDir: 'liquibase-pro-repo/pro/src/main/resources/www.liquibase.org/xml/ns/pro/'
-          remoteDir: '/xml/ns/pro/'
+  #     - name: Liquibase PRO xsds SFTP upload
+  #       uses: wangyucode/sftp-upload-action@v2.0.4
+  #       with:
+  #         host: ${{ secrets.WPENGINE_SFTP_HOST }}
+  #         port: ${{ secrets.WPENGINE_SFTP_PORT }}
+  #         username: ${{ secrets.WPENGINE_SFTP_USER }}
+  #         password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
+  #         compress: false
+  #         forceUpload: true
+  #         localDir: 'liquibase-pro-repo/pro/src/main/resources/www.liquibase.org/xml/ns/pro/'
+  #         remoteDir: '/xml/ns/pro/'
 
-      - name: Liquibase flow-file schema SFTP upload
-        uses: wangyucode/sftp-upload-action@v2.0.4
-        with:
-          host: ${{ secrets.WPENGINE_SFTP_HOST }}
-          port: ${{ secrets.WPENGINE_SFTP_PORT }}
-          username: ${{ secrets.WPENGINE_SFTP_USER }}
-          password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
-          compress: false
-          forceUpload: true
-          localDir: 'liquibase-pro-repo/pro/src/main/resources/schemas/'
-          remoteDir: '/json/schema/'
+  #     - name: Liquibase flow-file schema SFTP upload
+  #       uses: wangyucode/sftp-upload-action@v2.0.4
+  #       with:
+  #         host: ${{ secrets.WPENGINE_SFTP_HOST }}
+  #         port: ${{ secrets.WPENGINE_SFTP_PORT }}
+  #         username: ${{ secrets.WPENGINE_SFTP_USER }}
+  #         password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
+  #         compress: false
+  #         forceUpload: true
+  #         localDir: 'liquibase-pro-repo/pro/src/main/resources/schemas/'
+  #         remoteDir: '/json/schema/'
 
-      - name: Liquibase index.htm SFTP upload
-        uses: wangyucode/sftp-upload-action@v2.0.4
-        with:
-          host: ${{ secrets.WPENGINE_SFTP_HOST }}
-          port: ${{ secrets.WPENGINE_SFTP_PORT }}
-          username: ${{ secrets.WPENGINE_SFTP_USER }}
-          password: ${{ secrets.WPENGINE_SFTP_PASSWORD }} 
-          compress: false
-          forceUpload: true
-          localDir: 'index-file/'
-          remoteDir: '/xml/ns/dbchangelog/'
+  #     - name: Liquibase index.htm SFTP upload
+  #       uses: wangyucode/sftp-upload-action@v2.0.4
+  #       with:
+  #         host: ${{ secrets.WPENGINE_SFTP_HOST }}
+  #         port: ${{ secrets.WPENGINE_SFTP_PORT }}
+  #         username: ${{ secrets.WPENGINE_SFTP_USER }}
+  #         password: ${{ secrets.WPENGINE_SFTP_PASSWORD }} 
+  #         compress: false
+  #         forceUpload: true
+  #         localDir: 'index-file/'
+  #         remoteDir: '/xml/ns/dbchangelog/'
 
-  release-docker:
-    if: always()
-    name: Release docker images
-    needs: [ setup, manual_trigger_deployment ]
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Release liquibase/docker v${{ needs.setup.outputs.version }}
-        uses: codex-/return-dispatch@v2
-        id: docker_dispatch
-        with:
-          token: ${{ secrets.BOT_TOKEN }}
-          ref: main
-          repo: docker
-          owner: liquibase
-          workflow: create-release.yml
-          workflow_inputs: '{ "liquibaseVersion": "${{ needs.setup.outputs.version }}", "dryRun": "${{ inputs.dry_run || false }}" }'
-          workflow_timeout_seconds: 300
-          workflow_job_steps_retry_seconds: 10
+  # release-docker:
+  #   if: always()
+  #   name: Release docker images
+  #   needs: [ setup, manual_trigger_deployment ]
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - name: Release liquibase/docker v${{ needs.setup.outputs.version }}
+  #       uses: codex-/return-dispatch@v2
+  #       id: docker_dispatch
+  #       with:
+  #         token: ${{ secrets.BOT_TOKEN }}
+  #         ref: main
+  #         repo: docker
+  #         owner: liquibase
+  #         workflow: create-release.yml
+  #         workflow_inputs: '{ "liquibaseVersion": "${{ needs.setup.outputs.version }}", "dryRun": "${{ inputs.dry_run || false }}" }'
+  #         workflow_timeout_seconds: 300
+  #         workflow_job_steps_retry_seconds: 10
 
-      - name: Adding Docker run to job summary
-        if: success()
-        continue-on-error: true
-        run: echo '### 🐳 Docker Release Job -> ${{steps.docker_dispatch.outputs.run_url}}' >> $GITHUB_STEP_SUMMARY
+  #     - name: Adding Docker run to job summary
+  #       if: success()
+  #       continue-on-error: true
+  #       run: echo '### 🐳 Docker Release Job -> ${{steps.docker_dispatch.outputs.run_url}}' >> $GITHUB_STEP_SUMMARY
 
-  generate-PRO-tag:
-    if: ${{ inputs.dry_run == false }}
-    name: Generate PRO tags based on OSS release
-    needs: [ setup ]
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
-          repository: liquibase/liquibase-pro
-          event-type: oss-released-tag
+  # generate-PRO-tag:
+  #   if: ${{ inputs.dry_run == false }}
+  #   name: Generate PRO tags based on OSS release
+  #   needs: [ setup ]
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - name: Repository Dispatch
+  #       uses: peter-evans/repository-dispatch@v3
+  #       with:
+  #         token: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
+  #         repository: liquibase/liquibase-pro
+  #         event-type: oss-released-tag
 
-  package:
-    uses: liquibase/build-logic/.github/workflows/package.yml@main
-    needs: [ setup ]
-    secrets: inherit
-    with:
-      groupId: 'org.liquibase'
-      artifactId: 'liquibase'
-      version: ${{ needs.setup.outputs.version }}
-      dry_run: ${{ inputs.dry_run || false}}
-      dry_run_zip_url: ${{ inputs.dry_run_zip_url || '' }}
-      dry_run_tar_gz_url: ${{ inputs.dry_run_tar_gz_url || '' }}
+  # package:
+  #   uses: liquibase/build-logic/.github/workflows/package.yml@main
+  #   needs: [ setup ]
+  #   secrets: inherit
+  #   with:
+  #     groupId: 'org.liquibase'
+  #     artifactId: 'liquibase'
+  #     version: ${{ needs.setup.outputs.version }}
+  #     dry_run: ${{ inputs.dry_run || false}}
+  #     dry_run_zip_url: ${{ inputs.dry_run_zip_url || '' }}
+  #     dry_run_tar_gz_url: ${{ inputs.dry_run_tar_gz_url || '' }}
 
-  update-docs-oss-pro-version:
-    if: ${{ inputs.dry_run == false }}
-    name: Update OSS and PRO tags based on OSS release
-    needs: [ setup ]
-    runs-on: ubuntu-latest
-    outputs:
-      latest_version: ${{ steps.get_latest_oss_version.outputs.latest_version }}
-      previous_version: ${{ steps.get_latest_oss_version.outputs.previous_version }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          repository: liquibase/liquibase
-          ref: "${{ needs.setup.outputs.ref_branch }}"
-          fetch-depth: 0
+  # update-docs-oss-pro-version:
+  #   if: ${{ inputs.dry_run == false }}
+  #   name: Update OSS and PRO tags based on OSS release
+  #   needs: [ setup ]
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     latest_version: ${{ steps.get_latest_oss_version.outputs.latest_version }}
+  #     previous_version: ${{ steps.get_latest_oss_version.outputs.previous_version }}
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v4
+  #       with:
+  #         repository: liquibase/liquibase
+  #         ref: "${{ needs.setup.outputs.ref_branch }}"
+  #         fetch-depth: 0
 
-      - name: Get the oss release version
-        id: get_latest_oss_version
-        run: |
-            # Fetch all tags from the remote
-            git fetch --tags
-            # Get the latest tag
-            echo "latest_version=$(git describe --tags $(git rev-list --tags --max-count=1) | sed 's/^v//')" >> $GITHUB_OUTPUT
-            # Get the previous released version tag
-            echo "previous_version=$(git for-each-ref --sort=creatordate --format '%(tag)' refs/tags|tail -2|head -1| sed 's/^v//')" >> $GITHUB_OUTPUT
+  #     - name: Get the oss release version
+  #       id: get_latest_oss_version
+  #       run: |
+  #           # Fetch all tags from the remote
+  #           git fetch --tags
+  #           # Get the latest tag
+  #           echo "latest_version=$(git describe --tags $(git rev-list --tags --max-count=1) | sed 's/^v//')" >> $GITHUB_OUTPUT
+  #           # Get the previous released version tag
+  #           echo "previous_version=$(git for-each-ref --sort=creatordate --format '%(tag)' refs/tags|tail -2|head -1| sed 's/^v//')" >> $GITHUB_OUTPUT
 
 
-      - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
-          repository: liquibase/liquibase-docs
-          event-type: oss-released-version
-          client-payload: '{"latest_version": "${{ steps.get_latest_oss_version.outputs.latest_version }}", "previous_version": "${{ steps.get_latest_oss_version.outputs.previous_version }}"}'
+  #     - name: Repository Dispatch
+  #       uses: peter-evans/repository-dispatch@v3
+  #       with:
+  #         token: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
+  #         repository: liquibase/liquibase-docs
+  #         event-type: oss-released-version
+  #         client-payload: '{"latest_version": "${{ steps.get_latest_oss_version.outputs.latest_version }}", "previous_version": "${{ steps.get_latest_oss_version.outputs.previous_version }}"}'
 
-      # dispatch an event to `liquibase-aws-license-service` repository to update pom.xml with latest OSS Release
-      - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
-          repository: liquibase/liquibase-aws-license-service
-          event-type: oss-released-version
+  #     # dispatch an event to `liquibase-aws-license-service` repository to update pom.xml with latest OSS Release
+  #     - name: Repository Dispatch
+  #       uses: peter-evans/repository-dispatch@v3
+  #       with:
+  #         token: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
+  #         repository: liquibase/liquibase-aws-license-service
+  #         event-type: oss-released-version
 
-  dry_run_deploy_maven:
-    if: ${{ inputs.dry_run == true }}
-    name: Deploy to repo.liquibase.net
-    needs: [ setup ]
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Download dry-run release assets
-        uses: robinraju/release-downloader@v1.11
-        with:
-          repository: "liquibase/liquibase"
-          releaseId: "${{ inputs.dry_run_release_id }}"
-          fileName: "*"
-          out-file-path: "."
+  # dry_run_deploy_maven:
+  #   if: ${{ inputs.dry_run == true }}
+  #   name: Deploy to repo.liquibase.net
+  #   needs: [ setup ]
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - name: Download dry-run release assets
+  #       uses: robinraju/release-downloader@v1.11
+  #       with:
+  #         repository: "liquibase/liquibase"
+  #         releaseId: "${{ inputs.dry_run_release_id }}"
+  #         fileName: "*"
+  #         out-file-path: "."
 
-      - name: Set up Java for publishing to Maven Central Repository
-        uses: actions/setup-java@v4
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-          server-id: dry-run-sonatype-nexus-staging
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-          gpg-private-key: ${{ secrets.GPG_SECRET }}
-          gpg-passphrase: GPG_PASSPHRASE
-        env:
-          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+  #     - name: Set up Java for publishing to Maven Central Repository
+  #       uses: actions/setup-java@v4
+  #       with:
+  #         java-version: '11'
+  #         distribution: 'adopt'
+  #         server-id: dry-run-sonatype-nexus-staging
+  #         server-username: MAVEN_USERNAME
+  #         server-password: MAVEN_PASSWORD
+  #         gpg-private-key: ${{ secrets.GPG_SECRET }}
+  #         gpg-passphrase: GPG_PASSPHRASE
+  #       env:
+  #         GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Publish to repo.liquibase.net
-        env:
-          MAVEN_USERNAME: ${{ secrets.REPO_LIQUIBASE_NET_USER }}
-          MAVEN_PASSWORD: ${{ secrets.REPO_LIQUIBASE_NET_PASSWORD }}
-          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
-        run: |
-          version=${{ needs.setup.outputs.version }}
+  #     - name: Publish to repo.liquibase.net
+  #       env:
+  #         MAVEN_USERNAME: ${{ secrets.REPO_LIQUIBASE_NET_USER }}
+  #         MAVEN_PASSWORD: ${{ secrets.REPO_LIQUIBASE_NET_PASSWORD }}
+  #         GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+  #       run: |
+  #         version=${{ needs.setup.outputs.version }}
 
-          unzip -j liquibase-additional-*.zip
+  #         unzip -j liquibase-additional-*.zip
 
-          ##extracts and sign poms
-          for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-cdi' 'liquibase-cdi-jakarta' 'liquibase-commercial'; do
-            unzip -j $i-${version}.jar META-INF/maven/org.liquibase/$i/pom.xml
-            sed -i -e "s/<version>\(release\|master\)-SNAPSHOT<\/version>/<version>${version}<\/version>/" pom.xml
-            mv pom.xml $i-${version}.pom
-            if test 'liquibase-commercial' == $i; then
-              sed -i -e "s/<\/licenses>/<\/licenses><scm><connection>private<\/connection><developerConnection>private<\/developerConnection><url>private<\/url><\/scm>/" $i-${version}.pom   ## scm info not in the pom
-            fi
+  #         ##extracts and sign poms
+  #         for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-cdi' 'liquibase-cdi-jakarta' 'liquibase-commercial'; do
+  #           unzip -j $i-${version}.jar META-INF/maven/org.liquibase/$i/pom.xml
+  #           sed -i -e "s/<version>\(release\|master\)-SNAPSHOT<\/version>/<version>${version}<\/version>/" pom.xml
+  #           mv pom.xml $i-${version}.pom
+  #           if test 'liquibase-commercial' == $i; then
+  #             sed -i -e "s/<\/licenses>/<\/licenses><scm><connection>private<\/connection><developerConnection>private<\/developerConnection><url>private<\/url><\/scm>/" $i-${version}.pom   ## scm info not in the pom
+  #           fi
           
-            gpg --batch --pinentry-mode=loopback --passphrase "$GPG_PASSWORD" -ab $i-${version}.pom
+  #           gpg --batch --pinentry-mode=loopback --passphrase "$GPG_PASSWORD" -ab $i-${version}.pom
           
-            mvn -B org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1:deploy-file \
-              -Durl=https://repo.liquibase.net/repository/dry-run-sonatype-nexus-staging/ \
-              -DrepositoryId=dry-run-sonatype-nexus-staging \
-              -DpomFile=$i-${version}.pom \
-              -DgeneratePom=false \
-              -Dfile=$i-${version}.jar \
-              -Dsources=$i-${version}-sources.jar \
-              -Djavadoc=$i-${version}-javadoc.jar \
-              -Dfiles=$i-${version}.jar.asc,$i-${version}-sources.jar.asc,$i-${version}-javadoc.jar.asc,$i-${version}.pom.asc \
-              -Dtypes=jar.asc,jar.asc,jar.asc,pom.asc \
-              -Dclassifiers=,sources,javadoc,
+  #           mvn -B org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1:deploy-file \
+  #             -Durl=https://repo.liquibase.net/repository/dry-run-sonatype-nexus-staging/ \
+  #             -DrepositoryId=dry-run-sonatype-nexus-staging \
+  #             -DpomFile=$i-${version}.pom \
+  #             -DgeneratePom=false \
+  #             -Dfile=$i-${version}.jar \
+  #             -Dsources=$i-${version}-sources.jar \
+  #             -Djavadoc=$i-${version}-javadoc.jar \
+  #             -Dfiles=$i-${version}.jar.asc,$i-${version}-sources.jar.asc,$i-${version}-javadoc.jar.asc,$i-${version}.pom.asc \
+  #             -Dtypes=jar.asc,jar.asc,jar.asc,pom.asc \
+  #             -Dclassifiers=,sources,javadoc,
           
-          done
+  #         done
             
   publish_assets_to_internal_nexus:
     if: ${{ inputs.dry_run == false }}

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -583,7 +583,7 @@ jobs:
               -Durl=https://repo.liquibase.net/repository/oss-release-assets \
               -Dfile="$file" \
               -DgroupId=org.liquibase \
-              -DartifactId=$(basename "$file" | rev | cut -d'.' -f2- | rev) \ 
+              -DartifactId=liquibase \ 
               -Dversion=${version} \
               -Dpackaging=$(basename "$file" | cut -d'.' -f2-)
           done

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -101,443 +101,443 @@ jobs:
             echo "branch=${{ inputs.dry_run_branch_name }}" >> $GITHUB_OUTPUT
           fi
 
-  # manual_trigger_deployment:
-  #   if: ${{ inputs.dry_run == false }}
-  #   name: Manually trigger deployment
-  #   needs: [ setup ]
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - name: Get Version to deploy
-  #       uses: trstringer/manual-approval@v1
-  #       with:
-  #         secret: ${{ secrets.GITHUB_TOKEN }}
-  #         approvers: suryaaki2,rberezen,jnewton03,kristyldatical,sayaliM0412
-  #         minimum-approvals: 2
-  #         issue-title: "Deploying ${{ needs.setup.outputs.version }} to sonatype"
-  #         issue-body: "Please approve or deny the deployment of version ${{ needs.setup.outputs.version }}"
-  #         additional-approved-words: 'lgtm,✅,👍,proceed,shipit,:shipit:'
-  #         additional-denied-words: 'stop,error,failed,fail,broken,:x:,👎'
+  manual_trigger_deployment:
+    if: ${{ inputs.dry_run == false }}
+    name: Manually trigger deployment
+    needs: [ setup ]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Get Version to deploy
+        uses: trstringer/manual-approval@v1
+        with:
+          secret: ${{ secrets.GITHUB_TOKEN }}
+          approvers: suryaaki2,rberezen,jnewton03,kristyldatical,sayaliM0412
+          minimum-approvals: 2
+          issue-title: "Deploying ${{ needs.setup.outputs.version }} to sonatype"
+          issue-body: "Please approve or deny the deployment of version ${{ needs.setup.outputs.version }}"
+          additional-approved-words: 'lgtm,✅,👍,proceed,shipit,:shipit:'
+          additional-denied-words: 'stop,error,failed,fail,broken,:x:,👎'
 
-  # deploy_maven:
-  #   if: ${{ inputs.dry_run == false }}
-  #   name: Deploy to Maven
-  #   needs: [ setup, manual_trigger_deployment, deploy_javadocs, publish_to_github_packages, deploy_xsd, release-docker ]
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - name: Download release assets
-  #       uses: robinraju/release-downloader@v1.11
-  #       with:
-  #         repository: "liquibase/liquibase"
-  #         tag: "${{ needs.setup.outputs.tag }}"
-  #         fileName: "*"
-  #         out-file-path: "."
+  deploy_maven:
+    if: ${{ inputs.dry_run == false }}
+    name: Deploy to Maven
+    needs: [ setup, manual_trigger_deployment, deploy_javadocs, publish_to_github_packages, deploy_xsd, release-docker ]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download release assets
+        uses: robinraju/release-downloader@v1.11
+        with:
+          repository: "liquibase/liquibase"
+          tag: "${{ needs.setup.outputs.tag }}"
+          fileName: "*"
+          out-file-path: "."
 
-  #     - name: Set up Java for publishing to Maven Central Repository
-  #       uses: actions/setup-java@v4
-  #       with:
-  #         java-version: '11'
-  #         distribution: 'adopt'
-  #         server-id: sonatype-nexus-staging
-  #         server-username: MAVEN_USERNAME
-  #         server-password: MAVEN_PASSWORD
-  #         gpg-private-key: ${{ secrets.GPG_SECRET }}
-  #         gpg-passphrase: GPG_PASSPHRASE
-  #       env:
-  #         GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Set up Java for publishing to Maven Central Repository
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          server-id: sonatype-nexus-staging
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_SECRET }}
+          gpg-passphrase: GPG_PASSPHRASE
+        env:
+          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
 
-  #     - name: Publish to Maven Central
-  #       env:
-  #         MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-  #         MAVEN_PASSWORD: ${{ secrets.SONATYPE_TOKEN }}
-  #         GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
-  #       run: |
-  #         version=${{ needs.setup.outputs.version }}
+      - name: Publish to Maven Central
+        env:
+          MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.SONATYPE_TOKEN }}
+          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          version=${{ needs.setup.outputs.version }}
 
-  #         unzip -j liquibase-additional-*.zip
+          unzip -j liquibase-additional-*.zip
 
-  #         ##extracts and sign poms
-  #         for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-cdi' 'liquibase-cdi-jakarta' 'liquibase-commercial'; do
-  #           unzip -j $i-${version}.jar META-INF/maven/org.liquibase/$i/pom.xml
-  #           sed -i -e "s/<version>\(release\|master\)-SNAPSHOT<\/version>/<version>${version}<\/version>/" pom.xml
-  #           mv pom.xml $i-${version}.pom
-  #           if test 'liquibase-commercial' == $i; then
-  #             sed -i -e "s/<\/licenses>/<\/licenses><scm><connection>private<\/connection><developerConnection>private<\/developerConnection><url>private<\/url><\/scm>/" $i-${version}.pom   ## scm info not in the pom
-  #           fi
+          ##extracts and sign poms
+          for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-cdi' 'liquibase-cdi-jakarta' 'liquibase-commercial'; do
+            unzip -j $i-${version}.jar META-INF/maven/org.liquibase/$i/pom.xml
+            sed -i -e "s/<version>\(release\|master\)-SNAPSHOT<\/version>/<version>${version}<\/version>/" pom.xml
+            mv pom.xml $i-${version}.pom
+            if test 'liquibase-commercial' == $i; then
+              sed -i -e "s/<\/licenses>/<\/licenses><scm><connection>private<\/connection><developerConnection>private<\/developerConnection><url>private<\/url><\/scm>/" $i-${version}.pom   ## scm info not in the pom
+            fi
           
-  #           gpg --batch --pinentry-mode=loopback --passphrase "$GPG_PASSWORD" -ab $i-${version}.pom
+            gpg --batch --pinentry-mode=loopback --passphrase "$GPG_PASSWORD" -ab $i-${version}.pom
           
-  #           mvn -B org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1:deploy-file \
-  #             -Durl=https://oss.sonatype.org/service/local/staging/deploy/maven2/ \
-  #             -DrepositoryId=sonatype-nexus-staging \
-  #             -DpomFile=$i-${version}.pom \
-  #             -DgeneratePom=false \
-  #             -Dfile=$i-${version}.jar \
-  #             -Dsources=$i-${version}-sources.jar \
-  #             -Djavadoc=$i-${version}-javadoc.jar \
-  #             -Dfiles=$i-${version}.jar.asc,$i-${version}-sources.jar.asc,$i-${version}-javadoc.jar.asc,$i-${version}.pom.asc \
-  #             -Dtypes=jar.asc,jar.asc,jar.asc,pom.asc \
-  #             -Dclassifiers=,sources,javadoc,
-  #         done
+            mvn -B org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1:deploy-file \
+              -Durl=https://oss.sonatype.org/service/local/staging/deploy/maven2/ \
+              -DrepositoryId=sonatype-nexus-staging \
+              -DpomFile=$i-${version}.pom \
+              -DgeneratePom=false \
+              -Dfile=$i-${version}.jar \
+              -Dsources=$i-${version}-sources.jar \
+              -Djavadoc=$i-${version}-javadoc.jar \
+              -Dfiles=$i-${version}.jar.asc,$i-${version}-sources.jar.asc,$i-${version}-javadoc.jar.asc,$i-${version}.pom.asc \
+              -Dtypes=jar.asc,jar.asc,jar.asc,pom.asc \
+              -Dclassifiers=,sources,javadoc,
+          done
 
-  #         ## Release repository
-  #         ## Have to find the stagingRepositoryId that was auto-generated
-  #         api_output=$(curl -s -u "${{ secrets.SONATYPE_USERNAME }}:${{ secrets.SONATYPE_TOKEN }}" "https://oss.sonatype.org/service/local/staging/profile_repositories")
-  #         # Extract ids of repositories-item containing the string "liquibase"
-  #         repositories=$(echo "$api_output" | grep -B 8 "liquibase" | grep "<repositoryId>" | awk -F"<|>" '{print $3}')
-  #         echo "Repository IDs containing 'liquibase': $repositories"
-  #         for repo_id in $repositories; do
-  #           echo "Check if $repo_id repository is an extension"
-  #           api_output=$(curl -s -u "${{ secrets.SONATYPE_USERNAME }}:${{ secrets.SONATYPE_TOKEN }}" "https://oss.sonatype.org/service/local/repositories/$repo_id/content/org/liquibase/")
-  #           relative_path=$(echo "$api_output" | grep -oP '<relativePath>\K[^<]+' | awk 'NR==1')
-  #           echo "Relative path: $relative_path"
-  #           if [[ "$relative_path" == *"/org/liquibase/ext/"* ]]; then
-  #               echo "Relative path contains '/org/liquibase/ext/'. It is an extension."
-  #           else
-  #               echo "Relative path does not contain '/org/liquibase/ext/'. It is not an extension."
-  #               stagingRepositoryId=$repo_id
-  #               break
-  #           fi
-  #         done
+          ## Release repository
+          ## Have to find the stagingRepositoryId that was auto-generated
+          api_output=$(curl -s -u "${{ secrets.SONATYPE_USERNAME }}:${{ secrets.SONATYPE_TOKEN }}" "https://oss.sonatype.org/service/local/staging/profile_repositories")
+          # Extract ids of repositories-item containing the string "liquibase"
+          repositories=$(echo "$api_output" | grep -B 8 "liquibase" | grep "<repositoryId>" | awk -F"<|>" '{print $3}')
+          echo "Repository IDs containing 'liquibase': $repositories"
+          for repo_id in $repositories; do
+            echo "Check if $repo_id repository is an extension"
+            api_output=$(curl -s -u "${{ secrets.SONATYPE_USERNAME }}:${{ secrets.SONATYPE_TOKEN }}" "https://oss.sonatype.org/service/local/repositories/$repo_id/content/org/liquibase/")
+            relative_path=$(echo "$api_output" | grep -oP '<relativePath>\K[^<]+' | awk 'NR==1')
+            echo "Relative path: $relative_path"
+            if [[ "$relative_path" == *"/org/liquibase/ext/"* ]]; then
+                echo "Relative path contains '/org/liquibase/ext/'. It is an extension."
+            else
+                echo "Relative path does not contain '/org/liquibase/ext/'. It is not an extension."
+                stagingRepositoryId=$repo_id
+                break
+            fi
+          done
 
-  #         echo "Staging Repository Id: $stagingRepositoryId"
+          echo "Staging Repository Id: $stagingRepositoryId"
 
-  #         mvn org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8:rc-close \
-  #           -DnexusUrl=https://oss.sonatype.org/ \
-  #           -DserverId=sonatype-nexus-staging \
-  #           -DstagingRepositoryId=$stagingRepositoryId \
-  #           -DstagingProgressTimeoutMinutes=10
+          mvn org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8:rc-close \
+            -DnexusUrl=https://oss.sonatype.org/ \
+            -DserverId=sonatype-nexus-staging \
+            -DstagingRepositoryId=$stagingRepositoryId \
+            -DstagingProgressTimeoutMinutes=10
 
-  #         mvn org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8:rc-release \
-  #           -DautoDropAfterRelease=true \
-  #           -DnexusUrl=https://oss.sonatype.org/ \
-  #           -DserverId=sonatype-nexus-staging \
-  #           -DstagingRepositoryId=$stagingRepositoryId \
-  #           -DstagingProgressTimeoutMinutes=10
+          mvn org.sonatype.plugins:nexus-staging-maven-plugin:1.6.8:rc-release \
+            -DautoDropAfterRelease=true \
+            -DnexusUrl=https://oss.sonatype.org/ \
+            -DserverId=sonatype-nexus-staging \
+            -DstagingRepositoryId=$stagingRepositoryId \
+            -DstagingProgressTimeoutMinutes=10
 
-  # deploy_javadocs:
-  #   if: ${{ inputs.dry_run == false }}
-  #   name: Upload Javadocs
-  #   needs: [ setup, manual_trigger_deployment ]
-  #   runs-on: ubuntu-22.04
-  #   # These permissions are needed to interact with GitHub's OIDC Token endpoint.
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   steps:
-  #     - name: Download release javadocs
-  #       uses: robinraju/release-downloader@v1.11
-  #       with:
-  #         repository: "liquibase/liquibase"
-  #         tag: "${{ needs.setup.outputs.tag }}"
-  #         fileName: "liquibase-additional*.zip"
-  #         out-file-path: "."
+  deploy_javadocs:
+    if: ${{ inputs.dry_run == false }}
+    name: Upload Javadocs
+    needs: [ setup, manual_trigger_deployment ]
+    runs-on: ubuntu-22.04
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Download release javadocs
+        uses: robinraju/release-downloader@v1.11
+        with:
+          repository: "liquibase/liquibase"
+          tag: "${{ needs.setup.outputs.tag }}"
+          fileName: "liquibase-additional*.zip"
+          out-file-path: "."
 
-  #     - name: Unpack javadoc files and upload to s3
-  #       env:
-  #         AWS_ACCESS_KEY_ID: ${{ secrets.JAVADOCS_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.JAVADOCS_SECRET_ACCESS_KEY }}
-  #         AWS_DEFAULT_REGION: us-east-1
-  #       # unzip archives, create directory for each jar, and extract jar contents to directory.  Then delete the jar and zip files.  Then upload to s3.
-  #       run: |
-  #         unzip -j '*.zip' '*javadoc*.jar' 
+      - name: Unpack javadoc files and upload to s3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.JAVADOCS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.JAVADOCS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        # unzip archives, create directory for each jar, and extract jar contents to directory.  Then delete the jar and zip files.  Then upload to s3.
+        run: |
+          unzip -j '*.zip' '*javadoc*.jar' 
           
-  #         for jar in *liquibase*.jar; do
-  #           dir_name=$(basename "$jar" .jar)
-  #           dir_name=$(echo "$dir_name" | sed -E 's/(-[0-9]+(\.[0-9]+)*(-javadoc)?)//')
-  #           mkdir -p "$dir_name"
-  #           unzip -o "$jar" -d "$dir_name"
-  #         done
+          for jar in *liquibase*.jar; do
+            dir_name=$(basename "$jar" .jar)
+            dir_name=$(echo "$dir_name" | sed -E 's/(-[0-9]+(\.[0-9]+)*(-javadoc)?)//')
+            mkdir -p "$dir_name"
+            unzip -o "$jar" -d "$dir_name"
+          done
           
-  #         rm -rf *.jar *.zip
-  #         aws s3 sync . s3://javadocsliquibasecom-origin --only-show-errors
+          rm -rf *.jar *.zip
+          aws s3 sync . s3://javadocsliquibasecom-origin --only-show-errors
 
-  # publish_to_github_packages:
-  #   if: ${{ inputs.dry_run == false }}
-  #   name: Publish artifacts to Github Packages
-  #   runs-on: ubuntu-22.04
-  #   needs: [ setup, manual_trigger_deployment ]
-  #   permissions:
-  #     contents: read
-  #     packages: write
+  publish_to_github_packages:
+    if: ${{ inputs.dry_run == false }}
+    name: Publish artifacts to Github Packages
+    runs-on: ubuntu-22.04
+    needs: [ setup, manual_trigger_deployment ]
+    permissions:
+      contents: read
+      packages: write
 
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: Set up Java for publishing to GitHub Repository
-  #       uses: actions/setup-java@v4
-  #       with:
-  #         java-version: '17'
-  #         distribution: 'temurin'
-  #         cache: 'maven'
-  #         server-id: liquibase
-  #     - name: Set up Maven
-  #       uses: stCarolas/setup-maven@v5
-  #       with:
-  #         maven-version: ${{ env.MAVEN_VERSION }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java for publishing to GitHub Repository
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+          server-id: liquibase
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: ${{ env.MAVEN_VERSION }}
 
-  #     - name: Version artifact
-  #       run: mvn versions:set -DnewVersion="${{ needs.setup.outputs.version }}"
+      - name: Version artifact
+        run: mvn versions:set -DnewVersion="${{ needs.setup.outputs.version }}"
 
-  #     # Publish to GitHub Packages
-  #     - name: Publish package to Github
-  #       run: mvn -B clean deploy -DskipTests=true
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #         TARGET_ARTIFACT_REPOSITORY: liquibase
+      # Publish to GitHub Packages
+      - name: Publish package to Github
+        run: mvn -B clean deploy -DskipTests=true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_ARTIFACT_REPOSITORY: liquibase
 
-  # deploy_xsd:
-  #   if: ${{ inputs.dry_run == false }}
-  #   name: Upload xsds
-  #   needs: [ setup, manual_trigger_deployment]
-  #   runs-on: ubuntu-22.04
-  #   outputs:
-  #     tag: ${{ steps.collect-data.outputs.tag }}
-  #     version: ${{ needs.setup.outputs.version }}
-  #   steps:
-  #     - name: Download liquibase xsd
-  #       uses: actions/checkout@v4
-  #       with:
-  #         # Relative path under $GITHUB_WORKSPACE to place the repository
-  #         path: liquibase-core-repo
-  #         repository: "liquibase/liquibase"
+  deploy_xsd:
+    if: ${{ inputs.dry_run == false }}
+    name: Upload xsds
+    needs: [ setup, manual_trigger_deployment]
+    runs-on: ubuntu-22.04
+    outputs:
+      tag: ${{ steps.collect-data.outputs.tag }}
+      version: ${{ needs.setup.outputs.version }}
+    steps:
+      - name: Download liquibase xsd
+        uses: actions/checkout@v4
+        with:
+          # Relative path under $GITHUB_WORKSPACE to place the repository
+          path: liquibase-core-repo
+          repository: "liquibase/liquibase"
 
-  #     - name: Download liquibase-pro xsd
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: "${{ needs.setup.outputs.ref_branch }}"
-  #         token: ${{ secrets.BOT_TOKEN }}
-  #         # Relative path under $GITHUB_WORKSPACE to place the repository
-  #         path: liquibase-pro-repo
-  #         repository: "liquibase/liquibase-pro"
+      - name: Download liquibase-pro xsd
+        uses: actions/checkout@v4
+        with:
+          ref: "${{ needs.setup.outputs.ref_branch }}"
+          token: ${{ secrets.BOT_TOKEN }}
+          # Relative path under $GITHUB_WORKSPACE to place the repository
+          path: liquibase-pro-repo
+          repository: "liquibase/liquibase-pro"
 
-  #     - name: Upload to s3
-  #       env:
-  #         AWS_ACCESS_KEY_ID: ${{ secrets.LIQUIBASEORIGIN_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.LIQUIBASEORIGIN_SECRET_ACCESS_KEY }}
-  #         AWS_DEFAULT_REGION: us-east-1
-  #       # aws s3 sync syncs directories and S3 prefixes.
-  #       run: |
-  #         aws s3 sync liquibase-pro-repo/pro/src/main/resources/www.liquibase.org/xml/ns/pro/ s3://liquibaseorg-origin/xml/ns/pro/ --content-type application/octet-stream --only-show-errors
-  #         aws s3 sync liquibase-core-repo/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/ s3://liquibaseorg-origin/xml/ns/dbchangelog/ --content-type application/octet-stream --only-show-errors
-  #         aws s3 sync liquibase-pro-repo/pro/src/main/resources/schemas/ s3://liquibaseorg-origin/json/schema/ --content-type application/octet-stream --only-show-errors
+      - name: Upload to s3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.LIQUIBASEORIGIN_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.LIQUIBASEORIGIN_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        # aws s3 sync syncs directories and S3 prefixes.
+        run: |
+          aws s3 sync liquibase-pro-repo/pro/src/main/resources/www.liquibase.org/xml/ns/pro/ s3://liquibaseorg-origin/xml/ns/pro/ --content-type application/octet-stream --only-show-errors
+          aws s3 sync liquibase-core-repo/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/ s3://liquibaseorg-origin/xml/ns/dbchangelog/ --content-type application/octet-stream --only-show-errors
+          aws s3 sync liquibase-pro-repo/pro/src/main/resources/schemas/ s3://liquibaseorg-origin/json/schema/ --content-type application/octet-stream --only-show-errors
 
-  #     - name: Index.htm file upload
-  #       env:
-  #         AWS_ACCESS_KEY_ID: ${{ secrets.LIQUIBASEORIGIN_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.LIQUIBASEORIGIN_SECRET_ACCESS_KEY }}
-  #         AWS_DEFAULT_REGION: us-east-1
-  #       # get the major.minor xsd version. grab the index.htm from s3, add the new verison of xsd and sync with the s3 again
-  #       run: |
-  #         version=${{ needs.setup.outputs.version }}
-  #         arr=(${version//./ })
-  #         xsd_version=${arr[0]}"."${arr[1]}
-  #         mkdir index-file
-  #         aws s3 cp s3://liquibaseorg-origin/xml/ns/dbchangelog/index.htm index-file
-  #         if ! grep -q ${xsd_version} index-file/index.htm ; then
-  #           sed -ie "s/<\/ul>/  <li><a href=\"\/xml\/ns\/dbchangelog\/dbchangelog-${xsd_version}.xsd\">dbchangelog-${xsd_version}.xsd<\/a><\/li>\n<\/ul>/" index-file/index.htm
-  #           aws s3 sync index-file s3://liquibaseorg-origin/xml/ns/dbchangelog/ --only-show-errors
-  #         fi
+      - name: Index.htm file upload
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.LIQUIBASEORIGIN_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.LIQUIBASEORIGIN_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        # get the major.minor xsd version. grab the index.htm from s3, add the new verison of xsd and sync with the s3 again
+        run: |
+          version=${{ needs.setup.outputs.version }}
+          arr=(${version//./ })
+          xsd_version=${arr[0]}"."${arr[1]}
+          mkdir index-file
+          aws s3 cp s3://liquibaseorg-origin/xml/ns/dbchangelog/index.htm index-file
+          if ! grep -q ${xsd_version} index-file/index.htm ; then
+            sed -ie "s/<\/ul>/  <li><a href=\"\/xml\/ns\/dbchangelog\/dbchangelog-${xsd_version}.xsd\">dbchangelog-${xsd_version}.xsd<\/a><\/li>\n<\/ul>/" index-file/index.htm
+            aws s3 sync index-file s3://liquibaseorg-origin/xml/ns/dbchangelog/ --only-show-errors
+          fi
 
-  #     - name: Liquibase xsds SFTP upload
-  #       uses: wangyucode/sftp-upload-action@v2.0.4
-  #       with:
-  #         host: ${{ secrets.WPENGINE_SFTP_HOST }}
-  #         port: ${{ secrets.WPENGINE_SFTP_PORT }}
-  #         username: ${{ secrets.WPENGINE_SFTP_USER }}
-  #         password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
-  #         compress: true
-  #         forceUpload: true
-  #         localDir: 'liquibase-core-repo/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/'
-  #         remoteDir: '/xml/ns/dbchangelog/'
+      - name: Liquibase xsds SFTP upload
+        uses: wangyucode/sftp-upload-action@v2.0.4
+        with:
+          host: ${{ secrets.WPENGINE_SFTP_HOST }}
+          port: ${{ secrets.WPENGINE_SFTP_PORT }}
+          username: ${{ secrets.WPENGINE_SFTP_USER }}
+          password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
+          compress: true
+          forceUpload: true
+          localDir: 'liquibase-core-repo/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/'
+          remoteDir: '/xml/ns/dbchangelog/'
 
-  #     - name: Liquibase PRO xsds SFTP upload
-  #       uses: wangyucode/sftp-upload-action@v2.0.4
-  #       with:
-  #         host: ${{ secrets.WPENGINE_SFTP_HOST }}
-  #         port: ${{ secrets.WPENGINE_SFTP_PORT }}
-  #         username: ${{ secrets.WPENGINE_SFTP_USER }}
-  #         password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
-  #         compress: false
-  #         forceUpload: true
-  #         localDir: 'liquibase-pro-repo/pro/src/main/resources/www.liquibase.org/xml/ns/pro/'
-  #         remoteDir: '/xml/ns/pro/'
+      - name: Liquibase PRO xsds SFTP upload
+        uses: wangyucode/sftp-upload-action@v2.0.4
+        with:
+          host: ${{ secrets.WPENGINE_SFTP_HOST }}
+          port: ${{ secrets.WPENGINE_SFTP_PORT }}
+          username: ${{ secrets.WPENGINE_SFTP_USER }}
+          password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
+          compress: false
+          forceUpload: true
+          localDir: 'liquibase-pro-repo/pro/src/main/resources/www.liquibase.org/xml/ns/pro/'
+          remoteDir: '/xml/ns/pro/'
 
-  #     - name: Liquibase flow-file schema SFTP upload
-  #       uses: wangyucode/sftp-upload-action@v2.0.4
-  #       with:
-  #         host: ${{ secrets.WPENGINE_SFTP_HOST }}
-  #         port: ${{ secrets.WPENGINE_SFTP_PORT }}
-  #         username: ${{ secrets.WPENGINE_SFTP_USER }}
-  #         password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
-  #         compress: false
-  #         forceUpload: true
-  #         localDir: 'liquibase-pro-repo/pro/src/main/resources/schemas/'
-  #         remoteDir: '/json/schema/'
+      - name: Liquibase flow-file schema SFTP upload
+        uses: wangyucode/sftp-upload-action@v2.0.4
+        with:
+          host: ${{ secrets.WPENGINE_SFTP_HOST }}
+          port: ${{ secrets.WPENGINE_SFTP_PORT }}
+          username: ${{ secrets.WPENGINE_SFTP_USER }}
+          password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
+          compress: false
+          forceUpload: true
+          localDir: 'liquibase-pro-repo/pro/src/main/resources/schemas/'
+          remoteDir: '/json/schema/'
 
-  #     - name: Liquibase index.htm SFTP upload
-  #       uses: wangyucode/sftp-upload-action@v2.0.4
-  #       with:
-  #         host: ${{ secrets.WPENGINE_SFTP_HOST }}
-  #         port: ${{ secrets.WPENGINE_SFTP_PORT }}
-  #         username: ${{ secrets.WPENGINE_SFTP_USER }}
-  #         password: ${{ secrets.WPENGINE_SFTP_PASSWORD }} 
-  #         compress: false
-  #         forceUpload: true
-  #         localDir: 'index-file/'
-  #         remoteDir: '/xml/ns/dbchangelog/'
+      - name: Liquibase index.htm SFTP upload
+        uses: wangyucode/sftp-upload-action@v2.0.4
+        with:
+          host: ${{ secrets.WPENGINE_SFTP_HOST }}
+          port: ${{ secrets.WPENGINE_SFTP_PORT }}
+          username: ${{ secrets.WPENGINE_SFTP_USER }}
+          password: ${{ secrets.WPENGINE_SFTP_PASSWORD }} 
+          compress: false
+          forceUpload: true
+          localDir: 'index-file/'
+          remoteDir: '/xml/ns/dbchangelog/'
 
-  # release-docker:
-  #   if: always()
-  #   name: Release docker images
-  #   needs: [ setup, manual_trigger_deployment ]
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - name: Release liquibase/docker v${{ needs.setup.outputs.version }}
-  #       uses: codex-/return-dispatch@v2
-  #       id: docker_dispatch
-  #       with:
-  #         token: ${{ secrets.BOT_TOKEN }}
-  #         ref: main
-  #         repo: docker
-  #         owner: liquibase
-  #         workflow: create-release.yml
-  #         workflow_inputs: '{ "liquibaseVersion": "${{ needs.setup.outputs.version }}", "dryRun": "${{ inputs.dry_run || false }}" }'
-  #         workflow_timeout_seconds: 300
-  #         workflow_job_steps_retry_seconds: 10
+  release-docker:
+    if: always()
+    name: Release docker images
+    needs: [ setup, manual_trigger_deployment ]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Release liquibase/docker v${{ needs.setup.outputs.version }}
+        uses: codex-/return-dispatch@v2
+        id: docker_dispatch
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+          ref: main
+          repo: docker
+          owner: liquibase
+          workflow: create-release.yml
+          workflow_inputs: '{ "liquibaseVersion": "${{ needs.setup.outputs.version }}", "dryRun": "${{ inputs.dry_run || false }}" }'
+          workflow_timeout_seconds: 300
+          workflow_job_steps_retry_seconds: 10
 
-  #     - name: Adding Docker run to job summary
-  #       if: success()
-  #       continue-on-error: true
-  #       run: echo '### 🐳 Docker Release Job -> ${{steps.docker_dispatch.outputs.run_url}}' >> $GITHUB_STEP_SUMMARY
+      - name: Adding Docker run to job summary
+        if: success()
+        continue-on-error: true
+        run: echo '### 🐳 Docker Release Job -> ${{steps.docker_dispatch.outputs.run_url}}' >> $GITHUB_STEP_SUMMARY
 
-  # generate-PRO-tag:
-  #   if: ${{ inputs.dry_run == false }}
-  #   name: Generate PRO tags based on OSS release
-  #   needs: [ setup ]
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - name: Repository Dispatch
-  #       uses: peter-evans/repository-dispatch@v3
-  #       with:
-  #         token: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
-  #         repository: liquibase/liquibase-pro
-  #         event-type: oss-released-tag
+  generate-PRO-tag:
+    if: ${{ inputs.dry_run == false }}
+    name: Generate PRO tags based on OSS release
+    needs: [ setup ]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
+          repository: liquibase/liquibase-pro
+          event-type: oss-released-tag
 
-  # package:
-  #   uses: liquibase/build-logic/.github/workflows/package.yml@main
-  #   needs: [ setup ]
-  #   secrets: inherit
-  #   with:
-  #     groupId: 'org.liquibase'
-  #     artifactId: 'liquibase'
-  #     version: ${{ needs.setup.outputs.version }}
-  #     dry_run: ${{ inputs.dry_run || false}}
-  #     dry_run_zip_url: ${{ inputs.dry_run_zip_url || '' }}
-  #     dry_run_tar_gz_url: ${{ inputs.dry_run_tar_gz_url || '' }}
+  package:
+    uses: liquibase/build-logic/.github/workflows/package.yml@main
+    needs: [ setup ]
+    secrets: inherit
+    with:
+      groupId: 'org.liquibase'
+      artifactId: 'liquibase'
+      version: ${{ needs.setup.outputs.version }}
+      dry_run: ${{ inputs.dry_run || false}}
+      dry_run_zip_url: ${{ inputs.dry_run_zip_url || '' }}
+      dry_run_tar_gz_url: ${{ inputs.dry_run_tar_gz_url || '' }}
 
-  # update-docs-oss-pro-version:
-  #   if: ${{ inputs.dry_run == false }}
-  #   name: Update OSS and PRO tags based on OSS release
-  #   needs: [ setup ]
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     latest_version: ${{ steps.get_latest_oss_version.outputs.latest_version }}
-  #     previous_version: ${{ steps.get_latest_oss_version.outputs.previous_version }}
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4
-  #       with:
-  #         repository: liquibase/liquibase
-  #         ref: "${{ needs.setup.outputs.ref_branch }}"
-  #         fetch-depth: 0
+  update-docs-oss-pro-version:
+    if: ${{ inputs.dry_run == false }}
+    name: Update OSS and PRO tags based on OSS release
+    needs: [ setup ]
+    runs-on: ubuntu-latest
+    outputs:
+      latest_version: ${{ steps.get_latest_oss_version.outputs.latest_version }}
+      previous_version: ${{ steps.get_latest_oss_version.outputs.previous_version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: liquibase/liquibase
+          ref: "${{ needs.setup.outputs.ref_branch }}"
+          fetch-depth: 0
 
-  #     - name: Get the oss release version
-  #       id: get_latest_oss_version
-  #       run: |
-  #           # Fetch all tags from the remote
-  #           git fetch --tags
-  #           # Get the latest tag
-  #           echo "latest_version=$(git describe --tags $(git rev-list --tags --max-count=1) | sed 's/^v//')" >> $GITHUB_OUTPUT
-  #           # Get the previous released version tag
-  #           echo "previous_version=$(git for-each-ref --sort=creatordate --format '%(tag)' refs/tags|tail -2|head -1| sed 's/^v//')" >> $GITHUB_OUTPUT
+      - name: Get the oss release version
+        id: get_latest_oss_version
+        run: |
+            # Fetch all tags from the remote
+            git fetch --tags
+            # Get the latest tag
+            echo "latest_version=$(git describe --tags $(git rev-list --tags --max-count=1) | sed 's/^v//')" >> $GITHUB_OUTPUT
+            # Get the previous released version tag
+            echo "previous_version=$(git for-each-ref --sort=creatordate --format '%(tag)' refs/tags|tail -2|head -1| sed 's/^v//')" >> $GITHUB_OUTPUT
 
 
-  #     - name: Repository Dispatch
-  #       uses: peter-evans/repository-dispatch@v3
-  #       with:
-  #         token: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
-  #         repository: liquibase/liquibase-docs
-  #         event-type: oss-released-version
-  #         client-payload: '{"latest_version": "${{ steps.get_latest_oss_version.outputs.latest_version }}", "previous_version": "${{ steps.get_latest_oss_version.outputs.previous_version }}"}'
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
+          repository: liquibase/liquibase-docs
+          event-type: oss-released-version
+          client-payload: '{"latest_version": "${{ steps.get_latest_oss_version.outputs.latest_version }}", "previous_version": "${{ steps.get_latest_oss_version.outputs.previous_version }}"}'
 
-  #     # dispatch an event to `liquibase-aws-license-service` repository to update pom.xml with latest OSS Release
-  #     - name: Repository Dispatch
-  #       uses: peter-evans/repository-dispatch@v3
-  #       with:
-  #         token: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
-  #         repository: liquibase/liquibase-aws-license-service
-  #         event-type: oss-released-version
+      # dispatch an event to `liquibase-aws-license-service` repository to update pom.xml with latest OSS Release
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
+          repository: liquibase/liquibase-aws-license-service
+          event-type: oss-released-version
 
-  # dry_run_deploy_maven:
-  #   if: ${{ inputs.dry_run == true }}
-  #   name: Deploy to repo.liquibase.net
-  #   needs: [ setup ]
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - name: Download dry-run release assets
-  #       uses: robinraju/release-downloader@v1.11
-  #       with:
-  #         repository: "liquibase/liquibase"
-  #         releaseId: "${{ inputs.dry_run_release_id }}"
-  #         fileName: "*"
-  #         out-file-path: "."
+  dry_run_deploy_maven:
+    if: ${{ inputs.dry_run == true }}
+    name: Deploy to repo.liquibase.net
+    needs: [ setup ]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download dry-run release assets
+        uses: robinraju/release-downloader@v1.11
+        with:
+          repository: "liquibase/liquibase"
+          releaseId: "${{ inputs.dry_run_release_id }}"
+          fileName: "*"
+          out-file-path: "."
 
-  #     - name: Set up Java for publishing to Maven Central Repository
-  #       uses: actions/setup-java@v4
-  #       with:
-  #         java-version: '11'
-  #         distribution: 'adopt'
-  #         server-id: dry-run-sonatype-nexus-staging
-  #         server-username: MAVEN_USERNAME
-  #         server-password: MAVEN_PASSWORD
-  #         gpg-private-key: ${{ secrets.GPG_SECRET }}
-  #         gpg-passphrase: GPG_PASSPHRASE
-  #       env:
-  #         GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Set up Java for publishing to Maven Central Repository
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          server-id: dry-run-sonatype-nexus-staging
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_SECRET }}
+          gpg-passphrase: GPG_PASSPHRASE
+        env:
+          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
 
-  #     - name: Publish to repo.liquibase.net
-  #       env:
-  #         MAVEN_USERNAME: ${{ secrets.REPO_LIQUIBASE_NET_USER }}
-  #         MAVEN_PASSWORD: ${{ secrets.REPO_LIQUIBASE_NET_PASSWORD }}
-  #         GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
-  #       run: |
-  #         version=${{ needs.setup.outputs.version }}
+      - name: Publish to repo.liquibase.net
+        env:
+          MAVEN_USERNAME: ${{ secrets.REPO_LIQUIBASE_NET_USER }}
+          MAVEN_PASSWORD: ${{ secrets.REPO_LIQUIBASE_NET_PASSWORD }}
+          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          version=${{ needs.setup.outputs.version }}
 
-  #         unzip -j liquibase-additional-*.zip
+          unzip -j liquibase-additional-*.zip
 
-  #         ##extracts and sign poms
-  #         for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-cdi' 'liquibase-cdi-jakarta' 'liquibase-commercial'; do
-  #           unzip -j $i-${version}.jar META-INF/maven/org.liquibase/$i/pom.xml
-  #           sed -i -e "s/<version>\(release\|master\)-SNAPSHOT<\/version>/<version>${version}<\/version>/" pom.xml
-  #           mv pom.xml $i-${version}.pom
-  #           if test 'liquibase-commercial' == $i; then
-  #             sed -i -e "s/<\/licenses>/<\/licenses><scm><connection>private<\/connection><developerConnection>private<\/developerConnection><url>private<\/url><\/scm>/" $i-${version}.pom   ## scm info not in the pom
-  #           fi
+          ##extracts and sign poms
+          for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-cdi' 'liquibase-cdi-jakarta' 'liquibase-commercial'; do
+            unzip -j $i-${version}.jar META-INF/maven/org.liquibase/$i/pom.xml
+            sed -i -e "s/<version>\(release\|master\)-SNAPSHOT<\/version>/<version>${version}<\/version>/" pom.xml
+            mv pom.xml $i-${version}.pom
+            if test 'liquibase-commercial' == $i; then
+              sed -i -e "s/<\/licenses>/<\/licenses><scm><connection>private<\/connection><developerConnection>private<\/developerConnection><url>private<\/url><\/scm>/" $i-${version}.pom   ## scm info not in the pom
+            fi
           
-  #           gpg --batch --pinentry-mode=loopback --passphrase "$GPG_PASSWORD" -ab $i-${version}.pom
+            gpg --batch --pinentry-mode=loopback --passphrase "$GPG_PASSWORD" -ab $i-${version}.pom
           
-  #           mvn -B org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1:deploy-file \
-  #             -Durl=https://repo.liquibase.net/repository/dry-run-sonatype-nexus-staging/ \
-  #             -DrepositoryId=dry-run-sonatype-nexus-staging \
-  #             -DpomFile=$i-${version}.pom \
-  #             -DgeneratePom=false \
-  #             -Dfile=$i-${version}.jar \
-  #             -Dsources=$i-${version}-sources.jar \
-  #             -Djavadoc=$i-${version}-javadoc.jar \
-  #             -Dfiles=$i-${version}.jar.asc,$i-${version}-sources.jar.asc,$i-${version}-javadoc.jar.asc,$i-${version}.pom.asc \
-  #             -Dtypes=jar.asc,jar.asc,jar.asc,pom.asc \
-  #             -Dclassifiers=,sources,javadoc,
+            mvn -B org.apache.maven.plugins:maven-deploy-plugin:3.0.0-M1:deploy-file \
+              -Durl=https://repo.liquibase.net/repository/dry-run-sonatype-nexus-staging/ \
+              -DrepositoryId=dry-run-sonatype-nexus-staging \
+              -DpomFile=$i-${version}.pom \
+              -DgeneratePom=false \
+              -Dfile=$i-${version}.jar \
+              -Dsources=$i-${version}-sources.jar \
+              -Djavadoc=$i-${version}-javadoc.jar \
+              -Dfiles=$i-${version}.jar.asc,$i-${version}-sources.jar.asc,$i-${version}-javadoc.jar.asc,$i-${version}.pom.asc \
+              -Dtypes=jar.asc,jar.asc,jar.asc,pom.asc \
+              -Dclassifiers=,sources,javadoc,
           
-  #         done
+          done
             
   publish_assets_to_s3_bucket:
     if: ${{ inputs.dry_run == false }}

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -553,11 +553,15 @@ jobs:
           fileName: "*"
           out-file-path: "./${{ needs.setup.outputs.version }}-released-assets"
 
-      - name: Publish to s3 bucket
+      - name: Get current timestamp
+        id: timestamp
+        run: echo "timestamp=$(date +%Y%m%d-%H%M%S)" >> $GITHUB_ENV
+      
+      - name: Publish released assets to s3 bucket
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.LIQUIBASEORIGIN_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.LIQUIBASEORIGIN_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
         run: |
-          aws s3 sync "./${{ needs.setup.outputs.version }}-released-assets" s3://liquibaseorg-origin/oss-released-assets/${{ needs.setup.outputs.version }}-released-assets/ --only-show-errors
+          aws s3 sync "./${{ needs.setup.outputs.version }}-released-assets" s3://liquibaseorg-origin/oss-released-assets/${{ needs.setup.outputs.version }}-released-assets-${{ env.timestamp }}/ --only-show-errors
           

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -559,5 +559,5 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.LIQUIBASEORIGIN_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: us-east-1
         run: |
-          aws s3 sync "./${{ needs.setup.outputs.version }}-released-assets" s3://liquibaseorg-origin/${{ needs.setup.outputs.version }}-released-assets/ --only-show-errors
+          aws s3 sync "./${{ needs.setup.outputs.version }}-released-assets" s3://liquibaseorg-origin/oss-released-assets/${{ needs.setup.outputs.version }}-released-assets/ --only-show-errors
           


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/release-published.yml` file to update the process for publishing OSS released assets. The main change is switching from publishing to an internal Nexus repository to publishing to an S3 bucket.

Changes to publishing process:

* Renamed the job from `publish_assets_to_internal_nexus` to `publish_assets_to_s3_bucket` and updated the job name to reflect the new destination.
* Removed the environment variables related to Nexus and added AWS credentials for accessing the S3 bucket.
* Removed the step that checks if the version already exists in Nexus, as this is no longer relevant.
* Updated the publishing step to use `aws s3 sync` instead of Maven commands for deploying files to the S3 bucket.