### PR TITLE
🔧 DAT-19574: git checkout a specific branch from input parameter

### DIFF
--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -120,10 +120,11 @@ jobs:
   build-liquibase-checks:
       if: ${{ contains(inputs.extensions, 'liquibase-checks') }}
       needs: [ delete-extension-packages, get-liquibase-checks-version, delete-checks-packages ]
-      uses: liquibase/build-logic/.github/workflows/publish-for-liquibase.yml@main
+      uses: liquibase/build-logic/.github/workflows/publish-for-liquibase.yml@DAT-19574
       with:
           repository: liquibase/liquibase-checks
           version: ${{ needs.get-liquibase-checks-version.outputs.version }}
+          branch: "${{ inputs.branch }}"
       secrets: inherit
 
   build-and-deploy-extensions:
@@ -156,6 +157,7 @@ jobs:
               dep=$(echo $dep | xargs)  # Remove leading and trailing whitespaces
               echo "Checking out $dep"
               git clone https://github.com/liquibase/$dep.git $dep
+              git checkout ${{ inputs.branch }} 
           done
 
       - name: Set up JDK 21
@@ -275,6 +277,7 @@ jobs:
             if [ "$ext" != "liquibase-checks" ]; then
               echo "Checking out and building $ext"
               git clone https://github.com/liquibase/$ext.git $ext
+              git checkout $scripts_branch
               cd $ext
               sed -i "s/<liquibase.version>.*<\/liquibase.version>/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/" pom.xml
               mvn versions:set -DnewVersion=0-SNAPSHOT

--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -120,7 +120,7 @@ jobs:
   build-liquibase-checks:
       if: ${{ contains(inputs.extensions, 'liquibase-checks') }}
       needs: [ delete-extension-packages, get-liquibase-checks-version, delete-checks-packages ]
-      uses: liquibase/build-logic/.github/workflows/publish-for-liquibase.yml@DAT-19574
+      uses: liquibase/build-logic/.github/workflows/publish-for-liquibase.yml@main
       with:
           repository: liquibase/liquibase-checks
           version: ${{ needs.get-liquibase-checks-version.outputs.version }}


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/build-extension-jars.yml` file to improve the build process for Liquibase extensions. The most important changes include updating the workflow to use a specific branch, adding the branch input parameter, and ensuring the correct branch is checked out during various steps.

Updates to the build process:

* [`.github/workflows/build-extension-jars.yml`](diffhunk://#diff-dc83207379251c4eeafe63714db8ce416c176c525edf14a8bd6ad57ca0e9027bL123-R127): Changed the workflow reference to use the `DAT-19574` branch instead of `main` for the `publish-for-liquibase.yml` workflow.
* [`.github/workflows/build-extension-jars.yml`](diffhunk://#diff-dc83207379251c4eeafe63714db8ce416c176c525edf14a8bd6ad57ca0e9027bL123-R127): Added the `branch` input parameter to the `publish-for-liquibase.yml` workflow.
* [`.github/workflows/build-extension-jars.yml`](diffhunk://#diff-dc83207379251c4eeafe63714db8ce416c176c525edf14a8bd6ad57ca0e9027bR160): Added a step to check out the specified branch when cloning repositories during the build process. [[1]](diffhunk://#diff-dc83207379251c4eeafe63714db8ce416c176c525edf14a8bd6ad57ca0e9027bR160) [[2]](diffhunk://#diff-dc83207379251c4eeafe63714db8ce416c176c525edf14a8bd6ad57ca0e9027bR280)