### PR TITLE
chore(deps): upgrade testcontainers to 2.0.3

### DIFF
--- a/liquibase-extension-testing/pom.xml
+++ b/liquibase-extension-testing/pom.xml
@@ -21,7 +21,7 @@
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers-bom</artifactId>
-                <version>1.21.3</version>
+                <version>2.0.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -37,36 +37,43 @@
 
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>mariadb</artifactId>
+            <artifactId>testcontainers-mariadb</artifactId>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>mssqlserver</artifactId>
+            <artifactId>testcontainers-mssqlserver</artifactId>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>mysql</artifactId>
+            <artifactId>testcontainers-mysql</artifactId>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>oracle-xe</artifactId>
+            <artifactId>testcontainers-oracle-xe</artifactId>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
+            <artifactId>testcontainers-postgresql</artifactId>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>cockroachdb</artifactId>
+            <artifactId>testcontainers-cockroachdb</artifactId>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>db2</artifactId>
+            <artifactId>testcontainers-db2</artifactId>
         </dependency>
         <dependency>
             <groupId>org.firebirdsql</groupId>
             <artifactId>firebird-testcontainers-java</artifactId>
-            <version>1.6.0</version>
+            <version>2.0.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/liquibase-extension-testing/src/main/java/liquibase/extension/testing/testsystem/core/CockroachTestSystem.java
+++ b/liquibase-extension-testing/src/main/java/liquibase/extension/testing/testsystem/core/CockroachTestSystem.java
@@ -5,7 +5,7 @@ import liquibase.extension.testing.testsystem.wrapper.DatabaseWrapper;
 import liquibase.extension.testing.testsystem.wrapper.DockerDatabaseWrapper;
 import liquibase.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
-import org.testcontainers.containers.CockroachContainer;
+import org.testcontainers.cockroachdb.CockroachContainer;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.utility.DockerImageName;
 

--- a/liquibase-extension-testing/src/main/java/liquibase/extension/testing/testsystem/core/DB2TestSystem.java
+++ b/liquibase-extension-testing/src/main/java/liquibase/extension/testing/testsystem/core/DB2TestSystem.java
@@ -4,7 +4,7 @@ import liquibase.extension.testing.testsystem.DatabaseTestSystem;
 import liquibase.extension.testing.testsystem.wrapper.DatabaseWrapper;
 import liquibase.extension.testing.testsystem.wrapper.DockerDatabaseWrapper;
 import org.jetbrains.annotations.NotNull;
