### PR TITLE
🔧 Refactor matching branch logic in workflow for PRO repo

### DIFF
--- a/.github/workflows/build-extension-jars.yml
+++ b/.github/workflows/build-extension-jars.yml
@@ -87,7 +87,7 @@ jobs:
           token: ${{ secrets.BOT_TOKEN }}
           ignore-versions: "^((?!${{ inputs.liquibase-version }}$).)*$"
 
-  matching-branch-logic:
+  matching-branch-logic-extensions:
     runs-on: ubuntu-latest
     outputs:
       extensions_branch: ${{ steps.get-extensions-branch.outputs.extensions_branch }}
@@ -101,6 +101,20 @@ jobs:
             else
               echo "extensions_branch=${{ inputs.branch }}" >> "$GITHUB_OUTPUT"
             fi
+
+  matching-branch-logic-pro:
+    runs-on: ubuntu-latest
+    outputs:
+      pro_branch: ${{ steps.get-pro-branch.outputs.pro_branch }}
+    steps:
+      - id: get-pro-branch
+        name: Get Pro branch to use
+        run: |
+          if [ "${{ inputs.branch }}" == "master" ]; then
+            echo "pro_branch=master" >> "$GITHUB_OUTPUT"
+          else
+            echo "pro_branch=${{ inputs.branch }}" >> "$GITHUB_OUTPUT"
+          fi          
 
   get-liquibase-checks-version:
       if: ${{ contains(inputs.extensions, 'liquibase-checks') }}
@@ -134,16 +148,16 @@ jobs:
 
   build-liquibase-checks:
       if: ${{ contains(inputs.extensions, 'liquibase-checks') }}
-      needs: [ delete-extension-packages, get-liquibase-checks-version, delete-checks-packages, matching-branch-logic ]
+      needs: [ delete-extension-packages, get-liquibase-checks-version, delete-checks-packages, matching-branch-logic-extensions ]
       uses: liquibase/build-logic/.github/workflows/publish-for-liquibase.yml@main
       with:
           repository: liquibase/liquibase-checks
           version: ${{ needs.get-liquibase-checks-version.outputs.version }}
-          branch: ${{ needs.matching-branch-logic.outputs.extensions_branch }}
+          branch: ${{ needs.matching-branch-logic-extensions.outputs.extensions_branch }}
       secrets: inherit
 
   build-and-deploy-extensions:
-    needs: [delete-dependency-packages, delete-extension-packages, delete-checks-packages, matching-branch-logic]
+    needs: [delete-dependency-packages, delete-extension-packages, delete-checks-packages, matching-branch-logic-extensions]
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -159,7 +173,7 @@ jobs:
         name: Checkout liquibase-pro
         with:
           repository: liquibase/liquibase-pro
-          ref: ${{ needs.matching-branch-logic.outputs.extensions_branch }}
+          ref: ${{ needs.matching-branch-logic-pro.outputs.pro_branch }}
           path: liquibase-pro
           token: ${{ secrets.BOT_TOKEN }}
 
@@ -283,7 +297,7 @@ jobs:
           GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
         continue-on-error: true
         run: |
-          scripts_branch= ${{ needs.matching-branch-logic.outputs.extensions_branch }}
+          scripts_branch= ${{ needs.matching-branch-logic-extensions.outputs.extensions_branch }}
           git config --global credential.helper store
           echo "https://$GIT_USERNAME:$GIT_PASSWORD@github.com" > ~/.git-credentials
           IFS=',' read -ra EXT_ARRAY <<< "${{ inputs.extensions }}"


### PR DESCRIPTION
For failure here:
https://github.com/liquibase/liquibase/actions/runs/13246462172/job/36974852699#step:3:4
![Screenshot 2025-02-10 at 11 38 45 AM](https://github.com/user-attachments/assets/054caebd-80b0-4cab-8631-2e373db177f3)

We do not have a `main` PRO branch. 

This pull request includes several changes to the `.github/workflows/build-extension-jars.yml` file to improve the handling of branch logic for different types of builds. The changes primarily involve renaming and adding new job steps to better manage branch references for extensions and pro builds.

Branch logic improvements:

* Renamed `matching-branch-logic` to `matching-branch-logic-extensions` for better clarity and distinction between different branch logics.
* Added a new job `matching-branch-logic-pro` to handle branch logic specifically for pro builds. This includes determining the appropriate branch to use based on the input branch.

Workflow dependencies and references:

* Updated the `needs` dependencies in various jobs to reflect the renamed `matching-branch-logic-extensions`.
* Changed the branch reference in the `build-and-deploy-extensions` job to use the new `matching-branch-logic-pro` outputs for the pro branch.
* Updated the `scripts_branch` reference to use the renamed `matching-branch-logic-extensions` outputs.