### PR TITLE
Fixed Issue #7413: SQL Anywhere: Constraint name is not considered for PRIMARY KEY

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/AddPrimaryKeyGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/AddPrimaryKeyGenerator.java
@@ -47,12 +47,11 @@ public class AddPrimaryKeyGenerator extends AbstractSqlGenerator<AddPrimaryKeySt
     @Override
     public Sql[] generateSql(AddPrimaryKeyStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
         String sql;
-        if ((statement.getConstraintName() == null) || (database instanceof MySQLDatabase) || (database instanceof
-            SybaseASADatabase)) {
+        if ((statement.getConstraintName() == null) || (database instanceof MySQLDatabase)) {
             sql = "ALTER TABLE " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + " ADD PRIMARY KEY (" + database.escapeColumnNameList(statement.getColumnNames()) + ")";
         } else {
             sql = "ALTER TABLE " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName()) + " ADD CONSTRAINT " + database.escapeConstraintName(statement.getConstraintName())+" PRIMARY KEY";
-            if ((database instanceof MSSQLDatabase) && (statement.isClustered() != null)) {
+            if ((database instanceof MSSQLDatabase || database instanceof SybaseASADatabase) && (statement.isClustered() != null)) {
                 if (statement.isClustered()) {
                     sql += " CLUSTERED";
                 } else {


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Fixes #7413 

According to the latest [SQL Anywhere Manual](https://help.sap.com/docs/SAP_SQL_Anywhere/93079d4ba8e44920ae63ffb4def91f5b/8169d7966ce2101497b5ac611f7413ce.html?locale=en-US&state=PRODUCTION&version=LATEST&q=ALTER+TABKLE), the syntax for adding a primary key constraint is *not* a special case (and as an expert for this RDBMS I can confirm that it never had been since at least one decade). Hence, this PR removes the special case handling.

As a side change, as it is also covered by the mentioned manual, the support for the `(NON) CLUSTERED` syntax was enabled, without adding a separate issue.

## Things to be aware of

Nothing. Successfully used the change in production already.

## Things to worry about

Nothing.

## Additional Context

Nothing.