### PR TITLE
SEARCH_PATH setup as LOCAL for Postgres

### DIFF
--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/SearchPathIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/SearchPathIntegrationTest.groovy
@@ -130,9 +130,7 @@ class SearchPathIntegrationTest extends Specification {
         // The search_path should have reverted to the original value
         // This proves that SET LOCAL was used instead of persistent SET
         // (If persistent SET was used, the customSchema would still be in search_path)
-        currentSearchPath == originalSearchPath ||
-            currentSearchPath.startsWith("\"\$user\"") ||
-            currentSearchPath.startsWith("\"$postgres.username\"")
+        currentSearchPath == originalSearchPath
 
         // customSchema should NOT be in current path - this proves SET LOCAL worked
         !currentSearchPath.contains(customSchema)

--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/SearchPathIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/SearchPathIntegrationTest.groovy
@@ -1,0 +1,145 @@
+package liquibase.command
+
+import liquibase.Scope
+import liquibase.command.core.UpdateCommandStep
+import liquibase.command.core.helpers.DbUrlConnectionArgumentsCommandStep
+import liquibase.executor.ExecutorService
+import liquibase.extension.testing.testsystem.DatabaseTestSystem
+import liquibase.extension.testing.testsystem.TestSystemFactory
+import liquibase.extension.testing.testsystem.spock.LiquibaseIntegrationTest
+import liquibase.resource.SearchPathResourceAccessor
+import liquibase.statement.core.RawParameterizedSqlStatement
+import spock.lang.Shared
+import spock.lang.Specification
+
+@LiquibaseIntegrationTest
+class SearchPathIntegrationTest extends Specification {
+
+    @Shared
+    private DatabaseTestSystem postgres = (DatabaseTestSystem) Scope.getCurrentScope()
+            .getSingleton(TestSystemFactory.class)
+            .getTestSystem("postgresql")
+
+    def "update command works with custom defaultSchemaName for PostgreSQL"() {
+        given:
+        def customSchema = "test_schema_" + System.currentTimeMillis()
+        def database = postgres.getDatabaseFromFactory()
+        def connection = database.getConnection()
+        def statement = connection.createStatement()
+        statement.execute("CREATE SCHEMA IF NOT EXISTS " + customSchema)
+        connection.commit()
+
+        when:
+        def resourceAccessor = new SearchPathResourceAccessor(".,target/test-classes")
+        def scopeSettings = [
+                (Scope.Attr.resourceAccessor.name()): resourceAccessor
+        ]
+        Scope.child(scopeSettings, {
+            CommandScope commandScope = new CommandScope(UpdateCommandStep.COMMAND_NAME)
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.URL_ARG, postgres.getConnectionUrl())
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.USERNAME_ARG, postgres.getUsername())
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.PASSWORD_ARG, postgres.getPassword())
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.DEFAULT_SCHEMA_NAME_ARG, customSchema)
+            commandScope.addArgumentValue(UpdateCommandStep.CHANGELOG_FILE_ARG, "changelogs/pgsql/complete/simple.changelog.xml")
+            commandScope.execute()
+        } as Scope.ScopedRunner)
+
+        then:
+        noExceptionThrown()
+
+        // Verify that tables were created in the custom schema
+        def rs = connection.createStatement().executeQuery(
+            "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = '${customSchema}' AND table_name = 'databasechangelog'"
+        )
+        rs.next()
+        rs.getInt(1) == 1
+
+        cleanup:
+        try {
+            connection.createStatement().execute("DROP SCHEMA IF EXISTS " + customSchema + " CASCADE")
+        } catch (Exception e) {}
+    }
+
+    def "procedure creation works with custom schema for PostgreSQL"() {
+        given:
+        def customSchema = "proc_schema_" + System.currentTimeMillis()
+        def database = postgres.getDatabaseFromFactory()
+        def connection = database.getConnection()
+        def statement = connection.createStatement()
+        statement.execute("CREATE SCHEMA IF NOT EXISTS " + customSchema)
+        connection.commit()
+
+        when:
+        def resourceAccessor = new SearchPathResourceAccessor(".,target/test-classes")
+        def scopeSettings = [
+                (Scope.Attr.resourceAccessor.name()): resourceAccessor
+        ]
+        Scope.child(scopeSettings, {
+            CommandScope commandScope = new CommandScope(UpdateCommandStep.COMMAND_NAME)
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.URL_ARG, postgres.getConnectionUrl())
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.USERNAME_ARG, postgres.getUsername())
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.PASSWORD_ARG, postgres.getPassword())
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.DEFAULT_SCHEMA_NAME_ARG, customSchema)
+            commandScope.addArgumentValue(UpdateCommandStep.CHANGELOG_FILE_ARG, "changelogs/pgsql/update/createProcedureReplaceIfExists.xml")
+            commandScope.execute()
+        } as Scope.ScopedRunner)
+
+        then:
+        noExceptionThrown()
+
+        cleanup:
+        try {
+            connection.createStatement().execute("DROP SCHEMA IF EXISTS " + customSchema + " CASCADE")
+        } catch (Exception e) {}
+    }
+
+    def "SET LOCAL search_path reverts after transaction completes"() {
+        given:
+        def customSchema = "local_test_" + System.currentTimeMillis()
+        def database = postgres.getDatabaseFromFactory()
+        def connection = database.getConnection()
+        def statement = connection.createStatement()
+        statement.execute("CREATE SCHEMA IF NOT EXISTS " + customSchema)
+        connection.commit()
+
+        // Get the original search_path before any Liquibase operations
+        def executor = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database)
+        def originalSearchPath = executor.queryForObject(new RawParameterizedSqlStatement("SHOW SEARCH_PATH"), String.class)
+
+        when:
+        def resourceAccessor = new SearchPathResourceAccessor(".,target/test-classes")
+        def scopeSettings = [
+                (Scope.Attr.resourceAccessor.name()): resourceAccessor,
+        ]
+
+        // Run Liquibase update with custom schema (which will use SET LOCAL SEARCH_PATH)
+        Scope.child(scopeSettings, {
+            CommandScope commandScope = new CommandScope(UpdateCommandStep.COMMAND_NAME)
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.URL_ARG, postgres.getConnectionUrl())
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.USERNAME_ARG, postgres.getUsername())
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.PASSWORD_ARG, postgres.getPassword())
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.DEFAULT_SCHEMA_NAME_ARG, customSchema)
+            commandScope.addArgumentValue(UpdateCommandStep.CHANGELOG_FILE_ARG, "changelogs/pgsql/complete/simple.changelog.xml")
+            commandScope.execute()
+        } as Scope.ScopedRunner)
+
+        // After the transaction completes, check that search_path has reverted
+        def currentSearchPath = executor.queryForObject(new RawParameterizedSqlStatement("SHOW SEARCH_PATH"), String.class)
+
+        then:
+        // The search_path should have reverted to the original value
+        // This proves that SET LOCAL was used instead of persistent SET
+        // (If persistent SET was used, the customSchema would still be in search_path)
+        currentSearchPath == originalSearchPath ||
+            currentSearchPath.startsWith("\"\$user\"") ||
+            currentSearchPath.startsWith("\"$postgres.username\"")
+
+        // customSchema should NOT be in current path - this proves SET LOCAL worked
+        !currentSearchPath.contains(customSchema)
+
+        cleanup:
+        try {
+            connection.createStatement().execute("DROP SCHEMA IF EXISTS " + customSchema + " CASCADE")
+        } catch (Exception e) {}
+    }
+}

