### PR TITLE
feat: Rename misleading update methods in Liquibase class

### DIFF
--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/UpdateCommandsIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/UpdateCommandsIntegrationTest.groovy
@@ -106,7 +106,7 @@ class UpdateCommandsIntegrationTest extends Specification {
     def "run Update from Liquibase class using print writer"() {
         when:
         def liquibase = new Liquibase("liquibase/update-tests.yml", new ClassLoaderResourceAccessor(), h2.getDatabaseFromFactory())
-        liquibase.update(new Contexts(), new PrintWriter(System.out))
+        liquibase.updateSql(new Contexts(), null, new PrintWriter(System.out))
         h2.getConnection().createStatement().executeQuery("select count(1) from databasechangelog")
 
         then:

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
@@ -438,7 +438,7 @@ public abstract class AbstractIntegrationTest {
 
         liquibase = createLiquibase(completeChangeLog);
         liquibase.setChangeLogParameter("loginuser", testSystem.getUsername());
-        liquibase.update(this.contexts, output);
+        liquibase.updateSql(new Contexts(this.contexts), null, output);
 
         String outputResult = output.getBuffer().toString();
         assertNotNull("generated output change log must not be empty", outputResult);
@@ -963,7 +963,7 @@ public abstract class AbstractIntegrationTest {
         Liquibase liquibase = createLiquibase(encodingChangeLog);
 
         StringWriter writer=new StringWriter();
-        liquibase.update(this.contexts,writer);
+        liquibase.updateSql(new Contexts(this.contexts), null, writer);
         assertTrue("Update to SQL preserves encoding",
             new RegexMatcher(writer.toString(), new String[] {
                 //For the UTF-8 encoded cvs
@@ -1066,7 +1066,7 @@ public abstract class AbstractIntegrationTest {
         clearDatabase();
 
         liquibase = createLiquibase(includedChangeLog);
-        liquibase.update(contexts, output);
+        liquibase.updateSql(new Contexts(contexts), null, output);
 
         String outputResult = output.getBuffer().toString();
         assertNotNull("generated SQL may not be empty", outputResult);

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseUpdateSQL.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseUpdateSQL.java
@@ -44,7 +44,7 @@ public class LiquibaseUpdateSQL extends AbstractLiquibaseUpdateMojo {
 		} else if (StringUtil.isNotEmpty(toTag)) {
 			liquibase.updateToTagSql(toTag, new Contexts(contexts), new LabelExpression(getLabelFilter()), outputWriter);
 		} else {
-			liquibase.update(new Contexts(contexts), new LabelExpression(getLabelFilter()), outputWriter);
+			liquibase.updateSql(new Contexts(contexts), new LabelExpression(getLabelFilter()), outputWriter);
 		}
 	}
 

--- a/liquibase-standard/src/main/java/liquibase/Liquibase.java
+++ b/liquibase-standard/src/main/java/liquibase/Liquibase.java
@@ -280,20 +280,51 @@ public class Liquibase implements AutoCloseable {
                 new IgnoreChangeSetFilter());
     }
 
+    /**
+     * This method is actually an updateSql method that is called by the update method. To be removed in Liquibase 5.0
+     * @deprecated use {@link #updateSql(Contexts, LabelExpression, Writer)} . For the contexts String you just need to surround in a new Contexts(String)
+     */
+    @Deprecated
     public void update(String contexts, Writer output) throws LiquibaseException {
-        this.update(new Contexts(contexts), output);
+        this.updateSql(new Contexts(contexts), null, output);
     }
 
+    /**
+     * This method is actually an updateSql method that is called by the update method. To be removed in Liquibase 5.0
+     * @deprecated use {@link #updateSql(Contexts, LabelExpression, Writer)}
+     */
+    @Deprecated
     public void update(Contexts contexts, Writer output) throws LiquibaseException {
-        update(contexts, new LabelExpression(), output);
+        updateSql(contexts, new LabelExpression(), output);
     }
 
+    /**
+     * This method is actually an updateSql method that is called by the update method. To be removed in Liquibase 5.0
+     * @deprecated use {@link #updateSql(Contexts, LabelExpression, Writer)}
+     */
+    @Deprecated
     public void update(Contexts contexts, LabelExpression labelExpression, Writer output) throws LiquibaseException {
-        update(contexts, labelExpression, output, true);
+        updateSql(contexts, labelExpression, output);
     }
 
+    /**
+     * This method is actually an updateSql method that is called by the update method. To be removed in Liquibase 5.0
+     * @deprecated use {@link #updateSql(Contexts, LabelExpression, Writer)}
+     */
+    @Deprecated
     public void update(Contexts contexts, LabelExpression labelExpression, Writer output, boolean checkLiquibaseTables)
             throws LiquibaseException {
+        updateSql(contexts, labelExpression, output);
+    }
+
+    /**
+     * Generates SQL for the update operation based on the provided contexts and label expression.
+     * @param contexts the contexts to filter the changesets.
+     * @param labelExpression the label expression to filter the changesets.
+     * @param output the writer to output the generated SQL.
+     * @throws LiquibaseException if an error occurs while generating the SQL.
+     */
+    public void updateSql(Contexts contexts, LabelExpression labelExpression, Writer output) throws LiquibaseException {
         runInScope(() -> {
             CommandScope updateCommand = new CommandScope(UpdateSqlCommandStep.COMMAND_NAME);
             updateCommand.addArgumentValue(DbUrlConnectionArgumentsCommandStep.DATABASE_ARG, getDatabase());
@@ -453,7 +484,7 @@ public class Liquibase implements AutoCloseable {
     public void update(String tag, Contexts contexts, LabelExpression labelExpression, Writer output)
             throws LiquibaseException {
         if (tag == null) {
-            update(contexts, labelExpression, output);
+            updateSql(contexts, labelExpression, output);
             return;
         }
         changeLogParameters.setContexts(contexts);

--- a/liquibase-standard/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/commandline/Main.java
@@ -1594,7 +1594,7 @@ public class Main {
                     liquibase.update(commandParams.iterator().next(), new Contexts(contexts), new LabelExpression
                             (getLabelFilter()), getOutputWriter());
                 } else if (COMMANDS.UPDATE_SQL.equalsIgnoreCase(command)) {
-                    liquibase.update(new Contexts(contexts), new LabelExpression(getLabelFilter()), getOutputWriter());
+                    liquibase.updateSql(new Contexts(contexts), new LabelExpression(getLabelFilter()), getOutputWriter());
                 } else if (COMMANDS.ROLLBACK_TO_DATE.equalsIgnoreCase(command)) {
                     if (getCommandArgument() == null) {
                         throw new CommandLineParsingException(


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

feat: Rename misleading update methods in Liquibase class

This change clarifies the API by giving methods names that accurately reflect their behavior. The old method names were misleading because they suggested database modification when they actually only generate SQL statements.

- Deprecated the `update(Writer)` variants that write SQL to output
- Added new `updateSql()` method that better describes what the function does
- Updated all references in tests and plugins to use the new method