### PR TITLE
fix(TECHOPS-365): pin docker base image to temurin:21-jre-noble

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:25-jre-noble
+FROM eclipse-temurin:21-jre-noble
 
 # Create liquibase user
 RUN groupadd --gid 1001 liquibase && \


### PR DESCRIPTION
## Summary

Reverts the `eclipse-temurin` base image bump from `21-jre-noble` to `25-jre-noble` in `docker/Dockerfile` (originally landed via #7677, commit 768aae7b). After this PR, `main` is pinned back to `21-jre-noble` for the 5.2 release.

Ticket: [TECHOPS-365](https://datical.atlassian.net/browse/TECHOPS-365)

## Why

PR #7677 broke Docker Scan and Docker Test on `main` because `eclipse-temurin:25-jre-noble` no longer ships `wget` (Adoptium installs it temporarily for the JDK download then purges it). Per the team call on TECHOPS-365 ([Filipe's recommendation](https://datical.atlassian.net/browse/TECHOPS-365?focusedCommentId=198988)) — given we're late in the 5.2 process — the path forward is to **pin Java 21 for 5.2** and **defer Java 25 to L6**, when the integration-test matrix and liquibase-pro-tests can be aligned to the new JVM.

## Changes

- `docker/Dockerfile` line 1: `FROM eclipse-temurin:25-jre-noble` → `FROM eclipse-temurin:21-jre-noble`. No other changes.

## Test plan

- [ ] After merge, confirm Docker Scan and Docker Test on `main` go green again (currently broken on `main` due to #7677).

## Out of scope

- Bumping integration-tests / liquibase-pro-tests off Java 17 — separate work.
- The Java 25 bump itself — will be tracked under a new L6 ticket.
- Required-status-checks hardening called out in the TECHOPS-365 description — separate work.

## Related

- Reverts #7677.
- Supersedes #7690 (the Java 25 wget-fix attempt) — that PR will be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECHOPS-365]: https://datical.atlassian.net/browse/TECHOPS-365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