### PR TITLE
Fix #7385: Fix PostgreSQL rollback with quoted numeric schema names

### DIFF
--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/AbstractIntegrationTest.java
@@ -17,6 +17,7 @@ import liquibase.command.core.helpers.DbUrlConnectionArgumentsCommandStep;
 import liquibase.database.Database;
 import liquibase.database.DatabaseConnection;
 import liquibase.database.DatabaseFactory;
+import liquibase.database.ObjectQuotingStrategy;
 import liquibase.database.core.*;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.datatype.DataTypeFactory;
@@ -103,6 +104,7 @@ public abstract class AbstractIntegrationTest {
     private final String indexWithAssociatedWithChangeLog;
     private Database database;
     private String defaultSchemaName;
+    private ObjectQuotingStrategy objectQuotingStrategy;
 
     private final String pathChangeLog;
 
@@ -158,6 +160,11 @@ public abstract class AbstractIntegrationTest {
         // If we should test with a custom defaultSchemaName:
         if (getDefaultSchemaName() != null && getDefaultSchemaName().length() > 0) {
             database.setDefaultSchemaName(getDefaultSchemaName());
+        }
+
+        // If we should test with a custom QUOTING STRATEGY
+        if(getObjectQuotingStrategy() != null) {
+            database.setObjectQuotingStrategy(getObjectQuotingStrategy());
         }
 
         SnapshotGeneratorFactory.resetAll();
@@ -1201,6 +1208,14 @@ public abstract class AbstractIntegrationTest {
 
     public void setDefaultSchemaName(String defaultSchemaName) {
         this.defaultSchemaName = defaultSchemaName;
+    }
+
+    protected ObjectQuotingStrategy getObjectQuotingStrategy() {
+        return objectQuotingStrategy;
+    }
+
+    protected void setObjectQuotingStrategy(ObjectQuotingStrategy objectQuotingStrategy) {
+       this.objectQuotingStrategy = objectQuotingStrategy;
     }
 
     @Test

--- a/liquibase-integration-tests/src/test/resources/changelogs/pgsql/rollback/rollback-create-numeric-schema.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/pgsql/rollback/rollback-create-numeric-schema.xml
@@ -1,0 +1,12 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+          http://www.liquibase.org/xml/ns/dbchangelog
+          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.27.xsd">
+
+    <changeSet id="1" author="rohan">
+        <sql>CREATE SCHEMA "4b5d63f449304c05a291c4c27136ebb5"</sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/liquibase-integration-tests/src/test/resources/changelogs/pgsql/rollback/rollback-escape.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/pgsql/rollback/rollback-escape.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <preConditions>
+        <dbms type="postgresql"/>
+    </preConditions>
+
+    <changeSet id="22" author="rohan">
+        <createTable tableName="small_table">
+            <column name="id" type="int"/>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/liquibase-standard/src/main/java/liquibase/database/core/PostgresDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/PostgresDatabase.java
@@ -416,7 +416,7 @@ public class PostgresDatabase extends AbstractJdbcDatabase {
         // SET SEARCH_PATH SQL statements
         final Executor executor = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", this);
         if(executor.updatesDatabase()) {
-            DatabaseUtils.initializeDatabase(getDefaultCatalogName(), getDefaultSchemaName(), this);
+            DatabaseUtils.initializeDatabase(this.escapeObjectName(getDefaultCatalogName(), Catalog.class), this.escapeObjectName(getDefaultSchemaName(), Schema.class), this);
         }
     }
 

--- a/liquibase-standard/src/test/java/liquibase/database/core/PostgresDatabaseTest.java
+++ b/liquibase-standard/src/test/java/liquibase/database/core/PostgresDatabaseTest.java
@@ -7,6 +7,7 @@ import liquibase.database.Database;
 import liquibase.database.ObjectQuotingStrategy;
 import liquibase.exception.DatabaseException;
 import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.Schema;
 import liquibase.structure.core.Table;
 import liquibase.structure.core.View;
 import liquibase.util.StringUtil;
@@ -158,6 +159,23 @@ public class PostgresDatabaseTest extends AbstractJdbcDatabaseTest {
         final String expectedPrimaryKeyName = "name_" + StringUtil.repeat("\u03A9", 15) + "_pkey";
 
         assertPrimaryKeyName(expectedPrimaryKeyName, this.database.generatePrimaryKeyName(nameWith15NonAsciiSymbols));
+    }
+
+    @Test
+    void rollbackUsesEscapedSchemaName() {
+        PostgresDatabase database = new PostgresDatabase();
+        database.setObjectQuotingStrategy(ObjectQuotingStrategy.QUOTE_ALL_OBJECTS);
+        database.setDefaultSchemaName("4b5d63f449304c05a291c4c27136ebb5");
+
+        String escaped = database.escapeObjectName(
+                database.getDefaultSchemaName(),
+                Schema.class
+        );
+
+        assertEquals(
+                "\"4b5d63f449304c05a291c4c27136ebb5\"",
+                escaped
+        );
     }
 
 //    @Test


### PR DESCRIPTION
Fix #7385:  Fix PostgreSQL rollback with quoted numeric schema names and regression tests

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

Fixes #7385
Rollback fails on PostgreSQL when the default schema name starts with a digit and object quoting is enabled.
This occurs because PostgresDatabase.rollback() restores the search path using an unescaped schema name, which causes PostgreSQL to interpret the schema identifier as a numeric literal.

This change ensures that PostgreSQL rollback correctly escapes the default catalog and schema names when re-initializing the database after a rollback, preventing syntax errors for numeric or otherwise unsafe schema names.

## Things to be aware of

The fix is isolated to PostgreSQL rollback behavior and only affects cases where object quoting is enabled.

## Things to worry about

No known risks; existing escape methods are used in this change.
PostgreSQL integration tests are opt-in and require running with -Dliquibase.sdk.testSystem.test=postgresql.

## Additional Context

Regression coverage includes unit tests for escaped schema handling and an integration test validating rollback behavior with a numeric schema on PostgreSQL.
This issue was reproducible when using ObjectQuotingStrategy.QUOTE_ALL_OBJECTS with schemas starting with a digit.
isDatabaseChangeLogLockTableCreated -> expected SQLException -> rollback triggerred -> fails on Database Initializion
