### PR TITLE
TECHOPS-156: replace stale the-actions-org/workflow-dispatch (2 call sites)

### DIFF
--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -72,13 +72,13 @@ jobs:
 
       - name: Invoke Create Release
         id: trigger-step
-        uses: the-actions-org/workflow-dispatch@3133c5d135c7dbe4be4f9793872b6ef331b53bc7 # v4.0.0
+        uses: liquibase/build-logic/.github/actions/dispatch-and-wait@main
         with:
           workflow: create-release.yml
-          token: ${{ steps.get-token.outputs.token }}
-          inputs: '{"version": "dry-run-${{ github.run_id }}", "runId": "${{ needs.setup.outputs.dry_run_id }}", "standalone_zip": "false", "dry_run": "true", "branch": "main"}'
           ref: main
-          wait-for-completion: true
+          inputs: '{"version": "dry-run-${{ github.run_id }}", "runId": "${{ needs.setup.outputs.dry_run_id }}", "standalone_zip": "false", "dry_run": "true", "branch": "main"}'
+          wait: 'true'
+          gh-token: ${{ steps.get-token.outputs.token }}
 
       - name: Get Release Outputs
         id: wait_and_get_outputs
@@ -202,13 +202,13 @@ jobs:
           permission-actions: write
 
       - name: Trigger release-published-orchestrator workflow
-        uses: the-actions-org/workflow-dispatch@3133c5d135c7dbe4be4f9793872b6ef331b53bc7 # v4.0.0
+        uses: liquibase/build-logic/.github/actions/dispatch-and-wait@main
         with:
           workflow: release-published-orchestrator.yml
-          token: ${{ steps.get-token.outputs.token }}
-          inputs: '{"tag": "vdry-run-${{ github.run_id }}", "dry_run_release_id": "${{ needs.dry-run-create-release.outputs.dry_run_release_id }}", "dry_run_zip_url": "${{ needs.dry-run-create-release.outputs.dry_run_zip_url }}", "dry_run_tar_gz_url": "${{ needs.dry-run-create-release.outputs.dry_run_tar_gz_url }}", "dry_run": true, "dry_run_branch_name": "${{ needs.setup.outputs.dry_run_branch_name }}"}'
           ref: main
-          wait-for-completion: true
+          inputs: '{"tag": "vdry-run-${{ github.run_id }}", "dry_run_release_id": "${{ needs.dry-run-create-release.outputs.dry_run_release_id }}", "dry_run_zip_url": "${{ needs.dry-run-create-release.outputs.dry_run_zip_url }}", "dry_run_tar_gz_url": "${{ needs.dry-run-create-release.outputs.dry_run_tar_gz_url }}", "dry_run": true, "dry_run_branch_name": "${{ needs.setup.outputs.dry_run_branch_name }}"}'
+          wait: 'true'
+          gh-token: ${{ steps.get-token.outputs.token }}
 
   cleanup:
     runs-on: ubuntu-latest

--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Invoke Create Release
         id: trigger-step
-        uses: liquibase/build-logic/.github/actions/dispatch-and-wait@TECHOPS-156
+        uses: liquibase/build-logic/.github/actions/dispatch-and-wait@main
         with:
           workflow: create-release.yml
           ref: main
@@ -202,7 +202,7 @@ jobs:
           permission-actions: write
 
       - name: Trigger release-published-orchestrator workflow
-        uses: liquibase/build-logic/.github/actions/dispatch-and-wait@TECHOPS-156
+        uses: liquibase/build-logic/.github/actions/dispatch-and-wait@main
         with:
           workflow: release-published-orchestrator.yml
           ref: main

--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Invoke Create Release
         id: trigger-step
-        uses: liquibase/build-logic/.github/actions/dispatch-and-wait@main
+        uses: liquibase/build-logic/.github/actions/dispatch-and-wait@TECHOPS-156
         with:
           workflow: create-release.yml
           ref: main
@@ -202,7 +202,7 @@ jobs:
           permission-actions: write
 
       - name: Trigger release-published-orchestrator workflow
-        uses: liquibase/build-logic/.github/actions/dispatch-and-wait@main
+        uses: liquibase/build-logic/.github/actions/dispatch-and-wait@TECHOPS-156
         with:
           workflow: release-published-orchestrator.yml
           ref: main


### PR DESCRIPTION
## Summary

Replace stale `the-actions-org/workflow-dispatch@v4.0.0` (last push 2024-06-21) in `dry-run-release.yml` with the new `liquibase/build-logic/.github/actions/dispatch-and-wait@main` composite action. Resolves the `liquibase` portion of [TECHOPS-156](https://datical.atlassian.net/browse/TECHOPS-156); unblocks DAT-22654 allowlist cleanup.

**Blocked by:** [build-logic#582](https://github.com/liquibase/build-logic/pull/582) — must merge first.

## What changed

`.github/workflows/dry-run-release.yml` — two call sites in the dry-run flow:

| Step | Dispatched workflow | Wait? |
|---|---|---|
| "Invoke Create Release" | `create-release.yml` (this repo) | yes |
| "Trigger release-published-orchestrator" | `release-published-orchestrator.yml` (this repo) | yes |

Both swap `uses: the-actions-org/workflow-dispatch@v4.0.0` → `uses: liquibase/build-logic/.github/actions/dispatch-and-wait@main`. Same target workflows, same input JSON, same wait semantics. Token input renamed `token:` → `gh-token:` to match the new action's surface.

## Test plan

- [ ] PR build passes
- [ ] After both this and [build-logic#582](https://github.com/liquibase/build-logic/pull/582) merge: next dry-run dispatches `create-release.yml` and `release-published-orchestrator.yml` and waits as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECHOPS-156]: https://datical.atlassian.net/browse/TECHOPS-156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