### PR TITLE
Add Spring Framework 6.x to dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -109,3 +109,7 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Ignore Spring Framework 6.x updates (requires Java 17, project uses Java 8)
+      - dependency-name: "org.springframework:*"
+        versions: ["6.*", ">=6.0.0"]


### PR DESCRIPTION
## Summary
- Add Spring Framework 6.x to dependabot ignore list to prevent incompatible major version updates
- Spring Framework 6.x requires Java 17, but this project uses Java 8
- This prevents Spring 6.x updates from blocking grouped dependency PRs

## Test plan
- [ ] Verify dependabot configuration syntax is valid
- [ ] Confirm grouped PRs are no longer blocked by Spring 6.x updates
- [ ] Monitor that Spring 5.x patch/minor updates continue to be processed

🤖 Generated with [Claude Code](https://claude.ai/code)