### PR TITLE
CWE-316: clear password fields in Maven Mojo after execute()

### DIFF
--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
@@ -469,6 +469,34 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        try {
+            runExecute();
+        } finally {
+            // CWE-316: null the credential-bearing fields so the immutable String
+            // values become GC-eligible after the Mojo finishes. Most operationally
+            // relevant under Maven Daemon (mvnd) which keeps the JVM warm across
+            // builds; without this the credential Strings would persist for the
+            // entire daemon lifetime. Subclasses that hold additional credential
+            // fields (e.g. LiquibaseDatabaseDiff.referencePassword) override
+            // clearCredentialFields() and call super to extend the cleanup.
+            clearCredentialFields();
+        }
+    }
+
+    /**
+     * Null the credential-bearing fields so their (immutable) String values become
+     * GC-eligible after the Mojo finishes. Called from {@link #execute()}'s finally
+     * so it runs on success and on failure paths, including the early skip /
+     * skipOnFileExists returns. Subclasses with additional credential fields should
+     * override and call {@code super.clearCredentialFields()}.
+     * <p>
+     * CWE-316: Cleartext Storage of Sensitive Information in Memory.
+     */
+    protected void clearCredentialFields() {
+        this.password = null;
+    }
+
+    private void runExecute() throws MojoExecutionException, MojoFailureException {
         if (StringUtil.trimToNull(logging) != null) {
             getLog().error("The liquibase-maven-plugin now manages logging via the standard maven logging config, not the 'logging' configuration. Use the -e, -X or -q flags or see https://maven.apache.org/maven-logging.html");
         }

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseDatabaseDiff.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/LiquibaseDatabaseDiff.java
@@ -231,6 +231,18 @@ public class LiquibaseDatabaseDiff extends AbstractLiquibaseChangeLogMojo {
         super.execute();
     }
 
+    /**
+     * CWE-316: extend the base {@link AbstractLiquibaseMojo#clearCredentialFields()} to
+     * also null this Mojo's reference-database credential. Invoked from the base class's
+     * execute() finally block via dynamic dispatch, so it runs after super.execute()
+     * (and therefore after performLiquibaseTask has consumed referencePassword).
+     */
+    @Override
+    protected void clearCredentialFields() {
+        super.clearCredentialFields();
+        this.referencePassword = null;
+    }
+
     @Override
     protected void performLiquibaseTask(Liquibase liquibase) throws LiquibaseException {
         ClassLoader cl = null;

--- a/liquibase-maven-plugin/src/test/java/org/liquibase/maven/plugins/AbstractLiquibaseMojoCredentialClearTest.java
+++ b/liquibase-maven-plugin/src/test/java/org/liquibase/maven/plugins/AbstractLiquibaseMojoCredentialClearTest.java
@@ -13,11 +13,13 @@ import static org.junit.Assert.assertNull;
  * CWE-316 regression tests for the credential-field nulling added to
  * {@link AbstractLiquibaseMojo} and its {@link LiquibaseDatabaseDiff} subclass.
  * <p>
- * The cleanup is invoked from {@link AbstractLiquibaseMojo#execute()}'s finally
- * block; here we test the {@code clearCredentialFields()} hook directly to avoid
- * pulling in the full Maven-plugin test harness for a memory-hygiene assertion.
- * The runtime wiring (the call from {@code execute()}'s finally) is verified by
- * code review plus Java's {@code finally} semantics.
+ * Most tests exercise {@code clearCredentialFields()} directly to avoid pulling
+ * in the full Maven-plugin test harness for a memory-hygiene assertion. The
+ * runtime wiring (the call from {@code execute()}'s finally) is additionally
+ * exercised by
+ * {@link #execute_runs_clearCredentialFields_in_finally_when_skip_short_circuits()},
+ * which lets {@code runExecute()} short-circuit on {@code skip=true} so the
+ * finally fires without needing a real Maven plugin context.
  */
 public class AbstractLiquibaseMojoCredentialClearTest {
 
@@ -74,5 +76,42 @@ public class AbstractLiquibaseMojoCredentialClearTest {
         assertNull("referencePassword must be nulled by the override", mojo.referencePassword);
         assertEquals("username must remain set", "regular-user", mojo.username);
         assertEquals("url must remain set", "jdbc:postgresql://host:5432/db", mojo.url);
+    }
+
+    /**
+     * CWE-316 wiring regression: exercise the actual {@code execute()} entry
+     * point (instead of calling {@code clearCredentialFields()} directly) so
+     * that a future refactor accidentally removing the {@code try/finally}
+     * wrapper, or breaking dynamic dispatch to the subclass's override, will
+     * fail this test.
+     * <p>
+     * Uses {@code skip=true} so {@code runExecute()} short-circuits at the
+     * skip check — no Maven plugin runtime context is needed. The
+     * {@code getLog().warn(...)} call in the skip branch is safe because
+     * Maven's {@code AbstractMojo.getLog()} lazy-initializes a
+     * {@code SystemStreamLog} when no log has been set explicitly.
+     * <p>
+     * Uses {@link LiquibaseDatabaseDiff} (not the bare {@code TestMojo}) so
+     * the test simultaneously verifies that {@code clearCredentialFields()}
+     * dispatches dynamically to the override and clears
+     * {@code referencePassword} in addition to {@code password}.
+     */
+    @Test
+    public void execute_runs_clearCredentialFields_in_finally_when_skip_short_circuits() throws Exception {
+        LiquibaseDatabaseDiff mojo = new LiquibaseDatabaseDiff();
+        mojo.skip = true;
+        // AbstractLiquibaseMojo overrides getLog() to lazy-construct a MavenLog
+        // whose constructor calls Level.valueOf(logLevel); a null logLevel would
+        // NPE on the first getLog() call in the skip branch. Provide a valid level
+        // so runExecute()'s "Liquibase skipped due to Maven configuration" warning
+        // can be emitted without bringing in a full Maven plugin context.
+        mojo.logLevel = "INFO";
+        mojo.password = "supersecret-pw-12345";
+        mojo.referencePassword = "supersecret-ref-67890";
+
+        mojo.execute();
+
+        assertNull("password must be nulled from execute() finally", mojo.password);
+        assertNull("referencePassword must be nulled via dynamic dispatch in finally", mojo.referencePassword);
     }
 }

--- a/liquibase-maven-plugin/src/test/java/org/liquibase/maven/plugins/AbstractLiquibaseMojoCredentialClearTest.java
+++ b/liquibase-maven-plugin/src/test/java/org/liquibase/maven/plugins/AbstractLiquibaseMojoCredentialClearTest.java
@@ -1,0 +1,78 @@
+package org.liquibase.maven.plugins;
+
+import liquibase.Liquibase;
+import liquibase.exception.LiquibaseException;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * CWE-316 regression tests for the credential-field nulling added to
+ * {@link AbstractLiquibaseMojo} and its {@link LiquibaseDatabaseDiff} subclass.
+ * <p>
+ * The cleanup is invoked from {@link AbstractLiquibaseMojo#execute()}'s finally
+ * block; here we test the {@code clearCredentialFields()} hook directly to avoid
+ * pulling in the full Maven-plugin test harness for a memory-hygiene assertion.
+ * The runtime wiring (the call from {@code execute()}'s finally) is verified by
+ * code review plus Java's {@code finally} semantics.
+ */
+public class AbstractLiquibaseMojoCredentialClearTest {
+
+    /**
+     * Bare concrete subclass of {@link AbstractLiquibaseMojo} — supplies the
+     * one abstract method so the class is instantiable. We do not invoke
+     * {@code execute()} here; we only need a valid concrete subclass to exercise
+     * {@code clearCredentialFields()}.
+     */
+    private static final class TestMojo extends AbstractLiquibaseMojo {
+        @Override
+        protected void performLiquibaseTask(Liquibase liquibase) throws LiquibaseException {
+            // not invoked in these tests
+        }
+    }
+
+    @Test
+    public void clearCredentialFields_nulls_password_but_leaves_other_fields_intact() {
+        TestMojo mojo = new TestMojo();
+        mojo.password = "supersecret-pw-12345";
+        mojo.username = "regular-user";
+        mojo.url = "jdbc:postgresql://host:5432/db";
+        mojo.driver = "org.postgresql.Driver";
+
+        mojo.clearCredentialFields();
+
+        assertNull("password must be nulled", mojo.password);
+        assertEquals("username must remain set", "regular-user", mojo.username);
+        assertEquals("url must remain set", "jdbc:postgresql://host:5432/db", mojo.url);
+        assertEquals("driver must remain set", "org.postgresql.Driver", mojo.driver);
+    }
+
+    @Test
+    public void clearCredentialFields_is_idempotent_when_password_already_null() {
+        TestMojo mojo = new TestMojo();
+        mojo.password = null;
+
+        mojo.clearCredentialFields();
+
+        assertNull(mojo.password);
+    }
+
+    @Test
+    public void liquibaseDatabaseDiff_override_nulls_password_and_referencePassword() {
+        LiquibaseDatabaseDiff mojo = new LiquibaseDatabaseDiff();
+        mojo.password = "supersecret-pw-12345";
+        mojo.referencePassword = "supersecret-ref-67890";
+        mojo.username = "regular-user";
+        mojo.url = "jdbc:postgresql://host:5432/db";
+
+        mojo.clearCredentialFields();
+
+        assertNull("password must be nulled by super.clearCredentialFields()", mojo.password);
+        assertNull("referencePassword must be nulled by the override", mojo.referencePassword);
+        assertEquals("username must remain set", "regular-user", mojo.username);
+        assertEquals("url must remain set", "jdbc:postgresql://host:5432/db", mojo.url);
+    }
+}


### PR DESCRIPTION
## Impact

Companion to #7741 — same root cause (`java.lang.String` passwords never zeroed; **CWE-316**) applied to the `liquibase-maven-plugin` module. The Maven plugin holds credential Strings in two fields:

- `AbstractLiquibaseMojo.password` (line 123) — primary DB password injected by Maven from `@parameter property="liquibase.password"` or assigned from the configured wagon server.
- `LiquibaseDatabaseDiff.referencePassword` (line 75) — reference-database password used by the `diff` Mojo.

**Maven Daemon (`mvnd`) keeps the JVM warm across builds**, so without explicit clearing these credential Strings persist for the entire daemon lifetime — exactly the long-running embedded scenario the audit calls out. Plain `mvn` invocations exit per build so the residency window is shorter, but defense-in-depth still makes sense for the same reasons covered in #7741's PR body.

## Fix

**1. `AbstractLiquibaseMojo`** — extract the existing `execute()` body verbatim into a new private `runExecute()`, and have `execute()` wrap that call in `try { runExecute(); } finally { clearCredentialFields(); }`. Defines a new `protected void clearCredentialFields()` that nulls `password`. The wrapper is small (12 lines), and the moved body is byte-for-byte identical to the pre-change `execute()` — reviewers can confirm by inspection.

```java
@Override
public void execute() throws MojoExecutionException, MojoFailureException {
    try {
        runExecute();
    } finally {
        clearCredentialFields();
    }
}

protected void clearCredentialFields() {
    this.password = null;
}

private void runExecute() throws MojoExecutionException, MojoFailureException {
    // ... existing body, unchanged ...
}
```

**2. `LiquibaseDatabaseDiff`** — override `clearCredentialFields()` to `super.clearCredentialFields()` (nulls `password`) then null `referencePassword`. The override is invoked via dynamic dispatch from the base class's `finally`, which runs *after* `super.execute()` has finished — by which time `performLiquibaseTask` has already consumed `referencePassword`.

```java
@Override
protected void clearCredentialFields() {
    super.clearCredentialFields();
    this.referencePassword = null;
}
```

## Test

New `AbstractLiquibaseMojoCredentialClearTest`:

- `clearCredentialFields_nulls_password_but_leaves_other_fields_intact` — uses a small concrete subclass of `AbstractLiquibaseMojo`. Asserts `password` → `null`, `username` / `url` / `driver` remain set.
- `clearCredentialFields_is_idempotent_when_password_already_null` — double-clear safety.
- `liquibaseDatabaseDiff_override_nulls_password_and_referencePassword` — exercises the subclass override path; asserts BOTH fields nulled while `username` / `url` remain set.
- `execute_runs_clearCredentialFields_in_finally_when_skip_short_circuits` — added in the CodeRabbit follow-up (commit `6a06d44d2`); the only spec that exercises the actual `execute()` → `try/finally` runtime wiring (the three above call `clearCredentialFields()` directly). Constructs a `LiquibaseDatabaseDiff`, sets `skip = true` so `runExecute()` short-circuits before any Maven plugin context is needed, sets `logLevel = "INFO"` to avoid the `Level.valueOf(null)` NPE in `AbstractLiquibaseMojo.getLog()`'s lazy-initialised `MavenLog`, then calls `mojo.execute()` and asserts both `password` and `referencePassword` were nulled. A future refactor that accidentally removes the `try/finally` wrapper or breaks dynamic dispatch to the subclass override will fail this spec loudly.

```
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0 -- in AbstractLiquibaseMojoCredentialClearTest
[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0  (full liquibase-maven-plugin suite)
```

Pre-existing 16 Mojo tests pass unchanged (16 pre-existing + 4 new = 20 total).

## Design notes

- The runtime wiring (the call from `execute()`'s `finally`) is verified by code review plus Java's `finally` semantics rather than by an integration test, because integration-testing `execute()` properly requires the full Maven Mojo test harness and an embedded database. The hook function (`clearCredentialFields()`) is the part with branching behaviour, and it is tested directly.
- I deliberately did NOT make `execute()` `final`. `LiquibaseDatabaseDiff` already overrides it (calls `super.execute()` at line 231 after pre-populating `referencePassword` from the wagon), and locking the wrapper would break that. Future subclasses that override `execute()` should call `super.execute()` to get credential clearing; this is the same contract that already exists for getting the rest of the lifecycle.
- Method-split rather than inline `try/finally` keeps the diff small — reviewers see one new wrapper + one rename, instead of a 150-line indentation change in `git diff`.

## Known limitation (same as #7741)

Strings are immutable in Java; nulling the field is the closest equivalent to wiping the contents but does not actively erase the String value from the constant pool / interned cache. The proper long-term fix is a `Credential` / `SecretString` wrapper with explicit `clear()` and `char[]` backing storage, **already explicitly deferred to a follow-up spike in #7739**.

## Related

- #7741 — CWE-316 sibling for `liquibase-standard` (legacy CLI `Main.java` + `CommandScope.argumentValues`). Same audit ticket; same CWE; same `clearCredentialFields()` shape; different module.

