### PR TITLE
DAT-21768: Fix sonar workflow inputs and add missing thisSha output

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -50,6 +50,7 @@ jobs:
       timestamp: ${{ steps.get-date.outputs.date }}
       latestMergeSha: ${{ steps.get-sha.outputs.latestMergeSha }}
       thisBranchName: ${{ steps.get-branch-name.outputs.thisBranchName }}
+      thisSha: ${{ steps.get-sha.outputs.latestMergeSha }}
       setupSuccessful: "true"
     steps:
       - uses: actions/checkout@v6
@@ -279,7 +280,7 @@ jobs:
             ./liquibase-integration-tests/target/jacoco.exec
 
   sonar:
-    needs: [ build_tests, integration-test ]
+    needs: [ setup, build_tests, integration-test ]
     uses: liquibase/build-logic/.github/workflows/sonar-test-scan.yml@main
     permissions:
       pull-requests: write
@@ -288,7 +289,6 @@ jobs:
     with:
       thisBranchName: ${{ needs.setup.outputs.thisBranchName }}
       thisSha: ${{ needs.setup.outputs.thisSha }}
-      liquibaseBranchName: ${{ needs.setup.outputs.liquibaseBranchName }}
       pullRequestNumber: ${{ github.event.pull_request.number }}
       pullRequestBranchName: ${{ github.event.pull_request.head.ref }}
       pullRequestBaseBranchName: ${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
## Summary

- Add missing `thisSha` output to setup job
- Add `setup` to sonar job's needs array
- Remove deprecated `liquibaseBranchName` parameter

## Context

The SonarCloud workflow was failing because:
1. The sonar job referenced `needs.setup.outputs.thisSha` but this output didn't exist
2. The sonar job referenced `needs.setup.outputs.liquibaseBranchName` which also didn't exist
3. The sonar job didn't have `setup` in its needs array, so it couldn't access setup outputs

## Dependencies

⚠️ **This PR depends on build-logic PR**: https://github.com/liquibase/build-logic/pull/469

The build-logic PR must be merged first as it removes the `liquibaseBranchName` input parameter.

## Changes

- Add `thisSha: ${{ steps.get-sha.outputs.latestMergeSha }}` to setup job outputs
- Add `setup` to sonar job's needs array: `needs: [ setup, build_tests, integration-test ]`
- Remove `liquibaseBranchName` parameter from sonar workflow call

## Test plan

- [ ] Wait for build-logic PR to merge
- [ ] Verify SonarCloud analysis runs successfully on PR
- [ ] Verify SonarCloud analysis runs successfully on main branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)