### PR TITLE
Compile the helper class explicitly

### DIFF
--- a/.github/util/re-version.sh
+++ b/.github/util/re-version.sh
@@ -71,7 +71,8 @@ for jar in "${jars[@]}"
 do
   ## MANIFEST.MF settings
   unzip -q $workdir/$jar META-INF/* -d $workdir
-
+  
+  javac "$scriptDir/ManifestReversion.java"
   java -cp $scriptDir ManifestReversion $workdir/META-INF/MANIFEST.MF $version
   find $workdir/META-INF -name pom.xml -exec sed -i -e "s/<version>0-SNAPSHOT<\/version>/<version>$version<\/version>/g" {} \;
   find $workdir/META-INF -name pom.xml -exec sed -i -e "s/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/<liquibase.version>$version<\/liquibase.version>/g" {} \;

--- a/.github/util/re-version.sh
+++ b/.github/util/re-version.sh
@@ -72,7 +72,7 @@ do
   ## MANIFEST.MF settings
   unzip -q $workdir/$jar META-INF/* -d $workdir
 
-  javac $scriptDir/ManifestReversion.java
+  #javac $scriptDir/ManifestReversion.java
   java -cp $scriptDir ManifestReversion $workdir/META-INF/MANIFEST.MF $version
   find $workdir/META-INF -name pom.xml -exec sed -i -e "s/<version>0-SNAPSHOT<\/version>/<version>$version<\/version>/g" {} \;
   find $workdir/META-INF -name pom.xml -exec sed -i -e "s/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/<liquibase.version>$version<\/liquibase.version>/g" {} \;

--- a/.github/util/re-version.sh
+++ b/.github/util/re-version.sh
@@ -71,8 +71,8 @@ for jar in "${jars[@]}"
 do
   ## MANIFEST.MF settings
   unzip -q $workdir/$jar META-INF/* -d $workdir
-  
-  javac "$scriptDir/ManifestReversion.java"
+
+  javac $scriptDir/ManifestReversion.java
   java -cp $scriptDir ManifestReversion $workdir/META-INF/MANIFEST.MF $version
   find $workdir/META-INF -name pom.xml -exec sed -i -e "s/<version>0-SNAPSHOT<\/version>/<version>$version<\/version>/g" {} \;
   find $workdir/META-INF -name pom.xml -exec sed -i -e "s/<liquibase.version>0-SNAPSHOT<\/liquibase.version>/<liquibase.version>$version<\/liquibase.version>/g" {} \;

--- a/liquibase-dist/src/main/install4j/liquibase.install4j
+++ b/liquibase-dist/src/main/install4j/liquibase.install4j
@@ -17,7 +17,7 @@
         <entry>snowflake-*</entry>
       </macSearchedJars>
     </codeSigning>
-    <jreBundles jdkProviderId="Adoptium" release="21/jdk-21.0.7+6" />
+    <jreBundles jdkProviderId="Adoptium" release="21/jdk-21.0.5+11" />
   </application>
   <files>
     <mountPoints>


### PR DESCRIPTION
This pull request introduces a small change to the `.github/util/re-version.sh` script to compile a Java helper class before executing it. This ensures that the `ManifestReversion.java` file is compiled and available for use during the script's execution.

* [`.github/util/re-version.sh`](diffhunk://#diff-05532236ce14388a53050c18c36e556c73805595c14236636f93936059581289R75): Added a `javac` command to compile `ManifestReversion.java` before running it, ensuring the script functions as intended.

Jira-ticket: https://datical.atlassian.net/browse/DAT-20242