### PR TITLE
CWE-209: stop leaking credentials in OfflineConnection parse-error exceptions

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/database/OfflineConnection.java
+++ b/liquibase-standard/src/main/java/liquibase/database/OfflineConnection.java
@@ -4,6 +4,7 @@ import liquibase.Scope;
 import liquibase.changelog.ChangeLogHistoryService;
 import liquibase.changelog.ChangeLogHistoryServiceFactory;
 import liquibase.changelog.OfflineChangeLogHistoryService;
+import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.LiquibaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
@@ -58,7 +59,12 @@ public class OfflineConnection implements DatabaseConnection {
         this.url = url;
         Matcher matcher = OFFLINE_COMMAND_PATTERN.matcher(url);
         if (!matcher.matches()) {
-            throw new UnexpectedLiquibaseException("Could not parse offline url " + url);
+            // A common operator mistake is to paste a JDBC URL where an offline: URL
+            // was expected; route the raw input through sanitizeUrl so any embedded
+            // credentials (jdbc:mysql://user:pw@…, ?password=…) do not surface in
+            // the exception message, which flows into MDC, log appenders, and the
+            // CLI error UI.
+            throw new UnexpectedLiquibaseException("Could not parse offline url " + JdbcConnection.sanitizeUrl(url));
         }
         this.databaseShortName = matcher.group(1).toLowerCase();
         String params = StringUtil.trimToNull(matcher.group(2));
@@ -112,7 +118,14 @@ public class OfflineConnection implements DatabaseConnection {
                             }
                         }
                     } catch (LiquibaseException e) {
-                        throw new UnexpectedLiquibaseException("Cannot parse snapshot " + url, e);
+                        // Reference the snapshot file path (already parsed) and the
+                        // database short name instead of the full URL: offline URLs
+                        // accept arbitrary key=value params (including credentials)
+                        // and the registered sanitizeUrl patterns do not cover the
+                        // "offline:" prefix, so embedding the raw url here would
+                        // potentially leak co-located params into logs/MDC.
+                        throw new UnexpectedLiquibaseException("Cannot parse snapshot '" + snapshotFile
+                                + "' for offline database '" + databaseShortName + "'", e);
                     }
                 } else if ("sendsStringParametersAsUnicode".equals(paramEntry.getKey())) {
                     this.sendsStringParametersAsUnicode = Boolean.parseBoolean(paramEntry.getValue());

--- a/liquibase-standard/src/test/groovy/liquibase/database/OfflineConnectionTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/database/OfflineConnectionTest.groovy
@@ -1,5 +1,6 @@
 package liquibase.database
 
+import liquibase.exception.UnexpectedLiquibaseException
 import liquibase.resource.ResourceAccessor
 import liquibase.database.core.MockDatabase
 import liquibase.test.JUnitResourceAccessor
@@ -116,5 +117,38 @@ class OfflineConnectionTest extends Specification {
 
         then:
         "superuser" == username
+    }
+
+    def "parse-error exception does not leak credentials from a mistyped JDBC URL"() {
+        // CWE-209 regression: a user pasting a real JDBC URL where an offline: URL
+        // was expected must not see the embedded password echoed back into the
+        // exception message (which flows into MDC, log appenders, and the CLI
+        // error UI). The constructor routes the input through
+        // JdbcConnection.sanitizeUrl before embedding it.
+        when:
+        new OfflineConnection("jdbc:mysql://liquibaseuser:SuperSecretPwd123@host:3306/db", new JUnitResourceAccessor())
+
+        then:
+        UnexpectedLiquibaseException e = thrown()
+        e.message.contains("Could not parse offline url")
+        !e.message.contains("SuperSecretPwd123")
+    }
+
+    def "snapshot-parse exception references the snapshot file, not the full URL"() {
+        // CWE-209 regression: offline URLs accept arbitrary key=value params. The
+        // snapshot-parse failure path now reports the snapshot file path and the
+        // database short name (both already parsed and operationally useful) rather
+        // than the raw URL, which can have credentials co-located with snapshot=.
+        // ".qqq" guarantees SnapshotParserFactory.getParser throws
+        // UnknownFormatException -> LiquibaseException -> line 115's catch clause.
+        when:
+        new OfflineConnection("offline:postgresql?snapshot=secret-snapshot.qqq&password=SuperSecretPwd123", new JUnitResourceAccessor())
+
+        then:
+        UnexpectedLiquibaseException e = thrown()
+        e.message.contains("Cannot parse snapshot")
+        e.message.contains("secret-snapshot.qqq")
+        e.message.contains("postgresql")
+        !e.message.contains("SuperSecretPwd123")
     }
 }


