### PR TITLE
INT-1515: add supportsCatalogInObjectName for all Snowflake objects; override escapeObjectName in SnowflakeDatabase

### DIFF
--- a/liquibase-snowflake/src/test/java/liquibase/database/core/SnowflakeDatabaseTest.java
+++ b/liquibase-snowflake/src/test/java/liquibase/database/core/SnowflakeDatabaseTest.java
@@ -86,7 +86,7 @@ public class SnowflakeDatabaseTest {
 
     @Test
     public void testSupportsCatalogInObjectName() {
-        assertFalse(database.supportsCatalogInObjectName(null));
+        assertTrue(database.supportsCatalogInObjectName(null));
     }
 
     @Test


### PR DESCRIPTION
- Added support of catalog name in all `Snowflake` database object names;
- Overridden the `escapeObjectName` method in `SnowflakeDatabase` to fix an issue where `catalogName` is specified but `schemaName` is not specified, resulting in the following case : _'catalogName.null.objectName'_. Now the default `schemaName` will be **"PUBLIC"** in this case ('_catalogName.PUBLIC.objectName_')
- Added logic to correctly retrieve `schemaName` from offline connection in `supportsCatalogInObjectName` method.