### PR TITLE
Use LEFT JOIN instead of NOT IN for PostgreSQL sequence dependency detection

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
@@ -30,15 +30,6 @@ public class SequenceSnapshotGenerator extends JdbcSnapshotGenerator {
         super(Sequence.class, new Class[]{Schema.class});
     }
 
-    private static final StringBuilder COMMON_PG_SEQUENCE_QUERY = new StringBuilder("JOIN pg_namespace ns on c.relnamespace = ns.oid ")
-            .append("LEFT JOIN pg_depend d ON c.oid = d.objid AND d.deptype IN ('a', 'i') AND d.refobjsubid > 0 ")
-            .append("WHERE c.relkind = 'S' AND ns.nspname = 'SCHEMA_NAME' ")
-            .append("AND (d.objid IS NULL OR EXISTS ( ")
-            .append("SELECT 1 FROM pg_attribute a JOIN pg_class t ON t.oid = d.refobjid AND a.attrelid=t.oid AND a.attnum=d.refobjsubid ")
-            .append("LEFT JOIN pg_catalog.pg_attrdef ad ON ad.adrelid = a.attrelid AND ad.adnum = a.attnum ")
-            .append("WHERE a.attidentity NOT IN ('a', 'd') ")
-            .append("AND (a.atthasdef = false OR NOT (pg_get_expr(ad.adbin, ad.adrelid) ILIKE '%' || c.relname || '%')))) ");
-
     @Override
     protected void addTo(DatabaseObject foundObject, DatabaseSnapshot snapshot) throws DatabaseException, InvalidExampleException {
         if (!(foundObject instanceof Schema) || !snapshot.getDatabase().supports(Sequence.class)) {
@@ -205,15 +196,29 @@ public class SequenceSnapshotGenerator extends JdbcSnapshotGenerator {
         } else if (database instanceof PostgresDatabase) {
             int version = 9;
             try {
-                version = database.getDatabaseMajorVersion();
-            } catch (Exception ignore) {
-                Scope.getCurrentScope().getLog(getClass()).warning("Failed to retrieve database version: " + ignore);
+                if (database.getConnection() != null) {
+                    version = database.getDatabaseMajorVersion();
+                    Scope.getCurrentScope().getLog(getClass()).fine("Retrieved database version for PostgreSQL: " + version);
+                }
+            } catch (DatabaseException e) {
+                Scope.getCurrentScope().getLog(getClass()).warning("Failed to retrieve database version: " + e.getMessage());
             }
             String schemaName = schema.getName();
             if(schemaName == null) {
                 schemaName = database.getDefaultSchemaName();
             }
-            String pgSequenceQuery = COMMON_PG_SEQUENCE_QUERY.toString().replace("SCHEMA_NAME", schemaName);
+
+            // Build the query dynamically, only including the attidentity check for PG 10+
+            String pgSequenceQuery = new StringBuilder("JOIN pg_namespace ns on c.relnamespace = ns.oid ")
+                    .append("LEFT JOIN pg_depend d ON c.oid = d.objid AND d.deptype IN ('a', 'i') AND d.refobjsubid > 0 ")
+                    .append("WHERE c.relkind = 'S' AND ns.nspname = '").append(schemaName).append("' ")
+                    .append("AND (d.objid IS NULL OR EXISTS ( ")
+                    .append("SELECT 1 FROM pg_attribute a JOIN pg_class t ON t.oid = d.refobjid AND a.attrelid=t.oid AND a.attnum=d.refobjsubid ")
+                    .append("LEFT JOIN pg_catalog.pg_attrdef ad ON ad.adrelid = a.attrelid AND ad.adnum = a.attnum ")
+                    .append(version >= 10 ? "WHERE a.attidentity NOT IN ('a', 'd') AND " : "WHERE ")
+                    .append("(a.atthasdef = false OR NOT (pg_get_expr(ad.adbin, ad.adrelid) ILIKE '%' || c.relname || '%')))) ")
+                    .toString();
+
             if (version < 10) { // 'pg_sequence' view does not exists yet
                 return new RawParameterizedSqlStatement(String.format("SELECT c.relname AS \"SEQUENCE_NAME\" FROM pg_class c %s", pgSequenceQuery));
             } else {

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
@@ -31,7 +31,7 @@ public class SequenceSnapshotGenerator extends JdbcSnapshotGenerator {
     }
 
     private static final StringBuilder COMMON_PG_SEQUENCE_QUERY = new StringBuilder("JOIN pg_namespace ns on c.relnamespace = ns.oid ")
-            .append("LEFT JOIN pg_depend d ON c.oid = d.objid AND d.deptype IN ('a', 'i', 'n') AND d.refobjsubid > 0 ")
+            .append("LEFT JOIN pg_depend d ON c.oid = d.objid AND d.deptype IN ('a', 'i') AND d.refobjsubid > 0 ")
             .append("WHERE c.relkind = 'S' AND ns.nspname = 'SCHEMA_NAME' ")
             .append("AND (d.objid IS NULL OR EXISTS ( ")
             .append("SELECT 1 FROM pg_attribute a JOIN pg_class t ON t.oid = d.refobjid AND a.attrelid=t.oid AND a.attnum=d.refobjsubid ")

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
@@ -34,9 +34,10 @@ public class SequenceSnapshotGenerator extends JdbcSnapshotGenerator {
             .append("LEFT JOIN pg_depend d ON c.oid = d.objid AND d.deptype IN ('a', 'i') AND d.refobjsubid > 0 ")
             .append("WHERE c.relkind = 'S' AND ns.nspname = 'SCHEMA_NAME' ")
             .append("AND (d.objid IS NULL OR EXISTS ( ")
-            .append("select 1 from pg_attribute a JOIN pg_class t ON t.oid = d.refobjid AND a.attrelid=t.oid AND a.attnum=d.refobjsubid ")
+            .append("SELECT 1 FROM pg_attribute a JOIN pg_class t ON t.oid = d.refobjid AND a.attrelid=t.oid AND a.attnum=d.refobjsubid ")
             .append("LEFT JOIN pg_catalog.pg_attrdef ad ON ad.adrelid = a.attrelid AND ad.adnum = a.attnum ")
-            .append("WHERE a.atthasdef = false or not (pg_get_expr(ad.adbin, ad.adrelid) ilike '%' || c.relname || '%'))) ");
+            .append("WHERE (a.attidentity NOT IN ('a', 'd')) ")
+            .append("AND (a.atthasdef = false OR NOT (pg_get_expr(ad.adbin, ad.adrelid) ILIKE '%' || c.relname || '%')))) ");
 
     @Override
     protected void addTo(DatabaseObject foundObject, DatabaseSnapshot snapshot) throws DatabaseException, InvalidExampleException {

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
@@ -31,11 +31,12 @@ public class SequenceSnapshotGenerator extends JdbcSnapshotGenerator {
     }
 
     private static final StringBuilder COMMON_PG_SEQUENCE_QUERY = new StringBuilder("JOIN pg_namespace ns on c.relnamespace = ns.oid ")
-            .append("LEFT JOIN pg_depend d ON c.oid = d.objid WHERE c.relkind = 'S' AND ns.nspname = 'SCHEMA_NAME' ")
-            .append("AND (c.oid not in (select ds.objid FROM pg_depend ds where ds.refobjsubid > 0) OR ( d.deptype = 'a' AND EXISTS ( ")
+            .append("LEFT JOIN pg_depend d ON c.oid = d.objid AND d.deptype IN ('a', 'i') AND d.refobjsubid > 0 ")
+            .append("WHERE c.relkind = 'S' AND ns.nspname = 'SCHEMA_NAME' ")
+            .append("AND (d.objid IS NULL OR EXISTS ( ")
             .append("select 1 from pg_attribute a JOIN pg_class t ON t.oid = d.refobjid AND a.attrelid=t.oid AND a.attnum=d.refobjsubid ")
             .append("LEFT JOIN pg_catalog.pg_attrdef ad ON ad.adrelid = a.attrelid AND ad.adnum = a.attnum ")
-            .append("WHERE a.atthasdef = false or not (pg_get_expr(ad.adbin, ad.adrelid) ilike '%' || c.relname || '%'))))");
+            .append("WHERE a.atthasdef = false or not (pg_get_expr(ad.adbin, ad.adrelid) ilike '%' || c.relname || '%'))) ");
 
     @Override
     protected void addTo(DatabaseObject foundObject, DatabaseSnapshot snapshot) throws DatabaseException, InvalidExampleException {

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/SequenceSnapshotGenerator.java
@@ -31,12 +31,12 @@ public class SequenceSnapshotGenerator extends JdbcSnapshotGenerator {
     }
 
     private static final StringBuilder COMMON_PG_SEQUENCE_QUERY = new StringBuilder("JOIN pg_namespace ns on c.relnamespace = ns.oid ")
-            .append("LEFT JOIN pg_depend d ON c.oid = d.objid AND d.deptype IN ('a', 'i') AND d.refobjsubid > 0 ")
+            .append("LEFT JOIN pg_depend d ON c.oid = d.objid AND d.deptype IN ('a', 'i', 'n') AND d.refobjsubid > 0 ")
             .append("WHERE c.relkind = 'S' AND ns.nspname = 'SCHEMA_NAME' ")
             .append("AND (d.objid IS NULL OR EXISTS ( ")
             .append("SELECT 1 FROM pg_attribute a JOIN pg_class t ON t.oid = d.refobjid AND a.attrelid=t.oid AND a.attnum=d.refobjsubid ")
             .append("LEFT JOIN pg_catalog.pg_attrdef ad ON ad.adrelid = a.attrelid AND ad.adnum = a.attnum ")
-            .append("WHERE (a.attidentity NOT IN ('a', 'd')) ")
+            .append("WHERE a.attidentity NOT IN ('a', 'd') ")
             .append("AND (a.atthasdef = false OR NOT (pg_get_expr(ad.adbin, ad.adrelid) ILIKE '%' || c.relname || '%')))) ");
 
     @Override


### PR DESCRIPTION
## Impact

* [ ] Bug fix (non-breaking change which fixes expected existing functionality)
* [x] Enhancement/New feature (adds functionality without impacting existing logic)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary

This PR improves PostgreSQL sequence metadata handling in Liquibase by making the sequence discovery query more robust when dealing with **non-trivial or complex ownership scenarios**.

This change is intentionally scoped as an **incremental improvement**, not a complete solution for all PostgreSQL sequence ownership edge cases.

## Scope Clarification

This PR is related to issue **#7514**. During investigation and testing, it became clear that the full behavior described there depends on correct inference of PostgreSQL dependency direction and sequence–column relationships.

That underlying dependency modeling issue is tracked separately in **#7649**.

As such:

* This PR improves behavior in a subset of complex sequence ownership scenarios
* This PR does **not** fully resolve #7514 on its own
* The remaining cases are expected to be addressed once #7649 is implemented and its dependency model is consumed by the PostgreSQL snapshot logic

## What This PR Does

* Refactors the PostgreSQL sequence metadata query to use a `LEFT JOIN` on `pg_depend` instead of a `NOT IN` subquery
* Adds support for dependency types:

  * `'a'` — auto dependency (`SERIAL`)
  * `'i'` — internal dependency (`IDENTITY` columns in PostgreSQL 10+)
* Adjusts filtering logic to better account for sequences whose dependency relationships have been modified
* Simplifies the query structure by consolidating dependency checks into a single join
* Reduces reliance on assumptions about simple `OWNED BY` relationships during sequence discovery

## Related Issues

* Related to: **#7514**
* Root cause tracked in: **#7649**

## Things to be aware of

* **Foundational Metadata Improvement:** This PR focuses strictly on improving the **Sequence Snapshot** discovery logic.
* **Behavioral Alignment:** The change improves how sequence metadata reflects PostgreSQL ownership relationships.
* **Performance Improvement:** Replacing the subquery with a join simplifies the query plan and reduces repeated scans of `pg_depend`.

## Known Limitation

When a column originally defined with `SERIAL` is later decoupled from its sequence, the generated changelog may still mark the column as:

```xml
<column autoIncrement="true" name="id" type="INTEGER">
```

In PostgreSQL, this can cause a sequence name collision during deployment because PostgreSQL automatically creates a sequence for `autoIncrement` columns.

This behavior is expected to be addressed as part of **#7649**.