### PR TITLE
Fix dependabot.yml version syntax error

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -112,4 +112,4 @@ updates:
     ignore:
       # Ignore Spring Framework 6.x updates (requires Java 17, project uses Java 8)
       - dependency-name: "org.springframework:*"
-        versions: ["6.*", ">=6.0.0"]
+        versions: [">= 6.0.0"]


### PR DESCRIPTION
## Summary
- Fix invalid version requirements syntax in dependabot.yml ignore condition
- Remove invalid "6.*" pattern which is not supported for Maven dependencies
- Simplify to single ">= 6.0.0" version requirement

## Error Fixed
```
The property '#/updates/1/ignore/0/versions' includes invalid version requirements for a maven ignore condition
```

## Test plan
- [ ] Verify dependabot configuration parses without errors
- [ ] Confirm Spring Framework 6.x updates are still ignored
- [ ] Monitor that grouped PRs function correctly

🤖 Generated with [Claude Code](https://claude.ai/code)