### PR TITLE
fix: do not snapshot index type for cockroach DB as indexes behave different on this database and we don't know wher eto find it.

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -282,7 +282,7 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                 }
 
                 private void enrichPostgresqlResult(CatalogAndSchema catalogAndSchema, List<CachedRow> returnList) throws DatabaseException, SQLException {
-                    if (database instanceof PostgresDatabase) {
+                    if (database instanceof PostgresDatabase && !(database instanceof CockroachDatabase)) {
                         StringBuilder sql = new StringBuilder("SELECT ns.nspname as TABLE_SCHEM, tab.relname as TABLE_NAME, " +
                                 "cls.relname as INDEX_NAME, am.amname as INDEX_TYPE " +
                                 " FROM pg_index idx " +


### PR DESCRIPTION
## Impact

PR https://github.com/liquibase/liquibase/pull/6901 introduced index function snapshot capabilities for Postgresql database, but cockroachDB seems to be different and their indexes have more features (like primary and secundary, auto indexes, etc) . So do not snapshot index type for cockroach DB as indexes behave different on this database and we don't know where to find it.
