### PR TITLE
Fix #7602: Set database filter when user-provided ChangeLogParameters is passed

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/DatabaseChangelogCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/DatabaseChangelogCommandStep.java
@@ -60,16 +60,29 @@ public class DatabaseChangelogCommandStep extends AbstractHelperCommandStep impl
                 .build();
     }
 
+    /**
+     * Returns the classes provided by this command step.
+     * @return list of dependency classes
+     */
     @Override
     public List<Class<?>> providedDependencies() {
         return Arrays.asList(DatabaseChangeLog.class, ChangeLogParameters.class);
     }
 
+    /**
+     * Returns the classes required by this command step.
+     * @return list of required dependency classes
+     */
     @Override
     public List<Class<?>> requiredDependencies() {
         return Arrays.asList(Database.class);
     }
 
+    /**
+     * Executes the changelog command step.
+     * @param resultsBuilder the command results builder
+     * @throws Exception if an error occurs during execution
+     */
     @Override
     public void run(CommandResultsBuilder resultsBuilder) throws Exception {
         CommandScope commandScope = resultsBuilder.getCommandScope();
@@ -92,6 +105,18 @@ public class DatabaseChangelogCommandStep extends AbstractHelperCommandStep impl
         commandScope.provideDependency(ChangeLogParameters.class, changeLogParameters);
     }
 
+    /**
+     * Retrieves the ChangeLogParameters from the command scope, or creates a new instance if none was provided.
+     * <p>
+     * When a user-provided ChangeLogParameters is passed via CommandScope, the database filter
+     * ({@code filterDatabase}) is set from the actual database's short name to ensure that
+     * dbms-specific properties in changelogs are correctly resolved.
+     *
+     * @param commandScope the command scope containing optional CHANGELOG_PARAMETERS argument
+     * @param database the actual database being used
+     * @return the ChangeLogParameters with database filter set appropriately
+     * @see ChangeLogParameters#setDatabase(String)
+     */
     private ChangeLogParameters getChangeLogParameters(CommandScope commandScope, Database database) {
         ChangeLogParameters changeLogParameters = commandScope.getArgumentValue(CHANGELOG_PARAMETERS);
         if (changeLogParameters == null) {
@@ -129,6 +154,11 @@ public class DatabaseChangelogCommandStep extends AbstractHelperCommandStep impl
         addCommandFiltersMdc(labels, contexts);
     }
 
+    /**
+     * Adds label and context filter values to the MDC for logging purposes.
+     * @param labelExpression the label expression to log
+     * @param contexts the contexts to log
+     */
     public static void addCommandFiltersMdc(LabelExpression labelExpression, Contexts contexts) {
         String labelFilterMdc = labelExpression != null && labelExpression.getOriginalString() != null ? labelExpression.getOriginalString() : "";
         String contextFilterMdc = contexts != null ? contexts.toString() : "";
@@ -136,6 +166,14 @@ public class DatabaseChangelogCommandStep extends AbstractHelperCommandStep impl
         Scope.getCurrentScope().addMdcValue(MdcKey.COMMAND_CONTEXT_FILTER, contextFilterMdc);
     }
 
+    /**
+     * Parses and returns the database change log from the specified file.
+     * @param changeLogFile the path to the changelog file
+     * @param changeLogParameters the parameters for parsing
+     * @param database the database context
+     * @return the parsed DatabaseChangeLog
+     * @throws Exception if parsing fails
+     */
     public static DatabaseChangeLog getDatabaseChangeLog(String changeLogFile, ChangeLogParameters changeLogParameters, Database database) throws Exception {
         ResourceAccessor resourceAccessor = Scope.getCurrentScope().getResourceAccessor();
         AtomicReference<DatabaseChangeLog> changelog = new AtomicReference<>();
@@ -154,6 +192,15 @@ public class DatabaseChangelogCommandStep extends AbstractHelperCommandStep impl
         return changelog.get();
     }
 
+    /**
+     * Checks and initializes the liquibase tables if needed.
+     * @param updateExistingNullChecksums whether to update null checksums
+     * @param databaseChangeLog the database change log
+     * @param contexts the context filter
+     * @param labelExpression the label filter
+     * @param database the database
+     * @throws liquibase.exception.LiquibaseException if an error occurs
+     */
     private void checkLiquibaseTables(boolean updateExistingNullChecksums, DatabaseChangeLog databaseChangeLog,
                                       Contexts contexts, LabelExpression labelExpression, Database database) throws LiquibaseException {
         ChangeLogHistoryService changeLogHistoryService = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database);
@@ -169,11 +216,19 @@ public class DatabaseChangelogCommandStep extends AbstractHelperCommandStep impl
         LockServiceFactory.getInstance().getLockService(database).init();
     }
 
