### PR TITLE
DAT-22396: fix approvers and skip completed orchestrator jobs for v5.0.2 recovery

### DIFF
--- a/.github/workflows/release-manual-approval.yml
+++ b/.github/workflows/release-manual-approval.yml
@@ -41,7 +41,7 @@ jobs:
         uses: trstringer/manual-approval@v1
         with:
           secret: ${{ secrets.GITHUB_TOKEN }}
-          approvers: filipelautert,rberezen,jnewton03,kristyldatical,sayaliM0412
+          approvers: filipelautert,rberezen,jnewton03,jandroav,sayaliM0412
           minimum-approvals: 2
           issue-title: "Deploying ${{ inputs.version }} to Maven Central"
           issue-body: "Please approve or deny the deployment of version ${{ inputs.version }} to Maven Central"

--- a/.github/workflows/release-published-orchestrator.yml
+++ b/.github/workflows/release-published-orchestrator.yml
@@ -130,7 +130,7 @@ jobs:
   release-docker:
     name: Release Docker Images
     needs: [setup, manual-approval]
-    if: always() && needs.setup.result == 'success' && (needs.manual-approval.result == 'success' || needs.manual-approval.result == 'skipped')
+    if: false  # TEMP: skip for v5.0.2 recovery - already completed
     uses: ./.github/workflows/release-docker.yml
     permissions:
       contents: read
@@ -142,8 +142,8 @@ jobs:
 
   deploy-maven:
     name: Deploy to Maven Central
-    needs: [setup, manual-approval, deploy-javadocs, publish-github-packages, deploy-xsd, release-docker]
-    if: always() && needs.setup.result == 'success' && (needs.manual-approval.result == 'success' || needs.manual-approval.result == 'skipped') && (needs.deploy-javadocs.result == 'success' || needs.deploy-javadocs.result == 'skipped') && (needs.publish-github-packages.result == 'success' || needs.publish-github-packages.result == 'skipped') && (needs.deploy-xsd.result == 'success' || needs.deploy-xsd.result == 'skipped') && (needs.release-docker.result == 'success' || needs.release-docker.result == 'skipped')
+    needs: [setup, manual-approval, deploy-javadocs, publish-github-packages, deploy-xsd]
+    if: always() && needs.setup.result == 'success' && (needs.manual-approval.result == 'success' || needs.manual-approval.result == 'skipped') && (needs.deploy-javadocs.result == 'success' || needs.deploy-javadocs.result == 'skipped') && (needs.publish-github-packages.result == 'success' || needs.publish-github-packages.result == 'skipped') && (needs.deploy-xsd.result == 'success' || needs.deploy-xsd.result == 'skipped')
     uses: ./.github/workflows/release-deploy-maven.yml
     permissions:
       contents: write
@@ -159,7 +159,7 @@ jobs:
   package:
     name: Update Packages
     needs: [setup, manual-approval]
-    if: always() && needs.setup.result == 'success' && (needs.manual-approval.result == 'success' || needs.manual-approval.result == 'skipped')
+    if: false  # TEMP: skip for v5.0.2 recovery - already published
     uses: liquibase/build-logic/.github/workflows/package.yml@main
     permissions:
       actions: write
@@ -184,7 +184,7 @@ jobs:
   publish-assets-s3:
     name: Publish Assets to S3
     needs: [setup, package]
-    if: always() && needs.setup.result == 'success' && (needs.package.result == 'success' || needs.package.result == 'skipped')
+    if: false  # TEMP: skip for v5.0.2 recovery - already uploaded
     uses: ./.github/workflows/release-publish-assets-s3.yml
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Fix approvers list in `release-manual-approval.yml` — replace `kristyldatical` with `jandroav` (fixes HTTP 422)
- Skip `package`, `release-docker`, and `publish-assets-s3` in the **orchestrator** (already completed in original v5.0.2 run)
- Remove `release-docker` from `deploy-maven` needs so Maven deploy isn't blocked

**Note:** Previous PR #7590 modified `release-published.yml` (legacy monolith) which is NOT used by the orchestrator. This PR fixes the correct files.

## Context

The v5.0.2 orchestrator run failed because:
1. `release-manual-approval.yml` still had `kristyldatical` in approvers → HTTP 422
2. `publish-assets-s3` ran again (it only depends on setup+package, not approval)

These are **temporary changes** — will be reverted after recovery dispatch completes.

## Recovery steps after merge

1. `gh workflow run release-published-orchestrator.yml --ref master -f tag=v5.0.2 -f dry_run=false`
2. Approve deployment (2 approvers needed)
3. Verify: Javadocs, GitHub Packages, XSDs, Maven Central
4. Revert this commit and #7590's changes

## Test plan

- [ ] Approval gate uses correct approvers (no `kristyldatical`)
- [ ] `package`, `release-docker`, `publish-assets-s3` are skipped
- [ ] `deploy-maven` runs after javadocs, github packages, and XSD complete
- [ ] Revert after successful deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)