### PR TITLE
fix: Prevent duplicate entries in databasechangelog with runAlways and onFail="MARK_RAN"

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeSet.java
@@ -725,6 +725,9 @@ public class ChangeSet implements Conditional, ChangeLogChild {
                     this.getChangeLog().getSkippedBecauseOfPreconditionsChangeSets().add(this);
                 } else if (preconditions.getOnFail().equals(PreconditionContainer.FailOption.MARK_RAN)) {
                     execType = ExecType.MARK_RAN;
+                    if (this.alwaysRun && databaseChangeLog.getChangeSet(this.getStoredFilePath(), this.author, this.id) != null) {
+                        execType = ExecType.SKIPPED;
+                    }
                     skipChange = true;
 
                     log.info("Marking ChangeSet: \"" + this + "\" as ran despite precondition failure due to onFail='MARK_RAN': " + message);
@@ -753,6 +756,7 @@ public class ChangeSet implements Conditional, ChangeLogChild {
                     this.getChangeLog().getSkippedBecauseOfPreconditionsChangeSets().add(this);
                 } else if (preconditions.getOnError().equals(PreconditionContainer.ErrorOption.MARK_RAN)) {
                     execType = ExecType.MARK_RAN;
+
                     skipChange = true;
 
                     log.info("Marking ChangeSet: " + this + " ran despite precondition error: " + message);


### PR DESCRIPTION

When a changeset uses both `runAlways` and `preConditions onFail="MARK_RAN"`,
duplicate entries are created in the databasechangelog table. This happens
because:

1. When a precondition fails, we set `execType = ExecType.MARK_RAN`
2. For MARK_RAN, the `ranBefore` attribute is false
3. MarkChangeSetRanGenerator inserts a new row instead of updating existing one

The fix corrects the logic in ChangeSet execution to properly handle this
combination and prevent multiple entries for the same changeset.


Fixes #6821
