### PR TITLE
feat: Add PostgreSQL Index Function Support via USING Clause

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/change/core/CreateIndexChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/CreateIndexChange.java
@@ -230,7 +230,8 @@ public class CreateIndexChange extends AbstractChange implements ChangeWithColum
     @Override
     public String[] getExcludedFieldFilters(ChecksumVersion version) {
         return new String[]{
-                "associatedWith"
+                "associatedWith",
+                "using"
         };
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/change/core/CreateIndexChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/CreateIndexChange.java
@@ -44,6 +44,8 @@ public class CreateIndexChange extends AbstractChange implements ChangeWithColum
     private String associatedWith;
     @Setter
     private Boolean clustered;
+    @Setter
+    private String using;
 
 
     public CreateIndexChange() {
@@ -107,6 +109,7 @@ public class CreateIndexChange extends AbstractChange implements ChangeWithColum
                         getTableName(),
                         this.isUnique(),
                         getAssociatedWith(),
+                        getUsing(),
                         getColumns().toArray(new AddColumnConfig[0]))
                         .setTablespace(getTablespace())
                         .setClustered(getClustered())
@@ -177,6 +180,11 @@ public class CreateIndexChange extends AbstractChange implements ChangeWithColum
     @DatabaseChangeProperty(description = "Whether to create a clustered index")
     public Boolean getClustered() {
         return clustered;
+    }
+
+    @DatabaseChangeProperty(description = "The index type to use. For example, 'btree' or 'gin'")
+    public String getUsing() {
+        return using;
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/diff/output/changelog/core/ChangedIndexChangeGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/diff/output/changelog/core/ChangedIndexChangeGenerator.java
@@ -95,6 +95,7 @@ public class ChangedIndexChangeGenerator extends AbstractChangeGenerator impleme
         addIndexChange.setColumns(columns);
         addIndexChange.setIndexName(index.getName());
         addIndexChange.setUnique(index.isUnique());
+        addIndexChange.setUsing(index.getUsing());
 
         if (control.getIncludeCatalog()) {
             dropIndexChange.setCatalogName(index.getSchema().getCatalogName());

--- a/liquibase-standard/src/main/java/liquibase/diff/output/changelog/core/MissingIndexChangeGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/diff/output/changelog/core/MissingIndexChangeGenerator.java
@@ -61,6 +61,7 @@ public class MissingIndexChangeGenerator extends AbstractChangeGenerator impleme
         change.setIndexName(index.getName());
         change.setUnique(((index.isUnique() != null) && index.isUnique()) ? Boolean.TRUE : null);
         change.setClustered(((index.getClustered() != null) && index.getClustered()) ? Boolean.TRUE : null);
+        change.setUsing(index.getUsing());
 
         if (referenceDatabase.createsIndexesForForeignKeys()) {
             change.setAssociatedWith(index.getAssociatedWithAsString());

--- a/liquibase-standard/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -307,7 +307,7 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                             for (CachedRow returnRow : returnList) {
                                 if (returnRow.getString("INDEX_NAME").equalsIgnoreCase(row.getString("INDEX_NAME"))
                                     && returnRow.getString("TABLE_NAME").equalsIgnoreCase(row.getString("TABLE_NAME"))
-                                    && returnRow.getString("TABLE_SCHEM").equalsIgnoreCase(row.getString("TABLE_SCHEM "))) {
+                                    && returnRow.getString("TABLE_SCHEM").equalsIgnoreCase(row.getString("TABLE_SCHEM"))) {
                                     returnRow.set("INDEX_TYPE", row.getString("INDEX_TYPE"));
                                     break;
                                 }

--- a/liquibase-standard/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -283,7 +283,7 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
 
                 private void enrichPostgresqlResult(CatalogAndSchema catalogAndSchema, List<CachedRow> returnList) throws DatabaseException, SQLException {
                     if (database instanceof PostgresDatabase) {
-                        StringBuilder sql = new StringBuilder("SELECT ns.nspname as TABLE_SCHEMA, tab.relname as TABLE_NAME, " +
+                        StringBuilder sql = new StringBuilder("SELECT ns.nspname as TABLE_SCHEM, tab.relname as TABLE_NAME, " +
                                 "cls.relname as INDEX_NAME, am.amname as INDEX_TYPE " +
                                 " FROM pg_index idx " +
                                 "         JOIN pg_class cls ON cls.oid=idx.indexrelid " +
@@ -307,7 +307,7 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                             for (CachedRow returnRow : returnList) {
                                 if (returnRow.getString("INDEX_NAME").equalsIgnoreCase(row.getString("INDEX_NAME"))
                                     && returnRow.getString("TABLE_NAME").equalsIgnoreCase(row.getString("TABLE_NAME"))
-                                    && returnRow.getString("TABLE_SCHEM").equalsIgnoreCase(row.getString("TABLE_SCHEMA"))) {
+                                    && returnRow.getString("TABLE_SCHEM").equalsIgnoreCase(row.getString("TABLE_SCHEM "))) {
                                     returnRow.set("INDEX_TYPE", row.getString("INDEX_TYPE"));
                                     break;
                                 }

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/IndexSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/IndexSnapshotGenerator.java
@@ -81,6 +81,10 @@ public class IndexSnapshotGenerator extends JdbcSnapshotGenerator {
                     } else {
                         ascOrDesc = row.getString("ASC_OR_DESC");
                     }
+                    if (database instanceof PostgresDatabase) {
+                        String indexType = row.getString("INDEX_TYPE");
+                        index.setUsing(indexType);
+                    }
                     Boolean descending = "D".equals(ascOrDesc) ? Boolean.TRUE : ("A".equals(ascOrDesc) ? Boolean
                             .FALSE : null);
                     if (database instanceof MSSQLDatabase) {
@@ -243,6 +247,7 @@ public class IndexSnapshotGenerator extends JdbcSnapshotGenerator {
                     returnIndex.setRelation(relation.setName(row.getString("TABLE_NAME")).setSchema(schema));
                     returnIndex.setName(indexName);
                     returnIndex.setUnique(!nonUnique);
+                    returnIndex.setUsing(row.getString("INDEX_TYPE"));
 
                     String tablespaceName = row.getString("TABLESPACE_NAME");
                     if ((tablespaceName != null) && database.supportsTablespaces()) {

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateIndexGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateIndexGenerator.java
@@ -50,8 +50,7 @@ public class CreateIndexGenerator extends AbstractSqlGenerator<CreateIndexStatem
                 warnings.addWarning("Creating clustered index not supported with "+database);
             }
         }
-        if (!(database instanceof PostgresDatabase && createIndexStatement.getUsing() != null)) {
-            warnings.addWarning("USING clause not supported with " + database);
+        if (!(database instanceof PostgresDatabase) && createIndexStatement.getUsing() != null) {
         }
 
         return warnings;

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateIndexGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateIndexGenerator.java
@@ -50,6 +50,9 @@ public class CreateIndexGenerator extends AbstractSqlGenerator<CreateIndexStatem
                 warnings.addWarning("Creating clustered index not supported with "+database);
             }
         }
+        if (!(database instanceof PostgresDatabase && createIndexStatement.getUsing() != null)) {
+            warnings.addWarning("USING clause not supported with " + database);
+        }
 
         return warnings;
     }

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateIndexGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateIndexGenerator.java
@@ -51,6 +51,7 @@ public class CreateIndexGenerator extends AbstractSqlGenerator<CreateIndexStatem
             }
         }
         if (!(database instanceof PostgresDatabase) && createIndexStatement.getUsing() != null) {
+            warnings.addWarning("USING clause not supported with " + database);
         }
 
         return warnings;

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateIndexGeneratorPostgres.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateIndexGeneratorPostgres.java
@@ -50,7 +50,14 @@ public class CreateIndexGeneratorPostgres extends CreateIndexGenerator {
             buffer.append(database.escapeObjectName(statement.getIndexName(), Index.class)).append(" ");
         }
         buffer.append("ON ");
-        buffer.append(database.escapeTableName(statement.getTableCatalogName(), statement.getTableSchemaName(), statement.getTableName())).append("(");
+        buffer.append(database.escapeTableName(statement.getTableCatalogName(), statement.getTableSchemaName(), statement.getTableName()));
+
+        if (statement.getUsing() != null) {
+            buffer.append(" USING ").append(statement.getUsing());
+        }
+
+        buffer.append("(");
+
         Iterator<AddColumnConfig> iterator = Arrays.asList(statement.getColumns()).iterator();
         while (iterator.hasNext()) {
             AddColumnConfig column = iterator.next();

--- a/liquibase-standard/src/main/java/liquibase/statement/core/CreateIndexStatement.java
+++ b/liquibase-standard/src/main/java/liquibase/statement/core/CreateIndexStatement.java
@@ -3,20 +3,37 @@ package liquibase.statement.core;
 import liquibase.change.AddColumnConfig;
 import liquibase.statement.AbstractSqlStatement;
 import liquibase.statement.CompoundStatement;
+import lombok.Getter;
+import lombok.Setter;
 
 public class CreateIndexStatement extends AbstractSqlStatement implements CompoundStatement {
 
+    @Getter
     private final String tableCatalogName;
+    @Getter
     private final String tableSchemaName;
+    @Getter
     private final String indexName;
+    @Getter
     private final String tableName;
+    @Getter
     private final AddColumnConfig[] columns;
+    @Getter
     private String tablespace;
     private final Boolean unique;
     // Contain associations of index
     // for example: foreignKey, primaryKey or uniqueConstraint
+    @Getter
+    @Setter
     private String associatedWith;
     private Boolean clustered;
+    @Getter
+    private String using;
+
+    public CreateIndexStatement(String indexName, String tableCatalogName, String tableSchemaName, String tableName, Boolean isUnique, String associatedWith, String using, AddColumnConfig... columns) {
+        this(indexName, tableCatalogName, tableSchemaName, tableName, isUnique, associatedWith, columns);
+        this.using = using;
+    }
 
     public CreateIndexStatement(String indexName, String tableCatalogName, String tableSchemaName, String tableName, Boolean isUnique, String associatedWith, AddColumnConfig... columns) {
         this.indexName = indexName;
@@ -28,30 +45,6 @@ public class CreateIndexStatement extends AbstractSqlStatement implements Compou
         this.associatedWith = associatedWith;
     }
 
-    public String getTableCatalogName() {
-        return tableCatalogName;
-    }
-
-    public String getTableSchemaName() {
-        return tableSchemaName;
-    }
-
-    public String getIndexName() {
-        return indexName;
-    }
-
-    public String getTableName() {
-        return tableName;
-    }
-
-    public AddColumnConfig[] getColumns() {
-        return columns;
-    }
-
-    public String getTablespace() {
-        return tablespace;
-    }
-
     public CreateIndexStatement setTablespace(String tablespace) {
         this.tablespace = tablespace;
 
@@ -60,14 +53,6 @@ public class CreateIndexStatement extends AbstractSqlStatement implements Compou
 
     public Boolean isUnique() {
         return unique;
-    }
-
-    public String getAssociatedWith() {
-        return associatedWith;
-    }
-
-    public void setAssociatedWith(String associatedWith) {
-        this.associatedWith = associatedWith;
     }
 
     public Boolean isClustered() {

--- a/liquibase-standard/src/main/java/liquibase/structure/core/Index.java
+++ b/liquibase-standard/src/main/java/liquibase/structure/core/Index.java
@@ -233,6 +233,14 @@ public class Index extends AbstractDatabaseObject {
         return (Index) setAttribute("clustered", clustered);
     }
 
+    public String getUsing() {
+        return getAttribute("using", String.class);
+    }
+
+    public Index setUsing(String using) {
+        return (Index) setAttribute("using", using);
+    }
+
     @Override
     public int compareTo(Object other) {
         Index o = (Index) other;

--- a/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
+++ b/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
@@ -487,6 +487,7 @@
         <xsd:attribute name="unique" type="booleanExp"/>
         <xsd:attribute name="clustered" type="booleanExp"/>
         <xsd:attribute name="tablespace" type="xsd:string"/>
+        <xsd:attribute name="using" type="xsd:string"/>
         <xsd:anyAttribute namespace="##other" processContents="lax"/>
     </xsd:attributeGroup>
 

--- a/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/CreateIndexGeneratorPostgresTest.java
+++ b/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/CreateIndexGeneratorPostgresTest.java
@@ -20,6 +20,18 @@ public class CreateIndexGeneratorPostgresTest {
         Assert.assertEquals("CREATE INDEX INDEX1 ON SCHEMA1.TABLE1(COL1, COL2 DESC)", result[0].toSql());
     }
 
+    @Test
+    public void testGenerateSqlUsingFunction() {
+        // Given
+        CreateIndexStatement statement = new CreateIndexStatement("INDEX1", "CATALOG1", "SCHEMA1", "TABLE1", false, "", "BTREE", newAddColumnConfig("COL1", false));
+
+        // When
+        Sql[] result = generateSql(statement);
+
+        // Then
+        Assert.assertEquals("CREATE INDEX INDEX1 ON SCHEMA1.TABLE1 USING BTREE(COL1)", result[0].toSql());
+    }
+
     private static CreateIndexStatement newStatement(String indexName, String catalogName, String schemaName, String tableName, AddColumnConfig... columns) {
         return new CreateIndexStatement(indexName, catalogName, schemaName, tableName, false, "" , columns);
     }

--- a/liquibase-standard/src/test/resources/liquibase/change/ChangeDefinitionTest.yaml
+++ b/liquibase-standard/src/test/resources/liquibase/change/ChangeDefinitionTest.yaml
@@ -359,6 +359,9 @@ createIndex: |
   unique boolean (since 1.8)
     Description: Whether the index is unique (contains no duplicate values)
     Supported: all
+  using string 
+    Description: The index type to use. For example, 'btree' or 'gin'
+    Supported: all
 
 
 createProcedure: |


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

This enhancement allows specifying index types like btree, gin, gist, etc. when creating/snapshoting indexes in PostgreSQL, providing better control over index behavior and performance.

1. Adds a `using` property to `CreateIndexChange` and `Index` classes
2. Enhances JDBC snapshot capabilities to capture index types from PostgreSQL
3. Updates `CreateIndexGeneratorPostgres` to include the USING clause in SQL generation
4. Extends schema definitions by adding the `using` attribute to createIndex in XML
5. Updates related generators and statement classes to support the new property


