### PR TITLE
fix: escape mentions and special chars in release notes

### DIFF
--- a/.github/release-drafter-master.yml
+++ b/.github/release-drafter-master.yml
@@ -33,7 +33,7 @@ categories:
 
 
 change-template: '- (#$NUMBER) $TITLE @$AUTHOR '
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+change-title-escapes: '\<*_&@#`'
 version-resolver:
   major:
     labels:


### PR DESCRIPTION
Fixes #7515

## Summary

- Added `@`, `#`, and backtick (`` ` ``) to the `change-title-escapes` setting in the release-drafter config
- This prevents PR titles containing `@Deprecated`, `#issue`, or backticks from being incorrectly rendered as GitHub user mentions, issue links, or broken code blocks in auto-generated release notes

## Details

The `change-title-escapes` setting already escaped `\<*_&` (handling HTML tags like `<empty/>`). This change adds the three remaining recommended escape characters that the release-drafter documentation suggests.

For example, a PR titled "Handle @Deprecated annotations" would previously render as a link to a GitHub user. With this fix, the `@` is escaped and the title renders as plain text.

## Test plan

- [ ] Verify the next draft release generated by release-drafter properly escapes `@`, `#`, and backtick characters in PR titles