### PR TITLE
♻️ DAT-20252: add GitHub App token retrieval for access token

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -310,11 +310,21 @@ jobs:
           path: liquibase-core-repo
           repository: "liquibase/liquibase"
 
+      - name: Get GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: liquibase-pro
+          permission-contents: read
+
       - name: Download liquibase-pro xsd
         uses: actions/checkout@v4
         with:
           ref: "${{ needs.setup.outputs.ref_branch }}"
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.get-token.outputs.token }}
           # Relative path under $GITHUB_WORKSPACE to place the repository
           path: liquibase-pro-repo
           repository: "liquibase/liquibase-pro"

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -533,11 +533,15 @@ jobs:
         run: |
           # Fetch all tags from the remote
           git fetch --tags
-          # Get the latest tag
-          echo "latest_version=$(git describe --tags $(git rev-list --tags --max-count=1) | sed 's/^v//')" >> $GITHUB_OUTPUT
-          # Get the previous released version tag
-          echo "previous_version=$(git for-each-ref --sort=creatordate --format '%(refname:short)' refs/tags |sed 's/^v//')" >> $GITHUB_OUTPUT
+          # Get sorted list of tags, strip leading 'v', and get the latest
+          latest=$(git tag --sort=-creatordate | grep -E '^v?[0-9]' | head -n1 | sed 's/^v//')
+          previous=$(git tag --sort=-creatordate | grep -E '^v?[0-9]' | sed 's/^v//' | head -n2 | tail -n1)
 
+          echo "latest_version=$latest" >> $GITHUB_OUTPUT
+          echo "previous_version=$previous" >> $GITHUB_OUTPUT
+          echo "Latest Version: $latest"
+          echo "Previous Version: $previous"
+          
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v3
         with:


### PR DESCRIPTION
This pull request updates the `.github/workflows/release-published.yml` file to enhance security by using a GitHub App token for repository access instead of the default `GITHUB_TOKEN`. The most important changes are outlined below:

### Security Enhancements:

* **GitHub App Token Integration**: Added a new step, `Get GitHub App token`, which uses the `actions/create-github-app-token@v2` action to generate a GitHub App token. This step retrieves the token using the app's ID and private key, ensuring more secure access to the `liquibase-pro` repository.

* **Token Replacement**: Updated the `Download liquibase-pro xsd` step to use the newly generated GitHub App token (`steps.get-token.outputs.token`) instead of the default `GITHUB_TOKEN`. This change aligns with the enhanced security approach.