### PR TITLE
Fix path inconsistency in JAR file resource resolution

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/resource/AbstractResource.java
+++ b/liquibase-standard/src/main/java/liquibase/resource/AbstractResource.java
@@ -39,7 +39,7 @@ public abstract class AbstractResource implements Resource {
     private String handlePathForJarfile(String path) {
         String relative = this.uri.toString().replaceFirst(".*!", "");
         try {
-            if (!path.startsWith("..")) {
+            if (!path.startsWith("..") && !path.startsWith("/")) {
                 path = "/" + path;
             }
             return new URI(relative).resolve(new URI(path).normalize()).toString().replaceFirst("^/", "");


### PR DESCRIPTION
The handlePathForJarfile method in AbstractResource unconditionally prepends a leading slash to paths, causing inconsistent path normalization when the path already starts with "/". This creates different normalized paths between SpringResourceAccessor and ClassLoaderResourceAccessor for the same resource when running from JAR files.
Example of inconsistent behavior:

SpringResourceAccessor returns: /db/changelog/file.xml
ClassLoaderResourceAccessor returns: db/changelog/file.xml

This can lead to duplicate changeset validation errors and resource resolution issues.
Root Cause
In AbstractResource.handlePathForJarfile(), line 118:
```
javaif (!path.startsWith("..")) {
    path = "/" + path;  // Always prepends "/" without checking if already present
}
```
When input path is /db/changelog/file.xml, this creates //db/changelog/file.xml, which gets partially normalized but produces inconsistent results.
Solution
Add check to prevent prepending "/" when path already starts with one:
```
javaif (!path.startsWith("..") && !path.startsWith("/")) {
    path = "/" + path;
}
```
Testing

✅ Verified the issue exists in JAR environments with both classpath: and classpath*: paths
✅ Confirmed version 4.31.0 had correct behavior (no leading slash in results)
✅ Validated that fix restores consistent path normalization between different ResourceAccessors
✅ Tested with various path formats including relative and absolute paths

Regression Information

Introduced in: PR #6867
Affects versions: 4.33.0+
Related issue: #7268

Files Changed

src/main/java/liquibase/resource/AbstractResource.java - Modified handlePathForJarfile method condition

Breaking Changes
None - this fix restores the correct behavior from version 4.31.0.