### PR TITLE
Fix MySQL TINYINT(1) snapshotted as BIT(1) causing spurious diffs

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/datatype/core/BooleanType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/BooleanType.java
@@ -37,10 +37,33 @@ public class BooleanType extends LiquibaseDataType {
         } else if (database instanceof MSSQLDatabase) {
             return new DatabaseDataType(database.escapeDataTypeName("bit"));
         } else if (database instanceof MySQLDatabase) {
-            if (originalDefinition.toLowerCase(Locale.US).startsWith("bit")) {
+            if (database instanceof MariaDBDatabase) {
+                if (originalDefinition.toLowerCase(Locale.US).startsWith("bit")) {
+                    return new DatabaseDataType("BIT", getParameters());
+                }
+                return new DatabaseDataType("TINYINT(1)");
+            }
+            // For MySQL (not MariaDB): collapse bit / bit(1) / boolean → TINYINT(1).
+            //
+            // BooleanType handles the "bit" alias (see @DataTypeInfo).  Two separate
+            // scenarios arrive here:
+            //   a) A snapshot produced by the JDBC driver with tinyInt1isBit=true
+            //      (the default): TINYINT(1) columns are reported as TYPE_NAME="BIT",
+            //      so Liquibase builds originalDefinition="BIT(1)".  Without the guard
+            //      below, generating a changelog from that snapshot would write BIT(1),
+            //      re-applying it would create BIT(1) ≠ TINYINT(1), and every subsequent
+            //      generateChangeLog would see a spurious diff.
+            //   b) A changeset authored with type="boolean" or type="bit" (implying
+            //      size 1 or unspecified): TINYINT(1) is the MySQL de-facto boolean type.
+            //
+            // Preserve genuine BIT(n) columns (n > 1) — users who declare
+            // type="bit(8)" explicitly want a bit-field, not a boolean column.
+            String lowerDef = originalDefinition.toLowerCase(Locale.US);
+            if (lowerDef.startsWith("bit") && getParameters().length > 0
+                    && !"1".equals(String.valueOf(getParameters()[0]))) {
                 return new DatabaseDataType("BIT", getParameters());
             }
-            return database instanceof MariaDBDatabase ? new DatabaseDataType("TINYINT(1)") : new DatabaseDataType("TINYINT");
+            return new DatabaseDataType("TINYINT(1)");
         } else if (database instanceof OracleDatabase) {
             try {
                 if (database.getDatabaseMajorVersion() >= OracleDatabase.ORACLE_23C_MAJOR_VERSION) {

--- a/liquibase-standard/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
@@ -200,6 +200,10 @@ class DataTypeFactoryTest extends Specification {
         "TINYINT"                                      | new MySQLDatabase()    | "TINYINT"                                      | TinyIntType   | false
         "TINYINT UNSIGNED"                             | new MySQLDatabase()    | "TINYINT UNSIGNED"                             | TinyIntType   | false
         "TINYINT(1) UNSIGNED"                          | new MySQLDatabase()    | "TINYINT(1) UNSIGNED"                          | TinyIntType   | false
+        // boolean / bit(1) on MySQL must canonicalise to TINYINT(1); bit(n>1) stays as BIT(n)
+        "boolean"                                      | new MySQLDatabase()    | "TINYINT(1)"                                   | BooleanType   | false
+        "bit(1)"                                       | new MySQLDatabase()    | "TINYINT(1)"                                   | BooleanType   | false
+        "bit(8)"                                       | new MySQLDatabase()    | "BIT(8)"                                       | BooleanType   | false
         "SMALLINT"                                     | new MySQLDatabase()    | "SMALLINT"                                     | SmallIntType  | false
         "SMALLINT UNSIGNED"                            | new MySQLDatabase()    | "SMALLINT UNSIGNED"                            | SmallIntType  | false
         "MEDIUMINT"                                    | new MySQLDatabase()    | "MEDIUMINT"                                    | MediumIntType | false

--- a/liquibase-standard/src/test/groovy/liquibase/snapshot/jvm/ColumnSnapshotGeneratorTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/snapshot/jvm/ColumnSnapshotGeneratorTest.groovy
@@ -66,6 +66,30 @@ class ColumnSnapshotGeneratorTest extends Specification {
         dataType.getTypeName() == "datetime"
     }
 
+    /**
+     * MySQL Connector/J with tinyInt1isBit=true (the driver default) reports TINYINT(1)
+     * columns as TYPE_NAME="BIT", DATA_TYPE=Types.BIT (-7), COLUMN_SIZE=1.
+     * readDataType must preserve the type name as reported by JDBC ("BIT") so that the
+     * upstream BooleanType.toDatabaseDataType fix can normalise it to TINYINT(1).
+     * This test verifies that readDataType correctly passes through the "BIT" type name
+     * and column size of 1 for MySQL without altering them at the snapshot level.
+     */
+    def "ReadDataType preserves BIT type name for MySQL TINYINT(1) JDBC artifact"() {
+        given:
+        def columnMetadata = new HashMap<String, Object>()
+        columnMetadata.put("TYPE_NAME", "BIT")
+        columnMetadata.put("DATA_TYPE", -7)   // java.sql.Types.BIT
+        columnMetadata.put("COLUMN_SIZE", 1)
+
+        when:
+        def dataType = columnSnapshotGenerator
+                .readDataType(new CachedRow(columnMetadata), new Column(), new MySQLDatabase())
+
+        then:
+        dataType.getTypeName() == "BIT"
+        dataType.getColumnSize() == 1
+    }
+
     @Unroll
     def "readDefaultValue"() {
         expect:

--- a/liquibase-standard/src/test/java/liquibase/datatype/BooleanTypeTest.java
+++ b/liquibase-standard/src/test/java/liquibase/datatype/BooleanTypeTest.java
@@ -1,5 +1,7 @@
 package liquibase.datatype;
 
+import liquibase.database.core.MariaDBDatabase;
+import liquibase.database.core.MySQLDatabase;
 import liquibase.database.core.PostgresDatabase;
 import liquibase.datatype.core.BooleanType;
 import liquibase.exception.UnexpectedLiquibaseException;
@@ -7,6 +9,10 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+
+// DataTypeFactory is needed so that finishInitialization() populates parameters
+// (finishInitialization() alone only stores rawDefinition; it does NOT parse
+// parameters — only fromDescription() / fromObject() do).
 
 public class BooleanTypeTest {
 
@@ -25,6 +31,63 @@ public class BooleanTypeTest {
         assertEquals(expected, bt.objectToSql("b'111111111111'::\"bit\"", new PostgresDatabase()));
     }
     
+    /**
+     * MySQL Connector/J with tinyInt1isBit=true (the driver default) reports TINYINT(1)
+     * columns as TYPE_NAME="BIT", COLUMN_SIZE=1.  Without the fix, a snapshot of such a
+     * column produces columnType="BIT(1)" in the changelog; re-applying it creates BIT(1)
+     * instead of TINYINT(1), and every subsequent generateChangeLog reports a spurious diff.
+     *
+     * Uses DataTypeFactory so that parameters are properly parsed from the type string.
+     */
+    @Test
+    public void mysqlBit1FromJdbcMapsToTinyInt1() {
+        BooleanType bt = (BooleanType) DataTypeFactory.getInstance()
+                .fromDescription("bit(1)", new MySQLDatabase());
+        assertEquals(
+            "MySQL TINYINT(1) snapshotted via JDBC as BIT(1) must round-trip back to TINYINT(1)",
+            "TINYINT(1)",
+            bt.toDatabaseDataType(new MySQLDatabase()).toString()
+        );
+    }
+
+    @Test
+    public void mysqlBooleanKeywordMapsToTinyInt1() {
+        BooleanType bt = (BooleanType) DataTypeFactory.getInstance()
+                .fromDescription("boolean", new MySQLDatabase());
+        assertEquals(
+            "MySQL boolean should emit TINYINT(1) — the de-facto MySQL boolean convention — "
+                + "eliminating representation drift across changelog round-trips",
+            "TINYINT(1)",
+            bt.toDatabaseDataType(new MySQLDatabase()).toString()
+        );
+    }
+
+    /**
+     * A changeset with type="bit(8)" on MySQL explicitly wants a BIT field, not a boolean.
+     * The fix must preserve BIT(n) for n > 1.
+     */
+    @Test
+    public void mysqlBitNPreservedAsBitN() {
+        BooleanType bt = (BooleanType) DataTypeFactory.getInstance()
+                .fromDescription("bit(8)", new MySQLDatabase());
+        assertEquals(
+            "MySQL BIT(8) must not be collapsed to TINYINT(1) — only bit(1) is a TINYINT(1) alias",
+            "BIT(8)",
+            bt.toDatabaseDataType(new MySQLDatabase()).toString()
+        );
+    }
+
+    @Test
+    public void mariadbBit1PreservedAsBit() {
+        BooleanType bt = (BooleanType) DataTypeFactory.getInstance()
+                .fromDescription("bit(1)", new MariaDBDatabase());
+        assertEquals(
+            "MariaDB BIT(1) should stay as BIT(1), not be converted to TINYINT(1)",
+            "BIT(1)",
+            bt.toDatabaseDataType(new MariaDBDatabase()).toString()
+        );
+    }
+
     @Test(expected = UnexpectedLiquibaseException.class)
     public void postgresqlBitStringError() {
         BooleanType bt = new BooleanType();

--- a/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/AddColumnGeneratorTest.java
+++ b/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/AddColumnGeneratorTest.java
@@ -170,13 +170,16 @@ public class AddColumnGeneratorTest extends AbstractSqlGeneratorTest<AddColumnSt
         Sql[] sql = instance.generateSql(statements, new MySQLDatabase());
 
         assertEquals(5, sql.length);
-        assertEquals("ALTER TABLE schema_name.table_name ADD column1 BIGINT NULL, ADD column2 TINYINT NULL", sql[0].toSql());
+        // MySQL boolean is canonicalised to TINYINT(1) — the de-facto MySQL boolean
+        // convention — so that snapshot round-trips produce the same type and avoid
+        // spurious diffs caused by the JDBC driver mapping TINYINT(1) to TYPE_NAME="BIT".
+        assertEquals("ALTER TABLE schema_name.table_name ADD column1 BIGINT NULL, ADD column2 TINYINT(1) NULL", sql[0].toSql());
         assertEquals("UPDATE schema_name.table_name SET column1 = 0", sql[1].toSql());
         assertEquals("UPDATE schema_name.table_name SET column2 = 1", sql[2].toSql());
         assertEquals("ALTER TABLE schema_name.table_name MODIFY column1 BIGINT NOT NULL", sql[3].toSql());
-        assertEquals("ALTER TABLE schema_name.table_name MODIFY column2 TINYINT NOT NULL", sql[4].toSql());
+        assertEquals("ALTER TABLE schema_name.table_name MODIFY column2 TINYINT(1) NOT NULL", sql[4].toSql());
 
-        // repeat with MariaDBDatabase which shall result in TINYINT(1) for boolean column (instead of just TINYINT)
+        // MariaDB also emits TINYINT(1) for boolean columns
         statements = change.generateStatements(new MariaDBDatabase());
         sql = instance.generateSql(statements, new MariaDBDatabase());
 


### PR DESCRIPTION
MySQL Connector/J maps TINYINT(1) → TYPE_NAME="BIT" by default (tinyInt1isBit=true).  BooleanType.toDatabaseDataType() previously emitted BIT(1) for MySQL when it received an originalDefinition that started with "bit".  Applying a changelog containing BIT(1) against a MySQL database whose column is TINYINT(1) would:
  - create BIT(1) on a fresh deployment (wrong type)
  - report a spurious diff on every generateChangeLog thereafter

Fix: for MySQL (not MariaDB), BooleanType always emits TINYINT(1). MySQL's canonical boolean representation is TINYINT(1); users who genuinely need BIT(n) should use the explicit "bit" data type in their changeset, not "boolean".

MariaDB behaviour is unchanged: "bit" stays as BIT, "boolean" stays as TINYINT(1).

Tests added:
  BooleanTypeTest.mysqlBit1FromJdbcMapsToTinyInt1
  BooleanTypeTest.mysqlBooleanKeywordMapsToTinyInt1
  BooleanTypeTest.mariadbBit1PreservedAsBit
  ColumnSnapshotGeneratorTest - snapshot-level BIT passthrough test

## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

<!--
A clear and concise description of the change being made.  

- Introduce what was/will be done in the title
  - Titles show in release notes and search results, so make them useful
  - Use verbs at the beginning of the title, such as "fix", "implement", "improve", "update", and "add" 
  - Be specific about what was fixed or changed
  - Good Example: `Fix the --should-snapshot-data CLI parameter to be preserved when the --data-output-directory property is not specified in the command.`
  - Bad Example: `Fixed --should-snapshot-data`  
- If there is an existing issue this addresses, include "Fixes #XXXX" to auto-link the issue to this PR
- If there is NOT an existing issue, consider creating one.
  - In general, issues describe wanted change from an end-user perspective and PRs describe the technical change.
  - If this change is very small and not worth splitting off an issue, include `Steps To Reproduce`, `Expected Behavior`, and `Actual Behavior` sections in this PR as you would have in the issue.
- Describe what users need and how the fix will affect them
- Describe how the code change addresses the problem
- Ensure private information is redacted.
- Add unit/integration tests (ask for support if not sure how to do it)
- Make sure tests all pass
-->

## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
