### PR TITLE
fix: use gh CLI for dry-run Maven download in release-published.yml

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -518,12 +518,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Download dry-run release assets
-        uses: robinraju/release-downloader@v1.12
-        with:
-          repository: "liquibase/liquibase"
-          releaseId: "${{ inputs.dry_run_release_id }}"
-          fileName: "*"
-          out-file-path: "."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Use gh CLI which handles draft release auth correctly
+          gh release download "${{ needs.setup.outputs.tag }}" \
+            --repo liquibase/liquibase \
+            --pattern "*" \
+            --dir "."
 
       - name: Configure AWS credentials for vault access
         uses: aws-actions/configure-aws-credentials@v5


### PR DESCRIPTION
## Summary
- Fix `[getReleaseById] Unexpected response: 403` error in dry-run Maven deploy
- The inline `dry_run_deploy_maven` job in `release-published.yml` was still using `robinraju/release-downloader` with `releaseId`, which fails for draft releases
- Changed to use `gh release download` with the tag, which properly handles draft release authentication

## Related
- Part of DAT-21648 fix chain
- Companion to PR #7505 (fixed `release-deploy-maven.yml`)
- This fixes the inline job in `release-published.yml` which was missed

## Test plan
- [ ] Re-run dry-run release workflow
- [ ] Verify Maven deployment stage passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)