### PR TITLE
fix(DAT-23085): propagate packages: write to docker-release.yml top-level

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -60,6 +60,7 @@ on:
 permissions:
   contents: read
   id-token: write
+  packages: write
 
 jobs:
   # ── Step 1: Bump LIQUIBASE_VERSION ARG in Dockerfiles, commit to main ────────


### PR DESCRIPTION
## Summary

- Adds `packages: write` to the **top-level** `permissions` block of `.github/workflows/docker-release.yml` so the cap survives all the way down the reusable-workflow chain.
- Fixes the GHCR push that broke the v5.0.3 release: [orchestrator run 25916946676](https://github.com/liquibase/liquibase/actions/runs/25916946676) — both `Build community image` and `Build alpine image` failed with:

  ```
  buildx failed with: ERROR: failed to build: failed to solve:
    failed to push ghcr.io/liquibase/liquibase:latest:        denied: permission_denied: write_package
    failed to push ghcr.io/liquibase/liquibase:alpine-alpine: denied: permission_denied: write_package
  ```

## Root cause

Same class of bug as [TECHOPS-417 / #7702](https://github.com/liquibase/liquibase/pull/7702), but **one layer deeper** in the reusable-workflow chain. GitHub validates a called workflow's `GITHUB_TOKEN` as the **intersection** of every parent in the chain:

| Workflow | Workflow-level | Job-level |
|---|---|---|
| `release-published-orchestrator.yml` | `contents: read` | `release-docker` job grants `packages: write` ✅ |
| `release-docker.yml` | `packages: write` ✅ | `packages: write` ✅ |
| `docker-release.yml` | ❌ **missing `packages: write`** | `build-community` / `build-alpine` jobs declare `packages: write` ✅ |
| `liquibase/build-logic/.github/workflows/reusable-docker-build.yml` | — | declares `packages: write` ✅ |

The workflow-level block in `docker-release.yml` only had `contents: read, id-token: write`, so the cap was dropped at that hop. The leaf jobs declared `packages: write` but couldn't elevate beyond the cap they received. TECHOPS-417 propagated the permission through layers 1 and 2 but stopped before this one.

## Change

```diff
 permissions:
   contents: read
   id-token: write
+  packages: write
```

One line. The leaf jobs already declare `packages: write`; this just preserves it through the intersection.

## Test plan

- [ ] Trigger `release-docker.yml` via `workflow_dispatch` with `version = 5.0.3`, `dry_run = false` and confirm all GHCR tags for the community image (`:5.0.3`, `:5.0`, `:latest`) and the Alpine image push successfully.
- [ ] Confirm Docker Hub and public ECR pushes still succeed (unchanged behavior).
- [ ] After merge, re-run the v5.0.3 orchestrator (`workflow_dispatch` with `tag = v5.0.3`) so the Docker stage completes and the `Publish release` job runs.

## Out of scope

- Alpine image was pushed with the tag `ghcr.io/liquibase/liquibase:alpine-alpine` (suffix appears duplicated by the tag generator in `reusable-docker-build.yml`). Tracking separately under [DAT-23084](https://datical.atlassian.net/browse/DAT-23084) if reproducible after this fix lands.

## Links

- Jira: [DAT-23085](https://datical.atlassian.net/browse/DAT-23085) (child of epic [DAT-23084](https://datical.atlassian.net/browse/DAT-23084) — "Liquibase OSS v5.0.3 release issues")
- Related prior fix: [TECHOPS-417 / #7702](https://github.com/liquibase/liquibase/pull/7702)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DAT-23084]: https://datical.atlassian.net/browse/DAT-23084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