### PR TITLE
fix: improve URI normalization logic for resource paths inside jars

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/resource/AbstractResource.java
+++ b/liquibase-standard/src/main/java/liquibase/resource/AbstractResource.java
@@ -54,8 +54,20 @@ public abstract class AbstractResource implements Resource {
         // URI doesn't work as expected. So we need some manual handling
         if (uri.toString().contains(("!"))) {
             String[] uriSplit = uri.toString().split(("!"));
+            StringBuilder result = new StringBuilder();
             try {
-                return new URI(uriSplit[0] + "!" + new URI(uriSplit[1]).normalize());
+                for (int i = 0; i < uriSplit.length; i++) {
+                    if (i > 0) {
+                        result.append(new URI(uriSplit[i]).normalize());
+                    } else {
+                        result.append(uriSplit[i]);
+                    }
+                    // append a ! if it's not the last part
+                    if (i < uriSplit.length - 1) {
+                        result.append("!");
+                    }
+                }
+                return new URI(result.toString());
             } catch (URISyntaxException e) {
                 return uri.normalize();
             }


### PR DESCRIPTION
This pull request updates the `handleUriSyntax` method in `AbstractResource.java` to improve handling of complex URIs containing multiple `!` delimiters. The change ensures proper normalization of each segment of the URI while preserving the original structure.

Key change:

* [`liquibase-standard/src/main/java/liquibase/resource/AbstractResource.java`](diffhunk://#diff-746e5754522787705d996a0d74388f7bc92aebfcf4d0653a251e8f745ee8bd77R57-R70): Refactored the `handleUriSyntax` method to support URIs with multiple `!` delimiters by iterating over the split segments, normalizing each segment, and reconstructing the URI using a `StringBuilder`. This improves robustness and prevents potential issues with malformed URIs.
