### PR TITLE
fix: Main generateChangeLog didn't actually execute the command

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/commandline/Main.java
@@ -1767,6 +1767,8 @@ public class Main {
 
         this.setDatabaseArgumentsToCommand(generateChangelogCommand);
         this.setPreCompareArgumentsToCommand(generateChangelogCommand);
+
+        generateChangelogCommandq.execute();
     }
 
     private void runDiffChangelogCommandStep() throws CommandExecutionException, CommandLineParsingException, IOException {


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
I was following some old instructions to setup liquibase using only liquibase-core.jar (no CLI) and discovered `generateChangeLog` doesn't actually do anything when invoked from the deprecated `Main` class.  Per diff, it seems like a basic omission compared to every other `run*Command` method.

    java -cp ./jars liquibase.integration.commandline.Main generateChangeLog

## Things to be aware of

* I have not checked how this interacts with the various other ways of invoking generateChangeLog logic.
* It works fine from the `liquibase.integration.commandline.LiquibaseCommandLine` (provided you have picocli on cp)

## Things to worry about

Clearly the instructions I am following are not up to date or this would not have been live for two years :) The code is not deleted though so should work as expected.

## Additional Context

<!--
Add any other context about the problem here.
-->
