### PR TITLE
DAT-20288: fill in details for root's liquibase.build.properties file

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -112,6 +112,12 @@ jobs:
             echo "branch=${{ inputs.dry_run_branch_name }}" >> $GITHUB_OUTPUT
           fi
 
+      - name: Checkout the determined branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.ref-branch.outputs.branch }}
+          fetch-depth: 0
+
       - name: Get Latest Merge Commit SHA
         id: get-sha
         run: |

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -296,8 +296,7 @@ jobs:
     if: ${{ inputs.dry_run == false }}
     name: Publish artifacts to Github Packages
     runs-on: ubuntu-22.04
-    # needs: [setup, manual_trigger_deployment]
-    needs: [setup]
+    needs: [setup, manual_trigger_deployment]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Java for publishing to GitHub Repository

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -321,7 +321,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TARGET_ARTIFACT_REPOSITORY: liquibase
-        run: -pl '!liquibase-dist' -DskipTests=true "-Dbuild.repository.owner=liquibase" "-Dbuild.repository.name=liquibase" "-Dbuild.branch=${{ needs.setup.outputs.version }}" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=${{ needs.setup.outputs.latestMergeSha }}" "-Dbuild.timestamp=${{ needs.setup.outputs.timeStamp }}"
+        run: mvn -B clean deploy -pl '!liquibase-dist' -DskipTests=true "-Dbuild.repository.owner=liquibase" "-Dbuild.repository.name=liquibase" "-Dbuild.branch=${{ needs.setup.outputs.version }}" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=${{ needs.setup.outputs.latestMergeSha }}" "-Dbuild.timestamp=${{ needs.setup.outputs.timeStamp }}"
 
   # deploy_xsd:
   #   if: ${{ inputs.dry_run == false }}

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -130,174 +130,174 @@ jobs:
           timestamp=`(date +'%Y-%m-%d %H:%M:%S %Z')`
           echo "timeStamp=${timestamp}" >> $GITHUB_OUTPUT
 
-  manual_trigger_deployment:
-    if: ${{ inputs.dry_run == false }}
-    name: Manually trigger deployment
-    needs: [setup]
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Get Version to deploy
-        uses: trstringer/manual-approval@v1
-        with:
-          secret: ${{ secrets.GITHUB_TOKEN }}
-          approvers: suryaaki2,rberezen,jnewton03,kristyldatical,sayaliM0412
-          minimum-approvals: 2
-          issue-title: "Deploying ${{ needs.setup.outputs.version }} to sonatype"
-          issue-body: "Please approve or deny the deployment of version ${{ needs.setup.outputs.version }}"
-          additional-approved-words: "lgtm,✅,👍,proceed,shipit,:shipit:"
-          additional-denied-words: "stop,error,failed,fail,broken,:x:,👎"
+  # manual_trigger_deployment:
+  #   if: ${{ inputs.dry_run == false }}
+  #   name: Manually trigger deployment
+  #   needs: [setup]
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - name: Get Version to deploy
+  #       uses: trstringer/manual-approval@v1
+  #       with:
+  #         secret: ${{ secrets.GITHUB_TOKEN }}
+  #         approvers: suryaaki2,rberezen,jnewton03,kristyldatical,sayaliM0412
+  #         minimum-approvals: 2
+  #         issue-title: "Deploying ${{ needs.setup.outputs.version }} to sonatype"
+  #         issue-body: "Please approve or deny the deployment of version ${{ needs.setup.outputs.version }}"
+  #         additional-approved-words: "lgtm,✅,👍,proceed,shipit,:shipit:"
+  #         additional-denied-words: "stop,error,failed,fail,broken,:x:,👎"
 
-  deploy_maven:
-    if: ${{ inputs.dry_run == false }}
-    name: Deploy to Maven
-    needs:
-      [
-        setup,
-        manual_trigger_deployment,
-        deploy_javadocs,
-        publish_to_github_packages,
-        deploy_xsd,
-        release-docker,
-      ]
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Download release assets
-        uses: robinraju/release-downloader@v1.12
-        with:
-          repository: "liquibase/liquibase"
-          tag: "${{ needs.setup.outputs.tag }}"
-          fileName: "*"
-          out-file-path: "."
+  # deploy_maven:
+  #   if: ${{ inputs.dry_run == false }}
+  #   name: Deploy to Maven
+  #   needs:
+  #     [
+  #       setup,
+  #       manual_trigger_deployment,
+  #       deploy_javadocs,
+  #       publish_to_github_packages,
+  #       deploy_xsd,
+  #       release-docker,
+  #     ]
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - name: Download release assets
+  #       uses: robinraju/release-downloader@v1.12
+  #       with:
+  #         repository: "liquibase/liquibase"
+  #         tag: "${{ needs.setup.outputs.tag }}"
+  #         fileName: "*"
+  #         out-file-path: "."
 
-      - name: Set up Java for publishing to Maven Central Repository
-        uses: actions/setup-java@v4
-        with:
-          java-version: "11"
-          distribution: "adopt"
-          server-id: sonatype-nexus-staging
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-          gpg-private-key: ${{ secrets.GPG_SECRET }}
-          gpg-passphrase: GPG_PASSPHRASE
-        env:
-          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+  #     - name: Set up Java for publishing to Maven Central Repository
+  #       uses: actions/setup-java@v4
+  #       with:
+  #         java-version: "11"
+  #         distribution: "adopt"
+  #         server-id: sonatype-nexus-staging
+  #         server-username: MAVEN_USERNAME
+  #         server-password: MAVEN_PASSWORD
+  #         gpg-private-key: ${{ secrets.GPG_SECRET }}
+  #         gpg-passphrase: GPG_PASSPHRASE
+  #       env:
+  #         GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Publish to Maven Central
-        env:
-          MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.SONATYPE_TOKEN }}
-          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
-        run: |
-          version=${{ needs.setup.outputs.version }}
+  #     - name: Publish to Maven Central
+  #       env:
+  #         MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+  #         MAVEN_PASSWORD: ${{ secrets.SONATYPE_TOKEN }}
+  #         GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+  #       run: |
+  #         version=${{ needs.setup.outputs.version }}
 
-          unzip -j liquibase-additional-*.zip
+  #         unzip -j liquibase-additional-*.zip
 
-          ##extracts and sign poms, generate checksums for all artifacts
-          for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-commercial'; do
-            unzip -j $i-${version}.jar META-INF/maven/org.liquibase/$i/pom.xml
-            sed -i -e "s/<version>\(release\|master\)-SNAPSHOT<\/version>/<version>${version}<\/version>/" pom.xml
-            mv pom.xml $i-${version}.pom
-            if test 'liquibase-commercial' == $i; then
-              sed -i -e "s/<\/licenses>/<\/licenses><scm><connection>private<\/connection><developerConnection>private<\/developerConnection><url>private<\/url><\/scm>/" $i-${version}.pom   ## scm info not in the pom
-            fi
+  #         ##extracts and sign poms, generate checksums for all artifacts
+  #         for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-commercial'; do
+  #           unzip -j $i-${version}.jar META-INF/maven/org.liquibase/$i/pom.xml
+  #           sed -i -e "s/<version>\(release\|master\)-SNAPSHOT<\/version>/<version>${version}<\/version>/" pom.xml
+  #           mv pom.xml $i-${version}.pom
+  #           if test 'liquibase-commercial' == $i; then
+  #             sed -i -e "s/<\/licenses>/<\/licenses><scm><connection>private<\/connection><developerConnection>private<\/developerConnection><url>private<\/url><\/scm>/" $i-${version}.pom   ## scm info not in the pom
+  #           fi
 
-            # Sign POM file
-            gpg --batch --pinentry-mode=loopback --passphrase "$GPG_PASSWORD" -ab $i-${version}.pom
+  #           # Sign POM file
+  #           gpg --batch --pinentry-mode=loopback --passphrase "$GPG_PASSWORD" -ab $i-${version}.pom
             
-            # Generate checksums for POM file
-            md5sum $i-${version}.pom | cut -d' ' -f1 > $i-${version}.pom.md5
-            sha1sum $i-${version}.pom | cut -d' ' -f1 > $i-${version}.pom.sha1
+  #           # Generate checksums for POM file
+  #           md5sum $i-${version}.pom | cut -d' ' -f1 > $i-${version}.pom.md5
+  #           sha1sum $i-${version}.pom | cut -d' ' -f1 > $i-${version}.pom.sha1
             
-            # Generate checksums for all JAR files (main, sources, javadoc)
-            for jar_file in $i-${version}.jar $i-${version}-sources.jar $i-${version}-javadoc.jar; do
-              if [ -f "$jar_file" ]; then
-                md5sum "$jar_file" | cut -d' ' -f1 > "$jar_file.md5"
-                sha1sum "$jar_file" | cut -d' ' -f1 > "$jar_file.sha1"
-              fi
-            done
-          done
+  #           # Generate checksums for all JAR files (main, sources, javadoc)
+  #           for jar_file in $i-${version}.jar $i-${version}-sources.jar $i-${version}-javadoc.jar; do
+  #             if [ -f "$jar_file" ]; then
+  #               md5sum "$jar_file" | cut -d' ' -f1 > "$jar_file.md5"
+  #               sha1sum "$jar_file" | cut -d' ' -f1 > "$jar_file.sha1"
+  #             fi
+  #           done
+  #         done
 
-          # Create Maven repository layout structure for the bundle
-          mkdir -p "bundle/org/liquibase"
+  #         # Create Maven repository layout structure for the bundle
+  #         mkdir -p "bundle/org/liquibase"
           
-          # Copy all artifacts to proper Maven repository layout
-          for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-commercial'; do
-            mkdir -p "bundle/org/liquibase/$i/${version}"
-            cp $i-${version}* "bundle/org/liquibase/$i/${version}/"
-          done
+  #         # Copy all artifacts to proper Maven repository layout
+  #         for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-commercial'; do
+  #           mkdir -p "bundle/org/liquibase/$i/${version}"
+  #           cp $i-${version}* "bundle/org/liquibase/$i/${version}/"
+  #         done
           
-          # Create the bundle zip file
-          cd bundle
-          zip -r ../central-bundle.zip .
-          cd ..
+  #         # Create the bundle zip file
+  #         cd bundle
+  #         zip -r ../central-bundle.zip .
+  #         cd ..
           
-          # Create base64 encoded credentials for Bearer auth
-          AUTH_HEADER=$(printf "%s:%s" "${MAVEN_USERNAME}" "${MAVEN_PASSWORD}" | base64 -w 0)
+  #         # Create base64 encoded credentials for Bearer auth
+  #         AUTH_HEADER=$(printf "%s:%s" "${MAVEN_USERNAME}" "${MAVEN_PASSWORD}" | base64 -w 0)
           
-          # Upload bundle to Central Portal with AUTOMATIC publishing
-          echo "Uploading bundle to Central Portal for liquibase-${version}..."
-          UPLOAD_RESPONSE=$(curl -s -w "\n%{http_code}" \
-            -X POST \
-            -H "Authorization: Bearer ${AUTH_HEADER}" \
-            -F "bundle=@central-bundle.zip" \
-            "https://central.sonatype.com/api/v1/publisher/upload?publishingType=AUTOMATIC&name=liquibase-${version}")
+  #         # Upload bundle to Central Portal with AUTOMATIC publishing
+  #         echo "Uploading bundle to Central Portal for liquibase-${version}..."
+  #         UPLOAD_RESPONSE=$(curl -s -w "\n%{http_code}" \
+  #           -X POST \
+  #           -H "Authorization: Bearer ${AUTH_HEADER}" \
+  #           -F "bundle=@central-bundle.zip" \
+  #           "https://central.sonatype.com/api/v1/publisher/upload?publishingType=AUTOMATIC&name=liquibase-${version}")
           
-          # Parse response
-          HTTP_CODE=$(echo "$UPLOAD_RESPONSE" | tail -n1)
-          DEPLOYMENT_ID=$(echo "$UPLOAD_RESPONSE" | head -n1)
+  #         # Parse response
+  #         HTTP_CODE=$(echo "$UPLOAD_RESPONSE" | tail -n1)
+  #         DEPLOYMENT_ID=$(echo "$UPLOAD_RESPONSE" | head -n1)
           
-          echo "HTTP Status: $HTTP_CODE"
-          echo "Deployment ID: $DEPLOYMENT_ID"
+  #         echo "HTTP Status: $HTTP_CODE"
+  #         echo "Deployment ID: $DEPLOYMENT_ID"
           
-          if [ "$HTTP_CODE" != "201" ]; then
-            echo "Upload failed with HTTP status $HTTP_CODE"
-            echo "Response: $DEPLOYMENT_ID"
-            exit 1
-          fi
+  #         if [ "$HTTP_CODE" != "201" ]; then
+  #           echo "Upload failed with HTTP status $HTTP_CODE"
+  #           echo "Response: $DEPLOYMENT_ID"
+  #           exit 1
+  #         fi
           
