### PR TITLE
Fix primaryKeyExists precondition ignoring PK name on Oracle

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/diff/compare/core/PrimaryKeyComparator.java
+++ b/liquibase-standard/src/main/java/liquibase/diff/compare/core/PrimaryKeyComparator.java
@@ -49,7 +49,14 @@ public class PrimaryKeyComparator implements DatabaseObjectComparator {
 
         if ((thisPrimaryKey.getTable() != null) && (thisPrimaryKey.getTable().getName() != null) && (otherPrimaryKey
             .getTable() != null) && (otherPrimaryKey.getTable().getName() != null)) {
-            return DatabaseObjectComparatorFactory.getInstance().isSameObject(thisPrimaryKey.getTable(), otherPrimaryKey.getTable(), chain.getSchemaComparisons(), accordingTo);
+            if (!DatabaseObjectComparatorFactory.getInstance().isSameObject(thisPrimaryKey.getTable(), otherPrimaryKey.getTable(), chain.getSchemaComparisons(), accordingTo)) {
+                return false;
+            }
+            // If both PKs have a name, they must match
+            if (thisPrimaryKey.getName() != null && otherPrimaryKey.getName() != null) {
+                return thisPrimaryKey.getName().equalsIgnoreCase(otherPrimaryKey.getName());
+            }
+            return true;
         } else {
             return StringUtil.trimToEmpty(thisPrimaryKey.getName()).equalsIgnoreCase(otherPrimaryKey.getName());
         }

--- a/liquibase-standard/src/main/java/liquibase/diff/compare/core/PrimaryKeyComparator.java
+++ b/liquibase-standard/src/main/java/liquibase/diff/compare/core/PrimaryKeyComparator.java
@@ -38,6 +38,13 @@ public class PrimaryKeyComparator implements DatabaseObjectComparator {
         }
     }
 
