### PR TITLE
fix: add retry logic for draft release download in Maven job

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -521,11 +521,23 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Use gh CLI which handles draft release auth correctly
-          gh release download "${{ needs.setup.outputs.tag }}" \
-            --repo liquibase/liquibase \
-            --pattern "*" \
-            --dir "."
+          # Retry logic for draft release accessibility
+          # Draft releases may not be immediately accessible after creation
+          for i in 1 2 3 4 5; do
+            if gh release download "${{ needs.setup.outputs.tag }}" \
+                 --repo liquibase/liquibase \
+                 --pattern "*" \
+                 --dir "."; then
+              echo "Download successful on attempt $i"
+              break
+            fi
+            if [ $i -eq 5 ]; then
+              echo "Failed to download release after 5 attempts"
+              exit 1
+            fi
+            echo "Attempt $i failed, waiting $((i * 5)) seconds..."
+            sleep $((i * 5))
+          done
 
       - name: Configure AWS credentials for vault access
         uses: aws-actions/configure-aws-credentials@v5


### PR DESCRIPTION
## Summary
- Fix race condition where Maven dry-run job fails with `release not found`
- Draft releases may not be immediately accessible after creation
- Added retry logic with exponential backoff (5s, 10s, 15s, 20s, 25s)

## Root Cause Analysis
In workflow run 20843163922:
- Release created at **06:17:09**
- Maven job tried download at **06:17:57** (T+48s) → `release not found`
- Package job tried download at **06:18:10** (T+61s) → **SUCCESS**

The package job succeeded because it had more setup overhead, giving the draft release ~13 extra seconds to become accessible.

## Related
- Part of DAT-21648 fix chain
- Issue #7 in the fix sequence

## Test plan
- [ ] Re-run dry-run release workflow
- [ ] Verify Maven deployment stage passes with retry logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)