### PR TITLE
Fixed errors in tests on Windows 11 + git-bash cygwin

### DIFF
--- a/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineTest.groovy
+++ b/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineTest.groovy
@@ -803,6 +803,7 @@ https://docs.liquibase.com
     }
 
     def "help output" () {
+        System.setProperty("picocli.ansi", "false") // Required for cygwin / MSYS
         when:
         Assumptions.assumeTrue(System.getProperty("skipHelpTests") == null, "Skipping help test")
         def oldOut = System.out

--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/update/UpdateIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/update/UpdateIntegrationTest.groovy
@@ -16,6 +16,7 @@ import liquibase.extension.testing.testsystem.TestSystemFactory
 import liquibase.extension.testing.testsystem.spock.LiquibaseIntegrationTest
 import liquibase.logging.core.BufferedLogService
 import liquibase.resource.SearchPathResourceAccessor
+import liquibase.util.StringUtil
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -43,14 +44,14 @@ class UpdateIntegrationTest extends Specification {
         String output = results.getResult("output") as String
 
         then:
-        assert output == """Output of select * from parameter_value_tests order by id:
+        assert StringUtil.standardizeLineEndings(output) == """Output of select * from parameter_value_tests order by id:
 ID | DEPLOYMENT_ID | CHANGELOG_FILE | CHANGESET_ID | CHANGESET_AUTHOR |
-1 | """ + expectedDeploymentId + """ | src/test/resources/changelogs/h2/update/execution-parameter/1.xml | 1.1 | jlyle | 
-2 | """ + expectedDeploymentId + """ | src/test/resources/changelogs/h2/update/execution-parameter/1.xml | 1.2 | not_jlyle | 
-3 | """ + expectedDeploymentId + """ | src/test/resources/changelogs/h2/update/execution-parameter/1.xml | 1.3 | jlyle | 
-4 | """ + expectedDeploymentId + """ | src/test/resources/changelogs/h2/update/execution-parameter/2.xml | 2.1 | jlyle | 
-5 | """ + expectedDeploymentId + """ | src/test/resources/changelogs/h2/update/execution-parameter/2.xml | 2.2 | not_jlyle | 
-6 | """ + expectedDeploymentId + """ | src/test/resources/changelogs/h2/update/execution-parameter/2.xml | 2.3 | jlyle | 
+1 | $expectedDeploymentId | src/test/resources/changelogs/h2/update/execution-parameter/1.xml | 1.1 | jlyle | 
+2 | $expectedDeploymentId | src/test/resources/changelogs/h2/update/execution-parameter/1.xml | 1.2 | not_jlyle | 
+3 | $expectedDeploymentId | src/test/resources/changelogs/h2/update/execution-parameter/1.xml | 1.3 | jlyle | 
+4 | $expectedDeploymentId | src/test/resources/changelogs/h2/update/execution-parameter/2.xml | 2.1 | jlyle | 
+5 | $expectedDeploymentId | src/test/resources/changelogs/h2/update/execution-parameter/2.xml | 2.2 | not_jlyle | 
+6 | $expectedDeploymentId | src/test/resources/changelogs/h2/update/execution-parameter/2.xml | 2.3 | jlyle | 
 
 """
     }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description
Tests were failing:
1. `UpdateIntegrationTest.'check execution parameters are correctly replaced'` was failing the text comparison caused by line ending difference
	
	```
	...
	jlyle | \n(\r)\n
	jlyle | \n(-~)\n
	```
2. `liquibase-cli /.../ LiquibaseCommandLineTest."help output"` was failing string compare because liquibase generated ANSI escaped string

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
- Add unit/integration tests (ask for support if not sure how to do it)
- Make sure tests all pass
-->

## Things to be aware of
`liquibase-standard /.../ FormattedSqlChangeLogParserTest.invalidWithLexicalError()` Still fails with

```
FormattedSqlChangeLogParserTest.invalidWithLexicalError:530->SpecInternals.thrownImpl:71-
>SpecInternals.checkExceptionThrown:84 Expected exception of type 'liquibase.exception.UnexpectedLiquibaseException', but no exception was thrown
```

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
