### PR TITLE
CWE-78: opt-in restricted mode for executeCommand changelog change

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/GlobalConfiguration.java
+++ b/liquibase-standard/src/main/java/liquibase/GlobalConfiguration.java
@@ -53,6 +53,7 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
     public static final ConfigurationDefinition<Boolean> STRICT;
     public static final ConfigurationDefinition<Integer> DDL_LOCK_TIMEOUT;
     public static final ConfigurationDefinition<Boolean> SECURE_PARSING;
+    public static final ConfigurationDefinition<Boolean> ALLOW_EXECUTE_COMMAND;
     public static final ConfigurationDefinition<String> SEARCH_PATH;
 
     public static final ConfigurationDefinition<UIServiceEnum> UI_SERVICE;
@@ -221,6 +222,17 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
 
         SECURE_PARSING = builder.define("secureParsing", Boolean.class)
                 .setDescription("If true, remove functionality from file parsers which could be used insecurely. Examples include (but not limited to) disabling remote XML entity support.")
+                .setDefaultValue(true)
+                .build();
+
+        ALLOW_EXECUTE_COMMAND = builder.define("allowExecuteCommand", Boolean.class)
+                .setDescription("If false, the executeCommand changelog change is rejected at validation time " +
+                        "with a clear error instead of being allowed to invoke an OS shell command. " +
+                        "Defaults to true to preserve the documented executeCommand feature for the standard " +
+                        "trust model (team-authored, team-reviewed changelogs). Set to false in environments " +
+                        "that execute changelogs from less-trusted sources (multi-tenant SaaS running customer " +
+                        "changelogs, downloaded change-packs, contributor PRs prior to review) where arbitrary " +
+                        "OS-shell execution via changelog is not an acceptable risk (CWE-78).")
                 .setDefaultValue(true)
                 .build();
 

