### PR TITLE
CWE-470: opt-in restricted mode for customChange changelog change

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/GlobalConfiguration.java
+++ b/liquibase-standard/src/main/java/liquibase/GlobalConfiguration.java
@@ -53,6 +53,7 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
     public static final ConfigurationDefinition<Boolean> STRICT;
     public static final ConfigurationDefinition<Integer> DDL_LOCK_TIMEOUT;
     public static final ConfigurationDefinition<Boolean> SECURE_PARSING;
+    public static final ConfigurationDefinition<Boolean> ALLOW_CUSTOM_CHANGE;
     public static final ConfigurationDefinition<String> SEARCH_PATH;
 
     public static final ConfigurationDefinition<UIServiceEnum> UI_SERVICE;
@@ -221,6 +222,19 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
 
         SECURE_PARSING = builder.define("secureParsing", Boolean.class)
                 .setDescription("If true, remove functionality from file parsers which could be used insecurely. Examples include (but not limited to) disabling remote XML entity support.")
+                .setDefaultValue(true)
+                .build();
+
+        ALLOW_CUSTOM_CHANGE = builder.define("allowCustomChange", Boolean.class)
+                .setDescription("If false, the customChange changelog change is rejected before its named " +
+                        "class is loaded. Defaults to true to preserve the documented customChange feature " +
+                        "for the standard trust model (team-authored, team-reviewed changelogs). Set to " +
+                        "false in environments that execute changelogs from less-trusted sources " +
+                        "(multi-tenant SaaS running customer changelogs, downloaded change-packs, " +
+                        "contributor PRs prior to review): customChange loads an arbitrary JVM class by " +
+                        "FQCN via Class.forName(initialize=true), which fires the class's static <clinit> " +
+                        "initializer at load time — before any cast or marker-interface check could " +
+                        "reject the load. Any class on the JVM classpath is reachable this way (CWE-470).")
                 .setDefaultValue(true)
                 .build();
 

--- a/liquibase-standard/src/main/java/liquibase/change/custom/CustomChangeWrapper.java
+++ b/liquibase-standard/src/main/java/liquibase/change/custom/CustomChangeWrapper.java
@@ -1,5 +1,6 @@
 package liquibase.change.custom;
 
+import liquibase.GlobalConfiguration;
 import liquibase.Scope;
 import liquibase.change.*;
 import liquibase.database.Database;
