### PR TITLE
Rollback OpenCSV version to 5.10 and address CSV loading issue

### DIFF
--- a/liquibase-dist/pom.xml
+++ b/liquibase-dist/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
-            <version>5.11.2</version>
+            <version>${opencsv.version}</version>
             <scope>compile</scope>
             <exclusions>
                 <!-- not used by liquibase code -->

--- a/liquibase-standard/pom.xml
+++ b/liquibase-standard/pom.xml
@@ -119,7 +119,7 @@
         <dependency>
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
-            <version>5.11.2</version>
+            <version>${opencsv.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-beanutils</groupId>

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
@@ -997,6 +997,27 @@ class LoadDataChangeTest extends StandardChangeTest {
         sqlStatement.getColumnValues().keySet()[3] == " description"
     }
 
+    /**
+     * This test validates that blank lines in a CSV file are ignored during the load data process and that subsequent rows are processed correctly.
+     */
+    def "validate blank lines in CSV file are ignored but other rows are loaded as expected"() {
+        when:
+        def table = testTable("table")
+        SnapshotGeneratorFactory.instance = new MockSnapshotGeneratorFactory(table)
+
+        LoadDataChange change = new LoadDataChange()
+        change.setFile("liquibase/change/core/sample.data.with.blank.line.csv")
+        change.setTableName("table")
+
+        SqlStatement[] sqlStatements = change.generateStatements(mockDB)
+
+        then:
+        sqlStatements.length == 2
+        assert columnValue(sqlStatements[0], "username") == "bjohnson"
+        assert columnValue(sqlStatements[1], "username") == "jdoe"
+    }
+
+
 
     class ColDef {
         ColDef(Object n, String type) {

--- a/liquibase-standard/src/test/resources/liquibase/change/core/sample.data.with.blank.line.csv
+++ b/liquibase-standard/src/test/resources/liquibase/change/core/sample.data.with.blank.line.csv
@@ -1,0 +1,5 @@
+name,username
+
+Bob Johnson,bjohnson
+
+John Doe,jdoe

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
         <itCoverageAgent></itCoverageAgent>
         <sonar.coverage.jacoco.xmlReportPaths>target/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
         <surefire.failIfNoTests>true</surefire.failIfNoTests>
+        <opencsv.version>5.10</opencsv.version> <!-- 5.11 broke loading CSV files with empty lines, see https://sourceforge.net/p/opencsv/bugs/259/. There are tests in LoadDataChangeTest to validate this issue, once they all pass we can update -->
     </properties>
 
     <!-- comment -->


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This pull request rolls back the OpenCSV version to 5.10 to address an issue with loading CSV files that include empty lines. A corresponding test has been added to ensure this functionality works as expected.

## Things to be aware of

No significant impacts on the codebase. The change only affects the OpenCSV dependency version and resolves related issues with CSV processing.

Fixes #7020

## Things to worry about

None identified.

## Additional Context

None.