-          echo "Bundle uploaded successfully to Central Portal"
-          echo "Deployment ID: $DEPLOYMENT_ID"
-          echo "Automatic publishing initiated for liquibase-${version}"
+  #         echo "Bundle uploaded successfully to Central Portal"
+  #         echo "Deployment ID: $DEPLOYMENT_ID"
+  #         echo "Automatic publishing initiated for liquibase-${version}"
 
-  deploy_javadocs:
-    if: ${{ inputs.dry_run == false }}
-    name: Upload Javadocs
-    needs: [setup, manual_trigger_deployment]
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Download release javadocs
-        uses: robinraju/release-downloader@v1.12
-        with:
-          repository: "liquibase/liquibase"
-          tag: "${{ needs.setup.outputs.tag }}"
-          fileName: "liquibase-additional*.zip"
-          out-file-path: "."
+  # deploy_javadocs:
+  #   if: ${{ inputs.dry_run == false }}
+  #   name: Upload Javadocs
+  #   needs: [setup, manual_trigger_deployment]
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - name: Download release javadocs
+  #       uses: robinraju/release-downloader@v1.12
+  #       with:
+  #         repository: "liquibase/liquibase"
+  #         tag: "${{ needs.setup.outputs.tag }}"
+  #         fileName: "liquibase-additional*.zip"
+  #         out-file-path: "."
 
-      - name: Unpack javadoc files and upload to s3
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.JAVADOCS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.JAVADOCS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: us-east-1
-        # unzip archives, create directory for each jar, and extract jar contents to directory.  Then delete the jar and zip files.  Then upload to s3.
-        run: |
-          unzip -j '*.zip' '*javadoc*.jar'
+  #     - name: Unpack javadoc files and upload to s3
+  #       env:
+  #         AWS_ACCESS_KEY_ID: ${{ secrets.JAVADOCS_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.JAVADOCS_SECRET_ACCESS_KEY }}
+  #         AWS_DEFAULT_REGION: us-east-1
+  #       # unzip archives, create directory for each jar, and extract jar contents to directory.  Then delete the jar and zip files.  Then upload to s3.
+  #       run: |
+  #         unzip -j '*.zip' '*javadoc*.jar'
 
-          for jar in *liquibase*.jar; do
-            dir_name=$(basename "$jar" .jar)
-            dir_name=$(echo "$dir_name" | sed -E 's/(-[0-9]+(\.[0-9]+)*(-javadoc)?)//')
-            mkdir -p "$dir_name"
-            unzip -o "$jar" -d "$dir_name"
-          done
+  #         for jar in *liquibase*.jar; do
+  #           dir_name=$(basename "$jar" .jar)
+  #           dir_name=$(echo "$dir_name" | sed -E 's/(-[0-9]+(\.[0-9]+)*(-javadoc)?)//')
+  #           mkdir -p "$dir_name"
+  #           unzip -o "$jar" -d "$dir_name"
+  #         done
 
-          rm -rf *.jar *.zip
-          aws s3 sync . s3://javadocsliquibasecom-origin --only-show-errors
+  #         rm -rf *.jar *.zip
+  #         aws s3 sync . s3://javadocsliquibasecom-origin --only-show-errors
 
   publish_to_github_packages:
     if: ${{ inputs.dry_run == false }}
     name: Publish artifacts to Github Packages
     runs-on: ubuntu-22.04
-    needs: [setup, manual_trigger_deployment]
-
+    # needs: [setup, manual_trigger_deployment]
+    needs: [setup]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Java for publishing to GitHub Repository
@@ -323,397 +323,396 @@ jobs:
           TARGET_ARTIFACT_REPOSITORY: liquibase
         run: -pl '!liquibase-dist' -DskipTests=true "-Dbuild.repository.owner=liquibase" "-Dbuild.repository.name=liquibase" "-Dbuild.branch=${{ needs.setup.outputs.version }}" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=${{ needs.setup.outputs.latestMergeSha }}" "-Dbuild.timestamp=${{ needs.setup.outputs.timeStamp }}"
 
-  deploy_xsd:
-    if: ${{ inputs.dry_run == false }}
-    name: Upload xsds
-    needs: [setup, manual_trigger_deployment]
-    runs-on: ubuntu-22.04
-    outputs:
-      tag: ${{ steps.collect-data.outputs.tag }}
-      version: ${{ needs.setup.outputs.version }}
-    steps:
-      - name: Download liquibase xsd
-        uses: actions/checkout@v4
-        with:
-          # Relative path under $GITHUB_WORKSPACE to place the repository
-          path: liquibase-core-repo
-          repository: "liquibase/liquibase"
+  # deploy_xsd:
+  #   if: ${{ inputs.dry_run == false }}
+  #   name: Upload xsds
+  #   needs: [setup, manual_trigger_deployment]
+  #   runs-on: ubuntu-22.04
+  #   outputs:
+  #     tag: ${{ steps.collect-data.outputs.tag }}
+  #     version: ${{ needs.setup.outputs.version }}
+  #   steps:
+  #     - name: Download liquibase xsd
+  #       uses: actions/checkout@v4
+  #       with:
+  #         # Relative path under $GITHUB_WORKSPACE to place the repository
+  #         path: liquibase-core-repo
+  #         repository: "liquibase/liquibase"
 
-      - name: Get GitHub App token
-        id: get-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
-          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: liquibase-pro
-          permission-contents: read
+  #     - name: Get GitHub App token
+  #       id: get-token
+  #       uses: actions/create-github-app-token@v2
+  #       with:
+  #         app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+  #         private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+  #         owner: ${{ github.repository_owner }}
+  #         repositories: liquibase-pro
+  #         permission-contents: read
           
-      - name: Download liquibase-pro xsd
-        uses: actions/checkout@v4
-        with:
-          ref: "${{ needs.setup.outputs.ref_branch }}"
-          token: ${{ steps.get-token.outputs.token }}
-          # Relative path under $GITHUB_WORKSPACE to place the repository
-          path: liquibase-pro-repo
-          repository: "liquibase/liquibase-pro"
+  #     - name: Download liquibase-pro xsd
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: "${{ needs.setup.outputs.ref_branch }}"
+  #         token: ${{ steps.get-token.outputs.token }}
+  #         # Relative path under $GITHUB_WORKSPACE to place the repository
+  #         path: liquibase-pro-repo
+  #         repository: "liquibase/liquibase-pro"
 
-      - name: Upload to s3
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.LIQUIBASEORIGIN_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.LIQUIBASEORIGIN_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: us-east-1
-        # aws s3 sync syncs directories and S3 prefixes.
-        run: |
-          aws s3 sync liquibase-pro-repo/pro/src/main/resources/www.liquibase.org/xml/ns/pro/ s3://liquibaseorg-origin/xml/ns/pro/ --content-type application/octet-stream --only-show-errors
-          aws s3 sync liquibase-core-repo/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/ s3://liquibaseorg-origin/xml/ns/dbchangelog/ --content-type application/octet-stream --only-show-errors
-          aws s3 sync liquibase-pro-repo/pro/src/main/resources/schemas/ s3://liquibaseorg-origin/json/schema/ --content-type application/octet-stream --only-show-errors
+  #     - name: Upload to s3
+  #       env:
+  #         AWS_ACCESS_KEY_ID: ${{ secrets.LIQUIBASEORIGIN_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.LIQUIBASEORIGIN_SECRET_ACCESS_KEY }}
+  #         AWS_DEFAULT_REGION: us-east-1
+  #       # aws s3 sync syncs directories and S3 prefixes.
+  #       run: |
+  #         aws s3 sync liquibase-pro-repo/pro/src/main/resources/www.liquibase.org/xml/ns/pro/ s3://liquibaseorg-origin/xml/ns/pro/ --content-type application/octet-stream --only-show-errors
+  #         aws s3 sync liquibase-core-repo/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/ s3://liquibaseorg-origin/xml/ns/dbchangelog/ --content-type application/octet-stream --only-show-errors
+  #         aws s3 sync liquibase-pro-repo/pro/src/main/resources/schemas/ s3://liquibaseorg-origin/json/schema/ --content-type application/octet-stream --only-show-errors
 
