### PR TITLE
fix(DAT-22091): retarget docker drafter and docker-readme workflows from master to main

### DIFF
--- a/.github/workflows/docker-readme.yml
+++ b/.github/workflows/docker-readme.yml
@@ -3,7 +3,7 @@ name: Docker README
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - "docker/README.md"
   workflow_dispatch:

--- a/.github/workflows/release-drafter-docker.yml
+++ b/.github/workflows/release-drafter-docker.yml
@@ -3,7 +3,7 @@ name: Release Drafter (Docker)
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - "docker/**"
   pull_request:
@@ -25,11 +25,11 @@ jobs:
           # disable-releaser prevents creating/updating a draft release on PR events;
           # only the autolabeler runs, which avoids the invalid target_commitish error
           disable-releaser: true
-          commitish: master
+          commitish: main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Update Docker draft release (runs on push to master with docker/** changes)
+  # Update Docker draft release (runs on push to main with docker/** changes)
   draft-docker:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Stale `master` references in two docker-related workflow files were missed by the master→main rename in PR #7660. Updating them to `main`.

## Why

**1. `release-drafter-docker.yml`** — every PR opened against `main` post-rename is failing the `label-prs` check with:

```
Last release: v5.0.2
Fetching parent commits of master since 2026-03-04T00:27:25Z...
##[error]Data doesn't contain `nodes` field. Make sure the `paginatePath` is set...
```

The `label-prs` job calls `release-drafter/release-drafter` with `commitish: master`. Release-drafter's GraphQL query for parent commits of `master` returns an empty payload — GitHub's branch redirect doesn't extend to the action's `repository.ref(qualifiedName: "master")` lookup, so the response has no `nodes` field and the action errors out.

Failing example: [PR #7685 / Run 25338964365](https://github.com/liquibase/liquibase/actions/runs/25338964365/job/74291347433).

**2. `docker-readme.yml`** — push trigger pinned to `branches: master`. Currently a silent no-op: changes to `docker/README.md` pushed to `main` never trigger the Docker Hub README sync.

## Changes

- `release-drafter-docker.yml`
  - `push.branches`: `master` → `main`
  - `label-prs.commitish`: `master` → `main`
  - Comment on `draft-docker` job: "push to master" → "push to main"
- `docker-readme.yml`
  - `push.branches`: `master` → `main`

## Test plan

- [ ] After merge, open any PR against `main` and confirm `label-prs` passes (or simply re-check #7685's checks rollup)
- [ ] Push a `docker/**` change to `main` and confirm `draft-docker` job fires (currently it never has post-rename)
- [ ] Push a `docker/README.md` change to `main` and confirm `Docker README` workflow fires

## Out of scope

- The `disable-releaser` input on `release-drafter-docker.yml` emits a deprecation warning (release-drafter v6 dropped it). Replacement is `disable-autolabeler: false` + structuring the job differently. Separate follow-up so this PR stays minimal.
- The shared `tag-template: 'v$RESOLVED_VERSION'` between `release-drafter-docker.yml` and `release-drafter-main.yml` causes both drafters to overwrite the same draft release (Docker vs Liquibase naming flicker). Separate follow-up.

Related: TECHOPS-300, [PR #7684](https://github.com/liquibase/liquibase/pull/7684) (release-drafter-main unblock).

DAT-22091