### PR TITLE
fix(build): configure GMavenPlus 4.3.0 to detect Groovy in test scope

### DIFF
--- a/liquibase-extension-testing/pom.xml
+++ b/liquibase-extension-testing/pom.xml
@@ -112,6 +112,20 @@
 
     <build>
         <plugins>
+            <!-- This module has main Groovy sources, so we need compile goal (not just compileTests) -->
+            <plugin>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>groovy-compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>removeStubs</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -376,24 +376,12 @@
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
                 <version>4.3.0</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.groovy</groupId>
-                        <artifactId>groovy</artifactId>
-                        <version>${groovy.version}</version>
-                    </dependency>
-                </dependencies>
-                <configuration>
-                    <includeClasspath>PROJECT_AND_PLUGIN</includeClasspath>
-                </configuration>
                 <executions>
                     <execution>
                         <goals>
                             <goal>addSources</goal>
                             <goal>addTestSources</goal>
-                            <goal>compile</goal>
                             <goal>compileTests</goal>
-                            <goal>removeStubs</goal>
                             <goal>removeTestStubs</goal>
                         </goals>
                     </execution>


### PR DESCRIPTION
This pull request updates the build configuration for handling Groovy sources in the project. The main change is the addition of the `gmavenplus-plugin` to the `liquibase-extension-testing` module to ensure Groovy main sources are compiled properly, while redundant Groovy compilation steps are removed from the root `pom.xml`.

Build configuration improvements:

* Added the `gmavenplus-plugin` to the `liquibase-extension-testing/pom.xml` to compile main Groovy sources and remove stubs, ensuring proper handling of Groovy code in this module.
* Removed the `compile` and `removeStubs` goals from the `gmavenplus-plugin` execution in the root `pom.xml`, as these are now handled at the module level where needed.