### PR TITLE
[DAT-22653] Fix Windows CI: mkdir -p failure in Configure Maven settings

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -121,6 +121,7 @@ jobs:
 
       # look for dependencies in maven
       - name: Configure Maven settings
+        shell: bash
         run: |
           mkdir -p ~/.m2
           cp .github/maven/settings-snapshots.xml ~/.m2/settings.xml


### PR DESCRIPTION
## Summary

- PR #7639 introduced a `mkdir -p ~/.m2` step in `run-tests.yml` to configure Maven settings
- On Windows runners, the default shell is **PowerShell**, where `mkdir` is an alias for `New-Item` — it does not support `-p` and **errors when the directory already exists** (`C:\Users\runneradmin\.m2` is pre-created by `actions/setup-java` with `cache: 'maven'`)
- Adds `shell: bash` to the "Configure Maven settings" step so `mkdir -p` behaves idempotently on all OS types

## Test plan

- [ ] Windows matrix jobs (Java 21, Java 25) in `run-tests.yml` pass the "Configure Maven settings" step
- [ ] Linux and macOS jobs remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)