### PR TITLE
Revert: TECHOPS-497 smoke test marker

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -127,5 +127,3 @@ For example, the h2 configuration defines a "1.x" and a "2.x" profile:
 ```
 
 The advantage of profiles is to allow users to specify the exact version of h2 relevant for their testing.
-
-<!-- TECHOPS-497 smoke test marker — safe to revert -->


### PR DESCRIPTION
Reverts the smoke-test marker commit added to validate the TECHOPS-497 auto-create-on-merge flow.

The smoke test passed end-to-end:
- SECURE-148 auto-created with both required labels
- Remote link with `globalId` attached
- Idempotency check skipped a re-run cleanly
- #docs-review Slack ping fired

Reverting now that the validation is recorded. No milestone + `skipReleaseNotes` label means this PR is also a positive test of the workflow's skip path — the auto-create job should run and report `label 'skipReleaseNotes' applied`.

Closes the loop on TECHOPS-497.