--- a/liquibase-integration-tests/src/test/resources/changelogs/pgsql/complete/simple.changelog.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/pgsql/complete/simple.changelog.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet id="1" author="nvoxland">
+        <comment>
+            You can add comments to changeSets.
+            They can even be multiple lines if you would like.
+            They aren't used to compute the changeSet MD5Sum, so you can update them whenever you want without causing problems.
+        </comment>        
+        <createTable tableName="person">
+            <column name="id" type="int" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="firstname" type="varchar(50)"/>
+            <column name="lastname" type="varchar(50)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/liquibase-standard/src/main/java/liquibase/database/core/DatabaseUtils.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/DatabaseUtils.java
@@ -60,7 +60,7 @@ public class DatabaseUtils {
                         });
                     }
 
-                    executor.execute(new RawParameterizedSqlStatement(String.format("SET SEARCH_PATH TO %s", finalSearchPath)));
+                    executor.execute(new RawParameterizedSqlStatement(String.format("SET LOCAL SEARCH_PATH TO %s", finalSearchPath)));
                 }
 
             } else if (database instanceof AbstractDb2Database) {

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateProcedureGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateProcedureGenerator.java
@@ -161,11 +161,11 @@ public class CreateProcedureGenerator extends AbstractSqlGenerator<CreateProcedu
 
                 if (!originalSearchPath.equals(schemaName) && !originalSearchPath.startsWith(schemaName + ",") && !originalSearchPath.startsWith("\"" + schemaName + "\",")) {
                     if (database instanceof EnterpriseDBDatabase){
-                        sql.add(0, new UnparsedSql("ALTER SESSION SET SEARCH_PATH TO " + database.escapeObjectName(defaultSchema, Schema.class) + ", " + originalSearchPath));
-                        sql.add(new UnparsedSql("ALTER SESSION SET CURRENT SCHEMA " + originalSearchPath));
+                        sql.add(0, new UnparsedSql("SET LOCAL SEARCH_PATH TO " + database.escapeObjectName(defaultSchema, Schema.class) + ", " + originalSearchPath));
+                        sql.add(new UnparsedSql("SET LOCAL CURRENT SCHEMA " + originalSearchPath));
                     } else {
-                        sql.add(0, new UnparsedSql("SET SEARCH_PATH TO " + database.escapeObjectName(schemaName, Schema.class) + ", " + originalSearchPath));
-                        sql.add(new UnparsedSql("SET CURRENT SCHEMA " + originalSearchPath));
+                        sql.add(0, new UnparsedSql("SET LOCAL SEARCH_PATH TO " + database.escapeObjectName(schemaName, Schema.class) + ", " + originalSearchPath));
+                        sql.add(new UnparsedSql("SET LOCAL CURRENT SCHEMA " + originalSearchPath));
                     }
                 }
             }

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateProcedureGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateProcedureGenerator.java
@@ -160,12 +160,7 @@ public class CreateProcedureGenerator extends AbstractSqlGenerator<CreateProcedu
                 }
 
                 if (!originalSearchPath.equals(schemaName) && !originalSearchPath.startsWith(schemaName + ",") && !originalSearchPath.startsWith("\"" + schemaName + "\",")) {
-                    if (database instanceof EnterpriseDBDatabase){
-                        sql.add(0, new UnparsedSql("SET LOCAL SEARCH_PATH TO " + database.escapeObjectName(defaultSchema, Schema.class) + ", " + originalSearchPath));
-                        sql.add(new UnparsedSql("ALTER SESSION SET CURRENT SCHEMA " + originalSearchPath));
-                    } else {
-                        sql.add(0, new UnparsedSql("SET LOCAL SEARCH_PATH TO " + database.escapeObjectName(schemaName, Schema.class) + ", " + originalSearchPath));
-                    }
+                    sql.add(0, new UnparsedSql("SET LOCAL SEARCH_PATH TO " + database.escapeObjectName(schemaName, Schema.class) + ", " + originalSearchPath));
                 }
             }
         }

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateProcedureGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateProcedureGenerator.java
@@ -162,10 +162,9 @@ public class CreateProcedureGenerator extends AbstractSqlGenerator<CreateProcedu
                 if (!originalSearchPath.equals(schemaName) && !originalSearchPath.startsWith(schemaName + ",") && !originalSearchPath.startsWith("\"" + schemaName + "\",")) {
                     if (database instanceof EnterpriseDBDatabase){
                         sql.add(0, new UnparsedSql("SET LOCAL SEARCH_PATH TO " + database.escapeObjectName(defaultSchema, Schema.class) + ", " + originalSearchPath));
-                        sql.add(new UnparsedSql("SET LOCAL CURRENT SCHEMA " + originalSearchPath));
+                        sql.add(new UnparsedSql("ALTER SESSION SET CURRENT SCHEMA " + originalSearchPath));
                     } else {
                         sql.add(0, new UnparsedSql("SET LOCAL SEARCH_PATH TO " + database.escapeObjectName(schemaName, Schema.class) + ", " + originalSearchPath));
-                        sql.add(new UnparsedSql("SET LOCAL CURRENT SCHEMA " + originalSearchPath));
                     }
                 }
             }

