### PR TITLE
Fixed: #7186 - Liquibase creates too short VARCHAR and CHAR fields on MS SQL databases using multi-byte encodings, effectively leading to data truncation eventually

### DIFF
--- a/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineTest.groovy
+++ b/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineTest.groovy
@@ -353,6 +353,13 @@ Global Options
                                environment variable:
                                'LIQUIBASE_MONITOR_PERFORMANCE')
 
+      --mssql-bytes-per-char=PARAM
+                             Number of bytes needed to store one character
+                               (depends on database's character encoding)
+                             DEFAULT: 1
+                             (defaults file: 'mssql.bytesPerChar', environment
+                               variable: 'MSSQL_BYTES_PER_CHAR')
+
       --on-missing-include-changelog=PARAM
                              If set to WARN, then liquibase will not throw
                                exception on missing changelog file, instead

--- a/liquibase-standard/src/main/java/liquibase/database/core/MSSQLDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/MSSQLDatabase.java
@@ -6,6 +6,8 @@ import liquibase.Scope;
 import liquibase.change.AbstractSQLChange;
 import liquibase.change.Change;
 import liquibase.changelog.DatabaseChangeLog;
+import liquibase.configuration.AutoloadedConfigurations;
+import liquibase.configuration.ConfigurationDefinition;
 import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.DatabaseConnection;
 import liquibase.database.OfflineConnection;
@@ -49,6 +51,8 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
             throw new IllegalStateException("this class is not expected to be instantiated.");
         }
     }
+
+    public static final Pattern CHAR_PATTERN = Pattern.compile("^(\\d+)\\s*(?i)CHAR$");
 
     private final HashMap<String, Integer> defaultDataTypeParameters = new HashMap<>();
 
