### PR TITLE
CWE-22 deprecation flag: opt-in path containment via liquibase.allowParentDirectoryReferences

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/GlobalConfiguration.java
+++ b/liquibase-standard/src/main/java/liquibase/GlobalConfiguration.java
@@ -55,6 +55,7 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
     public static final ConfigurationDefinition<Boolean> SECURE_PARSING;
     public static final ConfigurationDefinition<Boolean> ALLOW_CUSTOM_CHANGE;
     public static final ConfigurationDefinition<Boolean> ALLOW_EXECUTE_COMMAND;
+    public static final ConfigurationDefinition<Boolean> ALLOW_PARENT_DIRECTORY_REFERENCES;
     public static final ConfigurationDefinition<String> SEARCH_PATH;
 
     public static final ConfigurationDefinition<UIServiceEnum> UI_SERVICE;
@@ -247,6 +248,23 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
                         "that execute changelogs from less-trusted sources (multi-tenant SaaS running customer " +
                         "changelogs, downloaded change-packs, contributor PRs prior to review) where arbitrary " +
                         "OS-shell execution via changelog is not an acceptable risk (CWE-78).")
+                .setDefaultValue(true)
+                .build();
+
+        ALLOW_PARENT_DIRECTORY_REFERENCES = builder.define("allowParentDirectoryReferences", Boolean.class)
+                .setDescription("If true (the default), AbstractPathResourceAccessor allows path payloads " +
+                        "containing '..' segments and symbolic links that resolve outside the configured " +
+                        "root directory. This preserves the behaviour that existed before the CWE-22 " +
+                        "path-containment fix landed, for legitimate multi-changelog layouts that depend on " +
+                        "parent-directory traversal — for example a shared 'dbarepo' at the project root " +
+                        "referenced as '../shared/foo.xml' from per-environment changelogs underneath it, " +
+                        "or a custom-check SCRIPT_PATH like '../checks/policy.py'. Set to false to enforce " +
+                        "strict containment: any '..' that resolves outside the accessor root, or any " +
+                        "symbolic link whose canonical real path escapes the canonical root, is rejected " +
+                        "with IOException. The default is true for one major release as a deprecation " +
+                        "window; a future major release will flip the default to false, at which point " +
+                        "callers depending on parent-directory traversal must either restructure their " +
+                        "layout or explicitly opt in via this flag (CWE-22).")
                 .setDefaultValue(true)
                 .build();
 

--- a/liquibase-standard/src/main/java/liquibase/resource/AbstractPathResourceAccessor.java
+++ b/liquibase-standard/src/main/java/liquibase/resource/AbstractPathResourceAccessor.java
@@ -1,5 +1,6 @@
 package liquibase.resource;
 
+import liquibase.GlobalConfiguration;
 import liquibase.Scope;
 import liquibase.logging.Logger;
 
@@ -13,13 +14,22 @@ import java.util.*;
  * Base class for {@link ResourceAccessor}s that resolve a caller-supplied path against a
  * configured root directory (file system, zip, etc.).
  * <p>
