### PR TITLE
🔧 Update release-published.yml

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -480,7 +480,7 @@ jobs:
             # Get the latest tag
             echo "latest_version=$(git describe --tags $(git rev-list --tags --max-count=1) | sed 's/^v//')" >> $GITHUB_OUTPUT
             # Get the previous released version tag
-            echo "previous_version=$(git for-each-ref --sort=creatordate --format '%(tag)' refs/tags|tail -2|head -1| sed 's/^v//')" >> $GITHUB_OUTPUT
+            echo "previous_version=$(git for-each-ref --sort=creatordate --format '%(refname:short)' refs/tags |sed 's/^v//')" >> $GITHUB_OUTPUT
 
 
       - name: Repository Dispatch


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release-published.yml` file. The change modifies the command used to get the previous released version tag to use a different format.

* [`.github/workflows/release-published.yml`](diffhunk://#diff-f7ca0660afb7c5d6e7220dee8a6db81db251b3c98818f4d76a3e4441b85c7a6dL483-R483): Changed the command to get the previous released version tag to use `%(refname:short)` instead of `%(tag)`.
* We were getting blanks when running `git for-each-ref --sort=creatordate --format '%(tag)' refs/tags`. 
The solution now will list both lightweight and annotated tags. 

![Screenshot 2025-02-17 at 11 04 16 AM](https://github.com/user-attachments/assets/76c90cf4-0128-4380-ab01-e38233ed1496)
