### PR TITLE
ci: exclude liquibase-parent-pom from extension release matrix

### DIFF
--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -5,6 +5,10 @@ on:
       version:
         description: 'Liquibase Version'
         required: true
+      repositories:
+        description: 'JSON array of repositories to release. Leave blank to use the default list (excludes liquibase-parent-pom, which has its own release cadence).'
+        required: false
+        default: '["liquibase-bigquery","liquibase-cache","liquibase-cassandra","liquibase-cosmosdb","liquibase-db2i","liquibase-filechangelog","liquibase-nochangeloglock","liquibase-hanadb","liquibase-maxdb","liquibase-modify-column","liquibase-mssql","liquibase-oracle","liquibase-postgresql","liquibase-redshift","liquibase-sqlfire","liquibase-teradata","liquibase-vertica","liquibase-yugabytedb","liquibase-hibernate","liquibase-cdi","liquibase-cdi-jakarta"]'
 
 jobs:
   automated-os-extensions-release:
@@ -12,4 +16,4 @@ jobs:
     secrets: inherit
     with:
       version: ${{ inputs.version }}
-
+      repositories: ${{ inputs.repositories }}


### PR DESCRIPTION
## Summary

- Expose a `repositories` input on `release-extensions.yml` so the extension list can be overridden.
- Default the list to **exclude `liquibase-parent-pom`**, which has its own versioning track and breaks the matrix.

## Why

When the workflow runs with `version: 5.0.3`, the reusable `extension-automated-release.yml` (in `liquibase/build-logic`) matrices every repo through a Release Draft step that calls:

```
jq --arg ver "v$VERSION" '[.[] | select(.draft == true and .tag_name == $ver)] | sort_by(.created_at) | last'
```

For all 5.x extensions this finds the matching draft. For `liquibase-parent-pom` it returns null (parent-pom is on its own 1.x cadence — currently has a `v1.0.3` draft, not `v5.0.3`), and the next line `jq -r '.assets[]'` blows up with `Cannot iterate over null`, taking the whole matrix down via fail-fast.

Failed run that motivated this fix: https://github.com/liquibase/liquibase/actions/runs/26030234905

`liquibase-parent-pom`'s own draft (`v1.0.3`, 4 assets) is unaffected and can be published manually from its repo. A follow-up PR will land in `liquibase/build-logic` to skip parent-pom at the reusable-workflow level so this calling workflow stays simple.

## Test plan

- [ ] Re-trigger this workflow with `version: 5.0.3` after merge; confirm all 21 listed extensions reach the Central Portal phase
- [ ] Confirm parent-pom is not in the matrix (no Release Draft job created for it)
- [ ] Verify the `repositories` input still accepts an override for ad-hoc runs