### PR TITLE
fix: use integerExp type for numeric sequence attributes in XSD

### DIFF
--- a/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
+++ b/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
@@ -455,12 +455,12 @@
         <xsd:attribute name="schemaName" type="xsd:string"/>
         <xsd:attribute name="sequenceName" type="xsd:string"
                        use="required"/>
-        <xsd:attribute name="startValue" type="xsd:string"/>
-        <xsd:attribute name="incrementBy" type="xsd:string"/>
-        <xsd:attribute name="maxValue" type="xsd:string"/>
-        <xsd:attribute name="minValue" type="xsd:string"/>
+        <xsd:attribute name="startValue" type="integerExp"/>
+        <xsd:attribute name="incrementBy" type="integerExp"/>
+        <xsd:attribute name="maxValue" type="integerExp"/>
+        <xsd:attribute name="minValue" type="integerExp"/>
         <xsd:attribute name="ordered" type="booleanExp"/>
-        <xsd:attribute name="cacheSize" type="xsd:string"/>
+        <xsd:attribute name="cacheSize" type="integerExp"/>
         <xsd:attribute name="dataType" type="xsd:string" />
         <xsd:attribute name="cycle" type="booleanExp">
             <xsd:annotation>


### PR DESCRIPTION
Fixes #1743

## Summary

- Changed `startValue`, `incrementBy`, `maxValue`, `minValue`, and `cacheSize` attributes in the `sequenceAttributes` group from `xsd:string` to `integerExp` in `dbchangelog-latest.xsd`
- The `integerExp` type validates values as proper integers (matching the `BigInteger` Java backing type) while still supporting `${}` property substitution
- This is consistent with how `booleanExp` is already used for the `ordered` and `cycle` attributes in the same group

## Context

The `sequenceAttributes` group used `xsd:string` for numeric fields, which allowed arbitrary non-numeric strings to pass XSD validation but fail at runtime with `NumberFormatException`. The existing `integerExp` custom type (union of `xsd:integer` and `propertyExpression`) is the correct fit since it supports arbitrary-precision integers (unlike `xsd:long`) and property expressions.

## Backward compatibility analysis

`integerExp`'s `propertyExpression` pattern (`$\{[\w\.]+\}`) is stricter than the runtime `ExpressionExpander`, which accepts any characters in property names and expands expressions embedded anywhere in the value. Three forms that work at runtime would newly fail XSD validation:

- Property names with characters outside `[\w.]`, e.g. `startValue="${start-value}"`
- Expressions mixed with literal text, e.g. `maxValue="${base}000"`
- The escape syntax `${:prop}`

Searched for real-world usage of these forms in sequence attributes:

| Source | Scope | Result |
|---|---|---|
| This repo | all XML changelogs | 0 expression usages in the 5 attributes (all 156 occurrences are integer literals) |
| Sourcegraph public index | regex search, incl. forks/archived | 0 Liquibase hits (only false positives in shell/JS files) |
| GitHub code search | per-attribute phrase search, XML | 0 Liquibase hits (control queries confirmed the method finds existing patterns) |
| GitHub code search | `${:` escape syntax in changelogs | 2 hits, both in `<column value=...>` attributes — not sequence attributes |

No public usage of `${}` expressions in these attributes was found in any form, including plain `${prop}`. Plain expressions remain valid regardless. Private changelogs are not observable, so this tightening should be called out in the release notes: *sequence numeric attributes (`startValue`, `incrementBy`, `maxValue`, `minValue`, `cacheSize`) now validate as integers or `${property}` expressions.* Anything newly rejected produces a clear XSD validation error naming the attribute, and non-expression values that fail the new validation were already failing at runtime with `NumberFormatException`.

Note: `booleanExp` on `ordered`/`cycle` has imposed the same expression restrictions in this group for years without reported issues.

## Test plan

- [x] Existing XML parser and CreateSequence tests pass (127 tests)
- [x] Verified that existing test changelogs with large numeric values (e.g., `maxValue="9999999999999999999999999999"`) remain valid since `integerExp` uses `xsd:integer` (arbitrary precision)
