### PR TITLE
DAT-20082: analytics: don't needlessly call isEnabled method when determining priority

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/analytics/LiquibaseAnalyticsListener.java
+++ b/liquibase-standard/src/main/java/liquibase/analytics/LiquibaseAnalyticsListener.java
@@ -49,28 +49,20 @@ public class LiquibaseAnalyticsListener implements AnalyticsListener {
 
     @Override
     public int getPriority() {
-        boolean analyticsEnabled = false;
-        try {
-            analyticsEnabled = isEnabled();
-        } catch (Exception e) {
-            Scope.getCurrentScope().getLog(AnalyticsListener.class).log(AnalyticsArgs.LOG_LEVEL.getCurrentValue(), "Failed to determine if analytics is enabled", e);
-        }
-        if (analyticsEnabled) {
-            return PRIORITY_SPECIALIZED;
-        } else {
-            return PRIORITY_NOT_APPLICABLE;
-        }
+        return PRIORITY_SPECIALIZED;
     }
 
     @Override
     public void handleEvent(Event event) throws Exception {
-        addSendEventsOnShutdownHook();
-        cachedEvents.add(event);
-        Integer maxCacheSize = Scope.getCurrentScope().get(Scope.Attr.maxAnalyticsCacheSize, getDefaultMaxAnalyticsCacheSize(event));
-        if (cachedEvents.size() >= maxCacheSize) {
-            flush();
-        } else {
-            Scope.getCurrentScope().getLog(getClass()).log(AnalyticsArgs.LOG_LEVEL.getCurrentValue(), "Caching analytics event to send later. Cache contains " + cachedEvents.size() + " event(s).", null);
+        if (isEnabled()) {
+            addSendEventsOnShutdownHook();
+            cachedEvents.add(event);
+            Integer maxCacheSize = Scope.getCurrentScope().get(Scope.Attr.maxAnalyticsCacheSize, getDefaultMaxAnalyticsCacheSize(event));
+            if (cachedEvents.size() >= maxCacheSize) {
+                flush();
+            } else {
+                Scope.getCurrentScope().getLog(getClass()).log(AnalyticsArgs.LOG_LEVEL.getCurrentValue(), "Caching analytics event to send later. Cache contains " + cachedEvents.size() + " event(s).", null);
+            }
         }
     }
 


### PR DESCRIPTION


## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

The isEnabled method was being called while determining priority, which was unnecessary when multiple analytics listeners are on the classpath. This change delays the call to the isEnabled flag until after priority has been determined, which means that it should only be called once.

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
- Add unit/integration tests (ask for support if not sure how to do it)
- Make sure tests all pass
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
