### PR TITLE
ci(docker-scan): disable CVE investigation dispatch for OSS images

### DIFF
--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -29,7 +29,7 @@ jobs:
       image_name: liquibase/liquibase
       vex_enabled: false
       upload_sarif: true
-      dispatch_new_cves: true
+      dispatch_new_cves: false
     secrets: inherit
 
   scan-alpine:
@@ -42,5 +42,5 @@ jobs:
       suffix: "-alpine"
       vex_enabled: false
       upload_sarif: true
-      dispatch_new_cves: true
+      dispatch_new_cves: false
     secrets: inherit


### PR DESCRIPTION
## Summary

The `Docker Scan` workflow runs `liquibase/build-logic/.github/workflows/reusable-docker-scan.yml`, which forwards `dispatch_new_cves` to `reusable-vulnerability-scan.yml`. That input triggers `investigate-cve.lock.yml` in `liquibase/liquibase-pro` for any unassessed HIGH/CRITICAL CVE.

That dispatch is documented as "only relevant for docker/liquibase-pro callers" (the `liquibase-secure` images). Community and alpine OSS Docker scans should not be feeding the pro investigation pipeline — vulnerabilities for OSS artifacts are tracked separately, and the cross-repo dispatch was flooding it.

This PR sets `dispatch_new_cves: false` on `scan-community` and `scan-alpine`.

A companion PR will flip the default in `build-logic` from `true` to `false` so future callers don't accidentally re-enable this. Until then, the explicit `false` here is the immediate fix.

## Test plan

- [ ] Next push or scheduled run of `Docker Scan` produces no `gh workflow run investigate-cve.lock.yml` calls (visible in the `Dispatch new CVEs for investigation` step summary)
- [ ] Trivy/Grype scanning, SBOM generation, and SARIF upload to the Security tab continue to function as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)