### PR TITLE
Extract checksum compatibility logic in StandardChangeLogHistoryService

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
@@ -250,7 +250,7 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
             }
 
             //check if any checksum is not using the current version
-            databaseChecksumsCompatible = getNotCompatibleDatabaseChangeLog().isEmpty();
+            databaseChecksumsCompatible = getIncompatibleDatabaseChangeLogs().isEmpty();
 
         } else if (!changeLogCreateAttempted) {
             executor.comment("Create Database Change Log Table");
@@ -510,7 +510,15 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
         return CONTEXTS_SIZE;
     }
 
-    public List<Map<String, ?>> getNotCompatibleDatabaseChangeLog() throws DatabaseException {
+    /**
+     * Retrieves changelog entries with checksums that are not compatible with the latest checksum version.
+     * This method can be overridden by database-specific implementations to provide custom queries for databases that
+     * don't support standard SQL constructs (e.g., Cassandra CQL).
+     *
+     * @return a list of maps containing MD5SUM values for incompatible changelog entries
+     * @throws DatabaseException if there is an error querying the database
+     */
+    public List<Map<String, ?>> getIncompatibleDatabaseChangeLogs() throws DatabaseException {
         SqlStatement databaseChangeLogStatement = new SelectFromDatabaseChangeLogStatement(
                 new SelectFromDatabaseChangeLogStatement.ByCheckSumNotNullAndNotLike(
                         ChecksumVersion.latest().getVersion()


### PR DESCRIPTION
## Impact
Enhancement
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description
This is a simple refactoring extracting the query retrieving the incompatible changelogs in an overridable method.
Doing this is a prerequisite to solve this issue in `liquibase-cassandra` module: https://github.com/liquibase/liquibase-cassandra/issues/375.

Indeed, the query executed here is not compatible with Cassandra-CQL (not supporting neither `NOT NULL` nor `!=` operators). So, making this query easily overridable in the `liquibase-cassandra`, we will be able to write a method compatible with Cassandra databases providing the expected results.

## Things to be aware of
N/A

## Things to worry about
N∕A

## Additional Context
See the analysis provided here: https://github.com/liquibase/liquibase-cassandra/issues/375#issuecomment-3477924353
