### PR TITLE
feat(github): Add Claude Code reusable workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,17 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+  actions: read
+
+jobs:
+  claude-review:
+    uses: liquibase/build-logic/.github/workflows/claude-code-review.yml@main
+    secrets: inherit

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,28 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+  actions: read
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    uses: liquibase/build-logic/.github/workflows/claude.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

This PR adds Claude Code integration workflows to enable:
- Automatic code reviews on pull requests
- Interactive @claude mentions in issues and PRs

## Changes

- Added `.github/workflows/claude-code-review.yml` - Automatically reviews PRs when opened or updated
- Added `.github/workflows/claude.yml` - Responds to @claude mentions in issues, PRs, and comments

## Implementation Details

Both workflows:
- Reference centralized reusable workflows from `liquibase/build-logic`
- Use OIDC authentication to securely access the Anthropic API key from AWS Secrets Manager
- Leverage organization-level secrets (no repository-specific configuration needed)
- Include proper permissions for GitHub API access

## Testing

Once merged, the workflows will:
- Automatically trigger on new/updated PRs
- Respond when team members mention @claude in issues or PRs

## References

- Part of LAI-51 initiative to add Claude Code across Liquibase repositories
- Follows the same pattern as setup-liquibase and liquibase-pro-tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated code review workflows to streamline pull request reviews and facilitate better collaboration in the development process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->