### PR TITLE
SnowflakeOAuthConnection Implementation for Null Username Issue

### DIFF
--- a/liquibase-snowflake/src/main/java/liquibase/database/jvm/SnowflakeOAuthConnection.java
+++ b/liquibase-snowflake/src/main/java/liquibase/database/jvm/SnowflakeOAuthConnection.java
@@ -1,0 +1,69 @@
+package liquibase.database.jvm;
+
+import java.sql.Connection;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A JDBC connection wrapper for Snowflake that specifically handles OAuth authentication.
+ * 
+ * This class addresses the issue where JDBC connection metadata returns null for username when
+ * using the OAuth authenticator with token in the URL, resulting in "null@jdbc:snowflake:..." in logs.
+ */
+public class SnowflakeOAuthConnection extends JdbcConnection {
+    
+    private static final Pattern AUTH_PATTERN = Pattern.compile("authenticator=(\\w+)");
+    private static final Pattern CLIENT_ID_PATTERN = Pattern.compile("client_id=([^&;]+)");
+    
+    public SnowflakeOAuthConnection(Connection connection) {
+        super(connection);
+    }
+    
+    @Override
+    public String getConnectionUserName() {
+        String standardUsername = super.getConnectionUserName();
+
+        if (standardUsername != null && !standardUsername.trim().isEmpty()) {
+            return standardUsername;
+        }
+        
+        // Otherwise, try to determine the authentication method from the URL
+        String url = getURL();
+        String authenticator = extractAuthenticator(url);
+        
+        if ("oauth".equalsIgnoreCase(authenticator)) {
+            String clientId = extractClientId(url);
+            return clientId != null ? clientId : "oauth-authenticated-user";
+        } else if (authenticator != null) {
+            return authenticator + "-authenticated-user";
+        }
+        
+        return "snowflake-user";
+    }
+
+    private String extractAuthenticator(String url) {
+        if (url == null) {
+            return null;
+        }
+        
+        Matcher matcher = AUTH_PATTERN.matcher(url);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        
+        return null;
+    }
+
+    private String extractClientId(String url) {
+        if (url == null) {
+            return null;
+        }
+        
+        Matcher matcher = CLIENT_ID_PATTERN.matcher(url);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        
+        return null;
+    }
+}

