### PR TITLE
perf: cache ranChangeSets lookup in SqlChangeLogParser.generateId

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/parser/core/sql/SqlChangeLogParser.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/core/sql/SqlChangeLogParser.java
@@ -27,12 +27,19 @@ import liquibase.util.StringUtil;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @SuppressWarnings("java:S2583")
 public class SqlChangeLogParser implements ChangeLogParser {
+
+    // Per-Database index of physicalChangeLogLocation -> interim changeset id, built lazily on
+    // the first generateId call and reused thereafter. Avoids an O(N) scan of getRanChangeSets()
+    // per SQL changelog file, which on workloads with many SQL changelogs and large
+    // DATABASECHANGELOG histories was the dominant cost of changelog parsing.
+    private final Map<Database, Map<String, String>> interimIdIndexByDatabase = new ConcurrentHashMap<>();
 
     @Override
     public boolean supports(String changeLogFile, ResourceAccessor resourceAccessor) {
@@ -107,26 +114,30 @@ public class SqlChangeLogParser implements ChangeLogParser {
         if (database == null || isOldFormat(database)) {
             return "raw";
         }
+        Map<String, String> index = interimIdIndexByDatabase.computeIfAbsent(database, this::buildInterimIdIndex);
+        return index.getOrDefault(physicalChangeLogLocation, "raw");
+    }
 
-        List<RanChangeSet> ranChangeSets = new ArrayList<>();
+    private Map<String, String> buildInterimIdIndex(Database database) {
         try {
-            ranChangeSets = new ArrayList<>(
-               Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database).getRanChangeSets());
+            Map<String, String> result = new HashMap<>();
+            for (RanChangeSet rc : Scope.getCurrentScope()
+                    .getSingleton(ChangeLogHistoryServiceFactory.class)
+                    .getChangeLogService(database).getRanChangeSets()) {
+                String id = rc.getId();
+                String changeLog = rc.getChangeLog();
+                if (id == null || changeLog == null || !"includeAll".equals(rc.getAuthor())) {
+                    continue;
+                }
+                String expectedInterimId = "raw_" + DatabaseChangeLog.normalizePath(changeLog).replace("/", "_");
+                if (id.equals(expectedInterimId)) {
+                    result.put(changeLog, id);
+                }
+            }
+            return result;
         } catch (Exception dbe) {
-            return "raw";
+            return Collections.emptyMap();
         }
-
-        String interimId = "raw_" + DatabaseChangeLog.normalizePath(physicalChangeLogLocation).replace("/", "_");
-        Optional<RanChangeSet> ranChangeSet =
-            ranChangeSets.stream().filter(rc -> {
-                return rc.getId().equals(interimId) &&
-                       rc.getAuthor().equals("includeAll") &&
-                       rc.getChangeLog().equals(physicalChangeLogLocation);
-            }).findFirst();
-        if (ranChangeSet.isPresent()) {
-            return interimId;
-        }
-        return "raw";
     }
 
     /**

--- a/liquibase-standard/src/main/java/liquibase/parser/core/sql/SqlChangeLogParser.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/core/sql/SqlChangeLogParser.java
@@ -30,16 +30,22 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 
 @SuppressWarnings("java:S2583")
 public class SqlChangeLogParser implements ChangeLogParser {
 
-    // Per-Database index of physicalChangeLogLocation -> interim changeset id, built lazily on
-    // the first generateId call and reused thereafter. Avoids an O(N) scan of getRanChangeSets()
-    // per SQL changelog file, which on workloads with many SQL changelogs and large
-    // DATABASECHANGELOG histories was the dominant cost of changelog parsing.
-    private final Map<Database, Map<String, String>> interimIdIndexByDatabase = new ConcurrentHashMap<>();
+    // Per-Scope, per-Database index of physicalChangeLogLocation -> interim changeset id, built
+    // lazily on the first generateId call and reused for the lifetime of the current Liquibase
+    // Scope. Avoids an O(N) scan of getRanChangeSets() per SQL changelog file, which on workloads
+    // with many SQL changelogs and large DATABASECHANGELOG histories was the dominant cost of
+    // changelog parsing. Keying by Scope means the cache naturally invalidates between commands:
+    // once a Scope is no longer referenced (the command that owned it has finished), the entry is
+    // GC'd, so a subsequent update→parse cycle on the same Database sees fresh history rather than
+    // a stale snapshot.
+    private static final Map<Scope, Map<Database, Map<String, String>>> INTERIM_ID_INDEX_BY_SCOPE =
+            Collections.synchronizedMap(new WeakHashMap<>());
 
     @Override
     public boolean supports(String changeLogFile, ResourceAccessor resourceAccessor) {
@@ -110,34 +116,55 @@ public class SqlChangeLogParser implements ChangeLogParser {
      * @return  String                       a change set ID
      *
      */
-    private String generateId(String physicalChangeLogLocation, Database database) {
+    String generateId(String physicalChangeLogLocation, Database database) {
         if (database == null || isOldFormat(database)) {
             return "raw";
         }
-        Map<String, String> index = interimIdIndexByDatabase.computeIfAbsent(database, this::buildInterimIdIndex);
+        Map<Database, Map<String, String>> indexByDatabase;
+        synchronized (INTERIM_ID_INDEX_BY_SCOPE) {
+            indexByDatabase = INTERIM_ID_INDEX_BY_SCOPE.computeIfAbsent(
+                    Scope.getCurrentScope(), s -> new ConcurrentHashMap<>());
+        }
+        Map<String, String> index;
+        try {
+            // computeIfAbsent does not cache the value when the mapping function throws, so a
+            // transient failure (e.g. database lookup error) won't poison the cache for the
+            // remainder of the Scope: the next call retries.
+            index = indexByDatabase.computeIfAbsent(database, db -> {
+                try {
+                    return buildInterimIdIndex(db);
+                } catch (DatabaseException e) {
+                    throw new UnexpectedLiquibaseException(e);
+                }
+            });
+        } catch (UnexpectedLiquibaseException e) {
+            Scope.getCurrentScope().getLog(getClass())
+                    .fine("Could not query ran changesets for interim id lookup; falling back to 'raw'", e);
+            return "raw";
+        }
         return index.getOrDefault(physicalChangeLogLocation, "raw");
     }
 
-    private Map<String, String> buildInterimIdIndex(Database database) {
-        try {
-            Map<String, String> result = new HashMap<>();
-            for (RanChangeSet rc : Scope.getCurrentScope()
-                    .getSingleton(ChangeLogHistoryServiceFactory.class)
-                    .getChangeLogService(database).getRanChangeSets()) {
-                String id = rc.getId();
-                String changeLog = rc.getChangeLog();
-                if (id == null || changeLog == null || !"includeAll".equals(rc.getAuthor())) {
-                    continue;
-                }
-                String expectedInterimId = "raw_" + DatabaseChangeLog.normalizePath(changeLog).replace("/", "_");
-                if (id.equals(expectedInterimId)) {
-                    result.put(changeLog, id);
-                }
+    private Map<String, String> buildInterimIdIndex(Database database) throws DatabaseException {
+        Map<String, String> result = new HashMap<>();
+        for (RanChangeSet rc : Scope.getCurrentScope()
+                .getSingleton(ChangeLogHistoryServiceFactory.class)
+                .getChangeLogService(database).getRanChangeSets()) {
+            String id = rc.getId();
+            String changeLog = rc.getChangeLog();
+            if (id == null || changeLog == null || !"includeAll".equals(rc.getAuthor())) {
+                continue;
             }
-            return result;
-        } catch (Exception dbe) {
-            return Collections.emptyMap();
+            String normalizedChangeLog = DatabaseChangeLog.normalizePath(changeLog);
+            if (normalizedChangeLog == null) {
+                continue;
+            }
+            String expectedInterimId = "raw_" + normalizedChangeLog.replace("/", "_");
+            if (id.equals(expectedInterimId)) {
+                result.put(changeLog, id);
+            }
         }
+        return result;
     }
 
     /**

--- a/liquibase-standard/src/test/groovy/liquibase/parser/core/sql/SqlChangeLogParserTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/parser/core/sql/SqlChangeLogParserTest.groovy
@@ -1,0 +1,128 @@
+package liquibase.parser.core.sql
+
+import liquibase.Scope
+import liquibase.changelog.ChangeLogHistoryService
+import liquibase.changelog.ChangeLogHistoryServiceFactory
+import liquibase.changelog.ChangeSet
+import liquibase.changelog.RanChangeSet
+import liquibase.database.Database
+import liquibase.database.core.MockDatabase
+import spock.lang.Specification
+
+import java.lang.reflect.Method
+
+import static liquibase.servicelocator.PrioritizedService.PRIORITY_DATABASE
+
+class SqlChangeLogParserTest extends Specification {
+
+    ChangeLogHistoryServiceFactory changeLogHistoryServiceFactory =
+            Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class)
+
+    ChangeLogHistoryService changeLogHistoryService
+
+    Database database = new MockDatabase()
+
+    def setup() {
+        changeLogHistoryService = Mock(ChangeLogHistoryService)
+        changeLogHistoryService.supports(database) >> true
+        changeLogHistoryService.getPriority() >> PRIORITY_DATABASE
+        changeLogHistoryServiceFactory.register(changeLogHistoryService)
+    }
+
+    void cleanup() {
+        changeLogHistoryServiceFactory.unregister(changeLogHistoryService)
+    }
+
+    def "generateId returns 'raw' when no ran changeset matches"() {
+        given:
+        changeLogHistoryService.getRanChangeSets() >> []
+        def parser = new SqlChangeLogParser()
+
+        when:
+        def result = invokeGenerateId(parser, "path/to/file.sql")
+
+        then:
+        result == "raw"
+    }
+
+    def "generateId returns the interim id when a matching ran changeset exists"() {
+        given:
+        changeLogHistoryService.getRanChangeSets() >> [
+                ranChangeSet("path/to/file.sql", "raw_path_to_file.sql", "includeAll")
+        ]
+        def parser = new SqlChangeLogParser()
+
+        when:
+        def result = invokeGenerateId(parser, "path/to/file.sql")
+
+        then:
+        result == "raw_path_to_file.sql"
+    }
+
+    def "generateId ignores ran changesets whose id does not match the interim id the filter would have computed"() {
+        given: "a ran changeset for the same path but with an unrelated id"
+        changeLogHistoryService.getRanChangeSets() >> [
+                ranChangeSet("path/to/file.sql", "some_other_id", "includeAll")
+        ]
+        def parser = new SqlChangeLogParser()
+
+        when:
+        def result = invokeGenerateId(parser, "path/to/file.sql")
+
+        then: "behavior matches the pre-cache code: fall back to 'raw'"
+        result == "raw"
+    }
+
+    def "generateId ignores ran changesets whose author is not 'includeAll'"() {
+        given:
+        changeLogHistoryService.getRanChangeSets() >> [
+                ranChangeSet("path/to/file.sql", "raw_path_to_file.sql", "someone-else")
+        ]
+        def parser = new SqlChangeLogParser()
+
+        when:
+        def result = invokeGenerateId(parser, "path/to/file.sql")
+
+        then:
+        result == "raw"
+    }
+
+    def "getRanChangeSets is only queried once across repeated generateId calls on the same Database"() {
+        given:
+        def parser = new SqlChangeLogParser()
+
+        when:
+        def r1 = invokeGenerateId(parser, "dir/a.sql")
+        def r2 = invokeGenerateId(parser, "dir/b.sql")
+        def r3 = invokeGenerateId(parser, "dir/a.sql")
+
+        then:
+        r1 == "raw"
+        r2 == "raw"
+        r3 == "raw"
+        1 * changeLogHistoryService.getRanChangeSets() >> []
+    }
+
+    private Object invokeGenerateId(SqlChangeLogParser parser, String path) {
+        Method m = SqlChangeLogParser.class.getDeclaredMethod("generateId", String.class, Database.class)
+        m.setAccessible(true)
+        return m.invoke(parser, path, database)
+    }
+
+    private static RanChangeSet ranChangeSet(String changeLog, String id, String author) {
+        return new RanChangeSet(
+                changeLog,
+                id,
+                author,
+                null,
+                new Date(),
+                null,
+                ChangeSet.ExecType.EXECUTED,
+                "",
+                "",
+                null,
+                null,
+                "dep-id"
+        )
+    }
+}

--- a/liquibase-standard/src/test/groovy/liquibase/parser/core/sql/SqlChangeLogParserTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/parser/core/sql/SqlChangeLogParserTest.groovy
@@ -6,10 +6,9 @@ import liquibase.changelog.ChangeLogHistoryServiceFactory
 import liquibase.changelog.ChangeSet
 import liquibase.changelog.RanChangeSet
 import liquibase.database.Database
+import liquibase.database.DatabaseConnection
 import liquibase.database.core.MockDatabase
 import spock.lang.Specification
-
-import java.lang.reflect.Method
 
 import static liquibase.servicelocator.PrioritizedService.PRIORITY_DATABASE
 
@@ -20,7 +19,9 @@ class SqlChangeLogParserTest extends Specification {
 
     ChangeLogHistoryService changeLogHistoryService
 
-    Database database = new MockDatabase()
+    // Connection set to null so SnapshotGeneratorFactory returns an EmptyDatabaseSnapshot,
+    // which lets isOldFormat() return false without trying real JDBC metadata calls.
+    Database database = new MockDatabase().tap { it.setConnection((DatabaseConnection) null) }
 
     def setup() {
         changeLogHistoryService = Mock(ChangeLogHistoryService)
@@ -39,7 +40,7 @@ class SqlChangeLogParserTest extends Specification {
         def parser = new SqlChangeLogParser()
 
         when:
-        def result = invokeGenerateId(parser, "path/to/file.sql")
+        def result = parser.generateId("path/to/file.sql", database)
 
         then:
         result == "raw"
@@ -53,7 +54,7 @@ class SqlChangeLogParserTest extends Specification {
         def parser = new SqlChangeLogParser()
 
         when:
-        def result = invokeGenerateId(parser, "path/to/file.sql")
+        def result = parser.generateId("path/to/file.sql", database)
 
         then:
         result == "raw_path_to_file.sql"
@@ -67,7 +68,7 @@ class SqlChangeLogParserTest extends Specification {
         def parser = new SqlChangeLogParser()
 
         when:
-        def result = invokeGenerateId(parser, "path/to/file.sql")
+        def result = parser.generateId("path/to/file.sql", database)
 
         then: "behavior matches the pre-cache code: fall back to 'raw'"
         result == "raw"
@@ -81,7 +82,7 @@ class SqlChangeLogParserTest extends Specification {
         def parser = new SqlChangeLogParser()
 
         when:
-        def result = invokeGenerateId(parser, "path/to/file.sql")
+        def result = parser.generateId("path/to/file.sql", database)
 
         then:
         result == "raw"
@@ -92,21 +93,15 @@ class SqlChangeLogParserTest extends Specification {
         def parser = new SqlChangeLogParser()
 
         when:
-        def r1 = invokeGenerateId(parser, "dir/a.sql")
-        def r2 = invokeGenerateId(parser, "dir/b.sql")
-        def r3 = invokeGenerateId(parser, "dir/a.sql")
+        def r1 = parser.generateId("dir/a.sql", database)
+        def r2 = parser.generateId("dir/b.sql", database)
+        def r3 = parser.generateId("dir/a.sql", database)
 
         then:
         r1 == "raw"
         r2 == "raw"
         r3 == "raw"
         1 * changeLogHistoryService.getRanChangeSets() >> []
-    }
-
-    private Object invokeGenerateId(SqlChangeLogParser parser, String path) {
-        Method m = SqlChangeLogParser.class.getDeclaredMethod("generateId", String.class, Database.class)
-        m.setAccessible(true)
-        return m.invoke(parser, path, database)
     }
 
     private static RanChangeSet ranChangeSet(String changeLog, String id, String author) {

--- a/liquibase-standard/src/test/groovy/liquibase/parser/core/sql/SqlChangeLogParserTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/parser/core/sql/SqlChangeLogParserTest.groovy
@@ -8,6 +8,7 @@ import liquibase.changelog.RanChangeSet
 import liquibase.database.Database
 import liquibase.database.DatabaseConnection
 import liquibase.database.core.MockDatabase
+import liquibase.exception.DatabaseException
 import spock.lang.Specification
 
 import static liquibase.servicelocator.PrioritizedService.PRIORITY_DATABASE
@@ -102,6 +103,20 @@ class SqlChangeLogParserTest extends Specification {
         r2 == "raw"
         r3 == "raw"
         1 * changeLogHistoryService.getRanChangeSets() >> []
+    }
+
+    def "generateId retries the index build after a transient failure instead of caching it"() {
+        given:
+        def parser = new SqlChangeLogParser()
+
+        when:
+        def first = parser.generateId("dir/a.sql", database)
+        def second = parser.generateId("dir/a.sql", database)
+
+        then:
+        first == "raw"
+        second == "raw"
+        2 * changeLogHistoryService.getRanChangeSets() >> { throw new DatabaseException("transient") } >> []
     }
 
     private static RanChangeSet ranChangeSet(String changeLog, String id, String author) {


### PR DESCRIPTION
### Problem
`SqlChangeLogParser.generateId` is called once per SQL changelog file and performs a defensive `ArrayList` copy + linear stream scan over `ChangeLogHistoryService.getRanChangeSets()`. With M SQL files and N rows in `DATABASECHANGELOG` this is O(M*N) work per update plus O(M*N) short-lived `RanChangeSet` references allocated.

On a real workload (~5,000 SQL changelogs, thousands of historical rows), parsing went from ~3 min on 4.31.1 to >15 min on 4.32.0+. Throughput collapses from ~625 file-events/sec to ~35 once the parser has warmed up (the cliff appears around 1,700 files parsed). Both 4.32.0 and 5.0.2 are affected — the code path is unchanged across those versions.

### Fix
Build the lookup once per `Database` as a `Map<changeLog, interimId>` and reuse it for every subsequent file. Total work becomes O(M+N) and the per-file cost returns to ~O(1).

Behavior is preserved: an index entry is added only when the `RanChangeSet`'s `id` equals the interim id the original filter would have computed, so `getOrDefault(path, "raw")` returns the same value as the previous `Optional.isPresent()` check.

### Tests
Added `SqlChangeLogParserTest` covering:
- default "raw" when nothing matches
- interim id returned when a matching ran changeset exists
- id mismatch is ignored (preserves original filter predicate)
- author mismatch is ignored
- `getRanChangeSets()` is invoked at most once across repeated `generateId` calls on the same `Database` (the performance invariant)

### Related
Likely the underlying cause of #7544.