### PR TITLE
fix: Change the rename column query for mysql v8 and later using rename column to

### DIFF
--- a/liquibase-standard/src/test/resources/liquibase/change/ChangeDefinitionTest.yaml
+++ b/liquibase-standard/src/test/resources/liquibase/change/ChangeDefinitionTest.yaml
@@ -913,7 +913,6 @@ renameColumn: |
   columnDataType string 
     Description: Data type of the column
     Supported: all
-    Required For: mariadb,mysql
   newColumnName string 
     Description: New name for the column
     Supported: all

--- a/liquibase-standard/src/test/resources/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/renameColumn/mariadb.sql
+++ b/liquibase-standard/src/test/resources/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/renameColumn/mariadb.sql
@@ -3,4 +3,4 @@
 -- Change Parameter: newColumnName=full_name
 -- Change Parameter: oldColumnName=name
 -- Change Parameter: tableName=person
-ALTER TABLE person CHANGE name full_name INT;
+ALTER TABLE person RENAME COLUMN name TO full_name;

--- a/liquibase-standard/src/test/resources/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/renameColumn/mariadb.sql
+++ b/liquibase-standard/src/test/resources/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/renameColumn/mariadb.sql
@@ -1,5 +1,4 @@
 -- Database: mariadb
--- Change Parameter: columnDataType=int
 -- Change Parameter: newColumnName=full_name
 -- Change Parameter: oldColumnName=name
 -- Change Parameter: tableName=person

--- a/liquibase-standard/src/test/resources/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/renameColumn/mysql.sql
+++ b/liquibase-standard/src/test/resources/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/renameColumn/mysql.sql
@@ -3,4 +3,4 @@
 -- Change Parameter: newColumnName=full_name
 -- Change Parameter: oldColumnName=name
 -- Change Parameter: tableName=person
-ALTER TABLE person CHANGE name full_name INT;
+ALTER TABLE person RENAME COLUMN name TO full_name;

--- a/liquibase-standard/src/test/resources/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/renameColumn/mysql.sql
+++ b/liquibase-standard/src/test/resources/verify/saved_state/compareGeneratedSqlWithExpectedSqlForMinimalChangesets/renameColumn/mysql.sql
@@ -1,5 +1,4 @@
 -- Database: mysql
--- Change Parameter: columnDataType=int
 -- Change Parameter: newColumnName=full_name
 -- Change Parameter: oldColumnName=name
 -- Change Parameter: tableName=person


### PR DESCRIPTION
## Impact

Fixes #6876

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

From MySQL v8, rename column is introduced to rename column without altering the column definition, which could cause default value to be reset

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

RenameColumnGeneratorTest unit test is commented out due to past issue so UT is not implemented for this change

## Additional Context

<!--
Add any other context about the problem here.
-->