@@ -708,5 +712,23 @@ public class MSSQLDatabase extends AbstractJdbcDatabase {
     @Override
     public boolean supportsDatabaseChangeLogHistory() {
         return true;
+    }
+
+    /**
+     * Calculates the number of bytes needed to hold the given number of characters.
+     *
+     * @param charCount The number of characters to hold.
+     * @return The number of bytes needed to hold the given number of characters.
+     */
+    public int byteSize(final int charCount) {
+        return charCount * SpecificConfiguration.BYTES_PER_CHAR.getCurrentValue();
+    }
+
+    public static class SpecificConfiguration implements AutoloadedConfigurations {
+        public static final ConfigurationDefinition<Integer> BYTES_PER_CHAR = new ConfigurationDefinition.Builder("mssql")
+                .define("bytesPerChar", Integer.class)
+                .setDefaultValue(1)
+                .setDescription("Number of bytes needed to store one character (depends on database's character encoding)")
+                .build();
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/CharType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/CharType.java
@@ -18,16 +18,24 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.regex.Matcher;
 
 @DataTypeInfo(name="char", aliases = {"java.sql.Types.CHAR", "bpchar", "character"}, minParameters = 0, maxParameters = 1, priority = LiquibaseDataType.PRIORITY_DEFAULT)
 public class CharType extends LiquibaseDataType {
     @Override
     public DatabaseDataType toDatabaseDataType(Database database) {
         if (database instanceof MSSQLDatabase) {
+            final MSSQLDatabase mssqlDatabase = (MSSQLDatabase) database;
             Object[] parameters = getParameters();
             if (parameters.length > 0) {
-                // MSSQL only supports (n) syntax but not (n CHAR) syntax, so we need to remove CHAR.
-                final String param1 = parameters[0].toString().replaceFirst("(?<=\\d+)\\s*(?i)CHAR$", "");
+                // MSSQL only supports (n) syntax but not (n CHAR) syntax, so we need to remove CHAR and apply bytes-per-char factor
+                String param1 = parameters[0].toString();
+                final Matcher matcher = MSSQLDatabase.CHAR_PATTERN.matcher(param1);
+                if (matcher.find()) {
+                    final int characterCount = Integer.parseInt(matcher.group(1));
+                    final int byteCount = mssqlDatabase.byteSize(characterCount);
+                    param1 = String.valueOf(byteCount);
+                }
                 parameters[0] =  param1;
                 if (!param1.matches("\\d+") || (new BigInteger(param1).compareTo(BigInteger.valueOf(8000)) > 0)) {
 

--- a/liquibase-standard/src/main/resources/META-INF/services/liquibase.configuration.AutoloadedConfigurations
+++ b/liquibase-standard/src/main/resources/META-INF/services/liquibase.configuration.AutoloadedConfigurations
@@ -5,3 +5,4 @@ liquibase.sql.SqlConfiguration
 liquibase.parser.ChangeLogParserConfiguration
 liquibase.analytics.configuration.AnalyticsArgs
 liquibase.license.LicenseTrackingArgs
+liquibase.database.core.MSSQLDatabase$SpecificConfiguration


### PR DESCRIPTION
## Impact

- [x] Bug fix (**non-breaking** change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality **without impacting** existing logic)
- [ ] ~Breaking change (fix or feature that would cause existing functionality to change)~

## Description

The target of this PR is to fix issue #7186, which was caused by *incorrectly* fixing issue #4682 using PR #4683.

The code introduced by PR #4683 needs to get extended slightly: MS SQL actually needs to know the *maximum* bytes to reserve, instead of the (current) *minimum*. In contrast to other RBMS (like PostgreSQL, Oracle and SQL Anywhere) MS SQL does *not* infer this value from the applied encoding, but it forces *the caller* to explicitly perform this calculation, which luckily is simple: `VARCHAR(n * bytesPerCharacter)`. Sad but true, MS SQL has no API or SQL function to read `bytesPerCharacter` from its encoding, so *the caller* needs to provide this as a database-specific paramter (`mssql.bytesPerChar`).

This PR implements the described solution in an at-most backwards-compatible yet future-proof way:
* When *omitting* `mssql.bytesPerChar`, a default value of `1` is applied, which is exactly what the software did *without* this PR, hence Liquibase behaves **backwards compatible**.
* When *providing* `mssql.bytesPerChar`, but `VARCHAR(n)` / `CHAR(n)` is used (i. e. *without* the explicit `CHAR` unit known from SQL dialects like Oracle and SQL Anywhere), the software **ignores** `mssql.bytesPerChar`, as *most* existing Liquibase schema documents are expected to be *intended* as `n BYTE`, but not `n CHAR`, as long as there is *no* unit specified **explicitly**. Hence, even in that case, Liquibase still works **backwards compatible**.
* **Only** in case **both**, `mssql.bytesPerChar` *and* the `CHAR` suffix, are *explicitly* given, the PR applies its powers and multiplies `n` by `mssql.bytesPerChar`. So Liquibase has a **double-opt-in** to be at-most safe with existing DBMS and schema documents, and is **backwards compatible**, as older Liquibase versions will still produce *the same* schema if *just* the `CHAR` suffix is used, but *not* the new `mssql.bytesPerChar` enabler, *or vice versa*.
* As no dynamic "tricks" (like asking the DBMS to decide about something) are applied, operations are **perfectly repeatable** when using *the same* configuration. Hence, Liquibase provides **stable** behavior.
* The `(n CHAR)` syntax is *interoperable* with the syntax already supported by Liquibase for SQL Anywhere, so a Liquibase schema document produced by reading an existing SQL Anywhere database (hence one that contains the `(n CHAR)` unit) auto-enables this solution in MS SQL. So Liquibase schema documents become *multi-vendor* enabled!


## Things to be aware of

* The new functionality is **disabled** by default. To apply it, *both*, the `CHAR` unit suffix *and* the `mssql.bytesPerChar` option MUST be specified.

* Generating a Liquibase schema document from an existing MS SQL database *intentionally* **not** produces `CHAR` unit suffix, as Liquibase shall always tell the truth: The database still is **not** dealing with characters, but with bytes! *If symmetric behavior is wanted, it should be more than easy to have another MS SQL specific option in future to enabled such "lying".*

## Things to worry about

* It should be made clear to the user that enabling this feature effectively makes it impossible to diff an original schema with a schema created from such a multi-byte enabled database. *As said above, if wanted, this is easily fixed with a future option to enable "lying"*.

## Additional Context

N/A