-      - name: Index.htm file upload
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.LIQUIBASEORIGIN_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.LIQUIBASEORIGIN_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: us-east-1
-        # get the major.minor xsd version. grab the index.htm from s3, add the new verison of xsd and sync with the s3 again
-        run: |
-          version=${{ needs.setup.outputs.version }}
-          arr=(${version//./ })
-          xsd_version=${arr[0]}"."${arr[1]}
-          mkdir index-file
-          aws s3 cp s3://liquibaseorg-origin/xml/ns/dbchangelog/index.htm index-file
-          if ! grep -q ${xsd_version} index-file/index.htm ; then
-            sed -ie "s/<\/ul>/  <li><a href=\"\/xml\/ns\/dbchangelog\/dbchangelog-${xsd_version}.xsd\">dbchangelog-${xsd_version}.xsd<\/a><\/li>\n<\/ul>/" index-file/index.htm
-            aws s3 sync index-file s3://liquibaseorg-origin/xml/ns/dbchangelog/ --only-show-errors
-          fi
+  #     - name: Index.htm file upload
+  #       env:
+  #         AWS_ACCESS_KEY_ID: ${{ secrets.LIQUIBASEORIGIN_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.LIQUIBASEORIGIN_SECRET_ACCESS_KEY }}
+  #         AWS_DEFAULT_REGION: us-east-1
+  #       # get the major.minor xsd version. grab the index.htm from s3, add the new verison of xsd and sync with the s3 again
+  #       run: |
+  #         version=${{ needs.setup.outputs.version }}
+  #         arr=(${version//./ })
+  #         xsd_version=${arr[0]}"."${arr[1]}
+  #         mkdir index-file
+  #         aws s3 cp s3://liquibaseorg-origin/xml/ns/dbchangelog/index.htm index-file
+  #         if ! grep -q ${xsd_version} index-file/index.htm ; then
+  #           sed -ie "s/<\/ul>/  <li><a href=\"\/xml\/ns\/dbchangelog\/dbchangelog-${xsd_version}.xsd\">dbchangelog-${xsd_version}.xsd<\/a><\/li>\n<\/ul>/" index-file/index.htm
+  #           aws s3 sync index-file s3://liquibaseorg-origin/xml/ns/dbchangelog/ --only-show-errors
+  #         fi
 
-      - name: Liquibase xsds SFTP upload
-        uses: wangyucode/sftp-upload-action@v2.0.4
-        with:
-          host: ${{ secrets.WPENGINE_SFTP_HOST }}
-          port: ${{ secrets.WPENGINE_SFTP_PORT }}
-          username: ${{ secrets.WPENGINE_SFTP_USER }}
-          password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
-          compress: true
-          forceUpload: true
-          localDir: "liquibase-core-repo/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/"
-          remoteDir: "/xml/ns/dbchangelog/"
+  #     - name: Liquibase xsds SFTP upload
+  #       uses: wangyucode/sftp-upload-action@v2.0.4
+  #       with:
+  #         host: ${{ secrets.WPENGINE_SFTP_HOST }}
+  #         port: ${{ secrets.WPENGINE_SFTP_PORT }}
+  #         username: ${{ secrets.WPENGINE_SFTP_USER }}
+  #         password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
+  #         compress: true
+  #         forceUpload: true
+  #         localDir: "liquibase-core-repo/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/"
+  #         remoteDir: "/xml/ns/dbchangelog/"
 
-      - name: Liquibase PRO xsds SFTP upload
-        uses: wangyucode/sftp-upload-action@v2.0.4
-        with:
-          host: ${{ secrets.WPENGINE_SFTP_HOST }}
-          port: ${{ secrets.WPENGINE_SFTP_PORT }}
-          username: ${{ secrets.WPENGINE_SFTP_USER }}
-          password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
-          compress: false
-          forceUpload: true
-          localDir: "liquibase-pro-repo/pro/src/main/resources/www.liquibase.org/xml/ns/pro/"
-          remoteDir: "/xml/ns/pro/"
+  #     - name: Liquibase PRO xsds SFTP upload
+  #       uses: wangyucode/sftp-upload-action@v2.0.4
+  #       with:
+  #         host: ${{ secrets.WPENGINE_SFTP_HOST }}
+  #         port: ${{ secrets.WPENGINE_SFTP_PORT }}
+  #         username: ${{ secrets.WPENGINE_SFTP_USER }}
+  #         password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
+  #         compress: false
+  #         forceUpload: true
+  #         localDir: "liquibase-pro-repo/pro/src/main/resources/www.liquibase.org/xml/ns/pro/"
+  #         remoteDir: "/xml/ns/pro/"
 
-      - name: Liquibase flow-file schema SFTP upload
-        uses: wangyucode/sftp-upload-action@v2.0.4
-        with:
-          host: ${{ secrets.WPENGINE_SFTP_HOST }}
-          port: ${{ secrets.WPENGINE_SFTP_PORT }}
-          username: ${{ secrets.WPENGINE_SFTP_USER }}
-          password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
-          compress: false
-          forceUpload: true
-          localDir: "liquibase-pro-repo/pro/src/main/resources/schemas/"
-          remoteDir: "/json/schema/"
+  #     - name: Liquibase flow-file schema SFTP upload
+  #       uses: wangyucode/sftp-upload-action@v2.0.4
+  #       with:
+  #         host: ${{ secrets.WPENGINE_SFTP_HOST }}
+  #         port: ${{ secrets.WPENGINE_SFTP_PORT }}
+  #         username: ${{ secrets.WPENGINE_SFTP_USER }}
+  #         password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
+  #         compress: false
+  #         forceUpload: true
+  #         localDir: "liquibase-pro-repo/pro/src/main/resources/schemas/"
+  #         remoteDir: "/json/schema/"
 
-      - name: Liquibase index.htm SFTP upload
-        uses: wangyucode/sftp-upload-action@v2.0.4
-        with:
-          host: ${{ secrets.WPENGINE_SFTP_HOST }}
-          port: ${{ secrets.WPENGINE_SFTP_PORT }}
-          username: ${{ secrets.WPENGINE_SFTP_USER }}
-          password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
-          compress: false
-          forceUpload: true
-          localDir: "index-file/"
-          remoteDir: "/xml/ns/dbchangelog/"
+  #     - name: Liquibase index.htm SFTP upload
+  #       uses: wangyucode/sftp-upload-action@v2.0.4
+  #       with:
+  #         host: ${{ secrets.WPENGINE_SFTP_HOST }}
+  #         port: ${{ secrets.WPENGINE_SFTP_PORT }}
+  #         username: ${{ secrets.WPENGINE_SFTP_USER }}
+  #         password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
+  #         compress: false
+  #         forceUpload: true
+  #         localDir: "index-file/"
+  #         remoteDir: "/xml/ns/dbchangelog/"
 
-  release-docker:
-    if: always()
-    name: Release docker images
-    needs: [setup, manual_trigger_deployment]
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Get GitHub App token
-        id: get-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
-          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          permission-contents: write
-          permission-actions: write
+  # release-docker:
+  #   if: always()
+  #   name: Release docker images
+  #   needs: [setup, manual_trigger_deployment]
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - name: Get GitHub App token
+  #       id: get-token
+  #       uses: actions/create-github-app-token@v2
+  #       with:
+  #         app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+  #         private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+  #         owner: ${{ github.repository_owner }}
+  #         permission-contents: write
+  #         permission-actions: write
 
-      - name: Release liquibase/docker v${{ needs.setup.outputs.version }}
-        uses: the-actions-org/workflow-dispatch@v4
-        id: docker_dispatch
-        with:
-          workflow: create-release.yml
-          token: ${{ steps.get-token.outputs.token }}
-          inputs: '{ "liquibaseVersion": "${{ needs.setup.outputs.version }}", "dryRun": "${{ inputs.dry_run || false }}" }'
-          ref: main
-          repo: liquibase/docker
-          wait-for-completion: true
-          workflow-logs: json-output
+  #     - name: Release liquibase/docker v${{ needs.setup.outputs.version }}
+  #       uses: the-actions-org/workflow-dispatch@v4
+  #       id: docker_dispatch
+  #       with:
+  #         workflow: create-release.yml
+  #         token: ${{ steps.get-token.outputs.token }}
+  #         inputs: '{ "liquibaseVersion": "${{ needs.setup.outputs.version }}", "dryRun": "${{ inputs.dry_run || false }}" }'
+  #         ref: main
+  #         repo: liquibase/docker
+  #         wait-for-completion: true
+  #         workflow-logs: json-output
 
-      - name: Adding Docker run to job summary
-        if: success()
-        continue-on-error: true
-        run: echo '### 🐳 Docker Release Job -> ${{steps.docker_dispatch.outputs.workflow-url}}' >> $GITHUB_STEP_SUMMARY
+  #     - name: Adding Docker run to job summary
+  #       if: success()
+  #       continue-on-error: true
+  #       run: echo '### 🐳 Docker Release Job -> ${{steps.docker_dispatch.outputs.workflow-url}}' >> $GITHUB_STEP_SUMMARY
 
-  release-minimal-docker:
-    if: ${{ inputs.dry_run == false }}
-    name: Release Minimal docker image
-    needs: [setup, manual_trigger_deployment]
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Get GitHub App token
-        id: get-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
-          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          permission-contents: write
-          permission-actions: write
+  # release-minimal-docker:
+  #   if: ${{ inputs.dry_run == false }}
+  #   name: Release Minimal docker image
+  #   needs: [setup, manual_trigger_deployment]
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - name: Get GitHub App token
+  #       id: get-token
+  #       uses: actions/create-github-app-token@v2
+  #       with:
+  #         app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+  #         private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+  #         owner: ${{ github.repository_owner }}
+  #         permission-contents: write
+  #         permission-actions: write
 
-      - name: Release liquibase/liquibase-infrastructure v${{ needs.setup.outputs.version }}
-        uses: the-actions-org/workflow-dispatch@v4
-        id: docker_dispatch
-        with:
-          workflow: build-liquibase-minimal.yml
-          token: ${{ steps.get-token.outputs.token }}
-          inputs: '{ "liquibaseVersion": "${{ needs.setup.outputs.version }}" }'
-          ref: master
-          repo: liquibase/liquibase-infrastructure
-          wait-for-completion: true
-          workflow-logs: json-output
+  #     - name: Release liquibase/liquibase-infrastructure v${{ needs.setup.outputs.version }}
+  #       uses: the-actions-org/workflow-dispatch@v4
+  #       id: docker_dispatch
+  #       with:
+  #         workflow: build-liquibase-minimal.yml
+  #         token: ${{ steps.get-token.outputs.token }}
+  #         inputs: '{ "liquibaseVersion": "${{ needs.setup.outputs.version }}" }'
+  #         ref: master
+  #         repo: liquibase/liquibase-infrastructure
+  #         wait-for-completion: true
+  #         workflow-logs: json-output
 
-  generate-PRO-tag:
-    if: ${{ inputs.dry_run == false }}
-    name: Generate PRO tags based on OSS release
-    needs: [setup]
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Get GitHub App token
-        id: get-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
-          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          permission-contents: write
-          permission-actions: write
+  # generate-PRO-tag:
+  #   if: ${{ inputs.dry_run == false }}
+  #   name: Generate PRO tags based on OSS release
+  #   needs: [setup]
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - name: Get GitHub App token
+  #       id: get-token
+  #       uses: actions/create-github-app-token@v2
+  #       with:
+  #         app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+  #         private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+  #         owner: ${{ github.repository_owner }}
+  #         permission-contents: write
+  #         permission-actions: write
 
-      - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ steps.get-token.outputs.token }}
-          repository: liquibase/liquibase-pro
-          event-type: oss-released-tag
+  #     - name: Repository Dispatch
+  #       uses: peter-evans/repository-dispatch@v3
+  #       with:
+  #         token: ${{ steps.get-token.outputs.token }}
+  #         repository: liquibase/liquibase-pro
+  #         event-type: oss-released-tag
 
-  package:
-    uses: liquibase/build-logic/.github/workflows/package.yml@main
-    needs: [setup]
-    secrets: inherit
-    with:
-      groupId: "org.liquibase"
-      artifactId: "liquibase"
-      version: ${{ needs.setup.outputs.version }}
-      dry_run: ${{ inputs.dry_run || false}}
-      dry_run_zip_url: ${{ inputs.dry_run_zip_url || '' }}
-      dry_run_tar_gz_url: ${{ inputs.dry_run_tar_gz_url || '' }}
-      dry_run_release_id: ${{ inputs.dry_run_release_id || '' }}
+  # package:
+  #   uses: liquibase/build-logic/.github/workflows/package.yml@main
+  #   needs: [setup]
+  #   secrets: inherit
+  #   with:
+  #     groupId: "org.liquibase"
+  #     artifactId: "liquibase"
+  #     version: ${{ needs.setup.outputs.version }}
+  #     dry_run: ${{ inputs.dry_run || false}}
+  #     dry_run_zip_url: ${{ inputs.dry_run_zip_url || '' }}
+  #     dry_run_tar_gz_url: ${{ inputs.dry_run_tar_gz_url || '' }}
+  #     dry_run_release_id: ${{ inputs.dry_run_release_id || '' }}
 
-  update-docs-oss-pro-version:
-    if: ${{ inputs.dry_run == false }}
-    name: Update OSS and PRO tags based on OSS release
-    needs: [setup]
-    runs-on: ubuntu-latest
-    outputs:
-      latest_version: ${{ steps.get_latest_oss_version.outputs.latest_version }}
-      previous_version: ${{ steps.get_latest_oss_version.outputs.previous_version }}
-    steps:
-      - name: Get GitHub App token
-        id: get-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
-          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          permission-contents: write
-          permission-actions: write
+  # update-docs-oss-pro-version:
+  #   if: ${{ inputs.dry_run == false }}
+  #   name: Update OSS and PRO tags based on OSS release
+  #   needs: [setup]
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     latest_version: ${{ steps.get_latest_oss_version.outputs.latest_version }}
+  #     previous_version: ${{ steps.get_latest_oss_version.outputs.previous_version }}
+  #   steps:
+  #     - name: Get GitHub App token
+  #       id: get-token
+  #       uses: actions/create-github-app-token@v2
+  #       with:
+  #         app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+  #         private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+  #         owner: ${{ github.repository_owner }}
+  #         permission-contents: write
+  #         permission-actions: write
 
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          repository: liquibase/liquibase
-          ref: "${{ needs.setup.outputs.ref_branch }}"
-          fetch-depth: 0
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v4
+  #       with:
+  #         repository: liquibase/liquibase
+  #         ref: "${{ needs.setup.outputs.ref_branch }}"
+  #         fetch-depth: 0
 
-      - name: Get the oss release version
-        id: get_latest_oss_version
-        run: |
-          # Fetch all tags from the remote
-          git fetch --tags
-          # Get the latest semver tag, strip 'v'
-          latest_tag=$(git tag --sort=-creatordate | grep -E '^v?[0-9]' | head -n1 | sed 's/^v//')
-          # Get the second latest tag
-          previous_tag=$(git tag --sort=-creatordate | grep -E '^v?[0-9]' | sed 's/^v//' | head -n2 | tail -n1)
-          echo "latest_version=$latest_tag" >> $GITHUB_OUTPUT
-          echo "previous_version=$previous_tag" >> $GITHUB_OUTPUT
-          echo "Latest Version: $latest_tag"
-          echo "Previous Version: $previous_tag"
+  #     - name: Get the oss release version
+  #       id: get_latest_oss_version
+  #       run: |
+  #         # Fetch all tags from the remote
+  #         git fetch --tags
+  #         # Get the latest semver tag, strip 'v'
+  #         latest_tag=$(git tag --sort=-creatordate | grep -E '^v?[0-9]' | head -n1 | sed 's/^v//')
+  #         # Get the second latest tag
+  #         previous_tag=$(git tag --sort=-creatordate | grep -E '^v?[0-9]' | sed 's/^v//' | head -n2 | tail -n1)
+  #         echo "latest_version=$latest_tag" >> $GITHUB_OUTPUT
+  #         echo "previous_version=$previous_tag" >> $GITHUB_OUTPUT
+  #         echo "Latest Version: $latest_tag"
+  #         echo "Previous Version: $previous_tag"
 
-      - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ steps.get-token.outputs.token }}
-          repository: liquibase/liquibase-docs
-          event-type: oss-released-version
-          client-payload: '{"latest_version": "${{ steps.get_latest_oss_version.outputs.latest_version }}", "previous_version": "${{ steps.get_latest_oss_version.outputs.previous_version }}"}'
+  #     - name: Repository Dispatch
+  #       uses: peter-evans/repository-dispatch@v3
+  #       with:
+  #         token: ${{ steps.get-token.outputs.token }}
+  #         repository: liquibase/liquibase-docs
+  #         event-type: oss-released-version
+  #         client-payload: '{"latest_version": "${{ steps.get_latest_oss_version.outputs.latest_version }}", "previous_version": "${{ steps.get_latest_oss_version.outputs.previous_version }}"}'
 
-      # dispatch an event to `liquibase-aws-license-service` repository to update pom.xml with latest OSS Release
-      - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ steps.get-token.outputs.token }}
-          repository: liquibase/liquibase-aws-license-service
-          event-type: oss-released-version
+  #     # dispatch an event to `liquibase-aws-license-service` repository to update pom.xml with latest OSS Release
+  #     - name: Repository Dispatch
+  #       uses: peter-evans/repository-dispatch@v3
+  #       with:
+  #         token: ${{ steps.get-token.outputs.token }}
+  #         repository: liquibase/liquibase-aws-license-service
+  #         event-type: oss-released-version
 
