### PR TITLE
fix updateSQL command ignoring endDelimiter for some statements #7148

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/executor/LoggingExecutor.java
+++ b/liquibase-standard/src/main/java/liquibase/executor/LoggingExecutor.java
@@ -158,7 +158,9 @@ public class LoggingExecutor extends AbstractExecutor {
                 } else {
                     String endDelimiter = ";";
                     String potentialDelimiter = null;
-                    if (sql instanceof RawParameterizedSqlStatement) {
+                    if (sql instanceof RawSqlStatement) {
+                        potentialDelimiter = ((RawSqlStatement) sql).getEndDelimiter();
+                    } else if (sql instanceof RawParameterizedSqlStatement) {
                         potentialDelimiter = ((RawParameterizedSqlStatement) sql).getEndDelimiter();
                     } else if (sql instanceof CreateProcedureStatement) {
                         potentialDelimiter = ((CreateProcedureStatement) sql).getEndDelimiter();


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 

## Description

updateSQL command ignores endDelimiter for some statements. Since 4.29.0 the generated SQL does no longer contain all expected endDelimiters.

Looking at the code changes for DAT-16825, it looks like an obvious oversight to me which can be fixed easily.

Fixes #7148




