### PR TITLE
docs(TECHOPS-428): document release-docker skip on dry-run

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -21,7 +21,6 @@ The following actions are identical to those in a regular Liquibase release, wit
 - Build `ansible` package
 - Executes the test for the `brew` PR creation
 - Deploy artifacts to Maven, to our internal Maven repository: `https://repo.liquibase.net/repository/dry-run-sonatype-nexus-staging`
-- Push `docker` images to our internal `ecr` repository: `812559712860.dkr.ecr.us-east-1.amazonaws.com/liquibase-dry-run`
 - Delete the dryRun draft release. i.e `dry-run-10522556642`
 - Delete the dryRun repository tag. i.e `vdry-run-10522556642`
 


### PR DESCRIPTION
## Summary

- The runtime fix for [TECHOPS-428](https://datical.atlassian.net/browse/TECHOPS-428) already landed in #7716 (commit `187353855`, "fix(ci): skip release-docker on dry-run"), which gated `release-docker` on `inputs.dry_run != true` in `release-published-orchestrator.yml`.
- The workflows README still listed pushing docker images to the internal ECR under *"What a DryRun Release does?"*, which is no longer accurate.
- Drop that one bullet. The "does" list should be the source of truth — if a step isn't on it, it doesn't run on dry-run. No corresponding entry added to "does not do" (that list is reserved for notable omissions like PRO tags / install packages, not exhaustive negations).

## Test plan

- [x] Docs only — no workflow logic changes.
- [x] Verified the runtime fix on main: dry-run release run `25784667701` (2026-05-13T07:23Z) succeeded after #7716 landed; the prior run `25783611979` failed on this exact SHA256 lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECHOPS-428]: https://datical.atlassian.net/browse/TECHOPS-428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