### PR TITLE
DAT-22396: temp skip completed jobs for v5.0.2 recovery

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -159,7 +159,6 @@ jobs:
         deploy_javadocs,
         publish_to_github_packages,
         deploy_xsd,
-        release-docker,
       ]
     runs-on: ubuntu-22.04
     steps:
@@ -442,7 +441,7 @@ jobs:
           remoteDir: "/xml/ns/dbchangelog/"
 
   release-docker:
-    if: always()
+    if: false  # TEMP: skip for v5.0.2 recovery - already completed
     name: Release docker images
     needs: [setup, manual_trigger_deployment]
     runs-on: ubuntu-22.04
@@ -489,6 +488,7 @@ jobs:
         run: echo '### 🐳 Docker Release Job -> ${{steps.docker_dispatch.outputs.workflow-url}}' >> $GITHUB_STEP_SUMMARY
 
   package:
+    if: false  # TEMP: skip for v5.0.2 recovery - already published
     uses: liquibase/build-logic/.github/workflows/package.yml@main
     needs: [setup]
     secrets: inherit
@@ -653,7 +653,7 @@ jobs:
           echo "Manual publishing required - visit https://central.sonatype.com/publishing/deployments to review and publish"
 
   publish_assets_to_s3_bucket:
-    if: ${{ inputs.dry_run == false }}
+    if: false  # TEMP: skip for v5.0.2 recovery - already uploaded
     name: Publish OSS released assets to s3 bucket liquibaseorg-origin
     needs: [setup]
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary

- Skip `package`, `release-docker`, and `publish_assets_to_s3_bucket` jobs that already completed successfully in the original v5.0.2 release [run 22723693659](https://github.com/liquibase/liquibase/actions/runs/22723693659)
- Remove `release-docker` from `deploy_maven` `needs` list so Maven deploy isn't blocked by the skipped docker job
- These are **temporary changes** that will be reverted after the recovery `workflow_dispatch` completes

## Context

The v5.0.2 "Release Published" workflow failed due to:
1. Manual approval gate HTTP 422 (fixed in #7588 — `kristyldatical` replaced with `jandroav`)
2. Docker official image update failure (being fixed in separate docker repo PR)

GitHub UI re-run won't work because it uses the original SHA's workflow file (before the approvers fix). A plain `workflow_dispatch` would re-run `package` and fail on duplicate Chocolatey/Ansible/SDKMAN artifacts.

## Recovery steps after merge

1. Trigger workflow: `gh workflow run release-published.yml --ref master -f tag=v5.0.2 -f dry_run=false`
2. Approve deployment (2 approvers needed)
3. Verify: Javadocs, GitHub Packages, XSDs, Maven Central
4. Revert this commit

## Test plan

- [ ] Verify workflow YAML is valid
- [ ] Confirm `workflow_dispatch` triggers only the needed jobs (setup, approval, javadocs, github packages, XSD, maven)
- [ ] Confirm skipped jobs (`package`, `release-docker`, `publish_assets_to_s3_bucket`) do not run
- [ ] After deployment, revert this PR's changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)