### PR TITLE
DAT-20616 Added configuration argument to allow backwards compatibility with the formatted SQL header check

### DIFF
--- a/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineTest.groovy
+++ b/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineTest.groovy
@@ -485,6 +485,15 @@ Global Options
                                environment variable:
                                'LIQUIBASE_SUPPRESS_LIQUIBASE_SQL')
 
+      --throw-exception-for-multiple-headers=PARAM
+                             Should Liquibase throw an exception for multiple
+                               formatted SQL changelog headers?
+                             DEFAULT: true
+                             (defaults file: 'liquibase.
+                               throwExceptionForMultipleHeaders', environment
+                               variable:
+                               'LIQUIBASE_THROW_EXCEPTION_FOR_MULTIPLE_HEADERS')
+
       --trim-load-data-file-header=PARAM
                              If true column headers will be trimmed in case
                                they were specified with spaces in the file.

--- a/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineTest.groovy
+++ b/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineTest.groovy
@@ -180,6 +180,16 @@ Global Options
                                variable:
                                'LIQUIBASE_ERROR_ON_CIRCULAR_INCLUDE_ALL')
 
+      --fail-on-multiple-formatted-sql-headers=PARAM
+                             Should Liquibase fail on multiple formatted SQL
+                               changelog headers?
+                             DEFAULT: true
+                             (defaults file: 'liquibase.
+                               failOnMultipleFormattedSqlHeaders', environment
+                               variable:
+                               'LIQUIBASE_FAIL_ON_MULTIPLE_FORMATTED_SQL_HEADERS
+                               ')
+
       --file-encoding=PARAM  Encoding to use when reading files. Valid values
                                include: UTF-8, UTF-16, UTF-16BE, UTF-16LE,
                                US-ASCII, or OS to use the system configured
@@ -484,15 +494,6 @@ Global Options
                              (defaults file: 'liquibase.suppressLiquibaseSql',
                                environment variable:
                                'LIQUIBASE_SUPPRESS_LIQUIBASE_SQL')
-
-      --throw-exception-for-multiple-headers=PARAM
-                             Should Liquibase throw an exception for multiple
-                               formatted SQL changelog headers?
-                             DEFAULT: true
-                             (defaults file: 'liquibase.
-                               throwExceptionForMultipleHeaders', environment
-                               variable:
-                               'LIQUIBASE_THROW_EXCEPTION_FOR_MULTIPLE_HEADERS')
 
       --trim-load-data-file-header=PARAM
                              If true column headers will be trimmed in case

--- a/liquibase-standard/src/main/java/liquibase/GlobalConfiguration.java
+++ b/liquibase-standard/src/main/java/liquibase/GlobalConfiguration.java
@@ -30,7 +30,7 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
     public static final ConfigurationDefinition<Boolean> ALWAYS_OVERRIDE_STORED_LOGIC_SCHEMA;
     public static final ConfigurationDefinition<Boolean> GENERATED_CHANGESET_IDS_INCLUDE_DESCRIPTION;
     public static final ConfigurationDefinition<Boolean> INCLUDE_CATALOG_IN_SPECIFICATION;
-    public static final ConfigurationDefinition<Boolean> THROW_EXCEPTION_FOR_MULTIPLE_HEADERS;
+    public static final ConfigurationDefinition<Boolean> FAIL_ON_MULTIPLE_FORMATTED_SQL_HEADERS;
     public static final ConfigurationDefinition<Boolean> SHOULD_SNAPSHOT_DATA;
     public static final ConfigurationDefinition<Boolean> INCLUDE_RELATIONS_FOR_COMPUTED_COLUMNS;
     public static final ConfigurationDefinition<Boolean> INCLUDE_SCHEMA_NAME_FOR_DEFAULT;
@@ -174,8 +174,8 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
                 .setDefaultValue(false)
                 .build();
 
-        THROW_EXCEPTION_FOR_MULTIPLE_HEADERS = builder.define("throwExceptionForMultipleHeaders", Boolean.class)
-                .setDescription("Should Liquibase throw an exception for multiple formatted SQL changelog headers?")
+        FAIL_ON_MULTIPLE_FORMATTED_SQL_HEADERS = builder.define("failOnMultipleFormattedSqlHeaders", Boolean.class)
+                .setDescription("Should Liquibase fail on multiple formatted SQL changelog headers?")
                 .setDefaultValue(true)
                 .build();
 

--- a/liquibase-standard/src/main/java/liquibase/GlobalConfiguration.java
+++ b/liquibase-standard/src/main/java/liquibase/GlobalConfiguration.java
@@ -30,6 +30,7 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
     public static final ConfigurationDefinition<Boolean> ALWAYS_OVERRIDE_STORED_LOGIC_SCHEMA;
     public static final ConfigurationDefinition<Boolean> GENERATED_CHANGESET_IDS_INCLUDE_DESCRIPTION;
     public static final ConfigurationDefinition<Boolean> INCLUDE_CATALOG_IN_SPECIFICATION;
+    public static final ConfigurationDefinition<Boolean> THROW_EXCEPTION_FOR_MULTIPLE_HEADERS;
     public static final ConfigurationDefinition<Boolean> SHOULD_SNAPSHOT_DATA;
     public static final ConfigurationDefinition<Boolean> INCLUDE_RELATIONS_FOR_COMPUTED_COLUMNS;
     public static final ConfigurationDefinition<Boolean> INCLUDE_SCHEMA_NAME_FOR_DEFAULT;
@@ -171,6 +172,11 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
         INCLUDE_CATALOG_IN_SPECIFICATION = builder.define("includeCatalogInSpecification", Boolean.class)
                 .setDescription("Should Liquibase include the catalog name when determining equality?")
                 .setDefaultValue(false)
+                .build();
+
+        THROW_EXCEPTION_FOR_MULTIPLE_HEADERS = builder.define("throwExceptionForMultipleHeaders", Boolean.class)
+                .setDescription("Should Liquibase throw an exception for multiple formatted SQL changelog headers?")
+                .setDefaultValue(true)
                 .build();
 
         SHOULD_SNAPSHOT_DATA = builder.define("shouldSnapshotData", Boolean.class)

--- a/liquibase-standard/src/main/java/liquibase/parser/AbstractFormattedChangeLogParser.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/AbstractFormattedChangeLogParser.java
@@ -1,5 +1,6 @@
 package liquibase.parser;
 
+import liquibase.GlobalConfiguration;
 import liquibase.Labels;
 import liquibase.Scope;
 import liquibase.change.AbstractSQLChange;
@@ -330,7 +331,9 @@ public abstract class AbstractFormattedChangeLogParser implements ChangeLogParse
                 if (foundHeader && changeLogPatternMatcher.matches()) {
                     String message = "Duplicate formatted SQL header at line " + count;
                     Scope.getCurrentScope().getLog(getClass()).warning(message);
-                    throw new ChangeLogParseException(message);
+                    if (GlobalConfiguration.THROW_EXCEPTION_FOR_MULTIPLE_HEADERS.getCurrentValue()) {
+                        throw new ChangeLogParseException(message);
+                    }
                 }
                 Matcher commentMatcher = COMMENT_PATTERN.matcher(line);
                 Matcher propertyPatternMatcher = PROPERTY_PATTERN.matcher(line);

--- a/liquibase-standard/src/main/java/liquibase/parser/AbstractFormattedChangeLogParser.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/AbstractFormattedChangeLogParser.java
@@ -331,7 +331,7 @@ public abstract class AbstractFormattedChangeLogParser implements ChangeLogParse
                 if (foundHeader && changeLogPatternMatcher.matches()) {
                     String message = "Duplicate formatted SQL header at line " + count;
                     Scope.getCurrentScope().getLog(getClass()).warning(message);
-                    if (GlobalConfiguration.THROW_EXCEPTION_FOR_MULTIPLE_HEADERS.getCurrentValue()) {
+                    if (GlobalConfiguration.FAIL_ON_MULTIPLE_FORMATTED_SQL_HEADERS.getCurrentValue()) {
                         throw new ChangeLogParseException(message);
                     }
                 }

--- a/liquibase-standard/src/test/groovy/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.groovy
@@ -471,6 +471,15 @@ CREATE TABLE public.Persons (
         e.getMessage().equals("Duplicate formatted SQL header at line 8")
     }
 
+    def duplicateHeaderLinesWithNoException() throws Exception {
+        when:
+        Scope.child("liquibase.throwExceptionForMultipleHeaders", "false", () -> {
+            new MockFormattedSqlChangeLogParser(INVALID_CHANGELOG_WITH_DUPLICATE_HEADERS).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+        })
+        then:
+        noExceptionThrown()
+    }
+
     def invalidPrecondition() throws Exception {
         when:
         new MockFormattedSqlChangeLogParser(INVALID_CHANGESET_ID).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())

--- a/liquibase-standard/src/test/groovy/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.groovy
@@ -473,7 +473,7 @@ CREATE TABLE public.Persons (
 
     def duplicateHeaderLinesWithNoException() throws Exception {
         when:
-        Scope.child("liquibase.throwExceptionForMultipleHeaders", "false", () -> {
+        Scope.child("liquibase.failOnMultipleFormattedSqlHeaders", "false", () -> {
             new MockFormattedSqlChangeLogParser(INVALID_CHANGELOG_WITH_DUPLICATE_HEADERS).parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
         })
         then:


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
- Add unit/integration tests (ask for support if not sure how to do it)
- Make sure tests all pass
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