--- a/liquibase-snowflake/src/test/java/liquibase/database/jvm/SnowflakeOAuthConnectionTest.java
+++ b/liquibase-snowflake/src/test/java/liquibase/database/jvm/SnowflakeOAuthConnectionTest.java
@@ -1,0 +1,103 @@
+package liquibase.database.jvm;
+
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SnowflakeOAuthConnectionTest {
+
+    @Test
+    public void testOAuthConnectionWithNullUsername() throws Exception {
+        Connection mockConnection = mock(Connection.class);
+        DatabaseMetaData mockMetaData = mock(DatabaseMetaData.class);
+        when(mockConnection.getMetaData()).thenReturn(mockMetaData);
+        when(mockMetaData.getUserName()).thenReturn(null);
+        when(mockMetaData.getURL()).thenReturn("jdbc:snowflake://account.snowflakecomputing.com/?authenticator=oauth&token=xyz");
+        
+        SnowflakeOAuthConnection connection = new SnowflakeOAuthConnection(mockConnection);
+        
+        String username = connection.getConnectionUserName();
+        assertNotNull("Username should not be null", username);
+        assertNotEquals("Username should not be 'null'", "null", username);
+        assertEquals("Should return the default OAuth user", "oauth-authenticated-user", username);
+    }
+
+    @Test
+    public void testOAuthConnectionWithClientId() throws Exception {
+        Connection mockConnection = mock(Connection.class);
+        DatabaseMetaData mockMetaData = mock(DatabaseMetaData.class);
+        when(mockConnection.getMetaData()).thenReturn(mockMetaData);
+        when(mockMetaData.getUserName()).thenReturn(null);
+        when(mockMetaData.getURL()).thenReturn("jdbc:snowflake://account.snowflakecomputing.com/?authenticator=oauth&client_id=my-client-id&token=xyz");
+        
+        SnowflakeOAuthConnection connection = new SnowflakeOAuthConnection(mockConnection);
+        
+        String username = connection.getConnectionUserName();
+        assertNotNull("Username should not be null", username);
+        assertEquals("Should return the client_id as username", "my-client-id", username);
+    }
+
+    @Test
+    public void testStandardUsernameIsReturned() throws Exception {
+        Connection mockConnection = mock(Connection.class);
+        DatabaseMetaData mockMetaData = mock(DatabaseMetaData.class);
+        when(mockConnection.getMetaData()).thenReturn(mockMetaData);
+        when(mockMetaData.getUserName()).thenReturn("standard-user");
+        when(mockMetaData.getURL()).thenReturn("jdbc:snowflake://account.snowflakecomputing.com/?authenticator=oauth&token=xyz");
+        
+        SnowflakeOAuthConnection connection = new SnowflakeOAuthConnection(mockConnection);
+        
+        String username = connection.getConnectionUserName();
+        assertEquals("Should return the original username", "standard-user", username);
+    }
+
+    @Test
+    public void testNonOAuthAuthenticator() throws Exception {
+        Connection mockConnection = mock(Connection.class);
+        DatabaseMetaData mockMetaData = mock(DatabaseMetaData.class);
+        when(mockConnection.getMetaData()).thenReturn(mockMetaData);
+        when(mockMetaData.getUserName()).thenReturn(null);
+        when(mockMetaData.getURL()).thenReturn("jdbc:snowflake://account.snowflakecomputing.com/?authenticator=externalbrowser");
+        
+        SnowflakeOAuthConnection connection = new SnowflakeOAuthConnection(mockConnection);
+        
+        String username = connection.getConnectionUserName();
+        assertNotNull("Username should not be null", username);
+        assertEquals("Should use authenticator type", "externalbrowser-authenticated-user", username);
+    }
+
+    @Test
+    public void testFallbackUsername() throws Exception {
+        Connection mockConnection = mock(Connection.class);
+        DatabaseMetaData mockMetaData = mock(DatabaseMetaData.class);
+        when(mockConnection.getMetaData()).thenReturn(mockMetaData);
+        when(mockMetaData.getUserName()).thenReturn(null);
+        when(mockMetaData.getURL()).thenReturn("jdbc:snowflake://account.snowflakecomputing.com/");
+        
+        SnowflakeOAuthConnection connection = new SnowflakeOAuthConnection(mockConnection);
+        
+        String username = connection.getConnectionUserName();
+        assertNotNull("Username should not be null", username);
+        assertEquals("Should use default username", "snowflake-user", username);
+    }
+
+    @Test
+    public void testHandlesNullUrl() throws Exception {
+        Connection mockConnection = mock(Connection.class);
+        DatabaseMetaData mockMetaData = mock(DatabaseMetaData.class);
+        when(mockConnection.getMetaData()).thenReturn(mockMetaData);
+        when(mockMetaData.getUserName()).thenReturn(null);
+        when(mockMetaData.getURL()).thenReturn(null);
+        
+        SnowflakeOAuthConnection connection = new SnowflakeOAuthConnection(mockConnection);
+        
+        String username = connection.getConnectionUserName();
+        assertNotNull("Username should not be null even with null URL", username);
+        assertEquals("Should use default username with null URL", "snowflake-user", username);
+    }
+}


### PR DESCRIPTION

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

Fixes an issue where connections to Snowflake using OAuth authentication (with token in URL) would display "null@jdbc:snowflake:..." in logs and status messages. This occurred because the JDBC driver returns null for username when using OAuth authentication with the token in the URL.

This PR introduces a specialized SnowflakeOAuthConnection class that provides meaningful username values for OAuth connections. The connection is automatically detected and wrapped by the SnowflakeDatabase class when OAuth authentication is detected in the URL.



## Things to be aware of

- Added a new class SnowflakeOAuthConnection that extends JdbcConnection to handle OAuth authentication
- Modified SnowflakeDatabase.setConnection() to detect OAuth connections and apply the wrapper


## Things to worry about

- The detection of OAuth authentication is based on the URL containing "authenticator=oauth" - this should be reliable but assumes a specific format

## Additional Context

When using an OAuth token in the URL, the connection would appear as "null@jdbc:snowflake:..." in logs because the JDBC driver's getUserName() method returns null in this case.

