### PR TITLE
fix(TECHOPS-417): propagate contents: write to nested docker workflows

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -28,7 +28,7 @@ on:
         default: false
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
   packages: write
 
@@ -37,7 +37,7 @@ jobs:
     name: Release docker images
     uses: ./.github/workflows/docker-release.yml
     permissions:
-      contents: read
+      contents: write
       id-token: write
       packages: write
     with:

--- a/.github/workflows/release-published-orchestrator.yml
+++ b/.github/workflows/release-published-orchestrator.yml
@@ -133,7 +133,7 @@ jobs:
     if: always() && needs.setup.result == 'success' && (needs.manual-approval.result == 'success' || needs.manual-approval.result == 'skipped') && needs.deploy-maven.result == 'success'
     uses: ./.github/workflows/release-docker.yml
     permissions:
-      contents: read
+      contents: write
       id-token: write
       packages: write
     with:


### PR DESCRIPTION
## Summary

- Follow-up to #7702. The release-published-orchestrator dry-run still fails with `startup_failure` because the nested `publish-release` job in `docker-release.yml` declares `contents: write` (it commits the version bump back), but the caller chain still caps `contents` at `read`.
- GitHub validates nested workflow permissions as a subset of every parent job's `permissions:` block, so the orchestrator fails workflow-file validation before any job runs.
- Propagate `contents: write` at the same three locations the previous PR added `packages: write`:
  - `release-published-orchestrator.yml` → `release-docker:` job
  - `release-docker.yml` → top-level
  - `release-docker.yml` → `release-docker:` job

## Failing run

[liquibase/liquibase/actions/runs/25756624906](https://github.com/liquibase/liquibase/actions/runs/25756624906) annotation:

> The workflow is not valid. `liquibase/liquibase/.github/workflows/release-docker.yml@<sha>` (Line: 36, Col: 3): Error calling workflow `liquibase/liquibase/.github/workflows/docker-release.yml@<sha>`. The nested job `publish-release` is requesting `contents: write`, but is only allowed `contents: read`.

Surfaced while testing TECHOPS-156 dry-run-releases.

## Test plan

- [ ] Re-run `dry-run-release.yml` (manual workflow_dispatch) and confirm the dispatched `release-published-orchestrator.yml` reaches `in_progress` instead of `startup_failure`.
- [ ] Confirm `publish-release` job in `docker-release.yml` is able to commit (or, in dry-run mode, dry-skip) the version bump without permission errors.