### PR TITLE
fix liquibase-cli dependencies when deploying to Maven Central

### DIFF
--- a/liquibase-cli/pom.xml
+++ b/liquibase-cli/pom.xml
@@ -33,6 +33,12 @@
             <version>4.7.6</version>
             <scope>compile</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/liquibase-cli/pom.xml
+++ b/liquibase-cli/pom.xml
@@ -24,6 +24,7 @@
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-standard</artifactId>
             <version>${project.version}</version>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>

--- a/liquibase-cli/src/main/java/liquibase/integration/commandline/CommandLineArgumentValueProvider.java
+++ b/liquibase-cli/src/main/java/liquibase/integration/commandline/CommandLineArgumentValueProvider.java
@@ -4,7 +4,6 @@ import liquibase.configuration.AbstractMapConfigurationValueProvider;
 import picocli.CommandLine;
 
 import java.util.Map;
-import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

Fix liquibase-cli deployed to Maven Central is unusable as standard is not published. So we remove the reference for it and let people include liquibase-core manually.

Fixes #6145 