### PR TITLE
CWE-693: add generic JDBC userinfo fallback to sanitizeUrl coverage

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/database/jvm/JdbcConnectionPatterns.java
+++ b/liquibase-standard/src/main/java/liquibase/database/jvm/JdbcConnectionPatterns.java
@@ -66,15 +66,9 @@ public class JdbcConnectionPatterns extends ConnectionPatterns {
         addJdbcBlankToObfuscatePatternsReplaceWithEmpty(PatternPair.of(Pattern.compile(mysqlMatcherRegex), Pattern.compile(FILTER_CREDS_MYSQL_TO_OBFUSCATE_EMPTY)));
         addJdbcBlankToObfuscatePatternsReplaceWithEmpty(PatternPair.of(Pattern.compile(mariadbMatcherRegex), Pattern.compile(FILTER_CREDS_MARIADB_TO_OBFUSCATE_EMPTY)));
 
-        // Generic JDBC userinfo fallback. Any "jdbc:<driver>://user:pass@host" URL whose
-        // dialect-specific matcher above did not match (postgresql, sqlserver, third-party
-        // drivers, future extensions) still gets basic credential redaction. The filter
-        // regexes are the same generic ones already used by mysql/mariadb; only the matcher
-        // is broadened to any jdbc:-prefixed URL. Registered last so dialect-specific entries
-        // win for their idiomatic URL shapes; the userinfo filter is idempotent when re-run
-        // on an already-redacted "*****:*****@..." string. Anchored to "jdbc:" so non-JDBC
-        // protocols (cosmosdb://, mongodb://, ...) continue to use only their dedicated
-        // patterns and are not subject to this fallback.
+        // Generic JDBC userinfo fallback for any jdbc: URL not covered by the dialect
+        // patterns above (postgresql, sqlserver, third-party drivers; CWE-693).
+        // See git blame / PR for design rationale and the dialect-vs-generic tradeoff.
         final Pattern anyJdbcUrl = Pattern.compile("(?i)jdbc:.*");
         addJdbcBlankPatterns(PatternPair.of(anyJdbcUrl, Pattern.compile(FILTER_CREDS)));
         addJdbcBlankToObfuscatePatterns(PatternPair.of(anyJdbcUrl, Pattern.compile(FILTER_CREDS_MYSQL_TO_OBFUSCATE)));

--- a/liquibase-standard/src/main/java/liquibase/database/jvm/JdbcConnectionPatterns.java
+++ b/liquibase-standard/src/main/java/liquibase/database/jvm/JdbcConnectionPatterns.java
@@ -65,5 +65,19 @@ public class JdbcConnectionPatterns extends ConnectionPatterns {
         addJdbcBlankToObfuscatePatternsReplaceWithEmpty(PatternPair.of(Pattern.compile(oracleThinMatcherRegex), Pattern.compile(FILTER_CREDS_ORACLE_TO_OBFUSCATE_EMPTY)));
         addJdbcBlankToObfuscatePatternsReplaceWithEmpty(PatternPair.of(Pattern.compile(mysqlMatcherRegex), Pattern.compile(FILTER_CREDS_MYSQL_TO_OBFUSCATE_EMPTY)));
         addJdbcBlankToObfuscatePatternsReplaceWithEmpty(PatternPair.of(Pattern.compile(mariadbMatcherRegex), Pattern.compile(FILTER_CREDS_MARIADB_TO_OBFUSCATE_EMPTY)));
+
+        // Generic JDBC userinfo fallback. Any "jdbc:<driver>://user:pass@host" URL whose
+        // dialect-specific matcher above did not match (postgresql, sqlserver, third-party
+        // drivers, future extensions) still gets basic credential redaction. The filter
+        // regexes are the same generic ones already used by mysql/mariadb; only the matcher
+        // is broadened to any jdbc:-prefixed URL. Registered last so dialect-specific entries
+        // win for their idiomatic URL shapes; the userinfo filter is idempotent when re-run
+        // on an already-redacted "*****:*****@..." string. Anchored to "jdbc:" so non-JDBC
+        // protocols (cosmosdb://, mongodb://, ...) continue to use only their dedicated
+        // patterns and are not subject to this fallback.
+        final Pattern anyJdbcUrl = Pattern.compile("(?i)jdbc:.*");
+        addJdbcBlankPatterns(PatternPair.of(anyJdbcUrl, Pattern.compile(FILTER_CREDS)));
+        addJdbcBlankToObfuscatePatterns(PatternPair.of(anyJdbcUrl, Pattern.compile(FILTER_CREDS_MYSQL_TO_OBFUSCATE)));
+        addJdbcBlankToObfuscatePatternsReplaceWithEmpty(PatternPair.of(anyJdbcUrl, Pattern.compile(FILTER_CREDS_MYSQL_TO_OBFUSCATE_EMPTY)));
     }
 }

