### PR TITLE
CWE-200: redact credential-bearing values stored in IntegrationDetails parameters

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/integration/IntegrationDetails.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/IntegrationDetails.java
@@ -1,11 +1,13 @@
 package liquibase.integration;
 
 import liquibase.configuration.ConfigurationValueObfuscator;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -25,6 +27,15 @@ public class IntegrationDetails {
      */
     private String name;
 
+    /**
+     * Backing storage for parameter key/value pairs. {@code final} so the reference cannot be
+     * swapped, and the Lombok-generated getter is suppressed via {@link AccessLevel#NONE}
+     * because {@link #getParameters()} below returns an unmodifiable view — any caller that
+     * tries to write directly into the map (e.g. {@code details.getParameters().put(key, raw)})
+     * must instead go through {@link #setParameter(String, String)} so the {@link #sanitize}
+     * boundary cannot be bypassed (CWE-200 defense in depth).
+     */
+    @Getter(AccessLevel.NONE)
     private final Map<String, String> parameters = new HashMap<>();
 
     /**
@@ -36,10 +47,26 @@ public class IntegrationDetails {
     /**
      * Lowercase substrings that mark a parameter key as carrying a credential value. Conservative
      * list matched against the lowercased key (with producer prefixes stripped).
+     * <p>
+     * <b>Matching is intentionally substring-based</b> so that keys like {@code "argument__bearerToken"}
+     * or {@code "authToken"} are caught by {@code "token"}, {@code "awsCredentials"} by
+     * {@code "credentials"}, and {@code "liquibaseProLicenseKey"}-style keys by their respective
+     * tokens. Future readers should NOT tighten this to exact-match without re-evaluating
+     * coverage — over-masking is intentionally preferred to under-masking here because the
+     * downstream sinks (MDC, telemetry, logs) treat redacted values as opaque anyway.
      */
     private static final Set<String> CREDENTIAL_KEY_TOKENS = Set.of(
-            "password", "passwd", "secret", "token", "apikey", "accesskey"
+            "password", "passwd", "secret", "token", "apikey", "accesskey", "credentials"
     );
+
+    /**
+     * Returns an unmodifiable view of the parameters map. Callers must use
+     * {@link #setParameter(String, String)} to add or replace entries so the
+     * {@link #sanitize} boundary cannot be bypassed (CWE-200 defense in depth).
+     */
+    public Map<String, String> getParameters() {
+        return Collections.unmodifiableMap(parameters);
+    }
 
     public void setParameter(String key, String value) {
         this.parameters.put(key, sanitize(key, value));

--- a/liquibase-standard/src/main/java/liquibase/integration/IntegrationDetails.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/IntegrationDetails.java
@@ -1,12 +1,15 @@
 package liquibase.integration;
 
+import liquibase.configuration.ConfigurationValueObfuscator;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Stores information about the integration running Liquibase.
@@ -24,7 +27,68 @@ public class IntegrationDetails {
 
     private final Map<String, String> parameters = new HashMap<>();
 
+    /**
+     * Producer-side prefixes that the CLI / Maven plugin / defaults-file loader attach to argument names
+     * before passing them here. Stripped before matching against {@link #CREDENTIAL_KEY_TOKENS}.
+     */
+    private static final String[] KEY_PREFIXES = {"argument__", "maven__", "defaultsFile__"};
+
+    /**
+     * Lowercase substrings that mark a parameter key as carrying a credential value. Conservative
+     * list matched against the lowercased key (with producer prefixes stripped).
+     */
+    private static final Set<String> CREDENTIAL_KEY_TOKENS = Set.of(
+            "password", "passwd", "secret", "token", "apikey", "accesskey"
+    );
+
     public void setParameter(String key, String value) {
-        this.parameters.put(key, value);
+        this.parameters.put(key, sanitize(key, value));
+    }
+
+    /**
+     * Defense-in-depth redaction at the boundary into the {@link #parameters} map. Producers (the CLI
+     * argument parser, defaults-file loader, Maven plugin Mojos) call {@link #setParameter} for every
+     * parameter they observe — including raw passwords and JDBC URLs containing credentials. The
+     * {@code IntegrationDetails} object is then attached to {@code Scope.Attr.integrationDetails} and is
+     * reachable across the JVM for the run; any current or future telemetry / report / MDC sink that
+     * serializes the parameters map would otherwise leak those credentials.
+     *
+     * <p>Redaction rules, applied in order:</p>
+     * <ul>
+     *   <li>Keys whose lowercase form (with any known producer prefix stripped) contains one of
+     *       {@link #CREDENTIAL_KEY_TOKENS} → value replaced with {@code "*****"} via
+     *       {@link ConfigurationValueObfuscator#STANDARD}.</li>
+     *   <li>Otherwise, values starting with {@code "jdbc:"} → passed through
+     *       {@link ConfigurationValueObfuscator#URL_OBFUSCATOR} (delegating to
+     *       {@link liquibase.database.jvm.JdbcConnection#sanitizeUrl}). Catches producers that put a
+     *       connection string under any key name.</li>
+     *   <li>Otherwise the value passes through unchanged.</li>
+     * </ul>
+     */
+    private static String sanitize(String key, String value) {
+        if (value == null) {
+            return null;
+        }
+        if (key != null) {
+            String matchable = stripPrefix(key).toLowerCase(Locale.ROOT);
+            for (String token : CREDENTIAL_KEY_TOKENS) {
+                if (matchable.contains(token)) {
+                    return ConfigurationValueObfuscator.STANDARD.obfuscate(value);
+                }
+            }
+        }
+        if (value.startsWith("jdbc:")) {
+            return ConfigurationValueObfuscator.URL_OBFUSCATOR.obfuscate(value);
+        }
+        return value;
+    }
+
+    private static String stripPrefix(String key) {
+        for (String prefix : KEY_PREFIXES) {
+            if (key.startsWith(prefix)) {
+                return key.substring(prefix.length());
+            }
+        }
+        return key;
     }
 }

--- a/liquibase-standard/src/test/groovy/liquibase/integration/IntegrationDetailsTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/integration/IntegrationDetailsTest.groovy
@@ -35,6 +35,8 @@ class IntegrationDetailsTest extends Specification {
         "argument__authToken"                 | "Bearer eyJ..."
         "argument__client_secret"             | "csecret"
         "argument__accessKey"                 | "AKIA..."
+        // "credentials" token — catches awsCredentials, credentialsFile, etc.
+        "argument__awsCredentials"            | "ASIA-creds-blob"
         // Case variants
         "argument__PASSWORD"                  | "upper-s3cret"
         "argument__Passwd"                    | "mixed-case"
@@ -155,5 +157,38 @@ class IntegrationDetailsTest extends Specification {
         then:
         details.name == "cli"
         details.parameters.isEmpty()
+    }
+
+    def "getParameters returns an unmodifiable view that cannot bypass the sanitize boundary"() {
+        // CWE-200 defense in depth (per @filipelautert + @coderabbitai review): a future caller
+        // that obtains a reference to getParameters() must not be able to write a raw credential
+        // into the map and skip setParameter()'s redaction.
+        given:
+        def details = new IntegrationDetails()
+        details.setParameter("argument__username", "regular-user")
+
+        when:
+        details.parameters["argument__password"] = "raw-leak-via-getter"
+
+        then:
+        thrown(UnsupportedOperationException)
+        // The map still holds the pre-attempt state — the failed put did not partially apply.
+        details.parameters["argument__username"] == "regular-user"
+        !details.parameters.containsKey("argument__password")
+    }
+
+    def "getParameters reads still work normally on the unmodifiable view"() {
+        // Confirms the unmodifiable wrap does NOT block legitimate read access patterns the
+        // existing tests and downstream consumers already rely on.
+        given:
+        def details = new IntegrationDetails()
+        details.setParameter("argument__password", "s3cret")
+        details.setParameter("argument__username", "regular-user")
+
+        expect:
+        details.parameters["argument__password"] == "*****"
+        details.parameters["argument__username"] == "regular-user"
+        details.parameters.containsKey("argument__password")
+        details.parameters.size() == 2
     }
 }

--- a/liquibase-standard/src/test/groovy/liquibase/integration/IntegrationDetailsTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/integration/IntegrationDetailsTest.groovy
@@ -1,0 +1,159 @@
+package liquibase.integration
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class IntegrationDetailsTest extends Specification {
+
+    @Unroll
+    def "setParameter redacts credential-bearing keys: key=#key"() {
+        given:
+        def details = new IntegrationDetails()
+
+        when:
+        details.setParameter(key, value)
+
+        then:
+        details.parameters[key] == "*****"
+
+        where:
+        key                                   | value
+        // CLI argument__ prefix
+        "argument__password"                  | "s3cret"
+        "argument__referencePassword"         | "ref-s3cret"
+        "argument__databaseChangeLogPassword" | "dcl-s3cret"
+        // Maven maven__ prefix
+        "maven__password"                     | "mvn-s3cret"
+        "maven__referencePassword"            | "mvn-ref-s3cret"
+        // defaults-file defaultsFile__ prefix
+        "defaultsFile__password"              | "df-s3cret"
+        // No prefix at all
+        "password"                            | "raw-s3cret"
+        // Other credential tokens
+        "argument__passwd"                    | "abbreviated"
+        "argument__apiKey"                    | "abcd1234"
+        "argument__authToken"                 | "Bearer eyJ..."
+        "argument__client_secret"             | "csecret"
+        "argument__accessKey"                 | "AKIA..."
+        // Case variants
+        "argument__PASSWORD"                  | "upper-s3cret"
+        "argument__Passwd"                    | "mixed-case"
+    }
+
+    @Unroll
+    def "setParameter sanitizes JDBC URL values regardless of key name: key=#key"() {
+        // URL formats here are limited to what JdbcConnection.sanitizeUrl currently covers
+        // (query-string `?password=`, property-string `;password=`, userinfo for mysql/mariadb/oracle).
+        // Coverage gaps in sanitizeUrl (e.g., PostgreSQL `user:pass@host` userinfo) are tracked
+        // separately (see audit ticket on sanitizeUrl regex coverage); this fix automatically
+        // benefits from any future improvement to sanitizeUrl.
+        given:
+        def details = new IntegrationDetails()
+
+        when:
+        details.setParameter(key, value)
+
+        then:
+        // Sanitized URL still starts with the JDBC scheme but no longer contains the cleartext password.
+        details.parameters[key].startsWith("jdbc:")
+        !details.parameters[key].contains("p4ss")
+
+        where:
+        key                          | value
+        // Query-string-style password (postgresql, snowflake, mysql ?-form)
+        "argument__url"              | "jdbc:postgresql://host:5432/db?user=u&password=p4ss"
+        "argument__referenceUrl"     | "jdbc:snowflake://account.snowflakecomputing.com?warehouse=W&user=u&password=p4ss"
+        "maven__url"                 | "jdbc:mysql://localhost:3306/db?user=u&password=p4ss"
+        // Property-string-style password (jtds sqlserver, databricks)
+        "defaultsFile__url"          | "jdbc:jtds:sqlserver://h:1433/db;user=u;password=p4ss"
+        // Userinfo-style (mysql, mariadb covered by sanitizeUrl)
+        "argument__connectionString" | "jdbc:mysql://u:p4ss@host:3306/db"
+        // Value-side rule catches non-"url" key names whose value is a JDBC URL — proves the rule
+        // is triggered by value, not key.
+        "any-future-key"             | "jdbc:mariadb://u:p4ss@host:3306/db"
+    }
+
+    @Unroll
+    def "setParameter passes non-credential, non-URL values through unchanged: key=#key"() {
+        given:
+        def details = new IntegrationDetails()
+
+        when:
+        details.setParameter(key, value)
+
+        then:
+        details.parameters[key] == value
+
+        where:
+        key                         | value
+        "argument__username"        | "victor"
+        "argument__databaseUser"    | "dba"
+        "argument__changeLogFile"   | "db.changelog.xml"
+        "argument__contexts"        | "prod,qa"
+        "argument__labels"          | "release-1"
+        "maven__driver"             | "org.postgresql.Driver"
+        "defaultsFile__rollbackTag" | "v1.0.0"
+        // Plain (non-jdbc:) URL is not auto-sanitized — only jdbc: prefix triggers value-side rule.
+        "argument__reportPath"      | "https://example.com/report"
+    }
+
+    def "setParameter handles null value by storing null (no mask)"() {
+        given:
+        def details = new IntegrationDetails()
+
+        when:
+        details.setParameter("argument__password", null)
+
+        then:
+        details.parameters.containsKey("argument__password")
+        details.parameters["argument__password"] == null
+    }
+
+    def "setParameter handles null key by storing the value under null (no credential check)"() {
+        given:
+        def details = new IntegrationDetails()
+
+        when:
+        details.setParameter(null, "plain-value")
+
+        then:
+        details.parameters[null] == "plain-value"
+    }
+
+    def "setParameter with null key still applies value-side JDBC URL sanitization"() {
+        given:
+        def details = new IntegrationDetails()
+
+        when:
+        details.setParameter(null, "jdbc:postgresql://host:5432/db?password=p4ss")
+
+        then:
+        details.parameters[null].startsWith("jdbc:")
+        !details.parameters[null].contains("p4ss")
+    }
+
+    def "setParameter overwrites prior values (still redacted)"() {
+        given:
+        def details = new IntegrationDetails()
+
+        when:
+        details.setParameter("argument__password", "first")
+        details.setParameter("argument__password", "second")
+
+        then:
+        details.parameters.size() == 1
+        details.parameters["argument__password"] == "*****"
+    }
+
+    def "name field is unaffected by sanitization"() {
+        given:
+        def details = new IntegrationDetails()
+
+        when:
+        details.setName("cli")
+
+        then:
+        details.name == "cli"
+        details.parameters.isEmpty()
+    }
+}


### PR DESCRIPTION
> **Supersedes #7736.** That PR was auto-closed when GitHub's branch-rename API deleted the old head ref (`head_ref_deleted` event fires `closed`). Same diff, same author, single clean commit. The branch was also renamed from `dat-23008-23009-…` to `cwe-200-redact-integration-details-parameters` so the head name matches the convention used by sibling PRs #7737 / #7738.

## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)

## Description

Redact credential-bearing parameter values at the boundary into `IntegrationDetails.parameters`. Producers — the CLI argument parser (`Main.java:185-216`), the defaults-file loader (`Main.java:1022`), and the Maven plugin Mojos (`AbstractLiquibaseMojo.java:541`) — currently call `setParameter` with raw passwords and JDBC URLs containing credentials. The `IntegrationDetails` object is attached to `Scope.Attr.integrationDetails` and is reachable across the JVM for the run; any current or future telemetry / report / MDC sink that serializes the parameters map would otherwise leak those credentials.

This addresses two High findings from a May-2026 OSS credential-handling audit (CWE-200: Exposure of Sensitive Information to an Unauthorized Actor):

- **Maven plugin variant** — `AbstractLiquibaseMojo.java:541` captures every Mojo parameter (`password`, `referencePassword`, full `url`) without filtering. The existing log-side mask in `AbstractLiquibaseMojo.printSettings()` (lines 893-894) is a separate code path and does not cover the `IntegrationDetails` sink.
- **Legacy CLI variant** — `Main.java:185-216` copies every `--key=value` CLI argument into `IntegrationDetails` via `setParameter("argument__"+key, value)`, and `Main.java:1022` similarly copies every entry from the `liquibase.properties` defaults file (prefix `defaultsFile__`). Both paths capture `password` cleartext. The newer `LiquibaseCommandLine.java` (lines 792-794) does not have this issue — finding is legacy-CLI-only, but legacy-CLI is still shipped.

### Threat model

This is **defense in depth**, not active leak remediation. A repo-wide grep confirms no production code path currently reads `IntegrationDetails.getParameters()` — the only sink reads `getName()`. However:

- `Scope.Attr.integrationDetails` is reachable from any thread for the run.
- `LiquibaseAnalyticsListener.sendEvent` YAML-serializes `Event` with `BeanAccess.FIELD`; if a `parameters` field were ever added to `Event`, the map contents would be serialized into the analytics payload without further code change.
- The existing log-side mask in `AbstractLiquibaseMojo.printSettings()` is a separate code path and does not cover the integration-details map.

Redacting at the capture point closes the latent gap without touching every producer.

## Things to be aware of

**Single boundary fix in `IntegrationDetails.setParameter`** — adds a `sanitize(key, value)` helper. All existing producers stay unchanged.

Rules applied in order:

1. If the lowercase key (with `argument__` / `maven__` / `defaultsFile__` prefix stripped) contains one of `password`, `passwd`, `secret`, `token`, `apikey`, `accesskey` → store `*****` via `ConfigurationValueObfuscator.STANDARD`.
2. Else if the value starts with `jdbc:` → pass through `ConfigurationValueObfuscator.URL_OBFUSCATOR` (delegates to `JdbcConnection.sanitizeUrl`). Catches any producer that puts a JDBC URL under a non-`url` key name (current and future).
3. Else passthrough unchanged.

Reuses the existing `ConfigurationValueObfuscator` abstractions; no new redaction primitives introduced.

**Alternatives considered and rejected:**

- **Callsite redaction** (the original audit suggestion). Requires patching every producer site (CLI `Main.java`, defaults-file loader, both Maven Mojos — including a downstream commercial Mojo that mirrors the loop). Future producers would be unprotected.
- **Sink-side redaction in `Event.java`**. Only fixes the current sink; the point of this fix is to prevent future telemetry/report sinks from inheriting the leak.
- **Typed `Credential` / `SecretString` wrapper.** Correct long-term direction (would also subsume the deferred "passwords stored as `String`, never zeroed" item) but a wide refactor across the CLI, Mojos, defaults-file loader, picocli binding, and downstream connection code. Best as a follow-up spike, not in this PR.

## Things to worry about

- **Denylist tokens are intentionally conservative**: `password`, `passwd`, `secret`, `token`, `apikey`, `accesskey`. If reviewers see commonly-used credential-bearing key names that don't match these tokens (e.g., `clientsecret`, `oauth`, `bearer`, `jwt`), please flag — easy to add.
- **`JdbcConnection.sanitizeUrl` coverage gaps inherited**. The value-side `jdbc:` rule reuses `sanitizeUrl`, which has known coverage gaps for some URL formats. A discovered example: PostgreSQL `user:pass@host` userinfo style is not currently sanitized by either variant (MySQL/MariaDB/Oracle userinfo styles are). My tests use formats `sanitizeUrl` covers; the gap is real and is being tracked separately. Any future improvement to `sanitizeUrl` (e.g., adding a postgresql userinfo pattern) automatically benefits this fix.
- **LTS backports** — `main` only here. If older release lines should also receive this, happy to follow up.

## Additional Context

**Test coverage** in new `liquibase-standard/src/test/groovy/liquibase/integration/IntegrationDetailsTest.groovy`:

- Credential-token matching across all 3 producer prefixes + no-prefix, all 6 tokens, case variants (`PASSWORD`, `Passwd`).
- JDBC URL value-side sanitization across `argument__url` / `argument__referenceUrl` / `maven__url` / `defaultsFile__url` / `argument__connectionString` / `any-future-key`, exercising query-string, property-string, and userinfo URL forms covered by `sanitizeUrl` (postgresql `?password=`, snowflake `?password=`, mysql `?password=`, jtds sqlserver `;password=`, mysql/mariadb `user:pass@host`).
- Non-credential keys pass through unchanged (`username`, `databaseUser` — proves no over-masking).
- Null key / null value / null-key-with-jdbc-value.
- Overwrite semantics (still redacted on second `setParameter` for the same key).
- `name` field unaffected by the sanitization path.

**Local verification**: `mvn test -pl liquibase-standard -Dtest=IntegrationDetailsTest` — 36 tests, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

