### PR TITLE
fix(DAT-22091): retarget docker-release.yml checkout from master to main

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -62,7 +62,7 @@ permissions:
   id-token: write
 
 jobs:
-  # ── Step 1: Bump LIQUIBASE_VERSION ARG in Dockerfiles, commit to master ──────
+  # ── Step 1: Bump LIQUIBASE_VERSION ARG in Dockerfiles, commit to main ────────
   update-dockerfiles:
     name: Update Dockerfile versions
     runs-on: ubuntu-latest
@@ -92,11 +92,11 @@ jobs:
           owner: ${{ github.repository_owner }}
           permission-contents: write
 
-      - name: Checkout master
+      - name: Checkout main
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.get-token.outputs.token }}
-          ref: master
+          ref: main
 
       - name: Resolve SHA256 checksums for ${{ inputs.liquibaseVersion }}
         id: checksums


### PR DESCRIPTION
## Summary

- `actions/checkout` in the `update-dockerfiles` job of `.github/workflows/docker-release.yml` still hardcodes `ref: master`, left over from #7660 (default-branch migration on 2026-05-04).
- The repo's `master` branch was deleted by that migration, so `git fetch +refs/heads/master*` exits 1 and the step fails before any Dockerfile work happens.
- Because `update-dockerfiles` is the first job in the docker-release chain, every downstream job (`build-community`, `build-alpine`, `publish-release`) skips — so the entire `release-docker` block of `release-published-orchestrator.yml` fails.

Same class of fix as #7686 (which retargeted the docker drafter and docker-readme workflows from master → main); this is one of the call sites that was missed.

## How it was surfaced

While validating TECHOPS-156 (replacing `the-actions-org/workflow-dispatch`) end-to-end:

- dry-run-release run [25759147311](https://github.com/liquibase/liquibase/actions/runs/25759147311) on `TECHOPS-156`
- → dispatched orchestrator run [25759415339](https://github.com/liquibase/liquibase/actions/runs/25759415339) on `main`
- → ❌ `Release Docker Images / Release docker images / Update Dockerfile versions` step:

```
git fetch --depth=1 origin +refs/heads/master*:refs/remotes/origin/master* +refs/tags/master*:refs/tags/master*
The process '/usr/bin/git' failed with exit code 1
```

## Test plan

- [ ] After merge, re-trigger `dry-run-release.yml` on the `TECHOPS-156` branch and confirm the orchestrator's docker-release chain reaches `Build community image` / `Build alpine image` instead of failing at the checkout step.
- [ ] (Optional) Confirm no other workflow files still reference `master` as a hardcoded ref:
  `grep -rn 'ref: master' .github/workflows/`