### PR TITLE
fix: grant actions:write permission for fossa workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,7 +7,7 @@ permissions:
   issues: write
   checks: write
   id-token: write
-  actions: read
+  actions: write
   packages: write
 
 on:


### PR DESCRIPTION
## Summary
- Change `actions: read` to `actions: write` in run-tests.yml workflow permissions
- Required for fossa workflow to upload artifacts when `generate_fossa_3p_license_report` is enabled

## Problem
The fossa workflow is failing with permission error:
> Error calling workflow 'liquibase/build-logic/.github/workflows/fossa_ai.yml@main'. The nested job 'fossa-scan' is requesting 'actions: write', but is only allowed 'actions: read'.

See: https://github.com/liquibase/liquibase/actions/runs/15494066342

## Solution
The fossa workflow needs `actions: write` permission to upload the FOSSA 3P License Report artifact. Updated the workflow-level permissions to grant this.

## Test plan
- [ ] Verify the fossa job runs successfully without permission errors
- [ ] Confirm artifacts are uploaded correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>