### PR TITLE
TECHOPS-432: add docker/.trivyignore to suppress SNAPSHOT-version false positive

### DIFF
--- a/docker/.trivyignore
+++ b/docker/.trivyignore
@@ -1,0 +1,7 @@
+# CVE-2022-0839 — SQL injection in changelog parameters, fixed in 4.8.0.
+# False positive on QA builds: Maven coordinates report version
+# "0.0.0.main-SNAPSHOT" which Trivy compares lexicographically against
+# the fix version 4.8.0 and concludes "vulnerable". main is well past
+# 4.8.0; real release artifacts are not affected.
+# Re-evaluate if/when the build is changed to inject a real version.
+CVE-2022-0839


### PR DESCRIPTION
## Summary

- New file `docker/.trivyignore` with a single entry: `CVE-2022-0839`, preceded by a 6-line comment explaining why it's suppressed.
- File is **inert** in this repo today. It becomes effective once the companion build-logic PR ([liquibase/build-logic#587](https://github.com/liquibase/build-logic/pull/587)) merges and `reusable-vulnerability-scan.yml` gains the `trivyignore_path` input that fetches this file at scan time.

## Why

[TECHOPS-431](https://datical.atlassian.net/browse/TECHOPS-431) shipped `build-qa-docker.yml` to this repo. The first smoke test ([run 25777429961](https://github.com/liquibase/liquibase/actions/runs/25777429961)) failed both scan jobs on a single Trivy finding: **CVE-2022-0839** (CRITICAL, CVSS 9.8) flagged against `org.liquibase:liquibase-core 0.0.0.main-SNAPSHOT` because Trivy compares `0.0.0` lexicographically against the fix version `4.8.0` and concludes "vulnerable." `main` is well past 4.8.0 — this is a pure **SNAPSHOT-version false positive**, not a real vulnerability.

Community scans have `dispatch_new_cves: false` (TECHOPS-408 non-negotiable) and no VEX/assessments path. Without an ignore mechanism, every QA dispatch from `main` would fail forever on the same false positive, training reviewers to ignore red builds.

## File contents (entire file)

```
# CVE-2022-0839 — SQL injection in changelog parameters, fixed in 4.8.0.
# False positive on QA builds: Maven coordinates report version
# "0.0.0.main-SNAPSHOT" which Trivy compares lexicographically against
# the fix version 4.8.0 and concludes "vulnerable". main is well past
# 4.8.0; real release artifacts are not affected.
# Re-evaluate if/when the build is changed to inject a real version.
CVE-2022-0839
```

No `exp:` expiry on the entry — the SNAPSHOT-versioning root cause is open-ended pending an upstream fix to inject a real Maven version into QA-built JARs.

## Convention for future entries

Every line in this file must be preceded by a multi-line `#` comment explaining:

1. The CVE summary and the upstream fix version.
2. Why it doesn't affect us (false positive class, scoped to specific build mode, etc.).
3. When to re-evaluate (a release event, an upstream fix, a date).

Entries that can't be justified in those terms shouldn't be ignored — they should be fixed.

## Validation

- [x] File exists at `docker/.trivyignore`, 7 lines, UTF-8 / LF.
- [x] Single active line (`CVE-2022-0839`), 6 comment lines.
- [x] Only file in this PR (`git diff main..HEAD --name-only` returns `docker/.trivyignore`).
- [ ] End-to-end smoke after both PRs merge: re-dispatch `build-qa-docker.yml` on `main` and confirm `total_vulns: 0` for both community + alpine scans, and the workflow run reports SUCCESS overall.

## Related

- Ticket: [TECHOPS-432](https://datical.atlassian.net/browse/TECHOPS-432)
- Discovered via: [TECHOPS-431](https://datical.atlassian.net/browse/TECHOPS-431) (#7713) smoke test
- **Companion PR (prerequisite for effect)**: [liquibase/build-logic#587](https://github.com/liquibase/build-logic/pull/587) — adds the `trivyignore_path` input and the caller-repo fetch
- Optional companion: `liquibase/liquibase-pro` README carve-out of the VEX-only policy

[TECHOPS-431]: https://datical.atlassian.net/browse/TECHOPS-431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TECHOPS-432]: https://datical.atlassian.net/browse/TECHOPS-432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