### PR TITLE
fix: Integration-Tests - Groovy - Wrong variable names

### DIFF
--- a/liquibase-integration-tests/src/test/groovy/MySQLTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/MySQLTest.groovy
@@ -13,9 +13,8 @@ import spock.lang.Specification
 @LiquibaseIntegrationTest
 class MySQLTest extends Specification {
 
-
     @Shared
-    private DatabaseTestSystem postgres = Scope.getCurrentScope().getSingleton(TestSystemFactory).getTestSystem("mysql") as DatabaseTestSystem
+    private DatabaseTestSystem mysql = Scope.getCurrentScope().getSingleton(TestSystemFactory).getTestSystem("mysql") as DatabaseTestSystem
 
     def "verify foreignKeyExists constraint is not created again when precondition fails because it already exists"() {
         when:
@@ -25,9 +24,9 @@ class MySQLTest extends Specification {
         ]
         Scope.child(scopeSettings, {
             CommandScope commandScope = new CommandScope(UpdateCommandStep.COMMAND_NAME)
-            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.URL_ARG, postgres.getConnectionUrl())
-            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.USERNAME_ARG, postgres.getUsername())
-            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.PASSWORD_ARG, postgres.getPassword())
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.URL_ARG, mysql.getConnectionUrl())
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.USERNAME_ARG, mysql.getUsername())
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.PASSWORD_ARG, mysql.getPassword())
             commandScope.addArgumentValue(UpdateCountCommandStep.CHANGELOG_FILE_ARG, changeLogFile)
             commandScope.execute()
         } as Scope.ScopedRunnerWithReturn<Void>)

--- a/liquibase-integration-tests/src/test/groovy/liquibase/MssqlTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/MssqlTest.groovy
@@ -15,7 +15,7 @@ import spock.lang.Specification
 class MssqlTest extends Specification {
 
     @Shared
-    private DatabaseTestSystem postgres = Scope.getCurrentScope().getSingleton(TestSystemFactory).getTestSystem("mssql") as DatabaseTestSystem
+    private DatabaseTestSystem mssql = Scope.getCurrentScope().getSingleton(TestSystemFactory).getTestSystem("mssql") as DatabaseTestSystem
 
     def "verify foreignKeyExists constraint is not created again when precondition fails because it already exists"() {
         when:
@@ -25,9 +25,9 @@ class MssqlTest extends Specification {
         ]
         Scope.child(scopeSettings, {
             CommandScope commandScope = new CommandScope(UpdateCommandStep.COMMAND_NAME)
-            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.URL_ARG, postgres.getConnectionUrl())
-            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.USERNAME_ARG, postgres.getUsername())
-            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.PASSWORD_ARG, postgres.getPassword())
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.URL_ARG, mssql.getConnectionUrl())
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.USERNAME_ARG, mssql.getUsername())
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.PASSWORD_ARG, mssql.getPassword())
             commandScope.addArgumentValue(UpdateCountCommandStep.CHANGELOG_FILE_ARG, changeLogFile)
             commandScope.execute()
         } as Scope.ScopedRunnerWithReturn<Void>)


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description
Very simple fix, some groovy tests uses wrong variable names (like `var postgres = ...` but actually it's about `mysql` test)   
  
I was reading the code to understand a thing and then I found out the wrong names.

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
- Add unit/integration tests (ask for support if not sure how to do it)
- Make sure tests all pass
-->

## Things to be aware of
Very simple fix.
<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about
N/A.
<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->

Fixes #6933