--- a/liquibase-standard/src/test/groovy/liquibase/sqlgenerator/core/CreateProcedureGeneratorTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/sqlgenerator/core/CreateProcedureGeneratorTest.groovy
@@ -2,6 +2,7 @@ package liquibase.sqlgenerator.core
 
 import liquibase.Scope
 import liquibase.database.core.DB2Database
+import liquibase.database.core.EnterpriseDBDatabase
 import liquibase.database.core.MSSQLDatabase
 import liquibase.database.core.OracleDatabase
 import liquibase.database.core.PostgresDatabase
@@ -99,12 +100,13 @@ class CreateProcedureGeneratorTest extends Specification {
         sql*.toString().join("\n").toString() == expected
 
         where:
-        schemaName | database             | expected
-        null       | new OracleDatabase() | "passed sql 1;\npassed sql 2;"
-        ""         | new OracleDatabase() | "passed sql 1;\npassed sql 2;"
-        "other"    | new OracleDatabase() | "ALTER SESSION SET CURRENT_SCHEMA=other;\npassed sql 1;\npassed sql 2;\nALTER SESSION SET CURRENT_SCHEMA=MAIN_SCHEMA;"
-        "other"    | new DB2Database()    | "SET CURRENT SCHEMA other;\npassed sql 1;\npassed sql 2;\nSET CURRENT SCHEMA main_schema;"
-        "other"    | new PostgresDatabase() | "SET SEARCH_PATH TO other, main_schema;\npassed sql 1;\npassed sql 2;\nSET CURRENT SCHEMA main_schema;"
+        schemaName | database                  | expected
+        null       | new OracleDatabase()      | "passed sql 1;\npassed sql 2;"
+        ""         | new OracleDatabase()      | "passed sql 1;\npassed sql 2;"
+        "other"    | new OracleDatabase()      | "ALTER SESSION SET CURRENT_SCHEMA=other;\npassed sql 1;\npassed sql 2;\nALTER SESSION SET CURRENT_SCHEMA=MAIN_SCHEMA;"
+        "other"    | new DB2Database()         | "SET CURRENT SCHEMA other;\npassed sql 1;\npassed sql 2;\nSET CURRENT SCHEMA main_schema;"
+        "other"    | new PostgresDatabase()    | "SET LOCAL SEARCH_PATH TO other, main_schema;\npassed sql 1;\npassed sql 2;\nSET LOCAL CURRENT SCHEMA main_schema;"
+        "other"    | new EnterpriseDBDatabase() | "SET LOCAL SEARCH_PATH TO main_schema, main_schema;\npassed sql 1;\npassed sql 2;\nSET LOCAL CURRENT SCHEMA main_schema;"
 
     }
 }

