### PR TITLE
DAT-21398: fix(tests): update macOS version in test matrix to macos-15-intel

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -91,12 +91,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, macos-13, windows-latest ]
+        os: [ ubuntu-22.04, macos-15-intel, windows-latest ]
         java: [ 17, 21, 25 ]
         exclude:
           - os: windows-latest
             java: 17
-          - os: macos-13
+          - os: macos-15-intel
             java: 17
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
This pull request updates the test matrix in the GitHub Actions workflow to use a newer macOS version and ensures exclusions are consistent with the new configuration.

Test matrix updates: https://github.com/actions/runner-images/issues/13046

* Changed the macOS runner from `macos-13` to `macos-15-intel` in the test matrix for broader compatibility and up-to-date testing.
* Updated the matrix exclusion to match the new macOS version, excluding `macos-15-intel` with Java 17 instead of `macos-13` with Java 17.