### PR TITLE
CWE-209: sanitize JDBC URL before embedding in DatabaseFactory exception message

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/database/DatabaseFactory.java
+++ b/liquibase-standard/src/main/java/liquibase/database/DatabaseFactory.java
@@ -292,7 +292,12 @@ public class DatabaseFactory implements SingletonObject {
         }
 
         if (selectedDriverClass == null) {
-            throw new RuntimeException("Driver class was not specified and could not be determined from the url (" + url + ")");
+            // Route the URL through sanitizeUrl so embedded credentials (e.g.
+            // jdbc:mysql://user:pw@host/db or ?password=…) are not surfaced in the
+            // exception message — which otherwise flows into MDC, log appenders,
+            // and the CLI error UI via CommandScope.logPrimaryExceptionToMdc.
+            throw new RuntimeException("Driver class was not specified and could not be determined from the url ("
+                    + JdbcConnection.sanitizeUrl(url) + ")");
         }
         return selectedDriverClass;
     }

--- a/liquibase-standard/src/test/java/liquibase/database/DatabaseFactoryTest.java
+++ b/liquibase-standard/src/test/java/liquibase/database/DatabaseFactoryTest.java
@@ -14,6 +14,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -61,6 +62,33 @@ public class DatabaseFactoryTest {
         DatabaseException expectedException = assertThrows(DatabaseException.class, () -> databaseFactory.openConnection("not:a:driver", "", "", null, resourceAccessor));
         assertThat(expectedException.getCause(), instanceOf(RuntimeException.class));
         assertThat(expectedException.getMessage(), containsString("Driver class was not specified and could not be determined from the url"));
+    }
+
+    @Test
+    public void openConnectionExceptionMessageDoesNotLeakPasswordWhenDriverCannotBeFoundByUrl() throws Exception {
+        // CWE-209 regression: when the URL prefix is not recognized, the resulting
+        // RuntimeException message must not surface credentials embedded in the URL.
+        // findDriverClass() now routes the URL through JdbcConnection.sanitizeUrl()
+        // before concatenating it into the message. The "cosmosdb://" URL is matched
+        // by sanitizeUrl's registered ConnectionPatterns (see JdbcConnectionTest) but
+        // is NOT recognised by findDefaultDriver (which only matches jdbc:-prefixed
+        // schemes), so this URL exercises both branches: sanitisation kicks in and
+        // the unrecognised-driver exception is the one that fires.
+        String url = "cosmosdb://liquibaseuser:SuperSecretPwd123@host:443/db";
+        DatabaseException expectedException = assertThrows(DatabaseException.class,
+                () -> databaseFactory.openConnection(url, "", "", null, resourceAccessor));
+        assertThat(expectedException.getCause(), instanceOf(RuntimeException.class));
+        assertThat(expectedException.getMessage(), containsString("Driver class was not specified and could not be determined from the url"));
+        // The credential value must not appear anywhere in the exception chain.
+        assertThat(expectedException.getMessage(), not(containsString("SuperSecretPwd123")));
+        Throwable cause = expectedException.getCause();
+        while (cause != null) {
+            String msg = cause.getMessage();
+            if (msg != null) {
+                assertThat(msg, not(containsString("SuperSecretPwd123")));
+            }
+            cause = cause.getCause();
+        }
     }
 
     @Test


### PR DESCRIPTION
## Impact

`liquibase.database.DatabaseFactory#findDriverClass` concatenates the raw connection URL into a `RuntimeException` message when no JDBC driver can be matched (unrecognised URL prefix, custom/third-party driver, typo'd scheme):

```java
throw new RuntimeException("Driver class was not specified and could not be determined from the url (" + url + ")");
```

That message then propagates through:

- `CommandScope.logPrimaryExceptionToMdc` → MDC fields persisted by every configured log appender
- the CLI's user-visible error UI
- the `DatabaseException` chain that wraps `openConnection` failures

If the supplied URL contained credentials in any of the well-known shapes (`jdbc:mysql://user:pw@host/db`, `jdbc:postgresql://host/db?user=…&password=…`, `jdbc:oracle:thin:user/pw@host`, etc.), those credentials end up in logs and operator-visible error output.

This is the same class of issue covered by **CWE-209: Generation of Error Message Containing Sensitive Information**.

## Fix

Route the URL through the existing `JdbcConnection.sanitizeUrl(...)` helper before embedding it in the exception message. This mirrors how URL sanitisation is already done in:

- `liquibase.report.DatabaseInfo`
- `liquibase.integration.commandline.Main`
- `liquibase.command.core.helpers.DbUrlConnectionCommandStep`
- `liquibase.command.core.helpers.ReferenceDbUrlConnectionCommandStep`
- `liquibase.command.core.helpers.AbstractDatabaseConnectionCommandStep`

`sanitizeUrl` is `static` and `JdbcConnection` is already imported in `DatabaseFactory`, so the fix is one-line.

## Test

Adds `openConnectionExceptionMessageDoesNotLeakPasswordWhenDriverCannotBeFoundByUrl` to `DatabaseFactoryTest`. The test uses a `cosmosdb://liquibaseuser:SuperSecretPwd123@host:443/db` URL — recognised by `sanitizeUrl`'s registered `ConnectionPatterns` (see existing coverage in `JdbcConnectionTest.sanitizeUrl`) but **not** recognised by `findDefaultDriver` (which only matches `jdbc:`-prefixed schemes). That lets the test simultaneously:

1. Trigger the unrecognised-driver branch (so the `RuntimeException` we changed actually fires).
2. Assert the password value (`SuperSecretPwd123`) never appears in the message or anywhere in the exception cause chain.

```
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.543 s -- in liquibase.database.DatabaseFactoryTest
[INFO] Tests run: 58, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.520 s -- in liquibase.database.jvm.JdbcConnectionTest
```

The pre-existing `openConnectionThrowsExceptionWhenDriverCannotBeFoundByUrl` is unchanged and still passes (its `"not:a:driver"` URL contains no credentials, so sanitisation is a no-op for it).

## Notes

- `sanitizeUrl(null)` returns `null` per `JdbcConnectionTest`, which renders as `(null)` in the message — no NPE risk.
- For URL shapes that `sanitizeUrl` does NOT recognise (e.g. an arbitrary custom-driver scheme with embedded credentials), the URL passes through unchanged. That's a separate gap in `sanitizeUrl`'s pattern coverage rather than in `DatabaseFactory`; this PR makes `DatabaseFactory` benefit from any future improvement to `sanitizeUrl` automatically.
