### PR TITLE
DAT-20252: use Github App Token

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -310,11 +310,21 @@ jobs:
           path: liquibase-core-repo
           repository: "liquibase/liquibase"
 
+      - name: Get GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: liquibase-pro
+          permission-contents: read
+          
       - name: Download liquibase-pro xsd
         uses: actions/checkout@v4
         with:
           ref: "${{ needs.setup.outputs.ref_branch }}"
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.get-token.outputs.token }}
           # Relative path under $GITHUB_WORKSPACE to place the repository
           path: liquibase-pro-repo
           repository: "liquibase/liquibase-pro"


### PR DESCRIPTION
This pull request updates the `.github/workflows/release-published.yml` file to enhance security by replacing the default GitHub token with a GitHub App token for accessing the `liquibase-pro` repository.

### Workflow security improvements:

* Added a new step, "Get GitHub App token," to generate a GitHub App token using the app ID and private key stored in secrets. This token is scoped to the `liquibase-pro` repository with `read` permissions for contents.
* Updated the "Download liquibase-pro xsd" step to use the newly generated GitHub App token instead of the default `GITHUB_TOKEN`.