### PR TITLE
Discover custom LogService before configuration init

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/Scope.java
+++ b/liquibase-standard/src/main/java/liquibase/Scope.java
@@ -147,15 +147,17 @@ public class Scope {
             rootScope.values.put(Attr.checksumVersion.name(), ChecksumVersion.latest());
 
             rootScope.values.put(Attr.ui.name(), new ConsoleUIService());
-            rootScope.getSingleton(LiquibaseConfiguration.class).init(rootScope);
 
+            // Discover custom LogService early, before LiquibaseConfiguration.init(),
+            // so that logging during configuration setup uses the correct LogService.
             LogService overrideLogService = rootScope.getSingleton(LogServiceFactory.class).getDefaultLogService();
             if (overrideLogService != null) {
                 rootScope.values.put(Attr.logService.name(), overrideLogService);
             } else {
-                // Log a warning using the already-created JavaLogService
                 rootScope.getLog(Scope.class).warning("Could not find log service via LogServiceFactory. Using JavaLogService as default.");
             }
+
+            rootScope.getSingleton(LiquibaseConfiguration.class).init(rootScope);
 
             //check for higher-priority serviceLocator
             ServiceLocator serviceLocator = rootScope.getServiceLocator();


### PR DESCRIPTION
Fixes #7520

## Summary

- Moved the `LogServiceFactory` lookup to occur **before** `LiquibaseConfiguration.init()` during root scope creation in `Scope.getCurrentScope()`
- Previously, the custom `LogService` was only discovered after configuration initialization, causing all logging during that phase to go through the default `JavaLogService`
- This ensures that custom `LogService` implementations (e.g. `liquibase-slf4j`) are active during configuration setup, capturing all logs from that phase


Personal note: the fix seems so simple, I wonder if there are further implications.

## Test plan

- [x] All 5878 existing tests pass (0 failures, 0 errors)
- [ ] Verify with `liquibase-slf4j` that log output during configuration init now goes through SLF4J