+  # dry_run_deploy_maven:
+  #   if: ${{ inputs.dry_run == true }}
+  #   name: Deploy to Maven Central Repository
+  #   needs: [setup]
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - name: Download dry-run release assets
+  #       uses: robinraju/release-downloader@v1.12
+  #       with:
+  #         repository: "liquibase/liquibase"
+  #         releaseId: "${{ inputs.dry_run_release_id }}"
+  #         fileName: "*"
+  #         out-file-path: "."
 
-  dry_run_deploy_maven:
-    if: ${{ inputs.dry_run == true }}
-    name: Deploy to Maven Central Repository
-    needs: [setup]
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Download dry-run release assets
-        uses: robinraju/release-downloader@v1.12
-        with:
-          repository: "liquibase/liquibase"
-          releaseId: "${{ inputs.dry_run_release_id }}"
-          fileName: "*"
-          out-file-path: "."
+  #     - name: Set up Java for publishing to Maven Central Repository
+  #       uses: actions/setup-java@v4
+  #       with:
+  #         java-version: "11"
+  #         distribution: "adopt"
+  #         server-id: dry-run-sonatype-nexus-staging
+  #         server-username: MAVEN_USERNAME
+  #         server-password: MAVEN_PASSWORD
+  #         gpg-private-key: ${{ secrets.GPG_SECRET }}
+  #         gpg-passphrase: GPG_PASSPHRASE
+  #       env:
+  #         GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Set up Java for publishing to Maven Central Repository
-        uses: actions/setup-java@v4
-        with:
-          java-version: "11"
-          distribution: "adopt"
-          server-id: dry-run-sonatype-nexus-staging
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-          gpg-private-key: ${{ secrets.GPG_SECRET }}
-          gpg-passphrase: GPG_PASSPHRASE
-        env:
-          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+  #     - name: Publish to Central Portal (Dry Run)
+  #       env:
+  #         MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+  #         MAVEN_PASSWORD: ${{ secrets.SONATYPE_TOKEN }}
+  #         GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+  #       run: |
+  #         version=${{ needs.setup.outputs.version }}
 
-      - name: Publish to Central Portal (Dry Run)
-        env:
-          MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.SONATYPE_TOKEN }}
-          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
-        run: |
-          version=${{ needs.setup.outputs.version }}
+  #         unzip -j liquibase-additional-*.zip
 
-          unzip -j liquibase-additional-*.zip
+  #         ##extracts and sign poms, generate checksums for all artifacts
+  #         for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-commercial'; do
+  #           unzip -j $i-${version}.jar META-INF/maven/org.liquibase/$i/pom.xml
+  #           sed -i -e "s/<version>\(release\|master\)-SNAPSHOT<\/version>/<version>${version}<\/version>/" pom.xml
+  #           mv pom.xml $i-${version}.pom
+  #           if test 'liquibase-commercial' == $i; then
+  #             sed -i -e "s/<\/licenses>/<\/licenses><scm><connection>private<\/connection><developerConnection>private<\/developerConnection><url>private<\/url><\/scm>/" $i-${version}.pom   ## scm info not in the pom
+  #           fi
 
-          ##extracts and sign poms, generate checksums for all artifacts
-          for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-commercial'; do
-            unzip -j $i-${version}.jar META-INF/maven/org.liquibase/$i/pom.xml
-            sed -i -e "s/<version>\(release\|master\)-SNAPSHOT<\/version>/<version>${version}<\/version>/" pom.xml
-            mv pom.xml $i-${version}.pom
-            if test 'liquibase-commercial' == $i; then
-              sed -i -e "s/<\/licenses>/<\/licenses><scm><connection>private<\/connection><developerConnection>private<\/developerConnection><url>private<\/url><\/scm>/" $i-${version}.pom   ## scm info not in the pom
-            fi
-
-            # Sign POM file
-            gpg --batch --pinentry-mode=loopback --passphrase "$GPG_PASSWORD" -ab $i-${version}.pom
+  #           # Sign POM file
+  #           gpg --batch --pinentry-mode=loopback --passphrase "$GPG_PASSWORD" -ab $i-${version}.pom
             
-            # Generate checksums for POM file
-            md5sum $i-${version}.pom | cut -d' ' -f1 > $i-${version}.pom.md5
-            sha1sum $i-${version}.pom | cut -d' ' -f1 > $i-${version}.pom.sha1
+  #           # Generate checksums for POM file
+  #           md5sum $i-${version}.pom | cut -d' ' -f1 > $i-${version}.pom.md5
+  #           sha1sum $i-${version}.pom | cut -d' ' -f1 > $i-${version}.pom.sha1
             
-            # Generate checksums for all JAR files (main, sources, javadoc)
-            for jar_file in $i-${version}.jar $i-${version}-sources.jar $i-${version}-javadoc.jar; do
-              if [ -f "$jar_file" ]; then
-                md5sum "$jar_file" | cut -d' ' -f1 > "$jar_file.md5"
-                sha1sum "$jar_file" | cut -d' ' -f1 > "$jar_file.sha1"
-              fi
-            done
-          done
+  #           # Generate checksums for all JAR files (main, sources, javadoc)
+  #           for jar_file in $i-${version}.jar $i-${version}-sources.jar $i-${version}-javadoc.jar; do
+  #             if [ -f "$jar_file" ]; then
+  #               md5sum "$jar_file" | cut -d' ' -f1 > "$jar_file.md5"
+  #               sha1sum "$jar_file" | cut -d' ' -f1 > "$jar_file.sha1"
+  #             fi
+  #           done
+  #         done
 
-          # Create Maven repository layout structure for the bundle
-          mkdir -p "bundle/org/liquibase"
+  #         # Create Maven repository layout structure for the bundle
+  #         mkdir -p "bundle/org/liquibase"
           
-          # Copy all artifacts to proper Maven repository layout
-          for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-commercial'; do
-            mkdir -p "bundle/org/liquibase/$i/${version}"
-            cp $i-${version}* "bundle/org/liquibase/$i/${version}/"
-          done
+  #         # Copy all artifacts to proper Maven repository layout
+  #         for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-commercial'; do
+  #           mkdir -p "bundle/org/liquibase/$i/${version}"
+  #           cp $i-${version}* "bundle/org/liquibase/$i/${version}/"
+  #         done
           
-          # Create the bundle zip file
-          cd bundle
-          zip -r ../central-bundle.zip .
-          cd ..
+  #         # Create the bundle zip file
+  #         cd bundle
+  #         zip -r ../central-bundle.zip .
+  #         cd ..
           
-          # Create base64 encoded credentials for Bearer auth
-          AUTH_HEADER=$(printf "%s:%s" "${MAVEN_USERNAME}" "${MAVEN_PASSWORD}" | base64 -w 0)
+  #         # Create base64 encoded credentials for Bearer auth
+  #         AUTH_HEADER=$(printf "%s:%s" "${MAVEN_USERNAME}" "${MAVEN_PASSWORD}" | base64 -w 0)
           
-          # Upload bundle to Central Portal with USER_MANAGED publishing (dry run)
-          echo "Uploading bundle to Central Portal for dry-run liquibase-${version}..."
-          UPLOAD_RESPONSE=$(curl -s -w "\n%{http_code}" \
-            -X POST \
-            -H "Authorization: Bearer ${AUTH_HEADER}" \
-            -F "bundle=@central-bundle.zip" \
-            "https://central.sonatype.com/api/v1/publisher/upload?publishingType=USER_MANAGED&name=liquibase-${version}-dry-run")
+  #         # Upload bundle to Central Portal with USER_MANAGED publishing (dry run)
+  #         echo "Uploading bundle to Central Portal for dry-run liquibase-${version}..."
+  #         UPLOAD_RESPONSE=$(curl -s -w "\n%{http_code}" \
+  #           -X POST \
+  #           -H "Authorization: Bearer ${AUTH_HEADER}" \
+  #           -F "bundle=@central-bundle.zip" \
+  #           "https://central.sonatype.com/api/v1/publisher/upload?publishingType=USER_MANAGED&name=liquibase-${version}-dry-run")
           
-          # Parse response
-          HTTP_CODE=$(echo "$UPLOAD_RESPONSE" | tail -n1)
-          DEPLOYMENT_ID=$(echo "$UPLOAD_RESPONSE" | head -n1)
+  #         # Parse response
+  #         HTTP_CODE=$(echo "$UPLOAD_RESPONSE" | tail -n1)
+  #         DEPLOYMENT_ID=$(echo "$UPLOAD_RESPONSE" | head -n1)
           
-          echo "HTTP Status: $HTTP_CODE"
-          echo "Deployment ID: $DEPLOYMENT_ID"
+  #         echo "HTTP Status: $HTTP_CODE"
+  #         echo "Deployment ID: $DEPLOYMENT_ID"
           
-          if [ "$HTTP_CODE" != "201" ]; then
-            echo "Upload failed with HTTP status $HTTP_CODE"
-            echo "Response: $DEPLOYMENT_ID"
-            exit 1
-          fi
+  #         if [ "$HTTP_CODE" != "201" ]; then
+  #           echo "Upload failed with HTTP status $HTTP_CODE"
+  #           echo "Response: $DEPLOYMENT_ID"
+  #           exit 1
+  #         fi
           
-          echo "Bundle uploaded successfully to Central Portal for dry-run"
-          echo "Deployment ID: $DEPLOYMENT_ID"
-          echo "Manual publishing required - visit https://central.sonatype.com/publishing/deployments to review and publish"
+  #         echo "Bundle uploaded successfully to Central Portal for dry-run"
+  #         echo "Deployment ID: $DEPLOYMENT_ID"
+  #         echo "Manual publishing required - visit https://central.sonatype.com/publishing/deployments to review and publish"
 
-  publish_assets_to_s3_bucket:
-    if: ${{ inputs.dry_run == false }}
-    name: Publish OSS released assets to s3 bucket liquibaseorg-origin
-    needs: [setup]
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Download released assets
-        uses: robinraju/release-downloader@v1.12
-        with:
-          repository: "liquibase/liquibase"
-          latest: true
-          fileName: "*"
-          out-file-path: "./${{ needs.setup.outputs.version }}-released-assets"
+  # publish_assets_to_s3_bucket:
+  #   if: ${{ inputs.dry_run == false }}
+  #   name: Publish OSS released assets to s3 bucket liquibaseorg-origin
+  #   needs: [setup]
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - name: Download released assets
+  #       uses: robinraju/release-downloader@v1.12
+  #       with:
+  #         repository: "liquibase/liquibase"
+  #         latest: true
+  #         fileName: "*"
+  #         out-file-path: "./${{ needs.setup.outputs.version }}-released-assets"
 
-      - name: Get current timestamp
-        id: timestamp
-        run: echo "timestamp=$(date +%Y%m%d-%H%M%S)" >> $GITHUB_ENV
+  #     - name: Get current timestamp
+  #       id: timestamp
+  #       run: echo "timestamp=$(date +%Y%m%d-%H%M%S)" >> $GITHUB_ENV
 
-      - name: Publish released assets to s3 bucket
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.LIQUIBASEORIGIN_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.LIQUIBASEORIGIN_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: us-east-1
-        run: |
-          aws s3 sync "./${{ needs.setup.outputs.version }}-released-assets" s3://liquibaseorg-origin/oss-released-assets/${{ needs.setup.outputs.version }}-released-assets-${{ env.timestamp }}/ --only-show-errors
+  #     - name: Publish released assets to s3 bucket
+  #       env:
+  #         AWS_ACCESS_KEY_ID: ${{ secrets.LIQUIBASEORIGIN_ACCESS_KEY_ID }}
+  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.LIQUIBASEORIGIN_SECRET_ACCESS_KEY }}
+  #         AWS_DEFAULT_REGION: us-east-1
+  #       run: |
+  #         aws s3 sync "./${{ needs.setup.outputs.version }}-released-assets" s3://liquibaseorg-origin/oss-released-assets/${{ needs.setup.outputs.version }}-released-assets-${{ env.timestamp }}/ --only-show-errors

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -130,167 +130,167 @@ jobs:
           timestamp=`(date +'%Y-%m-%d %H:%M:%S %Z')`
           echo "timeStamp=${timestamp}" >> $GITHUB_OUTPUT
 
