### PR TITLE
feat: add rawDateValue field to store unprocessed date input in ColumnConfig

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/change/ColumnConfig.java
+++ b/liquibase-standard/src/main/java/liquibase/change/ColumnConfig.java
@@ -13,6 +13,7 @@ import liquibase.statement.SequenceNextValueFunction;
 import liquibase.structure.core.*;
 import liquibase.util.*;
 import lombok.Getter;
+import org.apache.commons.lang3.BooleanUtils;
 
 import java.math.BigInteger;
 import java.text.NumberFormat;
@@ -20,9 +21,6 @@ import java.text.ParseException;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
-
-import lombok.Setter;
-import org.apache.commons.lang3.BooleanUtils;
 
 /**
  * The standard configuration used by Change classes to represent a column.
@@ -68,7 +66,6 @@ public class ColumnConfig extends AbstractLiquibaseSerializable {
      * This is useful for extensions that need to know the original value passed in, such as Neo4j extension
      */
     @Getter
-    @Setter
     private String rawDateValue;
 
     /**

--- a/liquibase-standard/src/main/java/liquibase/change/ColumnConfig.java
+++ b/liquibase-standard/src/main/java/liquibase/change/ColumnConfig.java
@@ -20,6 +20,8 @@ import java.text.ParseException;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
+
+import lombok.Setter;
 import org.apache.commons.lang3.BooleanUtils;
 
 /**
@@ -60,6 +62,14 @@ public class ColumnConfig extends AbstractLiquibaseSerializable {
     private String remarks;
     private Boolean descending;
     private Boolean included;
+
+    /**
+     * The raw date value as it was passed in, before any parsing or processing.
+     * This is useful for extensions that need to know the original value passed in, such as Neo4j extension
+     */
+    @Getter
+    @Setter
+    private String rawDateValue;
 
     /**
      * Create a ColumnConfig object based on a {@link Column} snapshot.
@@ -390,6 +400,7 @@ public class ColumnConfig extends AbstractLiquibaseSerializable {
      * @throws DateParseException if the columnType isn't supported for "now" or "today" values.
      */
     public ColumnConfig setValueDate(String valueDate) throws DateParseException {
+        this.rawDateValue = valueDate;
         if ((valueDate == null) || "null".equalsIgnoreCase(valueDate)) {
             this.valueDate = null;
         } else if (NowAndTodayUtil.isNowOrTodayFormat(valueDate)) {
@@ -819,9 +830,10 @@ public class ColumnConfig extends AbstractLiquibaseSerializable {
         setValueNumeric(parsedNode.getChildValue(null, "valueNumeric", String.class));
 
         try {
+            this.rawDateValue = parsedNode.getChildValue(null, "valueDate", String.class);
             valueDate = parsedNode.getChildValue(null, "valueDate", Date.class);
         } catch (ParsedNodeException e) {
-            valueComputed = new DatabaseFunction(parsedNode.getChildValue(null, "valueDate", String.class));
+            valueComputed = new DatabaseFunction(this.rawDateValue);
         }
         valueBoolean = parsedNode.getChildValue(null, "valueBoolean", Boolean.class);
         valueBlobFile = parsedNode.getChildValue(null, "valueBlobFile", String.class);

--- a/liquibase-standard/src/test/groovy/liquibase/change/ColumnConfigTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/ColumnConfigTest.groovy
@@ -445,7 +445,7 @@ class ColumnConfigTest extends Specification {
         assert column.getSerializableFieldValue(field).toString() == testValue.toString()
 
         where:
-        field << new ColumnConfig().getSerializableFields().findAll({ !it.equals("constraints") })
+        field << new ColumnConfig().getSerializableFields().findAll({ it != "constraints" && it != "rawDateValue" })
     }
 
     @Unroll("#featureName: #field")


### PR DESCRIPTION
- Introduced `rawDateValue` with getter and setter annotations to preserve original date input.
- Updated `setValueDate` and `load` methods to initialize `rawDateValue`.

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [X] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
Fixes #6983 