### PR TITLE
fix(TECHOPS-451): regenerate clean .sha256 sidecars for Maven Central bundle

### DIFF
--- a/.github/workflows/release-deploy-maven.yml
+++ b/.github/workflows/release-deploy-maven.yml
@@ -129,16 +129,22 @@ jobs:
 
             # Sign POM file
             gpg --batch --pinentry-mode=loopback --passphrase "$GPG_PASSWORD" -ab $i-${version}.pom
-            
+
             # Generate checksums for POM file
             md5sum $i-${version}.pom | cut -d' ' -f1 > $i-${version}.pom.md5
             sha1sum $i-${version}.pom | cut -d' ' -f1 > $i-${version}.pom.sha1
-            
-            # Generate checksums for all JAR files (main, sources, javadoc)
+            sha256sum $i-${version}.pom | cut -d' ' -f1 > $i-${version}.pom.sha256
+
+            # Generate checksums for all JAR files (main, sources, javadoc).
+            # .sha256 is regenerated here (not just inherited from
+            # liquibase-additional-*.zip) because the sidecars produced by
+            # sign-artifacts.sh carry a trailing space that Sonatype Central
+            # Portal rejects as "Invalid sha256 checksum".
             for jar_file in $i-${version}.jar $i-${version}-sources.jar $i-${version}-javadoc.jar; do
               if [ -f "$jar_file" ]; then
                 md5sum "$jar_file" | cut -d' ' -f1 > "$jar_file.md5"
                 sha1sum "$jar_file" | cut -d' ' -f1 > "$jar_file.sha1"
+                sha256sum "$jar_file" | cut -d' ' -f1 > "$jar_file.sha256"
               fi
             done
           done
@@ -254,16 +260,22 @@ jobs:
 
             # Sign POM file
             gpg --batch --pinentry-mode=loopback --passphrase "$GPG_PASSWORD" -ab $i-${version}.pom
-            
+
             # Generate checksums for POM file
             md5sum $i-${version}.pom | cut -d' ' -f1 > $i-${version}.pom.md5
             sha1sum $i-${version}.pom | cut -d' ' -f1 > $i-${version}.pom.sha1
-            
-            # Generate checksums for all JAR files (main, sources, javadoc)
+            sha256sum $i-${version}.pom | cut -d' ' -f1 > $i-${version}.pom.sha256
+
+            # Generate checksums for all JAR files (main, sources, javadoc).
+            # .sha256 is regenerated here (not just inherited from
+            # liquibase-additional-*.zip) because the sidecars produced by
+            # sign-artifacts.sh carry a trailing space that Sonatype Central
+            # Portal rejects as "Invalid sha256 checksum".
             for jar_file in $i-${version}.jar $i-${version}-sources.jar $i-${version}-javadoc.jar; do
               if [ -f "$jar_file" ]; then
                 md5sum "$jar_file" | cut -d' ' -f1 > "$jar_file.md5"
                 sha1sum "$jar_file" | cut -d' ' -f1 > "$jar_file.sha1"
+                sha256sum "$jar_file" | cut -d' ' -f1 > "$jar_file.sha256"
               fi
             done
           done


### PR DESCRIPTION
## Summary