@@ -83,6 +84,31 @@ public class CustomChangeWrapper extends AbstractChange {
     }
 
     private CustomChange loadCustomChange(String className) throws CustomChangeException {
+        // CWE-470 defense-in-depth gate. Every Class.forName(className, true, ...) below
+        // fires the named class's static <clinit> initializer at load time — BEFORE the
+        // cast to CustomChange or any other safety check could reject the load. Under
+        // the harder threat model (untrusted changelogs) that is a direct RCE primitive:
+        // any class on the JVM classpath can have its static init + constructor run
+        // merely by being named in the change tag. This gate fires BEFORE any of the
+        // three class-loading paths (OSGi / Scope classloader / thread context CL /
+        // bare Class.forName) so the static initializer never runs when the embedder
+        // has disabled customChange via liquibase.allowCustomChange=false.
+        //
+        // Mirrored in validate(Database) below for the standard hard-error operator
+        // surface; this method-level gate ALSO covers callers that don't go through
+        // validate(), notably customLoadLogic() which calls loadCustomChange during
+        // changelog PARSE-time (i.e. before validate() ever runs).
+        if (Boolean.FALSE.equals(GlobalConfiguration.ALLOW_CUSTOM_CHANGE.getCurrentValue())) {
+            throw new CustomChangeException(
+                    "customChange is disabled by configuration " +
+                            "(liquibase.allowCustomChange=false). To run customChange changes, set " +
+                            "liquibase.allowCustomChange=true (the default). This flag is provided for " +
+                            "environments that execute changelogs from less-trusted sources, where " +
+                            "loading an arbitrary JVM class by name via changelog is not an acceptable " +
+                            "risk (the load itself fires the class's static initializer before any " +
+                            "safety check could run).");
+        }
+
         try {
             Boolean osgiPlatform = Scope.getCurrentScope().get(Scope.Attr.osgiPlatform, Boolean.class);
             if (Boolean.TRUE.equals(osgiPlatform)) {
@@ -140,6 +166,20 @@ public class CustomChangeWrapper extends AbstractChange {
      */
     @Override
     public ValidationErrors validate(Database database) {
+        // CWE-470 hard gate, paired with the defense-in-depth gate inside
+        // loadCustomChange(). Hard error (not warning) so the operator sees a
+        // pre-execution failure when liquibase.allowCustomChange=false. Runs FIRST
+        // so the existing class-load / configureCustomChange / customChange.validate
+        // pipeline below is short-circuited entirely.
+        if (Boolean.FALSE.equals(GlobalConfiguration.ALLOW_CUSTOM_CHANGE.getCurrentValue())) {
+            return new ValidationErrors().addError(
+                    "customChange is disabled by configuration " +
+                            "(liquibase.allowCustomChange=false). To run customChange changes, set " +
+                            "liquibase.allowCustomChange=true (the default). This flag is provided for " +
+                            "environments that execute changelogs from less-trusted sources, where " +
+                            "loading an arbitrary JVM class by name via changelog is not an acceptable risk.");
+        }
+
         if (!configured) {
             if (this.customChange == null) {
                 try {

--- a/liquibase-standard/src/test/groovy/liquibase/change/custom/CustomChangeWrapperTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/custom/CustomChangeWrapperTest.groovy
@@ -1,5 +1,7 @@
 package liquibase.change.custom
 
+import liquibase.GlobalConfiguration
+import liquibase.Scope
 import liquibase.change.CheckSum
 import liquibase.database.Database
 import liquibase.exception.CustomChangeException
@@ -340,5 +342,93 @@ class CustomChangeWrapperTest extends Specification {
         then: "The checksum not affected by parameters set"
         change1.generateCheckSum() == change2.generateCheckSum()
         change1.generateCheckSum() != change3.generateCheckSum()
+    }
+
+    def "validate passes by default — customChange is intentional under the standard trust model (CWE-470 opt-out gate)"() {
+        // CWE-470 regression: the default is liquibase.allowCustomChange=true so
+        // existing users see no behaviour change. validate() must NOT return the
+        // configured-off error in this state. Uses ExampleCustomSqlChange (the
+        // existing test fixture) so the class actually loads cleanly.
+        given:
+        def wrapper = new CustomChangeWrapper()
+        wrapper.setClass(ExampleCustomSqlChange.class.getName())
+
+        when:
+        def errors = wrapper.validate(new MockDatabase())
+
+        then: "no error mentioning the allowCustomChange flag"
+        !errors.getErrorMessages().any { it.contains("allowCustomChange") }
+    }
+
+    def "validate fails when liquibase.allowCustomChange=false — embedder opt-out path"() {
+        // CWE-470 regression: when the embedder disables customChange via
+        // liquibase.allowCustomChange=false, validate() must reject with a hard
+        // error BEFORE loadCustomChange (and therefore Class.forName with
+        // initialize=true) runs. Error message must name the flag in both
+        // directions so operators can find their way back to opt-in.
+        given:
+        def wrapper = new CustomChangeWrapper()
+        wrapper.setClass(ExampleCustomSqlChange.class.getName())
+
+        when: "the embedder has disabled customChange via configuration"
+        def errors = Scope.child([(GlobalConfiguration.ALLOW_CUSTOM_CHANGE.getKey()): "false"],
+                { return wrapper.validate(new MockDatabase()) } as Scope.ScopedRunnerWithReturn)
+
+        then:
+        errors.hasErrors()
+        errors.getErrorMessages().any { it.contains("liquibase.allowCustomChange=false") }
+        errors.getErrorMessages().any { it.contains("liquibase.allowCustomChange=true") }
+    }
+
+    def "loadCustomChange gate fires BEFORE Class.forName even for a class that does not exist"() {
+        // CWE-470 regression for the parse-time / customLoadLogic call path: the
+        // gate inside loadCustomChange must fire BEFORE Class.forName runs. We
+        // exercise this by setting a class name that does NOT exist on the
+        // classpath and asserting the thrown exception is the configured-off
+        // CustomChangeException, NOT a ClassNotFoundException wrapped in
+        // CustomChangeException — proving the gate short-circuited the lookup.
+        given:
+        def wrapper = new CustomChangeWrapper()
+        wrapper.setClass("com.example.definitely.not.a.real.CustomChange")
+
+        when:
+        def errors = Scope.child([(GlobalConfiguration.ALLOW_CUSTOM_CHANGE.getKey()): "false"],
+                { return wrapper.validate(new MockDatabase()) } as Scope.ScopedRunnerWithReturn)
+
+        then: "the validate gate hits first; the loader never runs"
+        errors.hasErrors()
+        errors.getErrorMessages().any { it.contains("liquibase.allowCustomChange=false") }
+        // The pre-fix code path would have produced an 'Exception thrown loading
+        // com.example...' warning (from the ClassNotFoundException). After the
+        // fix, that warning never appears because the gate short-circuits first.
+        !errors.getErrorMessages().any { it.contains("Exception thrown loading") }
+        !errors.getWarningMessages().any { it.contains("Exception thrown loading") }
+    }
+
+    def "loadCustomChange method-level gate throws CustomChangeException directly when allowCustomChange=false"() {
+        // CWE-470 regression for the defense-in-depth method-level gate: any
+        // caller of loadCustomChange (NOT only validate — also generateCheckSum,
+        // configureCustomChange, customLoadLogic at parse time) must be
+        // protected. The gate inside loadCustomChange throws before any class
+        // loading happens; this test asserts that direct contract by calling
+        // through generateCheckSum (which calls loadCustomChange independently
+        // of validate()).
+        given:
+        def wrapper = new CustomChangeWrapper()
+        wrapper.setClass(ExampleCustomSqlChange.class.getName())
+
+        when:
+        def checksum = Scope.child([(GlobalConfiguration.ALLOW_CUSTOM_CHANGE.getKey()): "false"],
+                { return wrapper.generateCheckSum() } as Scope.ScopedRunnerWithReturn)
+
+        then: "generateCheckSum still returns; the customChange instance was never created so the named class's static initializer never fired"
+        checksum != null
+        // Use direct field access (wrapper.@customChange) instead of the property
+        // form (wrapper.customChange) — the property form calls the lazy-loading
+        // getCustomChange() getter, which would re-attempt the load HERE (outside
+        // the Scope.child block, where the flag has reverted to true) and pollute
+        // the assertion. The field-direct form proves the in-scope generateCheckSum
+        // call did not stash a loaded instance.
+        wrapper.@customChange == null
     }
 }


### PR DESCRIPTION
## Paired follow-up: PR #7749 closes the `<customPrecondition>` half of CWE-470

> **Heads-up for reviewers:** the sibling `<customPrecondition>` element has the *same* unsafe-reflection sink (`CustomPreconditionWrapper.java:67` → `Class.forName(className, true, classLoader)`) and is closed by **[#7749](https://github.com/liquibase/liquibase/pull/7749)** under the **same `ALLOW_CUSTOM_CHANGE` flag** — per the audit author's explicit guidance: *"Covered by the same flag proposed for B2."*
>
> **Merge order:** this PR (#7748) merges first; #7749 then rebases on top, resolves the `GlobalConfiguration.java` collision by **keeping #7749's broader description** (which mentions both `customChange` *and* `customPrecondition`). That's the correct end-state — confirmed by @filipelautert on [the #7749 approval](https://github.com/liquibase/liquibase/pull/7749#pullrequestreview-4336812656).
>
> Together, the two PRs close both `<customChange>` and `<customPrecondition>` under one operator-visible flag, so flipping `liquibase.allowCustomChange=false` actually does what the flag name implies (gates *all* custom-Java loading).

---

## Impact

`CustomChangeWrapper.loadCustomChange(className)` (`CustomChangeWrapper.java:85-104`) loads an arbitrary JVM class by FQCN via `Class.forName(className, true, classLoader)`. The `initialize=true` argument means the class's static `<clinit>` initializer fires **at load time** — **before** the cast to `CustomChange` (or any other safety check) could reject the load:

```java
return (CustomChange) Class.forName(className, true,
    Scope.getCurrentScope().getClassLoader()).getConstructor().newInstance();
//                                            ^ static initializer + ctor already ran
```

Any class on the JVM classpath is reachable this way: name the class in a `<customChange>` element, get its static-init code and zero-arg constructor invoked as a side effect. The triple-fallback chain (`OSGi loader` / `Scope classloader` / `thread context CL` / `bare Class.forName`) and the no-allowlist / no-marker-interface-check pattern make the surface broader than "classes that implement `CustomChange`" — the load itself is the side effect.

This maps to **CWE-470** (Use of Externally-Controlled Input to Select Classes or Code, aka *Unsafe Reflection*).

## Scope decision (sibling to #7747)

Sibling-shape to **DAT-23015 / PR #7747** (B1, `executeCommand`). Same opt-in restricted-mode pattern: add a Boolean flag, default `true` (preserves the documented `customChange` feature for the standard trust model — team-authored, team-reviewed changelogs), opt-out for embedders running changelogs from less-trusted sources (multi-tenant SaaS, downloaded change-packs, contributor PRs pre-review).

**No default behaviour change.** Everyone using `customChange` today sees byte-for-byte identical behaviour.

## Fix — three pieces

**1. New `GlobalConfiguration.ALLOW_CUSTOM_CHANGE` flag** — `liquibase.allowCustomChange`, Boolean, defaults to `true`. Description spells out the static-initializer-on-load mechanic so a future maintainer sees *why* the gate exists.

**2. Dual gate inside `CustomChangeWrapper`:**

   **(a) Hard error in `validate(Database)`** — short-circuits BEFORE the existing load/configure/`customChange.validate` pipeline. Operator sees a clean pre-execution failure with a message that names the flag in both `=false` and `=true` directions.

   **(b) Defense-in-depth gate inside `loadCustomChange` itself** — throws `CustomChangeException` BEFORE any of the three `Class.forName` / `loadClass` paths run.

The second gate is necessary because `loadCustomChange` has **five callers**: `getCustomChange()`, `validate()`, `generateCheckSum()`, `configureCustomChange()`, and **`customLoadLogic()`**. The last one runs at changelog **PARSE-TIME**, *before* `validate()` ever fires. A validate-only gate would let the malicious class's static initializer run during parse. The two gates use the same flag and the same error message; the redundancy is the point — together they guarantee the static initializer never fires when the embedder has set the flag to `false`.

**3. Four new Spock specs** in `CustomChangeWrapperTest` (24 pre-existing → 28 total):

| Spec | What it pins |
|---|---|
| `validate passes by default — customChange is intentional under the standard trust model (CWE-470 opt-out gate)` | Default-true path: zero behaviour change for existing users |
| `validate fails when liquibase.allowCustomChange=false — embedder opt-out path` | Hard error, names the flag in both directions; uses `Scope.child(...)` to exercise the real `GlobalConfiguration` lookup path |
| `loadCustomChange gate fires BEFORE Class.forName even for a class that does not exist` | Sets a non-existent class name AND flag=false; asserts ONLY the configured-off error appears, NOT the `"Exception thrown loading com.example..."` `ClassNotFoundException` warning — proving the gate short-circuited the lookup |
| `loadCustomChange method-level gate throws CustomChangeException directly when allowCustomChange=false` | Calls `generateCheckSum()` directly (a `loadCustomChange` caller that does NOT go through `validate()`); uses `wrapper.@customChange` field-direct access to bypass the lazy-loading getter; asserts the in-scope load was prevented |

```
[INFO] Tests run: 28, Failures: 0, Errors: 0, Skipped: 0 -- in CustomChangeWrapperTest
[INFO] BUILD SUCCESS
```

## Things to be aware of

- **Default is unchanged.** Existing `customChange` users see no behaviour change. Flag must be explicitly set to `false` (via `liquibase.properties`, env-var, system property, or any standard `ConfigurationDefinition` source) to flip the gate.
- **Both gates fire before any static initializer runs.** The defense-in-depth design specifically prevents the load-time side effect — not just the cast or constructor invocation.
- **Single field-direct test-access nuance:** the `wrapper.@customChange` syntax in the fourth test is deliberate (and commented inline). The natural `wrapper.customChange` form calls the lazy-loading `getCustomChange()` getter, which re-attempts the load *outside* the `Scope.child` block (where the flag has reverted to `true`) and pollutes the assertion. The field-direct form proves the in-scope load was prevented.
- **Chain 3 partial fix.** The broader env-var command-injection chain tracked in DAT-23027 combines B1 (#7747), B2 (this PR), and B10 (env-var substitution on changeset properties). With B1 + B2 gated, the chain's two RCE primitives are both opt-out-able; closing the chain fully requires B10 to land too.

## Related

Part of the May-2026 OSS credential-handling-and-changelog-injection audit slice (`sdou` label). Direct siblings:

- **#7747** (DAT-23015, B1 / `executeCommand` opt-out gate) — same opt-in restricted-mode shape applied to the sibling RCE primitive (merged).
- **#7749** (DAT-23017, B3 / `customPrecondition` opt-out gate) — paired follow-up using the same `ALLOW_CUSTOM_CHANGE` flag (open, approved).
