### PR TITLE
fix: stop modifying JUL logging config from library code

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/logging/core/JavaLogService.java
+++ b/liquibase-standard/src/main/java/liquibase/logging/core/JavaLogService.java
@@ -1,9 +1,6 @@
 package liquibase.logging.core;
 
-import liquibase.Liquibase;
 import liquibase.Scope;
-import liquibase.configuration.ConfiguredValue;
-import liquibase.integration.commandline.LiquibaseCommandLineConfiguration;
 import liquibase.logging.LogService;
 import liquibase.logging.Logger;
 import liquibase.serializer.LiquibaseSerializable;
@@ -32,7 +29,6 @@ public class JavaLogService extends AbstractLogService {
         JavaLogger logger = loggers.get(clazz);
         if (logger == null) {
             java.util.logging.Logger utilLogger = java.util.logging.Logger.getLogger(getLogName(clazz));
-            utilLogger.setUseParentHandlers(true);
             if (parent != null && !parent.getName().equals(utilLogger.getName())) {
                 utilLogger.setParent(parent);
             }
@@ -67,7 +63,11 @@ public class JavaLogService extends AbstractLogService {
         if (! configuredChannels.equalsIgnoreCase("all")) {
             channels = StringUtil.splitAndTrim(configuredChannels.toLowerCase(), ",");
             if (channels.contains(channelName.toLowerCase())) {
-                java.util.logging.Logger.getLogger(channelName).setLevel(logLevel);
+                try {
+                    java.util.logging.Logger.getLogger(channelName).setLevel(logLevel);
+                } catch (Exception e) {
+                    // Ignore errors from logging bridges (e.g. Log4j JUL bridge) that do not support setLevel
+                }
             }
         }
     }

--- a/liquibase-standard/src/test/java/liquibase/logging/core/JavaLogServiceTest.java
+++ b/liquibase-standard/src/test/java/liquibase/logging/core/JavaLogServiceTest.java
@@ -1,0 +1,67 @@
+package liquibase.logging.core;
+
+import liquibase.Scope;
+import liquibase.logging.Logger;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link JavaLogService}.
+ */
+class JavaLogServiceTest {
+
+    @Test
+    void getLog_doesNotModifyUseParentHandlers() {
+        JavaLogService service = new JavaLogService();
+        java.util.logging.Logger julLogger = java.util.logging.Logger.getLogger("liquibase.logging");
+        boolean originalValue = julLogger.getUseParentHandlers();
+
+        // Explicitly set to false to verify getLog does not force it to true
+        julLogger.setUseParentHandlers(false);
+
+        service.getLog(JavaLogService.class);
+
+        assertFalse(julLogger.getUseParentHandlers(),
+                "getLog should not modify useParentHandlers on the underlying JUL logger");
+
+        // Restore original value
+        julLogger.setUseParentHandlers(originalValue);
+    }
+
+    @Test
+    void getLog_returnsNonNullLogger() {
+        JavaLogService service = new JavaLogService();
+        Logger logger = service.getLog(JavaLogServiceTest.class);
+        assertNotNull(logger);
+    }
+
+    @Test
+    void getLog_returnsCachedLoggerOnSecondCall() {
+        JavaLogService service = new JavaLogService();
+        Logger first = service.getLog(JavaLogServiceTest.class);
+        Logger second = service.getLog(JavaLogServiceTest.class);
+        assertSame(first, second);
+    }
+
+    @Test
+    void getLogName_returnsSecondLevelPackage() {
+        JavaLogService service = new JavaLogService();
+        assertEquals("liquibase.logging", service.getLogName(JavaLogService.class));
+    }
+
+    @Test
+    void getLogName_returnsLiquibaseForTopLevelPackage() {
+        JavaLogService service = new JavaLogService();
+        assertEquals("liquibase", service.getLogName(liquibase.Scope.class));
+    }
+
+    @Test
+    void getLogName_returnsUnknownForNull() {
+        JavaLogService service = new JavaLogService();
+        assertEquals("unknown", service.getLogName(null));
+    }
+}


### PR DESCRIPTION
Fixes #7482

## Summary

- Removed the unnecessary `setUseParentHandlers(true)` call in `JavaLogService.getLog()`. The value `true` is already the JUL default, so this call was redundant. More importantly, it interferes with logging bridges like Log4j's JUL-to-Log4j bridge, which started warning on configuration changes in Log4j 2.25.x.
- Wrapped the `setLevel` call in `setChannelLogLevel` with a try-catch to gracefully handle logging bridges that reject programmatic level changes.
- Cleaned up unused imports (`Liquibase`, `ConfiguredValue`, `LiquibaseCommandLineConfiguration`).
- Added unit tests for `JavaLogService`.

## Test plan

- [x] New unit tests in `JavaLogServiceTest` verify that `getLog()` does not modify `useParentHandlers` on the underlying JUL logger
- [x] All existing tests pass
- [ ] Manual verification with Log4j 2.25+ JUL bridge to confirm warnings are eliminated