### PR TITLE
Bugfix: Dry-run releases exceeds the limit on called workflow depth of 3

### DIFF
--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -62,15 +62,27 @@ jobs:
 
   dry-run-release-published:
     needs: [ setup, dry-run-create-release, dry-run-get-draft-release ]
-    uses: ./.github/workflows/release-published.yml
-    with:
-      tag: "vdry-run-${{ github.run_id }}"
-      dry_run_release_id: ${{ needs.dry-run-get-draft-release.outputs.dry_run_release_id }}
-      dry_run_zip_url: ${{ needs.dry-run-create-release.outputs.dry_run_zip_url }}
-      dry_run_tar_gz_url: ${{ needs.dry-run-create-release.outputs.dry_run_tar_gz_url }}
-      dry_run: true
-      dry_run_branch_name: ${{ needs.dry-run-create-release.outputs.dry_run_branch_name }}
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger release-published workflow
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.BOT_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/actions/workflows/release-published.yml/dispatches \
+            -d '{
+              "ref": "master",
+              "inputs": {
+                "tag": "vdry-run-${{ github.run_id }}",
+                "dry_run_release_id": "${{ needs.dry-run-get-draft-release.outputs.dry_run_release_id }}",
+                "dry_run_zip_url": "${{ needs.dry-run-create-release.outputs.dry_run_zip_url }}",
+                "dry_run_tar_gz_url": "${{ needs.dry-run-create-release.outputs.dry_run_tar_gz_url }}",
+                "dry_run": "true",
+                "dry_run_branch_name": "${{ needs.dry-run-create-release.outputs.dry_run_branch_name }}"
+              }
+            }'
 
   cleanup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates the `dry-run-release-published` job in the `.github/workflows/dry-run-release.yml` file to use a different method for triggering the `release-published` workflow. The main change is replacing the `uses` directive with a `runs-on` directive and a `steps` block that uses a `curl` command to trigger the workflow.

Changes to workflow triggering method:

* [`.github/workflows/dry-run-release.yml`](diffhunk://#diff-da505eba40e5178912154d1d165e17f3353098ba24e44bd62d23ad028700e42aL65-R85): Replaced the `uses` directive with a `runs-on` directive and a `steps` block that uses a `curl` command to trigger the `release-published` workflow. This change includes setting headers and passing necessary inputs as JSON data.