### PR TITLE
DAT-22984/DAT-29985: Sanitize table names when saving files. Escape column-name list when running generate changelog

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/diff/output/changelog/core/MissingDataChangeGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/diff/output/changelog/core/MissingDataChangeGenerator.java
@@ -15,6 +15,7 @@ import liquibase.exception.CommandExecutionException;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.statement.DatabaseFunction;
 import liquibase.structure.DatabaseObject;
+import liquibase.structure.core.Column;
 import liquibase.structure.core.Data;
 import liquibase.structure.core.ForeignKey;
 import liquibase.structure.core.Index;
@@ -33,6 +34,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class MissingDataChangeGenerator extends AbstractChangeGenerator implements MissingObjectChangeGenerator {
 
@@ -92,7 +94,9 @@ public class MissingDataChangeGenerator extends AbstractChangeGenerator implemen
                     throw new CommandExecutionException(String.format("No columns matched with excludeObjects '%s' / includeObjects '%s'", excludeObjects, includeObjects));
                 }
 
-                String replacement = "\"" + String.join("\", \"", columnNames) + "\"";
+                String replacement = columnNames.stream()
+                        .map(col -> referenceDatabase.escapeObjectName(col, Column.class))
+                        .collect(Collectors.joining(", "));
                 // replace "*" in original SELECT statement with list of filtered column names
                 sql = sql.replace("*", replacement);
             }
@@ -196,7 +200,7 @@ public class MissingDataChangeGenerator extends AbstractChangeGenerator implemen
                 (withIncludeOnly && pattern.matcher(columnName).matches()) ||
                 (withExcludeOnly && !pattern.matcher(columnName).matches()))
             {
-                columnNames.add(isCaseSensitive ? "\\\"" + columnName + "\\\"" : columnName);
+                columnNames.add(columnName);
             }
         }
 

--- a/liquibase-standard/src/main/java/liquibase/diff/output/changelog/core/MissingDataExternalFileChangeGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/diff/output/changelog/core/MissingDataExternalFileChangeGenerator.java
@@ -58,9 +58,22 @@ public class MissingDataExternalFileChangeGenerator extends MissingDataChangeGen
         return stmt;
     }
 
