### PR TITLE
fix #5197: Ensure contexts from properties object are not ignored

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/DatabaseChangelogCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/DatabaseChangelogCommandStep.java
@@ -9,7 +9,6 @@ import liquibase.changelog.ChangeLogHistoryServiceFactory;
 import liquibase.changelog.ChangeLogParameters;
 import liquibase.changelog.DatabaseChangeLog;
 import liquibase.command.*;
-import liquibase.configuration.ConfigurationDefinition;
 import liquibase.database.Database;
 import liquibase.exception.LiquibaseException;
 import liquibase.lockservice.LockServiceFactory;
@@ -18,7 +17,7 @@ import liquibase.parser.ChangeLogParser;
 import liquibase.parser.ChangeLogParserFactory;
 import liquibase.parser.core.xml.XMLChangeLogSAXParser;
 import liquibase.resource.ResourceAccessor;
-import liquibase.util.StringUtil;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -99,14 +98,30 @@ public class DatabaseChangelogCommandStep extends AbstractHelperCommandStep impl
             changeLogParameters.addJavaProperties();
             changeLogParameters.addDefaultFileProperties();
         }
+        extractContextAndLabels(commandScope, changeLogParameters);
+        return changeLogParameters;
+    }
+
+    /**
+     * Extracts contexts and labels from the command scope and if present sets them in the changeLogParameters.
+     * Contexts and labels from dedicated parameters have priority over the values from the changeLogParameters.
+     */
+    private void extractContextAndLabels(CommandScope commandScope, ChangeLogParameters changeLogParameters) {
         Contexts contexts = new Contexts(commandScope.getArgumentValue(CONTEXTS_ARG));
-        changeLogParameters.setContexts(contexts);
+        if (contexts.isEmpty()) {
+            contexts = changeLogParameters.getContexts();
+        } else {
+            changeLogParameters.setContexts(contexts);
+        }
         commandScope.provideDependency(Contexts.class, contexts);
         LabelExpression labels = new LabelExpression(commandScope.getArgumentValue(LABEL_FILTER_ARG));
-        changeLogParameters.setLabels(labels);
+        if (labels.isEmpty()) {
+            labels = changeLogParameters.getLabels();
+        } else {
+            changeLogParameters.setLabels(labels);
+        }
         commandScope.provideDependency(LabelExpression.class, labels);
         addCommandFiltersMdc(labels, contexts);
-        return changeLogParameters;
     }
 
     public static void addCommandFiltersMdc(LabelExpression labelExpression, Contexts contexts) {
@@ -124,7 +139,7 @@ public class DatabaseChangelogCommandStep extends AbstractHelperCommandStep impl
         }
         DatabaseChangeLog changelog = Scope.child(Collections.singletonMap(Scope.Attr.database.name(), database),
                 () -> parser.parse(changeLogFile, changeLogParameters, resourceAccessor));
-        if (StringUtil.isNotEmpty(changelog.getLogicalFilePath())) {
+        if (StringUtils.isNotEmpty(changelog.getLogicalFilePath())) {
             Scope.getCurrentScope().addMdcValue(MdcKey.CHANGELOG_FILE, changelog.getLogicalFilePath());
         } else {
             Scope.getCurrentScope().addMdcValue(MdcKey.CHANGELOG_FILE, changeLogFile);


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Description

fix #5197: Ensure contexts from properties object are not ignored

This commit fixes an issue where context values defined in CHANGELOG_PARAMETERS object were being ignored by the cDatabaseChangelogCommandStep .

Now it extracts contexts and labels from the command scope and if present sets them in the changeLogParameters, otherwise don't use them. 

* Contexts and labels from dedicated parameters have priority over the values from the changeLogParameters object. Usually dedicated parameters come from the command line while changeLogParameters object comes from Liquibase class/maven. 

## Things to be aware of

It was broken since 4.22.0 (command refactoring)

