### PR TITLE
DAT-20693: Remove repository dispatch step for updating pom.xml for aws-license-service

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -686,14 +686,6 @@ jobs:
           event-type: oss-released-version
           client-payload: '{"latest_version": "${{ steps.get_latest_oss_version.outputs.latest_version }}", "previous_version": "${{ steps.get_latest_oss_version.outputs.previous_version }}"}'
 
-      # dispatch an event to `liquibase-aws-license-service` repository to update pom.xml with latest OSS Release
-      - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ steps.get-token.outputs.token }}
-          repository: liquibase/liquibase-aws-license-service
-          event-type: oss-released-version
-
   dry_run_deploy_maven:
     if: ${{ inputs.dry_run == true }}
     name: Deploy to Maven Central Repository


### PR DESCRIPTION
This pull request makes a small change to the `.github/workflows/release-published.yml` workflow file, specifically by removing a step that dispatched an event to the `liquibase-aws-license-service` repository to update its `pom.xml` with the latest OSS release version.