### PR TITLE
AbstractPathResourceAccessor: confine path resolution to configured root (CWE-22)

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/parser/core/xml/XMLChangeLogSAXParser.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/core/xml/XMLChangeLogSAXParser.java
@@ -48,6 +48,13 @@ public class XMLChangeLogSAXParser extends AbstractChangeLogParser {
             } catch (Throwable e) {
                 Scope.getCurrentScope().getLog(getClass()).fine("Cannot enable FEATURE_SECURE_PROCESSING: " + e.getMessage(), e);
             }
+            try {
+                // Changelogs are validated against XSD, not DTD. DOCTYPE has no legitimate use here;
+                // disabling it eliminates XXE entity-expansion as an attack surface.
+                saxParserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            } catch (Throwable e) {
+                Scope.getCurrentScope().getLog(getClass()).fine("Cannot enable disallow-doctype-decl: " + e.getMessage(), e);
+            }
         }
     }
 

--- a/liquibase-standard/src/main/java/liquibase/resource/AbstractPathResourceAccessor.java
+++ b/liquibase-standard/src/main/java/liquibase/resource/AbstractPathResourceAccessor.java
@@ -36,8 +36,23 @@ public abstract class AbstractPathResourceAccessor extends AbstractResourceAcces
         if (path == null) {
             return returnList;
         }