- * <b>Containment guarantee.</b> Both {@link #getAll(String)} and
+ * <b>Containment guarantee (gated by {@link GlobalConfiguration#ALLOW_PARENT_DIRECTORY_REFERENCES}).</b>
+ * When the flag is {@code false}, both {@link #getAll(String)} and
  * {@link #search(String, SearchOptions)} reject any path that, after normalisation, escapes
  * the configured {@link #getRootPath()}. They additionally verify the canonical real path
  * (after symbolic-link resolution) stays within the canonical root, so a symlink located
  * inside the root that targets a file outside it is not silently followed.
  * <p>
- * <b>Caveats.</b>
+ * When the flag is {@code true} (the current default, for one major release as a deprecation
+ * window), both checks are skipped — the behaviour matches the pre-CWE-22-fix code path.
+ * This preserves legitimate multi-changelog layouts that depend on parent-directory traversal
+ * (e.g. {@code <include file="../shared/foo.xml">} or a Pro custom-check {@code SCRIPT_PATH}
+ * pointing to a sibling directory). A future major release will flip the default to
+ * {@code false}, at which point callers depending on parent-directory traversal must either
+ * restructure their layout or explicitly opt in via the flag.
+ * <p>
+ * <b>Caveats (only applicable when the flag is {@code false}).</b>
  * <ul>
  *   <li>The containment check is evaluated at {@code getAll} / {@code search} time. A
  *       symlink created or modified after the check (TOCTOU race) is not re-validated
@@ -62,20 +72,30 @@ public abstract class AbstractPathResourceAccessor extends AbstractResourceAcces
         // no-op for that subclass — done defensively for other implementations.
         Path rootPath = getRootPath().normalize();
         Path finalPath = rootPath.resolve(path).normalize();
-        // Reject any payload that, after normalization, escapes the configured root.
-        // Java's Path.normalize() on a relative path leaves leading ".." segments intact,
-        // so a payload like "../../etc/passwd" survives standardizePath() and only
-        // collapses after resolve(); a startsWith check catches it before Files.exists
-        // would resolve it through the OS layer.
-        if (!finalPath.startsWith(rootPath)) {
-            throw new IOException("Path '" + path + "' resolves outside accessor root '" + rootPath + "'");
+        // CWE-22 containment is gated by liquibase.allowParentDirectoryReferences. When the
+        // flag is true (the deprecation-window default), both the syntactic and the canonical
+        // checks are skipped so legitimate '..'-bearing layouts continue to resolve. See the
+        // class javadoc for the deprecation rationale.
+        final boolean strictContainment =
+                !Boolean.TRUE.equals(GlobalConfiguration.ALLOW_PARENT_DIRECTORY_REFERENCES.getCurrentValue());
+        if (strictContainment) {
+            // Reject any payload that, after normalization, escapes the configured root.
+            // Java's Path.normalize() on a relative path leaves leading ".." segments intact,
+            // so a payload like "../../etc/passwd" survives standardizePath() and only
+            // collapses after resolve(); a startsWith check catches it before Files.exists
+            // would resolve it through the OS layer.
+            if (!finalPath.startsWith(rootPath)) {
+                throw new IOException("Path '" + path + "' resolves outside accessor root '" + rootPath + "'");
+            }
         }
         if (Files.exists(finalPath)) {
-            // Defense in depth: a symbolic link at finalPath could point outside the
-            // configured root. toRealPath() follows symlinks; reject if the canonical
-            // location escapes the canonical root.
-            if (!finalPath.toRealPath().startsWith(rootPath.toRealPath())) {
-                throw new IOException("Path '" + path + "' resolves outside accessor root via symlink");
+            if (strictContainment) {
+                // Defense in depth: a symbolic link at finalPath could point outside the
+                // configured root. toRealPath() follows symlinks; reject if the canonical
+                // location escapes the canonical root.
+                if (!finalPath.toRealPath().startsWith(rootPath.toRealPath())) {
+                    throw new IOException("Path '" + path + "' resolves outside accessor root via symlink");
+                }
             }
             returnList.add(createResource(finalPath, path));
         } else {
@@ -125,9 +145,16 @@ public abstract class AbstractPathResourceAccessor extends AbstractResourceAcces
         startPath = standardizePath(startPath.replaceFirst("^file:/+", ""));
         Logger log = Scope.getCurrentScope().getLog(getClass());
 
+        // CWE-22 containment is gated by liquibase.allowParentDirectoryReferences. When the
+        // flag is true (the deprecation-window default), both the syntactic check on startPath
+        // and the per-entry canonical (symlink) checks below are skipped — matching the
+        // pre-CWE-22-fix walking behaviour for legitimate '..'-bearing layouts.
+        final boolean strictContainment =
+                !Boolean.TRUE.equals(GlobalConfiguration.ALLOW_PARENT_DIRECTORY_REFERENCES.getCurrentValue());
+
         Path rootPath = getRootPath().normalize();
         Path basePath = rootPath.resolve(startPath).normalize();
-        if (!basePath.startsWith(rootPath)) {
+        if (strictContainment && !basePath.startsWith(rootPath)) {
             throw new IOException("Search startPath '" + startPath
                     + "' resolves outside accessor root '" + rootPath + "'");
         }
@@ -143,8 +170,9 @@ public abstract class AbstractPathResourceAccessor extends AbstractResourceAcces
         }
 
         // Cache the canonical root once so the per-entry containment check below
-        // doesn't re-resolve it on every visited file/directory.
-        final Path rootRealPath = rootPath.toRealPath();
+        // doesn't re-resolve it on every visited file/directory. Only computed when
+        // strict containment is active; otherwise the per-entry checks are no-ops.
+        final Path rootRealPath = strictContainment ? rootPath.toRealPath() : null;
 
         SimpleFileVisitor<Path> fileVisitor = new SimpleFileVisitor<Path>() {
             @Override
@@ -152,7 +180,7 @@ public abstract class AbstractPathResourceAccessor extends AbstractResourceAcces
                 // walkFileTree is invoked with FOLLOW_LINKS so subdirectories may be
                 // reached via symlinks. Skip any subtree whose canonical location
                 // escapes the canonical root.
-                if (!dir.toRealPath().startsWith(rootRealPath)) {
+                if (strictContainment && !dir.toRealPath().startsWith(rootRealPath)) {
                     log.fine("Skipping directory '" + dir + "' that resolves outside accessor root");
                     return FileVisitResult.SKIP_SUBTREE;
                 }
@@ -162,7 +190,7 @@ public abstract class AbstractPathResourceAccessor extends AbstractResourceAcces
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                 // Per-file symlink check (e.g. file-level link pointing outside the root).
-                if (!file.toRealPath().startsWith(rootRealPath)) {
+                if (strictContainment && !file.toRealPath().startsWith(rootRealPath)) {
                     log.fine("Skipping file '" + file + "' that resolves outside accessor root");
                     return FileVisitResult.CONTINUE;
                 }

--- a/liquibase-standard/src/test/groovy/liquibase/resource/DirectoryResourceAccessorTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/resource/DirectoryResourceAccessorTest.groovy
@@ -1,5 +1,6 @@
 package liquibase.resource
 
+import liquibase.Scope
 import liquibase.util.StreamUtil
 import spock.lang.IgnoreIf
 import spock.lang.Specification
@@ -154,14 +155,26 @@ class DirectoryResourceAccessorTest extends Specification {
                                      "com/example/users.csv"]
     }
 
-    @Unroll("getAll rejects path traversal: #payload")
-    def "getAll rejects path traversal payloads that escape the accessor root"() {
+    @Unroll("getAll rejects path traversal under strict mode: #payload")
+    def "getAll rejects path traversal payloads that escape the accessor root when allowParentDirectoryReferences=false"() {
+        // PR #7729 introduced the CWE-22 syntactic containment check. With the deprecation flag
+        // liquibase.allowParentDirectoryReferences defaulting to true, the check is opt-in; this
+        // spec exercises the opt-in (strict) path explicitly via Scope.child.
+        given:
+        IOException caught = null
+
         when:
-        simpleTestAccessor.getAll(payload)
+        Scope.child(["liquibase.allowParentDirectoryReferences": "false"] as Map, {
+            try {
+                simpleTestAccessor.getAll(payload)
+            } catch (IOException e) {
+                caught = e
+            }
+        } as Scope.ScopedRunner)
 
         then:
-        IOException e = thrown()
-        e.message.contains("resolves outside accessor root")
+        caught != null
+        caught.message.contains("resolves outside accessor root")
 
         where:
         payload << [
@@ -175,24 +188,100 @@ class DirectoryResourceAccessorTest extends Specification {
 
     def "getAll allows paths that traverse via .. but stay inside the root"() {
         // subdir/.. collapses pre-resolve and the resulting path stays under root.
+        // Behaviour is identical under both flag values — included in the default suite
+        // (flag=true) since that's the deprecation-window default.
         expect:
         simpleTestAccessor.getAll("liquibase/resource/foo/../DirectoryResourceAccessorTest.class")*.getPath() ==
                 ["liquibase/resource/DirectoryResourceAccessorTest.class"]
     }
 
-    def "search rejects path traversal in startPath"() {
+    def "getAll allows ../ payloads that resolve outside the root when allowParentDirectoryReferences=true (deprecation default)"() {
+        // Wesley/Filipe regression scenario: a customer with a 'shared dbarepo at the project
+        // root, per-environment changelogs underneath' layout references '../shared/foo' from
+        // within the accessor root. With the deprecation-default flag=true, the resolution
+        // succeeds (matching pre-CWE-22-fix behaviour); with flag=false (the future default),
+        // the same payload would be rejected.
+        given:
+        Path rootDir = Files.createTempDirectory("accessor-root-")
+        Path outsideDir = Files.createTempDirectory("outside-sibling-")
+        Path outsideFile = outsideDir.resolve("legit.txt")
+        Files.writeString(outsideFile, "legitimate sibling content")
+        def accessor = new DirectoryResourceAccessor(rootDir)
+        String payload = "../" + outsideDir.fileName.toString() + "/legit.txt"
+        List<Resource> result = null
+
         when:
-        simpleTestAccessor.search("../../etc", true)
+        Scope.child(["liquibase.allowParentDirectoryReferences": "true"] as Map, {
+            result = accessor.getAll(payload)
+        } as Scope.ScopedRunner)
 
         then:
-        IOException e = thrown()
-        e.message.contains("resolves outside accessor root")
+        result != null
+        result.size() == 1
+        result[0].getPath() == payload
+
+        cleanup:
+        Files.deleteIfExists(outsideFile)
+        Files.deleteIfExists(outsideDir)
+        Files.deleteIfExists(rootDir)
+    }
+
+    def "search rejects ../ startPath when allowParentDirectoryReferences=false"() {
+        // Strict-mode counterpart to the search() default-mode spec below. With the deprecation
+        // flag defaulting to true, this strict-rejection assertion runs inside Scope.child.
+        given:
+        IOException caught = null
+
+        when:
+        Scope.child(["liquibase.allowParentDirectoryReferences": "false"] as Map, {
+            try {
+                simpleTestAccessor.search("../../etc", true)
+            } catch (IOException e) {
+                caught = e
+            }
+        } as Scope.ScopedRunner)
+
+        then:
+        caught != null
+        caught.message.contains("resolves outside accessor root")
+    }
+
+    def "search allows ../ startPath that resolves outside the root when allowParentDirectoryReferences=true (deprecation default)"() {
+        // Mirrors the getAll() deprecation-default spec: a sibling directory referenced via
+        // '..' from the accessor root is reachable under flag=true. Wesley flagged Flow
+        // <conditions> and policy-check SCRIPT_PATH as call sites that depend on this.
+        given:
+        Path rootDir = Files.createTempDirectory("accessor-root-")
+        Path outsideDir = Files.createTempDirectory("outside-sibling-")
+        Path outsideFile = outsideDir.resolve("foo.txt")
+        Files.writeString(outsideFile, "content")
+        def accessor = new DirectoryResourceAccessor(rootDir)
+        String startPath = "../" + outsideDir.fileName.toString()
+        List<Resource> result = null
+
+        when:
+        Scope.child(["liquibase.allowParentDirectoryReferences": "true"] as Map, {
+            result = accessor.search(startPath, true)
+        } as Scope.ScopedRunner)
+
+        then:
+        result != null
+        result.size() == 1
+        result[0].getPath().endsWith("foo.txt")
+
+        cleanup:
+        Files.deleteIfExists(outsideFile)
+        Files.deleteIfExists(outsideDir)
+        Files.deleteIfExists(rootDir)
     }
 
     // Skipped on Windows because Files.createSymbolicLink requires the
     // SeCreateSymbolicLinkPrivilege (developer mode or admin).
     @IgnoreIf({ os.windows })
-    def "getAll rejects a symlink that escapes the accessor root"() {
+    def "getAll rejects a symlink that escapes the accessor root when allowParentDirectoryReferences=false"() {
+        // Strict-mode behaviour: a symlink whose canonical real path escapes the canonical
+        // root is rejected. With the deprecation flag defaulting to true, this assertion runs
+        // inside Scope.child.
         given:
         Path rootDir = Files.createTempDirectory("accessor-root-")
         Path outsideDir = Files.createTempDirectory("outside-secret-")
@@ -201,13 +290,51 @@ class DirectoryResourceAccessorTest extends Specification {
         Path symlinkInside = rootDir.resolve("escape-link")
         Files.createSymbolicLink(symlinkInside, outsideFile)
         def accessor = new DirectoryResourceAccessor(rootDir)
+        IOException caught = null
 
         when:
-        accessor.getAll("escape-link")
+        Scope.child(["liquibase.allowParentDirectoryReferences": "false"] as Map, {
+            try {
+                accessor.getAll("escape-link")
+            } catch (IOException e) {
+                caught = e
+            }
+        } as Scope.ScopedRunner)
 
         then:
-        IOException e = thrown()
-        e.message.contains("symlink") || e.message.contains("outside")
+        caught != null
+        caught.message.contains("symlink") || caught.message.contains("outside")
+
+        cleanup:
+        Files.deleteIfExists(symlinkInside)
+        Files.deleteIfExists(outsideFile)
+        Files.deleteIfExists(outsideDir)
+        Files.deleteIfExists(rootDir)
+    }
+
+    @IgnoreIf({ os.windows })
+    def "getAll follows a symlink that escapes the accessor root when allowParentDirectoryReferences=true (deprecation default)"() {
+        // Default-mode counterpart: legitimate symlink (e.g. customers using filesystem
+        // symlinks to share resources across projects) is followed without rejection.
+        given:
+        Path rootDir = Files.createTempDirectory("accessor-root-")
+        Path outsideDir = Files.createTempDirectory("outside-content-")
+        Path outsideFile = outsideDir.resolve("legit.txt")
+        Files.writeString(outsideFile, "legitimate symlinked content")
+        Path symlinkInside = rootDir.resolve("legit-link")
+        Files.createSymbolicLink(symlinkInside, outsideFile)
+        def accessor = new DirectoryResourceAccessor(rootDir)
+        List<Resource> result = null
+
+        when:
+        Scope.child(["liquibase.allowParentDirectoryReferences": "true"] as Map, {
+            result = accessor.getAll("legit-link")
+        } as Scope.ScopedRunner)
+
+        then:
+        result != null
+        result.size() == 1
+        result[0].getPath() == "legit-link"
 
         cleanup:
         Files.deleteIfExists(symlinkInside)

--- a/liquibase-standard/src/test/groovy/liquibase/resource/SearchPathResourceAccessorTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/resource/SearchPathResourceAccessorTest.groovy
@@ -1,6 +1,7 @@
 package liquibase.resource
 
 
+import liquibase.Scope
 import liquibase.util.StreamUtil
 import spock.lang.Specification
 
@@ -18,18 +19,28 @@ class SearchPathResourceAccessorTest extends Specification {
         accessor.describeLocations()[1].endsWith("classes")
     }
 
-    def "search-path wrapper does not bypass path-traversal containment"() {
+    def "search-path wrapper does not bypass path-traversal containment when allowParentDirectoryReferences=false"() {
+        // PR #7729 introduced CompositeResourceAccessor pass-through of the per-accessor
+        // IOException. With the deprecation flag liquibase.allowParentDirectoryReferences
+        // defaulting to true, the rejection is opt-in; this spec exercises the strict path.
         given:
         ResourceAccessor accessor = new SearchPathResourceAccessor(new File(".", "target/test-classes").getAbsolutePath())
+        IOException caught = null
 
         when:
-        accessor.getAll("../../../etc/passwd")
+        Scope.child(["liquibase.allowParentDirectoryReferences": "false"] as Map, {
+            try {
+                accessor.getAll("../../../etc/passwd")
+            } catch (IOException e) {
+                caught = e
+            }
+        } as Scope.ScopedRunner)
 
         then:
         // CompositeResourceAccessor.getAll iterates child accessors and unions results.
         // The per-accessor IOException from AbstractPathResourceAccessor propagates up
         // (the composite does not catch on getAll). Pin this behaviour.
-        IOException e = thrown()
-        e.message.contains("resolves outside accessor root")
+        caught != null
+        caught.message.contains("resolves outside accessor root")
     }
 }


### PR DESCRIPTION
## TL;DR

PR #7729 ("AbstractPathResourceAccessor: confine path resolution to configured root") shipped a correct CWE-22 fix but its `startsWith(rootPath)` containment check is too coarse: it rejects *every* `..` payload regardless of whether the resolved path still lives inside the user's implicit project trust boundary. The result is four customer-visible regressions (one of them a **silent disable of policy checks with exit code 0**) for legitimate multi-changelog layouts.

This PR adds **`liquibase.allowParentDirectoryReferences`** (Boolean, default `true`) as a deprecation-window escape hatch. With the flag at its default, both containment checks introduced in #7729 are skipped and behaviour matches the pre-CWE-22-fix path. Embedders that want the strict CWE-22 hardening flip the flag to `false`. A future major release will flip the default.

No production-side behaviour change for any caller that flips the flag explicitly. Default-true preserves customer compatibility for one major release.

## Regression scenarios this addresses

### 1. CRITICAL — Pro custom Python policy checks silently disabled

Customers with the very common "shared `dbarepo` at the project root, per-environment changelogs underneath" layout reference `SCRIPT_PATH: ../dbarepo/scripts/foo.py` from inside a project-local changelog. Post-#7729 the `..` payload is rejected with `IOException`, which is silently caught by `CustomCheck.getResource` in liquibase-pro and converted to a `MissingScriptResource`. The check is then recorded as non-applicable with reason `SCRIPT_NOT_FOUND` and `returnAtEndOfRule(..., false)` — meaning no violation fires. **Exit code stays 0.** CI keeps passing while policy regressions are no longer caught. The worst-case failure mode of #7729.

### 2. HIGH — OSS changelog `<include>` with the default `relativeToChangelogFile`

`<include file="../shared/foo.xml" relativeToChangelogFile="false">` (the default!) doesn't go through `DatabaseChangeLog.normalizePath()`, so the `..` reaches `resourceAccessor.get()` intact and the `IOException` propagates up as `ChangeLogParseException` or `UnexpectedLiquibaseException`. Broadest blast radius — hits OSS users too, not just Pro. `relativeToChangelogFile="true"` is *not* affected because `normalizePath()` collapses the `..` before resolution.

### 3. HIGH — Pro Flow `<include path="../shared/foo.yaml">`

`ResourceUtil.getResource` → `resourceAccessor.get` → `getAll` → `IOException`. The exception propagates *before* the `instanceof NotFoundResource && PRO_STRICT` gate is evaluated, so the `PRO_STRICT=false` "silent" branch becomes dead code for `..` payloads. Hard fail regardless of `PRO_STRICT`.

### 4. MEDIUM — Pro Flow `<conditions>` (`fileExists('../shared/foo')`)

`FlowFileUtil.exists()` invoked via MVEL. The `IOException` is wrapped as `RuntimeException` from `MVEL.executeExpression`. `Condition.evaluate()` only catches `CompileException`, so the wrapped exception reaches the flow stage runner. Hard fail.

## Root cause

PR #7729's `startsWith(rootPath)` check is correct for catching `../../etc/passwd`-style absolute traversal beyond the *configured root*. But the configured root (`AbstractPathResourceAccessor.getRootPath()`) is typically *the changelog directory* or another tightly-scoped directory — **not** "the entire trust boundary the user implicitly considers safe". The user's mental model is "anywhere under my project root is fine"; the code's containment is narrower.

Conflating these two boundaries means every legitimate `..` traversal that walks up one level inside the user's project is indistinguishable, to the check, from a `../../etc/passwd` attack.

## The flag

```java
GlobalConfiguration.ALLOW_PARENT_DIRECTORY_REFERENCES
// liquibase.allowParentDirectoryReferences
// Boolean, default TRUE
```

| Flag value | Syntactic `startsWith(rootPath)` check | Canonical `toRealPath()` symlink check | Behaviour matches |
|---|---|---|---|
| `true` (default) | SKIPPED | SKIPPED | pre-#7729 (legitimate `..` and symlinks work) |
| `false` (opt-in hardening) | ENFORCED | ENFORCED | #7729 strict CWE-22 |

**Why a single flag, not two:** Wesley's option 3 proposal explicitly framed it as a single escape hatch. The trusted-context allowlist (option 2 — accept `..` within a configurable project boundary while keeping symlink-escape rejection on by default) is deferred to a follow-up; it requires deciding on the boundary surface and is more invasive than this PR's scope.

**Why default `true`, not `false`:** A default-false would ship the regression Wesley flagged on the very first upgrade. The deprecation-window approach (default-true now, flip to false in a future major) gives customers a release cycle to either restructure their layouts or explicitly opt in. Embedders who *already* want CWE-22 hardening flip the flag immediately.

## Deprecation timeline

- **This release**: default `true`. CWE-22 hardening is opt-in. Customer compat preserved.
- **Future major release**: default flips to `false`. CWE-22 hardening becomes default. Customers depending on `..` traversal must restructure their layout or explicitly opt in via `liquibase.allowParentDirectoryReferences=true`.

This matches the "ship a strong security default with a one-major-release deprecation window" pattern used elsewhere in Liquibase (e.g. `liquibase.secureParsing`).

## Test plan

- **Existing PR #7729 strict-mode specs (5 in `DirectoryResourceAccessorTest`, 1 in `SearchPathResourceAccessorTest`)** wrapped in `Scope.child(allowParentDirectoryReferences=false)`. Strict-mode coverage preserved verbatim, just gated. Test names updated to mention "when allowParentDirectoryReferences=false" for clarity.
- **New default-mode specs** (3 added):
  - `getAll allows ../ payloads that resolve outside the root when allowParentDirectoryReferences=true` — real temp-dir sibling, mirrors Wesley's `dbarepo` scenario
  - `search allows ../ startPath that resolves outside the root when allowParentDirectoryReferences=true` — `search()` counterpart
  - `getAll follows a symlink that escapes the accessor root when allowParentDirectoryReferences=true` — Linux-only (Windows lacks `SeCreateSymbolicLinkPrivilege`), mirrors the strict-mode symlink-rejection spec
- **`getAll allows paths that traverse via .. but stay inside the root`** — unchanged; that behaviour is flag-independent (the `..` collapses pre-resolve into a clean inside-root path).
- **Broader regression check**: ran every `*ResourceAccessor*Test` plus `DatabaseChangeLogTest`, `IncludeAllTest`, `ChangeLogParserConfigurationTest`, `XMLChangeLogSAXParserTest`, and `GlobalConfigurationTest`. **337 tests across the suite — 0 failures, 2 skipped (the Windows-conditional symlink specs).**

```
[INFO] Tests run: 337, Failures: 0, Errors: 0, Skipped: 2
[INFO] BUILD SUCCESS
```

## Things to be aware of

- **No production behaviour change at the default flag value.** Anyone whose changelogs / flow files / policy checks worked pre-#7729 continues to work after this lands.
- **PR #7729 stays merged.** This PR doesn't revert anything — it adds the opt-in gate around the checks PR #7729 introduced.
- **Symlink coverage is part of the single flag.** A customer using legitimate filesystem symlinks (e.g. shared resources via symlink, common in monorepo-ish layouts) is also restored by `flag=true`. If a future user wants `..` allowed but symlinks still blocked, the option-2 follow-up will offer that granularity.
- **Zip / `ZipResourceAccessor` is unchanged.** Per #7729's own design note, zipfs `normalize()` already clamps `..` at root, so the containment check is a no-op there. The new flag is read but has no effect for zip.
- **Performance**: one `ConfigurationDefinition.getCurrentValue()` lookup per `getAll`/`search` call. These are not inner-loop calls (one per changelog include, one per script-path resolution). Negligible.

## Related

Sibling to the May-2026 OSS credential-handling-and-changelog-injection audit slice (`sdou` label). PR #7729 is the parent fix; this PR is the compat-preserving deprecation gate.

Other audit PRs (open at time of writing): #7748 (CWE-470 customChange, merged just before this), #7749 (CWE-470 customPrecondition, awaiting re-review). Merged: #7729, #7737, #7738, #7739, #7740, #7741, #7742, #7743, #7747.