-  # manual_trigger_deployment:
-  #   if: ${{ inputs.dry_run == false }}
-  #   name: Manually trigger deployment
-  #   needs: [setup]
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - name: Get Version to deploy
-  #       uses: trstringer/manual-approval@v1
-  #       with:
-  #         secret: ${{ secrets.GITHUB_TOKEN }}
-  #         approvers: suryaaki2,rberezen,jnewton03,kristyldatical,sayaliM0412
-  #         minimum-approvals: 2
-  #         issue-title: "Deploying ${{ needs.setup.outputs.version }} to sonatype"
-  #         issue-body: "Please approve or deny the deployment of version ${{ needs.setup.outputs.version }}"
-  #         additional-approved-words: "lgtm,✅,👍,proceed,shipit,:shipit:"
-  #         additional-denied-words: "stop,error,failed,fail,broken,:x:,👎"
+  manual_trigger_deployment:
+    if: ${{ inputs.dry_run == false }}
+    name: Manually trigger deployment
+    needs: [setup]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Get Version to deploy
+        uses: trstringer/manual-approval@v1
+        with:
+          secret: ${{ secrets.GITHUB_TOKEN }}
+          approvers: suryaaki2,rberezen,jnewton03,kristyldatical,sayaliM0412
+          minimum-approvals: 2
+          issue-title: "Deploying ${{ needs.setup.outputs.version }} to sonatype"
+          issue-body: "Please approve or deny the deployment of version ${{ needs.setup.outputs.version }}"
+          additional-approved-words: "lgtm,✅,👍,proceed,shipit,:shipit:"
+          additional-denied-words: "stop,error,failed,fail,broken,:x:,👎"
 
-  # deploy_maven:
-  #   if: ${{ inputs.dry_run == false }}
-  #   name: Deploy to Maven
-  #   needs:
-  #     [
-  #       setup,
-  #       manual_trigger_deployment,
-  #       deploy_javadocs,
-  #       publish_to_github_packages,
-  #       deploy_xsd,
-  #       release-docker,
-  #     ]
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - name: Download release assets
-  #       uses: robinraju/release-downloader@v1.12
-  #       with:
-  #         repository: "liquibase/liquibase"
-  #         tag: "${{ needs.setup.outputs.tag }}"
-  #         fileName: "*"
-  #         out-file-path: "."
+  deploy_maven:
+    if: ${{ inputs.dry_run == false }}
+    name: Deploy to Maven
+    needs:
+      [
+        setup,
+        manual_trigger_deployment,
+        deploy_javadocs,
+        publish_to_github_packages,
+        deploy_xsd,
+        release-docker,
+      ]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download release assets
+        uses: robinraju/release-downloader@v1.12
+        with:
+          repository: "liquibase/liquibase"
+          tag: "${{ needs.setup.outputs.tag }}"
+          fileName: "*"
+          out-file-path: "."
 
-  #     - name: Set up Java for publishing to Maven Central Repository
-  #       uses: actions/setup-java@v4
-  #       with:
-  #         java-version: "11"
-  #         distribution: "adopt"
-  #         server-id: sonatype-nexus-staging
-  #         server-username: MAVEN_USERNAME
-  #         server-password: MAVEN_PASSWORD
-  #         gpg-private-key: ${{ secrets.GPG_SECRET }}
-  #         gpg-passphrase: GPG_PASSPHRASE
-  #       env:
-  #         GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Set up Java for publishing to Maven Central Repository
+        uses: actions/setup-java@v4
+        with:
+          java-version: "11"
+          distribution: "adopt"
+          server-id: sonatype-nexus-staging
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_SECRET }}
+          gpg-passphrase: GPG_PASSPHRASE
+        env:
+          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
 
-  #     - name: Publish to Maven Central
-  #       env:
-  #         MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-  #         MAVEN_PASSWORD: ${{ secrets.SONATYPE_TOKEN }}
-  #         GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
-  #       run: |
-  #         version=${{ needs.setup.outputs.version }}
+      - name: Publish to Maven Central
+        env:
+          MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.SONATYPE_TOKEN }}
+          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          version=${{ needs.setup.outputs.version }}
 
-  #         unzip -j liquibase-additional-*.zip
+          unzip -j liquibase-additional-*.zip
 
-  #         ##extracts and sign poms, generate checksums for all artifacts
-  #         for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-commercial'; do
-  #           unzip -j $i-${version}.jar META-INF/maven/org.liquibase/$i/pom.xml
-  #           sed -i -e "s/<version>\(release\|master\)-SNAPSHOT<\/version>/<version>${version}<\/version>/" pom.xml
-  #           mv pom.xml $i-${version}.pom
-  #           if test 'liquibase-commercial' == $i; then
-  #             sed -i -e "s/<\/licenses>/<\/licenses><scm><connection>private<\/connection><developerConnection>private<\/developerConnection><url>private<\/url><\/scm>/" $i-${version}.pom   ## scm info not in the pom
-  #           fi
+          ##extracts and sign poms, generate checksums for all artifacts
+          for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-commercial'; do
+            unzip -j $i-${version}.jar META-INF/maven/org.liquibase/$i/pom.xml
+            sed -i -e "s/<version>\(release\|master\)-SNAPSHOT<\/version>/<version>${version}<\/version>/" pom.xml
+            mv pom.xml $i-${version}.pom
+            if test 'liquibase-commercial' == $i; then
+              sed -i -e "s/<\/licenses>/<\/licenses><scm><connection>private<\/connection><developerConnection>private<\/developerConnection><url>private<\/url><\/scm>/" $i-${version}.pom   ## scm info not in the pom
+            fi
 
-  #           # Sign POM file
-  #           gpg --batch --pinentry-mode=loopback --passphrase "$GPG_PASSWORD" -ab $i-${version}.pom
+            # Sign POM file
+            gpg --batch --pinentry-mode=loopback --passphrase "$GPG_PASSWORD" -ab $i-${version}.pom
             
-  #           # Generate checksums for POM file
-  #           md5sum $i-${version}.pom | cut -d' ' -f1 > $i-${version}.pom.md5
-  #           sha1sum $i-${version}.pom | cut -d' ' -f1 > $i-${version}.pom.sha1
+            # Generate checksums for POM file
+            md5sum $i-${version}.pom | cut -d' ' -f1 > $i-${version}.pom.md5
+            sha1sum $i-${version}.pom | cut -d' ' -f1 > $i-${version}.pom.sha1
             
-  #           # Generate checksums for all JAR files (main, sources, javadoc)
-  #           for jar_file in $i-${version}.jar $i-${version}-sources.jar $i-${version}-javadoc.jar; do
-  #             if [ -f "$jar_file" ]; then
-  #               md5sum "$jar_file" | cut -d' ' -f1 > "$jar_file.md5"
-  #               sha1sum "$jar_file" | cut -d' ' -f1 > "$jar_file.sha1"
-  #             fi
-  #           done
-  #         done
+            # Generate checksums for all JAR files (main, sources, javadoc)
+            for jar_file in $i-${version}.jar $i-${version}-sources.jar $i-${version}-javadoc.jar; do
+              if [ -f "$jar_file" ]; then
+                md5sum "$jar_file" | cut -d' ' -f1 > "$jar_file.md5"
+                sha1sum "$jar_file" | cut -d' ' -f1 > "$jar_file.sha1"
+              fi
+            done
+          done
 
-  #         # Create Maven repository layout structure for the bundle
-  #         mkdir -p "bundle/org/liquibase"
+          # Create Maven repository layout structure for the bundle
+          mkdir -p "bundle/org/liquibase"
           
-  #         # Copy all artifacts to proper Maven repository layout
-  #         for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-commercial'; do
-  #           mkdir -p "bundle/org/liquibase/$i/${version}"
-  #           cp $i-${version}* "bundle/org/liquibase/$i/${version}/"
-  #         done
+          # Copy all artifacts to proper Maven repository layout
+          for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-commercial'; do
+            mkdir -p "bundle/org/liquibase/$i/${version}"
+            cp $i-${version}* "bundle/org/liquibase/$i/${version}/"
+          done
           
-  #         # Create the bundle zip file
-  #         cd bundle
-  #         zip -r ../central-bundle.zip .
-  #         cd ..
+          # Create the bundle zip file
+          cd bundle
+          zip -r ../central-bundle.zip .
+          cd ..
           
-  #         # Create base64 encoded credentials for Bearer auth
-  #         AUTH_HEADER=$(printf "%s:%s" "${MAVEN_USERNAME}" "${MAVEN_PASSWORD}" | base64 -w 0)
+          # Create base64 encoded credentials for Bearer auth
+          AUTH_HEADER=$(printf "%s:%s" "${MAVEN_USERNAME}" "${MAVEN_PASSWORD}" | base64 -w 0)
           
-  #         # Upload bundle to Central Portal with AUTOMATIC publishing
-  #         echo "Uploading bundle to Central Portal for liquibase-${version}..."
-  #         UPLOAD_RESPONSE=$(curl -s -w "\n%{http_code}" \
-  #           -X POST \
-  #           -H "Authorization: Bearer ${AUTH_HEADER}" \
-  #           -F "bundle=@central-bundle.zip" \
-  #           "https://central.sonatype.com/api/v1/publisher/upload?publishingType=AUTOMATIC&name=liquibase-${version}")
+          # Upload bundle to Central Portal with AUTOMATIC publishing
+          echo "Uploading bundle to Central Portal for liquibase-${version}..."
+          UPLOAD_RESPONSE=$(curl -s -w "\n%{http_code}" \
+            -X POST \
+            -H "Authorization: Bearer ${AUTH_HEADER}" \
+            -F "bundle=@central-bundle.zip" \
+            "https://central.sonatype.com/api/v1/publisher/upload?publishingType=AUTOMATIC&name=liquibase-${version}")
           
-  #         # Parse response
-  #         HTTP_CODE=$(echo "$UPLOAD_RESPONSE" | tail -n1)
-  #         DEPLOYMENT_ID=$(echo "$UPLOAD_RESPONSE" | head -n1)
+          # Parse response
+          HTTP_CODE=$(echo "$UPLOAD_RESPONSE" | tail -n1)
+          DEPLOYMENT_ID=$(echo "$UPLOAD_RESPONSE" | head -n1)
           
-  #         echo "HTTP Status: $HTTP_CODE"
-  #         echo "Deployment ID: $DEPLOYMENT_ID"
+          echo "HTTP Status: $HTTP_CODE"
+          echo "Deployment ID: $DEPLOYMENT_ID"
           
-  #         if [ "$HTTP_CODE" != "201" ]; then
-  #           echo "Upload failed with HTTP status $HTTP_CODE"
-  #           echo "Response: $DEPLOYMENT_ID"
-  #           exit 1
-  #         fi
+          if [ "$HTTP_CODE" != "201" ]; then
+            echo "Upload failed with HTTP status $HTTP_CODE"
+            echo "Response: $DEPLOYMENT_ID"
+            exit 1
+          fi
           
-  #         echo "Bundle uploaded successfully to Central Portal"
-  #         echo "Deployment ID: $DEPLOYMENT_ID"
-  #         echo "Automatic publishing initiated for liquibase-${version}"
+          echo "Bundle uploaded successfully to Central Portal"
+          echo "Deployment ID: $DEPLOYMENT_ID"
+          echo "Automatic publishing initiated for liquibase-${version}"
 
-  # deploy_javadocs:
-  #   if: ${{ inputs.dry_run == false }}
-  #   name: Upload Javadocs
-  #   needs: [setup, manual_trigger_deployment]
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - name: Download release javadocs
-  #       uses: robinraju/release-downloader@v1.12
-  #       with:
-  #         repository: "liquibase/liquibase"
-  #         tag: "${{ needs.setup.outputs.tag }}"
-  #         fileName: "liquibase-additional*.zip"
-  #         out-file-path: "."
+  deploy_javadocs:
+    if: ${{ inputs.dry_run == false }}
+    name: Upload Javadocs
+    needs: [setup, manual_trigger_deployment]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download release javadocs
+        uses: robinraju/release-downloader@v1.12
+        with:
+          repository: "liquibase/liquibase"
+          tag: "${{ needs.setup.outputs.tag }}"
+          fileName: "liquibase-additional*.zip"
+          out-file-path: "."
 
-  #     - name: Unpack javadoc files and upload to s3
-  #       env:
-  #         AWS_ACCESS_KEY_ID: ${{ secrets.JAVADOCS_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.JAVADOCS_SECRET_ACCESS_KEY }}
-  #         AWS_DEFAULT_REGION: us-east-1
-  #       # unzip archives, create directory for each jar, and extract jar contents to directory.  Then delete the jar and zip files.  Then upload to s3.
-  #       run: |
-  #         unzip -j '*.zip' '*javadoc*.jar'
+      - name: Unpack javadoc files and upload to s3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.JAVADOCS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.JAVADOCS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        # unzip archives, create directory for each jar, and extract jar contents to directory.  Then delete the jar and zip files.  Then upload to s3.
+        run: |
+          unzip -j '*.zip' '*javadoc*.jar'
 
