### PR TITLE
Fix ChangeLogPropertyDefined precondition errors: #7345

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeSet.java
@@ -424,7 +424,7 @@ public class ChangeSet implements Conditional, ChangeLogChild {
     @Override
     public void load(ParsedNode node, ResourceAccessor resourceAccessor) throws ParsedNodeException {
         this.id = node.getChildValue(null, "id", String.class);
-        this.author = node.getChildValue(null, "author", String.class);
+        this.author = node.getChildValue(null, "author", "");
         this.alwaysRun = node.getChildValue(null, "runAlways", node.getChildValue(null, "alwaysRun", false));
         this.runOnChange = node.getChildValue(null, "runOnChange", false);
         this.runWith = node.getChildValue(null, "runWith", String.class);
@@ -525,7 +525,6 @@ public class ChangeSet implements Conditional, ChangeLogChild {
                     labels = new Labels(labelsString);
                 }
 
-
                 List<ParsedNode> potentialVisitors = child.getChildren();
                 for (ParsedNode node : potentialVisitors) {
                     SqlVisitor sqlVisitor = SqlVisitorFactory.getInstance().create(node.getName());
@@ -541,8 +540,6 @@ public class ChangeSet implements Conditional, ChangeLogChild {
                         addSqlVisitor(sqlVisitor);
                     }
                 }
-
-
                 break;
             case "preconditions":
             case "preConditions":
@@ -768,7 +765,7 @@ public class ChangeSet implements Conditional, ChangeLogChild {
 
             try {
                 if (preconditions != null) {
-                    preconditions.check(database, databaseChangeLog, this, listener);
+                    preconditions.check(database, this.changeLog, this, listener);
                 }
             } catch (PreconditionFailedException e) {
                 if (listener != null) {

--- a/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -37,6 +37,8 @@ import liquibase.util.FileUtil;
 import liquibase.util.LiquibaseLauncherSettings;
 import liquibase.util.StringUtil;
 import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -95,11 +97,12 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
 
     private final PreconditionContainer preconditionContainer = new GlobalPreconditionContainer();
 
-    @Getter
+    @Getter @Setter
     private String physicalFilePath;
+    @Setter
     private String logicalFilePath;
 
-    @Getter
+    @Getter @Setter
     private ObjectQuotingStrategy objectQuotingStrategy;
 
     @Getter
@@ -118,10 +121,10 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
     @Getter
     private final List<ChangeSet> skippedBecauseOfPreconditionsChangeSets = new ArrayList<>();
 
-    @Getter
+    @Getter  @Setter @Accessors(chain = true)
     private ChangeLogParameters changeLogParameters;
 
-    @Getter
+    @Getter @Setter
     private RuntimeEnvironment runtimeEnvironment;
 
     private DatabaseChangeLog rootChangeLog = ROOT_CHANGE_LOG.get();
@@ -129,7 +132,8 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
     @Getter
     private DatabaseChangeLog parentChangeLog = PARENT_CHANGE_LOG.get();
 
-    @Getter
+    @Setter
+	 @Getter
     private ContextExpression contextFilter;
 
     @Getter
@@ -145,9 +149,11 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
     private ParsedNode currentlyLoadedChangeSetNode;
 
     public DatabaseChangeLog() {
+        preconditionContainer.setChangeLog(this);
     }
 
     public DatabaseChangeLog(String physicalFilePath) {
+        this();
         this.physicalFilePath = physicalFilePath;
     }
 
@@ -163,10 +169,6 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
         this.parentChangeLog = parentChangeLog;
     }
 
-    public void setRuntimeEnvironment(RuntimeEnvironment runtimeEnvironment) {
-        this.runtimeEnvironment = runtimeEnvironment;
-    }
-
     @Override
     public PreconditionContainer getPreconditions() {
         return preconditionContainer;
@@ -175,15 +177,6 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
     @Override
     public void setPreconditions(PreconditionContainer precondition) {
         this.preconditionContainer.addNestedPrecondition(precondition);
-    }
-
-
-    public void setChangeLogParameters(ChangeLogParameters changeLogParameters) {
-        this.changeLogParameters = changeLogParameters;
-    }
-
-    public void setPhysicalFilePath(String physicalFilePath) {
-        this.physicalFilePath = physicalFilePath;
     }
 
     public String getRawLogicalFilePath() {
@@ -202,20 +195,12 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
         return SLASH_PATTERN.matcher(path).replaceFirst("");
     }
 
-    public void setLogicalFilePath(String logicalFilePath) {
-        this.logicalFilePath = logicalFilePath;
-    }
-
     public String getFilePath() {
         if (logicalFilePath == null) {
             return physicalFilePath;
         } else {
             return getLogicalFilePath();
         }
-    }
-
-    public void setObjectQuotingStrategy(ObjectQuotingStrategy objectQuotingStrategy) {
-        this.objectQuotingStrategy = objectQuotingStrategy;
     }
 
     /**
@@ -234,15 +219,9 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
         setContextFilter(contexts);
     }
 
-    public void setContextFilter(ContextExpression contextFilter) {
-        this.contextFilter = contextFilter;
-    }
-
-    /**
+	/**
      * @deprecated Correct version is {@link #setIncludeLabels(Labels)}. Kept for backwards compatibility.
      */
-
-
     @Deprecated
     public void setIncludeLabels(LabelExpression labels) {
         this.includeLabels = new Labels(labels.toString());

--- a/liquibase-standard/src/main/java/liquibase/executor/ExecutorService.java
+++ b/liquibase-standard/src/main/java/liquibase/executor/ExecutorService.java
@@ -9,6 +9,7 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class ExecutorService extends AbstractPluginFactory<Executor>  {
+    public static String JDBC = "jdbc";
 
     private final Map<Key, Executor> executors = new ConcurrentHashMap<>();
 
@@ -88,18 +89,18 @@ public class ExecutorService extends AbstractPluginFactory<Executor>  {
      * @deprecated Please use {@link #getExecutor(String, Database) } instead.
      */
     public Executor getExecutor(Database database) {
-        return getExecutor("jdbc", database);
+        return getExecutor(JDBC, database);
     }
 
     /**
-     * Sets the executor for the given database with the default name "jdbc". If an executor with the same name and database already exists,
+     * Sets the executor for the given database with the default name JDBC. If an executor with the same name and database already exists,
      * it will be replaced by the new one.
      *
      * @param database the {@code Database} for which the executor is set
      * @param executor the {@code Executor} to set
      */
     public void setExecutor(Database database, Executor executor) {
-        setExecutor("jdbc", database, executor);
+        setExecutor(JDBC, database, executor);
     }
 
     public void setExecutor(String name, Database database, Executor executor) {
@@ -113,7 +114,7 @@ public class ExecutorService extends AbstractPluginFactory<Executor>  {
      *
      */
     public void clearExecutor(Database database) {
-        clearExecutor("jdbc", database);
+        clearExecutor(JDBC, database);
     }
 
     public void clearExecutor(String name, Database database) {

--- a/liquibase-standard/src/main/java/liquibase/precondition/core/ChangeLogPropertyDefinedPrecondition.java
+++ b/liquibase-standard/src/main/java/liquibase/precondition/core/ChangeLogPropertyDefinedPrecondition.java
@@ -11,11 +11,13 @@ import liquibase.exception.ValidationErrors;
 import liquibase.exception.Warnings;
 import liquibase.precondition.AbstractPrecondition;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
 public class ChangeLogPropertyDefinedPrecondition extends AbstractPrecondition {
-
+    @Setter
     private String property;
+    @Setter
     private String value;
 
     @Override
@@ -28,14 +30,6 @@ public class ChangeLogPropertyDefinedPrecondition extends AbstractPrecondition {
         return "changeLogPropertyDefined";
     }
 
-    public void setProperty(String property) {
-        this.property = property;
-    }
-
-    public void setValue(String value) {
-        this.value = value;
-    }
-    
     @Override
     public Warnings warn(Database database) {
         return new Warnings();
@@ -43,7 +37,7 @@ public class ChangeLogPropertyDefinedPrecondition extends AbstractPrecondition {
 
     @Override
     public ValidationErrors validate(Database database) {
-        return new ValidationErrors();
+        return new ValidationErrors(this).checkRequiredField("property", property);
     }
 
     @Override
@@ -54,14 +48,12 @@ public class ChangeLogPropertyDefinedPrecondition extends AbstractPrecondition {
             throw new PreconditionFailedException("No Changelog properties were set", changeLog, this);
         }
         Object propertyValue = changeLogParameters.getValue(property, changeLog);
-        if (propertyValue == null) {
-            propertyValue = changeLogParameters.getLocalValue(property, changeSet);
-            if (null == propertyValue) {
-                throw new PreconditionFailedException("Changelog property '"+ property +"' was not set", changeLog, this);
-            }
+        if (null == propertyValue) {
+            throw new PreconditionFailedException("Changelog property '"+ property +"' was not set", changeLog, this);
         }
+
         if ((value != null) && !propertyValue.toString().equals(value)) {
-            throw new PreconditionFailedException("Expected changelog property '"+ property +"' to have a value of '"+value+"'.  Got '"+propertyValue+"'", changeLog, this);
+            throw new PreconditionFailedException("Expected changelog property '"+ property +"' to have a value of '"+value+"'. Got '"+propertyValue+"'", changeLog, this);
         }
     }
 }

--- a/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
+++ b/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
@@ -7,15 +7,13 @@
 
     <xsd:simpleType name="propertyExpression" id="propertyExpression">
         <xsd:restriction base="xsd:string">
-            <xsd:pattern value="$\{[\w\.]+\}"/>
+            <xsd:pattern value="\$\{[\w\.\-\+_]+\}"/>
         </xsd:restriction>
     </xsd:simpleType>
 
     <xsd:simpleType name="booleanExp" id="booleanExp">
         <xsd:annotation>
-            <xsd:appinfo>
-                <xsd:documentation>Extension to standard XSD boolean type to allow ${} parameters</xsd:documentation>
-            </xsd:appinfo>
+            <xsd:documentation>Extension to standard XSD boolean type to allow ${parameter} placeholders</xsd:documentation>
         </xsd:annotation>
         <xsd:union>
             <xsd:simpleType>
@@ -29,9 +27,7 @@
 
     <xsd:simpleType name="integerExp" id="integerExp">
         <xsd:annotation>
-            <xsd:appinfo>
-                <xsd:documentation>Extension to standard XSD integer type to allow ${} parameters</xsd:documentation>
-            </xsd:appinfo>
+            <xsd:documentation>Extension to standard XSD integer type to allow ${parameter} placeholders</xsd:documentation>
         </xsd:annotation>
         <xsd:union>
             <xsd:simpleType>
@@ -81,19 +77,28 @@
             <xsd:enumeration value="QUOTE_ONLY_RESERVED_WORDS"/>
         </xsd:restriction>
     </xsd:simpleType>
+
+    <xsd:simpleType name="propertyName">
+        <xsd:annotation>
+            <xsd:documentation>Name of the property
+                Supported format includes alphanumeric characters, +, -, . , and _
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:pattern value="[\w\.\-\+_]+"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
     <!-- include -->
     <xsd:element name="include">
         <xsd:complexType>
-            <xsd:attribute name="id" type="xsd:string"/>
-            <xsd:attribute name="author" type="xsd:string"/>
-            <xsd:attribute name="file" type="xsd:string" use="required"/>
+            <xsd:attribute name="file" type="nonEmptyString" use="required"/>
             <xsd:attribute name="relativeToChangelogFile" type="booleanExp"/>
             <xsd:attribute name="errorIfMissing" type="booleanExp" default="true"/>
             <xsd:attribute name="context" type="xsd:string"/>
             <xsd:attribute name="contextFilter" type="xsd:string"/>
             <xsd:attribute name="labels" type="xsd:string"/>
             <xsd:attribute name="ignore" type="xsd:string"/>
-            <xsd:attribute name="created" type="xsd:string"/>
             <xsd:attribute name="logicalFilePath" type="xsd:string"/>
             <xsd:anyAttribute namespace="##other" processContents="lax"/>
         </xsd:complexType>
@@ -102,7 +107,7 @@
     <!-- includeAll -->
     <xsd:element name="includeAll">
         <xsd:complexType>
-            <xsd:attribute name="path" type="xsd:string" use="required"/>
+            <xsd:attribute name="path" type="nonEmptyString" use="required"/>
             <xsd:attribute name="errorIfMissingOrEmpty" type="booleanExp" default="true"/>
             <xsd:attribute name="relativeToChangelogFile" type="booleanExp"/>
             <xsd:attribute name="resourceComparator" type="xsd:string"/>
@@ -136,23 +141,21 @@
                 </xsd:element>
                 <xsd:element name="property" minOccurs="0" maxOccurs="unbounded">
                     <xsd:complexType>
-                        <xsd:attribute name="file" type="xsd:string"/>
-                        <xsd:attribute name="relativeToChangelogFile" type="booleanExp" default="false"/>
-                        <xsd:attribute name="errorIfMissing" type="booleanExp" default="true"/>
-                        <xsd:attribute name="name" type="xsd:string"/>
+                        <xsd:attribute name="file" type="nonEmptyString"/>
+                        <xsd:attribute name="relativeToChangelogFile" type="booleanExp"/>
+                        <xsd:attribute name="errorIfMissing" type="booleanExp"/>
+                        <xsd:attribute name="name" type="propertyName"/>
                         <xsd:attribute name="value" type="xsd:string"/>
                         <xsd:attribute name="dbms" type="xsd:string"/>
                         <xsd:attribute name="context" type="xsd:string"/>
                         <xsd:attribute name="contextFilter" type="xsd:string"/>
                         <xsd:attribute name="labels" type="xsd:string"/>
-                        <xsd:attribute name="global" type="xsd:boolean"/>
-                        <xsd:attribute name="target" type="xsd:string"/>
+                        <xsd:attribute name="global" type="booleanExp"/>
                         <xsd:anyAttribute namespace="##other" processContents="lax"/>
                     </xsd:complexType>
                 </xsd:element>
 
-                <xsd:element name="preConditions" minOccurs="0"
-                             maxOccurs="1">
+                <xsd:element name="preConditions" minOccurs="0" maxOccurs="unbounded">
                     <xsd:complexType>
                         <xsd:choice>
                             <xsd:group ref="PreConditionChildren" maxOccurs="unbounded"/>
@@ -167,7 +170,6 @@
                                        type="onChangeLogPreconditionOnSqlOutput"/>
                     </xsd:complexType>
                 </xsd:element>
-
 
                 <xsd:choice minOccurs="0" maxOccurs="unbounded">
                     <xsd:element name="changeSet" minOccurs="0" maxOccurs="unbounded">
@@ -185,13 +187,11 @@
                                 <xsd:element name="preConditions" minOccurs="0"
                                              maxOccurs="1">
                                     <xsd:annotation>
-                                        <xsd:appinfo>
-                                            <xsd:documentation>onChangeLogPreconditionOnSqlOutput determines what should
-                                                happen when evaluating this precondition in updateSQL mode. TEST: Run
-                                                precondition, FAIL: Fail precondition, IGNORE: Skip precondition check
-                                                [DEFAULT]
-                                            </xsd:documentation>
-                                        </xsd:appinfo>
+                                        <xsd:documentation>onChangeLogPreconditionOnSqlOutput determines what should
+                                            happen when evaluating this precondition in updateSQL mode. TEST: Run
+                                            precondition, FAIL: Fail precondition, IGNORE: Skip precondition check
+                                            [DEFAULT]
+                                        </xsd:documentation>
                                     </xsd:annotation>
                                     <xsd:complexType>
                                         <xsd:choice>
@@ -378,11 +378,9 @@
         <xsd:attribute name="remarks" type="xsd:string"/>
         <xsd:attribute name="encoding" type="xsd:string">
             <xsd:annotation>
-                <xsd:appinfo>
-                    <xsd:documentation>
-                        Used with valueClobFile to specify file encoding explicitly.
-                    </xsd:documentation>
-                </xsd:appinfo>
+                <xsd:documentation>
+                    Used with valueClobFile to specify file encoding explicitly.
+                </xsd:documentation>
             </xsd:annotation>
         </xsd:attribute>
         <xsd:anyAttribute namespace="##other" processContents="lax"/>
@@ -835,7 +833,11 @@
 
     <xsd:element name="changeLogPropertyDefined">
         <xsd:complexType>
-            <xsd:attribute name="property" type="xsd:string" use="required"/>
+            <xsd:annotation>
+                <xsd:documentation>Check if the changeLog property with the name in @property is set to @value.
+                    If @value is not defined checks only if the property is defined at all</xsd:documentation>
+            </xsd:annotation>
+            <xsd:attribute name="property" type="propertyName" use="required"/>
             <xsd:attribute name="value" type="xsd:string"/>
         </xsd:complexType>
     </xsd:element>

--- a/liquibase-standard/src/test/groovy/liquibase/precondition/core/ChangeLogPropertyDefinedPreconditionTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/precondition/core/ChangeLogPropertyDefinedPreconditionTest.groovy
@@ -3,8 +3,11 @@ package liquibase.precondition.core
 import liquibase.changelog.ChangeLogParameters
 import liquibase.changelog.ChangeSet
 import liquibase.changelog.DatabaseChangeLog
+import liquibase.changelog.visitor.ValidatingVisitor
 import liquibase.database.core.MockDatabase
 import liquibase.exception.PreconditionFailedException
+import liquibase.parser.core.yaml.YamlChangeLogParser
+import liquibase.test.JUnitResourceAccessor
 import spock.lang.Specification
 
 class ChangeLogPropertyDefinedPreconditionTest extends Specification {
@@ -22,17 +25,17 @@ class ChangeLogPropertyDefinedPreconditionTest extends Specification {
 
         changeLogParameters.set("globalKey", "globalValue")
         changeLogParameters.setLocal("localKey", "localValue", childChangelog)
-        changeLog.setChangeLogParameters(changeLogParameters)
+        childChangelog.setChangeLogParameters(changeLogParameters)
 
         then:
         precondition.setProperty(property)
         precondition.setValue(value)
         if (null == expectedEx) {
-            precondition.check(database, changeLog, changeSet, null)
+            precondition.check(database, childChangelog, changeSet, null)
         } else {
             def exceptionThrown = false
             try {
-                precondition.check(database, changeLog, changeSet, null)
+                precondition.check(database, childChangelog, changeSet, null)
             } catch (Throwable th) {
                 expectedEx === th.getClass()
                 exceptionThrown = true
@@ -45,5 +48,31 @@ class ChangeLogPropertyDefinedPreconditionTest extends Specification {
         "globalKey"         | "globalValue"     | null
         "localKey"          | "localValue"      | null
         "nonExistentKey"    | null              | PreconditionFailedException.class
+    }
+
+    def 'ChangeLogPropertyDefinedPrecondition property required' () {
+        def precondition = new ChangeLogPropertyDefinedPrecondition()
+        when:
+        List<String> v = precondition.validate(new MockDatabase()).requiredErrorMessages
+        then:
+        v.size() == 1
+        v.any {it.contains('property') && it.contains('is required')}
+        when:
+        precondition.property = ' '
+        v = precondition.validate(new MockDatabase()).errorMessages
+        then:
+        v.size() == 1
+        v.any {it.contains('property') && it.contains('is empty')}
+    }
+
+    def "included changeset can access #c property from parent" () {
+        ValidatingVisitor vv = new ValidatingVisitor()
+        DatabaseChangeLog rootChangeLog = new YamlChangeLogParser().parse("properties/${c}.yml",
+                                          new ChangeLogParameters(), new JUnitResourceAccessor());
+        vv.validate(new MockDatabase(), rootChangeLog)
+        expect:
+        vv.validationPassed()
+        where:
+        c << ['local', 'global']
     }
 }

--- a/liquibase-standard/src/test/resources/properties/global.yml
+++ b/liquibase-standard/src/test/resources/properties/global.yml
@@ -1,0 +1,26 @@
+databaseChangeLog:
+  - property: { name: main-global, value: main-gv }
+  - preConditions:
+     - changeLogPropertyDefined: { property: main-global, value: main-gv }
+#    - not: [ changeLogPropertyDefined: { property: inc-global } ] # Does not work as one would expect
+  - include: { file: properties/inc.yml }
+  - changeSet:
+      id: after inc.yml before inc2.yml
+      author: g
+      preConditions:
+        - changeLogPropertyDefined: { property: main-global, value: main-gv }
+        - changeLogPropertyDefined: { property: inc-global, value: inc-gv }
+        - changeLogPropertyDefined: { property: inc.inc-global, value: inc.inc-gv }
+#        - not: [ changeLogPropertyDefined: { property: inc2-global } ]
+      output: global.yml > main-global:${main-global}, inc-global:${inc-global}, inc.inc-global:${inc.inc-global}
+  - include: { file: properties/inc2.yml }
+  - changeSet:
+      id: after inc2.yml
+      author: g
+      preConditions:
+      - changeLogPropertyDefined: { property: main-global, value: main-gv }
+      - changeLogPropertyDefined: { property: inc-global, value: inc-gv }
+      - changeLogPropertyDefined: { property: inc2-global, value: inc2-gv }
+      - changeLogPropertyDefined: { property: inc.inc-global, value: inc.inc-gv }
+      output: global.yml > main-global:${main-global}, inc-global:${inc-global}, inc2-global:${inc2-global},
+              inc.inc-global:${inc.inc-global}

--- a/liquibase-standard/src/test/resources/properties/inc-loc.inc.yml
+++ b/liquibase-standard/src/test/resources/properties/inc-loc.inc.yml
@@ -1,0 +1,18 @@
+databaseChangeLog:
+  - property: { name: inc.inc-local, value: inc.inc-lv, global: false }
+  - preConditions:
+    - changeLogPropertyDefined: { property: main-local, value: main-lv }
+    - changeLogPropertyDefined: { property: inc-local, value: inc-lv }
+    - changeLogPropertyDefined: { property: inc.inc-local, value: inc.inc-lv }
+  - changeSet:
+      id: 1
+      author: g
+      output: inc.loc-inc.yml > main-local:${main-local}, inc-local:${inc-local}, inc.inc-local:${inc.inc-local}
+  - changeSet:
+      id: test
+      author: g
+      preConditions:
+      - changeLogPropertyDefined: { property: main-local, value: main-lv }
+      - changeLogPropertyDefined: { property: inc-local,  value: inc-lv }
+      - changeLogPropertyDefined: { property: inc.inc-local, value: inc.inc-gv }
+      output: inc.loc-inc.yml > main-local:${main-local}, inc-local:${inc-local}, inc.inc-local:${inc.inc-local}

--- a/liquibase-standard/src/test/resources/properties/inc-loc.yml
+++ b/liquibase-standard/src/test/resources/properties/inc-loc.yml
@@ -1,0 +1,19 @@
+databaseChangeLog:
+ - property: { name: inc-local, value: inc-lv, global: false }
+ - preConditions:
+    - changeLogPropertyDefined: { property: main-local, value: main-lv }
+    - changeLogPropertyDefined: { property: inc-local, value: inc-lv }
+ - changeSet:
+     id: 1
+     author: g
+     output: inc.loc.yml > main-local:${main-local}, inc-local:${inc-local}
+ - include:
+    file: properties/inc-loc.inc.yml
+ - changeSet:
+    id: test
+    author: g
+    preConditions:
+     - changeLogPropertyDefined: { property: main-local, value: main-lv }
+     - changeLogPropertyDefined: { property: inc-local, value: inc-lv }
+     - not: [ changeLogPropertyDefined: { property: inc.inc-local } ]
+    output: inc.loc.yml > main-local:${main-local}, inc-local:${inc-local}

--- a/liquibase-standard/src/test/resources/properties/inc.inc.yml
+++ b/liquibase-standard/src/test/resources/properties/inc.inc.yml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - property: { name: inc.inc-global, value: inc.inc-gv }
+  - preConditions:
+    - changeLogPropertyDefined: { property: main-global, value: main-gv }
+    - changeLogPropertyDefined: { property: inc-global, value: inc-gv }
+    - changeLogPropertyDefined: { property: inc.inc-global, value: inc.inc-gv }
+  - changeSet:
+      id: 1
+      author: g
+      output: inc.inc.yml > main-global:${main-global}, inc-global:${inc-global}, inc.inc-global:${inc.inc-global}
+  - changeSet:
+      id: test
+      author: g
+      preConditions:
+      - changeLogPropertyDefined: { property: main-global, value: main-gv }
+      - changeLogPropertyDefined: { property: inc-global,  value: inc-gv }
+      - changeLogPropertyDefined: { property: inc.inc-global, value: inc.inc-gv }

--- a/liquibase-standard/src/test/resources/properties/inc.yml
+++ b/liquibase-standard/src/test/resources/properties/inc.yml
@@ -1,0 +1,19 @@
+databaseChangeLog:
+ - property: { name: inc-global, value: inc-gv }
+ - preConditions:
+   - changeLogPropertyDefined: { property: main-global, value: main-gv }
+   - changeLogPropertyDefined: { property: inc-global, value: inc-gv }
+ - changeSet:
+    id: before inc.inc.yml
+    author: g
+    output: inc.yml > main-global:${main-global}, inc-global:${inc-global}
+ - include:
+    file: properties/inc.inc.yml
+ - changeSet:
+    id: after inc.inc.yml
+    author: g
+    preConditions:
+     - changeLogPropertyDefined: { property: main-global, value: main-gv }
+     - changeLogPropertyDefined: { property: inc-global, value: inc-gv }
+     - changeLogPropertyDefined: { property: inc.inc-global, value: inc.inc-gv }
+    output: inc.yml > main-global:${main-global}, inc-global:${inc-global}, inc.inc-global:${inc.inc-global}

--- a/liquibase-standard/src/test/resources/properties/inc2-loc.yml
+++ b/liquibase-standard/src/test/resources/properties/inc2-loc.yml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - property: { name: inc2-local, value: inc2-lv, global: false }
+  - changeSet:
+      id: 1
+      author: g
+      output: inc2-loc.yml > main-local:${main-local}, inc2-local:${inc2-local}
+  - changeSet:
+      id: test
+      author: g
+      preConditions:
+      - changeLogPropertyDefined: { property: main-local, value: main-lv }
+      - changeLogPropertyDefined: { property: inc2-local, value: inc2-lv }
+      - not:
+        - changeLogPropertyDefined: { property: inc-local }
+        - changeLogPropertyDefined: { property: inc.inc-local }

--- a/liquibase-standard/src/test/resources/properties/inc2.yml
+++ b/liquibase-standard/src/test/resources/properties/inc2.yml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - property: { name: inc2-global, value: inc2-gv }
+  - changeSet:
+      id: 1
+      author: g
+      output: inc2.yml > main-global:${main-global}, inc-global:${inc-global},
+                      inc2-global:${inc2-global}, inc.inc-global:${inc.inc-global}
+  - changeSet:
+      id: test
+      author: g
+      preConditions:
+      - changeLogPropertyDefined: { property: main-global, value: main-gv }
+      - changeLogPropertyDefined: { property: inc-global, value: inc-gv }
+      - changeLogPropertyDefined: { property: inc2-global, value: inc2-gv }
+      - changeLogPropertyDefined: { property: inc.inc-global, value: inc.inc-gv }

--- a/liquibase-standard/src/test/resources/properties/local.yml
+++ b/liquibase-standard/src/test/resources/properties/local.yml
@@ -1,0 +1,16 @@
+databaseChangeLog:
+  - property: { name: main-local, value: main-lv, global: false }
+  - preConditions:
+    - changeLogPropertyDefined: { property: main-local, value: main-lv }
+#    - not: [ changeLogPropertyDefined: { property: inc-local } ]
+  - include: { file: properties/inc-loc.yml }
+  - include: { file: properties/inc2-loc.yml }
+  - changeSet:
+      id: test,
+      author: g
+      preConditions:
+      - changeLogPropertyDefined: { property: main-local, value: main-lv }
+      - not:
+        - changeLogPropertyDefined: { property: inc-local }
+        - changeLogPropertyDefined: { property: inc2-local }
+        - changeLogPropertyDefined: { property: inc.inc-local }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->
## Description
- Fixed #7345 NullPointerException when the checked property not found
- Fixed local property inheritance error: Not trying to 
- XSD updated to property name support all characters listed on the documentation site
- XSD changed to allow multiple `preConditions` on `databaseChangeLog`
- Removed unused attributes: `include@id`, `include@author`, `include@created`, `property@target`
 
<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
- Add unit/integration tests (ask for support if not sure how to do it)
- Make sure tests all pass
-->

## Things to be aware of
- The documentation does not have a single word about properties defined as `local`. In the PR #7032 local properties made visible in included changelogs also. So `local` property is accessible in the changelog it's defined and all included changelogs recursively. This might deserve a few sentences.
- There isn't any words about the visibility and lifecycle of the global properties either. One would think if a global property is defined in an included changelog, then that is not reachable in the root changelog. But that's not the case. e.g. `root.yml` includes `inc.yml` where property `inc-global` is defined. `inc-global` is accessible in `root.yml`.
- Property defined only in the included changelog is accessible in the root changelog even before the include. This should be also mentioned, because the XSD enforces `preConditions` placed before `include`s, which would logically imply sequential processing, that is not true.
- changelog formats other than (validated) XML allows multiple `preCondition`s. That could be helpfull in some cases like requested in #3116. The XSD has been updated to allow it, but `changeSet`s handle only the last instance now, that might be considered to change also see: #7428

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
