### PR TITLE
CWE-94: guard against future ${...} expansion in defaults-file loader

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/configuration/core/DefaultsFileValueProvider.java
+++ b/liquibase-standard/src/main/java/liquibase/configuration/core/DefaultsFileValueProvider.java
@@ -31,6 +31,13 @@ public class DefaultsFileValueProvider extends AbstractMapConfigurationValueProv
     public DefaultsFileValueProvider(InputStream stream, String sourceDescription) throws IOException {
         this.sourceDescription = sourceDescription;
         this.properties = new Properties();
+        // CWE-94 guard: keep this bare java.util.Properties.load(). Do NOT add
+        // ${...} interpolation, environment-variable expansion, or include-file
+        // directives here. A defaults file may contain user-controlled values;
+        // expansion engines have a documented history of CVE-grade injection /
+        // info-disclosure issues (e.g. CVE-2022-33980 in Apache Commons Configuration).
+        // Pro extensions that need safe substitution can register a
+        // ConfiguredValueModifier instead of changing this loader.
         this.properties.load(stream);
         trimAllProperties();
     }
@@ -40,6 +47,8 @@ public class DefaultsFileValueProvider extends AbstractMapConfigurationValueProv
 
         try (InputStream stream = Files.newInputStream(path.toPath())) {
             this.properties = new Properties();
+            // CWE-94 guard: see the InputStream-arg ctor above. Bare Properties.load —
+            // adding ${...} / env-var / include expansion requires a security review.
             this.properties.load(stream);
             trimAllProperties();
         }

--- a/liquibase-standard/src/test/groovy/liquibase/configuration/core/DefaultsFileValueProviderTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/configuration/core/DefaultsFileValueProviderTest.groovy
@@ -125,4 +125,34 @@ long.multiWord: Long MultiWord
         "liquibase.command.invalid" | ""
         "external.config"           | ""
     }
+
+    @Unroll
+    def "defaults-file loader keeps \${...} placeholders verbatim — CWE-94 no-expansion contract: #variant"() {
+        // CWE-94 regression: pairs with the guard comments inside DefaultsFileValueProvider.
+        // A comment can be deleted without CI signal (per @wwillard7800's review on #7744);
+        // this spec pins the runtime contract so any future change that introduces ${...}
+        // expansion (and silently removes the guard comment) trips a CI failure rather
+        // than passing silently. CVE-2022-33980 in Apache Commons Configuration's
+        // StringSubstitutor is the canonical precedent — interpolation in a defaults
+        // loader became an RCE / info-disclosure vector once StringSubstitutor was wired
+        // into the load path. Bare java.util.Properties.load is the chosen mitigation.
+        given:
+        def stream = new ByteArrayInputStream(("placeholder=" + placeholder + "\n").getBytes("UTF-8"))
+
+        when:
+        def provider = new DefaultsFileValueProvider(stream, "Test no-expansion")
+
+        then:
+        provider.getProvidedValue("placeholder").getValue() == placeholder
+
+        where:
+        variant                                  | placeholder
+        "env-var lookup"                         | '${env:HOME}'
+        "credential exfiltration via env-var"    | '${env:AWS_SECRET_ACCESS_KEY}'
+        "file-inclusion / arbitrary read"        | '${file:/etc/passwd}'
+        "key reference / property chaining"      | '${other.key}'
+        "nested / recursive expansion"           | '${outer${inner}}'
+        "empty placeholder"                      | '${}'
+        "placeholder embedded inside a JDBC URL" | 'jdbc:postgresql://host:5432/${dbname}'
+    }
 }


### PR DESCRIPTION
## Background

A May-2026 OSS security audit reviewed `DefaultsFileValueProvider` and classified the current behaviour as **safe, no code fix required** — it uses bare `java.util.Properties.load(stream)`, which does *not* perform `${...}` interpolation, environment-variable expansion, or include-file directives. The audit recorded a tracking note specifically *"to prevent well-intentioned but counterproductive future changes"* (i.e. someone adding `${...}` resolution as a "convenience" feature without realising it crosses a security boundary).

This PR operationalises that note where future maintainers will actually see it: as a guard comment at the `Properties.load(stream)` call sites themselves.

## Impact

- [x] Documentation / safety guardrail (no behavioural change)

## Threat model

`DefaultsFileValueProvider` reads `liquibase.properties` files. The file may contain values that are user-controlled (CI-generated, env-templated, copy-pasted from a teammate, fetched from a build cache, etc.). If the loader ever started resolving placeholders inline, an attacker who can influence even one value in that file could:

- exfiltrate environment variables (`${env:AWS_SECRET_ACCESS_KEY}`)
- exfiltrate filesystem contents (`${file:/etc/passwd}`)
- in expansion engines that support nested resolution, escalate to remote code execution

This isn't theoretical: Apache Commons Configuration's `StringSubstitutor` shipped exactly this pattern and produced **CVE-2022-33980** (CWE-94) — interpolation in a configuration loader became an RCE vector. The bare `Properties.load()` Liquibase uses today is immune to that class of issue *because* it does no expansion.

## What this PR does

Adds a brief `CWE-94 guard` comment at each of the two `Properties.load(stream)` call sites in `DefaultsFileValueProvider.java` (lines 34 and 43). The comment:

1. States the prohibition explicitly: no `${...}` / env / include expansion in this loader.
2. References CVE-2022-33980 as the canonical precedent so the comment doesn't read as paranoid.
3. Points future implementers at the existing `ConfiguredValueModifier` SPI as the safe alternative — Pro extensions that genuinely need substitution can register a modifier rather than touching the loader.

```java
// CWE-94 guard: keep this bare java.util.Properties.load(). Do NOT add
// ${...} interpolation, environment-variable expansion, or include-file
// directives here. A defaults file may contain user-controlled values;
// expansion engines have a documented history of CVE-grade injection /
// info-disclosure issues (e.g. CVE-2022-33980 in Apache Commons Configuration).
// Pro extensions that need safe substitution can register a
// ConfiguredValueModifier instead of changing this loader.
this.properties.load(stream);
```

A second, terser comment on the `File`-arg ctor cross-references the first.

## What this PR does NOT do

- **No behavioural change.** Both `Properties.load(stream)` calls are unchanged.
- **No test additions or modifications.** Pure documentation. All 36 existing `DefaultsFileValueProviderTest` specs continue to pass unchanged.
- **No SPI changes.** `ConfiguredValueModifier` is mentioned in the comment as the safe alternative for substitution, but its surface area is untouched.

## Verification

```
[INFO] Tests run: 36, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.219 s -- in liquibase.configuration.core.DefaultsFileValueProviderTest
[INFO] Tests run: 36, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## Why a PR for a doc-only change?

The audit ticket recording this finding is a private internal artefact — future maintainers (including downstream forks and contributors who don't have access to the audit tracker) won't see it. A code-level comment at the call site is the only place that survives forks, contributions, and code-search. The comment is small enough that it earns its keep on every future "let's add `${...}`" PR that triggers a reviewer to look at this file.

## Related

Part of the same May-2026 OSS credential-handling audit slice that produced #7737–#7743. This is the *informational* entry in that slice — the audit explicitly flagged it as "safe, no code fix needed" and the guard comment is the only artefact this finding produces.
