### PR TITLE
test(DAT-22091): validate PR triggers post master→main rename (typo fix)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,7 +12,7 @@ The `dryRun` process simulates our current production Liquibase release workflow
 
 The following actions are identical to those in a regular Liquibase release, with no modifications:
 
-- Get latests liquibase artifacts from the `run-tests.yml` workflow
+- Get latest liquibase artifacts from the `run-tests.yml` workflow
 - Re-version artifacts to `dry-run-GITHUB_RUN_ID` version. i.e `dry-run-10522556642`
 - Build installers
 - Attach artifacts (`zip` and `tar` files) to a dryRun draft release


### PR DESCRIPTION
## Summary

Trivial typo fix in `.github/workflows/README.md` (`latests` → `latest`) used as a vehicle to validate that PR-event workflows still trigger correctly after the `master` → `main` default branch rename (TECHOPS-300, PR #7660).

## Why

After the rename, we want to confirm that PR-triggered workflows fire as expected against `main`:

- Pull Request Labels (`label-pr.yml`)
- Run Test matrix (`run-tests.yml`)
- CodeQL
- Build & Package
- Trigger Test Harness Tests
- Claude Code Review
- Release Drafter (label-prs job)

If any of those don't appear in the checks rollup or fail with rename-related errors, that's the signal we need.

## Test plan

- [ ] Confirm all expected PR-triggered workflows appear in the checks rollup
- [ ] Confirm all that should pass actually pass (the typo fix is no-op for tests)
- [ ] Note any rename-related failures (workflows referencing `master` that no longer fire)
- [ ] Close without merging (or accept the typo fix if reviewer prefers)

Related: TECHOPS-300, [PR #7684](https://github.com/liquibase/liquibase/pull/7684) (release-drafter unblock).