### PR TITLE
feat: add additional zip and installer to nightly release (DAT-22379)

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -103,7 +103,7 @@ jobs:
 
           gh release create nightly \
             --repo "$REPO" \
-            --target master \
+            --target "$FULL_SHA" \
             --title "Nightly Build ($date_str)" \
             --notes "## Nightly Build
 


### PR DESCRIPTION
## Summary
- Add `liquibase-additional-nightly.zip` to nightly release, created from `.asc/.md5/.sha1` signature files already present in `liquibase-artifacts`
- Add best-effort download of Windows installer (`liquibase-windows-x64-installer-nightly.exe`) from `installer-build-check.yml` artifacts
- Make release asset list dynamic — installer and additional zip are conditionally included based on availability

## Notes
- The Windows installer is built by `installer-build-check.yml`, which currently only triggers on `workflow_dispatch` and `gha-scheduled-*` branches. The installer will only be included in the nightly release when a recent successful run of that workflow exists on master.
- To always include the installer, `installer-build-check.yml` would need to be modified to also trigger automatically on master (separate change).

## Test plan
- [ ] Run workflow_dispatch — verify additional zip is created from signature files
- [ ] Verify nightly release now includes `liquibase-additional-nightly.zip`
- [ ] Verify installer download gracefully skips when no `installer-build-check.yml` run exists
- [ ] If `installer-build-check.yml` has been run on master, verify `.exe` is included

Generated with Claude Code