### PR TITLE
feat: Upgrade Ubuntu version in CI workflow to 24.04

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -48,7 +48,7 @@ jobs:
   setup:
     name: setup
     needs: [authorize]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       timestamp: ${{ steps.get-date.outputs.date }}
       latestMergeSha: ${{ steps.get-sha.outputs.latestMergeSha }}
@@ -91,7 +91,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, macos-15-intel, windows-latest ]
+        os: [ ubuntu-24.04, macos-15-intel, windows-latest ]
         java: [ 17, 21, 25 ]
         exclude:
           - os: windows-latest
@@ -160,7 +160,7 @@ jobs:
           find . -name original-*.jar -exec rm {} \;
 
       - name: Upload Artifacts for build.yml
-        if: ${{ matrix.java == 17 && matrix.os == 'ubuntu-22.04'}}
+        if: ${{ matrix.java == 17 && matrix.os == 'ubuntu-24.04'}}
         uses: actions/upload-artifact@v6
         with:
           name: temp-artifact
@@ -177,7 +177,7 @@ jobs:
             ./**/target/site
 
       - name: Save Jacoco Report for Sonar
-        if: ${{ matrix.java == 17 && matrix.os == 'ubuntu-22.04'}}
+        if: ${{ matrix.java == 17 && matrix.os == 'ubuntu-24.04'}}
         uses: actions/upload-artifact@v6
         with:
           name: liquibase-jacoco-test-results
@@ -185,7 +185,7 @@ jobs:
             ./liquibase-standard/target/jacoco.exec
 
       - name: Archive Modules
-        if: ${{ matrix.java == 17 && matrix.os == 'ubuntu-22.04'}}
+        if: ${{ matrix.java == 17 && matrix.os == 'ubuntu-24.04'}}
         uses: actions/upload-artifact@v6
         with:
           name: liquibase-modules
@@ -204,7 +204,7 @@ jobs:
 
   integration-test:
     name: Integration Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use Ubuntu 24.04 instead of Ubuntu 22.04 in all relevant jobs and matrix configurations. This ensures that CI jobs run on a more up-to-date OS environment.

**CI Environment Updates:**

* Changed the `runs-on` property for the `setup` and `integration-test` jobs from `ubuntu-22.04` to `ubuntu-24.04` in `.github/workflows/run-tests.yml`. [[1]](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L51-R51) [[2]](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L207-R207)
* Updated the OS matrix in the test job to replace `ubuntu-22.04` with `ubuntu-24.04`.
* Updated conditional artifact upload steps to check for `ubuntu-24.04` instead of `ubuntu-22.04`. [[1]](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L163-R163) [[2]](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L180-R188)