--- a/liquibase-standard/src/test/groovy/liquibase/sqlgenerator/core/CreateProcedureGeneratorTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/sqlgenerator/core/CreateProcedureGeneratorTest.groovy
@@ -14,7 +14,7 @@ import liquibase.sql.UnparsedSql
 import spock.lang.Specification
 import spock.lang.Unroll
 
-class CreateProcedureGeatuneratorTest extends Specification {
+class CreateProcedureGeneratorTest extends Specification {
 
     @Unroll
     def "removeTrailingDelimiter"() {

--- a/liquibase-standard/src/test/groovy/liquibase/sqlgenerator/core/CreateProcedureGeneratorTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/sqlgenerator/core/CreateProcedureGeneratorTest.groovy
@@ -14,7 +14,7 @@ import liquibase.sql.UnparsedSql
 import spock.lang.Specification
 import spock.lang.Unroll
 
-class CreateProcedureGeneratorTest extends Specification {
+class CreateProcedureGeatuneratorTest extends Specification {
 
     @Unroll
     def "removeTrailingDelimiter"() {
@@ -105,8 +105,8 @@ class CreateProcedureGeneratorTest extends Specification {
         ""         | new OracleDatabase()      | "passed sql 1;\npassed sql 2;"
         "other"    | new OracleDatabase()      | "ALTER SESSION SET CURRENT_SCHEMA=other;\npassed sql 1;\npassed sql 2;\nALTER SESSION SET CURRENT_SCHEMA=MAIN_SCHEMA;"
         "other"    | new DB2Database()         | "SET CURRENT SCHEMA other;\npassed sql 1;\npassed sql 2;\nSET CURRENT SCHEMA main_schema;"
-        "other"    | new PostgresDatabase()    | "SET LOCAL SEARCH_PATH TO other, main_schema;\npassed sql 1;\npassed sql 2;\nSET LOCAL CURRENT SCHEMA main_schema;"
-        "other"    | new EnterpriseDBDatabase() | "SET LOCAL SEARCH_PATH TO main_schema, main_schema;\npassed sql 1;\npassed sql 2;\nSET LOCAL CURRENT SCHEMA main_schema;"
+        "other"    | new PostgresDatabase()    | "SET LOCAL SEARCH_PATH TO other, main_schema;\npassed sql 1;\npassed sql 2;"
+        "other"    | new EnterpriseDBDatabase() | "SET LOCAL SEARCH_PATH TO other, main_schema;\npassed sql 1;\npassed sql 2;"
 
     }
 }


### PR DESCRIPTION
- Update initializeDatabase method to make SEARCH_PATH be set as Local (transaction scope) for Postgres.
- Test added.

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

Liquibase uses persistent `SET SEARCH_PATH` commands for `PostgreSQL`, which sets the search_path for the entire database session. When using PgBouncer in transaction pooling mode, this causes cross-service interference because:

  1. PgBouncer reuses the same database connection across multiple client applications
  2. The search_path setting from one application persists on the connection
  3. The next application using that pooled connection inherits the wrong search_path

That's fixed by using  `SET LOCAL SEARCH_PATH` instead, which scopes the setting to the current transaction only. This ensures the search_path automatically reverts after each transaction commits, making Liquibase compatible with PgBouncer's transaction pooling while maintaining all existing functionality.

Fixes #7092

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
- Add unit/integration tests (ask for support if not sure how to do it)
- Make sure tests all pass
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