-  #         for jar in *liquibase*.jar; do
-  #           dir_name=$(basename "$jar" .jar)
-  #           dir_name=$(echo "$dir_name" | sed -E 's/(-[0-9]+(\.[0-9]+)*(-javadoc)?)//')
-  #           mkdir -p "$dir_name"
-  #           unzip -o "$jar" -d "$dir_name"
-  #         done
+          for jar in *liquibase*.jar; do
+            dir_name=$(basename "$jar" .jar)
+            dir_name=$(echo "$dir_name" | sed -E 's/(-[0-9]+(\.[0-9]+)*(-javadoc)?)//')
+            mkdir -p "$dir_name"
+            unzip -o "$jar" -d "$dir_name"
+          done
 
-  #         rm -rf *.jar *.zip
-  #         aws s3 sync . s3://javadocsliquibasecom-origin --only-show-errors
+          rm -rf *.jar *.zip
+          aws s3 sync . s3://javadocsliquibasecom-origin --only-show-errors
 
   publish_to_github_packages:
     if: ${{ inputs.dry_run == false }}
@@ -323,396 +323,396 @@ jobs:
           TARGET_ARTIFACT_REPOSITORY: liquibase
         run: mvn -B clean deploy -pl '!liquibase-dist' -DskipTests=true "-Dbuild.repository.owner=liquibase" "-Dbuild.repository.name=liquibase" "-Dbuild.branch=${{ needs.setup.outputs.version }}" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=${{ needs.setup.outputs.latestMergeSha }}" "-Dbuild.timestamp=${{ needs.setup.outputs.timeStamp }}"
 
-  # deploy_xsd:
-  #   if: ${{ inputs.dry_run == false }}
-  #   name: Upload xsds
-  #   needs: [setup, manual_trigger_deployment]
-  #   runs-on: ubuntu-22.04
-  #   outputs:
-  #     tag: ${{ steps.collect-data.outputs.tag }}
-  #     version: ${{ needs.setup.outputs.version }}
-  #   steps:
-  #     - name: Download liquibase xsd
-  #       uses: actions/checkout@v4
-  #       with:
-  #         # Relative path under $GITHUB_WORKSPACE to place the repository
-  #         path: liquibase-core-repo
-  #         repository: "liquibase/liquibase"
+  deploy_xsd:
+    if: ${{ inputs.dry_run == false }}
+    name: Upload xsds
+    needs: [setup, manual_trigger_deployment]
+    runs-on: ubuntu-22.04
+    outputs:
+      tag: ${{ steps.collect-data.outputs.tag }}
+      version: ${{ needs.setup.outputs.version }}
+    steps:
+      - name: Download liquibase xsd
+        uses: actions/checkout@v4
+        with:
+          # Relative path under $GITHUB_WORKSPACE to place the repository
+          path: liquibase-core-repo
+          repository: "liquibase/liquibase"
 
-  #     - name: Get GitHub App token
-  #       id: get-token
-  #       uses: actions/create-github-app-token@v2
-  #       with:
-  #         app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
-  #         private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
-  #         owner: ${{ github.repository_owner }}
-  #         repositories: liquibase-pro
-  #         permission-contents: read
+      - name: Get GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: liquibase-pro
+          permission-contents: read
           
-  #     - name: Download liquibase-pro xsd
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: "${{ needs.setup.outputs.ref_branch }}"
-  #         token: ${{ steps.get-token.outputs.token }}
-  #         # Relative path under $GITHUB_WORKSPACE to place the repository
-  #         path: liquibase-pro-repo
-  #         repository: "liquibase/liquibase-pro"
+      - name: Download liquibase-pro xsd
+        uses: actions/checkout@v4
+        with:
+          ref: "${{ needs.setup.outputs.ref_branch }}"
+          token: ${{ steps.get-token.outputs.token }}
+          # Relative path under $GITHUB_WORKSPACE to place the repository
+          path: liquibase-pro-repo
+          repository: "liquibase/liquibase-pro"
 
-  #     - name: Upload to s3
-  #       env:
-  #         AWS_ACCESS_KEY_ID: ${{ secrets.LIQUIBASEORIGIN_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.LIQUIBASEORIGIN_SECRET_ACCESS_KEY }}
-  #         AWS_DEFAULT_REGION: us-east-1
-  #       # aws s3 sync syncs directories and S3 prefixes.
-  #       run: |
-  #         aws s3 sync liquibase-pro-repo/pro/src/main/resources/www.liquibase.org/xml/ns/pro/ s3://liquibaseorg-origin/xml/ns/pro/ --content-type application/octet-stream --only-show-errors
-  #         aws s3 sync liquibase-core-repo/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/ s3://liquibaseorg-origin/xml/ns/dbchangelog/ --content-type application/octet-stream --only-show-errors
-  #         aws s3 sync liquibase-pro-repo/pro/src/main/resources/schemas/ s3://liquibaseorg-origin/json/schema/ --content-type application/octet-stream --only-show-errors
+      - name: Upload to s3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.LIQUIBASEORIGIN_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.LIQUIBASEORIGIN_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        # aws s3 sync syncs directories and S3 prefixes.
+        run: |
+          aws s3 sync liquibase-pro-repo/pro/src/main/resources/www.liquibase.org/xml/ns/pro/ s3://liquibaseorg-origin/xml/ns/pro/ --content-type application/octet-stream --only-show-errors
+          aws s3 sync liquibase-core-repo/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/ s3://liquibaseorg-origin/xml/ns/dbchangelog/ --content-type application/octet-stream --only-show-errors
+          aws s3 sync liquibase-pro-repo/pro/src/main/resources/schemas/ s3://liquibaseorg-origin/json/schema/ --content-type application/octet-stream --only-show-errors
 
-  #     - name: Index.htm file upload
-  #       env:
-  #         AWS_ACCESS_KEY_ID: ${{ secrets.LIQUIBASEORIGIN_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.LIQUIBASEORIGIN_SECRET_ACCESS_KEY }}
-  #         AWS_DEFAULT_REGION: us-east-1
-  #       # get the major.minor xsd version. grab the index.htm from s3, add the new verison of xsd and sync with the s3 again
-  #       run: |
-  #         version=${{ needs.setup.outputs.version }}
-  #         arr=(${version//./ })
-  #         xsd_version=${arr[0]}"."${arr[1]}
-  #         mkdir index-file
-  #         aws s3 cp s3://liquibaseorg-origin/xml/ns/dbchangelog/index.htm index-file
-  #         if ! grep -q ${xsd_version} index-file/index.htm ; then
-  #           sed -ie "s/<\/ul>/  <li><a href=\"\/xml\/ns\/dbchangelog\/dbchangelog-${xsd_version}.xsd\">dbchangelog-${xsd_version}.xsd<\/a><\/li>\n<\/ul>/" index-file/index.htm
-  #           aws s3 sync index-file s3://liquibaseorg-origin/xml/ns/dbchangelog/ --only-show-errors
-  #         fi
+      - name: Index.htm file upload
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.LIQUIBASEORIGIN_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.LIQUIBASEORIGIN_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        # get the major.minor xsd version. grab the index.htm from s3, add the new verison of xsd and sync with the s3 again
+        run: |
+          version=${{ needs.setup.outputs.version }}
+          arr=(${version//./ })
+          xsd_version=${arr[0]}"."${arr[1]}
+          mkdir index-file
+          aws s3 cp s3://liquibaseorg-origin/xml/ns/dbchangelog/index.htm index-file
+          if ! grep -q ${xsd_version} index-file/index.htm ; then
+            sed -ie "s/<\/ul>/  <li><a href=\"\/xml\/ns\/dbchangelog\/dbchangelog-${xsd_version}.xsd\">dbchangelog-${xsd_version}.xsd<\/a><\/li>\n<\/ul>/" index-file/index.htm
+            aws s3 sync index-file s3://liquibaseorg-origin/xml/ns/dbchangelog/ --only-show-errors
+          fi
 
-  #     - name: Liquibase xsds SFTP upload
-  #       uses: wangyucode/sftp-upload-action@v2.0.4
-  #       with:
-  #         host: ${{ secrets.WPENGINE_SFTP_HOST }}
-  #         port: ${{ secrets.WPENGINE_SFTP_PORT }}
-  #         username: ${{ secrets.WPENGINE_SFTP_USER }}
-  #         password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
-  #         compress: true
-  #         forceUpload: true
-  #         localDir: "liquibase-core-repo/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/"
-  #         remoteDir: "/xml/ns/dbchangelog/"
+      - name: Liquibase xsds SFTP upload
+        uses: wangyucode/sftp-upload-action@v2.0.4
+        with:
+          host: ${{ secrets.WPENGINE_SFTP_HOST }}
+          port: ${{ secrets.WPENGINE_SFTP_PORT }}
+          username: ${{ secrets.WPENGINE_SFTP_USER }}
+          password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
+          compress: true
+          forceUpload: true
+          localDir: "liquibase-core-repo/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/"
+          remoteDir: "/xml/ns/dbchangelog/"
 
-  #     - name: Liquibase PRO xsds SFTP upload
-  #       uses: wangyucode/sftp-upload-action@v2.0.4
-  #       with:
-  #         host: ${{ secrets.WPENGINE_SFTP_HOST }}
-  #         port: ${{ secrets.WPENGINE_SFTP_PORT }}
-  #         username: ${{ secrets.WPENGINE_SFTP_USER }}
-  #         password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
-  #         compress: false
-  #         forceUpload: true
-  #         localDir: "liquibase-pro-repo/pro/src/main/resources/www.liquibase.org/xml/ns/pro/"
-  #         remoteDir: "/xml/ns/pro/"
+      - name: Liquibase PRO xsds SFTP upload
+        uses: wangyucode/sftp-upload-action@v2.0.4
+        with:
+          host: ${{ secrets.WPENGINE_SFTP_HOST }}
+          port: ${{ secrets.WPENGINE_SFTP_PORT }}
+          username: ${{ secrets.WPENGINE_SFTP_USER }}
+          password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
+          compress: false
+          forceUpload: true
+          localDir: "liquibase-pro-repo/pro/src/main/resources/www.liquibase.org/xml/ns/pro/"
+          remoteDir: "/xml/ns/pro/"
 
-  #     - name: Liquibase flow-file schema SFTP upload
-  #       uses: wangyucode/sftp-upload-action@v2.0.4
-  #       with:
-  #         host: ${{ secrets.WPENGINE_SFTP_HOST }}
-  #         port: ${{ secrets.WPENGINE_SFTP_PORT }}
-  #         username: ${{ secrets.WPENGINE_SFTP_USER }}
-  #         password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
-  #         compress: false
-  #         forceUpload: true
-  #         localDir: "liquibase-pro-repo/pro/src/main/resources/schemas/"
-  #         remoteDir: "/json/schema/"
+      - name: Liquibase flow-file schema SFTP upload
+        uses: wangyucode/sftp-upload-action@v2.0.4
+        with:
+          host: ${{ secrets.WPENGINE_SFTP_HOST }}
+          port: ${{ secrets.WPENGINE_SFTP_PORT }}
+          username: ${{ secrets.WPENGINE_SFTP_USER }}
+          password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
+          compress: false
+          forceUpload: true
+          localDir: "liquibase-pro-repo/pro/src/main/resources/schemas/"
+          remoteDir: "/json/schema/"
 
-  #     - name: Liquibase index.htm SFTP upload
-  #       uses: wangyucode/sftp-upload-action@v2.0.4
-  #       with:
-  #         host: ${{ secrets.WPENGINE_SFTP_HOST }}
-  #         port: ${{ secrets.WPENGINE_SFTP_PORT }}
-  #         username: ${{ secrets.WPENGINE_SFTP_USER }}
-  #         password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
-  #         compress: false
-  #         forceUpload: true
-  #         localDir: "index-file/"
-  #         remoteDir: "/xml/ns/dbchangelog/"
+      - name: Liquibase index.htm SFTP upload
+        uses: wangyucode/sftp-upload-action@v2.0.4
+        with:
+          host: ${{ secrets.WPENGINE_SFTP_HOST }}
+          port: ${{ secrets.WPENGINE_SFTP_PORT }}
+          username: ${{ secrets.WPENGINE_SFTP_USER }}
+          password: ${{ secrets.WPENGINE_SFTP_PASSWORD }}
+          compress: false
+          forceUpload: true
+          localDir: "index-file/"
+          remoteDir: "/xml/ns/dbchangelog/"
 
-  # release-docker:
-  #   if: always()
-  #   name: Release docker images
-  #   needs: [setup, manual_trigger_deployment]
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - name: Get GitHub App token
-  #       id: get-token
-  #       uses: actions/create-github-app-token@v2
-  #       with:
-  #         app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
-  #         private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
-  #         owner: ${{ github.repository_owner }}
-  #         permission-contents: write
-  #         permission-actions: write
+  release-docker:
+    if: always()
+    name: Release docker images
+    needs: [setup, manual_trigger_deployment]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Get GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: write
+          permission-actions: write
 
-  #     - name: Release liquibase/docker v${{ needs.setup.outputs.version }}
-  #       uses: the-actions-org/workflow-dispatch@v4
-  #       id: docker_dispatch
-  #       with:
-  #         workflow: create-release.yml
-  #         token: ${{ steps.get-token.outputs.token }}
-  #         inputs: '{ "liquibaseVersion": "${{ needs.setup.outputs.version }}", "dryRun": "${{ inputs.dry_run || false }}" }'
-  #         ref: main
-  #         repo: liquibase/docker
-  #         wait-for-completion: true
-  #         workflow-logs: json-output
+      - name: Release liquibase/docker v${{ needs.setup.outputs.version }}
+        uses: the-actions-org/workflow-dispatch@v4
+        id: docker_dispatch
+        with:
+          workflow: create-release.yml
+          token: ${{ steps.get-token.outputs.token }}
+          inputs: '{ "liquibaseVersion": "${{ needs.setup.outputs.version }}", "dryRun": "${{ inputs.dry_run || false }}" }'
+          ref: main
+          repo: liquibase/docker
+          wait-for-completion: true
+          workflow-logs: json-output
 
-  #     - name: Adding Docker run to job summary
-  #       if: success()
-  #       continue-on-error: true
-  #       run: echo '### 🐳 Docker Release Job -> ${{steps.docker_dispatch.outputs.workflow-url}}' >> $GITHUB_STEP_SUMMARY
+      - name: Adding Docker run to job summary
+        if: success()
+        continue-on-error: true
+        run: echo '### 🐳 Docker Release Job -> ${{steps.docker_dispatch.outputs.workflow-url}}' >> $GITHUB_STEP_SUMMARY
 
-  # release-minimal-docker:
-  #   if: ${{ inputs.dry_run == false }}
-  #   name: Release Minimal docker image
-  #   needs: [setup, manual_trigger_deployment]
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - name: Get GitHub App token
-  #       id: get-token
-  #       uses: actions/create-github-app-token@v2
-  #       with:
-  #         app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
-  #         private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
-  #         owner: ${{ github.repository_owner }}
-  #         permission-contents: write
-  #         permission-actions: write
+  release-minimal-docker:
+    if: ${{ inputs.dry_run == false }}
+    name: Release Minimal docker image
+    needs: [setup, manual_trigger_deployment]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Get GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: write
+          permission-actions: write
 
-  #     - name: Release liquibase/liquibase-infrastructure v${{ needs.setup.outputs.version }}
-  #       uses: the-actions-org/workflow-dispatch@v4
-  #       id: docker_dispatch
-  #       with:
-  #         workflow: build-liquibase-minimal.yml
-  #         token: ${{ steps.get-token.outputs.token }}
-  #         inputs: '{ "liquibaseVersion": "${{ needs.setup.outputs.version }}" }'
-  #         ref: master
-  #         repo: liquibase/liquibase-infrastructure
-  #         wait-for-completion: true
-  #         workflow-logs: json-output
+      - name: Release liquibase/liquibase-infrastructure v${{ needs.setup.outputs.version }}
+        uses: the-actions-org/workflow-dispatch@v4
+        id: docker_dispatch
+        with:
+          workflow: build-liquibase-minimal.yml
+          token: ${{ steps.get-token.outputs.token }}
+          inputs: '{ "liquibaseVersion": "${{ needs.setup.outputs.version }}" }'
+          ref: master
+          repo: liquibase/liquibase-infrastructure
+          wait-for-completion: true
+          workflow-logs: json-output
 
-  # generate-PRO-tag:
-  #   if: ${{ inputs.dry_run == false }}
-  #   name: Generate PRO tags based on OSS release
-  #   needs: [setup]
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - name: Get GitHub App token
-  #       id: get-token
-  #       uses: actions/create-github-app-token@v2
-  #       with:
-  #         app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
-  #         private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
-  #         owner: ${{ github.repository_owner }}
-  #         permission-contents: write
-  #         permission-actions: write
+  generate-PRO-tag:
+    if: ${{ inputs.dry_run == false }}
+    name: Generate PRO tags based on OSS release
+    needs: [setup]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Get GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: write
+          permission-actions: write
 
-  #     - name: Repository Dispatch
-  #       uses: peter-evans/repository-dispatch@v3
-  #       with:
-  #         token: ${{ steps.get-token.outputs.token }}
-  #         repository: liquibase/liquibase-pro
-  #         event-type: oss-released-tag
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ steps.get-token.outputs.token }}
+          repository: liquibase/liquibase-pro
+          event-type: oss-released-tag
 
