### PR TITLE
docs(TECHOPS-428): document dry-run docker chain gap in workflows README

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -32,6 +32,26 @@ The following actions are identical to those in a regular Liquibase release, wit
 - Upload `javadocs` and `xsds` to `S3`
 - Deploy artifacts to `GPM`
 
+## :construction: Known limitations / open work
+
+### 🐳 Docker chain is currently broken in dry-run — tracked in [TECHOPS-428](https://datical.atlassian.net/browse/TECHOPS-428)
+
+The "Push `docker` images to our internal `ecr` repository" line above is the **intended** behavior, but as of 2026-05-12 the docker chain fails at the first step in dry-run mode:
+
+- `docker-release.yml::update-dockerfiles` → "Resolve SHA256 checksums" curls `https://package.liquibase.com/downloads/dockerhub/official/liquibase-${LB_VERSION}.tar.gz`.
+- In dry-run, `LB_VERSION` is the synthetic `dry-run-<run_id>` (e.g. `dry-run-25760954216`); no such tarball is published on the CDN, so curl returns 404 and the step exits 1. Every downstream docker job (`build-community`, `build-alpine`, `publish-release`) is then skipped.
+
+This gap was introduced by [#7669 (DAT-22523)](https://github.com/liquibase/liquibase/pull/7669) on 2026-04-28 when the community Dockerfile was migrated into this repo and the cross-repo dispatcher was replaced with an intra-repo `release-docker.yml` → `docker-release.yml` call chain. It stayed latent until two earlier blockers were cleared in the orchestrator path:
+
+1. [TECHOPS-417](https://datical.atlassian.net/browse/TECHOPS-417) — `packages: write` / `contents: write` permission propagation through nested workflows (fixed by [#7702](https://github.com/liquibase/liquibase/pull/7702) and [#7709](https://github.com/liquibase/liquibase/pull/7709)).
+2. [DAT-22091](https://datical.atlassian.net/browse/DAT-22091) leftover — stale `ref: master` in `actions/checkout` after the default-branch rename (fixed by [#7710](https://github.com/liquibase/liquibase/pull/7710)).
+
+With those landed, the chain now executes far enough to hit the SHA256 step and surface the original gap.
+
+**Planned fix (TECHOPS-428):** plumb `dry_run_tar_gz_url` from the orchestrator through `release-docker.yml` → `docker-release.yml`, and through `docker/Dockerfile` / `docker/Dockerfile.alpine` (via build-arg) so the docker build pulls the dry-run draft-release tarball instead of `package.liquibase.com`. This preserves the original design intent (real docker images pushed to the dry-run ECR) instead of silently skipping the chain.
+
+Until TECHOPS-428 ships, dry-run runs will continue to fail at this step. The orchestrator and the rest of the pipeline (Maven dry-run, javadocs guard, etc.) are unaffected and validated by every dry-run attempt.
+
 ## :wrench: How a DryRun Release works?
 
 You can check the `dry-run-release.yml` workflow, which is essentially composed of calls to existing release workflows such as `create-release.yml` and `release-published-orchestrator.yml`. It sends them a new input, `dry_run: true`, to control which steps are executed for regular releases versus dry-run releases.


### PR DESCRIPTION
## Summary

- Adds a "Known limitations / open work" section to `.github/workflows/README.md` documenting that the docker chain in dry-run mode currently fails at the SHA256 resolution step in `docker-release.yml::update-dockerfiles` (404 on the synthetic `dry-run-<run_id>` tarball).
- Anchors the context — intent, origin commit, prior masking blockers (TECHOPS-417, DAT-22091), and the planned long-run fix — directly in the README so future readers don't have to reconstruct it from the Jira/PR trail.
- Long-run fix tracked in [TECHOPS-428](https://datical.atlassian.net/browse/TECHOPS-428): plumb `dry_run_tar_gz_url` from the orchestrator through `release-docker.yml` → `docker-release.yml` → `docker/Dockerfile.*` (build-arg) so dry-run images really are built from the dry-run draft-release tarball. **Not** the "skip docker in dry-run" shortcut.

## How this came up

Surfaced while validating [TECHOPS-156](https://datical.atlassian.net/browse/TECHOPS-156) end-to-end after [#7709 (TECHOPS-417)](https://github.com/liquibase/liquibase/pull/7709) and [#7710 (DAT-22091 leftover)](https://github.com/liquibase/liquibase/pull/7710) cleared the orchestrator validation path. Reference run: [25761254239](https://github.com/liquibase/liquibase/actions/runs/25761254239).

## Test plan

- [ ] Render `.github/workflows/README.md` on GitHub and confirm the new "Known limitations / open work" section appears between "What a DryRun Release does not do?" and "How a DryRun Release works?" with all cross-links rendering.

[TECHOPS-428]: https://datical.atlassian.net/browse/TECHOPS-428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TECHOPS-156]: https://datical.atlassian.net/browse/TECHOPS-156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