--- a/liquibase-standard/src/test/groovy/liquibase/database/jvm/JdbcConnectionTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/database/jvm/JdbcConnectionTest.groovy
@@ -38,6 +38,10 @@ class JdbcConnectionTest extends Specification {
         "jdbc:oracle:thin:user/password@host:1521/db"                                        | "jdbc:oracle:thin:user@host:1521/db"
         "jdbc:oracle:thin:@host:1521/db"                                                     | "jdbc:oracle:thin:@host:1521/db"
         "jdbc:databricks://databricks.azuredatabricks.net:443/default;transportMode=http;ssl=1;AuthMech=11;Auth_Flow=1;httpPath=/sql/1.0/warehouses/warehouseId;ConnCatalog=myCatalog;ConnSchema=mySchema;OAuth2ClientId=MyClientID;OAuth2Secret=MySecret;" | "jdbc:databricks://databricks.azuredatabricks.net:443/default;transportMode=http;ssl=1;AuthMech=11;Auth_Flow=1;httpPath=/sql/1.0/warehouses/warehouseId;ConnCatalog=myCatalog;ConnSchema=mySchema;OAuth2ClientId=MyClientID;"
+        // Generic jdbc: userinfo fallback (CWE-693) — postgresql + third-party drivers
+        "jdbc:postgresql://liquibaseuser:secret@host:5432/db"                                | "jdbc:postgresql:@host:5432/db"
+        "jdbc:sqlserver://user:secret@host:1433/db"                                          | "jdbc:sqlserver:@host:1433/db"
+        "jdbc:vendor-x://liquibaseuser:secret@host:9999/db"                                  | "jdbc:vendor-x:@host:9999/db"
         null                                                                                 | null
     }
 
@@ -75,6 +79,11 @@ class JdbcConnectionTest extends Specification {
         "jdbc:oracle:thin:@host:1521/db"                                                     | "jdbc:oracle:thin:@host:1521/db"
         "cosmosdb://maincosmosliquibase.documents.azure.com:t27yJICDSFdR1HN==@maincosmosliquibase.documents.azure.com:443/testdb1" | "cosmosdb://maincosmosliquibase.documents.azure.com:*****@maincosmosliquibase.documents.azure.com:443/testdb1"
         "jdbc:databricks://databricks.azuredatabricks.net:443/default;transportMode=http;ssl=1;AuthMech=11;Auth_Flow=1;httpPath=/sql/1.0/warehouses/warehouseId;ConnCatalog=myCatalog;ConnSchema=mySchema;OAuth2ClientId=MyClientID;OAuth2Secret=MySecret;" | "jdbc:databricks://databricks.azuredatabricks.net:443/default;transportMode=http;ssl=1;AuthMech=11;Auth_Flow=1;httpPath=/sql/1.0/warehouses/warehouseId;ConnCatalog=myCatalog;ConnSchema=mySchema;OAuth2ClientId=MyClientID;OAuth2Secret=*****;"
+        // Generic jdbc: userinfo fallback (CWE-693): postgresql + sqlserver + third-party drivers
+        // previously bypassed sanitizeUrl because their dialects had no matcher registered.
+        "jdbc:postgresql://liquibaseuser:secret@host:5432/db"                                | "jdbc:postgresql://*****:*****@host:5432/db"
+        "jdbc:sqlserver://user:secret@host:1433/db"                                          | "jdbc:sqlserver://*****:*****@host:1433/db"
+        "jdbc:vendor-x://liquibaseuser:secret@host:9999/db"                                  | "jdbc:vendor-x://*****:*****@host:9999/db"
         null                                                                                 | null
     }
 
