### PR TITLE
fix: use CURRENT_TIMESTAMP instead of SYSTIMESTAMP for Oracle

### DIFF
--- a/liquibase-integration-tests/src/test/java/liquibase/statementexecute/MarkChangeSetRanExecutorTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/statementexecute/MarkChangeSetRanExecutorTest.java
@@ -42,7 +42,7 @@ public class MarkChangeSetRanExecutorTest extends AbstractExecutorTest {
                 MSSQLDatabase.class);
         assertCorrect(String.format("insert into databasechangelog (id, author, filename, dateexecuted, orderexecuted, " +
                         "md5sum, description, comments, exectype, contexts, labels, liquibase, deployment_id) values " +
-                        "('a', 'b', 'c', systimestamp, 1, '9:d41d8cd98f00b204e9800998ecf8427e', 'empty', '', " +
+                        "('a', 'b', 'c', current_timestamp, 1, '9:d41d8cd98f00b204e9800998ecf8427e', 'empty', '', " +
                         "'executed', 'e', null, '" + version + "', '%s')", deploymentId),
                 OracleDatabase.class);
         assertCorrect(String.format("insert into [databasechangelog] ([id], [author], [filename], [dateexecuted], " +
@@ -133,7 +133,7 @@ public class MarkChangeSetRanExecutorTest extends AbstractExecutorTest {
                         " 'a' and" +
                         " [author] = 'b' and [filename] = 'c'", deploymentId),
                 MSSQLDatabase.class);
-        assertCorrect(String.format("update databasechangelog set comments = '', contexts = 'e', dateexecuted = systimestamp, deployment_id = '%s', [description] = 'empty', exectype = " +
+        assertCorrect(String.format("update databasechangelog set comments = '', contexts = 'e', dateexecuted = current_timestamp, deployment_id = '%s', [description] = 'empty', exectype = " +
                         "'reran', labels = null, liquibase = 'dev', md5sum = '9:d41d8cd98f00b204e9800998ecf8427e', orderexecuted = 1 where id = 'a' and" +
                         " author " +
                         "= 'b' and filename = 'c'", deploymentId),

--- a/liquibase-standard/src/main/java/liquibase/database/core/OracleDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/OracleDatabase.java
@@ -62,7 +62,7 @@ public class OracleDatabase extends AbstractJdbcDatabase {
     public OracleDatabase() {
         super.unquotedObjectsAreUppercased = true;
         //noinspection HardCodedStringLiteral
-        super.setCurrentDateTimeFunction("SYSTIMESTAMP");
+        super.setCurrentDateTimeFunction("CURRENT_TIMESTAMP");
         // Setting list of Oracle's native functions
         //noinspection HardCodedStringLiteral
         dateFunctions.add(new DatabaseFunction("SYSDATE"));

--- a/liquibase-standard/src/test/java/liquibase/database/core/OracleDatabaseTest.java
+++ b/liquibase-standard/src/test/java/liquibase/database/core/OracleDatabaseTest.java
@@ -97,7 +97,7 @@ public class OracleDatabaseTest extends AbstractJdbcDatabaseTest {
     @Override
     @Test
     public void getCurrentDateTimeFunction() {
-        assertEquals("SYSTIMESTAMP", getDatabase().getCurrentDateTimeFunction(), "Oracle Database's 'give me the current timestamp' function is correctly reported.");
+        assertEquals("CURRENT_TIMESTAMP", getDatabase().getCurrentDateTimeFunction(), "Oracle Database's 'give me the current timestamp' function is correctly reported.");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #4779

- Changed `OracleDatabase`'s default `currentDateTimeFunction` from `SYSTIMESTAMP` to `CURRENT_TIMESTAMP`
- `SYSTIMESTAMP` returns the timestamp in the OS timezone, while `CURRENT_TIMESTAMP` returns it in the database session timezone
- When users specify `CURRENT_TIMESTAMP()` in changelogs, they expect the session timezone, not the system timezone
- Updated the corresponding unit test assertion

## Test plan

- [x] Existing `OracleDatabaseTest` updated and passing (33 tests, 0 failures)
- [ ] Verify on an Oracle instance where system timezone differs from session timezone that `CURRENT_TIMESTAMP` is generated instead of `SYSTIMESTAMP`