### PR TITLE
fix: set logical file path for changelog

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/parser/AbstractFormattedChangeLogParser.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/AbstractFormattedChangeLogParser.java
@@ -451,8 +451,8 @@ public abstract class AbstractFormattedChangeLogParser implements ChangeLogParse
                     }
                     if (logicalFilePath != null) {
                         logicalFilePath = changeLogParameters.expandExpressions(logicalFilePath, changeLog);
+                        changeLog.setLogicalFilePath(logicalFilePath);
                     }
-                    changeLog.setLogicalFilePath( logicalFilePath );
                     
                     String dbms = handleDbms(changeLogParameters, line, changeLog);
 


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
 


## Description
This pull request introduces a change to the `parse` method in `AbstractFormattedChangeLogParser.java` to ensure the `logicalFilePath` is explicitly set on the `changeLog` object after being expanded like in the YamlChangeLogParser. 
This fix #7019  

Key change:

* [`liquibase-standard/src/main/java/liquibase/parser/AbstractFormattedChangeLogParser.java`](diffhunk://#diff-72a90d1968d64a41245b1069d04619bd52543261610281ecf7402ecd8cb63a79R445-R446): Added a call to `changeLog.setLogicalFilePath(logicalFilePath)` after expanding the `logicalFilePath` expressions to ensure it is properly set in the `changeLog` object.

Fix #7019 