### PR TITLE
CWE-316: clear password memory after use in legacy CLI + CommandScope

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/command/CommandScope.java
+++ b/liquibase-standard/src/main/java/liquibase/command/CommandScope.java
@@ -54,10 +54,15 @@ public class CommandScope {
      * Substring tokens (lowercase) that mark an argument key as credential-bearing.
      * Values for matching keys are overwritten with {@code "*****"} at the end of
      * {@link #execute()} so the original credential Strings become GC-eligible and
-     * do not linger in heap for the rest of the JVM lifetime (CWE-316). Mirrors
-     * the denylist used by {@code IntegrationDetails.setParameter}, plus
-     * {@code "licensekey"} to also catch {@code liquibaseProLicenseKey} which is
-     * placed in this map via {@code Main.createLiquibaseCommand()}.
+     * do not linger in heap for the rest of the JVM lifetime (CWE-316).
+     * <p>
+     * Matching is intentionally substring-based on the lowercased key: keys like
+     * {@code "argument__bearerToken"} are caught by {@code "token"};
+     * {@code "liquibaseProLicenseKey"} (placed in this map via
+     * {@code Main.createLiquibaseCommand()}) is caught by {@code "licensekey"};
+     * AWS-style {@code accessKeyId} by {@code "accesskey"}. Over-masking is
+     * intentionally preferred to under-masking — downstream sinks treat redacted
+     * values as opaque, so false positives are harmless.
      */
     private static final String[] CREDENTIAL_KEY_TOKENS = {
             "password", "passwd", "secret", "token", "apikey", "accesskey", "licensekey"

--- a/liquibase-standard/src/main/java/liquibase/command/CommandScope.java
+++ b/liquibase-standard/src/main/java/liquibase/command/CommandScope.java
@@ -403,7 +403,11 @@ public class CommandScope {
             if (key == null) {
                 continue;
             }
-            String lowerKey = key.toLowerCase();
+            // Locale.ROOT explicitly: bare String.toLowerCase() is locale-sensitive
+            // and would mis-lowercase ASCII letters under e.g. Turkish locale
+            // ("APIKEY" -> "apıkey" with dotless ı, which would then fail the
+            // contains("apikey") substring check and silently skip redaction).
+            String lowerKey = key.toLowerCase(Locale.ROOT);
             for (String token : CREDENTIAL_KEY_TOKENS) {
                 if (lowerKey.contains(token)) {
                     entry.setValue("*****");

--- a/liquibase-standard/src/main/java/liquibase/command/CommandScope.java
+++ b/liquibase-standard/src/main/java/liquibase/command/CommandScope.java
@@ -55,10 +55,12 @@ public class CommandScope {
      * Values for matching keys are overwritten with {@code "*****"} at the end of
      * {@link #execute()} so the original credential Strings become GC-eligible and
      * do not linger in heap for the rest of the JVM lifetime (CWE-316). Mirrors
-     * the denylist used by {@code IntegrationDetails.setParameter}.
+     * the denylist used by {@code IntegrationDetails.setParameter}, plus
+     * {@code "licensekey"} to also catch {@code liquibaseProLicenseKey} which is
+     * placed in this map via {@code Main.createLiquibaseCommand()}.
      */
     private static final String[] CREDENTIAL_KEY_TOKENS = {
-            "password", "passwd", "secret", "token", "apikey", "accesskey"
+            "password", "passwd", "secret", "token", "apikey", "accesskey", "licensekey"
     };
 
     private final Map<Class<?>, Object> dependencies = new HashMap<>();

--- a/liquibase-standard/src/main/java/liquibase/command/CommandScope.java
+++ b/liquibase-standard/src/main/java/liquibase/command/CommandScope.java
@@ -50,6 +50,17 @@ public class CommandScope {
 
     private final SortedMap<String, Object> argumentValues = new TreeMap<>();
 
+    /**
+     * Substring tokens (lowercase) that mark an argument key as credential-bearing.
+     * Values for matching keys are overwritten with {@code "*****"} at the end of
+     * {@link #execute()} so the original credential Strings become GC-eligible and
+     * do not linger in heap for the rest of the JVM lifetime (CWE-316). Mirrors
+     * the denylist used by {@code IntegrationDetails.setParameter}.
+     */
+    private static final String[] CREDENTIAL_KEY_TOKENS = {
+            "password", "passwd", "secret", "token", "apikey", "accesskey"
+    };
+
     private final Map<Class<?>, Object> dependencies = new HashMap<>();
 
     /**
@@ -361,6 +372,37 @@ public class CommandScope {
             throw e;
         } catch (Exception e) {
             throw new CommandExecutionException(e);
+        } finally {
+            clearCredentialArguments();
+        }
+    }
+
+    /**
+     * Overwrite the values of any credential-bearing argument keys with
+     * {@code "*****"} so the original credential Strings stop being referenced by
+     * this scope. Strings are immutable and cannot be wiped in-place, but dropping
+     * the reference here makes them GC-eligible (assuming no other references hold
+     * the same String) instead of letting them live for the rest of the JVM in
+     * long-running embedded scenarios (CWE-316: Cleartext Storage of Sensitive
+     * Information in Memory). Called from {@link #execute()}'s outer finally so
+     * it runs regardless of command outcome; package-private for direct testing.
+     */
+    void clearCredentialArguments() {
+        if (argumentValues.isEmpty()) {
+            return;
+        }
+        for (Map.Entry<String, Object> entry : argumentValues.entrySet()) {
+            String key = entry.getKey();
+            if (key == null) {
+                continue;
+            }
+            String lowerKey = key.toLowerCase();
+            for (String token : CREDENTIAL_KEY_TOKENS) {
+                if (lowerKey.contains(token)) {
+                    entry.setValue("*****");
+                    break;
+                }
+            }
         }
     }
 

--- a/liquibase-standard/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/commandline/Main.java
@@ -1271,6 +1271,14 @@ public class Main {
                 // is cleared separately by clearCredentialFields() in run()'s
                 // finally block.
                 char[] pwdChars = c.readPassword(attributeName + ": ");
+                // Console.readPassword returns null on EOF (Ctrl+D on Unix, Ctrl+Z on
+                // Windows). Without this guard, the subsequent new String(pwdChars)
+                // and Arrays.fill(pwdChars, '\0') would NPE rather than producing a
+                // clear parsing error.
+                if (pwdChars == null) {
+                    throw new CommandLineParsingException(
+                            "No value provided for '" + attributeName + "' (end-of-input reached)");
+                }
                 try {
                     value = new String(pwdChars);
                 } finally {

--- a/liquibase-standard/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/commandline/Main.java
@@ -1282,7 +1282,7 @@ public class Main {
                 try {
                     value = new String(pwdChars);
                 } finally {
-                    java.util.Arrays.fill(pwdChars, '\0');
+                    Arrays.fill(pwdChars, '\0');
                 }
             } else {
                 value = c.readLine(attributeName + ": ");

--- a/liquibase-standard/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/commandline/Main.java
@@ -447,11 +447,33 @@ public class Main {
                         } else {
                             throw new LiquibaseException(String.format(coreBundle.getString("unexpected.error"), message), e);
                         }
+                    } finally {
+                        // CWE-316: null the credential-bearing fields so the immutable
+                        // String values become GC-eligible promptly after the command
+                        // run finishes, rather than living for the rest of the JVM in
+                        // embedded scenarios. The String contents themselves cannot be
+                        // wiped in-place (Strings are immutable in Java); nulling the
+                        // field is the closest equivalent. The char[] returned by
+                        // Console.readPassword is already zeroed at its read site.
+                        main.clearCredentialFields();
                     }
 
                     return 0;
                 }
             });
+    }
+
+    /**
+     * Null the credential-bearing fields so their (immutable) String values become
+     * GC-eligible after a command run finishes. Called from {@link #run(String[])}'s
+     * finally block. Package-private to allow direct testing.
+     * <p>
+     * CWE-316: Cleartext Storage of Sensitive Information in Memory.
+     */
+    void clearCredentialFields() {
+        this.password = null;
+        this.referencePassword = null;
+        this.liquibaseProLicenseKey = null;
     }
 
     private static boolean setupNeeded(Main main) throws CommandLineParsingException {
@@ -1241,7 +1263,19 @@ public class Main {
             }
             //Prompt for value
             if (attributeName.toLowerCase().contains("password")) {
-                value = new String(c.readPassword(attributeName + ": "));
+                // Console.readPassword returns char[] precisely so callers can zero
+                // the buffer after use. Wrapping in `new String(...)` copies the
+                // chars into the (immutable) String constant; we explicitly clear
+                // the original char[] in `finally` so it does not linger in heap
+                // (CWE-316). The String copy that ends up in the destination field
+                // is cleared separately by clearCredentialFields() in run()'s
+                // finally block.
+                char[] pwdChars = c.readPassword(attributeName + ": ");
+                try {
+                    value = new String(pwdChars);
+                } finally {
+                    java.util.Arrays.fill(pwdChars, '\0');
+                }
             } else {
                 value = c.readLine(attributeName + ": ");
             }

--- a/liquibase-standard/src/test/groovy/liquibase/command/CommandScopeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/command/CommandScopeTest.groovy
@@ -118,30 +118,35 @@ class CommandScopeTest extends Specification {
         // the lowercased key.
         given:
         def scope = new CommandScope("mock")
-        scope.addArgumentValue("password",         "supersecret-pw-12345")
-        scope.addArgumentValue("apiSecret",        "secret-svc-token")
-        scope.addArgumentValue("authToken",        "bearer-xyz")
-        scope.addArgumentValue("AccessKey",        "AKIA-EXAMPLE")
-        scope.addArgumentValue("PASSWORD",         "case-insensitive-match")
-        scope.addArgumentValue("ldap.passwd",      "embedded-token-match")
-        scope.addArgumentValue("username",         "regular-user")
-        scope.addArgumentValue("url",              "jdbc:postgresql://host:5432/db")
-        scope.addArgumentValue("driver",           "org.postgresql.Driver")
+        scope.addArgumentValue("password",                "supersecret-pw-12345")
+        scope.addArgumentValue("apiSecret",               "secret-svc-token")
+        scope.addArgumentValue("authToken",               "bearer-xyz")
+        scope.addArgumentValue("AccessKey",               "AKIA-EXAMPLE")
+        scope.addArgumentValue("PASSWORD",                "case-insensitive-match")
+        scope.addArgumentValue("ldap.passwd",             "embedded-token-match")
+        // CommandScope receives liquibaseProLicenseKey via Main.createLiquibaseCommand()
+        // putting it into argsMap. Lowercase form "liquibaseprolicensekey" contains
+        // the "licensekey" token, so it must be redacted alongside passwords / secrets.
+        scope.addArgumentValue("liquibaseProLicenseKey",  "PRO-LICENSE-KEY-VALUE-12345")
+        scope.addArgumentValue("username",                "regular-user")
+        scope.addArgumentValue("url",                     "jdbc:postgresql://host:5432/db")
+        scope.addArgumentValue("driver",                  "org.postgresql.Driver")
 
         when:
         scope.clearCredentialArguments()
         def values = scope.@argumentValues
 
         then:
-        values["password"]    == "*****"
-        values["apiSecret"]   == "*****"
-        values["authToken"]   == "*****"
-        values["AccessKey"]   == "*****"
-        values["PASSWORD"]    == "*****"
-        values["ldap.passwd"] == "*****"
-        values["username"]    == "regular-user"
-        values["url"]         == "jdbc:postgresql://host:5432/db"
-        values["driver"]      == "org.postgresql.Driver"
+        values["password"]               == "*****"
+        values["apiSecret"]              == "*****"
+        values["authToken"]              == "*****"
+        values["AccessKey"]              == "*****"
+        values["PASSWORD"]               == "*****"
+        values["ldap.passwd"]            == "*****"
+        values["liquibaseProLicenseKey"] == "*****"
+        values["username"]               == "regular-user"
+        values["url"]                    == "jdbc:postgresql://host:5432/db"
+        values["driver"]                 == "org.postgresql.Driver"
     }
 
     def "clearCredentialArguments is a no-op when there are no arguments"() {

--- a/liquibase-standard/src/test/groovy/liquibase/command/CommandScopeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/command/CommandScopeTest.groovy
@@ -109,6 +109,104 @@ class CommandScopeTest extends Specification {
         e.message == "Invalid argument 'requiredArg': missing required argument"
     }
 
+    def "clearCredentialArguments redacts credential-bearing keys but leaves others"() {
+        // CWE-316 regression: credential-bearing argument values must be overwritten
+        // with "*****" so the original Strings become GC-eligible and don't linger
+        // in heap for the rest of the JVM lifetime. Non-credential keys (username,
+        // url, driver) must pass through unchanged so post-execution diagnostics
+        // still have context. Matching is case-insensitive and substring-based on
+        // the lowercased key.
+        given:
+        def scope = new CommandScope("mock")
+        scope.addArgumentValue("password",         "supersecret-pw-12345")
+        scope.addArgumentValue("apiSecret",        "secret-svc-token")
+        scope.addArgumentValue("authToken",        "bearer-xyz")
+        scope.addArgumentValue("AccessKey",        "AKIA-EXAMPLE")
+        scope.addArgumentValue("PASSWORD",         "case-insensitive-match")
+        scope.addArgumentValue("ldap.passwd",      "embedded-token-match")
+        scope.addArgumentValue("username",         "regular-user")
+        scope.addArgumentValue("url",              "jdbc:postgresql://host:5432/db")
+        scope.addArgumentValue("driver",           "org.postgresql.Driver")
+
+        when:
+        scope.clearCredentialArguments()
+        def values = scope.@argumentValues
+
+        then:
+        values["password"]    == "*****"
+        values["apiSecret"]   == "*****"
+        values["authToken"]   == "*****"
+        values["AccessKey"]   == "*****"
+        values["PASSWORD"]    == "*****"
+        values["ldap.passwd"] == "*****"
+        values["username"]    == "regular-user"
+        values["url"]         == "jdbc:postgresql://host:5432/db"
+        values["driver"]      == "org.postgresql.Driver"
+    }
+
+    def "clearCredentialArguments is a no-op when there are no arguments"() {
+        given:
+        def scope = new CommandScope("mock")
+
+        when:
+        scope.clearCredentialArguments()
+
+        then:
+        noExceptionThrown()
+        scope.@argumentValues.isEmpty()
+    }
+
+    def "execute invokes credential clearing in its outer finally on the success path"() {
+        // CWE-316 wiring check: confirms the outer finally added to execute()
+        // actually calls clearCredentialArguments(). Pre-supplies the 'requiredArg'
+        // value so this test is order-independent w.r.t. the 'execute with failing
+        // argument validation' spec that registers requiredArg as required on
+        // 'mock' (Spock test order in a single Specification is declaration-order,
+        // but the side effect of CommandBuilder is global to the JVM).
+        given:
+        def scope = new CommandScope("mock")
+        scope.addArgumentValue("requiredArg", "anything")
+        scope.addArgumentValue("password",    "supersecret-pw-12345")
+        scope.addArgumentValue("username",    "regular-user")
+
+        MockCommandStep.logic = new MockCommandStep() {
+            @Override
+            void run(CommandResultsBuilder resultsBuilder) throws Exception {
+                // no-op pipeline body — we are testing the finally-block wiring, not the step.
+            }
+        }
+
+        when:
+        scope.execute()
+
+        then:
+        scope.@argumentValues["password"]    == "*****"
+        scope.@argumentValues["requiredArg"] == "anything"
+        scope.@argumentValues["username"]    == "regular-user"
+    }
+
+    def "execute invokes credential clearing in its outer finally even when the pipeline throws"() {
+        // CWE-316 wiring check: the outer finally must run on the failure path too.
+        given:
+        def scope = new CommandScope("mock")
+        scope.addArgumentValue("requiredArg", "anything")
+        scope.addArgumentValue("password",    "supersecret-pw-12345")
+
+        MockCommandStep.logic = new MockCommandStep() {
+            @Override
+            void run(CommandResultsBuilder resultsBuilder) throws Exception {
+                throw new RuntimeException("simulated command failure")
+            }
+        }
+
+        when:
+        scope.execute()
+
+        then:
+        thrown(liquibase.exception.CommandExecutionException)
+        scope.@argumentValues["password"] == "*****"
+    }
+
     def "ValueModifiers are used in getArgumentValue"() {
         when:
         def valueModifier = new ConfiguredValueModifier<String>() {

--- a/liquibase-standard/src/test/groovy/liquibase/command/CommandScopeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/command/CommandScopeTest.groovy
@@ -161,6 +161,41 @@ class CommandScopeTest extends Specification {
         scope.@argumentValues.isEmpty()
     }
 
+    def "clearCredentialArguments uses Locale.ROOT so Turkish-locale 'I' does not break the ASCII substring match"() {
+        // CWE-316 regression for the Turkish-locale "dotless i" bug (per @coderabbitai
+        // on PR #7741): under tr-TR, bare String.toLowerCase() converts ASCII 'I' to
+        // dotless 'ı' (U+0131), so "argument__APIKEY".toLowerCase() becomes
+        // "argument__apıkey" — which does NOT contain the ASCII token "apikey". On a
+        // JVM whose default locale is Turkish (or any other locale with non-ASCII
+        // lowercasing of ASCII letters), credentials with uppercase-I keys would
+        // silently survive execute() unredacted. clearCredentialArguments() must
+        // therefore use toLowerCase(Locale.ROOT) explicitly. This test exercises the
+        // bug condition directly so the contract is locked in by CI, not just by a
+        // comment.
+        given:
+        Locale savedDefault = Locale.getDefault()
+        Locale.setDefault(Locale.forLanguageTag("tr-TR"))
+
+        def scope = new CommandScope("mock")
+        scope.addArgumentValue("argument__APIKEY",     "secret-api-key-12345")
+        scope.addArgumentValue("argument__PASSWORD",   "secret-pw-67890")
+        scope.addArgumentValue("argument__LICENSEKEY", "license-XYZ-ABC")
+        scope.addArgumentValue("argument__username",   "regular-user")
+
+        when:
+        scope.clearCredentialArguments()
+        def values = scope.@argumentValues
+
+        then:
+        values["argument__APIKEY"]     == "*****"
+        values["argument__PASSWORD"]   == "*****"
+        values["argument__LICENSEKEY"] == "*****"
+        values["argument__username"]   == "regular-user"
+
+        cleanup:
+        Locale.setDefault(savedDefault)
+    }
+
     def "execute invokes credential clearing in its outer finally on the success path"() {
         // CWE-316 wiring check: confirms the outer finally added to execute()
         // actually calls clearCredentialArguments(). Pre-supplies the 'requiredArg'

--- a/liquibase-standard/src/test/java/liquibase/integration/commandline/MainTest.java
+++ b/liquibase-standard/src/test/java/liquibase/integration/commandline/MainTest.java
@@ -18,6 +18,7 @@ import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 
@@ -67,6 +68,31 @@ public class MainTest {
         main.changeLogFile = "changelog.xml";
         messages = main.checkSetup();
         assertEquals("There should be one message from Main.checkSetup", 1, messages.size());
+    }
+
+    /**
+     * CWE-316 regression: clearCredentialFields() must null all credential-bearing
+     * String fields so they become GC-eligible after a command run. Non-credential
+     * fields (url, username) must NOT be touched - operators rely on those staying
+     * set for post-execution log/MDC entries.
+     */
+    @Test
+    public void clearCredentialFields_nulls_credentials_but_leaves_other_fields_intact() {
+        Main main = new Main();
+        main.password = "supersecret-pw-12345";
+        main.referencePassword = "supersecret-ref-67890";
+        main.liquibaseProLicenseKey = "license-key-abcdef";
+        main.username = "regular-user";
+        main.url = "jdbc:postgresql://host:5432/db";
+
+        main.clearCredentialFields();
+
+        assertNull("password must be nulled", main.password);
+        assertNull("referencePassword must be nulled", main.referencePassword);
+        assertNull("liquibaseProLicenseKey must be nulled", main.liquibaseProLicenseKey);
+        assertEquals("username must remain set after credential clearing", "regular-user", main.username);
+        assertEquals("url must remain set after credential clearing",
+                "jdbc:postgresql://host:5432/db", main.url);
     }
 
 //    @Rule


### PR DESCRIPTION
## Impact

Passwords are represented as `java.lang.String` throughout the codebase and are never explicitly zeroed — **CWE-316: Cleartext Storage of Sensitive Information in Memory**. On long-running embedded JVMs and on hosts where heap-dump / memory-forensics is part of the threat model, the credential Strings remain reachable long after the operations that needed them have finished. This is the first slice of a wider audit ticket; the cross-cutting `Credential` / `SecretString` wrapper was already explicitly deferred in #7739 as a separate spike.

This PR addresses three concrete misuses in the legacy CLI:

1. **`Main.java:1244`** — `value = new String(c.readPassword(...))`. `Console.readPassword` deliberately returns `char[]` so callers can wipe the buffer after use; wrapping in `new String(...)` and immediately discarding the `char[]` without clearing defeats the API contract. Source even comments this is the "most notable" instance in the audit.

2. **`Main.java:86, 118, 138`** — the `password`, `referencePassword`, and `liquibaseProLicenseKey` fields hold credential Strings for the lifetime of the `Main` instance. No cleanup hook exists.

3. **`CommandScope.argumentValues` (CommandScope.java:51)** — holds every command argument (including any credential-bearing keys) for the full command duration. Not cleared after `execute()` completes, so the original credential Strings remain reachable from `Scope`-adjacent code paths post-command.

## Fix

**Item 1 — Console.readPassword `char[]` zeroing.** Read into a local `char[]`, construct the `String` in `try`, `Arrays.fill('\0')` in `finally`:

```java
char[] pwdChars = c.readPassword(attributeName + ": ");
try {
    value = new String(pwdChars);
} finally {
    java.util.Arrays.fill(pwdChars, '\0');
}
```

The String copy still lives in the destination field (Strings are immutable in Java — they cannot be wiped in-place), but the original buffer is reliably zeroed.

**Item 2 — `Main.clearCredentialFields()`.** New package-private method that nulls `password`, `referencePassword`, and `liquibaseProLicenseKey`. Called from `run()`'s **outer `finally`** so it runs on success and on any `catch (Throwable)` failure path. Nulling the field is the closest Java equivalent to wiping a String — the String becomes GC-eligible if no other references hold it.

**Item 3 — `CommandScope.clearCredentialArguments()`.** New package-private method using a substring-matched credential-key denylist (`password`, `passwd`, `secret`, `token`, `apikey`, `accesskey`, `licensekey` — the last one catches `liquibaseProLicenseKey` which `Main.createLiquibaseCommand()` places into this map). The sibling PR #7739 (not yet merged) introduces the same set of tokens in `IntegrationDetails.setParameter`; the two denylists will converge to a shared helper as follow-up work once both PRs land. Overwrites matching entries with `"*****"` rather than removing them, preserving map semantics for any late-binding reader that walks the map after `execute()`. Called from a new **outer `finally`** in `execute()`.

## Tests

- **`MainTest.clearCredentialFields_nulls_credentials_but_leaves_other_fields_intact`** — verifies `password` / `referencePassword` / `liquibaseProLicenseKey` go to `null` while `username` / `url` are untouched (so post-execution diagnostics keep their context).
- **`CommandScopeTest`** adds four specs:
  - `clearCredentialArguments redacts credential-bearing keys but leaves others` — direct unit test of the denylist (case-insensitive, substring, including `PASSWORD`, `ldap.passwd`, plus pass-through for `username` / `url` / `driver`).
  - `clearCredentialArguments is a no-op when there are no arguments`.
  - `execute invokes credential clearing in its outer finally on the success path` — wiring check, order-independent (pre-supplies `requiredArg`).
  - `execute invokes credential clearing in its outer finally even when the pipeline throws`.

```
[INFO] Tests run: 32, Failures: 0, Errors: 0, Skipped: 0 -- in MainTest
[INFO] Tests run: 19, Failures: 0, Errors: 0, Skipped: 0 -- in CommandScopeTest
[INFO] Tests run: 277, Failures: 0, Errors: 0, Skipped: 0  (broader command/jdbc/database scope)
```

No regressions in the broader CommandScope-adjacent subset (`DbUrlConnectionCommandStepTest`, `HistoryCommandStepTest`, `JdbcConnectionTest`, `OfflineConnectionTest`, `ProCommandsRegistryTest`, etc.).

## Known limitations

- **Strings are immutable in Java**; nulling the field is the closest equivalent to zeroing but does not actively erase the String contents. The fix narrows the residency window but does not solve the underlying problem. The proper long-term fix is a `Credential` / `SecretString` wrapper with explicit `clear()` and `char[]` backing storage — already explicitly deferred to a follow-up spike in #7739.
- The credential-key denylist is intentionally duplicated rather than shared — the matching sibling denylist lives in PR #7739, which is still in review at the time this PR was opened. A shared `CredentialKeyDetector` is a natural follow-up once both PRs have merged and the two token lists have stabilised.

## Out of scope (separate PRs)

This ticket lists five locations; the other two get their own PRs because they are different shapes of fix:

- **`liquibase-maven-plugin/.../AbstractLiquibaseMojo.java`** — Maven Daemon (`mvnd`) keeps the JVM warm across builds, making the field hygiene meaningful. Fix shape is the same as Item 2 here, but lives in a different module with a different review surface, so it will land as a separate PR against the same audit ticket.
- **`liquibase-standard/.../ant/type/DatabaseType.java`** — Ant's `<typedef>` + `refid` model intentionally reuses the same `DatabaseType` instance across multiple tasks in a build, so the "null in `finally`" shape used here is architecturally wrong for Ant. A proper fix needs either a `BuildListener`-based hook on project end or a `DatabaseType.clearCredentials()` API invoked by specific tasks at last-use. Tracked under the same audit ticket but warrants its own design discussion.

