### PR TITLE
fix: update snapshot logic to handle null snapshot returns

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotGeneratorChain.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotGeneratorChain.java
@@ -62,18 +62,23 @@ public class SnapshotGeneratorChain {
             return null;
         }
 
-        T objectToSnapshot = example;
+        //Initialize objectToSnapshot as null, so if nothing is found we return null
+        T objectToSnapshot = null;
         while (snapshotGenerators.hasNext()) {
             SnapshotGenerator generator = snapshotGenerators.next();
             if (replacedGenerators.contains(generator.getClass())) {
                 continue;
             }
-            T object = generator.snapshot(objectToSnapshot, snapshot, this);
-            if ((object != null) && (object.getSnapshotId() == null)) {
-                object.setSnapshotId(snapshotIdService.generateId());
+            T object = generator.snapshot(objectToSnapshot == null ? example : objectToSnapshot, snapshot, this);
+            if (object != null) {
+                // don't overwrite the previous finding with null
+                objectToSnapshot = object;
+                if (object.getSnapshotId() == null) {
+                    object.setSnapshotId(snapshotIdService.generateId());
+                }
             }
-            objectToSnapshot = object;
         }
         return objectToSnapshot;
     }
+
 }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

- Initialize objectToSnapshot as null , so if nothing is found we return null
- Updated `SnapshotGeneratorChain` to pass `example` only if the previous generator could not find it.
- Don't overwrite the existing snapshot if the current generator returns null.