### PR DESCRIPTION
## Impact

`liquibase.database.OfflineConnection` has two `throw` sites that embed the raw, caller-supplied URL into the exception message:

```java
// line 61 — offline-URL pattern mismatch
throw new UnexpectedLiquibaseException("Could not parse offline url " + url);
// line 115 — snapshot=<file> failed to parse
throw new UnexpectedLiquibaseException("Cannot parse snapshot " + url, e);
```

That message then propagates through:

- `CommandScope.logPrimaryExceptionToMdc` → MDC fields persisted by every configured log appender
- the CLI's user-visible error UI
- the `UnexpectedLiquibaseException` cause chain wherever it surfaces

A common operator mistake is to paste a real JDBC URL (with embedded `user:pw@host` credentials or `?password=…` params) where an `offline:` URL was expected. The current code then echoes the password back into logs.

This is the same class of issue as **CWE-209: Generation of Error Message Containing Sensitive Information**, in the same epic as #7737.

## Fix

**Line 61** — route the input through `JdbcConnection.sanitizeUrl(...)` before embedding it. `sanitizeUrl` already covers the realistic threat shape (mistyped JDBC URL) via the registered `ConnectionPatterns` (`mysql`, `mariadb`, `postgresql`, `oracle`, `snowflake`, `jtds`, `databricks`, `cosmosdb`) — see existing coverage in `JdbcConnectionTest.sanitizeUrl`.

**Line 115** — drop the URL from the message entirely and reference `snapshotFile` (already parsed on line 101) and `databaseShortName` (field, populated by the matching regex) instead. Rationale: by the time we reach line 115, the URL is guaranteed to start with `offline:` — a prefix that the registered `sanitizeUrl` patterns **do not cover** — so mechanically applying `sanitizeUrl` here would be a no-op for the realistic threat (`offline:db?snapshot=…&password=…`). Using the parsed snapshot file path and short name gives operators strictly better debugging signal while removing the URL-borne leak deterministically.

Both options were sanctioned by the security ticket author: "Pass url through `JdbcConnection.sanitizeUrl(url)` … Alternatively, since these are `offline:` URLs, strip everything after the first non-alphanumeric char that's not part of the `offline:` path before logging." Line 61 takes the first option; line 115 takes the second.

## Test

Adds two Spock specs to `OfflineConnectionTest`:

1. **`parse-error exception does not leak credentials from a mistyped JDBC URL`** — constructs `OfflineConnection("jdbc:mysql://liquibaseuser:SuperSecretPwd123@host:3306/db", …)`, asserts the resulting `UnexpectedLiquibaseException` contains `"Could not parse offline url"` and does **not** contain `"SuperSecretPwd123"`.

2. **`snapshot-parse exception references the snapshot file, not the full URL`** — constructs `OfflineConnection("offline:postgresql?snapshot=secret-snapshot.qqq&password=SuperSecretPwd123", …)`. The `.qqq` extension deterministically triggers `SnapshotParserFactory.getParser` → `UnknownFormatException` → caught at line 114 → line 115's new exception. Asserts the message contains `"Cannot parse snapshot"`, `"secret-snapshot.qqq"`, `"postgresql"`, and does **not** contain `"SuperSecretPwd123"`.

```
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.422 s -- in liquibase.database.OfflineConnectionTest
[INFO] Tests run: 58, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.555 s -- in liquibase.database.jvm.JdbcConnectionTest
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.985 s -- in liquibase.database.DatabaseFactoryTest
[INFO] Tests run: 84, Failures: 0, Errors: 0, Skipped: 0
```

The 15 pre-existing specs in `OfflineConnectionTest` pass unchanged.

## Related

Companion PR for the sibling finding in the same security audit epic (different file, identical CWE class): #7737 (`DatabaseFactory#findDriverClass`). The two PRs are independent — each can be reviewed, merged, and reverted on its own.
