### PR TITLE
fix(ci): skip release-docker on dry-run

### DIFF
--- a/.github/workflows/release-published-orchestrator.yml
+++ b/.github/workflows/release-published-orchestrator.yml
@@ -130,7 +130,12 @@ jobs:
   release-docker:
     name: Release Docker Images
     needs: [setup, manual-approval, deploy-maven]
-    if: always() && needs.setup.result == 'success' && (needs.manual-approval.result == 'success' || needs.manual-approval.result == 'skipped') && needs.deploy-maven.result == 'success'
+    # Skip on dry-run: docker-release.yml resolves SHA256 from
+    # package.liquibase.com/.../liquibase-${version}.tar.gz, which only hosts GA
+    # tarballs — a dry-run-${run_id} version yields a zero-byte archive and the
+    # job intentionally exits 1. Docker builds are exercised by docker-test.yml
+    # and build-qa-docker.yml; nothing else needs validating here on dry-run.
+    if: always() && inputs.dry_run != true && needs.setup.result == 'success' && (needs.manual-approval.result == 'success' || needs.manual-approval.result == 'skipped') && needs.deploy-maven.result == 'success'
     uses: ./.github/workflows/release-docker.yml
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

The weekly **Dry run release** workflow has been failing since `ff05483bc` (DAT-22523, Apr 28) lifted the `if: false` gate on `release-docker`. From that point on, the dry-run pipeline started invoking `release-docker.yml` → `docker-release.yml` with `version=dry-run-${{ github.run_id }}`.

The `update-dockerfiles` job at `docker-release.yml:101-111` curls

```
https://package.liquibase.com/downloads/dockerhub/official/liquibase-${VERSION}.tar.gz
```

to compute SHA256 for the Dockerfile `LB_SHA256` ARG. That URL only hosts real GA tarballs — a `dry-run-XXX` version yields a 0-byte response, the script detects the empty-file SHA (`e3b0…b855`) and intentionally exits 1:

```
SHA256 resolution failed — empty or zero-byte archive for version dry-run-25783611979
```

Even if that guard were softened, the Dockerfile itself downloads from the same GA-only host, so docker release is **structurally incompatible** with a dry-run version string.

### Fix

Restore the prior behavior: skip `release-docker` when `inputs.dry_run == true`. Coverage is unchanged — docker builds are exercised on every push/PR by `docker-test.yml` and on schedule by `build-qa-docker.yml`.

### Recent failures
- [`25783611979`](https://github.com/liquibase/liquibase/actions/runs/25783611979) — Dry run release (scheduled)
- [`25783890737`](https://github.com/liquibase/liquibase/actions/runs/25783890737) — Release Published Orchestrator (dispatched)

### Out of scope (pre-existing)
`generate-summary` requires `package` and `publish-assets-s3` to be `success`, but both are gated `if: false  # TEMP: skip for v5.0.2 recovery`. The dry-run summary already reports "❌ FAILED" on every run regardless of this PR — worth a separate cleanup.

## Test plan

- [ ] Manually trigger `dry-run-release.yml` via `workflow_dispatch` once merged
- [ ] Confirm `Release Docker Images` shows `⏭️ Skipped` in the orchestrator's pipeline-results table
- [ ] Confirm no `SHA256 resolution failed` error in the orchestrator logs
- [ ] (Optional) Next scheduled run on Wednesday completes without paging the dry-run channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)