### PR TITLE
Rollback Mockito version to 4.11.0 for Java 8 compatibility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -116,3 +116,6 @@ updates:
       # Ignore H2 updates as it requires Java 11, project uses Java 8
       - dependency-name: "com.h2database:h2"
         versions: [ ">= 2.2.224" ]
+      # Ignore Mockito 5.x updates (requires Java 11, project uses Java 8)
+      - dependency-name: "org.mockito:mockito-core"
+        versions: [">= 5.0.0"]

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
         <sonar.coverage.jacoco.xmlReportPaths>target/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
         <surefire.failIfNoTests>true</surefire.failIfNoTests>
         <opencsv.version>5.12.0</opencsv.version>
+        <mockito.version>4.11.0</mockito.version>
     </properties>
 
     <!-- comment -->
@@ -198,7 +199,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.19.0</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -587,7 +588,7 @@
                 <dependency>
                     <groupId>org.mockito</groupId>
                     <artifactId>mockito-core</artifactId>
-                    <version>5.19.0</version>
+                    <version>${mockito.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

This pull request rolls back the `Mockito` library version to 4.11.0 for compatibility with Java 8. Mockito 5.x versions require Java 11, which caused compatibility issues in certain environments. Additionally, updates to Mockito 5.x have been ignored in dependency management to prevent future compatibility problems.

## Things to be aware of

No additional changes or upgrades were made beyond rolling back the version number. Affected systems utilizing Java 8 will now maintain functionality.

## Things to worry about

This change will restrict access to features introduced in Mockito 5.x for Java 11+. It's recommended to revisit this decision should a migration to Java 11 occur in the future.

## Additional Context

No additional context at this time.