### PR TITLE
fix(TECHOPS-365): bump docker base image to temurin:25-jre-noble

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:25-jre-noble
+FROM eclipse-temurin:21-jre-noble
 
 # Create liquibase user
 RUN groupadd --gid 1001 liquibase && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre-noble
+FROM eclipse-temurin:25-jre-noble
 
 # Create liquibase user
 RUN groupadd --gid 1001 liquibase && \
@@ -11,6 +11,11 @@ WORKDIR /liquibase
 
 ARG LIQUIBASE_VERSION=5.0.2
 ARG LB_SHA256=10356bea9dc57868a57fc3af88ad471f5027d67ad1f5fc88a9c2221401cbae23
+
+# wget is not shipped in eclipse-temurin:25-jre-noble (purged from the base image); install it for the downloads below and remove with the unzip purge in the lpm RUN.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends wget ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN wget -q -O liquibase-${LIQUIBASE_VERSION}.tar.gz "https://package.liquibase.com/downloads/dockerhub/official/liquibase-${LIQUIBASE_VERSION}.tar.gz" && \
     echo "$LB_SHA256 *liquibase-${LIQUIBASE_VERSION}.tar.gz" | sha256sum -c - && \
@@ -45,7 +50,7 @@ RUN apt-get update && \
     echo "$LPM_SHA256 *lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip" | sha256sum -c - && \
     unzip lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip -d bin/ && \
     rm lpm-${LPM_VERSION}-linux${DOWNLOAD_ARCH}.zip && \
-    apt-get purge -y --auto-remove unzip && \
+    apt-get purge -y --auto-remove unzip wget && \
     ln -s /liquibase/bin/lpm /usr/local/bin/lpm && \
     lpm --version
 


### PR DESCRIPTION
## Summary

Bumps the community Docker image base from `eclipse-temurin:21-jre-noble` to `eclipse-temurin:25-jre-noble`. The previous attempt at this bump failed in CI ([run 25363773817](https://github.com/liquibase/liquibase/actions/runs/25363773817)) and was reverted in commit f0497f778. This PR restores the bump and fixes the underlying cause.

Ticket: [TECHOPS-365](https://liquibase.atlassian.net/browse/TECHOPS-365)

## Root cause of the earlier failure

The first `RUN` in `docker/Dockerfile` invokes `wget` to fetch the Liquibase tarball. On the bumped image the build aborted with **exit code 127 ("command not found")** because `wget` is not present in `eclipse-temurin:25-jre-noble`.

| Base image | `wget` in final image? |
|---|---|
| `eclipse-temurin:21-jre-noble` | **Yes** — installed alongside `curl`, `gnupg`, `ca-certificates` and left in place |
| `eclipse-temurin:25-jre-noble` | **No** — Adoptium tightened the image: `wget` and `gnupg` are installed only to download/verify the JDK and then removed via `apt-get purge -y --auto-remove`. `curl` is not installed at all. |

References (Adoptium upstream Dockerfiles):
- [21/jre/ubuntu/noble/Dockerfile](https://github.com/adoptium/containers/blob/main/21/jre/ubuntu/noble/Dockerfile) — no purge of wget
- [25/jre/ubuntu/noble/Dockerfile](https://github.com/adoptium/containers/blob/main/25/jre/ubuntu/noble/Dockerfile) — `apt-get purge -y --auto-remove` removes wget/gnupg

So the breakage was **not** unrelated infrastructure — it was a deterministic consequence of the base image change. Our Dockerfile implicitly relied on the base image shipping `wget`, which held for 21 but no longer holds for 25.

## Changes

`docker/Dockerfile`:
1. `FROM eclipse-temurin:21-jre-noble` → `FROM eclipse-temurin:25-jre-noble`
2. New `apt-get install -y --no-install-recommends wget ca-certificates` block before the first `wget` invocation, so the image no longer depends on the base shipping a downloader.
3. Existing `apt-get purge -y --auto-remove unzip` in the lpm `RUN` extended to `unzip wget` so `wget` remains a transient build dep (mirrors Adoptium's own pattern) and the final image stays minimal.

## Alternatives considered

- *Replace `wget` with `curl`* — `curl` is also absent in `25-jre-noble`, no benefit.
- *Use Docker `ADD <url>`* — loses the inline `sha256sum -c` verification.
- *Multi-stage build with a downloader stage* — over-engineered for two tarballs.
- *Switch to `eclipse-temurin:25-jdk-noble`* — keeps more tools but bloats the production image with the full JDK.

## Verification

- Local `docker build` passes; resulting image runs `liquibase --version` (5.0.2 on Java 25.0.3 / Temurin-25.0.3+9 LTS) and `lpm --version` cleanly. `wget` and `unzip` confirmed absent in the final image.
- CI on this branch:
  - **Docker Scan** ✓ [run 25400110068](https://github.com/liquibase/liquibase/actions/runs/25400110068)
  - **Docker Test** ✓ [run 25400110073](https://github.com/liquibase/liquibase/actions/runs/25400110073) — all four jobs green (community + alpine × ubuntu-latest + macos-15-intel)

## Test plan

- [x] Docker Scan workflow green on branch
- [x] Docker Test workflow green on branch (ubuntu + macOS, community + alpine)
- [x] Local build produces a working image on Java 25.0.3
- [ ] Reviewer sanity-check that the alpine image (`docker/Dockerfile.alpine`) is unaffected (it pins its own JRE separately)

## Out of scope

- `docker/Dockerfile.alpine` is unchanged — alpine uses a different base and was not failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECHOPS-365]: https://datical.atlassian.net/browse/TECHOPS-365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