### PR TITLE
fix: add contents:write permission for draft release download

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -516,6 +516,9 @@ jobs:
     name: Deploy to Maven Central Repository
     needs: [setup]
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write  # Required for downloading draft releases
+      id-token: write  # Required for AWS OIDC
     steps:
       - name: Download dry-run release assets
         env:


### PR DESCRIPTION
## Summary
- Fix `release not found` error in dry-run Maven deployment
- Draft releases require `contents: write` permission to download via `gh release download`
- The `dry_run_deploy_maven` job was inheriting workflow-level `contents: read` permission

## Root Cause Analysis
From workflow run 20843395080, comparing token permissions:

| Job | Contents Permission | Result |
|-----|---------------------|--------|
| package | `write` | SUCCESS |
| dry_run_deploy_maven | `read` | FAILURE |

The retry logic (PR #7507) wasn't the issue - even after 5 retries spanning 75 seconds, the download failed because the GITHUB_TOKEN lacked write permission.

## Changes
Added explicit permissions to `dry_run_deploy_maven` job:
```yaml
permissions:
  contents: write  # Required for downloading draft releases
  id-token: write  # Required for AWS OIDC
```

## Related
- Part of DAT-21648 fix chain
- Follows PR #7507 (retry logic - still useful for edge cases)

## Test plan
- [ ] Re-run dry-run release workflow
- [ ] Verify Maven deployment downloads successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)