### PR TITLE
🔧 Fix syntax for branch comparison in workflow script

### DIFF
--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -95,11 +95,12 @@ jobs:
       - id: get-extensions-branch
         name: Get Extensions branch to use
         run: |
-          if inputs.branch == 'master'; then
-            echo "extensions_branch=main" >> $GITHUB_OUTPUT
-          else
-            echo "extensions_branch=${{ inputs.branch }}" >> $GITHUB_OUTPUT
-          fi
+          run: |
+            if [ "${{ inputs.branch }}" == "master" ]; then
+              echo "extensions_branch=main" >> "$GITHUB_OUTPUT"
+            else
+              echo "extensions_branch=${{ inputs.branch }}" >> "$GITHUB_OUTPUT"
+            fi
 
   get-liquibase-checks-version:
       if: ${{ contains(inputs.extensions, 'liquibase-checks') }}


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/build-extension-jars.yml` file to improve the shell script syntax. The most important change is:

* Updated the `run` script to use proper shell script syntax by adding square brackets around the condition and quoting the `$GITHUB_OUTPUT` variable.