### PR TITLE
TECHOPS-427: bump LPM_VERSION 0.3.3 → 0.3.4 to clear 5 Go stdlib HIGH CVEs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,9 +20,9 @@ RUN wget -q -O liquibase-${LIQUIBASE_VERSION}.tar.gz "https://package.liquibase.
     ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
     liquibase --version
 
-ARG LPM_VERSION=0.3.3
-ARG LPM_SHA256=07756491e640be2d7eb9a24a9342e77c13829be1ce3658b00eca4a38fee1ef4b
-ARG LPM_SHA256_ARM=68a8f9bad54ed81861fc2aa2297194cc8ffd9d57c8ceb8fa98beb207e5df9b96
+ARG LPM_VERSION=0.3.4
+ARG LPM_SHA256=b57165a49951e359e782e6f92777ca4b5d152f711a627f1b8dc287dbf661a064
+ARG LPM_SHA256_ARM=6370065118cf306a4b0d0518989c1ae738e600d55f03ceb4f4e005a7080d03aa
 
 # Add metadata labels
 LABEL org.opencontainers.image.description="Liquibase Container Image"

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -27,9 +27,9 @@ RUN set -x && \
     ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh && \
     liquibase --version
 
-ARG LPM_VERSION=0.3.3
-ARG LPM_SHA256=07756491e640be2d7eb9a24a9342e77c13829be1ce3658b00eca4a38fee1ef4b
-ARG LPM_SHA256_ARM=68a8f9bad54ed81861fc2aa2297194cc8ffd9d57c8ceb8fa98beb207e5df9b96
+ARG LPM_VERSION=0.3.4
+ARG LPM_SHA256=b57165a49951e359e782e6f92777ca4b5d152f711a627f1b8dc287dbf661a064
+ARG LPM_SHA256_ARM=6370065118cf306a4b0d0518989c1ae738e600d55f03ceb4f4e005a7080d03aa
 
 # Add metadata labels
 LABEL org.opencontainers.image.description="Liquibase Container Image (Alpine)"


### PR DESCRIPTION
## Summary

Bumps `LPM_VERSION` from `0.3.3` to `0.3.4` (and the corresponding SHA256/SHA256_ARM checksums) in the two community Dockerfiles in this repo: `docker/Dockerfile` and `docker/Dockerfile.alpine`. These Dockerfiles were introduced by [#7669](https://github.com/liquibase/liquibase/pull/7669) (DAT-22523) when the community docker assets were migrated from `liquibase/docker` into this repo on 2026-04-28.

Same fix shape as the parallel community-image PR [liquibase/docker#548](https://github.com/liquibase/docker/pull/548) and the pro-image PR [liquibase/liquibase-pro#3794](https://github.com/liquibase/liquibase-pro/pull/3794).

## CVEs cleared by 0.3.4

QA vulnerability scans on the community Docker image flagged 5 HIGH-severity Go stdlib CVEs in the bundled lpm binary. All are fixed in Go 1.25.10 / 1.26.3:

| CVE | Issue |
|---|---|
| CVE-2026-33811 | cgo DNS LookupCNAME |
| CVE-2026-33814 | HTTP/2 SETTINGS frames |
| CVE-2026-39820 | mail ParseAddress / ParseAddressList |
| CVE-2026-39836 | Dial / LookupPort NUL byte panic |
| CVE-2026-42499 | consumePhrase DoS |

[liquibase-package-manager#619](https://github.com/liquibase/liquibase-package-manager/pull/619) bumped the toolchain to Go 1.25.10 on main, and [v0.3.4](https://github.com/liquibase/liquibase-package-manager/releases/tag/v0.3.4) (released 2026-05-12 21:59Z) is the first tag carrying the fix. v0.3.3 was built with Go 1.25.9 and is the version currently baked into both Dockerfiles.

## Checksum provenance

Pulled directly from the [v0.3.4 `checksums.txt`](https://github.com/liquibase/liquibase-package-manager/releases/download/v0.3.4/checksums.txt) asset:

```
b57165a49951e359e782e6f92777ca4b5d152f711a627f1b8dc287dbf661a064  lpm-0.3.4-linux.zip
6370065118cf306a4b0d0518989c1ae738e600d55f03ceb4f4e005a7080d03aa  lpm-0.3.4-linux-arm64.zip
```

## Test plan

- [ ] CI vulnerability scan of the rebuilt community image no longer flags CVE-2026-33811/33814/39820/39836/42499 in the lpm binary.
- [ ] Verify `lpm --version` reports `0.3.4` from a built image.
- [ ] Confirm both amd64 and arm64 SHA256 checks pass (build will exit non-zero if either checksum mismatches).