### PR TITLE
Fix snapshot performance issue when using tableExists, viewExists, and indexExists preconditions

### DIFF
--- a/liquibase-integration-tests/src/test/groovy/liquibase/DB2Test.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/DB2Test.groovy
@@ -1,0 +1,39 @@
+package liquibase
+
+
+import liquibase.command.CommandScope
+import liquibase.command.core.UpdateCommandStep
+import liquibase.command.core.UpdateCountCommandStep
+import liquibase.command.core.helpers.DbUrlConnectionArgumentsCommandStep
+import liquibase.extension.testing.testsystem.DatabaseTestSystem
+import liquibase.extension.testing.testsystem.TestSystemFactory
+import liquibase.extension.testing.testsystem.spock.LiquibaseIntegrationTest
+import liquibase.resource.SearchPathResourceAccessor
+import spock.lang.Shared
+import spock.lang.Specification
+
+@LiquibaseIntegrationTest
+class DB2Test extends Specification {
+
+    @Shared
+    private DatabaseTestSystem db2 = Scope.getCurrentScope().getSingleton(TestSystemFactory).getTestSystem("db2") as DatabaseTestSystem
+
+    def "verify tableExists, viewExists, and indexExists preconditions work efficiently on DB2"() {
+        when:
+        def changeLogFile = "changelogs/db2/preconditions-test.xml"
+        def scopeSettings = [
+                (Scope.Attr.resourceAccessor.name()): new SearchPathResourceAccessor(".,target/test-classes")
+        ]
+        Scope.child(scopeSettings, {
+            CommandScope commandScope = new CommandScope(UpdateCommandStep.COMMAND_NAME)
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.URL_ARG, db2.getConnectionUrl())
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.USERNAME_ARG, db2.getUsername())
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.PASSWORD_ARG, db2.getPassword())
+            commandScope.addArgumentValue(UpdateCountCommandStep.CHANGELOG_FILE_ARG, changeLogFile)
+            commandScope.execute()
+        } as Scope.ScopedRunnerWithReturn<Void>)
+
+        then:
+        noExceptionThrown()
+    }
+}

