### PR TITLE
chore: Migrate Windows runners to Blacksmith for cost and performance

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - blacksmith-2vcpu-windows-2025

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -152,7 +152,7 @@ jobs:
           ./mvnw -B "-Dbuild.repository.owner=liquibase" "-Dbuild.repository.name=liquibase" "-Dbuild.branch=${{ needs.setup.outputs.thisBranchName }}" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=${{ needs.setup.outputs.latestMergeSha }}" "-DtrimStackTrace=false" -P 'skip-integration-tests' clean test package surefire-report:report
 
       - name: Remove Original Jars for *nix
-        if: env.OS_TYPE != 'blacksmith-2vcpu-windows-2025'
+        if: runner.os != 'Windows'
         run: |
           find . -name original-*.jar -exec rm {} \;
 


### PR DESCRIPTION
## Summary
- Migrates Windows runner from `windows-latest` to `blacksmith-2vcpu-windows-2025` in run-tests.yml

## Benefits
- ~50% cost reduction for Windows CI/CD
- ~2x performance improvement
- Rapid provisioning (< 3 seconds boot time)

## Changes
- Updated OS matrix: `windows-latest` → `blacksmith-2vcpu-windows-2025`
- Updated exclude rule for Java 17 on Windows
- Updated OS_TYPE conditional check for removing original jars

## Test plan
- [ ] Verify Windows tests run successfully on Blacksmith runner
- [ ] Verify all Java versions (21, 25) execute correctly on Windows
- [ ] Confirm artifact generation works

DAT-21557

🤖 Generated with [Claude Code](https://claude.com/claude-code)