### PR TITLE
fix(mysql): preserve timestamp column attributes in native types

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/datatype/core/TimestampType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/TimestampType.java
@@ -64,6 +64,10 @@ public class TimestampType extends DateTimeType {
             // All timestamp types (with or without timezone) map to TIMESTAMP
             String lowerDef = originalDefinition.toLowerCase();
 
+            if (isNativeMySqlTimestampDefinitionWithColumnAttributes(lowerDef)) {
+                return new DatabaseDataType(getRawDefinition());
+            }
+
             if (lowerDef.startsWith("java.sql.types.timestamp_with_timezone")
                     || lowerDef.startsWith("java.sql.types.timestamp")
                     || lowerDef.startsWith("java.sql.timestamp")
@@ -219,6 +223,15 @@ public class TimestampType extends DateTimeType {
         }
 
         return super.toDatabaseDataType(database);
+    }
+
+    private boolean isNativeMySqlTimestampDefinitionWithColumnAttributes(String lowerDefinition) {
+        if (!lowerDefinition.matches("^timestamp(\\s|\\(|$).*")
+                || lowerDefinition.matches("^timestamp\\s*(\\([^)]*\\))?\\s*$")) {
+            return false;
+        }
+
+        return !lowerDefinition.matches("^timestamp\\s*(\\([^)]*\\))?\\s+(with|without)\\s+time\\s*zone$");
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/TimestampType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/TimestampType.java
@@ -225,6 +225,11 @@ public class TimestampType extends DateTimeType {
         return super.toDatabaseDataType(database);
     }
 
+    /**
+     * Returns true for lowercased MySQL-like TIMESTAMP definitions that include
+     * column attributes to preserve, while excluding plain TIMESTAMP precision
+     * forms and WITH/WITHOUT TIME ZONE aliases that should keep normal handling.
+     */
     private boolean isNativeMySqlTimestampDefinitionWithColumnAttributes(String lowerDefinition) {
         if (!lowerDefinition.matches("^timestamp(\\s|\\(|$).*")
                 || lowerDefinition.matches("^timestamp\\s*(\\([^)]*\\))?\\s*$")) {

--- a/liquibase-standard/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
@@ -219,6 +219,8 @@ class DataTypeFactoryTest extends Specification {
         "java.sql.Types.TIMESTAMP_WITH_TIMEZONE(6)"    | new MySQLDatabase()    | "timestamp(6)"                                 | TimestampType | false
         "timestamp"                                    | new MySQLDatabase()    | "timestamp"                                    | TimestampType | false
         "timestamp(3)"                                 | new MySQLDatabase()    | "timestamp(3)"                                 | TimestampType | false
+        "TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP" | new MySQLDatabase() | "TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP" | TimestampType | false
+        "timestamp(3) not null default current_timestamp(3) on update current_timestamp(3)" | new MySQLDatabase() | "timestamp(3) not null default current_timestamp(3) on update current_timestamp(3)" | TimestampType | false
         "TIMESTAMPTZ"                                  | new MySQLDatabase()    | "timestamp"                                    | TimestampType | false
         "timestamptz(3)"                               | new MySQLDatabase()    | "timestamp(3)"                                 | TimestampType | false
         "java.sql.Types.TIMESTAMP"                     | new MySQLDatabase()    | "timestamp"                                    | TimestampType | false

--- a/liquibase-standard/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
@@ -220,6 +220,7 @@ class DataTypeFactoryTest extends Specification {
         "timestamp"                                    | new MySQLDatabase()    | "timestamp"                                    | TimestampType | false
         "timestamp(3)"                                 | new MySQLDatabase()    | "timestamp(3)"                                 | TimestampType | false
         "TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP" | new MySQLDatabase() | "TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP" | TimestampType | false
+        "TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP" | new MariaDBDatabase() | "TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP" | TimestampType | false
         "timestamp(3) not null default current_timestamp(3) on update current_timestamp(3)" | new MySQLDatabase() | "timestamp(3) not null default current_timestamp(3) on update current_timestamp(3)" | TimestampType | false
         "TIMESTAMPTZ"                                  | new MySQLDatabase()    | "timestamp"                                    | TimestampType | false
         "timestamptz(3)"                               | new MySQLDatabase()    | "timestamp(3)"                                 | TimestampType | false


### PR DESCRIPTION
## Impact
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature
- [ ] Breaking Change

## Description
Fixes #7637.

MySQL timestamp conversion now preserves native `timestamp` definitions when they include column attributes such as `NOT NULL`, `DEFAULT CURRENT_TIMESTAMP`, or `ON UPDATE CURRENT_TIMESTAMP`. Plain `timestamp`, precision-only `timestamp(3)`, and timezone aliases continue to normalize through the existing MySQL timestamp mapping.

## Things to be aware of
The parser can drop trailing attributes from precision-bearing raw definitions before they become additional information, so this check uses the raw definition to detect native MySQL timestamp column attributes.

## Things to worry about
None.

## Additional Context
Validation:
- `./mvnw -pl liquibase-standard -Dtest=liquibase.datatype.DataTypeFactoryTest test -DtrimStackTrace=false`