### PR TITLE
fix(DAT-22091): unblock release-drafter after master→main rename

### DIFF
--- a/.github/release-drafter-main.yml
+++ b/.github/release-drafter-main.yml
@@ -1,7 +1,12 @@
 
 name-template: 'Liquibase v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
-filter-by-commitish: true
+# filter-by-commitish must stay false: existing releases (v4.x and v5.0.x)
+# have target_commitish: master, which GitHub does not auto-update on branch
+# rename. Filtering by commitish: main would exclude every prior release,
+# causing release-drafter to walk full repo history (~3.6k PRs, ~300KB body)
+# and fail GitHub's 125KB release-body limit. See DAT-22091.
+filter-by-commitish: false
 commitish: main
 exclude-labels:
   - 'skipReleaseNotes'


### PR DESCRIPTION
## Summary

- Set `filter-by-commitish: false` in `.github/release-drafter-main.yml` so release-drafter can find historical releases (which still target `master`) as anchor points.
- Added inline comment documenting the constraint so the filter is not reintroduced.

## Why

After PR #7660 renamed the default branch from `master` to `main`, the `create_draft_release_main_branch` workflow started failing with:

https://github.com/liquibase/liquibase/actions/runs/25330420959

```
##[error]Validation Failed: {"resource":"Release","code":"custom","field":"body","message":"body is too long (maximum is 125000 characters)"}
```

Root cause: `filter-by-commitish: true` + `commitish: main` excluded every existing release because GitHub does not auto-update `target_commitish` on branch rename. All v4.x and v5.0.x releases still target `master` (a few target older release branches like `4.4.x`, `4.3.x`, `release`, `refs/heads/master`).

With no prior release matching the filter, release-drafter logged `No last release found`, walked the full repo history (`Found 14252 commits` / `Found 3652 pull requests`), and produced a 299,594-character body — 2.4× GitHub's hard limit.

Setting `filter-by-commitish: false` lets release-drafter sort by semver and pick the latest matching tag as last release regardless of which branch it targeted, restoring normal incremental drafts.

## Test plan

- [ ] Re-run the `create_draft_release_main_branch` workflow on `main` after merge
- [ ] Confirm the run produces a draft with body under 125KB and only PRs since the previous semver release
- [ ] Confirm `Liquibase v$RESOLVED_VERSION` draft is created/updated with sane version bump (not `v0.1.0`)

## Out of scope (follow-ups to file separately)

- `release-drafter-docker.yml` shares `tag-template: 'v$RESOLVED_VERSION'` with the main config, causing the two drafters to overwrite each other's drafts — needs a unique tag prefix (e.g. `docker-v$RESOLVED_VERSION`).
- `release-drafter-docker.yml` workflow trigger is still `branches: master` post-rename.
- One-time `gh api PATCH` over historical releases to retarget `master` → `main` (cosmetic, not required to unblock).

DAT-22091