### PR TITLE
Treat 'NULL' default value as null for MySQL/MariaDB enum columns

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
@@ -573,6 +573,10 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
 
         if (database instanceof MySQLDatabase) {
             readDefaultValueForMysqlDatabase(columnMetadataResultSet, columnInfo, database);
+            if ((columnMetadataResultSet.get(COLUMN_DEF_COL) != null)
+                    && StringUtil.equalsWordNull((String) columnMetadataResultSet.get(COLUMN_DEF_COL))) {
+                columnMetadataResultSet.set(COLUMN_DEF_COL, null);
+            }
         }
 
         if ((database instanceof AbstractDb2Database)

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
@@ -573,8 +573,10 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
 
         if (database instanceof MySQLDatabase) {
             readDefaultValueForMysqlDatabase(columnMetadataResultSet, columnInfo, database);
-            if ((columnMetadataResultSet.get(COLUMN_DEF_COL) != null)
-                    && StringUtil.equalsWordNull((String) columnMetadataResultSet.get(COLUMN_DEF_COL))) {
+            Object defaultValue = columnMetadataResultSet.get(COLUMN_DEF_COL);
+            if ((defaultValue instanceof String)
+                    && isMySqlEnumType(columnInfo)
+                    && StringUtil.equalsWordNull((String) defaultValue)) {
                 columnMetadataResultSet.set(COLUMN_DEF_COL, null);
             }
         }
@@ -611,6 +613,13 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
         }
 
         return SqlUtil.parseValue(database, columnMetadataResultSet.get(COLUMN_DEF_COL), columnInfo.getType());
+    }
+
+    private boolean isMySqlEnumType(Column columnInfo) {
+        if ((columnInfo == null) || (columnInfo.getType() == null) || (columnInfo.getType().getTypeName() == null)) {
+            return false;
+        }
+        return columnInfo.getType().getTypeName().toLowerCase(Locale.ENGLISH).startsWith("enum");
     }
 
     private void readDefaultValueForMysqlDatabase(CachedRow columnMetadataResultSet, Column column, Database database) {

--- a/liquibase-standard/src/test/groovy/liquibase/snapshot/jvm/ColumnSnapshotGeneratorTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/snapshot/jvm/ColumnSnapshotGeneratorTest.groovy
@@ -1,12 +1,16 @@
 package liquibase.snapshot.jvm
 
+import liquibase.Scope
 import liquibase.database.core.MSSQLDatabase
 import liquibase.database.core.MySQLDatabase
 import liquibase.database.core.PostgresDatabase
+import liquibase.executor.Executor
+import liquibase.executor.ExecutorService
 import liquibase.snapshot.CachedRow
 import liquibase.statement.DatabaseFunction
 import liquibase.structure.core.Column
 import liquibase.structure.core.DataType
+import liquibase.structure.core.Table
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -92,8 +96,15 @@ class ColumnSnapshotGeneratorTest extends Specification {
 
     @Unroll
     def "readDefaultValue"() {
+        given:
+        if (db instanceof MySQLDatabase) {
+            def executor = Mock(Executor)
+            executor.queryForObject(_, _) >> null
+            Scope.currentScope.getSingleton(ExecutorService).setExecutor("jdbc", db, executor)
+        }
+
         expect:
-        columnSnapshotGenerator.readDefaultValue(new CachedRow(["COLUMN_DEF": columnValue]), new Column("col").setType(new DataType(datatype)), db) == expected
+        columnSnapshotGenerator.readDefaultValue(new CachedRow(["COLUMN_DEF": columnValue]), column(datatype), db) == expected
 
         where:
         columnValue          | datatype  | db                     | expected
@@ -104,5 +115,12 @@ class ColumnSnapshotGeneratorTest extends Specification {
         "(3)::real"          | "float"   | new PostgresDatabase() | 3
         "3::real"            | "float"   | new PostgresDatabase() | 3
         "'a value'::varchar" | "varchar" | new PostgresDatabase() | "a value"
+        "NULL"               | "enum"    | new MySQLDatabase()    | null
+        "NULL"               | "varchar" | new MySQLDatabase()    | "NULL"
+        3                    | "enum"    | new MySQLDatabase()    | 3
+    }
+
+    private static Column column(String datatype) {
+        new Column(Table, "catalog", "schema", "table", "col").setType(new DataType(datatype))
     }
 }


### PR DESCRIPTION
When I run `generateChangeLog` on a MariaDB table with an enum column that has `DEFAULT NULL`, the output contains `defaultValue="null"` (the string "null") instead of either omitting the default entirely or using `defaultValueComputed="NULL"`.

The root cause is that the MySQL JDBC driver returns the string "NULL" for such columns, and Liquibase was passing it through as a regular string value. Oracle and DB2 already have handling for this case (converting "NULL" strings to actual null), but MySQL/MariaDB did not.

I added the same check for MySQL databases in `ColumnSnapshotGenerator.readDefaultValue()`.

**Testing:** I verified the fix by stepping through the code with a debugger and confirmed that enum columns with DEFAULT NULL now result in a null defaultValue, meaning no `defaultValue` attribute is emitted in the changelog XML.

Fixes #3444