@@ -112,6 +121,10 @@ class JdbcConnectionTest extends Specification {
         "jdbc:oracle:thin:@host:1521/db"                                                     | "jdbc:oracle:thin:@host:1521/db"
         "cosmosdb://maincosmosliquibase.documents.azure.com:t27yJICDSFdR1HN==@maincosmosliquibase.documents.azure.com:443/testdb1" | "cosmosdb://maincosmosliquibase.documents.azure.com:*****@maincosmosliquibase.documents.azure.com:443/testdb1"
         "jdbc:databricks://databricks.azuredatabricks.net:443/default;transportMode=http;ssl=1;AuthMech=11;Auth_Flow=1;httpPath=/sql/1.0/warehouses/warehouseId;ConnCatalog=myCatalog;ConnSchema=mySchema;OAuth2ClientId=MyClientID;OAuth2Secret=MySecret;" | "jdbc:databricks://databricks.azuredatabricks.net:443/default;transportMode=http;ssl=1;AuthMech=11;Auth_Flow=1;httpPath=/sql/1.0/warehouses/warehouseId;ConnCatalog=myCatalog;ConnSchema=mySchema;OAuth2ClientId=MyClientID;OAuth2Secret=*****;"
+        // Generic jdbc: userinfo fallback (CWE-693): replaceWithEmpty path
+        "jdbc:postgresql://liquibaseuser:secret@host:5432/db"                                | "jdbc:postgresql://host:5432/db"
+        "jdbc:sqlserver://user:secret@host:1433/db"                                          | "jdbc:sqlserver://host:1433/db"
+        "jdbc:vendor-x://liquibaseuser:secret@host:9999/db"                                  | "jdbc:vendor-x://host:9999/db"
         null                                                                                 | null
     }
 }


### PR DESCRIPTION
## Impact

