### PR TITLE
CWE-316: clear Ant DatabaseType credentials at buildFinished

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/integration/ant/type/ConnectionProperties.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/ant/type/ConnectionProperties.java
@@ -5,9 +5,24 @@ import org.apache.tools.ant.types.PropertySet;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Properties;
 
 public class ConnectionProperties {
+
+    /**
+     * Substring tokens (lowercase) that mark a {@code <connectionProperty>} as
+     * credential-bearing for the {@link #clearCredentialValues()} sweep. Matched
+     * case-insensitively against the lowercased property name via
+     * {@link Locale#ROOT} so the Turkish-locale dotless-i quirk does not cause
+     * an {@code I} in {@code APIKEY} to map to {@code ı} and miss the
+     * {@code apikey} token. Mirrors the analogous denylists used elsewhere in
+     * the May-2026 OSS credential-handling audit (CommandScope, IntegrationDetails).
+     */
+    private static final String[] CREDENTIAL_NAME_TOKENS = {
+            "password", "passwd", "secret", "token", "apikey", "accesskey", "credentials"
+    };
+
     private final List<PropertySet> propertySets;
     private final List<Property> properties;
 
@@ -34,5 +49,33 @@ public class ConnectionProperties {
 
     public void addConnectionProperty(Property property) {
         properties.add(property);
+    }
+
+    /**
+     * Overwrites the value of any {@code <connectionProperty>} whose name marks it as
+     * credential-bearing (per {@link #CREDENTIAL_NAME_TOKENS}) with {@code "*****"} so
+     * the raw credential String no longer lives in this object after the Ant build
+     * finishes. Called from {@link DatabaseType#clearCredentials()}'s buildFinished
+     * listener (CWE-316: Cleartext Storage of Sensitive Information in Memory).
+     * <p>
+     * Note: this method intentionally does <em>not</em> touch {@link #propertySets}.
+     * Those entries reference Project-level property sets owned by the surrounding
+     * Ant build, not the {@code DatabaseType} itself; clearing them would mutate
+     * unrelated build state.
+     */
+    void clearCredentialValues() {
+        for (Property property : properties) {
+            String name = property.getName();
+            if (name == null) {
+                continue;
+            }
+            String lowerName = name.toLowerCase(Locale.ROOT);
+            for (String token : CREDENTIAL_NAME_TOKENS) {
+                if (lowerName.contains(token)) {
+                    property.setValue("*****");
+                    break;
+                }
+            }
+        }
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/integration/ant/type/DatabaseType.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/ant/type/DatabaseType.java
@@ -320,7 +320,7 @@ public class DatabaseType extends DataType {
         if (credentialCleanupRegistered) {
             return;
         }
-        Project project = getProject();
+        final Project project = getProject();
         if (project == null) {
             return;
         }
@@ -334,7 +334,18 @@ public class DatabaseType extends DataType {
                     // One-shot: detach the listener so it (and the DatabaseType
                     // it closes over) can be GC'd in long-lived embedded Ant
                     // scenarios where the Project survives across many builds.
-                    event.getProject().removeBuildListener(this);
+                    // Use the captured `project` instead of event.getProject()
+                    // so the deregister target is the same Project we attached
+                    // to, regardless of which Project fired the event.
+                    project.removeBuildListener(this);
+                    // Reset the idempotency flag so a SUBSEQUENT build on the
+                    // same DatabaseType instance — possible in long-lived
+                    // embedded hosts that reuse DataType instances across
+                    // builds — can register a fresh listener. Without this
+                    // reset, build 1's credentials would be cleared but build
+                    // 2 and onward would silently skip re-registration (per
+                    // @coderabbitai's review on #7743).
+                    credentialCleanupRegistered = false;
                 }
             }
             @Override public void targetStarted(BuildEvent event) {}

--- a/liquibase-standard/src/main/java/liquibase/integration/ant/type/DatabaseType.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/ant/type/DatabaseType.java
@@ -4,7 +4,9 @@ import liquibase.database.Database;
 import liquibase.database.DatabaseFactory;
 import liquibase.exception.DatabaseException;
 import liquibase.resource.ResourceAccessor;
+import org.apache.tools.ant.BuildEvent;
 import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.BuildListener;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.types.DataType;
 import org.apache.tools.ant.types.Reference;
@@ -35,11 +37,14 @@ public class DatabaseType extends DataType {
     private String databaseChangeLogLockTableName;
     private String liquibaseTablespaceName;
 
+    private boolean credentialCleanupRegistered = false;
+
     public DatabaseType(Project project) {
         setProject(project);
     }
 
     public Database createDatabase(ResourceAccessor resourceAccessor) {
+        registerCredentialCleanup();
         logParameters();
         validateParameters();
         try {
@@ -278,5 +283,73 @@ public class DatabaseType extends DataType {
 
     public void setLiquibaseTablespaceName(String liquibaseTablespaceName) {
         this.liquibaseTablespaceName = liquibaseTablespaceName;
+    }
+
+    /**
+     * Register a one-shot Project BuildListener that nulls this DatabaseType's
+     * credential fields when the Ant build finishes (CWE-316: Cleartext Storage
+     * of Sensitive Information in Memory). Idempotent — only the first call per
+     * instance registers the listener.
+     * <p>
+     * <b>Why <code>buildFinished</code> and not at task end?</b> Ant's
+     * <code>&lt;typedef&gt;</code> + <code>databaseRef</code> pattern is
+     * specifically designed to let multiple tasks share a single
+     * <code>&lt;database id="…"&gt;</code> definition (e.g. an update followed
+     * by a rollback followed by a status check, all pointing at the same DB).
+     * Clearing credentials at task end would break the second and third tasks.
+     * <code>buildFinished</code> fires after the very last task on the project,
+     * so credentials are gone before the JVM idles but never while another task
+     * still needs them.
+     * <p>
+     * Called automatically from {@link #createDatabase(ResourceAccessor)} so any
+     * Ant task that consumes this type opts in implicitly; package-private
+     * accessibility allows direct testing.
+     */
+    void registerCredentialCleanup() {
+        if (credentialCleanupRegistered) {
+            return;
+        }
+        Project project = getProject();
+        if (project == null) {
+            return;
+        }
+        credentialCleanupRegistered = true;
+        project.addBuildListener(new BuildListener() {
+            @Override public void buildStarted(BuildEvent event) {}
+            @Override public void buildFinished(BuildEvent event) {
+                clearCredentials();
+            }
+            @Override public void targetStarted(BuildEvent event) {}
+            @Override public void targetFinished(BuildEvent event) {}
+            @Override public void taskStarted(BuildEvent event) {}
+            @Override public void taskFinished(BuildEvent event) {}
+            @Override public void messageLogged(BuildEvent event) {}
+        });
+    }
+
+    /**
+     * Null the credential-bearing fields. Strings are immutable in Java and
+     * cannot be wiped in place; nulling the field is the closest equivalent and
+     * makes the String GC-eligible if no other references hold it.
+     * <p>
+     * For refid-based shells whose getters delegate to a referenced
+     * <code>DatabaseType</code> (the typedef+databaseRef pattern), also clear
+     * the referenced instance's credentials so the actual shared field is
+     * wiped. Safe to call multiple times on the same referenced instance —
+     * subsequent calls are no-ops because the field is already null.
+     */
+    void clearCredentials() {
+        this.password = null;
+        if (isReference()) {
+            try {
+                Object ref = getCheckedRef();
+                if (ref instanceof DatabaseType) {
+                    ((DatabaseType) ref).clearCredentials();
+                }
+            } catch (BuildException ignored) {
+                // The referenced object may no longer be resolvable at buildFinished
+                // time (project tear-down). The local shell's field is already null.
+            }
+        }
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/integration/ant/type/DatabaseType.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/ant/type/DatabaseType.java
@@ -358,6 +358,18 @@ public class DatabaseType extends DataType {
      */
     void clearCredentials() {
         this.password = null;
+        // Also wipe credential-bearing <connectionProperty> values — per
+        // @filipelautert's review on #7743, a build that uses
+        //   <connectionProperty name="password" value="hunter2"/>
+        // instead of (or in addition to) <password> would otherwise leave the
+        // raw value sitting in the Property list past buildFinished. Walk only
+        // the local connectionProperties — for refid shells, setRefid() rejects
+        // any locally-set attribute, so connectionProperties is always null on
+        // the shell; the referenced DatabaseType's connectionProperties get
+        // cleared via the refid traversal below.
+        if (this.connectionProperties != null) {
+            this.connectionProperties.clearCredentialValues();
+        }
         if (isReference()) {
             try {
                 // Type-safe Ant API (since 1.8) — the zero-arg getCheckedRef() form is

--- a/liquibase-standard/src/main/java/liquibase/integration/ant/type/DatabaseType.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/ant/type/DatabaseType.java
@@ -342,13 +342,16 @@ public class DatabaseType extends DataType {
         this.password = null;
         if (isReference()) {
             try {
-                Object ref = getCheckedRef();
-                if (ref instanceof DatabaseType) {
-                    ((DatabaseType) ref).clearCredentials();
-                }
+                // Type-safe Ant API (since 1.8) — the zero-arg getCheckedRef() form is
+                // deprecated. getCheckedRef(Class, String) returns the dereferenced
+                // value already cast, or throws BuildException if the refid does not
+                // resolve to a DatabaseType (which is the only valid use here).
+                DatabaseType ref = getCheckedRef(DatabaseType.class, "database");
+                ref.clearCredentials();
             } catch (BuildException ignored) {
                 // The referenced object may no longer be resolvable at buildFinished
-                // time (project tear-down). The local shell's field is already null.
+                // time (project tear-down), or the refid may point to a non-DatabaseType.
+                // The local shell's field is already null.
             }
         }
     }

--- a/liquibase-standard/src/main/java/liquibase/integration/ant/type/DatabaseType.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/ant/type/DatabaseType.java
@@ -301,6 +301,17 @@ public class DatabaseType extends DataType {
      * so credentials are gone before the JVM idles but never while another task
      * still needs them.
      * <p>
+     * <b>Why the listener deregisters itself.</b> In a one-shot Ant CLI build the
+     * Project is GC'd after the build and the listener with it. But the audit
+     * threat model specifically covers long-running embedded hosts (Ant embedded
+     * in a build daemon, IDE plugin, MPS-style tool) that reuse one Project
+     * across many builds. Without explicit deregistration, every new DatabaseType
+     * would permanently add a listener; each listener holds a strong reference to
+     * its closed-over DatabaseType, accumulating empty (post-clear) shells for
+     * the host's lifetime — exactly the residency-window problem the rest of this
+     * audit slice is narrowing. {@code event.getProject().removeBuildListener(this)}
+     * inside {@code buildFinished} makes the listener truly one-shot.
+     * <p>
      * Called automatically from {@link #createDatabase(ResourceAccessor)} so any
      * Ant task that consumes this type opts in implicitly; package-private
      * accessibility allows direct testing.
@@ -317,7 +328,14 @@ public class DatabaseType extends DataType {
         project.addBuildListener(new BuildListener() {
             @Override public void buildStarted(BuildEvent event) {}
             @Override public void buildFinished(BuildEvent event) {
-                clearCredentials();
+                try {
+                    clearCredentials();
+                } finally {
+                    // One-shot: detach the listener so it (and the DatabaseType
+                    // it closes over) can be GC'd in long-lived embedded Ant
+                    // scenarios where the Project survives across many builds.
+                    event.getProject().removeBuildListener(this);
+                }
             }
             @Override public void targetStarted(BuildEvent event) {}
             @Override public void targetFinished(BuildEvent event) {}

--- a/liquibase-standard/src/test/java/liquibase/integration/ant/type/DatabaseTypeCredentialClearTest.java
+++ b/liquibase-standard/src/test/java/liquibase/integration/ant/type/DatabaseTypeCredentialClearTest.java
@@ -150,4 +150,59 @@ public class DatabaseTypeCredentialClearTest {
         shell.clearCredentials();
         assertTrue("clearCredentials must not throw on a dangling refid", true);
     }
+
+    @Test
+    public void registerCredentialCleanup_listener_deregisters_itself_after_firing() {
+        // CWE-316 regression for the long-lived embedded Ant case (per @wwillard7800's
+        // review on #7743). In one-shot Ant CLI builds the Project is GC'd after the
+        // build and any attached listeners go with it. In embedded hosts that reuse a
+        // single Project across many builds (build daemons, IDE plugins, MPS-style
+        // tools), each new DatabaseType would otherwise add a permanent listener that
+        // holds a strong reference back to the (now-cleared) DatabaseType — defeating
+        // the residency-window goal this PR series is trying to achieve. The listener
+        // must deregister itself from the Project once buildFinished fires.
+        Project project = new Project();
+        int listenerCountBefore = project.getBuildListeners().size();
+
+        DatabaseType type = new DatabaseType(project);
+        type.setPassword("supersecret-pw-12345");
+        type.registerCredentialCleanup();
+
+        // Sanity: the listener was registered.
+        assertEquals("registerCredentialCleanup must add exactly one BuildListener",
+                listenerCountBefore + 1, project.getBuildListeners().size());
+
+        // Fire buildFinished — listener should run clearCredentials AND remove itself.
+        project.fireBuildFinished(null);
+
+        assertNull("password must be nulled when buildFinished fires", type.getPassword());
+        assertEquals("listener must deregister itself from the Project after firing",
+                listenerCountBefore, project.getBuildListeners().size());
+    }
+
+    @Test
+    public void multiple_databaseTypes_all_deregister_their_listeners_in_embedded_scenario() {
+        // CWE-316 regression for accumulation (per @wwillard7800): in a long-lived
+        // embedded Ant host that reuses one Project across N builds, N DatabaseType
+        // instances should result in zero residual listeners after all builds finish —
+        // not N listeners stuck holding references to empty DatabaseType shells.
+        Project project = new Project();
+        int listenerCountBefore = project.getBuildListeners().size();
+
+        DatabaseType firstBuild  = new DatabaseType(project);
+        DatabaseType secondBuild = new DatabaseType(project);
+        DatabaseType thirdBuild  = new DatabaseType(project);
+        firstBuild.registerCredentialCleanup();
+        secondBuild.registerCredentialCleanup();
+        thirdBuild.registerCredentialCleanup();
+
+        assertEquals("three DatabaseType instances must register three distinct listeners",
+                listenerCountBefore + 3, project.getBuildListeners().size());
+
+        // One buildFinished cycle drains all three at once.
+        project.fireBuildFinished(null);
+
+        assertEquals("all three listeners must deregister themselves — no accumulation",
+                listenerCountBefore, project.getBuildListeners().size());
+    }
 }

--- a/liquibase-standard/src/test/java/liquibase/integration/ant/type/DatabaseTypeCredentialClearTest.java
+++ b/liquibase-standard/src/test/java/liquibase/integration/ant/type/DatabaseTypeCredentialClearTest.java
@@ -1,0 +1,153 @@
+package liquibase.integration.ant.type;
+
+import org.apache.tools.ant.BuildListener;
+import org.apache.tools.ant.Project;
+import org.junit.Test;
+
+import java.util.Vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * CWE-316 regression tests for the credential-clearing mechanism added to
+ * {@link DatabaseType}. We exercise the {@code clearCredentials()} method and
+ * the {@code registerCredentialCleanup()} listener-registration directly,
+ * including the refid traversal — running through a full Ant build with a real
+ * database would require the broader Ant test harness, but the listener
+ * contract (Project fires {@code buildFinished} after the last task) is
+ * well-defined and tested by Ant itself.
+ */
+public class DatabaseTypeCredentialClearTest {
+
+    @Test
+    public void clearCredentials_nulls_password_on_a_simple_databaseType() {
+        Project project = new Project();
+        DatabaseType type = new DatabaseType(project);
+        type.setUrl("jdbc:h2:mem:test");
+        type.setUser("regular-user");
+        type.setPassword("supersecret-pw-12345");
+
+        type.clearCredentials();
+
+        assertNull("password must be nulled", type.getPassword());
+        assertEquals("user must remain set", "regular-user", type.getUser());
+        assertEquals("url must remain set", "jdbc:h2:mem:test", type.getUrl());
+    }
+
+    @Test
+    public void clearCredentials_traverses_refid_and_clears_the_referenced_instance() {
+        // Simulate the typedef+databaseRef pattern: a referenced DatabaseType
+        // (id="mydb") that holds the actual credential, plus a local "shell"
+        // DatabaseType whose getters delegate to the referenced one. The
+        // local shell's clearCredentials must follow the refid to the actual
+        // shared instance so the password Strings on the referenced field
+        // also become GC-eligible.
+        Project project = new Project();
+        DatabaseType referenced = new DatabaseType(project);
+        referenced.setUrl("jdbc:h2:mem:shared");
+        referenced.setUser("regular-user");
+        referenced.setPassword("supersecret-pw-12345");
+        project.addReference("mydb", referenced);
+
+        DatabaseType shell = new DatabaseType(project);
+        org.apache.tools.ant.types.Reference ref = new org.apache.tools.ant.types.Reference(project, "mydb");
+        shell.setRefid(ref);
+
+        // Sanity check: the shell's getPassword delegates to the referenced.
+        assertEquals("supersecret-pw-12345", shell.getPassword());
+
+        shell.clearCredentials();
+
+        assertNull("referenced password must be nulled via refid traversal", referenced.getPassword());
+        assertNull("shell's delegating getPassword must reflect the cleared value", shell.getPassword());
+        assertEquals("user must remain set on the referenced", "regular-user", referenced.getUser());
+    }
+
+    @Test
+    public void registerCredentialCleanup_registers_a_BuildListener_that_fires_on_buildFinished() {
+        Project project = new Project();
+        DatabaseType type = new DatabaseType(project);
+        type.setPassword("supersecret-pw-12345");
+
+        int listenerCountBefore = project.getBuildListeners().size();
+        type.registerCredentialCleanup();
+        int listenerCountAfter = project.getBuildListeners().size();
+
+        assertEquals("registerCredentialCleanup must add exactly one BuildListener",
+                listenerCountBefore + 1, listenerCountAfter);
+
+        // Fire buildFinished and verify the password is nulled.
+        project.fireBuildFinished(null);
+        assertNull("password must be nulled when the Project fires buildFinished",
+                type.getPassword());
+    }
+
+    @Test
+    public void registerCredentialCleanup_is_idempotent() {
+        // Multiple Ant tasks consuming the same DatabaseType (whether by
+        // <database> nesting or by databaseRef) will each call createDatabase,
+        // which in turn calls registerCredentialCleanup. Only the first call
+        // should register a listener; subsequent calls must be no-ops.
+        Project project = new Project();
+        DatabaseType type = new DatabaseType(project);
+
+        int listenerCountBefore = project.getBuildListeners().size();
+        type.registerCredentialCleanup();
+        type.registerCredentialCleanup();
+        type.registerCredentialCleanup();
+        int listenerCountAfter = project.getBuildListeners().size();
+
+        assertEquals("registerCredentialCleanup must be idempotent on the same DatabaseType",
+                listenerCountBefore + 1, listenerCountAfter);
+    }
+
+    @Test
+    public void registerCredentialCleanup_listener_only_implements_buildFinished_meaningfully() {
+        // The listener must not throw or have side effects on the non-credential
+        // lifecycle events (targetStarted, taskStarted, etc.) — those fire during
+        // the build and we cannot null the password yet.
+        Project project = new Project();
+        DatabaseType type = new DatabaseType(project);
+        type.setPassword("supersecret-pw-12345");
+
+        type.registerCredentialCleanup();
+
+        Vector<BuildListener> listeners = project.getBuildListeners();
+        BuildListener last = listeners.lastElement();
+        assertNotNull(last);
+
+        // Fire the during-build events; password must still be present.
+        org.apache.tools.ant.BuildEvent event = new org.apache.tools.ant.BuildEvent(project);
+        last.buildStarted(event);
+        last.targetStarted(event);
+        last.taskStarted(event);
+        last.taskFinished(event);
+        last.targetFinished(event);
+        last.messageLogged(event);
+        assertEquals("password must be retained during the build",
+                "supersecret-pw-12345", type.getPassword());
+
+        // Now fire buildFinished and verify clearing.
+        last.buildFinished(event);
+        assertNull("password must be nulled at buildFinished", type.getPassword());
+    }
+
+    @Test
+    public void clearCredentials_is_safe_on_a_refid_shell_whose_referenced_was_dropped() {
+        // Defensive: if the project tear-down removed the reference before our
+        // BuildListener fires (unusual but possible), clearCredentials must not
+        // throw — it should still null its own (empty) field cleanly.
+        Project project = new Project();
+        DatabaseType shell = new DatabaseType(project);
+        org.apache.tools.ant.types.Reference ref =
+                new org.apache.tools.ant.types.Reference(project, "no-such-ref");
+        shell.setRefid(ref);
+
+        // No exception expected — clearCredentials catches BuildException from getCheckedRef.
+        shell.clearCredentials();
+        assertTrue("clearCredentials must not throw on a dangling refid", true);
+    }
+}

--- a/liquibase-standard/src/test/java/liquibase/integration/ant/type/DatabaseTypeCredentialClearTest.java
+++ b/liquibase-standard/src/test/java/liquibase/integration/ant/type/DatabaseTypeCredentialClearTest.java
@@ -324,4 +324,48 @@ public class DatabaseTypeCredentialClearTest {
         p.setValue(value);
         return p;
     }
+
+    @Test
+    public void registerCredentialCleanup_resets_idempotency_flag_so_subsequent_builds_re_register() {
+        // CWE-316 regression for @coderabbitai's review on #7743: the one-shot
+        // BuildListener calls removeBuildListener(this) at buildFinished but
+        // (pre-fix) never reset credentialCleanupRegistered. In long-lived
+        // embedded hosts that reuse one DatabaseType across multiple builds,
+        // build 1's credentials would be cleared but build 2's registerCredentialCleanup
+        // would early-return on the stale flag — no listener registered — and
+        // build 2's credentials would silently survive.
+        Project project = new Project();
+        int listenerCountBefore = project.getBuildListeners().size();
+
+        DatabaseType type = new DatabaseType(project);
+
+        // ----- Build 1 cycle -----
+        type.setPassword("build-1-pw");
+        type.registerCredentialCleanup();
+        assertEquals("build 1: listener attached", listenerCountBefore + 1, project.getBuildListeners().size());
+
+        project.fireBuildFinished(null);
+        assertNull("build 1: password cleared at buildFinished", type.getPassword());
+        assertEquals("build 1: listener detached at buildFinished", listenerCountBefore, project.getBuildListeners().size());
+
+        // ----- Build 2 cycle on the SAME DatabaseType instance -----
+        // This is the case CodeRabbit flagged. Without the idempotency-flag
+        // reset, registerCredentialCleanup() would early-return on the stale
+        // flag and the new password would survive past buildFinished.
+        type.setPassword("build-2-pw");
+        type.registerCredentialCleanup();
+        assertEquals("build 2: listener re-attached (idempotency flag was reset)",
+                listenerCountBefore + 1, project.getBuildListeners().size());
+
+        project.fireBuildFinished(null);
+        assertNull("build 2: password cleared at buildFinished", type.getPassword());
+        assertEquals("build 2: listener detached at buildFinished", listenerCountBefore, project.getBuildListeners().size());
+
+        // ----- Build 3 cycle (one more, to lock the contract for N builds) -----
+        type.setPassword("build-3-pw");
+        type.registerCredentialCleanup();
+        project.fireBuildFinished(null);
+        assertNull("build 3: password cleared", type.getPassword());
+        assertEquals("build 3: listener detached", listenerCountBefore, project.getBuildListeners().size());
+    }
 }

--- a/liquibase-standard/src/test/java/liquibase/integration/ant/type/DatabaseTypeCredentialClearTest.java
+++ b/liquibase-standard/src/test/java/liquibase/integration/ant/type/DatabaseTypeCredentialClearTest.java
@@ -205,4 +205,123 @@ public class DatabaseTypeCredentialClearTest {
         assertEquals("all three listeners must deregister themselves — no accumulation",
                 listenerCountBefore, project.getBuildListeners().size());
     }
+
+    @Test
+    public void clearCredentials_wipes_credential_bearing_connectionProperty_values() {
+        // CWE-316 regression for @filipelautert's review gap on #7743: a build that
+        // uses <connectionProperty name="password" value="hunter2"/> instead of (or in
+        // addition to) <password> would otherwise leave the raw value in the Property
+        // list past buildFinished. clearCredentials() must walk connectionProperties
+        // and overwrite credential-bearing values.
+        Project project = new Project();
+        DatabaseType type = new DatabaseType(project);
+        type.setUrl("jdbc:h2:mem:test");
+        type.setUser("regular-user");
+
+        ConnectionProperties props = new ConnectionProperties();
+        org.apache.tools.ant.taskdefs.Property credentialProp = new org.apache.tools.ant.taskdefs.Property();
+        credentialProp.setProject(project);
+        credentialProp.setName("password");
+        credentialProp.setValue("hunter2");
+        props.addConnectionProperty(credentialProp);
+
+        org.apache.tools.ant.taskdefs.Property nonCredentialProp = new org.apache.tools.ant.taskdefs.Property();
+        nonCredentialProp.setProject(project);
+        nonCredentialProp.setName("connectTimeout");
+        nonCredentialProp.setValue("30000");
+        props.addConnectionProperty(nonCredentialProp);
+
+        type.addConnectionProperties(props);
+
+        type.clearCredentials();
+
+        assertEquals("credential-bearing <connectionProperty> value must be wiped",
+                "*****", credentialProp.getValue());
+        assertEquals("non-credential <connectionProperty> value must pass through unchanged",
+                "30000", nonCredentialProp.getValue());
+    }
+
+    @Test
+    public void clearCredentials_matches_credential_property_names_case_insensitively_locale_safe() {
+        // CWE-316 regression: case-insensitive substring matching must use
+        // Locale.ROOT — the Turkish "I" → "ı" quirk would otherwise let
+        // <connectionProperty name="APIKEY" .../> escape the sweep on a JVM
+        // whose default locale is Turkish. Also exercises a few common
+        // credential-naming variants to lock the denylist coverage in.
+        Project project = new Project();
+        DatabaseType type = new DatabaseType(project);
+        type.setUrl("jdbc:h2:mem:test");
+
+        ConnectionProperties props = new ConnectionProperties();
+        org.apache.tools.ant.taskdefs.Property[] credentialProps = new org.apache.tools.ant.taskdefs.Property[]{
+                makeProp(project, "PASSWORD",            "uppercase-pw"),
+                makeProp(project, "Passwd",              "mixed-pw"),
+                makeProp(project, "APIKEY",              "uppercase-i-key"),
+                makeProp(project, "client_secret",       "embedded-secret"),
+                makeProp(project, "accessKey",           "aws-key"),
+                makeProp(project, "awsCredentials",      "creds-blob"),
+                makeProp(project, "ldap.bearerToken",    "embedded-token-name"),
+        };
+        for (org.apache.tools.ant.taskdefs.Property p : credentialProps) {
+            props.addConnectionProperty(p);
+        }
+        // A non-credential property among them to verify no over-masking.
+        org.apache.tools.ant.taskdefs.Property nonCred = makeProp(project, "fetchSize", "1000");
+        props.addConnectionProperty(nonCred);
+
+        // Set Turkish locale for the duration of the call so the Locale.ROOT
+        // guarantee is actually exercised (a bare String.toLowerCase() would
+        // turn "APIKEY" into "apıkey" with dotless ı under tr-TR and miss
+        // the "apikey" token).
+        java.util.Locale savedDefault = java.util.Locale.getDefault();
+        try {
+            java.util.Locale.setDefault(java.util.Locale.forLanguageTag("tr-TR"));
+            type.addConnectionProperties(props);
+            type.clearCredentials();
+        } finally {
+            java.util.Locale.setDefault(savedDefault);
+        }
+
+        for (org.apache.tools.ant.taskdefs.Property p : credentialProps) {
+            assertEquals("credential-named property '" + p.getName() + "' must be wiped",
+                    "*****", p.getValue());
+        }
+        assertEquals("non-credential property must pass through",
+                "1000", nonCred.getValue());
+    }
+
+    @Test
+    public void clearCredentials_traverses_refid_and_wipes_referenced_connectionProperty_values() {
+        // CWE-316 regression: the typedef+databaseRef pattern shares one
+        // DatabaseType (with its connectionProperties) across many tasks. The
+        // refid traversal in clearCredentials must reach the referenced
+        // ConnectionProperties so the actual shared Property list is wiped.
+        Project project = new Project();
+        DatabaseType referenced = new DatabaseType(project);
+        referenced.setUrl("jdbc:h2:mem:shared");
+
+        ConnectionProperties props = new ConnectionProperties();
+        org.apache.tools.ant.taskdefs.Property pw = makeProp(project, "password", "shared-pw");
+        props.addConnectionProperty(pw);
+        referenced.addConnectionProperties(props);
+
+        project.addReference("mydb", referenced);
+
+        DatabaseType shell = new DatabaseType(project);
+        org.apache.tools.ant.types.Reference ref = new org.apache.tools.ant.types.Reference(project, "mydb");
+        shell.setRefid(ref);
+
+        shell.clearCredentials();
+
+        assertEquals("referenced <connectionProperty name=\"password\"> must be wiped via refid traversal",
+                "*****", pw.getValue());
+    }
+
+    private static org.apache.tools.ant.taskdefs.Property makeProp(Project project, String name, String value) {
+        org.apache.tools.ant.taskdefs.Property p = new org.apache.tools.ant.taskdefs.Property();
+        p.setProject(project);
+        p.setName(name);
+        p.setValue(value);
+        return p;
+    }
 }


### PR DESCRIPTION
## Impact

Third companion to #7741 and #7742 — same root cause (`java.lang.String` passwords never zeroed; **CWE-316**), applied to the Ant integration's `liquibase.integration.ant.type.DatabaseType`. The `password` field on this type holds a credential String for the lifetime of the Ant `Project` with no cleanup hook.

## Why this PR is shaped differently from #7741 / #7742

Ant `DatabaseType` **cannot** use the "null in `execute()` finally" pattern that #7741 (CLI) and #7742 (Maven Mojo) use. Ant's `<typedef>` + `databaseRef` mechanism is **specifically designed** to let multiple tasks share a single `<database id="…">` instance across a build:

```xml
<database id="mydb" password="secret" url="..." />
<liquibase:update     databaseRef="mydb" changelog="x.xml" />
<liquibase:rollback   databaseRef="mydb" changelog="x.xml" toTag="v1" />
<liquibase:status     databaseRef="mydb" />
```

Nulling `password` at the end of `update`'s `execute()` would break `rollback` and `status`. The right lifecycle hook is **`Project.buildFinished`** — it fires after the very last task on the project, so credentials are gone before the JVM idles but never while another task still needs them.

## Fix

Self-contained in `DatabaseType.java` — no changes to `BaseLiquibaseTask`, `AbstractDatabaseDiffTask`, or any task consumer.

**1. `clearCredentials()`** — package-private. Nulls `password`. For refid shells (DatabaseTypes whose getters delegate to a referenced instance via `setRefid`), traverses to the referenced `DatabaseType` so the actual shared field is wiped. Defensively wraps the ref traversal in `try/catch` for `BuildException` so a dangling refid at project tear-down does not throw.

```java
void clearCredentials() {
    this.password = null;
    if (isReference()) {
        try {
            Object ref = getCheckedRef();
            if (ref instanceof DatabaseType) {
                ((DatabaseType) ref).clearCredentials();
            }
        } catch (BuildException ignored) { /* dangling ref at tear-down */ }
    }
}
```

**2. `registerCredentialCleanup()`** — package-private. Attaches a one-shot `BuildListener` to the `Project` that calls `clearCredentials()` on `buildFinished`. The listener implements only `buildFinished` meaningfully; `buildStarted` / `targetStarted` / `taskStarted` / etc. are no-ops because during the build the credentials may still be needed by another consumer.

**3. Auto-registration from `createDatabase()`** — the first call to `createDatabase(...)` on a given `DatabaseType` instance invokes `registerCredentialCleanup()`; subsequent calls are no-ops thanks to the `credentialCleanupRegistered` flag. Any Ant task that consumes this type via `createDatabase(...)` opts in implicitly.

## Test

New `DatabaseTypeCredentialClearTest` covers six scenarios:

- `clearCredentials_nulls_password_on_a_simple_databaseType` — straight password nulling; user / url untouched.
- `clearCredentials_traverses_refid_and_clears_the_referenced_instance` — exercises the typedef+`databaseRef` pattern. A real referenced `DatabaseType` holds the credential; a refid shell calls `clearCredentials`; the referenced instance's password is asserted nulled afterwards.
- `registerCredentialCleanup_registers_a_BuildListener_that_fires_on_buildFinished` — counts Project listeners before/after; `Project.fireBuildFinished(null)` triggers the clearing.
- `registerCredentialCleanup_is_idempotent` — three calls add exactly one listener.
- `registerCredentialCleanup_listener_only_implements_buildFinished_meaningfully` — fires `buildStarted` / `targetStarted` / `taskStarted` / `taskFinished` / `targetFinished` / `messageLogged` and asserts password is still set; only `buildFinished` clears.
- `clearCredentials_is_safe_on_a_refid_shell_whose_referenced_was_dropped` — defensive case (dangling refid at tear-down does not throw).

```
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0 -- in DatabaseTypeCredentialClearTest
```

No regressions in the surrounding Ant code (changes are purely additive — new field, new methods; existing methods unchanged).

## Design alternatives considered

- **Null in `BaseLiquibaseTask.execute()` finally** — rejected: breaks the typedef+`databaseRef` sharing pattern (would null on the first task, break the second).
- **Per-task reference counting** — rejected: Ant doesn't tell us "no more references will be added", so we cannot decide when "done".
- **Explicit `<liquibase:clearCredentials>` task** — rejected: opt-in default is bad for security; users will not know to add it.
- **`Project.buildFinished` BuildListener (chosen)** — Ant guarantees it fires after the last task on the project. Tested behaviour.

## Known limitation

Strings are immutable in Java; nulling the field is the closest equivalent to wiping the contents but does not actively erase the String value from the JVM heap / interned cache. The proper long-term fix is a `Credential` / `SecretString` wrapper, already explicitly deferred to a follow-up spike in #7739.

## Related

- #7741 — CWE-316 sibling for `liquibase-standard` legacy CLI (Main.java + CommandScope.argumentValues).
- #7742 — CWE-316 sibling for `liquibase-maven-plugin` (Mojo password fields).

Same audit ticket, same CWE, three different module-specific fix shapes. PRs are independent — any merge order works.
