### PR TITLE
INT-1558: fix exclude/include objects for diff command with offline snapshots

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/snapshot/DatabaseSnapshot.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/DatabaseSnapshot.java
@@ -662,10 +662,14 @@ public abstract class DatabaseSnapshot implements LiquibaseSerializable {
             }
 
             for (DatabaseObject object : objects.values()) {
-                this.allFound.add(object);
+                if (snapshotControl.shouldInclude(object)) {
+                    this.allFound.add(object);
+                }
             }
             for (DatabaseObject object : referencedObjects.values()) {
-                this.referencedObjects.add(object);
+                if (snapshotControl.shouldInclude(object)) {
+                    this.referencedObjects.add(object);
+                }
             }
         } catch (Exception e) {
             throw new ParsedNodeException(e);

--- a/liquibase-standard/src/main/java/liquibase/snapshot/RestoredDatabaseSnapshot.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/RestoredDatabaseSnapshot.java
@@ -9,4 +9,8 @@ public class RestoredDatabaseSnapshot extends DatabaseSnapshot {
     public RestoredDatabaseSnapshot(Database database) throws DatabaseException, InvalidExampleException {
         super(new DatabaseObject[0], database);
     }
+
+    public RestoredDatabaseSnapshot(Database database, SnapshotControl snapshotControl) throws DatabaseException, InvalidExampleException {
+        super(new DatabaseObject[0], database, snapshotControl);
+    }
 }

--- a/liquibase-standard/src/test/groovy/liquibase/snapshot/JsonSnapshotParserTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/snapshot/JsonSnapshotParserTest.groovy
@@ -1,11 +1,15 @@
 package liquibase.snapshot
 
 import liquibase.Scope
+import liquibase.diff.output.StandardObjectChangeFilter
 import liquibase.parser.SnapshotParser
 import liquibase.parser.SnapshotParserFactory
 import liquibase.parser.core.yaml.YamlSnapshotParser
 import liquibase.resource.SearchPathResourceAccessor
+import liquibase.structure.core.Column
 import liquibase.structure.core.Index
+import liquibase.structure.core.Schema
+import liquibase.structure.core.Table
 import liquibase.structure.core.View
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -34,5 +38,57 @@ class JsonSnapshotParserTest extends Specification {
         indexes[110]
         indexes[110].getTable() == null
         indexes[110].getRelation() instanceof View
+    }
+
+    def "Parse snapshot without filters"() {
+        when:
+        YamlSnapshotParser parser = new YamlSnapshotParser()
+        def snapshot = parser.parse("schemas-snapshot.json", new SearchPathResourceAccessor("target/test-classes"))
+
+        then:
+        snapshot != null
+        snapshot instanceof RestoredDatabaseSnapshot
+        snapshot.get(Schema.class).size() == 5
+    }
+
+    def "Parse snapshot with excludeObjects filter in Scope"() {
+        def objectChangeFilter = new StandardObjectChangeFilter(StandardObjectChangeFilter.FilterType.EXCLUDE, "s1,s3")
+
+        when:
+        def snapshot = null
+        Scope.child(["objectChangeFilter": objectChangeFilter], { ->
+            YamlSnapshotParser parser = new YamlSnapshotParser()
+            snapshot = parser.parse("schemas-snapshot.json", new SearchPathResourceAccessor("target/test-classes"))
+        } as Scope.ScopedRunner)
+
+        then:
+        snapshot != null
+        snapshot instanceof RestoredDatabaseSnapshot
+        Set<Schema> schemas = snapshot.get(Schema.class)
+        schemas.size() == 3
+        schemas.find { it.name == "s1" } == null
+        schemas.find { it.name == "s3" } == null
+        schemas.find { it.name == "s2" } != null
+        schemas.find { it.name == "s4" } != null
+        schemas.find { it.name == "s5" } != null
+    }
+
+    def "Parse snapshot with snapshotTypes filter in Scope"() {
+        def snapshotControl = new SnapshotControl(null, Schema.class)
+
+        when:
+        def snapshot = null
+        Scope.child(["snapshotControl": snapshotControl], { ->
+            YamlSnapshotParser parser = new YamlSnapshotParser()
+            snapshot = parser.parse("schemas-snapshot.json", new SearchPathResourceAccessor("target/test-classes"))
+        } as Scope.ScopedRunner)
+
+        then:
+        snapshot != null
+        snapshot instanceof RestoredDatabaseSnapshot
+        snapshot.get(Schema.class).size() == 5
+        snapshot.get(Table.class).isEmpty()
+        snapshot.get(Column.class).isEmpty()
+        snapshot.get(View.class).isEmpty()
     }
 }


### PR DESCRIPTION
Filters were ignored because OfflineConnection parses snapshot before SnapshotControl is created. Pass filters through Scope instead.
Affects both object filters (excludeObjects/includeObjects) and snapshot type filters (snapshotTypes parameter).