-  # package:
-  #   uses: liquibase/build-logic/.github/workflows/package.yml@main
-  #   needs: [setup]
-  #   secrets: inherit
-  #   with:
-  #     groupId: "org.liquibase"
-  #     artifactId: "liquibase"
-  #     version: ${{ needs.setup.outputs.version }}
-  #     dry_run: ${{ inputs.dry_run || false}}
-  #     dry_run_zip_url: ${{ inputs.dry_run_zip_url || '' }}
-  #     dry_run_tar_gz_url: ${{ inputs.dry_run_tar_gz_url || '' }}
-  #     dry_run_release_id: ${{ inputs.dry_run_release_id || '' }}
+  package:
+    uses: liquibase/build-logic/.github/workflows/package.yml@main
+    needs: [setup]
+    secrets: inherit
+    with:
+      groupId: "org.liquibase"
+      artifactId: "liquibase"
+      version: ${{ needs.setup.outputs.version }}
+      dry_run: ${{ inputs.dry_run || false}}
+      dry_run_zip_url: ${{ inputs.dry_run_zip_url || '' }}
+      dry_run_tar_gz_url: ${{ inputs.dry_run_tar_gz_url || '' }}
+      dry_run_release_id: ${{ inputs.dry_run_release_id || '' }}
 
-  # update-docs-oss-pro-version:
-  #   if: ${{ inputs.dry_run == false }}
-  #   name: Update OSS and PRO tags based on OSS release
-  #   needs: [setup]
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     latest_version: ${{ steps.get_latest_oss_version.outputs.latest_version }}
-  #     previous_version: ${{ steps.get_latest_oss_version.outputs.previous_version }}
-  #   steps:
-  #     - name: Get GitHub App token
-  #       id: get-token
-  #       uses: actions/create-github-app-token@v2
-  #       with:
-  #         app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
-  #         private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
-  #         owner: ${{ github.repository_owner }}
-  #         permission-contents: write
-  #         permission-actions: write
+  update-docs-oss-pro-version:
+    if: ${{ inputs.dry_run == false }}
+    name: Update OSS and PRO tags based on OSS release
+    needs: [setup]
+    runs-on: ubuntu-latest
+    outputs:
+      latest_version: ${{ steps.get_latest_oss_version.outputs.latest_version }}
+      previous_version: ${{ steps.get_latest_oss_version.outputs.previous_version }}
+    steps:
+      - name: Get GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: write
+          permission-actions: write
 
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4
-  #       with:
-  #         repository: liquibase/liquibase
-  #         ref: "${{ needs.setup.outputs.ref_branch }}"
-  #         fetch-depth: 0
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: liquibase/liquibase
+          ref: "${{ needs.setup.outputs.ref_branch }}"
+          fetch-depth: 0
 
-  #     - name: Get the oss release version
-  #       id: get_latest_oss_version
-  #       run: |
-  #         # Fetch all tags from the remote
-  #         git fetch --tags
-  #         # Get the latest semver tag, strip 'v'
-  #         latest_tag=$(git tag --sort=-creatordate | grep -E '^v?[0-9]' | head -n1 | sed 's/^v//')
-  #         # Get the second latest tag
-  #         previous_tag=$(git tag --sort=-creatordate | grep -E '^v?[0-9]' | sed 's/^v//' | head -n2 | tail -n1)
-  #         echo "latest_version=$latest_tag" >> $GITHUB_OUTPUT
-  #         echo "previous_version=$previous_tag" >> $GITHUB_OUTPUT
-  #         echo "Latest Version: $latest_tag"
-  #         echo "Previous Version: $previous_tag"
+      - name: Get the oss release version
+        id: get_latest_oss_version
+        run: |
+          # Fetch all tags from the remote
+          git fetch --tags
+          # Get the latest semver tag, strip 'v'
+          latest_tag=$(git tag --sort=-creatordate | grep -E '^v?[0-9]' | head -n1 | sed 's/^v//')
+          # Get the second latest tag
+          previous_tag=$(git tag --sort=-creatordate | grep -E '^v?[0-9]' | sed 's/^v//' | head -n2 | tail -n1)
+          echo "latest_version=$latest_tag" >> $GITHUB_OUTPUT
+          echo "previous_version=$previous_tag" >> $GITHUB_OUTPUT
+          echo "Latest Version: $latest_tag"
+          echo "Previous Version: $previous_tag"
 
-  #     - name: Repository Dispatch
-  #       uses: peter-evans/repository-dispatch@v3
-  #       with:
-  #         token: ${{ steps.get-token.outputs.token }}
-  #         repository: liquibase/liquibase-docs
-  #         event-type: oss-released-version
-  #         client-payload: '{"latest_version": "${{ steps.get_latest_oss_version.outputs.latest_version }}", "previous_version": "${{ steps.get_latest_oss_version.outputs.previous_version }}"}'
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ steps.get-token.outputs.token }}
+          repository: liquibase/liquibase-docs
+          event-type: oss-released-version
+          client-payload: '{"latest_version": "${{ steps.get_latest_oss_version.outputs.latest_version }}", "previous_version": "${{ steps.get_latest_oss_version.outputs.previous_version }}"}'
 
-  #     # dispatch an event to `liquibase-aws-license-service` repository to update pom.xml with latest OSS Release
-  #     - name: Repository Dispatch
-  #       uses: peter-evans/repository-dispatch@v3
-  #       with:
-  #         token: ${{ steps.get-token.outputs.token }}
-  #         repository: liquibase/liquibase-aws-license-service
-  #         event-type: oss-released-version
+      # dispatch an event to `liquibase-aws-license-service` repository to update pom.xml with latest OSS Release
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ steps.get-token.outputs.token }}
+          repository: liquibase/liquibase-aws-license-service
+          event-type: oss-released-version
 
-  # dry_run_deploy_maven:
-  #   if: ${{ inputs.dry_run == true }}
-  #   name: Deploy to Maven Central Repository
-  #   needs: [setup]
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - name: Download dry-run release assets
-  #       uses: robinraju/release-downloader@v1.12
-  #       with:
-  #         repository: "liquibase/liquibase"
-  #         releaseId: "${{ inputs.dry_run_release_id }}"
-  #         fileName: "*"
-  #         out-file-path: "."
+  dry_run_deploy_maven:
+    if: ${{ inputs.dry_run == true }}
+    name: Deploy to Maven Central Repository
+    needs: [setup]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download dry-run release assets
+        uses: robinraju/release-downloader@v1.12
+        with:
+          repository: "liquibase/liquibase"
+          releaseId: "${{ inputs.dry_run_release_id }}"
+          fileName: "*"
+          out-file-path: "."
 
-  #     - name: Set up Java for publishing to Maven Central Repository
-  #       uses: actions/setup-java@v4
-  #       with:
-  #         java-version: "11"
-  #         distribution: "adopt"
-  #         server-id: dry-run-sonatype-nexus-staging
-  #         server-username: MAVEN_USERNAME
-  #         server-password: MAVEN_PASSWORD
-  #         gpg-private-key: ${{ secrets.GPG_SECRET }}
-  #         gpg-passphrase: GPG_PASSPHRASE
-  #       env:
-  #         GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Set up Java for publishing to Maven Central Repository
+        uses: actions/setup-java@v4
+        with:
+          java-version: "11"
+          distribution: "adopt"
+          server-id: dry-run-sonatype-nexus-staging
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_SECRET }}
+          gpg-passphrase: GPG_PASSPHRASE
+        env:
+          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
 
-  #     - name: Publish to Central Portal (Dry Run)
-  #       env:
-  #         MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-  #         MAVEN_PASSWORD: ${{ secrets.SONATYPE_TOKEN }}
-  #         GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
-  #       run: |
-  #         version=${{ needs.setup.outputs.version }}
+      - name: Publish to Central Portal (Dry Run)
+        env:
+          MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.SONATYPE_TOKEN }}
+          GPG_PASSWORD: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          version=${{ needs.setup.outputs.version }}
 
-  #         unzip -j liquibase-additional-*.zip
+          unzip -j liquibase-additional-*.zip
 
