### PR TITLE
feat: new tagDatabase parameter to keep tag on rollback

### DIFF
--- a/liquibase-integration-tests/src/test/resources/changelogs/common/test.tag.not.removed.by.rollback.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/common/test.tag.not.removed.by.rollback.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="1" author="mallod">
+        <comment>example-comment</comment>
+        <createTable tableName="TestTagTable">
+            <column name="id" type="int" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="name" type="varchar(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="address1" type="varchar(50)"/>
+            <column name="address2" type="varchar(50)"/>
+            <column name="city" type="varchar(30)"/>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="tagTest" author="mallod">
+        <tagDatabase tag="tagTest" keepTagOnRollback="true"/>
+    </changeSet>
+
+    <changeSet id="2" author="mallod">
+        <createTable tableName="TestTagTable2">
+            <column name="id" type="int" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="name" type="varchar(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="address1" type="varchar(50)"/>
+            <column name="address2" type="varchar(50)"/>
+            <column name="city" type="varchar(30)"/>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/liquibase-standard/src/main/java/liquibase/change/core/TagDatabaseChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/TagDatabaseChange.java
@@ -1,5 +1,6 @@
 package liquibase.change.core;
 
+import liquibase.ChecksumVersion;
 import liquibase.Scope;
 import liquibase.change.*;
 import liquibase.changelog.ChangeLogHistoryServiceFactory;
