### PR TITLE
Allow anyAttribute in dbchangelog-latest.xsd complex types

### DIFF
--- a/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
+++ b/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
@@ -1241,7 +1241,9 @@
     <!-- dropTable -->
     <xsd:element name="dropTable">
         <xsd:complexType>
-            <xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:choice minOccurs="0" maxOccurs="unbounded">
+                <xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+            </xsd:choice>
             <xsd:attributeGroup ref="changeAttributes"/>
             <xsd:attributeGroup ref="dropTableAttributes"/>
             <xsd:anyAttribute namespace="##other" processContents="lax"/>


### PR DESCRIPTION
This pull request updates the XML schema definition in `dbchangelog-latest.xsd` to make several change elements more extensible. The main improvement is allowing additional, non-standard XML elements and attributes within the `dropTable`, `createSequence`, `alterSequence`, and `dropSequence` change types, which increases flexibility for future extensions or integrations.

Schema extensibility enhancements:

* Added an `<xsd:choice>` block with `<xsd:any>` to each of the following elements: `dropTable`, `createSequence`, `alterSequence`, and `dropSequence`, allowing arbitrary XML elements from other namespaces to be included. [[1]](diffhunk://#diff-851acbf08f82c01dbf5cec5013ce71f19b38a254140eb3405ed5aee31a960e71R1244-R1249) [[2]](diffhunk://#diff-851acbf08f82c01dbf5cec5013ce71f19b38a254140eb3405ed5aee31a960e71R1308-R1335)
* Added `<xsd:anyAttribute>` to each of these elements, permitting additional attributes from other namespaces. [[1]](diffhunk://#diff-851acbf08f82c01dbf5cec5013ce71f19b38a254140eb3405ed5aee31a960e71R1244-R1249) [[2]](diffhunk://#diff-851acbf08f82c01dbf5cec5013ce71f19b38a254140eb3405ed5aee31a960e71R1308-R1335)



## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

Added support for `anyAttribute` in `dbchangelog-latest.xsd` complex types to improve flexibility and extensibility when working with XML schemas. 

This change allows users to define additional attributes seamlessly while maintaining XML schema compliance.

## Things to be aware of

None.

## Things to worry about

None.

## Additional Context

None.