### PR TITLE
Fix snapshot for MSSQL decimal sequences (DAT-19504)

### DIFF
--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/core/GenerateChangeLogMSSQLIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/core/GenerateChangeLogMSSQLIntegrationTest.groovy
@@ -157,4 +157,17 @@ CREATE VIEW employees_view AS SELECT FirstName FROM [dbo].Employees;
         cleanup:
         outputFile.delete()
     }
+
+    def "Should generate decimal sequence without overflow"() {
+        when:
+        CommandUtil.runUpdate(mssql,'src/test/resources/changelogs/mssql/issues/decimal.sequence.sql')
+        CommandUtil.runGenerateChangelog(mssql, 'sequence.mssql.sql')
+        then:
+        def outputFile = new File('sequence.mssql.sql')
+        FileUtil.getContents(outputFile).contains("CREATE SEQUENCE big AS decimal(19) START WITH 100000000000 INCREMENT BY 1 MINVALUE -9999999999999999999 MAXVALUE 9999999999999999999;")
+        FileUtil.getContents(outputFile).contains("CREATE SEQUENCE small START WITH 1 INCREMENT BY 1 MINVALUE 0 MAXVALUE 20")
+
+        cleanup:
+        outputFile.delete()
+    }
 }

--- a/liquibase-integration-tests/src/test/resources/changelogs/mssql/issues/decimal.sequence.sql
+++ b/liquibase-integration-tests/src/test/resources/changelogs/mssql/issues/decimal.sequence.sql
@@ -1,0 +1,15 @@
+-- liquibase formatted sql
+-- changeset test:create-sequence-big
+create sequence big
+    as decimal (19)
+    start with 100000000000
+    increment by 1
+    minvalue -9999999999999999999
+    maxvalue 9999999999999999999;
+
+-- changeset test:create-sequence-small
+create sequence small
+    start with 1
+    increment by 1
+    minvalue 0
+    maxvalue 20;


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description
When snapshotting a sequence created with decimal(19) because we cast everything to a bigint we may hit an arithmetic overflow when casting the min, max, or start value of the sequence. 

This change:
1. Captures the data type and precision of the decimal sequence in our snapshot query
2. Generates the correct sql if we have a decimal sequence. Previously all MSSQL snapshots were assumed to be of type bigint, which is not necessary to include in your create sequence statement. 
<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
- Add unit/integration tests (ask for support if not sure how to do it)
- Make sure tests all pass
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about
Are there other data types that I should worry about while I'm here? I very intentionally did not add the data type for all sequences so as to not produce differences in diff from a previously generated changelog.
<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