-  #         ##extracts and sign poms, generate checksums for all artifacts
-  #         for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-commercial'; do
-  #           unzip -j $i-${version}.jar META-INF/maven/org.liquibase/$i/pom.xml
-  #           sed -i -e "s/<version>\(release\|master\)-SNAPSHOT<\/version>/<version>${version}<\/version>/" pom.xml
-  #           mv pom.xml $i-${version}.pom
-  #           if test 'liquibase-commercial' == $i; then
-  #             sed -i -e "s/<\/licenses>/<\/licenses><scm><connection>private<\/connection><developerConnection>private<\/developerConnection><url>private<\/url><\/scm>/" $i-${version}.pom   ## scm info not in the pom
-  #           fi
+          ##extracts and sign poms, generate checksums for all artifacts
+          for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-commercial'; do
+            unzip -j $i-${version}.jar META-INF/maven/org.liquibase/$i/pom.xml
+            sed -i -e "s/<version>\(release\|master\)-SNAPSHOT<\/version>/<version>${version}<\/version>/" pom.xml
+            mv pom.xml $i-${version}.pom
+            if test 'liquibase-commercial' == $i; then
+              sed -i -e "s/<\/licenses>/<\/licenses><scm><connection>private<\/connection><developerConnection>private<\/developerConnection><url>private<\/url><\/scm>/" $i-${version}.pom   ## scm info not in the pom
+            fi
 
-  #           # Sign POM file
-  #           gpg --batch --pinentry-mode=loopback --passphrase "$GPG_PASSWORD" -ab $i-${version}.pom
+            # Sign POM file
+            gpg --batch --pinentry-mode=loopback --passphrase "$GPG_PASSWORD" -ab $i-${version}.pom
             
-  #           # Generate checksums for POM file
-  #           md5sum $i-${version}.pom | cut -d' ' -f1 > $i-${version}.pom.md5
-  #           sha1sum $i-${version}.pom | cut -d' ' -f1 > $i-${version}.pom.sha1
+            # Generate checksums for POM file
+            md5sum $i-${version}.pom | cut -d' ' -f1 > $i-${version}.pom.md5
+            sha1sum $i-${version}.pom | cut -d' ' -f1 > $i-${version}.pom.sha1
             
-  #           # Generate checksums for all JAR files (main, sources, javadoc)
-  #           for jar_file in $i-${version}.jar $i-${version}-sources.jar $i-${version}-javadoc.jar; do
-  #             if [ -f "$jar_file" ]; then
-  #               md5sum "$jar_file" | cut -d' ' -f1 > "$jar_file.md5"
-  #               sha1sum "$jar_file" | cut -d' ' -f1 > "$jar_file.sha1"
-  #             fi
-  #           done
-  #         done
+            # Generate checksums for all JAR files (main, sources, javadoc)
+            for jar_file in $i-${version}.jar $i-${version}-sources.jar $i-${version}-javadoc.jar; do
+              if [ -f "$jar_file" ]; then
+                md5sum "$jar_file" | cut -d' ' -f1 > "$jar_file.md5"
+                sha1sum "$jar_file" | cut -d' ' -f1 > "$jar_file.sha1"
+              fi
+            done
+          done
 
-  #         # Create Maven repository layout structure for the bundle
-  #         mkdir -p "bundle/org/liquibase"
+          # Create Maven repository layout structure for the bundle
+          mkdir -p "bundle/org/liquibase"
           
-  #         # Copy all artifacts to proper Maven repository layout
-  #         for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-commercial'; do
-  #           mkdir -p "bundle/org/liquibase/$i/${version}"
-  #           cp $i-${version}* "bundle/org/liquibase/$i/${version}/"
-  #         done
+          # Copy all artifacts to proper Maven repository layout
+          for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-commercial'; do
+            mkdir -p "bundle/org/liquibase/$i/${version}"
+            cp $i-${version}* "bundle/org/liquibase/$i/${version}/"
+          done
           
-  #         # Create the bundle zip file
-  #         cd bundle
-  #         zip -r ../central-bundle.zip .
-  #         cd ..
+          # Create the bundle zip file
+          cd bundle
+          zip -r ../central-bundle.zip .
+          cd ..
           
-  #         # Create base64 encoded credentials for Bearer auth
-  #         AUTH_HEADER=$(printf "%s:%s" "${MAVEN_USERNAME}" "${MAVEN_PASSWORD}" | base64 -w 0)
+          # Create base64 encoded credentials for Bearer auth
+          AUTH_HEADER=$(printf "%s:%s" "${MAVEN_USERNAME}" "${MAVEN_PASSWORD}" | base64 -w 0)
           
-  #         # Upload bundle to Central Portal with USER_MANAGED publishing (dry run)
-  #         echo "Uploading bundle to Central Portal for dry-run liquibase-${version}..."
-  #         UPLOAD_RESPONSE=$(curl -s -w "\n%{http_code}" \
-  #           -X POST \
-  #           -H "Authorization: Bearer ${AUTH_HEADER}" \
-  #           -F "bundle=@central-bundle.zip" \
-  #           "https://central.sonatype.com/api/v1/publisher/upload?publishingType=USER_MANAGED&name=liquibase-${version}-dry-run")
+          # Upload bundle to Central Portal with USER_MANAGED publishing (dry run)
+          echo "Uploading bundle to Central Portal for dry-run liquibase-${version}..."
+          UPLOAD_RESPONSE=$(curl -s -w "\n%{http_code}" \
+            -X POST \
+            -H "Authorization: Bearer ${AUTH_HEADER}" \
+            -F "bundle=@central-bundle.zip" \
+            "https://central.sonatype.com/api/v1/publisher/upload?publishingType=USER_MANAGED&name=liquibase-${version}-dry-run")
           
-  #         # Parse response
-  #         HTTP_CODE=$(echo "$UPLOAD_RESPONSE" | tail -n1)
-  #         DEPLOYMENT_ID=$(echo "$UPLOAD_RESPONSE" | head -n1)
+          # Parse response
+          HTTP_CODE=$(echo "$UPLOAD_RESPONSE" | tail -n1)
+          DEPLOYMENT_ID=$(echo "$UPLOAD_RESPONSE" | head -n1)
           
-  #         echo "HTTP Status: $HTTP_CODE"
-  #         echo "Deployment ID: $DEPLOYMENT_ID"
+          echo "HTTP Status: $HTTP_CODE"
+          echo "Deployment ID: $DEPLOYMENT_ID"
           
-  #         if [ "$HTTP_CODE" != "201" ]; then
-  #           echo "Upload failed with HTTP status $HTTP_CODE"
-  #           echo "Response: $DEPLOYMENT_ID"
-  #           exit 1
-  #         fi
+          if [ "$HTTP_CODE" != "201" ]; then
+            echo "Upload failed with HTTP status $HTTP_CODE"
+            echo "Response: $DEPLOYMENT_ID"
+            exit 1
+          fi
           
-  #         echo "Bundle uploaded successfully to Central Portal for dry-run"
-  #         echo "Deployment ID: $DEPLOYMENT_ID"
-  #         echo "Manual publishing required - visit https://central.sonatype.com/publishing/deployments to review and publish"
+          echo "Bundle uploaded successfully to Central Portal for dry-run"
+          echo "Deployment ID: $DEPLOYMENT_ID"
+          echo "Manual publishing required - visit https://central.sonatype.com/publishing/deployments to review and publish"
 
-  # publish_assets_to_s3_bucket:
-  #   if: ${{ inputs.dry_run == false }}
-  #   name: Publish OSS released assets to s3 bucket liquibaseorg-origin
-  #   needs: [setup]
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - name: Download released assets
-  #       uses: robinraju/release-downloader@v1.12
-  #       with:
-  #         repository: "liquibase/liquibase"
-  #         latest: true
-  #         fileName: "*"
-  #         out-file-path: "./${{ needs.setup.outputs.version }}-released-assets"
+  publish_assets_to_s3_bucket:
+    if: ${{ inputs.dry_run == false }}
+    name: Publish OSS released assets to s3 bucket liquibaseorg-origin
+    needs: [setup]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download released assets
+        uses: robinraju/release-downloader@v1.12
+        with:
+          repository: "liquibase/liquibase"
+          latest: true
+          fileName: "*"
+          out-file-path: "./${{ needs.setup.outputs.version }}-released-assets"
 
-  #     - name: Get current timestamp
-  #       id: timestamp
-  #       run: echo "timestamp=$(date +%Y%m%d-%H%M%S)" >> $GITHUB_ENV
+      - name: Get current timestamp
+        id: timestamp
+        run: echo "timestamp=$(date +%Y%m%d-%H%M%S)" >> $GITHUB_ENV
 
-  #     - name: Publish released assets to s3 bucket
-  #       env:
-  #         AWS_ACCESS_KEY_ID: ${{ secrets.LIQUIBASEORIGIN_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.LIQUIBASEORIGIN_SECRET_ACCESS_KEY }}
-  #         AWS_DEFAULT_REGION: us-east-1
-  #       run: |
-  #         aws s3 sync "./${{ needs.setup.outputs.version }}-released-assets" s3://liquibaseorg-origin/oss-released-assets/${{ needs.setup.outputs.version }}-released-assets-${{ env.timestamp }}/ --only-show-errors
+      - name: Publish released assets to s3 bucket
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.LIQUIBASEORIGIN_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.LIQUIBASEORIGIN_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          aws s3 sync "./${{ needs.setup.outputs.version }}-released-assets" s3://liquibaseorg-origin/oss-released-assets/${{ needs.setup.outputs.version }}-released-assets-${{ env.timestamp }}/ --only-show-errors

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -75,6 +75,8 @@ jobs:
       version: ${{ steps.collect-data.outputs.version }}
       ref_branch: ${{ steps.ref-branch.outputs.branch }}
       dry_run_branch_name: ${{ inputs.dry_run_branch_name }}
+      latestMergeSha: ${{ steps.get-sha.outputs.latestMergeSha }}
+      timeStamp: ${{ steps.get-timestamp.outputs.timeStamp }}
     steps:
       - name: Collect Data
         id: collect-data
@@ -109,6 +111,18 @@ jobs:
           else
             echo "branch=${{ inputs.dry_run_branch_name }}" >> $GITHUB_OUTPUT
           fi
+
+      - name: Get Latest Merge Commit SHA
+        id: get-sha
+        run: |
+          latest_merge_sha=`(git rev-parse --short HEAD)`
+          echo "latestMergeSha=${latest_merge_sha}" >> $GITHUB_OUTPUT
+
+      - name: Get Timestamp
+        id: get-timestamp
+        run: |
+          timestamp=`(date +'%Y-%m-%d %H:%M:%S %Z')`
+          echo "timeStamp=${timestamp}" >> $GITHUB_OUTPUT
 
   manual_trigger_deployment:
     if: ${{ inputs.dry_run == false }}
@@ -287,6 +301,7 @@ jobs:
           distribution: "temurin"
           cache: "maven"
           server-id: liquibase
+
       - name: Set up Maven
         uses: stCarolas/setup-maven@v5
         with:
@@ -297,10 +312,10 @@ jobs:
 
       # Publish to GitHub Packages
       - name: Publish package to Github
-        run: mvn -B clean deploy -DskipTests=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TARGET_ARTIFACT_REPOSITORY: liquibase
+        run: -pl '!liquibase-dist' -DskipTests=true "-Dbuild.repository.owner=liquibase" "-Dbuild.repository.name=liquibase" "-Dbuild.branch=${{ needs.setup.outputs.version }}" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=${{ needs.setup.outputs.latestMergeSha }}" "-Dbuild.timestamp=${{ needs.setup.outputs.timeStamp }}"
 
   deploy_xsd:
     if: ${{ inputs.dry_run == false }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/release-published.yml` file to enhance the release workflow. Key changes include adding steps to capture the latest merge commit SHA and timestamp, modifying the Maven deployment command to include additional metadata, and reorganizing certain steps for better clarity and functionality.

### Enhancements to workflow metadata:

* Added steps to capture the latest merge commit SHA (`latestMergeSha`) and the timestamp (`timeStamp`) during the workflow execution. These values are now available as outputs for subsequent steps. [[1]](diffhunk://#diff-f7ca0660afb7c5d6e7220dee8a6db81db251b3c98818f4d76a3e4441b85c7a6dR78-R79) [[2]](diffhunk://#diff-f7ca0660afb7c5d6e7220dee8a6db81db251b3c98818f4d76a3e4441b85c7a6dR115-R132)

### Improvements to Maven deployment:

* Updated the Maven deployment command to include additional metadata such as repository owner, branch, commit SHA, and timestamp, enabling more detailed tracking of builds.

### Workflow step reorganization:

* Introduced a step to checkout the determined branch before proceeding with other operations, ensuring the correct branch context is used.
* Added a step to set up Maven using `stCarolas/setup-maven@v5` for better Maven configuration management.
* Removed unnecessary empty lines and reorganized certain steps for improved readability and maintainability. [[1]](diffhunk://#diff-f7ca0660afb7c5d6e7220dee8a6db81db251b3c98818f4d76a3e4441b85c7a6dL280) [[2]](diffhunk://#diff-f7ca0660afb7c5d6e7220dee8a6db81db251b3c98818f4d76a3e4441b85c7a6dL569)