### PR TITLE
feat(docker-scan): persist main HEAD scan to scan-results branch [TECHOPS-408]

### DIFF
--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -44,3 +44,43 @@ jobs:
       upload_sarif: true
       dispatch_new_cves: false
     secrets: inherit
+
+  # Publishes the community-image scan of main HEAD to the scan-results branch
+  # under liquibase/liquibase/latest/. The Liquibase internal security portal
+  # picks this up and renders it as a "main (dev)" entry alongside released
+  # versions. Skipped on PRs and on non-main pushes so PR builds and forks
+  # cannot write to scan-results. Shares the scan-results-writer concurrency
+  # group with trivy-scan-published-images.yml so the two workflows never
+  # race on the same branch. [TECHOPS-408]
+  persist-main-latest:
+    name: Persist main HEAD scan to scan-results
+    needs: scan-community
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      actions: read
+    concurrency:
+      group: scan-results-writer
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Download community scan artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: scan-artifacts
+          # Pull only the community-image artifact (suffix=""), not the alpine
+          # variant. persist-scan-results.sh parses the artifact name to derive
+          # image+tag; vulnerability-report-liquibase-liquibase-latest maps to
+          # liquibase/liquibase:latest in scan-results.
+          pattern: vulnerability-report-liquibase-liquibase-latest
+
+      - name: Persist to scan-results branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          scripts/persist-scan-results.sh scan-artifacts


### PR DESCRIPTION
## Summary
- Adds a `persist-main-latest` job to `.github/workflows/docker-scan.yml` so the community-image scan of main HEAD lands in the `scan-results` branch under `liquibase/liquibase/latest/`.
- The Liquibase internal security portal (`security-internal.liquibase.net`) will render this as a **main (dev)** entry alongside released versions on the Docker dashboard.

## What this does
- New job, gated on `github.event_name != 'pull_request' && github.ref == 'refs/heads/main'` — PR builds and forks cannot write to `scan-results`.
- Downloads only the community-image vulnerability-report artifact (suffix `""`), not the alpine variant.
- Reuses the existing `scripts/persist-scan-results.sh`, which already handles `latest` end-to-end (tag parser at line 122–125; manifest sort at 287–300).
- Shares the `scan-results-writer` concurrency group with `trivy-scan-published-images.yml` so the two workflows never race on the same branch.

## Trigger cadence (unchanged from existing workflow)
- push to `main` touching `docker/**`
- weekday cron at `0 7 * * 1-5`
- manual `workflow_dispatch`

## Companion PRs
- `liquibase/liquibase-pro#…` — same pattern for `liquibase/liquibase-secure/latest/`
- `liquibase/liquibase-internal-security-hub#…` — portal-side merge of both scan-results branches

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML valid
- [ ] After merge, manually dispatch `Docker Scan` from `main` and confirm:
  - `scan-results` branch has a new commit
  - `liquibase/liquibase/latest/` exists with `trivy-surface.json`, `trivy-deep.json`, `grype-results.json`, `metadata.json`
  - `manifest.json` includes `"latest"` in `images["liquibase/liquibase"]`
- [ ] Confirm the next weekday cron also lands a fresh commit

Jira: [TECHOPS-408](https://liquibase.atlassian.net/browse/TECHOPS-408)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECHOPS-408]: https://datical.atlassian.net/browse/TECHOPS-408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