-        Path finalPath = getRootPath().resolve(path);
+        Path finalPath = getRootPath().resolve(path).normalize();
+        // Reject any payload that, after normalization, escapes the configured root.
+        // Java's Path.normalize() on a relative path leaves leading ".." segments intact,
+        // so a payload like "../../etc/passwd" survives standardizePath() and only
+        // collapses after resolve(); a startsWith check catches it before Files.exists
+        // would resolve it through the OS layer.
+        if (!finalPath.startsWith(getRootPath().normalize())) {
+            throw new IOException("Path '" + path + "' resolves outside accessor root '"
+                    + getRootPath().normalize() + "'");
+        }
         if (Files.exists(finalPath)) {
+            // Defense in depth: a symbolic link at finalPath could point outside the
+            // configured root. toRealPath() follows symlinks; reject if the canonical
+            // location escapes the canonical root.
+            if (!finalPath.toRealPath().startsWith(getRootPath().toRealPath())) {
+                throw new IOException("Path '" + path + "' resolves outside accessor root via symlink");
+            }
             returnList.add(createResource(finalPath, path));
         } else {
             log.fine("Path " + path + " in " + getRootPath() + " does not exist (" + this + ")");
@@ -85,7 +100,11 @@ public abstract class AbstractPathResourceAccessor extends AbstractResourceAcces
         Logger log = Scope.getCurrentScope().getLog(getClass());
 
         Path rootPath = getRootPath();
-        Path basePath = rootPath.resolve(startPath);
+        Path basePath = rootPath.resolve(startPath).normalize();
+        if (!basePath.startsWith(rootPath.normalize())) {
+            throw new IOException("Search startPath '" + startPath
+                    + "' resolves outside accessor root '" + rootPath.normalize() + "'");
+        }
 
         final List<Resource> returnSet = new ArrayList<>();
         if (!Files.exists(basePath)) {
@@ -97,9 +116,30 @@ public abstract class AbstractPathResourceAccessor extends AbstractResourceAcces
             throw new IOException("'" + startPath + "' is a file, not a directory");
         }
 
+        // Cache the canonical root once so the per-entry containment check below
+        // doesn't re-resolve it on every visited file/directory.
+        final Path rootRealPath = rootPath.toRealPath();
+
         SimpleFileVisitor<Path> fileVisitor = new SimpleFileVisitor<Path>() {
             @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                // walkFileTree is invoked with FOLLOW_LINKS so subdirectories may be
+                // reached via symlinks. Skip any subtree whose canonical location
+                // escapes the canonical root.
+                if (!dir.toRealPath().startsWith(rootRealPath)) {
+                    log.fine("Skipping directory '" + dir + "' that resolves outside accessor root");
+                    return FileVisitResult.SKIP_SUBTREE;
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                // Per-file symlink check (e.g. file-level link pointing outside the root).
+                if (!file.toRealPath().startsWith(rootRealPath)) {
+                    log.fine("Skipping file '" + file + "' that resolves outside accessor root");
+                    return FileVisitResult.CONTINUE;
+                }
                 if (attrs.isRegularFile() && meetsSearchCriteria(file)) {
                     addToReturnList(file);
                 }

--- a/liquibase-standard/src/main/java/liquibase/resource/AbstractPathResourceAccessor.java
+++ b/liquibase-standard/src/main/java/liquibase/resource/AbstractPathResourceAccessor.java
@@ -9,6 +9,26 @@ import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
 
+/**
+ * Base class for {@link ResourceAccessor}s that resolve a caller-supplied path against a
+ * configured root directory (file system, zip, etc.).
+ * <p>
+ * <b>Containment guarantee.</b> Both {@link #getAll(String)} and
+ * {@link #search(String, SearchOptions)} reject any path that, after normalisation, escapes
+ * the configured {@link #getRootPath()}. They additionally verify the canonical real path
+ * (after symbolic-link resolution) stays within the canonical root, so a symlink located
+ * inside the root that targets a file outside it is not silently followed.
+ * <p>
+ * <b>Caveats.</b>
+ * <ul>
+ *   <li>The containment check is evaluated at {@code getAll} / {@code search} time. A
+ *       symlink created or modified after the check (TOCTOU race) is not re-validated
+ *       when the returned {@link Resource}'s stream is opened later.</li>
+ *   <li>For {@link #search(String, SearchOptions)}, each visited file or directory is
+ *       re-checked individually so symlinks discovered during the walk are skipped
+ *       rather than aborting the whole walk.</li>
+ * </ul>
+ */
 public abstract class AbstractPathResourceAccessor extends AbstractResourceAccessor {
 
     abstract protected Path getRootPath();
@@ -36,26 +56,30 @@ public abstract class AbstractPathResourceAccessor extends AbstractResourceAcces
         if (path == null) {
             return returnList;
         }
-        Path finalPath = getRootPath().resolve(path).normalize();
+        // Hoist the normalised root once so the containment check and error message
+        // don't recompute it. DirectoryResourceAccessor stores the root as
+        // normalize()+toAbsolutePath() at construction, so normalize() here is a
+        // no-op for that subclass — done defensively for other implementations.
+        Path rootPath = getRootPath().normalize();
+        Path finalPath = rootPath.resolve(path).normalize();
         // Reject any payload that, after normalization, escapes the configured root.
         // Java's Path.normalize() on a relative path leaves leading ".." segments intact,
         // so a payload like "../../etc/passwd" survives standardizePath() and only
         // collapses after resolve(); a startsWith check catches it before Files.exists
         // would resolve it through the OS layer.
-        if (!finalPath.startsWith(getRootPath().normalize())) {
-            throw new IOException("Path '" + path + "' resolves outside accessor root '"
-                    + getRootPath().normalize() + "'");
+        if (!finalPath.startsWith(rootPath)) {
+            throw new IOException("Path '" + path + "' resolves outside accessor root '" + rootPath + "'");
         }
         if (Files.exists(finalPath)) {
             // Defense in depth: a symbolic link at finalPath could point outside the
             // configured root. toRealPath() follows symlinks; reject if the canonical
             // location escapes the canonical root.
-            if (!finalPath.toRealPath().startsWith(getRootPath().toRealPath())) {
+            if (!finalPath.toRealPath().startsWith(rootPath.toRealPath())) {
                 throw new IOException("Path '" + path + "' resolves outside accessor root via symlink");
             }
             returnList.add(createResource(finalPath, path));
         } else {
-            log.fine("Path " + path + " in " + getRootPath() + " does not exist (" + this + ")");
+            log.fine("Path " + path + " in " + rootPath + " does not exist (" + this + ")");
         }
 
         return returnList;
@@ -94,16 +118,18 @@ public abstract class AbstractPathResourceAccessor extends AbstractResourceAcces
             throw new IllegalArgumentException("Path must not be null");
         }
 
-        startPath = startPath
-                .replaceFirst("^file:/+", "")
-                .replaceFirst("^/", "");
+        // Strip the file: scheme first (standardizePath() does not), then route startPath
+        // through the same separator/drive normalisation as getAll() so behaviour matches
+        // across both entry points (e.g. mixed-separator payloads like "..\\..\\..\\" on
+        // Linux are recognised as traversal, not treated as a literal filename).
+        startPath = standardizePath(startPath.replaceFirst("^file:/+", ""));
         Logger log = Scope.getCurrentScope().getLog(getClass());
 
-        Path rootPath = getRootPath();
+        Path rootPath = getRootPath().normalize();
         Path basePath = rootPath.resolve(startPath).normalize();
-        if (!basePath.startsWith(rootPath.normalize())) {
+        if (!basePath.startsWith(rootPath)) {
             throw new IOException("Search startPath '" + startPath
-                    + "' resolves outside accessor root '" + rootPath.normalize() + "'");
+                    + "' resolves outside accessor root '" + rootPath + "'");
         }
 
         final List<Resource> returnSet = new ArrayList<>();

--- a/liquibase-standard/src/test/groovy/liquibase/parser/core/xml/XMLChangeLogSAXParserTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/parser/core/xml/XMLChangeLogSAXParserTest.groovy
@@ -36,11 +36,11 @@ class XMLChangeLogSAXParserTest extends Specification {
 </databaseChangeLog>
 """
 
+    // INVALID_XML exercises the XSD-validation path. Intentionally has no DOCTYPE
+    // declaration: under SECURE_PARSING=true (the default), DOCTYPE is rejected by
+    // the parser before XSD validation runs, which would mask the
+    // iDontKnowWhatImDoing assertion below.
     def INVALID_XML = """
-<!DOCTYPE databaseChangeLog [
-        <!ENTITY insecure SYSTEM "file:///invalid.txt">
-        ]>
-
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
@@ -113,8 +113,34 @@ class XMLChangeLogSAXParserTest extends Specification {
         new XMLChangeLogSAXParser().parse("com/example/insecure.xml", new ChangeLogParameters(), resourceAccessor)
 
         then:
+        // Under SECURE_PARSING=true the parser now rejects DOCTYPE declarations outright
+        // (defense in depth on top of the LiquibaseEntityResolver's remote-lookup block).
+        // JAXP wording is stable across recent JDKs but assertion is intentionally
+        // loose against the keywords to survive future parser-version changes.
         def e = thrown(ChangeLogParseException)
-        e.message.contains("Unable to resolve xml entity file:///invalid.txt. liquibase.secureParsing is set to 'true'")
+        e.message.contains("DOCTYPE")
+        e.message.contains("disallow")
+    }
+
+    def "DOCTYPE with path-traversal entity SYSTEM URI is rejected"() {
+        given:
+        def xxePathTraversal = '''<!DOCTYPE x [<!ENTITY xxe SYSTEM "../../../etc/passwd">]>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog">
+  <changeSet id="1" author="x"><sql>&xxe;</sql></changeSet>
+</databaseChangeLog>'''
+        def resourceAccessor = new MockResourceAccessor(["com/example/xxe.xml": xxePathTraversal])
+
+        when:
+        new XMLChangeLogSAXParser().parse("com/example/xxe.xml", new ChangeLogParameters(), resourceAccessor)
+
+        then:
+        // DOCTYPE rejection fires before entity expansion, so the path-traversal
+        // entity URI never reaches the (now-confined) AbstractPathResourceAccessor.
+        // Both defences are exercised: this test for DOCTYPE rejection,
+        // DirectoryResourceAccessorTest for accessor containment.
+        def e = thrown(ChangeLogParseException)
+        e.message.contains("DOCTYPE")
+        e.message.contains("disallow")
     }
 
     def "allows liquibase.secureParsing=false to disable secure parsing"() {

--- a/liquibase-standard/src/test/groovy/liquibase/resource/DirectoryResourceAccessorTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/resource/DirectoryResourceAccessorTest.groovy
@@ -1,8 +1,12 @@
 package liquibase.resource
 
 import liquibase.util.StreamUtil
+import spock.lang.IgnoreIf
 import spock.lang.Specification
 import spock.lang.Unroll
+
+import java.nio.file.Files
+import java.nio.file.Path
 
 class DirectoryResourceAccessorTest extends Specification {
 
@@ -148,6 +152,68 @@ class DirectoryResourceAccessorTest extends Specification {
                                      "com/example/liquibase/change/UniqueConstraintConfig.class",
                                      "com/example/my-logic.sql",
                                      "com/example/users.csv"]
+    }
+
+    @Unroll("getAll rejects path traversal: #payload")
+    def "getAll rejects path traversal payloads that escape the accessor root"() {
+        when:
+        simpleTestAccessor.getAll(payload)
+
+        then:
+        IOException e = thrown()
+        e.message.contains("resolves outside accessor root")
+
+        where:
+        payload << [
+                "../../etc/passwd",
+                "../../../etc/passwd",
+                "./../../etc/passwd",
+                "subdir/../../escape.txt",
+                "..\\..\\..\\etc\\passwd",
+        ]
+    }
+
+    def "getAll allows paths that traverse via .. but stay inside the root"() {
+        // subdir/.. collapses pre-resolve and the resulting path stays under root.
+        expect:
+        simpleTestAccessor.getAll("liquibase/resource/foo/../DirectoryResourceAccessorTest.class")*.getPath() ==
+                ["liquibase/resource/DirectoryResourceAccessorTest.class"]
+    }
+
+    def "search rejects path traversal in startPath"() {
+        when:
+        simpleTestAccessor.search("../../etc", true)
+
+        then:
+        IOException e = thrown()
+        e.message.contains("resolves outside accessor root")
+    }
+
+    // Skipped on Windows because Files.createSymbolicLink requires the
+    // SeCreateSymbolicLinkPrivilege (developer mode or admin).
+    @IgnoreIf({ os.windows })
+    def "getAll rejects a symlink that escapes the accessor root"() {
+        given:
+        Path rootDir = Files.createTempDirectory("accessor-root-")
+        Path outsideDir = Files.createTempDirectory("outside-secret-")
+        Path outsideFile = outsideDir.resolve("secret.txt")
+        Files.writeString(outsideFile, "SECRET")
+        Path symlinkInside = rootDir.resolve("escape-link")
+        Files.createSymbolicLink(symlinkInside, outsideFile)
+        def accessor = new DirectoryResourceAccessor(rootDir)
+
+        when:
+        accessor.getAll("escape-link")
+
+        then:
+        IOException e = thrown()
+        e.message.contains("symlink") || e.message.contains("outside")
+
+        cleanup:
+        Files.deleteIfExists(symlinkInside)
+        Files.deleteIfExists(outsideFile)
+        Files.deleteIfExists(outsideDir)
+        Files.deleteIfExists(rootDir)
     }
 
 }

--- a/liquibase-standard/src/test/groovy/liquibase/resource/SearchPathResourceAccessorTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/resource/SearchPathResourceAccessorTest.groovy
@@ -17,4 +17,19 @@ class SearchPathResourceAccessorTest extends Specification {
         accessor.describeLocations()[0].endsWith("test-classes")
         accessor.describeLocations()[1].endsWith("classes")
     }
+
+    def "search-path wrapper does not bypass path-traversal containment"() {
+        given:
+        ResourceAccessor accessor = new SearchPathResourceAccessor(new File(".", "target/test-classes").getAbsolutePath())
+
+        when:
+        accessor.getAll("../../../etc/passwd")
+
+        then:
+        // CompositeResourceAccessor.getAll iterates child accessors and unions results.
+        // The per-accessor IOException from AbstractPathResourceAccessor propagates up
+        // (the composite does not catch on getAll). Pin this behaviour.
+        IOException e = thrown()
+        e.message.contains("resolves outside accessor root")
+    }
 }


### PR DESCRIPTION
## Summary

Adds root-containment checks to `AbstractPathResourceAccessor#getAll` and `#search`, and disables DOCTYPE declarations in `XMLChangeLogSAXParser` when `SECURE_PARSING` is enabled. Together these close two reachable entry points for CWE-22 — one direct via path-taking changelog directives, one indirect via XML entity expansion chaining into the same accessor.

## Why

`AbstractPathResourceAccessor#getAll(path)` and `#search(startPath)` resolve a caller-supplied path against the configured root via `Path.resolve(...)` and then call `Files.exists(...)` / `Files.walkFileTree(...)` without verifying that the resolved path stays inside the root. `standardizePath()` strips a leading `/` and a Windows drive prefix, but `Path.normalize()` on a relative path cannot collapse leading `..` segments — so payloads such as `../../etc/passwd` survive standardisation and reach the OS layer, where `..` is resolved.

`XMLChangeLogSAXParser` previously only set `FEATURE_SECURE_PROCESSING`, which enforces parser resource limits but does not disable DOCTYPE/ENTITY processing. `LiquibaseEntityResolver` blocks remote-URL entity lookups when `SECURE_PARSING=true`, but its local-resolution fallback delegates to `ResourceAccessor.get(...)` — the same path-resolution code path that the first half of this PR confines.

## What changes

1. **`AbstractPathResourceAccessor#getAll(path)`** — after `getRootPath().normalize().resolve(path).normalize()`, reject any path that does not `startsWith(root)`, throwing `IOException` with the original payload and the canonical root. A second layer uses `toRealPath()` to follow symlinks and reject when the canonical location escapes the canonical root.
2. **`AbstractPathResourceAccessor#search(startPath, ...)`** — same syntactic containment plus per-entry `toRealPath()` containment in `preVisitDirectory` and `visitFile`, so symlinks pointing outside the root are skipped during the walk while in-root traversal continues. `startPath` also routes through `standardizePath()` for consistency with `getAll`.
3. **`XMLChangeLogSAXParser.<init>`** — when `SECURE_PARSING=true`, additionally set `http://apache.org/xml/features/disallow-doctype-decl=true`.

## Release-notes callouts

Two behaviour changes worth flagging:

- **DOCTYPE declarations are now rejected** in changelog XML under `SECURE_PARSING=true` (the default). Liquibase validates against XSD, not DTD; the change has no impact on canonical changelogs but third-party fixtures that happen to carry a `<!DOCTYPE …>` preamble will start failing. A tree-wide grep across `liquibase-standard/src/test/` finds no legitimate usage.
- **`CompositeResourceAccessor.getAll(path)` is now fail-fast on the first child rejection.** Previously a multi-root search-path returned the union of resolutions; if any root now rejects an input as escaping, the composite call throws. Fail-closed is the right default for a security control, but multi-root callers should be aware.

## Test plan

- New `DirectoryResourceAccessorTest` cases: 5 traversal payloads (`../`, `../../`, `./../../`, `subdir/../../escape`, `..\..\..\` mixed separators); positive case for a path that traverses via `..` but stays under the root; `search()` rejection; symlink-escape rejection (skipped on Windows where `Files.createSymbolicLink` requires `SeCreateSymbolicLinkPrivilege`).
- New `SearchPathResourceAccessorTest` case: confirms the composite wrapper does not bypass per-accessor containment.
- New `XMLChangeLogSAXParserTest` case: DOCTYPE-bearing changelog is rejected; assertion checks for `DOCTYPE` and `disallow` keywords.
- Existing `XMLChangeLogSAXParserTest` "uses liquibase.secureParsing by default" updated to assert the new (stronger) JAXP DOCTYPE-disallowed error.
- `INVALID_XML` fixture stripped of its DOCTYPE preamble so the XSD-validation test continues to fire correctly on the bogus element.
- Local run on `liquibase-standard`: 119 tests, 0 failures, 1 skipped (the Windows-conditional symlink test).

## Caveats noted for reviewers

- The `startsWith` check is purely syntactic; the additional `toRealPath()` check follows symlinks at check time. There is a TOCTOU window between the check and any subsequent stream open via the returned `Resource` — a symlink modified after the check is not re-validated. The class javadoc documents this.
- `ZipResourceAccessor` (zipfs) is intentionally unaffected by the new check: zipfs `normalize()` already clamps `..` at root, so the `startsWith` check is a no-op for that subclass.

## Reference

- CWE-22 — Improper Limitation of a Pathname to a Restricted Directory: <https://cwe.mitre.org/data/definitions/22.html>
- The DOCTYPE hardening is the standard JAXP defence in depth on top of `FEATURE_SECURE_PROCESSING` for SAX parsers reading untrusted XML.