-import org.testcontainers.containers.Db2Container;
+import org.testcontainers.db2.Db2Container;
 import org.testcontainers.utility.DockerImageName;
 
 public class DB2TestSystem extends DatabaseTestSystem {

--- a/liquibase-extension-testing/src/main/java/liquibase/extension/testing/testsystem/core/MSSQLTestSystem.java
+++ b/liquibase-extension-testing/src/main/java/liquibase/extension/testing/testsystem/core/MSSQLTestSystem.java
@@ -5,7 +5,7 @@ import liquibase.extension.testing.testsystem.wrapper.DatabaseWrapper;
 import liquibase.extension.testing.testsystem.wrapper.DockerDatabaseWrapper;
 import org.jetbrains.annotations.NotNull;
 import org.testcontainers.containers.JdbcDatabaseContainer;
-import org.testcontainers.containers.MSSQLServerContainer;
+import org.testcontainers.mssqlserver.MSSQLServerContainer;
 import org.testcontainers.utility.DockerImageName;
 
 public class MSSQLTestSystem extends DatabaseTestSystem {

--- a/liquibase-extension-testing/src/main/java/liquibase/extension/testing/testsystem/core/MariaDBTestSystem.java
+++ b/liquibase-extension-testing/src/main/java/liquibase/extension/testing/testsystem/core/MariaDBTestSystem.java
@@ -3,7 +3,7 @@ package liquibase.extension.testing.testsystem.core;
 import liquibase.extension.testing.testsystem.DatabaseTestSystem;
 import liquibase.extension.testing.testsystem.wrapper.DatabaseWrapper;
 import liquibase.extension.testing.testsystem.wrapper.DockerDatabaseWrapper;
-import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.mariadb.MariaDBContainer;
 import org.testcontainers.utility.DockerImageName;
 
 public class MariaDBTestSystem extends DatabaseTestSystem {

--- a/liquibase-extension-testing/src/main/java/liquibase/extension/testing/testsystem/core/MySQLTestSystem.java
+++ b/liquibase-extension-testing/src/main/java/liquibase/extension/testing/testsystem/core/MySQLTestSystem.java
@@ -4,7 +4,7 @@ import liquibase.extension.testing.testsystem.DatabaseTestSystem;
 import liquibase.extension.testing.testsystem.wrapper.DatabaseWrapper;
 import liquibase.extension.testing.testsystem.wrapper.DockerDatabaseWrapper;
 import org.jetbrains.annotations.NotNull;
-import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.mysql.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 public class MySQLTestSystem extends DatabaseTestSystem {

--- a/liquibase-extension-testing/src/main/java/liquibase/extension/testing/testsystem/core/PostgresTestSystem.java
+++ b/liquibase-extension-testing/src/main/java/liquibase/extension/testing/testsystem/core/PostgresTestSystem.java
@@ -4,7 +4,7 @@ import liquibase.extension.testing.testsystem.DatabaseTestSystem;
 import liquibase.extension.testing.testsystem.wrapper.DatabaseWrapper;
 import liquibase.extension.testing.testsystem.wrapper.DockerDatabaseWrapper;
 import org.jetbrains.annotations.NotNull;
-import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 public class PostgresTestSystem extends DatabaseTestSystem {

--- a/liquibase-extension-testing/src/main/java/liquibase/extension/testing/testsystem/wrapper/DockerDatabaseWrapper.java
+++ b/liquibase-extension-testing/src/main/java/liquibase/extension/testing/testsystem/wrapper/DockerDatabaseWrapper.java
@@ -13,6 +13,7 @@ import liquibase.extension.testing.testsystem.core.DB2TestSystem;
 import liquibase.util.CollectionUtil;
 import liquibase.util.StringUtil;
 import org.springframework.test.util.TestSocketUtils;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import java.util.*;
@@ -40,7 +41,7 @@ public class DockerDatabaseWrapper extends DatabaseWrapper {
         return "Docker image: " + container.getDockerImageName() + "\n" +
                 "Container name: " + container.getContainerName() + "\n" +
                 "Exposed ports: " + StringUtil.join(container.getExposedPorts(), ",") + "\n" +
-                "Reusable: " + container.isShouldBeReused();
+                "Reusable: " + testSystem.getKeepRunning();
 
     }
 
@@ -50,7 +51,7 @@ public class DockerDatabaseWrapper extends DatabaseWrapper {
             return;
         }
 
-        final DockerClient dockerClient = container.getDockerClient();
+        final DockerClient dockerClient = DockerClientFactory.instance().client();
         for (Container container : dockerClient.listContainersCmd().exec()) {
             final String containerTestSystem = container.getLabels().get(TEST_SYSTEM_LABEL);
             if (containerTestSystem != null && containerTestSystem.equals(testSystem.getDefinition().toString())) {
@@ -148,7 +149,7 @@ public class DockerDatabaseWrapper extends DatabaseWrapper {
         if (container.isRunning()) {
             container.stop();
         } else {
-            final DockerClient dockerClient = container.getDockerClient();
+            final DockerClient dockerClient = DockerClientFactory.instance().client();
             final List<Container> containers = dockerClient.listContainersCmd().withLabelFilter(Collections.singletonMap(TEST_SYSTEM_LABEL, testSystem.getDefinition().toString())).exec();
             if (containers.size() == 0) {
                 throw new UnexpectedLiquibaseException("Cannot find running container " + testSystem.getDefinition().getName());


### PR DESCRIPTION
## Summary

- Upgrades `org.testcontainers:testcontainers-bom` from 1.21.3 to 2.0.3
- Upgrades `org.firebirdsql:firebird-testcontainers-java` from 1.6.0 to 2.0.0
- Renames 7 database module artifact IDs to match the new `testcontainers-` prefix convention in TC 2.0
- Updates container class imports to new 2.0 canonical package locations (e.g., `org.testcontainers.mysql.MySQLContainer`)
- Replaces removed `getDockerClient()` API with `DockerClientFactory.instance().client()`
- Replaces removed `isShouldBeReused()` with `testSystem.getKeepRunning()`
- Adds explicit `junit:junit:4.13.2` dependency (previously transitive via TC 1.x, needed at compile scope for `TestSystem` which implements JUnit 4 `TestRule`)

Supersedes #7474 and #7570 (dependabot PRs that only bumped versions without the required migration changes).

## Test plan

- [x] `liquibase-extension-testing` module compiles successfully
- [x] All 44 extension-testing unit tests pass
- [x] Full project test suite passes (1268 tests, 0 failures)
- [x] Shaded JAR packages correctly with renamed artifacts
- [ ] CI passes on all platforms (Linux, macOS, Windows) and Java versions (17, 21, 25)