+    /**
+     * Strips path traversal sequences and non-filesystem-safe characters from a table name so the
+     * resulting CSV filename stays within the configured data directory. Any character that is not
+     * alphanumeric, an underscore, or a hyphen is replaced with an underscore and the result is
+     * lowercased.
+     *
+     * @param tableName the raw table name from database metadata
+     * @return a filesystem-safe, lowercase basename suitable for use as a CSV filename
+     */
+    static String sanitizeTableName(String tableName) {
+        return tableName.replaceAll("[^a-zA-Z0-9_\\-]", "_").toLowerCase();
+    }
+
     @Override
     public Change[] fixMissing(DatabaseObject missingObject, DiffOutputControl outputControl, Database referenceDatabase, Database comparisionDatabase, ChangeGeneratorChain chain) {
-    
+
         ResultSet rs = null;
         try (
             Statement stmt = createStatement(referenceDatabase);
@@ -86,7 +99,7 @@ public class MissingDataExternalFileChangeGenerator extends MissingDataChangeGen
                 }
 
                 final PathHandlerFactory pathHandlerFactory = Scope.getCurrentScope().getSingleton(PathHandlerFactory.class);
-                String fileName = table.getName().toLowerCase() + ".csv";
+                String fileName = sanitizeTableName(table.getName()) + ".csv";
                 Resource externalFileResource = pathHandlerFactory.getResource(fileName);
                 if (dataDir != null) {
                     Resource dataDirResource = pathHandlerFactory.getResource(dataDir);

--- a/liquibase-standard/src/test/groovy/liquibase/diff/output/changelog/core/MissingDataChangeGeneratorTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/diff/output/changelog/core/MissingDataChangeGeneratorTest.groovy
@@ -1,0 +1,71 @@
+package liquibase.diff.output.changelog.core
+
+import liquibase.database.core.MockDatabase
+import liquibase.database.jvm.JdbcConnection
+import liquibase.diff.output.DiffOutputControl
+import liquibase.diff.output.changelog.ChangeGeneratorChain
+import liquibase.structure.DatabaseObject
+import liquibase.structure.core.Column
+import liquibase.structure.core.Data
+import liquibase.structure.core.Table
+import spock.lang.Specification
+
+import java.sql.Connection
+import java.sql.ResultSet
+import java.sql.ResultSetMetaData
+import java.sql.Statement
+
+class MissingDataChangeGeneratorTest extends Specification {
+
+    def "fixMissing escapes column names containing double quotes to prevent SQL injection"() {
+        given:
+        def maliciousColumnName = 'secret" FROM evil_table --'
+        def capturedSql = []
+
+        def metaData = Mock(ResultSetMetaData) {
+            getColumnCount() >> 1
+            getColumnName(1) >> maliciousColumnName
+        }
+        def metaRs = Mock(ResultSet) {
+            getMetaData() >> metaData
+            next() >> false
+        }
+        def dataRs = Mock(ResultSet) {
+            next() >> false
+        }
+        def stmt = Mock(Statement) {
+            executeQuery(_) >> { String sql ->
+                capturedSql << sql
+                sql.contains("WHERE 1=0") ? metaRs : dataRs
+            }
+            setFetchSize(_) >> {}
+        }
+        def jdbcConn = Mock(Connection) {
+            createStatement(_, _) >> stmt
+        }
+        def database = new MockDatabase() {
+            @Override
+            liquibase.database.DatabaseConnection getConnection() {
+                new JdbcConnection(jdbcConn)
+            }
+
+            @Override
+            String escapeObjectName(String objectName, Class<? extends DatabaseObject> objectType) {
+                '"' + objectName.replace('"', '""') + '"'
+            }
+        }
+
+        def table = new Table("cat", "schema", "test_table")
+        def data = new Data().setTable(table)
+        def control = new DiffOutputControl()
+        control.setIncludeObjects("column:.*")
+
+        when:
+        new MissingDataChangeGenerator().fixMissing(data, control, database, database, new ChangeGeneratorChain(null))
+
+        then:
+        def dataSql = capturedSql.find { !it.contains("WHERE 1=0") }
+        dataSql.contains('"secret"" FROM evil_table --"')
+        !dataSql.contains(maliciousColumnName)
+    }
+}

--- a/liquibase-standard/src/test/groovy/liquibase/diff/output/changelog/core/MissingDataExternalFileChangeGeneratorTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/diff/output/changelog/core/MissingDataExternalFileChangeGeneratorTest.groovy
@@ -1,0 +1,49 @@
+package liquibase.diff.output.changelog.core
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class MissingDataExternalFileChangeGeneratorTest extends Specification {
+
+    @Unroll
+    def "sanitizeTableName blocks path traversal: '#input' -> '#expected'"() {
+        expect:
+        MissingDataExternalFileChangeGenerator.sanitizeTableName(input) == expected
+
+        where:
+        input                      | expected
+        "../escaped/export_target" | "___escaped_export_target"
+        "../../etc/passwd"         | "______etc_passwd"
+        ".."                       | "__"
+        "../sibling"               | "___sibling"
+    }
+
+    @Unroll
+    def "sanitizeTableName preserves safe characters: '#input' -> '#expected'"() {
+        expect:
+        MissingDataExternalFileChangeGenerator.sanitizeTableName(input) == expected
+
+        where:
+        input              | expected
+        "my_table"         | "my_table"
+        "MyTable"          | "mytable"
+        "table-name"       | "table-name"
+        "table123"         | "table123"
+        "UPPER_CASE_TABLE" | "upper_case_table"
+    }
+
+    @Unroll
+    def "sanitizeTableName replaces special characters: '#input' -> '#expected'"() {
+        expect:
+        MissingDataExternalFileChangeGenerator.sanitizeTableName(input) == expected
+
+        where:
+        input           | expected
+        "table name"    | "table_name"
+        "table.name"    | "table_name"
+        "table/name"    | "table_name"
+        "table\\name"   | "table_name"
+        "table!@#name"  | "table___name"
+        "schéma_table"  | "sch_ma_table"
+    }
+}


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
* Update fixMissing logic to sanitize table names when writing CSV files to the filesystem. This will replace anything that isn't a alphanumeric, an underscore or a hyphen with underscores when writing the file.
* When running generate-changelog a user could supply a malicious string to the column-name filter to inject sql into the column metadata query. These changes avoid this sql injection by escaping the column names prior to execution of the query.

Credits to @FORIMOC, @Yuremin and @invoke1442 for reporting these issues!