`JdbcConnection.sanitizeUrl` is the centralised credential-redaction helper used across many logging / exception / MDC paths in Liquibase (DatabaseFactory, DatabaseInfo, AbstractDatabaseConnectionCommandStep, DbUrlConnectionCommandStep, ReferenceDbUrlConnectionCommandStep, Main, and — after PRs #7737 / #7738 / #7739 — several other call sites in the audit). Its userinfo-style matchers, however, are **dialect-specific**: only Oracle-thin, MySQL, MariaDB, and CosmosDB URLs get `user:pass@host` credentials redacted. Any other `jdbc:<driver>://` URL passes through `sanitizeUrl` **unmodified**, credentials intact.

Concrete misses today:

- `jdbc:postgresql://user:pass@host/db` (PostgreSQL JDBC accepts userinfo)
- `jdbc:sqlserver://user:pass@host/db`
- `jdbc:<third-party>://user:pass@host/db` — any extension or future driver

The downstream consequence: log lines, MDC entries, and exception messages that funnel through `sanitizeUrl` to be "safe" can still surface cleartext credentials for these URL shapes.

This maps to **CWE-693: Protection Mechanism Failure** — the protection mechanism silently no-ops on URLs outside its allowlist, defeating the defense its callers depend on. It is also explicitly noted as a known limitation in #7737's and #7739's PR bodies; this PR closes that gap.

## Fix

The three filter regexes in `JdbcConnectionPatterns`:

- `FILTER_CREDS = "(?i)/(.*)((?=@))"` (used by `stripPasswordPropFromJdbcUrl` for `getURL()`)
- `FILTER_CREDS_MYSQL_TO_OBFUSCATE = "(?i).+://(.*?)([:])(.*?)((?=@))"` (used by `sanitizeUrl` standard path)
- `FILTER_CREDS_MYSQL_TO_OBFUSCATE_EMPTY = "(?i).+://(.*?)([:])(.*?@)"` (used by `sanitizeUrl(url, true)`)

…are already generic — they match any `scheme://user:pass@host` shape. **Only the matchers** restrict them to specific dialects. Register the same three filters one additional time with a wildcard matcher, `Pattern.compile("(?i)jdbc:.*")`, so any jdbc-prefixed URL whose dialect-specific matcher did not fire still gets basic redaction.

```java
final Pattern anyJdbcUrl = Pattern.compile("(?i)jdbc:.*");
addJdbcBlankPatterns(PatternPair.of(anyJdbcUrl, Pattern.compile(FILTER_CREDS)));
addJdbcBlankToObfuscatePatterns(PatternPair.of(anyJdbcUrl, Pattern.compile(FILTER_CREDS_MYSQL_TO_OBFUSCATE)));
addJdbcBlankToObfuscatePatternsReplaceWithEmpty(PatternPair.of(anyJdbcUrl, Pattern.compile(FILTER_CREDS_MYSQL_TO_OBFUSCATE_EMPTY)));
```

## Design considerations

- **Anchored to `jdbc:`**. Non-JDBC protocols (`cosmosdb://`, `mongodb://`, future protocols) continue to use **only** their dedicated patterns. This preserves the existing `cosmosdb` test data byte-for-byte: cosmosdb's format places the hostname before `:<key>@`, and a fully generic userinfo filter would over-redact the hostname there. A `jdbc:`-only anchor avoids that without sacrificing coverage of any current JDBC dialect.
- **Registered after the dialect-specific entries**. For URLs covered by both (mysql/mariadb/oracle), the dialect entry redacts first, and the generic pass on the already-redacted `*****:*****@…` is **idempotent** — `jdbcUrl.replace("*****:*****", "*****:*****")` is a no-op.
- **No new filter regexes**. Reuses the three existing constants. This keeps the surface area of the change to one pattern variable + three `addX` calls.

## Test

Adds nine assertions to `JdbcConnectionTest` across the three existing `@Unroll` blocks — `getUrl`, `sanitizeUrl`, `sanitizeUrl replaceWithEmpty` — covering:

- `jdbc:postgresql://liquibaseuser:secret@host:5432/db`
- `jdbc:sqlserver://user:secret@host:1433/db`
- `jdbc:vendor-x://liquibaseuser:secret@host:9999/db` (synthetic third-party driver)

```
[INFO] Tests run: 67, Failures: 0, Errors: 0, Skipped: 0 -- in liquibase.database.jvm.JdbcConnectionTest
[INFO] Tests run: 9,  Failures: 0, Errors: 0, Skipped: 0 -- in liquibase.database.DatabaseFactoryTest
[INFO] Tests run: 15, Failures: 0, Errors: 0, Skipped: 0 -- in liquibase.database.OfflineConnectionTest
[INFO] Tests run: 91, Failures: 0, Errors: 0, Skipped: 0
```

All 58 pre-existing assertions in `JdbcConnectionTest` pass unchanged — cosmosdb, mysql, mariadb, oracle-thin, snowflake, jtds, databricks assertions byte-for-byte identical.

## Known limitation

URLs whose path contains `@` (e.g. `jdbc:foo://host:port/path@suffix`) would have `host:port/path` incorrectly redacted as `*****:*****`. JDBC URLs rarely have `@` outside of credentials, so the risk is low; over-redaction here means slightly noisier logs, not weaker security.

## Related

This is the upstream-side benefactor of the "JdbcConnection.sanitizeUrl coverage gaps inherited" follow-up explicitly flagged in #7737 and #7739. After this PR merges, those PRs and the broader `sanitizeUrl`-based defense chain automatically gain coverage for postgresql / sqlserver / third-party JDBC userinfo URLs.
