### PR TITLE
INT-185 - Solving the situation where the customer tries to connect t…

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/database/jvm/JdbcConnection.java
+++ b/liquibase-standard/src/main/java/liquibase/database/jvm/JdbcConnection.java
@@ -18,6 +18,7 @@ import java.util.regex.Pattern;
 public class JdbcConnection implements DatabaseConnection {
     private java.sql.Connection con;
     private static final Pattern PROXY_USER = Pattern.compile(".*(?:thin|oci)\\:(.+)/@.*");
+    private String originalUrl; // Store the original URL for OAuth validation
 
     private static final List<ConnectionPatterns> JDBC_CONNECTION_PATTERNS = Scope.getCurrentScope().getServiceLocator().findInstances(ConnectionPatterns.class);
 
@@ -39,6 +40,8 @@ public class JdbcConnection implements DatabaseConnection {
         String driverClassName = driverObject.getClass().getName();
         String errorMessage = "Connection could not be created to " + sanitizeUrl(url) + " with driver " + driverClassName;
         try {
+            this.originalUrl = url;
+            
             this.con = driverObject.connect(url, driverProperties);
             if (this.con == null) {
                 throw new DatabaseException(errorMessage + ".  Possibly the wrong driver for the given database URL");
@@ -207,7 +210,14 @@ public class JdbcConnection implements DatabaseConnection {
     @Override
     public String getConnectionUserName() {
         try {
-            return con.getMetaData().getUserName();
+            String username = con.getMetaData().getUserName();
+            // Handle Snowflake OAuth authentication with null username
+            // TODO: Move this to Snowflake extension later when appropriate
+            if (username == null && originalUrl != null && originalUrl.startsWith("jdbc:snowflake:") 
+                && originalUrl.contains("authenticator=oauth")) {
+                return "oauth-authenticated-user";
+            }
+            return username;
         } catch (SQLException e) {
             throw new UnexpectedLiquibaseException(e);
         }


### PR DESCRIPTION
## Fix showing null username when connecting to Snowflake using an OAuth token without defining a username
## Impact
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
Fixes an issue where Liquibase shows a null value in logs when connecting to Snowflake using OAuth authentication without explicitly setting a username.

When connecting to Snowflake using OAuth token authentication without providing a username, the logs would display a null value where the username would normally appear:

`4 changesets have not been applied to null@jdbc:snowflake://<host>:443/`

This fix modifies the `getConnectionUserName()` method in the JdbcConnection class to detect Snowflake OAuth authentication from the connection URL and return a meaningful placeholder username ("oauth-authenticated-user") when the actual username is null.

This improves log readability and prevents confusion when reviewing Liquibase operation logs.

## Things to be aware of
- This fix is specifically targeted at Snowflake OAuth authentication
- The code includes a TODO comment noting that this logic should be moved to the Snowflake extension in the future when appropriate
- The change only affects log output and doesn't change any functional behavior

## Things to worry about
- This is a temporary solution within the standard module
- In the future, this logic should be moved to the Snowflake extension for better code organization

## Additional Context
When using OAuth token authentication with Snowflake, the system can pull in default values for warehouse, database, or schema, but the username may be null if not explicitly provided. This fix ensures that logs display meaningful information rather than null values in such cases.