### PR TITLE
✨ feat: add support for liquibase-minimal version packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,19 +208,8 @@ jobs:
           echo "Saving windows key"
           echo "$INSTALL4J_WINDOWS_KEY" | base64 -d > liquibase-dist/target/keys/datical_windows.pfx
           # we are packaging and deploying liquibase tar which includes liquibase-commercial
-          # Build liquibase-commercial version
-          ./mvnw -B -pl liquibase-dist -P liquibase-commercial source:jar package failsafe:integration-test failsafe:verify \
-          "-Dliquibase.checks=true" \
-          "-Dliquibase-pro.version=${{ needs.setup.outputs.proBranchNamePrefix }}-SNAPSHOT" \
-          "-Dbuild.repository.owner=liquibase" \
-          "-Dbuild.repository.name=liquibase" \
-          "-Dbuild.branch=${{ needs.setup.outputs.thisBranchName }}" \
-          "-Dbuild.number=${{ github.run_number }}" \
-          "-Dbuild.commit=${{ needs.setup.outputs.latestMergeSha }}-SNAPSHOT" \
-          "-Dbuild.timestamp=${{ needs.setup.outputs.timeStamp }}"
-
-          # Build liquibase-minimal version
-          ./mvnw -B -pl liquibase-dist -P liquibase-minimal source:jar package failsafe:integration-test failsafe:verify \
+          # Build liquibase-commercial version and liquibase-minimal version
+          ./mvnw -B -pl liquibase-dist -P liquibase-commercial,liquibase-minimal source:jar package failsafe:integration-test failsafe:verify \
           "-Dliquibase.checks=true" \
           "-Dliquibase-pro.version=${{ needs.setup.outputs.proBranchNamePrefix }}-SNAPSHOT" \
           "-Dbuild.repository.owner=liquibase" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,21 +208,51 @@ jobs:
           echo "Saving windows key"
           echo "$INSTALL4J_WINDOWS_KEY" | base64 -d > liquibase-dist/target/keys/datical_windows.pfx
           # we are packaging and deploying liquibase tar which includes liquibase-commercial
-          ./mvnw -B -pl liquibase-dist -P liquibase-commercial source:jar package failsafe:integration-test failsafe:verify "-Dliquibase.checks=true" "-Dliquibase-pro.version=${{ needs.setup.outputs.proBranchNamePrefix }}-SNAPSHOT" "-Dbuild.repository.owner=liquibase" "-Dbuild.repository.name=liquibase" "-Dbuild.branch=${{ needs.setup.outputs.thisBranchName }}" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=${{ needs.setup.outputs.latestMergeSha }}-SNAPSHOT" "-Dbuild.timestamp=${{ needs.setup.outputs.timeStamp }}"
+          # Build liquibase-commercial version
+          ./mvnw -B -pl liquibase-dist -P liquibase-commercial source:jar package failsafe:integration-test failsafe:verify \
+          "-Dliquibase.checks=true" \
+          "-Dliquibase-pro.version=${{ needs.setup.outputs.proBranchNamePrefix }}-SNAPSHOT" \
+          "-Dbuild.repository.owner=liquibase" \
+          "-Dbuild.repository.name=liquibase" \
+          "-Dbuild.branch=${{ needs.setup.outputs.thisBranchName }}" \
+          "-Dbuild.number=${{ github.run_number }}" \
+          "-Dbuild.commit=${{ needs.setup.outputs.latestMergeSha }}-SNAPSHOT" \
+          "-Dbuild.timestamp=${{ needs.setup.outputs.timeStamp }}"
+
+          # Build liquibase-minimal version
+          ./mvnw -B -pl liquibase-dist -P liquibase-minimal source:jar package failsafe:integration-test failsafe:verify \
+          "-Dliquibase.checks=true" \
+          "-Dliquibase-pro.version=${{ needs.setup.outputs.proBranchNamePrefix }}-SNAPSHOT" \
+          "-Dbuild.repository.owner=liquibase" \
+          "-Dbuild.repository.name=liquibase" \
+          "-Dbuild.branch=${{ needs.setup.outputs.thisBranchName }}" \
+          "-Dbuild.number=${{ github.run_number }}" \
+          "-Dbuild.commit=${{ needs.setup.outputs.latestMergeSha }}-SNAPSHOT" \
+          "-Dbuild.timestamp=${{ needs.setup.outputs.timeStamp }}"
+
+          # Move liquibase-minimal tarball to avoid overwriting the commercial one
+          mv liquibase-dist/target/liquibase-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT.tar.gz liquibase-dist/target/liquibase-${{ needs.setup.outputs.thisBranchName }}-minimal-SNAPSHOT.tar.gz
+          mv liquibase-dist/target/liquibase-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT.zip liquibase-dist/target/liquibase-${{ needs.setup.outputs.thisBranchName }}-minimal-SNAPSHOT.zip
 
           # Extract the tarball to allow us to upload the liquibase installation files to our
           # github actions workflow so that we don't double zip the archive
           mkdir -p branch-artifacts
           tar -xzf liquibase-dist/target/liquibase-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT.tar.gz -C branch-artifacts
