### PR TITLE
fix: remove workflow-logs option to eliminate skipped job warnings

### DIFF
--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -178,7 +178,6 @@ jobs:
           inputs: '{"tag": "vdry-run-${{ github.run_id }}", "dry_run_release_id": "${{ needs.dry-run-create-release.outputs.dry_run_release_id }}", "dry_run_zip_url": "${{ needs.dry-run-create-release.outputs.dry_run_zip_url }}", "dry_run_tar_gz_url": "${{ needs.dry-run-create-release.outputs.dry_run_tar_gz_url }}", "dry_run": "true", "dry_run_branch_name": "${{ needs.setup.outputs.dry_run_branch_name }}"}'
           ref: master
           wait-for-completion: true
-          workflow-logs: json-output
 
   cleanup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Fix 8 "Not Found" warnings in dry-run release workflow summary
- The `workflow-dispatch` action with `workflow-logs: json-output` tries to fetch logs for all jobs
- Skipped jobs (8 in dry-run mode) return 404 when queried for logs

## Root Cause
In `release-published.yml`, 8 jobs are skipped during dry-run:
- Manually trigger deployment
- package / upload_secure_ansible_role
- Publish artifacts to Github Packages
- Publish OSS released assets to s3 bucket
- Upload Javadocs
- Upload xsds
- package / create-placeholder-branch
- Deploy to Maven

The `workflow-logs: json-output` option attempts to fetch logs for ALL jobs, including these skipped ones, causing 404 errors that appear as warnings.

## Fix
Remove `workflow-logs: json-output` to use the default behavior (`ignore`). Child workflow logs remain accessible via the GitHub UI.

## Test plan
- [ ] Run dry-run release workflow
- [ ] Verify no "Not Found" warnings in summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)