### PR TITLE
excluded junit from commons-collections4

### DIFF
--- a/liquibase-standard/pom.xml
+++ b/liquibase-standard/pom.xml
@@ -174,6 +174,12 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
             <version>${commons-collections4.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
`commons-collections4` version 4.4 (from 2019) that we have may screw up tests as it contains outdated `org.junit.jupiter.engine.discovery.predicates.IsTestableMethod` that tries to use `ReflectionUtils.returnsVoid()` that doesn't exist anymore in `junit-platform-commons`.
Newer `junit-platform-commons` has `ReflectionUtils.returnsPrimitiveVoid()` instead.
So it ends up with 2 `org.junit.jupiter.engine.discovery.predicates.IsTestableMethod` implementations - one from outdated junit 4.12 and new, and based on other things in classpath it may pick up the correct or wrong one. 
For me (on Windows) it usually picks up wrong. 
Overall `commons-collections4` should not bring `junit` with it.
