### PR TITLE
DAT-22397:fix: update approvers list for manual deployment approval

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -142,7 +142,7 @@ jobs:
         uses: trstringer/manual-approval@v1
         with:
           secret: ${{ secrets.GITHUB_TOKEN }}
-          approvers: filipelautert,rberezen,jnewton03,kristyldatical,sayaliM0412
+          approvers: filipelautert,rberezen,jnewton03,jandroav,sayaliM0412
           minimum-approvals: 2
           issue-title: "Deploying ${{ needs.setup.outputs.version }} to sonatype"
           issue-body: "Please approve or deny the deployment of version ${{ needs.setup.outputs.version }}"


### PR DESCRIPTION
This pull request makes a minor update to the release workflow by changing the list of users authorized to approve deployments.

- Updated the `approvers` list in `.github/workflows/release-published.yml` to replace `kristyldatical` with `jandroav` for manual deployment approvals.