### PR TITLE
[DAT-22458] Fix SHA-SNAPSHOT package cleanup — delete step was always skipped

### DIFF
--- a/.github/workflows/cleanup-branch-builds.yml
+++ b/.github/workflows/cleanup-branch-builds.yml
@@ -122,7 +122,11 @@ jobs:
         # Cache all branch HEAD SHAs once to avoid per-version API calls
         # and handle pagination (repo has ~190 branches, default page is 30)
         echo "Fetching all branch heads..."
-        BRANCH_HEADS=$(gh api --paginate "repos/$REPO/branches?per_page=100" --jq '.[].commit.sha' 2>/dev/null || echo "")
+        BRANCH_HEADS=$(gh api --paginate "repos/$REPO/branches?per_page=100" --jq '.[].commit.sha')
+        if [ $? -ne 0 ] || [ -z "$BRANCH_HEADS" ]; then
+          echo "::error::Failed to fetch branch heads — aborting to prevent incorrect deletions"
+          exit 1
+        fi
         BRANCH_COUNT=$(echo "$BRANCH_HEADS" | grep -c '.' || echo "0")
         echo "Cached $BRANCH_COUNT branch head SHAs"
 
@@ -135,9 +139,17 @@ jobs:
           IS_ORPHAN=true
 
           # First: does the commit still exist in the repo?
-          COMMIT_EXISTS=$(gh api "repos/$REPO/commits/$COMMIT_SHA" --jq '.sha' 2>/dev/null || echo "")
-          if [ -z "$COMMIT_EXISTS" ]; then
-            echo "ORPHANED (commit gone): $VERSION_NAME"
+          # Capture both output and exit code to distinguish 404 from transient errors
+          COMMIT_RESPONSE=$(gh api "repos/$REPO/commits/$COMMIT_SHA" --jq '.sha' 2>&1)
+          COMMIT_EXIT=$?
+          if [ $COMMIT_EXIT -ne 0 ]; then
+            if echo "$COMMIT_RESPONSE" | grep -q "404\|Not Found"; then
+              echo "ORPHANED (commit gone): $VERSION_NAME"
+            else
+              # Non-404 failure (429/503/network) — skip to be safe
+              echo "SKIPPED (API error): $VERSION_NAME — $COMMIT_RESPONSE"
+              continue
+            fi
           else
             # Check if any branch HEAD points to this commit (using cached list)
             BRANCH_MATCH=$(printf '%s\n' "$BRANCH_HEADS" | grep -c "^${COMMIT_SHA}$" || true)
@@ -149,14 +161,24 @@ jobs:
               # compare/{commit}...{base} returns "behind" when base has commits
               # the commit doesn't — meaning the commit is an ancestor of base.
               # "identical" means they point to the same commit.
+              API_FAILED=false
               for BASE_BRANCH in master release; do
-                COMPARE_STATUS=$(gh api "repos/$REPO/compare/${COMMIT_SHA}...${BASE_BRANCH}" --jq '.status' 2>/dev/null || echo "error")
+                COMPARE_STATUS=$(gh api "repos/$REPO/compare/${COMMIT_SHA}...${BASE_BRANCH}" --jq '.status' 2>/dev/null || echo "api_error")
+                if [[ "$COMPARE_STATUS" == "api_error" ]]; then
+                  echo "SKIPPED (compare API error for $BASE_BRANCH): $VERSION_NAME"
+                  API_FAILED=true
+                  break
+                fi
                 if [[ "$COMPARE_STATUS" == "ahead" || "$COMPARE_STATUS" == "identical" ]]; then
                   IS_ORPHAN=false
                   echo "REACHABLE: $VERSION_NAME (ancestor of $BASE_BRANCH)"
                   break
                 fi
               done
+              # If compare API failed, skip this version entirely — don't mark as orphan
+              if [ "$API_FAILED" = "true" ]; then
+                continue
+              fi
             fi
           fi
 


### PR DESCRIPTION
## Problem

The `delete-sha-package` job in `cleanup-branch-builds.yml` has never actually deleted any SHA-SNAPSHOT packages.

**Root cause:** The job runs on branch `delete` events and tries to compare the deleted branch against `master`/`release` using the GitHub compare API. But by the time the workflow runs, the branch is already gone — the API returns 404, the commit list is empty, and the delete step is skipped.

Confirmed by checking all 10 recent workflow runs — the "Delete package versions" step was **skipped every time**.

This caused 53 stale SHA-SNAPSHOT packages to accumulate (~2 GB), which were manually deleted as part of DAT-22458.

## Fix

Replaced the broken branch-comparison logic with orphan detection:

1. List all package versions matching the SHA-SNAPSHOT pattern (`^[0-9a-f]{40}-SNAPSHOT$`)
2. For each SHA, check if the commit is reachable from `master` or `release`
3. If not reachable, check if any active branch points to it
4. Only delete versions where the commit is fully orphaned

## What it does NOT delete

- `master-SNAPSHOT` — does not match the 40-char hex SHA pattern
- `4.30.0-SNAPSHOT` or any semver — does not match the pattern
- `DAT-12345-SNAPSHOT` — does not match the pattern
- Any SHA-SNAPSHOT where the commit is still reachable from `master`/`release` or is a branch head

<img width="1271" height="545" alt="Screenshot 2026-04-01 at 2 34 09 PM" src="https://github.com/user-attachments/assets/05dbb675-b11a-458e-aa57-957abed96dd6" />


## Test plan

- [ ] Trigger the workflow manually via `workflow_dispatch` and verify orphan detection logs
- [ ] Confirm orphaned SHA versions are deleted
- [ ] Confirm active SHA versions (on existing branches) are preserved
- [ ] Verify DAT-SNAPSHOT cleanup (first job) still works as before — no changes to that job

🤖 Generated with [Claude Code](https://claude.com/claude-code)