### PR TITLE
feat(ci): auto-create Jira ticket on Community PR merge [TECHOPS-497]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -47,16 +47,23 @@ A clear and concise description of the change being made.
 ## Release note
 
 <!--
-RECOMMENDED — one paragraph for customers. Audience-facing copy; what changed and why
-it matters to users (not implementation details).
+RECOMMENDED — one or two sentences for customers. What's better now from
+the user's perspective? Plain language, no implementation detail.
 
-Why this matters: when this PR is merged, an automation creates a Jira ticket in SECURE
-for the docs team (per TECHOPS-497). That ticket's release-note section is filled from
-this section. If you skip this, the auto-created ticket gets a "[Release note needed]"
-placeholder and the docs team has to chase you to fill it in.
+Examples:
+  ✓ "Aurora Serverless v2 is now a first-class target — add
+     `db: aurora-serverless-v2` to liquibase.properties, no driver
+     path needed."
+  ✓ "Fixed a regression where the diff command silently dropped
+     UNIQUE constraints on Oracle databases."
+  ✗ "Refactored DatabaseFactory to use the new SPI loader." (too internal)
 
-If the change is genuinely not customer-facing (CI tweak, internal refactor, dep update),
-leave this empty AND apply the `skipReleaseNotes` label — no Jira ticket gets created.
+Where this goes: on merge, an auto-created Jira ticket (TECHOPS-497)
+lands in the docs-review queue with this text. Empty → docs sees
+`[Release note needed]` and will chase you to fill it in.
+
+Not customer-facing (CI, internal refactor, dep bump)? Leave this blank
+AND apply the `skipReleaseNotes` label — no ticket gets created.
 
 Convention: https://github.com/liquibase/liquibase-infrastructure/blob/main/jira/docs/description-conventions.md
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -44,6 +44,24 @@ A clear and concise description of the change being made.
 - Make sure tests all pass
 -->
 
+## Release note
+
+<!--
+RECOMMENDED — one paragraph for customers. Audience-facing copy; what changed and why
+it matters to users (not implementation details).
+
+Why this matters: when this PR is merged, an automation creates a Jira ticket in SECURE
+for the docs team (per TECHOPS-497). That ticket's release-note section is filled from
+this section. If you skip this, the auto-created ticket gets a "[Release note needed]"
+placeholder and the docs team has to chase you to fill it in.
+
+If the change is genuinely not customer-facing (CI tweak, internal refactor, dep update),
+leave this empty AND apply the `skipReleaseNotes` label — no Jira ticket gets created.
+
+Convention: https://github.com/liquibase/liquibase-infrastructure/blob/main/jira/docs/description-conventions.md
+-->
+
+
 ## Things to be aware of
 
 <!--

--- a/.github/workflows/auto-create-jira-on-merge.yml
+++ b/.github/workflows/auto-create-jira-on-merge.yml
@@ -25,6 +25,17 @@ name: "Auto-create Jira ticket on Community PR merge"
 #   /vault/liquibase must contain JIRA_USER + JIRA_API_TOKEN with
 #   Browse + Create + Edit + Resolve Issues on SECURE.
 
+# Serialize runs to prevent duplicate SECURE tickets from concurrent merges.
+# The idempotency check uses Jira's `text ~` JQL, which hits an async-indexed
+# store — two parallel runs can both read "no ticket yet" before either
+# commits and both create duplicates. Queueing closes that window.
+# `cancel-in-progress: false` is LOAD-BEARING — flipping it to true makes
+# runs drop instead of queue, which is worse than the original race.
+# Per Filipe's review on PR #7745 (CodeRabbit finding).
+concurrency:
+  group: auto-create-jira-${{ github.repository }}
+  cancel-in-progress: false
+
 on:
   pull_request:
     types: [closed, milestoned]
@@ -219,8 +230,14 @@ jobs:
               const issue = await jiraFetch('POST', '/rest/api/3/issue', issuePayload);
               core.info(`Created ${issue.key} for PR #${pr.number}`);
 
