### PR TITLE
fix(changelog): fall back when stored changelog path is missing

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/changelog/RanChangeSet.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/RanChangeSet.java
@@ -86,6 +86,13 @@ public class RanChangeSet {
         return (Date) dateExecuted.clone();
     }
 
+    public String getStoredChangeLog() {
+        if (storedChangeLog == null) {
+            return changeLog;
+        }
+        return storedChangeLog;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/liquibase-standard/src/test/java/liquibase/changelog/RanChangeSetTest.java
+++ b/liquibase-standard/src/test/java/liquibase/changelog/RanChangeSetTest.java
@@ -2,6 +2,7 @@ package liquibase.changelog;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -26,5 +27,19 @@ public class RanChangeSetTest {
         RanChangeSet ranChangeSet = new RanChangeSet("db/ran-changeset.log", "1", "author", null, null, null, null, null, null, null, null, null);
         ChangeSet incomingChangeSet = new ChangeSet("1", "author", false, false, "classpath:/db/file.log", null, null, null);
         assertFalse(ranChangeSet.isSameAs(incomingChangeSet));
+    }
+
+    @Test
+    public void stored_change_log_falls_back_to_change_log() {
+        RanChangeSet ranChangeSet = new RanChangeSet("db/file.log", "1", "author", null, null, null, null, null, null, null, null, null);
+
+        assertEquals("db/file.log", ranChangeSet.getStoredChangeLog());
+    }
+
+    @Test
+    public void stored_change_log_uses_explicit_stored_path() {
+        RanChangeSet ranChangeSet = new RanChangeSet("logical/file.log", "1", "author", null, null, null, null, null, null, null, null, null, "physical/file.log");
+
+        assertEquals("physical/file.log", ranChangeSet.getStoredChangeLog());
     }
 }


### PR DESCRIPTION
## Impact
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature
- [ ] Breaking Change

## Description
Fixes #7667.
Fixes #7587.

`RanChangeSet.getStoredChangeLog()` now falls back to the changelog path when an older changelog history service or extension does not provide a separate stored path. Explicit stored changelog paths still take precedence when available.

## Things to be aware of
This keeps existing constructor behavior intact and centralizes the fallback in the getter used by logical file path comparisons.

## Things to worry about
None.

## Additional Context
Validation:
- `./mvnw -pl liquibase-standard -Dtest=liquibase.changelog.RanChangeSetTest test -DtrimStackTrace=false`