### PR TITLE
DAT-22398: Update condition for release-docker step

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -441,7 +441,7 @@ jobs:
           remoteDir: "/xml/ns/dbchangelog/"
 
   release-docker:
-    if: false  # TEMP: skip for v5.0.2 recovery - already completed
+    if: ${{ inputs.dry_run == false }}
     name: Release docker images
     needs: [setup, manual_trigger_deployment]
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This pull request updates the release workflow to control the execution of the Docker image release step based on a `dry_run` input parameter, instead of always skipping it.

Workflow logic improvement:

* [`.github/workflows/release-published.yml`](diffhunk://#diff-f7ca0660afb7c5d6e7220dee8a6db81db251b3c98818f4d76a3e4441b85c7a6dL444-R444): Changed the condition for the `release-docker` job to run only when `inputs.dry_run` is false, replacing the previous hardcoded skip (`if: false`). This allows for more flexible control during releases.