### PR TITLE
✨ Add matching branch logic to workflow for dynamic branch handling

### DIFF
--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -87,6 +87,20 @@ jobs:
           token: ${{ secrets.BOT_TOKEN }}
           ignore-versions: "^((?!${{ inputs.liquibase-version }}$).)*$"
 
+  matching-branch-logic:
+    runs-on: ubuntu-latest
+    outputs:
+      extensions_branch: ${{ steps.get-extensions-branch.outputs.extensions_branch }}
+    steps:
+      - id: get-extensions-branch
+        name: Get Extensions branch to use
+        run: |
+          if inputs.branch == 'master'; then
+            echo "extensions_branch=main" >> $GITHUB_OUTPUT
+          else
+            echo "extensions_branch=${{ inputs.branch }}" >> $GITHUB_OUTPUT
+          fi
+
   get-liquibase-checks-version:
       if: ${{ contains(inputs.extensions, 'liquibase-checks') }}
       runs-on: ubuntu-latest
@@ -119,16 +133,16 @@ jobs:
 
   build-liquibase-checks:
       if: ${{ contains(inputs.extensions, 'liquibase-checks') }}
-      needs: [ delete-extension-packages, get-liquibase-checks-version, delete-checks-packages ]
+      needs: [ delete-extension-packages, get-liquibase-checks-version, delete-checks-packages, matching-branch-logic ]
       uses: liquibase/build-logic/.github/workflows/publish-for-liquibase.yml@main
       with:
           repository: liquibase/liquibase-checks
           version: ${{ needs.get-liquibase-checks-version.outputs.version }}
-          branch: "${{ inputs.branch }}"
+          branch: ${{ needs.matching-branch-logic.outputs.extensions_branch }}
       secrets: inherit
 
   build-and-deploy-extensions:
-    needs: [delete-dependency-packages, delete-extension-packages, delete-checks-packages]
+    needs: [delete-dependency-packages, delete-extension-packages, delete-checks-packages, matching-branch-logic]
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -144,7 +158,7 @@ jobs:
         name: Checkout liquibase-pro
         with:
           repository: liquibase/liquibase-pro
-          ref: "${{ inputs.branch }}"
+          ref: ${{ needs.matching-branch-logic.outputs.extensions_branch }}
           path: liquibase-pro
           token: ${{ secrets.BOT_TOKEN }}
 
@@ -268,7 +282,7 @@ jobs:
           GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
         continue-on-error: true
         run: |
-          scripts_branch=${{ inputs.branch }}
+          scripts_branch= ${{ needs.matching-branch-logic.outputs.extensions_branch }}
           git config --global credential.helper store
           echo "https://$GIT_USERNAME:$GIT_PASSWORD@github.com" > ~/.git-credentials
           IFS=',' read -ra EXT_ARRAY <<< "${{ inputs.extensions }}"


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/build-extension-jars.yml` file to introduce a new job for determining the appropriate branch to use for extensions. This ensures that the correct branch is referenced throughout the workflow. The most important changes include adding the `matching-branch-logic` job and updating various jobs to depend on its output.

Improvements to branch handling:

* Added a new job `matching-branch-logic` to determine the appropriate branch for extensions based on the input branch.
* Updated the `build-liquibase-checks` job to depend on the `matching-branch-logic` job and use its output for the branch reference.
* Updated the `build-and-deploy-extensions` job to depend on the `matching-branch-logic` job.
* Modified the `Checkout liquibase-pro` step to use the branch determined by the `matching-branch-logic` job.
* Updated the script to set the `scripts_branch` variable using the output from the `matching-branch-logic` job.