-          
+          tar -xzf liquibase-dist/target/liquibase-${{ needs.setup.outputs.thisBranchName }}-minimal-SNAPSHOT.tar.gz -C branch-artifacts
+
           ##create installer - disabled here but run as nightly job and as part of release workflow
           # (cd liquibase-dist && ${{ github.workspace }}/.github/util/package-install4j.sh 0-SNAPSHOT)
 
+          # Remove original JARs
           find . -name original-*.jar -exec rm {} \;
 
+          # Copy artifacts
           mkdir -p artifacts
+
           cp liquibase-dist/target/liquibase-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT.tar.gz artifacts
           cp liquibase-dist/target/liquibase-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT.zip artifacts
+          cp liquibase-dist/target/liquibase-${{ needs.setup.outputs.thisBranchName }}-minimal-SNAPSHOT.tar.gz artifacts
+          cp liquibase-dist/target/liquibase-${{ needs.setup.outputs.thisBranchName }}-minimal-SNAPSHOT.zip artifacts
           cp liquibase-core/target/liquibase-core-0-SNAPSHOT.jar artifacts/liquibase-core-0-SNAPSHOT.jar
           #cp liquibase-dist/target/liquibase-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT/internal/lib/liquibase-core.jar artifacts/liquibase-core-0-SNAPSHOT.jar
 
@@ -258,6 +288,7 @@ jobs:
           mkdir artifacts-named
           
           cp liquibase-dist/target/liquibase-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT.tar.gz artifacts-named/liquibase-${{ needs.setup.outputs.thisBranchName }}.tar.gz
+          cp liquibase-dist/target/liquibase-${{ needs.setup.outputs.thisBranchName }}-minimal-SNAPSHOT.tar.gz artifacts-named/liquibase-${{ needs.setup.outputs.thisBranchName }}-minimal.tar.gz
           cp liquibase-extension-testing/target/liquibase-extension-testing-0-SNAPSHOT-deps.jar artifacts-named/liquibase-extension-testing-${{ needs.setup.outputs.thisBranchName }}-deps.jar
           
           for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-cdi' 'liquibase-cdi-jakarta' 'liquibase-extension-testing'; do

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -454,7 +454,7 @@ jobs:
 
   run-build-publish-file:
     needs: [ build_tests,integration-test ]
-    uses: liquibase/liquibase/.github/workflows/build.yml@master
+    uses: ./.github/workflows/build.yml
     secrets: inherit
 
 


### PR DESCRIPTION
This pull request involves updates to the build process in the `.github/workflows/build.yml` file to include a new `liquibase-minimal` version alongside the existing `liquibase-commercial` version. The key changes include separate build steps for the new version, adjustments to artifact handling, and updates to ensure both versions are properly managed.

### Build process updates:

* Added build steps for the `liquibase-minimal` version alongside the existing `liquibase-commercial` version, including packaging, integration tests, and verification.
* Added commands to move the `liquibase-minimal` tarball and zip files to avoid overwriting the `liquibase-commercial` artifacts.
* Updated the artifact copying steps to include the `liquibase-minimal` tarball and zip files.
* Added steps to copy the `liquibase-minimal` tarball to the `artifacts-named` directory.