@@ -18,9 +19,16 @@ public class TagDatabaseChange extends AbstractChange {
 
     private String tag;
 
+    private Boolean keepTagOnRollback;
+
     @DatabaseChangeProperty(description = "Tag to apply", exampleValue = "version_1.3")
     public String getTag() {
         return tag;
+    }
+
+    @DatabaseChangeProperty(description = "Tag should not be removed during a rollback Default: false.")
+    public Boolean isKeepTagOnRollback() {
+        return keepTagOnRollback;
     }
 
     /**
@@ -55,5 +63,12 @@ public class TagDatabaseChange extends AbstractChange {
     @Override
     public String getSerializedObjectNamespace() {
         return STANDARD_CHANGELOG_NAMESPACE;
+    }
+
+    @Override
+    public String[] getExcludedFieldFilters(ChecksumVersion version) {
+        return new String[]{
+                "keepTagOnRollback"
+        };
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/change/core/TagDatabaseChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/TagDatabaseChange.java
@@ -26,7 +26,7 @@ public class TagDatabaseChange extends AbstractChange {
         return tag;
     }
 
-    @DatabaseChangeProperty(description = "Tag should not be removed during a rollback Default: false.")
+    @DatabaseChangeProperty(description = "Tag should not be removed during a rollback. Default: false.")
     public Boolean isKeepTagOnRollback() {
         return keepTagOnRollback;
     }

--- a/liquibase-standard/src/main/java/liquibase/changelog/filter/AfterTagChangeSetFilter.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/filter/AfterTagChangeSetFilter.java
@@ -2,13 +2,16 @@ package liquibase.changelog.filter;
 
 import liquibase.Scope;
 import liquibase.TagVersionEnum;
+import liquibase.change.core.TagDatabaseChange;
 import liquibase.changelog.ChangeSet;
+import liquibase.changelog.DatabaseChangeLog;
 import liquibase.changelog.RanChangeSet;
 import liquibase.exception.RollbackFailedException;
 import liquibase.integration.commandline.LiquibaseCommandLineConfiguration;
 import liquibase.logging.mdc.MdcKey;
 import liquibase.logging.mdc.MdcValue;
-import liquibase.util.StringUtil;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -20,10 +23,17 @@ public class AfterTagChangeSetFilter implements ChangeSetFilter {
 
     private final String tag;
     private final Set<String> changeLogsAfterTag = new HashSet<>();
+    private final DatabaseChangeLog databaseChangeLog;
 
-    public AfterTagChangeSetFilter(String tag, List<RanChangeSet> ranChangeSets, TagVersionEnum tagVersion)
+
+    public AfterTagChangeSetFilter(String tag, List<RanChangeSet> ranChangeSets, TagVersionEnum tagVersion) throws RollbackFailedException {
+        this(tag, ranChangeSets, tagVersion, null);
+    }
+
+    public AfterTagChangeSetFilter(String tag, List<RanChangeSet> ranChangeSets, TagVersionEnum tagVersion, DatabaseChangeLog databaseChangeLog)
             throws RollbackFailedException {
         this.tag = tag;
+        this.databaseChangeLog = databaseChangeLog;
         if (tagVersion == TagVersionEnum.OLDEST) {
             oldestVersion(ranChangeSets);
             return;
@@ -32,9 +42,7 @@ public class AfterTagChangeSetFilter implements ChangeSetFilter {
         //
         // Check to see if the tag exists
         //
-        boolean seenTag = ranChangeSets.stream().anyMatch(ranChangeSet ->  {
-            return tag.equalsIgnoreCase(ranChangeSet.getTag());
-        });
+        boolean seenTag = ranChangeSets.stream().anyMatch(ranChangeSet -> tag.equalsIgnoreCase(ranChangeSet.getTag()));
         if (! seenTag) {
             Scope.getCurrentScope().addMdcValue(MdcKey.DEPLOYMENT_OUTCOME, MdcValue.COMMAND_FAILED);
             throw new RollbackFailedException("Could not find tag '"+tag+"' in the database");
@@ -54,8 +62,8 @@ public class AfterTagChangeSetFilter implements ChangeSetFilter {
         //
         for (RanChangeSet ranChangeSet : reversedRanChangeSets) {
             if (tag.equalsIgnoreCase(ranChangeSet.getTag())) {
-                if ("tagDatabase".equals(StringUtil.trimToEmpty(ranChangeSet.getDescription()))) {
-                    changeLogsAfterTag.add(ranChangeSet.toString());
+                if ("tagDatabase".equals(StringUtils.trimToEmpty(ranChangeSet.getDescription())) && shouldRemoveTag(ranChangeSet)) {
+                        changeLogsAfterTag.add(ranChangeSet.toString());
                 }
                 break;
             }
@@ -81,15 +89,30 @@ public class AfterTagChangeSetFilter implements ChangeSetFilter {
             }
             //changeSet is just tagging the database. Also remove it.
             if (tag.equalsIgnoreCase(ranChangeSet.getTag()) &&
-                ("tagDatabase".equals(StringUtil.trimToEmpty(ranChangeSet.getDescription())))) {
-                changeLogsAfterTag.add(ranChangeSet.toString());
-            }
+                ("tagDatabase".equals(StringUtils.trimToEmpty(ranChangeSet.getDescription()))) &&
+                    shouldRemoveTag(ranChangeSet)) {
+                    changeLogsAfterTag.add(ranChangeSet.toString());
+                }
+
         }
 
         if (!seenTag) {
             Scope.getCurrentScope().addMdcValue(MdcKey.DEPLOYMENT_OUTCOME, MdcValue.COMMAND_FAILED);
             throw new RollbackFailedException("Could not find tag '" + tag + "' in the database");
         }
+    }
+
+    /**
+     * Check if the tag should be removed on rollback
+     */
+    private boolean shouldRemoveTag(RanChangeSet ranChangeSet) {
+        if (databaseChangeLog != null) {
+            ChangeSet changeSet = databaseChangeLog.getChangeSet(ranChangeSet);
+            if (changeSet != null) {
+                return (changeSet.getChanges().stream().noneMatch(c -> (c instanceof TagDatabaseChange) && BooleanUtils.isTrue(((TagDatabaseChange) c).isKeepTagOnRollback())));
+            }
+        }
+        return true;
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/changelog/filter/AfterTagChangeSetFilter.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/filter/AfterTagChangeSetFilter.java
@@ -62,7 +62,7 @@ public class AfterTagChangeSetFilter implements ChangeSetFilter {
         //
         for (RanChangeSet ranChangeSet : reversedRanChangeSets) {
             if (tag.equalsIgnoreCase(ranChangeSet.getTag())) {
-                if ("tagDatabase".equals(StringUtils.trimToEmpty(ranChangeSet.getDescription())) && shouldRemoveTag(ranChangeSet)) {
+                if ("tagDatabase".equals(StringUtils.trimToEmpty(ranChangeSet.getDescription())) && shouldKeepTag(ranChangeSet)) {
                         changeLogsAfterTag.add(ranChangeSet.toString());
                 }
                 break;
@@ -90,7 +90,7 @@ public class AfterTagChangeSetFilter implements ChangeSetFilter {
             //changeSet is just tagging the database. Also remove it.
             if (tag.equalsIgnoreCase(ranChangeSet.getTag()) &&
                 ("tagDatabase".equals(StringUtils.trimToEmpty(ranChangeSet.getDescription()))) &&
-                    shouldRemoveTag(ranChangeSet)) {
+                    shouldKeepTag(ranChangeSet)) {
                     changeLogsAfterTag.add(ranChangeSet.toString());
                 }
 
@@ -105,7 +105,7 @@ public class AfterTagChangeSetFilter implements ChangeSetFilter {
     /**
      * Check if the tag should be removed on rollback
      */
-    private boolean shouldRemoveTag(RanChangeSet ranChangeSet) {
+    private boolean shouldKeepTag(RanChangeSet ranChangeSet) {
         if (databaseChangeLog != null) {
             ChangeSet changeSet = databaseChangeLog.getChangeSet(ranChangeSet);
             if (changeSet != null) {

--- a/liquibase-standard/src/main/java/liquibase/command/core/RollbackCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/RollbackCommandStep.java
@@ -2,6 +2,7 @@ package liquibase.command.core;
 
 import liquibase.Scope;
 import liquibase.TagVersionEnum;
+import liquibase.changelog.DatabaseChangeLog;
 import liquibase.changelog.RanChangeSet;
 import liquibase.changelog.filter.AfterTagChangeSetFilter;
 import liquibase.command.*;
@@ -12,7 +13,6 @@ import liquibase.report.RollbackReportParameters;
 import liquibase.util.StringUtil;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -58,7 +58,7 @@ public class RollbackCommandStep extends AbstractRollbackCommandStep {
         List<RanChangeSet> ranChangeSetList = database.getRanChangeSetList();
         TagVersionEnum tagVersion = TagVersionEnum.valueOf(commandScope.getArgumentValue(TAG_VERSION_ARG));
         try {
-            AfterTagChangeSetFilter afterTagChangeSetFilter = new AfterTagChangeSetFilter(tagToRollBackTo, ranChangeSetList, tagVersion); // This can throw an exception
+            AfterTagChangeSetFilter afterTagChangeSetFilter = new AfterTagChangeSetFilter(tagToRollBackTo, ranChangeSetList, tagVersion, (DatabaseChangeLog)commandScope.getDependency(DatabaseChangeLog.class)); // This can throw an exception
             this.doRollback(resultsBuilder, ranChangeSetList, afterTagChangeSetFilter, rollbackReportParameters);
         } catch (Exception exception) {
             rollbackReportParameters.setSuccess(false);

--- a/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
+++ b/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
@@ -1193,6 +1193,7 @@
         <xsd:complexType>
             <xsd:attributeGroup ref="changeAttributes"/>
             <xsd:attribute name="tag" type="xsd:string" use="required"/>
+            <xsd:attribute name="keepTagOnRollback" type="booleanExp" />
             <xsd:anyAttribute namespace="##other"  processContents="lax"/>
         </xsd:complexType>
     </xsd:element>

--- a/liquibase-standard/src/test/java/liquibase/changelog/filter/AfterTagChangeSetFilterTest.java
+++ b/liquibase-standard/src/test/java/liquibase/changelog/filter/AfterTagChangeSetFilterTest.java
@@ -2,9 +2,10 @@ package liquibase.changelog.filter;
 
 import liquibase.TagVersionEnum;
 import liquibase.change.CheckSum;
+import liquibase.change.core.TagDatabaseChange;
 import liquibase.changelog.ChangeSet;
+import liquibase.changelog.DatabaseChangeLog;
 import liquibase.changelog.RanChangeSet;
-import liquibase.command.core.RollbackCommandStep;
 import liquibase.exception.RollbackFailedException;
 import org.junit.Test;
 
@@ -35,6 +36,34 @@ public class AfterTagChangeSetFilterTest {
 
         assertFalse(filter.accepts(new ChangeSet("1", "testAuthor", false, false, "path/changelog", null, null, null)).isAccepted());
         assertFalse(filter.accepts(new ChangeSet("2", "testAuthor", false, false, "path/changelog", null, null, null)).isAccepted());
+        assertTrue(filter.accepts(new ChangeSet("3", "testAuthor", false, false, "path/changelog", null, null, null)).isAccepted());
+
+    }
+
+    @Test
+    public void keepTag() throws Exception {
+        ArrayList<RanChangeSet> ranChanges = new ArrayList<RanChangeSet>();
+        ranChanges.add(new RanChangeSet("path/changelog", "1", "testAuthor", CheckSum.parse("12345"), new Date(), null, null, null, null, null, null, null));
+        ranChanges.add(new RanChangeSet("path/changelog", "2", "testAuthor", CheckSum.parse("12345"), new Date(), "tag1", null, "tagDatabase", null, null, null, null));
+        ranChanges.add(new RanChangeSet("path/changelog", "3", "testAuthor", CheckSum.parse("12345"), new Date(), null, null, null, null, null, null, null));
+
+        DatabaseChangeLog changeLog = new DatabaseChangeLog();
+        ranChanges.forEach(change -> {
+            ChangeSet changeSet = new ChangeSet(change.getId(), change.getAuthor(), false, false, change.getChangeLog(), null, null, changeLog );
+            if (change.getTag() != null) {
+                TagDatabaseChange tagChange = new TagDatabaseChange();
+                tagChange.setTag(change.getTag());
+                tagChange.setKeepTagOnRollback(true);
+                changeSet.addChange(tagChange);
+            }
+            changeLog.addChangeSet(changeSet);
+        });
+
+        AfterTagChangeSetFilter filter = new AfterTagChangeSetFilter("tag1", ranChanges, TagVersionEnum.OLDEST, changeLog);
+
+
+        assertFalse(filter.accepts(new ChangeSet("1", "testAuthor", false, false, "path/changelog", null, null, null)).isAccepted());
+        assertTrue(filter.accepts(new ChangeSet("2", "testAuthor", false, false, "path/changelog", null, null, null)).isAccepted());
         assertTrue(filter.accepts(new ChangeSet("3", "testAuthor", false, false, "path/changelog", null, null, null)).isAccepted());
 
     }

--- a/liquibase-standard/src/test/java/liquibase/changelog/filter/AfterTagChangeSetFilterTest.java
+++ b/liquibase-standard/src/test/java/liquibase/changelog/filter/AfterTagChangeSetFilterTest.java
@@ -22,7 +22,7 @@ public class AfterTagChangeSetFilterTest {
             new AfterTagChangeSetFilter("tag1", new ArrayList<RanChangeSet>(), TagVersionEnum.OLDEST);
             fail("Did not throw exception");
         } catch (RollbackFailedException e) {
-            ; //what we wanted
+            //what we wanted
         }
     }
 
@@ -36,6 +36,20 @@ public class AfterTagChangeSetFilterTest {
 
         assertFalse(filter.accepts(new ChangeSet("1", "testAuthor", false, false, "path/changelog", null, null, null)).isAccepted());
         assertFalse(filter.accepts(new ChangeSet("2", "testAuthor", false, false, "path/changelog", null, null, null)).isAccepted());
+        assertTrue(filter.accepts(new ChangeSet("3", "testAuthor", false, false, "path/changelog", null, null, null)).isAccepted());
+
+    }
+
+    @Test
+    public void acceptsFromTagCommand() throws Exception {
+        ArrayList<RanChangeSet> ranChanges = new ArrayList<RanChangeSet>();
+        ranChanges.add(new RanChangeSet("path/changelog", "1", "testAuthor", CheckSum.parse("12345"), new Date(), null, null, null, null, null, null, null));
+        ranChanges.add(new RanChangeSet("path/changelog", "2", "testAuthor", CheckSum.parse("12345"), new Date(), "tag1", null, "tagDatabase", null, null, null, null));
+        ranChanges.add(new RanChangeSet("path/changelog", "3", "testAuthor", CheckSum.parse("12345"), new Date(), null, null, null, null, null, null, null));
+        AfterTagChangeSetFilter filter = new AfterTagChangeSetFilter("tag1", ranChanges, TagVersionEnum.OLDEST);
+
+        assertFalse(filter.accepts(new ChangeSet("1", "testAuthor", false, false, "path/changelog", null, null, null)).isAccepted());
+        assertTrue(filter.accepts(new ChangeSet("2", "testAuthor", false, false, "path/changelog", null, null, null)).isAccepted());
         assertTrue(filter.accepts(new ChangeSet("3", "testAuthor", false, false, "path/changelog", null, null, null)).isAccepted());
 
     }
@@ -61,10 +75,9 @@ public class AfterTagChangeSetFilterTest {
 
         AfterTagChangeSetFilter filter = new AfterTagChangeSetFilter("tag1", ranChanges, TagVersionEnum.OLDEST, changeLog);
 
-
-        assertFalse(filter.accepts(new ChangeSet("1", "testAuthor", false, false, "path/changelog", null, null, null)).isAccepted());
-        assertTrue(filter.accepts(new ChangeSet("2", "testAuthor", false, false, "path/changelog", null, null, null)).isAccepted());
-        assertTrue(filter.accepts(new ChangeSet("3", "testAuthor", false, false, "path/changelog", null, null, null)).isAccepted());
+        assertFalse(filter.accepts(changeLog.getChangeSets().get(0)).isAccepted());
+        assertFalse(filter.accepts(changeLog.getChangeSets().get(1)).isAccepted());
+        assertTrue(filter.accepts(changeLog.getChangeSets().get(2)).isAccepted());
 
     }
 }

--- a/liquibase-standard/src/test/resources/liquibase/change/ChangeDefinitionTest.yaml
+++ b/liquibase-standard/src/test/resources/liquibase/change/ChangeDefinitionTest.yaml
@@ -1083,7 +1083,7 @@ stop: |
 
 tagDatabase: |
   keepTagOnRollback boolean 
-    Description: Tag should not be removed during a rollback Default: false.
+    Description: Tag should not be removed during a rollback. Default: false.
     Supported: all
   tag string 
     Description: Tag to apply

--- a/liquibase-standard/src/test/resources/liquibase/change/ChangeDefinitionTest.yaml
+++ b/liquibase-standard/src/test/resources/liquibase/change/ChangeDefinitionTest.yaml
@@ -1082,6 +1082,9 @@ stop: |
     Supported: all
 
 tagDatabase: |
+  keepTagOnRollback boolean 
+    Description: Tag should not be removed during a rollback Default: false.
+    Supported: all
   tag string 
     Description: Tag to apply
     Supported: all


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 


## Description

Implement functionality to preserve tags when performing rollback operations in Liquibase, by adding a new `keepTagOnRollback` parameter to the `tag` change type.
 This ensures tag information is maintained in the database change history during rollback scenarios, providing better traceability and consistency for database version control.

## Things to be aware of

The `keepTagOnRollback` flag is not stored in dbcl table, but is always reloaded from the changelog. It's also not used to calculate the checksum. 
So you can change the value and it will be reflected in the next execution.


Fixes #6728