### PR TITLE
Fix generateChangelog output message when no changelog file specified

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/command/core/GenerateChangelogCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/GenerateChangelogCommandStep.java
@@ -163,10 +163,10 @@ public class GenerateChangelogCommandStep extends AbstractChangelogCommandStep {
                 }
             }
             if (!areThereChangeObjectsToWrite(diffResult)) {
-                Scope.getCurrentScope().getUI().sendMessage(String.format("Changelog not generated. There are no changesets to write to %s changelog", changeLogFile));
+                Scope.getCurrentScope().getUI().sendMessage(String.format("Changelog not generated. There are no changesets to write to %s changelog", changeLogFile != null ? changeLogFile : "stdout"));
             }
             else {
-                Scope.getCurrentScope().getUI().sendMessage("Generated changelog written to " + changeLogFile);
+                Scope.getCurrentScope().getUI().sendMessage("Generated changelog written to " + (changeLogFile != null ? changeLogFile : "stdout"));
             }
         } finally {
             referenceDatabase.setObjectQuotingStrategy(originalStrategy);


### PR DESCRIPTION
## Problem

When executing the `generateChangelog` command without specifying a changelog file, Liquibase outputs:

Generated changelog written to null

## Solution

This PR fixes the output message to correctly show:

Generated changelog written to stdout


## Changes
- Modified `GenerateChangelogCommandStep.java` to use conditional logic that displays "stdout" when `changeLogFile` is null
- Fixed both the success message and the "no changesets" message for consistency
- Improves user experience by providing clear indication of where the output is directed

## Testing
- Manual testing can be done by running `generateChangelog` without the `--changelog-file` parameter
- The fix is minimal and safe, maintaining backward compatibility

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
- Add unit/integration tests (ask for support if not sure how to do it)
- Make sure tests all pass
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
