### PR TITLE
fix: prevent rawDateValue from being used for checksum calculations

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/change/ColumnConfig.java
+++ b/liquibase-standard/src/main/java/liquibase/change/ColumnConfig.java
@@ -972,7 +972,9 @@ public class ColumnConfig extends AbstractLiquibaseSerializable {
     public Object getSerializableFieldValue(String field) {
         Object o = ReflectionSerializer.getInstance().getValue(this, field);
         if (field.equals("valueDate") || field.equals("defaultValueDate")) {
-            return new ISODateFormat().format((Date)o);
+            return new ISODateFormat().format((Date) o);
+        } if (field.equals("rawDateValue")) { // this field should not be used for checksum purposes
+            return null;
         } else {
             return o;
         }


### PR DESCRIPTION
## Description

This pull request introduces a small fix to the `ColumnConfig.java` file, specifically within the `getSerializableFieldValue` method. The change ensures that the `rawDateValue` field is excluded from checksum calculations by returning `null` for this field.

## Things to be aware of

Caused by https://github.com/liquibase/liquibase/pull/7046

Fixes https://github.com/liquibase/liquibase/issues/7100