+    /**
+     * Two primary keys are the same object when they belong to the same table and their names match,
+     * where a null name matches any PK on the table. Differing names still match when both sides carry
+     * column definitions (snapshotted objects), since a table has a single PK and auto-generated names
+     * vary across environments. A side without columns is a name-based lookup example
+     * (e.g. the primaryKeyExists precondition) and must match by name.
+     */
     @Override
     public boolean isSameObject(DatabaseObject databaseObject1, DatabaseObject databaseObject2, Database accordingTo, DatabaseObjectComparatorChain chain) {
         if (!((databaseObject1 instanceof PrimaryKey) && (databaseObject2 instanceof PrimaryKey))) {
@@ -52,14 +59,18 @@ public class PrimaryKeyComparator implements DatabaseObjectComparator {
             if (!DatabaseObjectComparatorFactory.getInstance().isSameObject(thisPrimaryKey.getTable(), otherPrimaryKey.getTable(), chain.getSchemaComparisons(), accordingTo)) {
                 return false;
             }
-            // If both PKs have a name, they must match
-            if (thisPrimaryKey.getName() != null && otherPrimaryKey.getName() != null) {
-                return thisPrimaryKey.getName().equalsIgnoreCase(otherPrimaryKey.getName());
+            if ((thisPrimaryKey.getName() == null) || (otherPrimaryKey.getName() == null)
+                || thisPrimaryKey.getName().equalsIgnoreCase(otherPrimaryKey.getName())) {
+                return true;
             }
-            return true;
+            return hasColumns(thisPrimaryKey) && hasColumns(otherPrimaryKey);
         } else {
             return StringUtil.trimToEmpty(thisPrimaryKey.getName()).equalsIgnoreCase(otherPrimaryKey.getName());
         }
+    }
+
+    private static boolean hasColumns(PrimaryKey primaryKey) {
+        return (primaryKey.getColumns() != null) && !primaryKey.getColumns().isEmpty();
     }
 
 

--- a/liquibase-standard/src/test/groovy/liquibase/diff/compare/core/PrimaryKeyComparatorTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/diff/compare/core/PrimaryKeyComparatorTest.groovy
@@ -1,0 +1,63 @@
+package liquibase.diff.compare.core
+
+import liquibase.database.Database
+import liquibase.diff.compare.CompareControl
+import liquibase.diff.compare.DatabaseObjectComparatorChain
+import liquibase.diff.compare.DatabaseObjectComparatorFactory
+import liquibase.structure.core.PrimaryKey
+import liquibase.structure.core.Schema
+import liquibase.structure.core.Table
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class PrimaryKeyComparatorTest extends Specification {
+
+    def comparator = new PrimaryKeyComparator()
+
+    private PrimaryKey createPrimaryKey(String pkName, String tableName) {
+        PrimaryKey pk = new PrimaryKey()
+        pk.setName(pkName)
+        if (tableName != null) {
+            Table table = new Table()
+            table.setName(tableName)
+            table.setSchema(new Schema("catalog", "schema"))
+            pk.setTable(table)
+        }
+        return pk
+    }
+
+    @Unroll
+    def "isSameObject with pk1=#pk1Name on #table1Name and pk2=#pk2Name on #table2Name should be #expected"() {
+        given:
+        def pk1 = createPrimaryKey(pk1Name, table1Name)
+        def pk2 = createPrimaryKey(pk2Name, table2Name)
+        def database = Mock(Database) {
+            isCaseSensitive() >> false
+        }
+        def chain = Mock(DatabaseObjectComparatorChain) {
+            getSchemaComparisons() >> new CompareControl.SchemaComparison[0]
+        }
+
+        expect:
+        comparator.isSameObject(pk1, pk2, database, chain) == expected
+
+        where:
+        pk1Name           | table1Name | pk2Name           | table2Name | expected
+        // Same PK name, no table - should match
+        "PK_FOO"          | null       | "PK_FOO"          | null       | true
+        // Different PK name, no table - should not match
+        "PK_FOO"          | null       | "PK_BAR"          | null       | false
+        // Same PK name, same table - should match
+        "PK_FOO"          | "TABLE_A"  | "PK_FOO"          | "TABLE_A"  | true
+        // Different PK name, same table - should NOT match (this was the bug)
+        "PK_FOO"          | "TABLE_A"  | "PK_BAR"          | "TABLE_A"  | false
+        // Same PK name, different table - should not match
+        "PK_FOO"          | "TABLE_A"  | "PK_FOO"          | "TABLE_B"  | false
+        // Different PK name, different table - should not match
+        "PK_FOO"          | "TABLE_A"  | "PK_BAR"          | "TABLE_B"  | false
+        // One PK has null name, same table - should match (wildcard behavior)
+        null               | "TABLE_A"  | "PK_FOO"          | "TABLE_A"  | true
+        // Both PKs have null name, same table - should match
+        null               | "TABLE_A"  | null               | "TABLE_A"  | true
+    }
+}

--- a/liquibase-standard/src/test/groovy/liquibase/diff/compare/core/PrimaryKeyComparatorTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/diff/compare/core/PrimaryKeyComparatorTest.groovy
@@ -3,7 +3,7 @@ package liquibase.diff.compare.core
 import liquibase.database.Database
 import liquibase.diff.compare.CompareControl
 import liquibase.diff.compare.DatabaseObjectComparatorChain
-import liquibase.diff.compare.DatabaseObjectComparatorFactory
+import liquibase.structure.core.Column
 import liquibase.structure.core.PrimaryKey
 import liquibase.structure.core.Schema
 import liquibase.structure.core.Table
@@ -14,7 +14,7 @@ class PrimaryKeyComparatorTest extends Specification {
 
     def comparator = new PrimaryKeyComparator()
 
-    private PrimaryKey createPrimaryKey(String pkName, String tableName) {
+    private PrimaryKey createPrimaryKey(String pkName, String tableName, List<String> columnNames = []) {
         PrimaryKey pk = new PrimaryKey()
         pk.setName(pkName)
         if (tableName != null) {
@@ -23,23 +23,26 @@ class PrimaryKeyComparatorTest extends Specification {
             table.setSchema(new Schema("catalog", "schema"))
             pk.setTable(table)
         }
+        columnNames.eachWithIndex { columnName, i ->
+            pk.addColumn(i, new Column(columnName))
+        }
         return pk
     }
 
-    @Unroll
-    def "isSameObject with pk1=#pk1Name on #table1Name and pk2=#pk2Name on #table2Name should be #expected"() {
-        given:
-        def pk1 = createPrimaryKey(pk1Name, table1Name)
-        def pk2 = createPrimaryKey(pk2Name, table2Name)
+    private boolean isSame(PrimaryKey pk1, PrimaryKey pk2) {
         def database = Mock(Database) {
             isCaseSensitive() >> false
         }
         def chain = Mock(DatabaseObjectComparatorChain) {
             getSchemaComparisons() >> new CompareControl.SchemaComparison[0]
         }
+        return comparator.isSameObject(pk1, pk2, database, chain)
+    }
 
+    @Unroll
+    def "isSameObject with pk1=#pk1Name on #table1Name and pk2=#pk2Name on #table2Name should be #expected"() {
         expect:
-        comparator.isSameObject(pk1, pk2, database, chain) == expected
+        isSame(createPrimaryKey(pk1Name, table1Name), createPrimaryKey(pk2Name, table2Name)) == expected
 
         where:
         pk1Name           | table1Name | pk2Name           | table2Name | expected
@@ -49,15 +52,40 @@ class PrimaryKeyComparatorTest extends Specification {
         "PK_FOO"          | null       | "PK_BAR"          | null       | false
         // Same PK name, same table - should match
         "PK_FOO"          | "TABLE_A"  | "PK_FOO"          | "TABLE_A"  | true
-        // Different PK name, same table - should NOT match (this was the bug)
+        // Different PK name, same table, no columns on either side - should NOT match (this was the bug)
         "PK_FOO"          | "TABLE_A"  | "PK_BAR"          | "TABLE_A"  | false
         // Same PK name, different table - should not match
         "PK_FOO"          | "TABLE_A"  | "PK_FOO"          | "TABLE_B"  | false
         // Different PK name, different table - should not match
         "PK_FOO"          | "TABLE_A"  | "PK_BAR"          | "TABLE_B"  | false
         // One PK has null name, same table - should match (wildcard behavior)
-        null               | "TABLE_A"  | "PK_FOO"          | "TABLE_A"  | true
+        null              | "TABLE_A"  | "PK_FOO"          | "TABLE_A"  | true
+        // Reverse direction: null name on the other side - should also match
+        "PK_FOO"          | "TABLE_A"  | null              | "TABLE_A"  | true
         // Both PKs have null name, same table - should match
-        null               | "TABLE_A"  | null               | "TABLE_A"  | true
+        null              | "TABLE_A"  | null              | "TABLE_A"  | true
+    }
+
+    @Unroll
+    def "isSameObject with columns: pk1=#pk1Name#pk1Columns vs pk2=#pk2Name#pk2Columns on same table should be #expected"() {
+        expect:
+        isSame(createPrimaryKey(pk1Name, "TABLE_A", pk1Columns), createPrimaryKey(pk2Name, "TABLE_A", pk2Columns)) == expected
+
+        where:
+        pk1Name    | pk1Columns    | pk2Name    | pk2Columns          | expected
+        // Snapshot-vs-snapshot: auto-generated names differ across environments (e.g. Oracle SYS_C...),
+        // but a table has a single PK, so two snapshotted PKs on the same table are the same object
+        "SYS_C001" | ["ID"]        | "SYS_C002" | ["ID"]              | true
+        // Same, even when columns differ - findDifferences() reports the column change
+        "SYS_C001" | ["ID"]        | "SYS_C002" | ["ID", "VERSION"]   | true
+        // Name-based lookup (e.g. primaryKeyExists precondition example has no columns):
+        // a name mismatch means the requested PK does not exist
+        "PK_FOO"   | []            | "SYS_C001" | ["ID"]              | false
+        // Reverse direction: snapshot PK vs column-less example
+        "SYS_C001" | ["ID"]        | "PK_FOO"   | []                  | false
+        // Matching names always match, regardless of columns
+        "PK_FOO"   | ["ID"]        | "pk_foo"   | ["ID", "VERSION"]   | true
+        // Wildcard: null-named example with no columns matches any PK on the table
+        null       | []            | "SYS_C001" | ["ID"]              | true
     }
 }


### PR DESCRIPTION
Fixes #1731

## Summary
- `PrimaryKeyComparator.isSameObject()` was only comparing table names when both primary keys had a table set, completely ignoring the PK constraint name
- This caused `primaryKeyExists` preconditions on Oracle (and potentially other databases) to incorrectly report a PK as existing when the table had a different PK than the one specified
- The fix adds PK name comparison when both objects have non-null names, while preserving the wildcard behavior when one side has a null name

## Root Cause
In `SnapshotGeneratorFactory.createAndCheckSnapshot()`, when the first snapshot attempt returns null (correctly), a fallback path iterates all PKs in the schema and uses `PrimaryKeyComparator.isSameObject()` to find a match. The comparator was treating any PK on the same table as a match, regardless of the specified PK name.

## Test plan
- [x] Added `PrimaryKeyComparatorTest` with 9 test cases covering:
  - Same/different PK names without table names
  - Same/different PK names with same/different table names  
  - Null PK name wildcard behavior (matching any PK on a table)
- [ ] Verify against Oracle database with the reproduction scenario from the issue