--- a/liquibase-integration-tests/src/test/groovy/liquibase/DB2Test.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/DB2Test.groovy
@@ -11,6 +11,7 @@ import liquibase.extension.testing.testsystem.spock.LiquibaseIntegrationTest
 import liquibase.resource.SearchPathResourceAccessor
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
 
 @LiquibaseIntegrationTest
 class DB2Test extends Specification {
@@ -18,12 +19,30 @@ class DB2Test extends Specification {
     @Shared
     private DatabaseTestSystem db2 = Scope.getCurrentScope().getSingleton(TestSystemFactory).getTestSystem("db2") as DatabaseTestSystem
 
+    /**
+     * Performance timeout threshold in seconds.
+     * Issue #6660 reported precondition checks taking "many minutes" with ~30 views and numerous indexes.
+     * Our test uses a simple changelog (1 table, 1 view, 1 index) on an empty database.
+     * With the optimization using hasIgnoreNested(), execution should complete in seconds.
+     * We set a 60-second timeout to account for:
+     * - CI environment variability and system load
+     * - Remote DB2 instance network latency
+     * - Database container startup overhead
+     * This is generous enough for reliable CI execution while still catching major regressions.
+     * Even if the optimization broke, this simple test wouldn't take "many minutes", but any
+     * execution exceeding 60 seconds would indicate a performance problem.
+     */
+    private static final int PERFORMANCE_TIMEOUT_SECONDS = 60
+
     def "verify tableExists, viewExists, and indexExists preconditions work efficiently on DB2"() {
-        when:
+        given:
         def changeLogFile = "changelogs/db2/preconditions-test.xml"
         def scopeSettings = [
                 (Scope.Attr.resourceAccessor.name()): new SearchPathResourceAccessor(".,target/test-classes")
         ]
+
+        when:
+        def startTime = System.currentTimeMillis()
         Scope.child(scopeSettings, {
             CommandScope commandScope = new CommandScope(UpdateCommandStep.COMMAND_NAME)
             commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.URL_ARG, db2.getConnectionUrl())
@@ -32,8 +51,16 @@ class DB2Test extends Specification {
             commandScope.addArgumentValue(UpdateCountCommandStep.CHANGELOG_FILE_ARG, changeLogFile)
             commandScope.execute()
         } as Scope.ScopedRunnerWithReturn<Void>)
+        def endTime = System.currentTimeMillis()
+        def executionTimeSeconds = (endTime - startTime) / 1000.0
 
         then:
         noExceptionThrown()
+
+        and: "precondition checks complete within performance threshold"
+        executionTimeSeconds < PERFORMANCE_TIMEOUT_SECONDS
+
+        and: "log execution time for monitoring"
+        println "DB2 precondition test completed in ${executionTimeSeconds} seconds (threshold: ${PERFORMANCE_TIMEOUT_SECONDS}s)"
     }
 }

--- a/liquibase-integration-tests/src/test/groovy/liquibase/DB2Test.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/DB2Test.groovy
@@ -34,7 +34,7 @@ class DB2Test extends Specification {
      */
     private static final int PERFORMANCE_TIMEOUT_SECONDS = 60
 
-    def "verify tableExists, viewExists, and indexExists preconditions work efficiently on DB2"() {
+    def "verify all database object preconditions work efficiently on DB2"() {
         given:
         def changeLogFile = "changelogs/db2/preconditions-test.xml"
         def scopeSettings = [

--- a/liquibase-integration-tests/src/test/resources/changelogs/db2/preconditions-test.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/db2/preconditions-test.xml
@@ -108,4 +108,66 @@
         </sql>
     </changeSet>
 
+    <!-- Create a test sequence -->
+    <changeSet author="liquibase" id="db2-precondition-test-10">
+        <createSequence sequenceName="TEST_SEQUENCE_PRECOND" startValue="1" incrementBy="1"/>
+    </changeSet>
+
+    <!-- Test sequenceExists precondition - should pass -->
+    <changeSet author="liquibase" id="db2-precondition-test-11">
+        <preConditions onFail="HALT">
+            <sequenceExists sequenceName="TEST_SEQUENCE_PRECOND"/>
+        </preConditions>
+        <comment>Verify sequenceExists precondition works with DB2 optimization</comment>
+        <sql>
+            -- This changeset should execute because the sequence exists
+            INSERT INTO TEST_TABLE_PRECOND (ID, NAME) VALUES (7, 'Test Data 7')
+        </sql>
+    </changeSet>
+
+    <!-- Test negative case: sequenceExists should fail for non-existent sequence -->
+    <changeSet author="liquibase" id="db2-precondition-test-12">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <sequenceExists sequenceName="NON_EXISTENT_SEQUENCE"/>
+            </not>
+        </preConditions>
+        <comment>Verify sequenceExists precondition correctly identifies non-existent sequence</comment>
+        <sql>
+            -- This changeset should execute because the sequence does NOT exist
+            INSERT INTO TEST_TABLE_PRECOND (ID, NAME) VALUES (8, 'Test Data 8')
+        </sql>
+    </changeSet>
+
+    <!-- Add a unique constraint to the table -->
+    <changeSet author="liquibase" id="db2-precondition-test-13">
+        <addUniqueConstraint tableName="TEST_TABLE_PRECOND" columnNames="NAME" constraintName="UQ_TEST_PRECOND_NAME"/>
+    </changeSet>
+
+    <!-- Test uniqueConstraintExists precondition - should pass -->
+    <changeSet author="liquibase" id="db2-precondition-test-14">
+        <preConditions onFail="HALT">
+            <uniqueConstraintExists tableName="TEST_TABLE_PRECOND" constraintName="UQ_TEST_PRECOND_NAME"/>
+        </preConditions>
+        <comment>Verify uniqueConstraintExists precondition works with DB2 optimization</comment>
+        <sql>
+            -- This changeset should execute because the unique constraint exists
+            INSERT INTO TEST_TABLE_PRECOND (ID, NAME) VALUES (9, 'Test Data 9')
+        </sql>
+    </changeSet>
+
+    <!-- Test negative case: uniqueConstraintExists should fail for non-existent constraint -->
+    <changeSet author="liquibase" id="db2-precondition-test-15">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <uniqueConstraintExists tableName="TEST_TABLE_PRECOND" constraintName="NON_EXISTENT_CONSTRAINT"/>
+            </not>
+        </preConditions>
+        <comment>Verify uniqueConstraintExists precondition correctly identifies non-existent constraint</comment>
+        <sql>
+            -- This changeset should execute because the constraint does NOT exist
+            INSERT INTO TEST_TABLE_PRECOND (ID, NAME) VALUES (10, 'Test Data 10')
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>

--- a/liquibase-integration-tests/src/test/resources/changelogs/db2/preconditions-test.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/db2/preconditions-test.xml
@@ -1,0 +1,111 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+                   http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!-- Create a test table -->
+    <changeSet author="liquibase" id="db2-precondition-test-1">
+        <createTable tableName="TEST_TABLE_PRECOND">
+            <column name="ID" type="INT">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="NAME" type="VARCHAR(100)"/>
+        </createTable>
+    </changeSet>
+
+    <!-- Create a test view -->
+    <changeSet author="liquibase" id="db2-precondition-test-2">
+        <createView viewName="TEST_VIEW_PRECOND">
+            SELECT ID, NAME FROM TEST_TABLE_PRECOND
+        </createView>
+    </changeSet>
+
+    <!-- Create an index on the table -->
+    <changeSet author="liquibase" id="db2-precondition-test-3">
+        <createIndex indexName="IDX_TEST_PRECOND" tableName="TEST_TABLE_PRECOND">
+            <column name="NAME"/>
+        </createIndex>
+    </changeSet>
+
+    <!-- Test tableExists precondition - should pass -->
+    <changeSet author="liquibase" id="db2-precondition-test-4">
+        <preConditions onFail="HALT">
+            <tableExists tableName="TEST_TABLE_PRECOND"/>
+        </preConditions>
+        <comment>Verify tableExists precondition works with DB2 optimization</comment>
+        <sql>
+            -- This changeset should execute because the table exists
+            INSERT INTO TEST_TABLE_PRECOND (ID, NAME) VALUES (1, 'Test Data')
+        </sql>
+    </changeSet>
+
+    <!-- Test viewExists precondition - should pass -->
+    <changeSet author="liquibase" id="db2-precondition-test-5">
+        <preConditions onFail="HALT">
+            <viewExists viewName="TEST_VIEW_PRECOND"/>
+        </preConditions>
+        <comment>Verify viewExists precondition works with DB2 optimization</comment>
+        <sql>
+            -- This changeset should execute because the view exists
+            INSERT INTO TEST_TABLE_PRECOND (ID, NAME) VALUES (2, 'Test Data 2')
+        </sql>
+    </changeSet>
+
+    <!-- Test indexExists precondition - should pass -->
+    <changeSet author="liquibase" id="db2-precondition-test-6">
+        <preConditions onFail="HALT">
+            <indexExists indexName="IDX_TEST_PRECOND"/>
+        </preConditions>
+        <comment>Verify indexExists precondition works with DB2 optimization</comment>
+        <sql>
+            -- This changeset should execute because the index exists
+            INSERT INTO TEST_TABLE_PRECOND (ID, NAME) VALUES (3, 'Test Data 3')
+        </sql>
+    </changeSet>
+
+    <!-- Test negative case: tableExists should fail for non-existent table -->
+    <changeSet author="liquibase" id="db2-precondition-test-7">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="NON_EXISTENT_TABLE"/>
+            </not>
+        </preConditions>
+        <comment>Verify tableExists precondition correctly identifies non-existent table</comment>
+        <sql>
+            -- This changeset should execute because the table does NOT exist
+            INSERT INTO TEST_TABLE_PRECOND (ID, NAME) VALUES (4, 'Test Data 4')
+        </sql>
+    </changeSet>
+
+    <!-- Test negative case: viewExists should fail for non-existent view -->
+    <changeSet author="liquibase" id="db2-precondition-test-8">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <viewExists viewName="NON_EXISTENT_VIEW"/>
+            </not>
+        </preConditions>
+        <comment>Verify viewExists precondition correctly identifies non-existent view</comment>
+        <sql>
+            -- This changeset should execute because the view does NOT exist
+            INSERT INTO TEST_TABLE_PRECOND (ID, NAME) VALUES (5, 'Test Data 5')
+        </sql>
+    </changeSet>
+
+    <!-- Test negative case: indexExists should fail for non-existent index -->
+    <changeSet author="liquibase" id="db2-precondition-test-9">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="NON_EXISTENT_INDEX"/>
+            </not>
+        </preConditions>
+        <comment>Verify indexExists precondition correctly identifies non-existent index</comment>
+        <sql>
+            -- This changeset should execute because the index does NOT exist
+            INSERT INTO TEST_TABLE_PRECOND (ID, NAME) VALUES (6, 'Test Data 6')
+        </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/liquibase-standard/src/main/java/liquibase/database/Database.java
+++ b/liquibase-standard/src/main/java/liquibase/database/Database.java
@@ -679,6 +679,16 @@ public interface Database extends PrioritizedService, AutoCloseable {
     }
 
     /**
+     * Does the database support efficient precondition existence checks using hasIgnoreNested()?
+     * Some databases (Derby, H2, Oracle) require full nested object searches to correctly identify
+     * tables and views, while others (DB2) can efficiently check existence without nested searches.
+     * @return true if the database supports efficient existence checks, false otherwise (default)
+     */
+    default boolean supportsEfficientPreconditionChecks() {
+        return false;
+    }
+
+    /**
      * Some databases (such as MongoDB) require you to verify the connection to the database
      * to ensure that the database is accessible.
      * It can be "ping" signal to the database

--- a/liquibase-standard/src/main/java/liquibase/database/core/AbstractDb2Database.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/AbstractDb2Database.java
@@ -70,6 +70,11 @@ public abstract class AbstractDb2Database extends AbstractJdbcDatabase {
     }
 
     @Override
+    public boolean supportsEfficientPreconditionChecks() {
+        return true;
+    }
+
+    @Override
     protected String getDefaultDatabaseProductName() {
         return "DB2";
     }

--- a/liquibase-standard/src/main/java/liquibase/precondition/core/SequenceExistsPrecondition.java
+++ b/liquibase-standard/src/main/java/liquibase/precondition/core/SequenceExistsPrecondition.java
@@ -66,7 +66,16 @@ public class SequenceExistsPrecondition extends AbstractPrecondition {
                 checkPostgresSequence(database, changeLog);
             } else {
                 Schema schema = new Schema(getCatalogName(), getSchemaName());
-                if (!SnapshotGeneratorFactory.getInstance().has(new Sequence().setName(getSequenceName()).setSchema(schema), database)) {
+                Sequence sequence = new Sequence().setName(getSequenceName()).setSchema(schema);
+                boolean sequenceExists;
+
+                if (database.supportsEfficientPreconditionChecks()) {
+                    sequenceExists = SnapshotGeneratorFactory.getInstance().hasIgnoreNested(sequence, database);
+                } else {
+                    sequenceExists = SnapshotGeneratorFactory.getInstance().has(sequence, database);
+                }
+
+                if (!sequenceExists) {
                     throw new PreconditionFailedException("Sequence " + database.escapeSequenceName(getCatalogName(), getSchemaName(), getSequenceName()) + " does not exist", changeLog, this);
                 }
             }

--- a/liquibase-standard/src/main/java/liquibase/precondition/core/TableExistsPrecondition.java
+++ b/liquibase-standard/src/main/java/liquibase/precondition/core/TableExistsPrecondition.java
@@ -56,7 +56,16 @@ public class TableExistsPrecondition extends AbstractPrecondition {
             throws PreconditionFailedException, PreconditionErrorException {
     	try {
             String correctedTableName = database.correctObjectName(getTableName(), Table.class);
-            if (!SnapshotGeneratorFactory.getInstance().has(new Table().setName(correctedTableName).setSchema(new Schema(getCatalogName(), getSchemaName())), database)) {
+            Table exampleTable = (Table) new Table().setName(correctedTableName).setSchema(new Schema(getCatalogName(), getSchemaName()));
+            boolean tableExists;
+
+            if (database.supportsEfficientPreconditionChecks()) {
+                tableExists = SnapshotGeneratorFactory.getInstance().hasIgnoreNested(exampleTable, database);
+            } else {
+                tableExists = SnapshotGeneratorFactory.getInstance().has(exampleTable, database);
+            }
+
+            if (!tableExists) {
                 throw new PreconditionFailedException("Table "+database.escapeTableName(getCatalogName(), getSchemaName(), getTableName())+" does not exist", changeLog, this);
             }
         } catch (PreconditionFailedException e) {

--- a/liquibase-standard/src/main/java/liquibase/precondition/core/UniqueConstraintExistsPrecondition.java
+++ b/liquibase-standard/src/main/java/liquibase/precondition/core/UniqueConstraintExistsPrecondition.java
@@ -111,7 +111,15 @@ public class UniqueConstraintExistsPrecondition extends AbstractPrecondition {
 		}
 
 		try {
-			if (!SnapshotGeneratorFactory.getInstance().has(example, database)) {
+			boolean constraintExists;
+
+			if (database.supportsEfficientPreconditionChecks()) {
+				constraintExists = SnapshotGeneratorFactory.getInstance().hasIgnoreNested(example, database);
+			} else {
+				constraintExists = SnapshotGeneratorFactory.getInstance().has(example, database);
+			}
+
+			if (!constraintExists) {
 				throw new PreconditionFailedException(String.format("%s does not exist", example), changeLog, this);
 			}
 		} catch (DatabaseException | InvalidExampleException e) {

--- a/liquibase-standard/src/main/java/liquibase/precondition/core/ViewExistsPrecondition.java
+++ b/liquibase-standard/src/main/java/liquibase/precondition/core/ViewExistsPrecondition.java
@@ -60,7 +60,16 @@ public class ViewExistsPrecondition extends AbstractPrecondition {
     	try {
             currentCatalogName = getCatalogName();
             currentSchemaName = getSchemaName();
-            if (!SnapshotGeneratorFactory.getInstance().has(new View().setName(database.correctObjectName(getViewName(), View.class)).setSchema(new Schema(currentCatalogName, currentSchemaName)), database)) {
+            View exampleView = (View) new View().setName(database.correctObjectName(getViewName(), View.class)).setSchema(new Schema(currentCatalogName, currentSchemaName));
+            boolean viewExists;
+
+            if (database.supportsEfficientPreconditionChecks()) {
+                viewExists = SnapshotGeneratorFactory.getInstance().hasIgnoreNested(exampleView, database);
+            } else {
+                viewExists = SnapshotGeneratorFactory.getInstance().has(exampleView, database);
+            }
+
+            if (!viewExists) {
                 throw new PreconditionFailedException("View "+database.escapeTableName(currentCatalogName, currentSchemaName, getViewName())+" does not exist", changeLog, this);
             }
         } catch (PreconditionFailedException e) {

--- a/liquibase-standard/src/test/java/liquibase/database/core/DB2DatabaseTest.java
+++ b/liquibase-standard/src/test/java/liquibase/database/core/DB2DatabaseTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DB2DatabaseTest {
 
@@ -24,5 +25,12 @@ public class DB2DatabaseTest {
     public void testMaxFractionDigits() {
         Database database = new DB2Database();
         assertEquals(12, database.getMaxFractionalDigitsForTimestamp());
+    }
+
+    @Test
+    public void testSupportsEfficientPreconditionChecks() {
+        Database database = new DB2Database();
+        assertTrue(database.supportsEfficientPreconditionChecks(),
+                "DB2 should support efficient precondition checks to avoid performance issues with snapshots");
     }
 }

--- a/liquibase-standard/src/test/java/liquibase/database/core/DB2zDatabaseTest.java
+++ b/liquibase-standard/src/test/java/liquibase/database/core/DB2zDatabaseTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DB2zDatabaseTest {
 
@@ -24,5 +25,12 @@ public class DB2zDatabaseTest {
     public void testMaxFractionDigits() {
         Database database = new Db2zDatabase();
         assertEquals(12, database.getMaxFractionalDigitsForTimestamp());
+    }
+
+    @Test
+    public void testSupportsEfficientPreconditionChecks() {
+        Database database = new Db2zDatabase();
+        assertTrue(database.supportsEfficientPreconditionChecks(),
+                "DB2z should support efficient precondition checks to avoid performance issues with snapshots");
     }
 }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

A significant performance problem with DB2 databases when using tableExists, viewExists, and indexExists preconditions has been fixed. Each precondition check was triggering a full database snapshot with nested object searches, causing wait times of several minutes for users with ~30 views and numerous indexes—operations that could complete in under one second with direct SQL queries. The reason of this performance degradation was that some of mentioned preconditions were still using `SnapshotGeneratorFactory.has()` which creates full snapshots with `searchNestedObjects=true`.

Solution made was following a database-specific approach, for this:

- We added `supportsEfficientPreconditionChecks()` to Database interface (default: false to avoid making this a breaking change)
- Enabled optimization for all DB2 databases.
- Modified `TableExistsPrecondition` and `ViewExistsPrecondition` to use `hasIgnoreNested()` for those DBs that support efficient checks, and keep using `has()` for the ones that do not support it.

Fixes #6660 

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
- Add unit/integration tests (ask for support if not sure how to do it)
- Make sure tests all pass
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
