### PR TITLE
🔧 Fix/generate-oss-pro-sbom-reports

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -498,7 +498,7 @@ jobs:
           token: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
           repository: liquibase/build-logic
           event-type: oss-released-version
-          client-payload: '{"latest_version": "${{ needs.update-docs-oss-pro-version.outputs.latest_version }}", "repo_name": "${{ matrix.repo }}" }'
+          client-payload: '{"latest_version": "${{ needs.update-docs-oss-pro-version.outputs.latest_version }}", "repo_name": "${{ matrix.repo }}", "branch_name": "${{ github.ref }}" }'
 
   dry_run_deploy_maven:
     if: ${{ inputs.dry_run == true }}

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -252,27 +252,7 @@ jobs:
           aws s3 sync . s3://javadocsliquibasecom-origin --only-show-errors
 
 
-  trigger-sbom-generation-lb-lbpo:
-    if: ${{ inputs.dry_run == false }}
-    name: Generate SBOMS for liquibase and liquibase-pro
-    runs-on: ubuntu-latest
-    needs: [ setup ]
-    strategy:
-      matrix:
-        repo: [ 'liquibase/liquibase', 'liquibase/liquibase-pro' ]
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
-          repository: ${{ matrix.repo }}
-          event-type: oss-released-version
-          client-payload: '{"latest_version": "${{ steps.get_latest_oss_version.outputs.latest_version }}"'
-
+  
   publish_to_github_packages:
     if: ${{ inputs.dry_run == false }}
     name: Publish artifacts to Github Packages
@@ -498,6 +478,27 @@ jobs:
           token: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
           repository: liquibase/liquibase-aws-license-service
           event-type: oss-released-version
+
+  trigger-sbom-generation-lb-lbpo:
+    if: ${{ inputs.dry_run == false }}
+    name: Generate SBOMS for liquibase and liquibase-pro
+    runs-on: ubuntu-latest
+    needs: [ setup, update-docs-oss-pro-version ]
+    strategy:
+      matrix:
+        repo: [ 'liquibase/liquibase', 'liquibase/liquibase-pro' ]
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}
+          repository: liquibase/build-logic
+          event-type: oss-released-version
+          client-payload: '{"latest_version": "${{ needs.update-docs-oss-pro-version.outputs.latest_version }}", "repo_name": "${{ matrix.repo }}" }'
 
   dry_run_deploy_maven:
     if: ${{ inputs.dry_run == true }}


### PR DESCRIPTION
This pull request includes modifications to the GitHub Actions workflow configuration in the `.github/workflows/release-published.yml` file. The changes involve re-adding and updating the job for generating SBOMs (Software Bill of Materials) for Liquibase and Liquibase Pro.

Changes to the GitHub Actions workflow:

* Removed the `trigger-sbom-generation-lb-lbpo` job and then re-added it with updated dependencies and parameters. The job now depends on both the `setup` and `update-docs-oss-pro-version` jobs and includes an updated `client-payload` for the repository dispatch step. [[1]](diffhunk://#diff-f7ca0660afb7c5d6e7220dee8a6db81db251b3c98818f4d76a3e4441b85c7a6dL255-L274) [[2]](diffhunk://#diff-f7ca0660afb7c5d6e7220dee8a6db81db251b3c98818f4d76a3e4441b85c7a6dR482-R502)