+    /**
+     * Returns the command names defined by this step.
+     * @return array of command name arrays
+     */
     @Override
     public String[][] defineCommandNames() {
         return new String[][]{COMMAND_NAME};
     }
 
+    /**
+     * Cleans up resources held by this command step.
+     * @param resultsBuilder the command results builder
+     */
     @Override
     public void cleanUp(CommandResultsBuilder resultsBuilder) {
         Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).resetAll();

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/DatabaseChangelogCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/DatabaseChangelogCommandStep.java
@@ -98,6 +98,10 @@ public class DatabaseChangelogCommandStep extends AbstractHelperCommandStep impl
             changeLogParameters = new ChangeLogParameters(database);
             changeLogParameters.addJavaProperties();
             changeLogParameters.addDefaultFileProperties();
+        } else {
+            // When a user-provided ChangeLogParameters is passed, we still need to set the database
+            // filter so that dbms-specific properties are correctly resolved.
+            changeLogParameters.setDatabase(database.getShortName());
         }
         extractContextAndLabels(commandScope, changeLogParameters);
         return changeLogParameters;

--- a/liquibase-standard/src/test/groovy/liquibase/command/core/helpers/DatabaseChangelogCommandStepTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/command/core/helpers/DatabaseChangelogCommandStepTest.groovy
@@ -1,0 +1,73 @@
+package liquibase.command.core.helpers
+
+import liquibase.Scope
+import liquibase.changelog.ChangeLogParameters
+import liquibase.changelog.DatabaseChangeLog
+import liquibase.command.CommandResultsBuilder
+import liquibase.command.CommandScope
+import liquibase.command.core.UpdateCommandStep
+import liquibase.command.core.helpers.DatabaseChangelogCommandStep
+import liquibase.database.core.MockDatabase
+import liquibase.database.core.PostgresDatabase
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * Tests for {@link DatabaseChangelogCommandStep}, specifically the fix for issue #7602
+ * where dbms-specific properties were not being correctly filtered when a user-provided
+ * ChangeLogParameters was passed via CommandScope.
+ */
+class DatabaseChangelogCommandStepTest extends Specification {
+
+    /**
+     * Test that verifies the fix for issue #7602.
+     * When a user creates ChangeLogParameters without a database and passes it via CommandScope,
+     * the database filter should still be set correctly so that dbms-specific properties
+     * in the changelog are resolved correctly.
+     */
+    def "user-provided ChangeLogParameters should have database filter set for dbms resolution"() {
+        given: "A user-created ChangeLogParameters without a database, and a PostgreSQL database"
+        def postgresDb = new PostgresDatabase()
+        
+        // User creates their own ChangeLogParameters (as described in issue #7602)
+        def userParams = new ChangeLogParameters()
+        userParams.set("description", "An DBMS specialized in storing and retrieving data.")
+        
+        // At this point, userParams.getDatabase() is null
+        expect: "userParams has no database filter set"
+        userParams.getDatabase() == null
+        
+        when: "getChangeLogParameters is called with user params and postgres database"
+        def commandScope = new CommandScope("update")
+        commandScope.addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_PARAMETERS, userParams)
+        
+        def changeLogParams = Scope.instance((Scope.ScopedRunnerWithReturn<ChangeLogParameters>) {
+            return getChangeLogParametersInternal(commandScope, postgresDb)
+        })
+        
+        then: "the database filter should be set to postgres's short name"
+        changeLogParams.getDatabase() == "postgresql"
+        
+        cleanup:
+        postgresDb.close()
+    }
+    
+    /**
+     * Helper method that replicates the logic of getChangeLogParameters for testing.
+     * This is needed because the method is private.
+     */
+    private ChangeLogParameters getChangeLogParametersInternal(CommandScope commandScope, liquibase.database.Database database) {
+        ChangeLogParameters changeLogParameters = commandScope.getArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_PARAMETERS)
+        if (changeLogParameters == null) {
+            changeLogParameters = new ChangeLogParameters(database)
+            changeLogParameters.addJavaProperties()
+            changeLogParameters.addDefaultFileProperties()
+        } else {
+            // This is the fix for issue #7602 - when a user-provided ChangeLogParameters is passed,
+            // we still need to set the database filter so that dbms-specific properties
+            // are correctly resolved.
+            changeLogParameters.setDatabase(database.getShortName())
+        }
+        return changeLogParameters
+    }
+}

--- a/liquibase-standard/src/test/groovy/liquibase/command/core/helpers/DatabaseChangelogCommandStepTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/command/core/helpers/DatabaseChangelogCommandStepTest.groovy
@@ -1,6 +1,5 @@
 package liquibase.command.core.helpers
 
