### PR TITLE
feat: Improve Command Definition Internal Status Inheritance

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/command/CommandFactory.java
+++ b/liquibase-standard/src/main/java/liquibase/command/CommandFactory.java
@@ -149,9 +149,12 @@ public class CommandFactory implements SingletonObject {
     }
 
     private void adjustCommandDefinitionForSteps(CommandDefinition commandDefinition) {
+        boolean allInternal = true;
         for (CommandStep step : commandDefinition.getPipeline()) {
             step.adjustCommandDefinition(commandDefinition);
+            allInternal = step.isInternal() && allInternal;
         }
+        commandDefinition.setInternal(allInternal);
     }
 
     /**

--- a/liquibase-standard/src/main/java/liquibase/command/CommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/CommandStep.java
@@ -1,5 +1,6 @@
 package liquibase.command;
 
+import liquibase.Beta;
 import liquibase.exception.CommandValidationException;
 
 import java.util.List;
@@ -74,4 +75,13 @@ public interface CommandStep {
      * @return list with the provided classes types
      */
     List<Class<?>> providedDependencies();
+
+    /**
+     * Informational method to determine if this step is internal to Liquibase and should not be disclosed to end users
+     * @return true if this step is internal to Liquibase and should not be shown in the help output
+     */
+    @Beta
+    default boolean isInternal() {
+        return false;
+    }
 }

--- a/liquibase-standard/src/main/java/liquibase/command/core/InternalSnapshotCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/InternalSnapshotCommandStep.java
@@ -132,4 +132,8 @@ public class InternalSnapshotCommandStep extends AbstractCommandStep {
         }
     }
 
+    @Override
+    public boolean isInternal() {
+        return true;
+    }
 }

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/AbstractArgumentCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/AbstractArgumentCommandStep.java
@@ -15,4 +15,9 @@ public abstract class AbstractArgumentCommandStep extends AbstractCommandStep {
 
     @Override
     public abstract List<Class<?>> providedDependencies();
+
+    @Override
+    public boolean isInternal() {
+        return true;
+    }
 }

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/AbstractArgumentCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/AbstractArgumentCommandStep.java
@@ -1,17 +1,10 @@
 package liquibase.command.core.helpers;
 
 import liquibase.command.AbstractCommandStep;
-import liquibase.command.CommandDefinition;
-import liquibase.util.HelpUtil;
 
 import java.util.List;
 
 public abstract class AbstractArgumentCommandStep extends AbstractCommandStep {
-
-    @Override
-    public final void adjustCommandDefinition(CommandDefinition commandDefinition) {
-        HelpUtil.hideCommandNameInHelpView(commandDefinition);
-    }
 
     @Override
     public abstract List<Class<?>> providedDependencies();

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/AbstractHelperCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/AbstractHelperCommandStep.java
@@ -18,4 +18,8 @@ public abstract class AbstractHelperCommandStep extends AbstractCommandStep {
         }
     }
 
+    @Override
+    public boolean isInternal() {
+        return true;
+    }
 }

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/ShowSummaryArgument.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/ShowSummaryArgument.java
@@ -3,7 +3,6 @@ package liquibase.command.core.helpers;
 import liquibase.UpdateSummaryEnum;
 import liquibase.UpdateSummaryOutputEnum;
 import liquibase.command.*;
-import liquibase.util.HelpUtil;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -75,11 +74,6 @@ public class ShowSummaryArgument extends AbstractCommandStep {
         UpdateSummaryOutputEnum showSummaryOutputArgument = commandScope.getArgumentValue(SHOW_SUMMARY_OUTPUT);
         commandScope.provideDependency(UpdateSummaryEnum.class, showSummaryArgument);
         commandScope.provideDependency(UpdateSummaryOutputEnum.class, showSummaryOutputArgument);
-    }
-
-    @Override
-    public void adjustCommandDefinition(CommandDefinition commandDefinition) {
-        HelpUtil.hideCommandNameInHelpView(commandDefinition);
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/ShowSummaryArgument.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/ShowSummaryArgument.java
@@ -81,4 +81,9 @@ public class ShowSummaryArgument extends AbstractCommandStep {
     public void adjustCommandDefinition(CommandDefinition commandDefinition) {
         HelpUtil.hideCommandNameInHelpView(commandDefinition);
     }
+
+    @Override
+    public boolean isInternal() {
+        return true;
+    }
 }

--- a/liquibase-standard/src/main/java/liquibase/util/HelpUtil.java
+++ b/liquibase-standard/src/main/java/liquibase/util/HelpUtil.java
@@ -1,7 +1,20 @@
 package liquibase.util;
 
+import liquibase.command.CommandDefinition;
+
 public class HelpUtil {
 
     public static final String HISTORY_URL = "https://docs.liquibase.com/DATABASECHANGELOGHISTORY";
+    /**
+     * Hides the command name when running liquibase --help
+     * @param commandDefinition the command definition to adjust
+     * @deprecated instead of using this method, use the {@link liquibase.command.CommandDefinition#setInternal(boolean)} method in your commands
+     */
+    @Deprecated
+    public static void hideCommandNameInHelpView(CommandDefinition commandDefinition) {
+        if (commandDefinition.getPipeline().size() == 1) {
+            commandDefinition.setInternal(true);
+        }
+    }
 
 }

--- a/liquibase-standard/src/main/java/liquibase/util/HelpUtil.java
+++ b/liquibase-standard/src/main/java/liquibase/util/HelpUtil.java
@@ -1,17 +1,7 @@
 package liquibase.util;
 
-import liquibase.command.CommandDefinition;
-
 public class HelpUtil {
 
     public static final String HISTORY_URL = "https://docs.liquibase.com/DATABASECHANGELOGHISTORY";
-    /**
-     * Hides the command name when running liquibase --help
-     * @param commandDefinition the command definition to adjust
-     */
-    public static void hideCommandNameInHelpView(CommandDefinition commandDefinition) {
-        if (commandDefinition.getPipeline().size() == 1) {
-            commandDefinition.setInternal(true);
-        }
-    }
+
 }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
This PR ensures that commands are correctly marked as internal when all of their pipeline steps are internal. It adds logic to `CommandFactory.adjustCommandDefinitionForSteps()` to track if all steps are internal, and then sets the command definition's internal status accordingly.

It also removes the command name hiding functionality from helper classes. It:

1. Removes the `adjustCommandDefinition()` method from `AbstractArgumentCommandStep`
2. Removes the same method override from `ShowSummaryArgument`
3. Removes the utility method `hideCommandNameInHelpView()` from `HelpUtil`

This change simplifies the codebase by relying on the `isInternal()` method alone to determine command visibility, eliminating redundant code that manipulated command definitions directly.
