### PR TITLE
🔧 DAT-20252: get latest_version and previous_version for OSS

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -536,7 +536,7 @@ jobs:
           # Get the latest semver tag, strip 'v'
           latest_tag=$(git tag --sort=-creatordate | grep -E '^v?[0-9]' | head -n1 | sed 's/^v//')
           # Get the second latest tag
-          previous=$(git tag --sort=-creatordate | grep -E '^v?[0-9]' | sed 's/^v//' | head -n2 | tail -n1)
+          previous_tag=$(git tag --sort=-creatordate | grep -E '^v?[0-9]' | sed 's/^v//' | head -n2 | tail -n1)
           echo "latest_version=$latest_tag" >> $GITHUB_OUTPUT
           echo "previous_version=$previous_tag" >> $GITHUB_OUTPUT
           echo "Latest Version: $latest_tag"

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -533,10 +533,14 @@ jobs:
         run: |
           # Fetch all tags from the remote
           git fetch --tags
-          # Get the latest tag
-          echo "latest_version=$(git describe --tags $(git rev-list --tags --max-count=1) | sed 's/^v//')" >> $GITHUB_OUTPUT
-          # Get the previous released version tag
-          echo "previous_version=$(git for-each-ref --sort=creatordate --format '%(refname:short)' refs/tags |sed 's/^v//')" >> $GITHUB_OUTPUT
+          # Get the latest semver tag, strip 'v'
+          latest_tag=$(git tag --sort=-creatordate | grep -E '^v?[0-9]' | head -n1 | sed 's/^v//')
+          # Get the second latest tag
+          previous=$(git tag --sort=-creatordate | grep -E '^v?[0-9]' | sed 's/^v//' | head -n2 | tail -n1)
+          echo "latest_version=$latest_tag" >> $GITHUB_OUTPUT
+          echo "previous_version=$previous_tag" >> $GITHUB_OUTPUT
+          echo "Latest Version: $latest_tag"
+          echo "Previous Version: $previous_tag"
 
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v3


### PR DESCRIPTION
This pull request updates the workflow for determining the latest and previous version tags in the `.github/workflows/release-published.yml` file. It replaces the previous implementation with a more robust method for fetching and processing semver tags.

### Workflow improvements:
* Updated the logic for fetching the latest and previous version tags to ensure proper handling of semver tags, including stripping the `v` prefix and sorting by creation date.

Tested locally:
<img width="1155" alt="Screenshot 2025-05-21 at 1 03 38 PM" src="https://github.com/user-attachments/assets/805852b4-ca9c-42ef-ac21-3cdc93337e3f" />