--- a/liquibase-standard/src/main/java/liquibase/change/core/ExecuteShellCommandChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/ExecuteShellCommandChange.java
@@ -103,6 +103,26 @@ public class ExecuteShellCommandChange extends AbstractChange {
     @Override
     public ValidationErrors validate(Database database) {
         ValidationErrors validationErrors = new ValidationErrors();
+
+        // CWE-78 defense-in-depth gate: if the embedder has disabled executeCommand
+        // via liquibase.allowExecuteCommand=false, reject the change at validation
+        // time so the bad change is caught BEFORE ProcessBuilder.start() runs. The
+        // default is true, which preserves the documented feature for the standard
+        // Liquibase trust model (team-authored, team-reviewed changelogs). The
+        // opt-out exists for hosts that execute changelogs from less-trusted
+        // sources (multi-tenant SaaS running customer changelogs, downloaded
+        // change-packs, contributor PRs prior to review) — see the description on
+        // GlobalConfiguration.ALLOW_EXECUTE_COMMAND for the full threat model.
+        if (Boolean.FALSE.equals(GlobalConfiguration.ALLOW_EXECUTE_COMMAND.getCurrentValue())) {
+            validationErrors.addError(
+                    "executeCommand change is disabled by configuration " +
+                            "(liquibase.allowExecuteCommand=false). To run shell commands via changelog, " +
+                            "set liquibase.allowExecuteCommand=true (the default). This flag is provided " +
+                            "for environments that execute changelogs from less-trusted sources, where " +
+                            "arbitrary OS-shell execution via changelog is not an acceptable risk.");
+            return validationErrors;
+        }
+
         if (!StringUtils.isEmpty(timeout)) {
             // check for the timeout values, accept only positive value with one letter unit (s/m/h)
             Matcher matcher = TIMEOUT_PATTERN.matcher(timeout);

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/ExecuteShellCommandChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/ExecuteShellCommandChangeTest.groovy
@@ -1,5 +1,7 @@
 package liquibase.change.core
 
+import liquibase.GlobalConfiguration
+import liquibase.Scope
 import liquibase.exception.SetupException
 import liquibase.parser.core.ParsedNodeException
 import liquibase.sdk.supplier.resource.ResourceSupplier
@@ -73,5 +75,80 @@ class ExecuteShellCommandChangeTest extends Specification {
         change.timeout == "10s"
         that change.getOs(), Matchers.contains(["linux", "mac"].toArray())
         that change.args, Matchers.contains("-out", "-test")
+    }
+
+    def "validate passes by default — executeCommand is intentional under the standard trust model (CWE-78 opt-out gate)"() {
+        // CWE-78 regression: the default is liquibase.allowExecuteCommand=true so
+        // existing users see no behaviour change. validate() must NOT return an
+        // error in this state, and the timeout/etc. existing checks still run.
+        given:
+        def change = new ExecuteShellCommandChange()
+        change.setExecutable("/usr/bin/test")
+
+        when:
+        def errors = change.validate(null)
+
+        then:
+        !errors.hasErrors()
+    }
+
+    def "validate fails when liquibase.allowExecuteCommand=false — embedder opt-out path"() {
+        // CWE-78 regression: when the embedder sets liquibase.allowExecuteCommand=false,
+        // executeCommand changes must be rejected at validation time BEFORE
+        // ProcessBuilder.start() runs. The error message must name the flag so
+        // operators can find their way back to the documented opt-in.
+        given:
+        def change = new ExecuteShellCommandChange()
+        change.setExecutable("/usr/bin/test")
+
+        when: "the embedder has disabled executeCommand via configuration"
+        def errors = Scope.child([(GlobalConfiguration.ALLOW_EXECUTE_COMMAND.getKey()): "false"],
+                { return change.validate(null) } as Scope.ScopedRunnerWithReturn)
+
+        then:
+        errors.hasErrors()
+        // Specifically the disabled-by-config error, not the generic timeout error.
+        errors.getErrorMessages().any { it.contains("liquibase.allowExecuteCommand=false") }
+        errors.getErrorMessages().any { it.contains("liquibase.allowExecuteCommand=true") }
+    }
+
+    def "validate gate short-circuits — unrelated timeout-validation errors do not appear when the change is disabled"() {
+        // CWE-78 regression: the gate runs first and short-circuits, so a
+        // changelog that has BOTH an invalid timeout AND is rejected by the flag
+        // returns only the configuration error. This keeps operator-facing
+        // messaging focused — they need to fix the config or move the changelog,
+        // not chase a timeout format question that is irrelevant once the change
+        // is disabled.
+        given:
+        def change = new ExecuteShellCommandChange()
+        change.setExecutable("/usr/bin/test")
+        change.setTimeout("definitely not a valid duration")
+
+        when:
+        def errors = Scope.child([(GlobalConfiguration.ALLOW_EXECUTE_COMMAND.getKey()): "false"],
+                { return change.validate(null) } as Scope.ScopedRunnerWithReturn)
+
+        then:
+        errors.hasErrors()
+        // Only the gate's message; the timeout-validation message must NOT appear.
+        errors.getErrorMessages().any { it.contains("liquibase.allowExecuteCommand=false") }
+        !errors.getErrorMessages().any { it.contains("Invalid value specified for timeout") }
+    }
+
+    def "validate when flag is true still runs the existing timeout validation"() {
+        // Sanity check that the new gate's short-circuit does not skip the
+        // existing checks when the flag is at its default (true).
+        given:
+        def change = new ExecuteShellCommandChange()
+        change.setExecutable("/usr/bin/test")
+        change.setTimeout("definitely not a valid duration")
+
+        when:
+        def errors = change.validate(null)
+
+        then:
+        errors.hasErrors()
+        errors.getErrorMessages().any { it.contains("Invalid value specified for timeout") }
+        !errors.getErrorMessages().any { it.contains("liquibase.allowExecuteCommand") }
     }
 }


### PR DESCRIPTION
## Impact

`ExecuteShellCommandChange` (the `executeCommand` changelog change tag) spawns arbitrary host shell commands via `ProcessBuilder` at `ExecuteShellCommandChange.java:181-182`:

```java
ProcessBuilder pb = createProcessBuilder(database);
Process p = pb.start();
```

Under the standard Liquibase trust model (team-authored, team-reviewed changelogs) this is intentional and documented — the change tag is the supported way to invoke a host command (e.g. `mysqldump`) inline with a database migration. Under the **harder threat model** — multi-tenant SaaS platforms running customer-supplied changelogs, downloaded change-packs, contributor PRs prior to review — it is full RCE as the Liquibase JVM user with no operator-controllable opt-out.

The only pre-existing filter is the `os.name` string-match at lines 120-127, which is metadata the **changelog author fully controls** — so it is not a real defense.

This maps to **CWE-78** (Improper Neutralization of Special Elements used in an OS Command).

## Scope decision

The audit ticket is explicit: *"Severity: Critical under untrusted-changelog threat model; **by-design under trusted-changelog model**. Suggested mitigation: Add an opt-in restricted mode ... Do NOT flip the default — that breaks every existing user."*

This PR follows that brief exactly. **No default behaviour change.** A new opt-in flag exists so embedders running untrusted changelogs can disable the feature; everyone else's pipelines work identically.

## Fix

**1. New `GlobalConfiguration.ALLOW_EXECUTE_COMMAND` flag** — `Boolean`, **defaults to `true`** (preserves existing behaviour). Lives next to `SECURE_PARSING`, which is the closest existing security-flag template. Description ties the flag to CWE-78 explicitly so a future grep finds the link:

```java
ALLOW_EXECUTE_COMMAND = builder.define("allowExecuteCommand", Boolean.class)
        .setDescription("If false, the executeCommand changelog change is rejected at validation time ...")
        .setDefaultValue(true)
        .build();
```

**2. Gate inside `ExecuteShellCommandChange.validate(Database)`** — checks the flag FIRST and short-circuits with a clear error when set to `false`. Validation is the natural enforcement point because it runs **before** `generateStatements()` → `executeCommand()` → `ProcessBuilder.start()`, so the malicious change is rejected before any side effects.

```java
if (Boolean.FALSE.equals(GlobalConfiguration.ALLOW_EXECUTE_COMMAND.getCurrentValue())) {
    validationErrors.addError(
            "executeCommand change is disabled by configuration (liquibase.allowExecuteCommand=false). " +
            "To run shell commands via changelog, set liquibase.allowExecuteCommand=true (the default). " +
            "This flag is provided for environments that execute changelogs from less-trusted sources, " +
            "where arbitrary OS-shell execution via changelog is not an acceptable risk.");
    return validationErrors;
}
```

The error message names the flag in both directions (*"is set to false"* AND *"set it to true to re-enable"*) so an operator seeing the message in CI output can recover without reading documentation.

## Tests

Four new specs in `ExecuteShellCommandChangeTest` (3 pre-existing → 7 total):

| Spec | What it pins |
|---|---|
| `validate passes by default — executeCommand is intentional under the standard trust model (CWE-78 opt-out gate)` | The default-true path: zero behaviour change for existing users |
| `validate fails when liquibase.allowExecuteCommand=false — embedder opt-out path` | Uses `Scope.child(...)` to set the flag — exercises the actual `GlobalConfiguration` lookup path, not a static mock. Asserts the error message names the flag in both `=false` and `=true` forms |
| `validate gate short-circuits — unrelated timeout-validation errors do not appear when the change is disabled` | When BOTH the flag is off AND timeout is malformed, only the gate error appears — keeps operator messaging focused |
| `validate when flag is true still runs the existing timeout validation` | Sanity that the short-circuit does not skip downstream checks at the default |

```
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0 -- in ExecuteShellCommandChangeTest
[INFO] BUILD SUCCESS
```

## Things to be aware of

- **Default is unchanged.** Anyone whose existing changelogs use `executeCommand` will see no behaviour change. The flag has to be deliberately set to `false` (via `liquibase.properties`, env-var, system property, or any of the standard `ConfigurationDefinition` sources) to flip the gate.
- **Validation-time enforcement.** The gate runs in `validate(Database)`, so disallowed changes are caught during the standard pre-execution validation pass — before `generateStatements()` or `executeCommand()` run. There is no window where a `ProcessBuilder.start()` could fire after the gate has rejected the change.
- **The gate is opt-in, not allowlist-style.** If you need finer-grained control (e.g. *"allow only `executeCommand` invocations of a specific executable"*) that's a separate fix shape — register your own `Change` subclass with allowlist validation, or contribute an additional `ConfigurationValueProvider`. This PR delivers the binary toggle the audit ticket asked for.
- **Chain 3 partial fix.** The broader "env-var command injection chain" tracked in DAT-23027 combines B1 (this PR) with B10 (env-var substitution) and B2 (`customChange` arbitrary-Java). Fully closing Chain 3 requires landing companion opt-out gates for B10 and B2 as separate PRs against their respective audit child tickets.

## Related

Part of the May-2026 OSS credential-handling-and-changelog-injection audit slice (`sdou` label). Sibling PRs:

- **MERGED**: #7737 (CWE-209 `DatabaseFactory`), #7738 (CWE-209 `OfflineConnection`)
- **OPEN**: #7739, #7740, #7741, #7742, #7743, #7744, #7746
