### PR TITLE
Guard SqlChangeLogParser.generateId against null DB connection

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/parser/core/sql/SqlChangeLogParser.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/core/sql/SqlChangeLogParser.java
@@ -133,7 +133,10 @@ public class SqlChangeLogParser implements ChangeLogParser {
             index = indexByDatabase.computeIfAbsent(database, db -> {
                 try {
                     return buildInterimIdIndex(db);
-                } catch (DatabaseException e) {
+                } catch (Exception e) {
+                    // Catch any exception (DatabaseException, IllegalArgumentException from a null
+                    // JDBC connection in offline mode, etc.) so the parser falls back to "raw"
+                    // instead of failing parsing of changelog-scope `checks run` and similar paths.
                     throw new UnexpectedLiquibaseException(e);
                 }
             });

--- a/liquibase-standard/src/test/groovy/liquibase/parser/core/sql/SqlChangeLogParserTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/parser/core/sql/SqlChangeLogParserTest.groovy
@@ -119,6 +119,18 @@ class SqlChangeLogParserTest extends Specification {
         2 * changeLogHistoryService.getRanChangeSets() >> { throw new DatabaseException("transient") } >> []
     }
 
+    def "generateId falls back to 'raw' when the index build throws a non-DatabaseException"() {
+        given: "the lookup throws IllegalArgumentException, as PreparedStatementFactory(null) does in offline mode"
+        changeLogHistoryService.getRanChangeSets() >> { throw new IllegalArgumentException("connection is null") }
+        def parser = new SqlChangeLogParser()
+
+        when:
+        def result = parser.generateId("path/to/file.sql", database)
+
+        then:
+        result == "raw"
+    }
+
     private static RanChangeSet ranChangeSet(String changeLog, String id, String author) {
         return new RanChangeSet(
                 changeLog,


### PR DESCRIPTION
## Summary
- Widens the inner catch in `SqlChangeLogParser.generateId` from `DatabaseException` to `Exception` so the `buildInterimIdIndex` path falls back to `"raw"` cleanly when the JDBC connection is null.
- Adds a unit test covering the regression.

## Background
PR #7674 added a `buildInterimIdIndex` path that queries `DATABASECHANGELOG` during changelog parsing. The pre-existing `try/catch` only wraps `DatabaseException`, missing the `IllegalArgumentException` thrown by `PreparedStatementFactory` when `database.getConnection()` returns null.

Stack:

```
SqlChangeLogParser.parse → generateId → buildInterimIdIndex
  → StandardChangeLogHistoryService.getRanChangeSets
    → SnapshotGeneratorFactory.checkLiquibaseTablesExistence
      → JdbcExecutor.queryForInt → new PreparedStatementFactory(null) → IllegalArgumentException
```

This is hit by, among other paths, the changelog-scope `checks run` flow against H2-generated SQL with no `--url`.

## Behavior change
Behavior unchanged when a live JDBC connection is present. When the lookup fails (any reason), parsing falls back to `"raw"`. The "retries on transient failure" semantics provided by `computeIfAbsent`'s no-cache-on-throw behavior continue to apply, for both `DatabaseException` and `IllegalArgumentException`.

## Tests
- New: `SqlChangeLogParserTest > generateId falls back to 'raw' when the index build throws a non-DatabaseException` — fails on `main` (IAE escapes), passes with this change.
- Existing: full `SqlChangeLogParserTest` (7/7) green.