### PR TITLE
make all command names public

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/command/core/CalculateChecksumCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/CalculateChecksumCommandStep.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 public class CalculateChecksumCommandStep extends AbstractCommandStep {
 
-    protected static final String[] COMMAND_NAME = {"calculateChecksum"};
+    public static final String[] COMMAND_NAME = {"calculateChecksum"};
 
     public static final CommandArgumentDefinition<String> CHANGELOG_FILE_ARG;
     public static final CommandArgumentDefinition<String> CHANGESET_PATH_ARG;

--- a/liquibase-standard/src/main/java/liquibase/command/core/TagCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/TagCommandStep.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 public class TagCommandStep extends AbstractCommandStep {
 
-    protected static final String[] COMMAND_NAME = {"tag"};
+    public static final String[] COMMAND_NAME = {"tag"};
 
     public static final CommandArgumentDefinition<String> TAG_ARG;
 

--- a/liquibase-standard/src/main/java/liquibase/command/core/TagExistsCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/TagExistsCommandStep.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 public class TagExistsCommandStep  extends AbstractCommandStep {
 
-    protected static final String[] COMMAND_NAME = {"tagExists"};
+    public static final String[] COMMAND_NAME = {"tagExists"};
 
     public static final CommandArgumentDefinition<String> TAG_ARG;
     public static final CommandResultDefinition<Boolean> TAG_EXISTS_RESULT;

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/AbstractChangelogCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/AbstractChangelogCommandStep.java
@@ -19,7 +19,7 @@ import java.util.stream.Stream;
 
 public abstract class AbstractChangelogCommandStep extends AbstractCommandStep {
 
-    protected static final String[] COMMAND_NAME = {"abstractChangelogCommandStep"};
+    public static final String[] COMMAND_NAME = {"abstractChangelogCommandStep"};
     public static final CommandArgumentDefinition<String> RUN_ON_CHANGE_TYPES_ARG;
     public static final CommandArgumentDefinition<String> REPLACE_IF_EXISTS_TYPES_ARG;
     public static final CommandArgumentDefinition<Boolean> SKIP_OBJECT_SORTING;

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/AbstractDatabaseConnectionCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/AbstractDatabaseConnectionCommandStep.java
@@ -22,7 +22,7 @@ import static java.util.ResourceBundle.getBundle;
  */
 public abstract class AbstractDatabaseConnectionCommandStep extends AbstractHelperCommandStep implements CleanUpCommandStep {
 
-    protected static final String[] COMMAND_NAME = {"abstractDatabaseConnectionCommandStep"};
+    public static final String[] COMMAND_NAME = {"abstractDatabaseConnectionCommandStep"};
     private static final ResourceBundle coreBundle = getBundle("liquibase/i18n/liquibase-core");
 
     private Database database;

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/ChangeExecListenerCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/ChangeExecListenerCommandStep.java
@@ -18,7 +18,7 @@ import java.util.List;
  */
 public class ChangeExecListenerCommandStep extends AbstractHelperCommandStep {
 
-    protected static final String[] COMMAND_NAME = {"changeExecListener"};
+    public static final String[] COMMAND_NAME = {"changeExecListener"};
 
     public static final CommandArgumentDefinition<String> CHANGE_EXEC_LISTENER_CLASS_ARG;
     public static final CommandArgumentDefinition<String> CHANGE_EXEC_LISTENER_PROPERTIES_FILE_ARG;

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/DatabaseChangelogCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/DatabaseChangelogCommandStep.java
@@ -28,7 +28,7 @@ import java.util.List;
  * object used to instantiate it.
  */
 public class DatabaseChangelogCommandStep extends AbstractHelperCommandStep implements CleanUpCommandStep {
-    protected static final String[] COMMAND_NAME = {"changelogCommandStep"};
+    public static final String[] COMMAND_NAME = {"changelogCommandStep"};
 
     public static final CommandArgumentDefinition<String> CHANGELOG_FILE_ARG;
     public static final CommandArgumentDefinition<DatabaseChangeLog> CHANGELOG_ARG;

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/DbUrlConnectionCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/DbUrlConnectionCommandStep.java
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class DbUrlConnectionCommandStep extends AbstractDatabaseConnectionCommandStep implements CleanUpCommandStep {
 
-    protected static final String[] COMMAND_NAME = {"dbUrlConnectionCommandStep"};
+    public static final String[] COMMAND_NAME = {"dbUrlConnectionCommandStep"};
 
     /**
      * @deprecated This field is retained for backwards compatibility. Use the fields in {@link DbUrlConnectionArgumentsCommandStep} instead.

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/LockServiceCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/LockServiceCommandStep.java
@@ -18,7 +18,7 @@ import java.util.List;
  */
 public class LockServiceCommandStep extends AbstractHelperCommandStep implements CleanUpCommandStep {
 
-    protected static final String[] COMMAND_NAME = {"lockServiceCommandStep"};
+    public static final String[] COMMAND_NAME = {"lockServiceCommandStep"};
 
     private boolean isDBLocked = false;
 

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/PreCompareCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/PreCompareCommandStep.java
@@ -20,7 +20,7 @@ import java.util.List;
  */
 public class PreCompareCommandStep extends AbstractHelperCommandStep {
 
-    protected static final String[] COMMAND_NAME = {"preCompareCommandStep"};
+    public static final String[] COMMAND_NAME = {"preCompareCommandStep"};
     public static final CommandArgumentDefinition<String> EXCLUDE_OBJECTS_ARG;
     public static final CommandArgumentDefinition<String> INCLUDE_OBJECTS_ARG;
     public static final CommandArgumentDefinition<String> SCHEMAS_ARG;

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/ReferenceDbUrlConnectionCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/ReferenceDbUrlConnectionCommandStep.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class ReferenceDbUrlConnectionCommandStep extends AbstractDatabaseConnectionCommandStep implements CleanUpCommandStep {
 
-    protected static final String[] COMMAND_NAME = {"referenceDbUrlConnectionCommandStep"};
+    public static final String[] COMMAND_NAME = {"referenceDbUrlConnectionCommandStep"};
 
     public static final CommandArgumentDefinition<Database> REFERENCE_DATABASE_ARG;
     public static final CommandArgumentDefinition<String> REFERENCE_USERNAME_ARG;

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/ShowSummaryArgument.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/ShowSummaryArgument.java
@@ -14,7 +14,7 @@ import java.util.List;
  * See {@link liquibase.util.ShowSummaryUtil} for implementation.
  */
 public class ShowSummaryArgument extends AbstractCommandStep {
-    protected static final String[] COMMAND_NAME = {"showSummary"};
+    public static final String[] COMMAND_NAME = {"showSummary"};
 
     public static final CommandArgumentDefinition<UpdateSummaryEnum> SHOW_SUMMARY;
     public static final CommandArgumentDefinition<UpdateSummaryOutputEnum> SHOW_SUMMARY_OUTPUT;


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
- Add unit/integration tests (ask for support if not sure how to do it)
- Make sure tests all pass
-->
without this it is not possible to use the constants from the outside, in which case one instead has to manually write the magic string, which is error-prone.

other command names are already public and can already be used from the outside.

this has been done using search & replace and should've solved it for all existing commands.

## Things to be aware of

n/a
<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

n/a
<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

i noticed this for `TagCommandStep` while working on `liquibase-opensearch` but decided to fix it for all of them.
you might want to add an automated test (based on reflection) which ensures that all `COMMAND_NAME` and `*_ARG` fields in `liquibase.command.core.*CommandStep` classes are always `public` to ensure that this doesn't happen again? but please do so in a follow-up PR as i'd like to see this land in the next release so that i can clean up my code 😉 

<!--
Add any other context about the problem here.
-->
