### PR TITLE
fix(TECHOPS-417): propagate packages: write to nested docker workflows

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -30,6 +30,7 @@ on:
 permissions:
   contents: read
   id-token: write
+  packages: write
 
 jobs:
   release-docker:
@@ -38,6 +39,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: write
     with:
       liquibaseVersion: ${{ inputs.version }}
       dryRun: ${{ inputs.dry_run || false }}

--- a/.github/workflows/release-published-orchestrator.yml
+++ b/.github/workflows/release-published-orchestrator.yml
@@ -135,6 +135,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: write
     with:
       version: ${{ needs.setup.outputs.version }}
       dry_run: ${{ inputs.dry_run || false }}


### PR DESCRIPTION
## Summary

Fixes [TECHOPS-417](https://datical.atlassian.net/browse/TECHOPS-417) — `release-published-orchestrator.yml` has been failing with `startup_failure` on every `workflow_dispatch` since **2026-04-29** because the nested docker build jobs (`build-community`, `build-alpine` in `docker-release.yml`) request `packages: write` for GHCR pushes, but the orchestrator and its caller chain only propagate `contents: read, id-token: write`.

GitHub validates nested workflow permissions as a **subset** of every parent in the chain, so the entire workflow fails validation at startup before any job runs.

## Error (from failed run [25691241979](https://github.com/liquibase/liquibase/actions/runs/25691241979))

> Invalid workflow file: `.github/workflows/release-published-orchestrator.yml#L35`
> The nested job `'build-community'` is requesting `'packages: write'`, but is only allowed `'packages: none'`.
> The nested job `'build-alpine'` is requesting `'packages: write'`, but is only allowed `'packages: none'`.

## Changes

Added `packages: write` at 3 spots in the call chain:

| File | Spot | Change |
|---|---|---|
| `release-published-orchestrator.yml` | `release-docker:` job (line 135) | + `packages: write` |
| `release-docker.yml` | top-level `permissions:` (line 30) | + `packages: write` |
| `release-docker.yml` | `release-docker:` job (line 38) | + `packages: write` |

The leaf jobs `build-community` and `build-alpine` in `docker-release.yml` already correctly declare `packages: write` — this PR just propagates that permission downward through the call chain.

## Regression history

| Date | Branch | Result |
|---|---|---|
| 2026-04-22 | master | success |
| 2026-04-29 | master | startup_failure |
| 2026-05-04 | main | startup_failure |
| 2026-05-06 | main | startup_failure |
| 2026-05-11 | main | startup_failure (surfaced during TECHOPS-156 testing) |

Last green dry-run: 2026-04-22. Likely introduced by a "minimal permissions" tightening between 2026-04-22 and 2026-04-29 (the `# Security: Minimal workflow-level permissions` comment at line 63 of the orchestrator is consistent with that).

## Test plan

- [ ] Re-run the TECHOPS-156 dry-run dispatch test against this branch — both nested dispatches should now succeed
- [ ] Verify `release-published-orchestrator.yml` workflow_dispatch can be triggered without startup_failure
- [ ] Confirm GHCR push step is reachable (dry-run flag prevents actual publish)

[TECHOPS-417]: https://datical.atlassian.net/browse/TECHOPS-417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