Sonatype Central Portal rejected the v5.0.3 Maven Central deployment ([deployment `40f24e49-a9cd-4639-ac46-2d55d9643bb3`](https://central.sonatype.com/publishing/deployments)) with `Invalid sha256 checksum` for every JAR (9 files across `liquibase-core`, `liquibase-maven-plugin`, `liquibase-cli`).

The recorded hash is **correct** — but the `.sha256` file has a trailing space before the newline. Sonatype's new Central Portal validator is stricter than the legacy OSSRH and rejects the format.

```
hex dump of liquibase-core-5.0.3.jar.sha256 from v5.0.3 release:
00000000: 3363 6364 ... 3431 3536 20 0a
                                    ^^ ^^
                              trailing space + LF
```

## Root cause

1. `.github/util/sign-artifacts.sh` produces `.sha256` sidecars upstream during `create-release.yml` like this:
   ```bash
   sha256sum < $i > $i.sha256              # writes "<hash>  -"
   sed -i 's/ -//' "$archiveDir/*.sha256"  # strips one space + dash
   ```
   That leaves one trailing space before the newline.
2. These sidecars are bundled into `liquibase-additional-${version}.zip` and attached to the GitHub release.
3. `release-deploy-maven.yml` downloads the release, unzips `liquibase-additional`, and passes the dirty `.sha256` files straight through into the Sonatype bundle.

MD5/SHA1 are unaffected because `release-deploy-maven.yml` regenerates them in the bundle script with `cut -d' ' -f1` (clean `<hash><LF>` format). The same was never done for SHA256.

## Fix

Add `sha256sum "$file" | cut -d' ' -f1 > "$file.sha256"` to both the **production** and **dry-run** jobs of `release-deploy-maven.yml`, alongside the existing `md5sum`/`sha1sum` calls. This overwrites the dirty `.sha256` (unpacked from `liquibase-additional`) with a clean one **before** the bundle is zipped — so the next deploy of v5.0.3 (or any version going forward) will pass Sonatype validation without needing to re-cut `create-release`.

Also added a `.sha256` for the POM (it had `.md5`/`.sha1` but no `.sha256`). Sonatype doesn't currently flag a missing POM `.sha256`, but the bundle is now consistent across artifacts.

## Why fix the deploy workflow and not `sign-artifacts.sh`?

`sign-artifacts.sh` is the upstream root cause and is shared with `nightly-release.yml` and `installer-build-check.yml`. Changing its output format affects three workflows and the `liquibase-additional-*.zip` shipped on every GitHub release — broader blast radius for a behavior change. The deploy-workflow fix is surgical, immediately unblocks v5.0.3 republishing, and leaves the upstream sidecar format intact for the GitHub release consumers who may already depend on it.

A follow-up to also tighten `sign-artifacts.sh` (so the GitHub release `.sha256` files are themselves clean for third-party consumers verifying against them) can land separately if desired — tracked alongside TECHOPS-449.

## Test plan

- [ ] After merge, drop the failed Sonatype deployment `40f24e49-a9cd-4639-ac46-2d55d9643bb3` via the Central Portal.
- [ ] Re-trigger `release-deploy-maven.yml` via `workflow_dispatch` with `version = 5.0.3`, `tag = v5.0.3`, `dry_run = false`.
- [ ] Confirm the new Sonatype deployment passes all Component Validations (no `Invalid sha256 checksum` errors).
- [ ] Confirm `liquibase-core:5.0.3`, `liquibase-maven-plugin:5.0.3`, and `liquibase-cli:5.0.3` resolve from `repo1.maven.org`.
- [ ] (Optional) Run the dry-run job once against a non-prod version to confirm the dry-run branch was patched correctly too.

## Local verification

```
$ shasum -a 256 liquibase-core-5.0.3.jar
3ccd4608829836b4c0f7fb1d23a4619bac16c68ca725d623aae0838bce734156  liquibase-core-5.0.3.jar

$ cat liquibase-core-5.0.3.jar.sha256
3ccd4608829836b4c0f7fb1d23a4619bac16c68ca725d623aae0838bce734156  ← (trailing space + LF — what Sonatype rejected)

$ xxd liquibase-core-5.0.3.jar.sha256 | tail -1
00000040: 200a                                      .
          ^^ trailing space + LF
```

Hash matches. Only the format differs.

## Links

- Jira: [TECHOPS-451](https://datical.atlassian.net/browse/TECHOPS-451) (child of epic [TECHOPS-449](https://datical.atlassian.net/browse/TECHOPS-449))
- Failing orchestrator run: https://github.com/liquibase/liquibase/actions/runs/25916946676

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECHOPS-451]: https://datical.atlassian.net/browse/TECHOPS-451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