### PR TITLE
feat: add logic to exclude resources from liquibaseHomeUri/internal in resource processing for includeAll

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -907,6 +907,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
                 for (Resource resourcePath : unsortedResources) {
                     // if the resource is inside a jar located in liquibaseHomeUri/internal, we don't want to include it
                     if (liquibaseHomeInternalUri != null && resourcePath.getUri().toString().startsWith("jar:" + liquibaseHomeInternalUri.toString())) {
+                        Scope.getCurrentScope().getLog(getClass()).info("Skipping resource from jar file in liquibase home internal: " + resourcePath);
                         continue;
                     }
                     if ((resourceFilter == null) || resourceFilter.include(resourcePath.getPath())) {


### PR DESCRIPTION

This pull request introduces a mechanism to exclude resources located in liquibase `internal `directory when searching for changelog resources to be included. It also adds a utility method to retrieve the URI of this internal directory. Below is a summary of the most important changes:

### Enhancements to Resource Filtering:
* Updated the `findResources` method in `DatabaseChangeLog` to exclude resources located in the `internal` subdirectory of the Liquibase home directory. This is determined by checking if the resource URI starts with `jar:<LiquibaseHome>/internal`.

How to reproduce it: 

Create a changelog.yml like this one: 

```
databaseChangeLog:
- includeAll:
    path: .
    endsWithFilter: .sql
```

Notice that we are not using `relativeToChangelogFile: true` neither `searchPath` property. So you need to be inside the directory with your sql files to be included when trying to reproduce this issue.
