### PR TITLE
fix: add checkout step to fix nightly release 403 (DAT-22379)

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -29,6 +29,8 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+
       - name: Get run ID for artifact download
         id: get-run-id
         env:


### PR DESCRIPTION
## Summary
- Add `actions/checkout@v6` to nightly-release.yml to fix `HTTP 403: Resource not accessible by integration` when creating releases
- The `gh` CLI needs a repo checkout for the `GITHUB_TOKEN` to be properly scoped when triggered via `workflow_run`

## Test plan
- [ ] Merge and wait for next successful test run on master, or trigger via workflow_dispatch
- [ ] Verify nightly release is created successfully at https://github.com/liquibase/liquibase/releases/tag/nightly

Generated with Claude Code