-import liquibase.Scope
 import liquibase.changelog.ChangeLogParameters
 import liquibase.command.CommandScope
 import liquibase.database.core.PostgresDatabase
@@ -45,9 +44,8 @@ class DatabaseChangelogCommandStepTest extends Specification {
         )
         method.setAccessible(true)
         
-        def changeLogParams = Scope.instance((Scope.ScopedRunnerWithReturn<ChangeLogParameters>) {
-            return (ChangeLogParameters) method.invoke(null, commandScope, postgresDb)
-        })
+        def step = new DatabaseChangelogCommandStep()
+        def changeLogParams = (ChangeLogParameters) method.invoke(step, commandScope, postgresDb)
         
         then: "the database filter should be set to postgres's short name"
         changeLogParams.getDatabase() == "postgresql"

--- a/liquibase-standard/src/test/groovy/liquibase/command/core/helpers/DatabaseChangelogCommandStepTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/command/core/helpers/DatabaseChangelogCommandStepTest.groovy
@@ -2,15 +2,11 @@ package liquibase.command.core.helpers
 
 import liquibase.Scope
 import liquibase.changelog.ChangeLogParameters
-import liquibase.changelog.DatabaseChangeLog
-import liquibase.command.CommandResultsBuilder
 import liquibase.command.CommandScope
-import liquibase.command.core.UpdateCommandStep
-import liquibase.command.core.helpers.DatabaseChangelogCommandStep
-import liquibase.database.core.MockDatabase
 import liquibase.database.core.PostgresDatabase
 import spock.lang.Specification
-import spock.lang.Unroll
+
+import java.lang.reflect.Method
 
 /**
  * Tests for {@link DatabaseChangelogCommandStep}, specifically the fix for issue #7602
@@ -41,8 +37,16 @@ class DatabaseChangelogCommandStepTest extends Specification {
         def commandScope = new CommandScope("update")
         commandScope.addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_PARAMETERS, userParams)
         
+        // Use reflection to call the actual private method
+        Method method = DatabaseChangelogCommandStep.getDeclaredMethod(
+            "getChangeLogParameters",
+            CommandScope,
+            liquibase.database.Database
+        )
+        method.setAccessible(true)
+        
         def changeLogParams = Scope.instance((Scope.ScopedRunnerWithReturn<ChangeLogParameters>) {
-            return getChangeLogParametersInternal(commandScope, postgresDb)
+            return (ChangeLogParameters) method.invoke(null, commandScope, postgresDb)
         })
         
         then: "the database filter should be set to postgres's short name"
@@ -50,24 +54,5 @@ class DatabaseChangelogCommandStepTest extends Specification {
         
         cleanup:
         postgresDb.close()
-    }
-    
-    /**
-     * Helper method that replicates the logic of getChangeLogParameters for testing.
-     * This is needed because the method is private.
-     */
-    private ChangeLogParameters getChangeLogParametersInternal(CommandScope commandScope, liquibase.database.Database database) {
-        ChangeLogParameters changeLogParameters = commandScope.getArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_PARAMETERS)
-        if (changeLogParameters == null) {
-            changeLogParameters = new ChangeLogParameters(database)
-            changeLogParameters.addJavaProperties()
-            changeLogParameters.addDefaultFileProperties()
-        } else {
-            // This is the fix for issue #7602 - when a user-provided ChangeLogParameters is passed,
-            // we still need to set the database filter so that dbms-specific properties
-            // are correctly resolved.
-            changeLogParameters.setDatabase(database.getShortName())
-        }
-        return changeLogParameters
     }
 }


### PR DESCRIPTION
## Description

When a user creates their own `ChangeLogParameters` instance and passes it via `CommandScope` (e.g., to add custom properties), the database filter was not being set. This caused dbms-specific properties in changelogs to be incorrectly resolved.

## Root Cause

In `DatabaseChangelogCommandStep.getChangeLogParameters()`, when a user-provided `ChangeLogParameters` is passed, the database filter (`filterDatabase`) was never set. The `DatabaseList.definitionMatches()` method with a null database and `returnValueIfEmpty=true` would incorrectly match all dbms filters.

## Example

With PostgreSQL:
- property with `dbms: "db2i"` was incorrectly matching because `DatabaseList.definitionMatches(["db2i"], null, true)` returns `true` when the database is null
- property with no dbms filter (fallback) was being skipped

## Fix

When a user-provided `ChangeLogParameters` is passed, we now set the database filter to the actual database's short name, ensuring dbms filtering works correctly.

## Testing

Added `DatabaseChangelogCommandStepTest` to verify the fix.

Fixes: https://github.com/liquibase/liquibase/issues/7602