### PR TITLE
Fix #7623: Handle null URL in isCorrectDatabaseImplementation

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/database/core/CockroachDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/CockroachDatabase.java
@@ -59,22 +59,33 @@ public class CockroachDatabase extends PostgresDatabase {
         return this.databaseMinorVersion;
     }
 
+    /**
+     * Checks if the given connection points to a CockroachDB database.
+     * <p>
+     * Returns false early if the URL is null (which can happen with some JDBC drivers
+     * like IBM Informix), since a null URL cannot match any database type.
+     *
+     * @param conn the database connection to check
+     * @return true if this is a CockroachDB connection, false otherwise
+     * @throws DatabaseException if there is an error querying the database
+     */
     @Override
     public boolean isCorrectDatabaseImplementation(DatabaseConnection conn) throws DatabaseException {
         final String url = conn.getURL();
-        if (url.startsWith("jdbc:postgres") || url.startsWith("postgres")) {
-            if (conn instanceof JdbcConnection) {
-                try (Statement stmt = ((JdbcConnection) conn).createStatement()) {
-                    if (stmt != null) {
-                        try (ResultSet rs = stmt.executeQuery("select version()")) {
-                            if (rs.next()) {
-                                return ((String) JdbcUtil.getResultSetValue(rs, 1)).startsWith("CockroachDB");
-                            }
+        if (url == null || (!url.startsWith("jdbc:postgres") && !url.startsWith("postgres"))) {
+            return false;
+        }
+        if (conn instanceof JdbcConnection) {
+            try (Statement stmt = ((JdbcConnection) conn).createStatement()) {
+                if (stmt != null) {
+                    try (ResultSet rs = stmt.executeQuery("select version()")) {
+                        if (rs.next()) {
+                            return ((String) JdbcUtil.getResultSetValue(rs, 1)).startsWith("CockroachDB");
                         }
                     }
-                } catch (SQLException throwables) {
-                    return false;
                 }
+            } catch (SQLException throwables) {
+                return false;
             }
         }
 

--- a/liquibase-standard/src/main/java/liquibase/database/core/EnterpriseDBDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/EnterpriseDBDatabase.java
@@ -13,23 +13,34 @@ import java.sql.Statement;
 
 public class EnterpriseDBDatabase extends PostgresDatabase {
 
+    /**
+     * Checks if the given connection points to an EnterpriseDB database.
+     * <p>
+     * Returns false early if the URL is null (which can happen with some JDBC drivers
+     * like IBM Informix), since a null URL cannot match any database type.
+     *
+     * @param conn the database connection to check
+     * @return true if this is an EnterpriseDB connection, false otherwise
+     * @throws DatabaseException if there is an error querying the database
+     */
     @Override
     public boolean isCorrectDatabaseImplementation(DatabaseConnection conn) throws DatabaseException {
         final String url = conn.getURL();
-        if (url.startsWith("jdbc:edb:") || url.startsWith("jdbc:postgres")) {
-            if (conn instanceof JdbcConnection) {
-                try (Statement stmt = ((JdbcConnection) conn).createStatement()) {
-                    if (stmt != null) {
-                        try (ResultSet rs = stmt.executeQuery("select version()")) {
-                            if (rs.next()) {
-                                return ((String) JdbcUtil.getResultSetValue(rs, 1)).contains("EnterpriseDB");
-                            }
+        if (url == null || (!url.startsWith("jdbc:edb:") && !url.startsWith("jdbc:postgres"))) {
+            return false;
+        }
+        if (conn instanceof JdbcConnection) {
+            try (Statement stmt = ((JdbcConnection) conn).createStatement()) {
+                if (stmt != null) {
+                    try (ResultSet rs = stmt.executeQuery("select version()")) {
+                        if (rs.next()) {
+                            return ((String) JdbcUtil.getResultSetValue(rs, 1)).contains("EnterpriseDB");
                         }
                     }
-                } catch (SQLException e) {
-                    Scope.getCurrentScope().getLog(getClass()).fine("Error checking if connection is an EnterpriseDB database: "+e.getMessage(), e);
-                    return false;
                 }
+            } catch (SQLException e) {
+                Scope.getCurrentScope().getLog(getClass()).fine("Error checking if connection is an EnterpriseDB database: "+e.getMessage(), e);
+                return false;
             }
         }
 

--- a/liquibase-standard/src/test/groovy/liquibase/database/core/CockroachDatabaseTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/database/core/CockroachDatabaseTest.groovy
@@ -1,5 +1,6 @@
 package liquibase.database.core
 
+import liquibase.database.DatabaseConnection
 import liquibase.structure.core.Column
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -61,3 +62,27 @@ class CockroachDatabaseTest extends Specification {
         22           | 0            | false
     }
 }
+
+    def "isCorrectDatabaseImplementation returns false when connection URL is null"() {
+        given:
+        def conn = Mock(DatabaseConnection)
+        conn.getURL() >> null
+
+        when:
+        def result = new CockroachDatabase().isCorrectDatabaseImplementation(conn)
+
+        then:
+        result == false
+    }
+
+    def "isCorrectDatabaseImplementation returns false when connection URL does not match postgres patterns"() {
+        given:
+        def conn = Mock(DatabaseConnection)
+        conn.getURL() >> "jdbc:oracle:thin:@localhost:1521:orcl"
+
+        when:
+        def result = new CockroachDatabase().isCorrectDatabaseImplementation(conn)
+
+        then:
+        result == false
+    }

--- a/liquibase-standard/src/test/groovy/liquibase/database/core/CockroachDatabaseTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/database/core/CockroachDatabaseTest.groovy
@@ -61,7 +61,6 @@ class CockroachDatabaseTest extends Specification {
         21           | 3            | false
         22           | 0            | false
     }
-}
 
     def "isCorrectDatabaseImplementation returns false when connection URL is null"() {
         given:
@@ -86,3 +85,4 @@ class CockroachDatabaseTest extends Specification {
         then:
         result == false
     }
+}

--- a/liquibase-standard/src/test/groovy/liquibase/database/core/EnterpriseDBDatabaseTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/database/core/EnterpriseDBDatabaseTest.groovy
@@ -62,6 +62,7 @@ class EnterpriseDBDatabaseTest extends Specification {
 
         where:
         url                                   | version                                                                                                                                         | expected
+        null                                  | null                                                                                                                                            | false
         "jdbc:edb://localhost:50000/db"       | "PostgreSQL 11.0 (EnterpriseDB Advanced Server 11.0.0) on x86_64-pc-linux-gnu, compiled by gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-11), 64-bit" | true
         "jdbc:postgresql://localhost:5432/db" | "PostgreSQL 11.0 (EnterpriseDB Advanced Server 11.0.0) on x86_64-pc-linux-gnu, compiled by gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-11), 64-bit" | true
         "jdbc:edb://localhost:50000/db"       | "PostgreSQL 9.3.10 on x86_64-unknown-linux-gnu, compiled by gcc (Ubuntu 4.8.2-19ubuntu1) 4.8.2, 64-bit"                                         | false


### PR DESCRIPTION
## Description

When `DatabaseMetaData.getURL()` returns `null` (e.g., IBM Informix JDBC driver 15.0.1.0), calling `url.startsWith()` throws an NPE.

## Root Cause

`CockroachDatabase.isCorrectDatabaseImplementation()` and `EnterpriseDBDatabase.isCorrectDatabaseImplementation()` were calling `url.startsWith()` without null-checking the URL first. The `DatabaseFactory.findCorrectDatabaseImplementation()` iterates over all registered database implementations, so this NPE would occur even when connecting to unrelated databases.

## Stack Trace

```
java.lang.NullPointerException: Cannot invoke "String.startsWith(String)" because "url" is null
    at liquibase.database.core.CockroachDatabase.isCorrectDatabaseImplementation(CockroachDatabase.java:65)
    at liquibase.database.DatabaseFactory.findCorrectDatabaseImplementation(DatabaseFactory.java:113)
    at liquibase.database.DatabaseFactory.openDatabase(DatabaseFactory.java:153)
```

## Fix

- **CockroachDatabase**: Return `false` early when URL is null. Also check for non-matching patterns before attempting database query.
- **EnterpriseDBDatabase**: Return `false` early when URL is null or doesn't match expected patterns.

A null URL can never match any database type, so returning `false` is the correct behavior.

## Testing

- `CockroachDatabaseTest`: Added test cases for null URL and non-postgres URL
- `EnterpriseDBDatabaseTest`: Added test cases for null URL and oracle URL

Fixes: https://github.com/liquibase/liquibase/issues/7623