### PR TITLE
Handle situation that occurs when generateChangeLog is run with diffTypes=data

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/command/core/GenerateChangelogCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/GenerateChangelogCommandStep.java
@@ -23,6 +23,9 @@ import liquibase.exception.CommandValidationException;
 import liquibase.resource.PathHandlerFactory;
 import liquibase.resource.Resource;
 
+import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.Catalog;
+import liquibase.structure.core.Schema;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
@@ -176,9 +179,25 @@ public class GenerateChangelogCommandStep extends AbstractChangelogCommandStep {
     private boolean areThereChangeObjectsToWrite(DiffResult diffResult) {
         // diffResult always includes catalog and schema as missing objects
         // in this context, they are not counted as effective changes
-        return diffResult.getMissingObjects().size() > 2 ||
+        return hasMissingObjects(diffResult) ||
                !diffResult.getUnexpectedObjects().isEmpty() ||
                !diffResult.getChangedObjects().isEmpty();
+    }
+
+    /**
+     *
+     * Check for conditions that indicate that there are missing objects
+     *
+     * @param   diffResult       The DiffResult object
+     * @return  boolean          True if there are missing objects to write out False if not
+     *
+     */
+    private static boolean hasMissingObjects(DiffResult diffResult) {
+        if (diffResult.getChangedObjects().size() > 2) {
+            return true;
+        }
+        DatabaseObject next = diffResult.getMissingObjects().iterator().next();
+        return diffResult.getMissingObjects().size() == 1 && !(next instanceof Schema || next instanceof Catalog);
     }
 
     @Override


### PR DESCRIPTION
DAT-20536

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
- Add unit/integration tests (ask for support if not sure how to do it)
- Make sure tests all pass
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
