### PR TITLE
fix: Change column type from tinyint to bool in mysql

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/datatype/core/BooleanType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/BooleanType.java
@@ -40,7 +40,7 @@ public class BooleanType extends LiquibaseDataType {
             if (originalDefinition.toLowerCase(Locale.US).startsWith("bit")) {
                 return new DatabaseDataType("BIT", getParameters());
             }
-            return database instanceof MariaDBDatabase ? new DatabaseDataType("TINYINT(1)") : new DatabaseDataType("TINYINT");
+            return database instanceof MariaDBDatabase ? new DatabaseDataType("TINYINT(1)") : new DatabaseDataType("BOOL");
         } else if (database instanceof OracleDatabase) {
             try {
                 if (database.getDatabaseMajorVersion() >= OracleDatabase.ORACLE_23C_MAJOR_VERSION) {

--- a/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/AddColumnGeneratorTest.java
+++ b/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/AddColumnGeneratorTest.java
@@ -170,11 +170,11 @@ public class AddColumnGeneratorTest extends AbstractSqlGeneratorTest<AddColumnSt
         Sql[] sql = instance.generateSql(statements, new MySQLDatabase());
 
         assertEquals(5, sql.length);
-        assertEquals("ALTER TABLE schema_name.table_name ADD column1 BIGINT NULL, ADD column2 TINYINT NULL", sql[0].toSql());
+        assertEquals("ALTER TABLE schema_name.table_name ADD column1 BIGINT NULL, ADD column2 BOOL NULL", sql[0].toSql());
         assertEquals("UPDATE schema_name.table_name SET column1 = 0", sql[1].toSql());
         assertEquals("UPDATE schema_name.table_name SET column2 = 1", sql[2].toSql());
         assertEquals("ALTER TABLE schema_name.table_name MODIFY column1 BIGINT NOT NULL", sql[3].toSql());
-        assertEquals("ALTER TABLE schema_name.table_name MODIFY column2 TINYINT NOT NULL", sql[4].toSql());
+        assertEquals("ALTER TABLE schema_name.table_name MODIFY column2 BOOL NOT NULL", sql[4].toSql());
 
         // repeat with MariaDBDatabase which shall result in TINYINT(1) for boolean column (instead of just TINYINT)
         statements = change.generateStatements(new MariaDBDatabase());


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description
Change column type from tinyint to bool in mysql
Fix #6763 

## Things to be aware of


## Things to worry about

## Additional Context

