### PR TITLE
docs: bump README release dates for 5.0.3 / 5.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Together, these options ensure that teams can choose the path that best fits the
 ### Build Access and Release Planning
 
 - **Nightly builds:** The latest Main branch build is available at https://github.com/liquibase/liquibase/releases/tag/nightly — download `liquibase-nightly.tar.gz` (Linux/macOS) or `liquibase-nightly.zip` (Windows). Updated automatically after each successful test run on main.
-- **Latest Release: v5.0.2 — March 5, 2026** \
+- **Latest Release: v5.0.3 — May 15, 2026** \
 https://www.liquibase.com/download-community
-- **Next Planned Release: May 15, 2026** 
+- **Next Planned Release: August 20, 2026** 
 - **Roadmap:** \
 https://github.com/orgs/liquibase/projects/3/views/9?layout=board
 


### PR DESCRIPTION
## Summary

Two-line bump to the Release Cadence section in README.md:

- **Latest Release**: v5.0.2 (March 5, 2026) → **v5.0.3 (May 15, 2026)**
- **Next Planned Release**: May 15, 2026 → **August 20, 2026**

## Why

v5.0.3 of liquibase-core was published to GitHub on 2026-05-15. The 21 community extensions completed their Sonatype/Maven Central rollout on 2026-05-18. The next planned release per the quarterly cadence (Feb / May / Aug / Nov) is August 20, 2026.

## Test plan

- [ ] README renders correctly on github.com/liquibase/liquibase
- [ ] Both date strings match the public release record