### PR TITLE
Potential fix for code scanning alert no. 4: Cross-site scripting

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/integration/servlet/GenericStatusServlet.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/servlet/GenericStatusServlet.java
@@ -1,6 +1,7 @@
 package liquibase.integration.servlet;
 
 import liquibase.Scope;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -91,7 +92,7 @@ class GenericStatusServlet {
         if (currentLevel.equals(level)) {
             return level.getName();
         } else {
-            return "<a href=" + request.getRequestURI() + "?logLevel=" + level.getName() + ">" + level.getName() + "</a>";
+            return "<a href=" + StringEscapeUtils.escapeHtml4(request.getRequestURI()) + "?logLevel=" + level.getName() + ">" + level.getName() + "</a>";
         }
     }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/liquibase/liquibase/security/code-scanning/4](https://github.com/liquibase/liquibase/security/code-scanning/4)

To fix the cross-site scripting vulnerability, we need to ensure that any user-provided data is properly sanitized or encoded before being included in the HTML response. The best way to fix this issue is to use a library that provides HTML encoding functions to escape any potentially harmful characters.

In this case, we can use the `StringEscapeUtils` class from the Apache Commons Text library to encode the user-provided URI. This will ensure that any special characters are properly escaped, preventing XSS attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
