### PR TITLE
DAT-21648: Pass tag parameter to package workflow for release downloads

### DIFF
--- a/.github/workflows/release-published-orchestrator.yml
+++ b/.github/workflows/release-published-orchestrator.yml
@@ -173,6 +173,7 @@ jobs:
       groupId: "org.liquibase"
       artifactId: "liquibase"
       version: ${{ needs.setup.outputs.version }}
+      tag: ${{ needs.setup.outputs.tag }}
       dry_run: ${{ inputs.dry_run || false}}
       dry_run_zip_url: ${{ inputs.dry_run_zip_url || '' }}
       dry_run_tar_gz_url: ${{ inputs.dry_run_tar_gz_url || '' }}

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -502,6 +502,7 @@ jobs:
       groupId: "org.liquibase"
       artifactId: "liquibase"
       version: ${{ needs.setup.outputs.version }}
+      tag: ${{ needs.setup.outputs.tag }}
       dry_run: ${{ inputs.dry_run || false}}
       dry_run_zip_url: ${{ inputs.dry_run_zip_url || '' }}
       dry_run_tar_gz_url: ${{ inputs.dry_run_tar_gz_url || '' }}


### PR DESCRIPTION
## Summary
- Pass `tag` parameter to the package workflow in both `release-published-orchestrator.yml` and `release-published.yml`
- This fixes the error "Config error: Please input a valid tag or release ID, or specify latest" that was occurring during releases

## Root Cause
The package workflow in `liquibase/build-logic` was not receiving the release tag, which is needed for downstream workflows to properly download release assets.

## Changes
- `release-published-orchestrator.yml`: Added `tag: ${{ needs.setup.outputs.tag }}` to package job
- `release-published.yml`: Added `tag: ${{ needs.setup.outputs.tag }}` to package job

## Dependencies
- **Requires**: https://github.com/liquibase/build-logic/pull/459 (must be merged first)

## Test plan
- [ ] Merge build-logic PR first
- [ ] Merge this PR
- [ ] Run a dry-run release to verify all package publishing stages pass
- [ ] Verify no "Config error: Please input a valid tag or release ID" errors

## Related
- Jira: [DAT-21648](https://datical.atlassian.net/browse/DAT-21648)
- Failing run: https://github.com/liquibase/liquibase/actions/runs/2075724532

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DAT-21648]: https://datical.atlassian.net/browse/DAT-21648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