### PR TITLE
fix: OracleDatabase.correctObjectName() no longer mangles column names starting with "int"

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/database/core/OracleDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/OracleDatabase.java
@@ -685,7 +685,8 @@ public class OracleDatabase extends AbstractJdbcDatabase {
     @Override
     public String correctObjectName(String objectName, Class<? extends DatabaseObject> objectType) {
         // Internally Oracle converts int/integer to number, so when we need to extract and compare it we need number too
-        if (objectType.equals(Column.class) && StringUtils.startsWithIgnoreCase(objectName, "int")) {
+        if (objectType.equals(Column.class)
+                && ("int".equalsIgnoreCase(objectName) || "integer".equalsIgnoreCase(objectName))) {
             return "NUMBER(*, 0)";
         }
         return super.correctObjectName(objectName, objectType);

--- a/liquibase-standard/src/test/groovy/liquibase/database/core/OracleDatabaseSpec.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/database/core/OracleDatabaseSpec.groovy
@@ -25,18 +25,27 @@ class OracleDatabaseSpec extends Specification {
         }
 
         where:
-        quotingStrategy           || objectName       | objectType || expectedCorrect  | expectedEscape
-        null                      || 'col1'           | Column     || 'COL1'           | 'col1'
-        null                      || 'COL1'           | Column     || 'COL1'           | 'COL1'
-        null                      || 'Col1'           | Column     || 'COL1'           | 'Col1'
-        null                      || 'col with space' | Column     || 'COL WITH SPACE' | '"col with space"'
-        QUOTE_ONLY_RESERVED_WORDS || 'col1'           | Column     || 'COL1'           | 'col1'
-        QUOTE_ONLY_RESERVED_WORDS || 'COL1'           | Column     || 'COL1'           | 'COL1'
-        QUOTE_ONLY_RESERVED_WORDS || 'Col1'           | Column     || 'COL1'           | 'Col1'
-        QUOTE_ONLY_RESERVED_WORDS || 'col with space' | Column     || 'COL WITH SPACE' | '"col with space"'
-        QUOTE_ALL_OBJECTS         || 'col1'           | Column     || 'col1'           | '"col1"'
-        QUOTE_ALL_OBJECTS         || 'COL1'           | Column     || 'COL1'           | '"COL1"'
-        QUOTE_ALL_OBJECTS         || 'Col1'           | Column     || 'Col1'           | '"Col1"'
-        QUOTE_ALL_OBJECTS         || 'col with space' | Column     || 'col with space' | '"col with space"'
+        quotingStrategy           || objectName              | objectType || expectedCorrect         | expectedEscape
+        null                      || 'col1'                  | Column     || 'COL1'                  | 'col1'
+        null                      || 'COL1'                  | Column     || 'COL1'                  | 'COL1'
+        null                      || 'Col1'                  | Column     || 'COL1'                  | 'Col1'
+        null                      || 'col with space'        | Column     || 'COL WITH SPACE'        | '"col with space"'
+        QUOTE_ONLY_RESERVED_WORDS || 'col1'                  | Column     || 'COL1'                  | 'col1'
+        QUOTE_ONLY_RESERVED_WORDS || 'COL1'                  | Column     || 'COL1'                  | 'COL1'
+        QUOTE_ONLY_RESERVED_WORDS || 'Col1'                  | Column     || 'COL1'                  | 'Col1'
+        QUOTE_ONLY_RESERVED_WORDS || 'col with space'        | Column     || 'COL WITH SPACE'        | '"col with space"'
+        QUOTE_ALL_OBJECTS         || 'col1'                  | Column     || 'col1'                  | '"col1"'
+        QUOTE_ALL_OBJECTS         || 'COL1'                  | Column     || 'COL1'                  | '"COL1"'
+        QUOTE_ALL_OBJECTS         || 'Col1'                  | Column     || 'Col1'                  | '"Col1"'
+        QUOTE_ALL_OBJECTS         || 'col with space'        | Column     || 'col with space'        | '"col with space"'
+        // #7018: "int"/"integer" type names should map to NUMBER(*, 0)
+        null                      || 'int'                   | Column     || 'NUMBER(*, 0)'          | 'int'
+        null                      || 'integer'               | Column     || 'NUMBER(*, 0)'          | 'integer'
+        null                      || 'INT'                   | Column     || 'NUMBER(*, 0)'          | 'INT'
+        null                      || 'INTEGER'               | Column     || 'NUMBER(*, 0)'          | 'INTEGER'
+        // #7018: column names starting with "int" must NOT be converted
+        null                      || 'internalPhoneNumber'   | Column     || 'INTERNALPHONENUMBER'   | 'internalPhoneNumber'
+        null                      || 'internal_payload_id'   | Column     || 'INTERNAL_PAYLOAD_ID'   | 'internal_payload_id'
+        null                      || 'integration_type'      | Column     || 'INTEGRATION_TYPE'      | 'integration_type'
     }
 }


### PR DESCRIPTION
## Summary
- **Root cause**: PR #6094 introduced `startsWithIgnoreCase(objectName, "int")` in `OracleDatabase.correctObjectName()`, which matched column **names** like `internalPhoneNumber`, `internal_payload_id`, `integration_type` — not just the `int`/`integer` data types it was intended for — and incorrectly converted them to `NUMBER(*, 0)`.
- **Fix**: Replaced prefix matching with exact case-insensitive matching for `"int"` and `"integer"` only.
- **Tests**: Added 7 data-driven test cases covering both the type mapping (preserved) and column name handling (fixed).

Fixes #7018

## Test plan
- [x] Existing `OracleDatabaseSpec` tests pass (12 original cases)
- [x] New test cases verify `int`/`integer`/`INT`/`INTEGER` still map to `NUMBER(*, 0)`
- [x] New test cases verify `internalPhoneNumber`, `internal_payload_id`, `integration_type` are uppercased normally
- [x] `OracleDatabaseTest` (33 tests) passes with no regressions