-              // Remote link back to the PR
+              // Remote link back to the PR. `globalId` makes the POST
+              // idempotent — re-posting with the same globalId updates the
+              // existing link instead of creating a duplicate. Belt-and-
+              // suspenders against the same race the `concurrency:` block
+              // above closes (issue-create side); this side covers re-runs
+              // and milestone-rename fan-out re-touching the same ticket.
               await jiraFetch('POST', `/rest/api/3/issue/${issue.key}/remotelink`, {
+                globalId: `github-pr-${pr.html_url}`,
                 object: {
                   url: pr.html_url,
                   title: `PR #${pr.number}: ${pr.title}`,

--- a/.github/workflows/auto-create-jira-on-merge.yml
+++ b/.github/workflows/auto-create-jira-on-merge.yml
@@ -1,0 +1,302 @@
+name: "Auto-create Jira ticket on Community PR merge"
+
+# Per TECHOPS-497. When a qualifying Community PR is merged in this repo,
+# auto-creates a SECURE Story in Jira so the docs team gets a guaranteed
+# queue of every shipping change without scraping merged PRs at release
+# time. Full process: https://github.com/liquibase/liquibase-infrastructure/blob/main/jira/docs/community-release-process.md
+#
+# Three triggers cover real-world merge patterns:
+#   1. PR closed (merged) WITH milestone → create ticket immediately
+#   2. PR milestoned AFTER merge (forgot-to-set case) → create ticket
+#   3. Milestone renamed (e.g. 1NEXT → 5.0.4) → backfill Fix Version on
+#      every auto-created ticket in that milestone
+#
+# Decoupled from TECHOPS-273 (release-tag Fix Version automation): this
+# workflow owns the full Community-PR → Jira lifecycle on its own.
+#
+# Filter rules (a PR is SKIPPED when):
+#   - skipReleaseNotes label applied (per TECHOPS-478)
+#   - dependencies label applied
+#   - Author is dependabot[bot] or renovate[bot]
+#   - All changed files match the internal-only allowlist
+#     (.github/**, **/README.md, pom.xml — extend per Filipe's input)
+#
+# Required org-level setup (shared with the FixVersion workflow):
+#   /vault/liquibase must contain JIRA_USER + JIRA_API_TOKEN with
+#   Browse + Create + Edit + Resolve Issues on SECURE.
+
+on:
+  pull_request:
+    types: [closed, milestoned]
+  milestone:
+    types: [edited]
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  auto-create:
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'milestone' ||
+      (github.event_name == 'pull_request' &&
+        ((github.event.action == 'closed' && github.event.pull_request.merged == true) ||
+         (github.event.action == 'milestoned' && github.event.pull_request.merged == true)))
+    steps:
+      - name: Configure AWS credentials for vault access
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Get Jira service-account credentials from vault
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            ,/vault/liquibase
+          parse-json-secrets: true
+
+      - name: Auto-create / update tickets
+        uses: actions/github-script@v8
+        env:
+          JIRA_BASE_URL: https://datical.atlassian.net
+          JIRA_EMAIL: ${{ env.JIRA_USER }}
+          JIRA_TOKEN: ${{ env.JIRA_API_TOKEN }}
+        with:
+          script: |
+            // ---- Config -----------------------------------------------------
+            const SECURE_PROJECT_KEY = 'SECURE';
+            const STORY_ISSUE_TYPE = 'Story';
+            const SKIP_LABELS = ['skipReleaseNotes', 'dependencies'];
+            const BOT_AUTHORS = ['dependabot[bot]', 'renovate[bot]'];
+            const INTERNAL_ONLY_PATTERNS = [
+              /^\.github\//,
+              /^README\.md$/i,
+              /\/README\.md$/i,
+              /^pom\.xml$/,
+            ];
+            const VERSION_PATTERN = /^v?(\d+\.\d+\.\d+)$/;
+
+            // ---- Jira helpers ----------------------------------------------
+            const baseUrl = process.env.JIRA_BASE_URL.replace(/\/$/, '');
+            const email = process.env.JIRA_EMAIL;
+            const token = process.env.JIRA_TOKEN;
+            if (!email || !token) {
+              core.setFailed('JIRA_USER or JIRA_API_TOKEN not set in /vault/liquibase');
+              return;
+            }
+            const auth = Buffer.from(`${email}:${token}`).toString('base64');
+            const jiraHeaders = {
+              'Authorization': `Basic ${auth}`,
+              'Content-Type': 'application/json',
+              'Accept': 'application/json',
+            };
+
+            async function jiraFetch(method, path, body) {
+              const response = await fetch(`${baseUrl}${path}`, {
+                method,
+                headers: jiraHeaders,
+                body: body ? JSON.stringify(body) : undefined,
+              });
+              if (!response.ok) {
+                const text = await response.text();
+                throw new Error(`${method} ${path} -> ${response.status}: ${text.slice(0, 500)}`);
+              }
+              if (response.status === 204) return null;
+              return await response.json();
+            }
+
+            async function findExistingTicket(prUrl) {
+              const escaped = prUrl.replace(/"/g, '\\"');
+              const jql = `project = ${SECURE_PROJECT_KEY} AND labels = "auto-created" AND text ~ "\\"${escaped}\\""`;
+              const result = await jiraFetch('POST', '/rest/api/3/search/jql', {
+                jql,
+                fields: ['summary'],
+                maxResults: 1,
+              });
+              return result.issues && result.issues[0] ? result.issues[0].key : null;
+            }
+
+            // ---- ADF helpers ------------------------------------------------
+            const text = (s, marks) => ({ type: 'text', text: s, ...(marks ? { marks } : {}) });
+            const link = (s, href) => text(s, [{ type: 'link', attrs: { href } }]);
+            const para = (...content) => ({ type: 'paragraph', content });
+            const heading = (level, ...content) => ({ type: 'heading', attrs: { level }, content });
+
+            function extractReleaseNote(prBody) {
+              if (!prBody) return null;
+              const re = /##\s+(?:Release note|User benefit \(release note\))\s*\r?\n([\s\S]*?)(?=\r?\n##\s|$)/i;
+              const m = prBody.match(re);
+              if (!m) return null;
+              const cleaned = m[1].replace(/<!--[\s\S]*?-->/g, '').trim();
+              return cleaned || null;
+            }
+
+            function buildDescription(releaseNote, pr) {
+              const noteParas = releaseNote
+                ? releaseNote.split(/\n\n+/).map(p => para(text(p.trim())))
+                : [para(text('[Release note needed — fill in here or apply skipReleaseNotes label]'))];
+              const mergedBy = pr.merged_by ? pr.merged_by.login : pr.user.login;
+              return {
+                type: 'doc',
+                version: 1,
+                content: [
+                  heading(2, text('Release note')),
+                  ...noteParas,
+                  heading(2, text('Source')),
+                  para(
+                    text('Auto-created from '),
+                    link(`PR #${pr.number}`, pr.html_url),
+                    text(` (merged by @${mergedBy} at ${pr.merged_at}).`),
+                  ),
+                ],
+              };
+            }
+
+            // ---- PR-level filter --------------------------------------------
+            async function shouldSkipPR(pr) {
+              const labelNames = pr.labels.map(l => l.name);
+              for (const skip of SKIP_LABELS) {
+                if (labelNames.includes(skip)) return `label '${skip}' applied`;
+              }
+              if (BOT_AUTHORS.includes(pr.user.login)) return `bot author '${pr.user.login}'`;
+
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+              });
+              if (files.length === 0) return 'no files changed';
+              const allInternal = files.every(f =>
+                INTERNAL_ONLY_PATTERNS.some(p => p.test(f.filename))
+              );
+              if (allInternal) return 'all files match internal-only allowlist';
+              return null;
+            }
+
+            // ---- Trigger 1 + 2: PR merged ----------------------------------
+            async function handlePullRequest() {
+              const pr = context.payload.pull_request;
+              if (!pr.merged) {
+                core.info('PR not merged, skipping');
+                return;
+              }
+              if (!pr.milestone) {
+                core.info('PR has no milestone, skipping');
+                return;
+              }
+
+              const existing = await findExistingTicket(pr.html_url);
+              if (existing) {
+                core.info(`Ticket ${existing} already exists for PR #${pr.number}, skipping (idempotent)`);
+                return;
+              }
+
+              const skipReason = await shouldSkipPR(pr);
+              if (skipReason) {
+                core.info(`Skipping PR #${pr.number}: ${skipReason}`);
+                return;
+              }
+
+              const releaseNote = extractReleaseNote(pr.body);
+              const milestoneName = pr.milestone.title;
+              const versionMatch = milestoneName.match(VERSION_PATTERN);
+              const fixVersion = versionMatch ? versionMatch[1] : null;
+
+              const issuePayload = {
+                fields: {
+                  project: { key: SECURE_PROJECT_KEY },
+                  summary: pr.title,
+                  description: buildDescription(releaseNote, pr),
+                  issuetype: { name: STORY_ISSUE_TYPE },
+                  labels: ['community-source', 'auto-created'],
+                  ...(fixVersion ? { fixVersions: [{ name: fixVersion }] } : {}),
+                },
+              };
+
+              const issue = await jiraFetch('POST', '/rest/api/3/issue', issuePayload);
+              core.info(`Created ${issue.key} for PR #${pr.number}`);
+
+              // Remote link back to the PR
+              await jiraFetch('POST', `/rest/api/3/issue/${issue.key}/remotelink`, {
+                object: {
+                  url: pr.html_url,
+                  title: `PR #${pr.number}: ${pr.title}`,
+                  icon: { url16x16: 'https://github.githubassets.com/favicon.ico' },
+                },
+              });
+
+              const fvLine = fixVersion
+                ? `Fix Version set to **${fixVersion}** (from milestone "${milestoneName}").`
+                : `Fix Version pending — milestone "${milestoneName}" isn't a version pattern; will be set when milestone is renamed.`;
+              await core.summary
+                .addHeading('Auto-created Jira ticket')
+                .addRaw(`[${issue.key}](${baseUrl}/browse/${issue.key}) created for PR #${pr.number}\n\n${fvLine}`)
+                .write();
+            }
+
+            // ---- Trigger 3: milestone renamed -------------------------------
+            async function handleMilestoneEdit() {
+              const milestone = context.payload.milestone;
+              const before = (context.payload.changes && context.payload.changes.title && context.payload.changes.title.from) || null;
+              if (!before || before === milestone.title) {
+                core.info('Milestone edit was not a rename, skipping');
+                return;
+              }
+              const versionMatch = milestone.title.match(VERSION_PATTERN);
+              if (!versionMatch) {
+                core.info(`Milestone renamed to "${milestone.title}" but not a version pattern, skipping`);
+                return;
+              }
+              const fixVersion = versionMatch[1];
+              core.info(`Milestone renamed "${before}" → "${milestone.title}"; updating Fix Version on linked tickets`);
+
+              const issues = await github.paginate(github.rest.issues.listForRepo, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                milestone: milestone.number,
+                state: 'closed',
+                per_page: 100,
+              });
+              const prs = issues.filter(i => i.pull_request);
+
+              let updated = 0;
+              const errors = [];
+              for (const pr of prs) {
+                const prUrl = pr.html_url;
+                const issueKey = await findExistingTicket(prUrl);
+                if (!issueKey) continue;
+                try {
+                  await jiraFetch('PUT', `/rest/api/3/issue/${issueKey}`, {
+                    fields: { fixVersions: [{ name: fixVersion }] },
+                  });
+                  core.info(`Updated ${issueKey} Fix Version -> ${fixVersion}`);
+                  updated++;
+                } catch (e) {
+                  core.warning(`Failed to update ${issueKey}: ${e.message}`);
+                  errors.push({ issueKey, prNumber: pr.number, error: e.message });
+                }
+              }
+
+              await core.summary
+                .addHeading('Milestone rename → Fix Version updates')
+                .addRaw(`Milestone "${milestone.title}" picked up; updated **${updated}** auto-created tickets`)
+                .write();
+              if (errors.length) {
+                await core.summary
+                  .addHeading('Errors')
+                  .addRaw(errors.map(e => `- ${e.issueKey} (PR #${e.prNumber}): ${e.error}`).join('\n'))
+                  .write();
+              }
+            }
+
+            // ---- Dispatch ---------------------------------------------------
+            if (context.eventName === 'pull_request') {
+              await handlePullRequest();
+            } else if (context.eventName === 'milestone' && context.payload.action === 'edited') {
+              await handleMilestoneEdit();
+            } else {
+              core.info(`Event ${context.eventName}/${context.payload.action} not handled; no-op`);
+            }


### PR DESCRIPTION
## Summary

Adds an automation that creates a SECURE Jira ticket whenever a qualifying PR is merged in this repo. Closes a longstanding docs-team gap where Community PRs slip through release-notes review because no Jira ticket exists for them.

## The story (Steve's threes)

- **Problem:** Docs scrapes merged PRs at release time to find Community changes, and things slip. Filipe hand-tracks via milestones; the docs team has no Jira queue.
- **What we did:** Added a workflow that fires on merge + on milestone-rename, creates a SECURE Story per qualifying PR, fills its release-note section from the PR template, links back to the source PR, and stamps Fix Version when the milestone is finalized.
- **Result:** Docs gets a single Jira queue per release; engineers don't file tickets; the release-notes aggregator (TECHOPS-498) consumes the auto-created tickets at release time.

## What this PR contains

| File | Purpose |
|---|---|
| `.github/workflows/auto-create-jira-on-merge.yml` (new, ~300 lines) | The workflow itself. Three triggers, ADF body construction, idempotency check, internal-only filter, milestone-rename fan-out. |
| `.github/pull_request_template.md` (edit) | Adds a recommended `## Release note` section between Description and Things-to-be-aware-of. |

## Three triggers (handle real merge patterns)

| Trigger | When | Why |
|---|---|---|
| `pull_request: closed` (merged=true) | PR merged with milestone assigned | Standard path |
| `pull_request: milestoned` | PR was merged earlier, milestone added later | Catches "forgot to set the milestone" |
| `milestone: edited` | Milestone renamed e.g. `1NEXT → 5.0.4` | Picks up deferred Fix Version stamping |

## Filter (a PR is SKIPPED when ANY of)

- `skipReleaseNotes` or `dependencies` label
- Author is `dependabot[bot]` or `renovate[bot]`
- All changed files match the internal-only allowlist (`.github/**`, `**/README.md`, `pom.xml`)
- PR closed without merging

Conservative defaults — anything touching real source files generates a ticket. Filipe / maintainers can refine the allowlist over time.

## Required setup (already in place)

The workflow reuses the same `LIQUIBASE_VAULT_OIDC_ROLE_ARN` secret + `/vault/liquibase` JIRA creds pattern as the existing `jira-set-fixversion-on-release.yml` reusable workflow. No new vault entries needed.

Jira service account needs `Browse + Create + Edit + Resolve Issues` on the SECURE project. Existing service account permissions cover Create + Edit + Resolve already; Browse on SECURE should be in place.

## The auto-created ticket shape

For each qualifying PR, a SECURE Story is created with:

- **Summary** = PR title
- **Description** = `## Release note` H2 (per TECHOPS-479 convention) + content from the PR template section, OR a placeholder if empty
- **Labels** = `community-source`, `auto-created`
- **Fix Version** = the milestone name if it matches `\d+\.\d+\.\d+`, otherwise unset (filled later when the milestone is renamed)
- **Remote link** = back to this PR

## Idempotency

Before creating, the workflow searches Jira for existing tickets with the PR URL in their description. If one exists, no duplicate is created. So re-runs (e.g. milestoned event firing after the initial close event) are safe.

## Decoupled from TECHOPS-273

The existing release-tag Fix Version automation (TECHOPS-273 in `build-logic`) is unchanged. This workflow owns the full Community-PR → Jira lifecycle on its own — including Fix Version stamping when the milestone is renamed. No commit-message hacks; no dependency on tag pushes.

## Process documentation

Full process doc lives in `liquibase-infrastructure`:
- Doc PR: https://github.com/liquibase/liquibase-infrastructure/pull/3739
- Process doc (when that PR merges): `liquibase-infrastructure/jira/docs/community-release-process.md`

## Test plan

- [x] YAML lints cleanly (verified locally)
- [x] Workflow `if:` guards ensure only merged PRs or milestone-rename events trigger the heavy work
- [ ] **Pilot test:** maintainer merges a test PR with `1NEXT` milestone → ticket appears in SECURE within 10s
- [ ] **Filter test:** maintainer merges a `.github/` PR labelled `skipReleaseNotes` → no ticket created (verified in workflow run log)
- [ ] **Milestone rename test:** maintainer renames `1NEXT → 5.0.4` after a real release → linked tickets get Fix Version stamped
- [ ] **Idempotency test:** re-run the workflow on the same PR → no duplicate ticket

## Decisions worth flagging for reviewers

1. **PR template addition is recommended, not mandatory.** Labels remain the mandatory PR gate; the `## Release note` section is added as a recommended convenience. Engineers who skip it get a ticket with a placeholder.

2. **Three triggers, not one.** Filipe mentioned the `1NEXT → version` rename pattern; other engineers may set the version directly. The three-trigger design handles all cases without forcing a single convention.

3. **Filter is conservative.** Better to over-create and let Filipe apply `Close (Won't Do)` than under-create and lose tickets. Easy to expand the allowlist post-pilot.

4. **Decoupled from TECHOPS-273.** The release-tag automation stays as the Fix Version stamping mechanism for *normal* tickets (engineer-filed). This workflow handles its own Fix Version stamping at milestone rename time so the auto-created tickets don't need to appear in tag commit ranges.

5. **No Slack ping yet.** `#docs-review` notification is gated on TECHOPS-344 Slack integration. The workflow will be extended once 344 lands.

## Companion PR

- `liquibase-infrastructure#3739` — process docs, label conventions, README/runbook cross-references. Already open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)