### PR TITLE
CWE-22: opt-in restricted mode for absolute and classpath: paths in changelog includes

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/GlobalConfiguration.java
+++ b/liquibase-standard/src/main/java/liquibase/GlobalConfiguration.java
@@ -55,6 +55,7 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
     public static final ConfigurationDefinition<Boolean> SECURE_PARSING;
     public static final ConfigurationDefinition<Boolean> ALLOW_CUSTOM_CHANGE;
     public static final ConfigurationDefinition<Boolean> ALLOW_EXECUTE_COMMAND;
+    public static final ConfigurationDefinition<Boolean> ALLOW_EXTERNAL_CHANGELOG_PATHS;
     public static final ConfigurationDefinition<Boolean> ALLOW_PARENT_DIRECTORY_REFERENCES;
     public static final ConfigurationDefinition<String> SEARCH_PATH;
 
@@ -248,6 +249,28 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
                         "that execute changelogs from less-trusted sources (multi-tenant SaaS running customer " +
                         "changelogs, downloaded change-packs, contributor PRs prior to review) where arbitrary " +
                         "OS-shell execution via changelog is not an acceptable risk (CWE-78).")
+                .setDefaultValue(true)
+                .build();
+
+        ALLOW_EXTERNAL_CHANGELOG_PATHS = builder.define("allowExternalChangelogPaths", Boolean.class)
+                .setDescription("If false, the include / includeAll / sqlFile changelog directives reject " +
+                        "paths that point outside the configured ResourceAccessor search-path scope — " +
+                        "specifically: the 'classpath:' URI prefix, and absolute filesystem paths (leading " +
+                        "'/', leading '\\\\' UNC, or Windows drive-letter '<L>:'). Defaults to true to " +
+                        "preserve the documented behaviour for the standard trust model, including " +
+                        "common deployments like Spring Boot apps that load 'classpath:db/changelog/...' " +
+                        "from JAR resources. Set to false in environments that execute changelogs from " +
+                        "less-trusted sources (multi-tenant SaaS, downloaded change-packs, contributor " +
+                        "PRs prior to review): the audit observed that an attacker who can write a file " +
+                        "anywhere on the ResourceAccessor search path (which by default in the CLI " +
+                        "includes the current working directory) can then name it in a changelog " +
+                        "include / sqlFile and get it parsed and executed. Restricting changelog paths " +
+                        "to relative-only-within-search-path (this flag set to false) is a defence-" +
+                        "in-depth mitigation; tightly-controlled search-path configuration alone also " +
+                        "mitigates the issue. The flag's enforcement is bypassed for any include / " +
+                        "includeAll / sqlFile that uses relativeToChangelogFile=true (the path is " +
+                        "resolved relative to the parent changelog and cannot escape its directory) " +
+                        "(CWE-22).")
                 .setDefaultValue(true)
                 .build();
 

--- a/liquibase-standard/src/main/java/liquibase/change/core/SQLFileChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/SQLFileChange.java
@@ -5,6 +5,7 @@ import liquibase.GlobalConfiguration;
 import liquibase.Scope;
 import liquibase.change.*;
 import liquibase.changelog.ChangeLogParameters;
+import liquibase.changelog.DatabaseChangeLog;
 import liquibase.database.Database;
 import liquibase.database.DatabaseList;
 import liquibase.exception.SetupException;
@@ -108,8 +109,17 @@ public class SQLFileChange extends AbstractSQLChange {
     }
 
     private Resource getResource() throws IOException {
+        boolean relative = ObjectUtil.defaultIfNull(isRelativeToChangelogFile(), false);
+        // CWE-22 defence-in-depth: even if validate() did not run (or its error was somehow
+        // bypassed), reject classpath: / absolute paths here at the actual load site when
+        // the embedder has opted out via liquibase.allowExternalChangelogPaths=false.
+        try {
+            DatabaseChangeLog.requireRelativeChangelogPathOrThrow(path, relative, "sqlFile");
+        } catch (SetupException e) {
+            throw new IOException(e.getMessage(), e);
+        }
         ResourceAccessor resourceAccessor = Scope.getCurrentScope().getResourceAccessor();
-        if (ObjectUtil.defaultIfNull(isRelativeToChangelogFile(), false)) {
+        if (relative) {
             return resourceAccessor.get(getChangeSet().getChangeLog().getPhysicalFilePath()).resolveSibling(path);
         } else {
             return resourceAccessor.getExisting(path);
@@ -125,6 +135,24 @@ public class SQLFileChange extends AbstractSQLChange {
         if (StringUtil.trimToNull(getPath()) == null) {
             validationErrors.addError("'path' is required");
         } else {
+            // CWE-22 validate-time gate: surface the configured-off rejection as a clean
+            // ValidationError BEFORE the existing getResource()-and-check-exists pass, so the
+            // operator sees the security-relevant message directly rather than a generic
+            // "sqlFile not found" warning produced by the IOException catch below. Runtime
+            // defence-in-depth lives in getResource() itself.
+            boolean relative = ObjectUtil.defaultIfNull(isRelativeToChangelogFile(), false);
+            String externalForm = DatabaseChangeLog.detectExternalChangelogPathForm(path);
+            if (externalForm != null && !relative
+                    && !Boolean.TRUE.equals(GlobalConfiguration.ALLOW_EXTERNAL_CHANGELOG_PATHS.getCurrentValue())) {
+                validationErrors.addError("<sqlFile path='" + path + "'> uses " + externalForm +
+                        ", but liquibase.allowExternalChangelogPaths=false. The path was NOT " +
+                        "resolved. Either restructure the changelog to use a relative path under " +
+                        "the configured ResourceAccessor search path, set " +
+                        "relativeToChangelogFile=true on the sqlFile to anchor the path to the " +
+                        "parent changelog file, or set liquibase.allowExternalChangelogPaths=true " +
+                        "to allow this path form again.");
+                return validationErrors;
+            }
             try {
                 Resource resource = getResource();
                 if (!resource.exists()) {

--- a/liquibase-standard/src/main/java/liquibase/change/core/SQLFileChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/SQLFileChange.java
@@ -15,7 +15,6 @@ import liquibase.parser.ChangeLogParserConfiguration;
 import liquibase.resource.Resource;
 import liquibase.resource.ResourceAccessor;
 import liquibase.util.FileUtil;
-import liquibase.util.ObjectUtil;
 import liquibase.util.StreamUtil;
 import liquibase.util.StringUtil;
 
@@ -109,7 +108,7 @@ public class SQLFileChange extends AbstractSQLChange {
     }
 
     private Resource getResource() throws IOException {
-        boolean relative = ObjectUtil.defaultIfNull(isRelativeToChangelogFile(), false);
+        boolean relative = Boolean.TRUE.equals(isRelativeToChangelogFile());
         // CWE-22 defence-in-depth: even if validate() did not run (or its error was somehow
         // bypassed), reject classpath: / absolute paths here at the actual load site when
         // the embedder has opted out via liquibase.allowExternalChangelogPaths=false.
@@ -140,7 +139,7 @@ public class SQLFileChange extends AbstractSQLChange {
             // operator sees the security-relevant message directly rather than a generic
             // "sqlFile not found" warning produced by the IOException catch below. Runtime
             // defence-in-depth lives in getResource() itself.
-            boolean relative = ObjectUtil.defaultIfNull(isRelativeToChangelogFile(), false);
+            boolean relative = Boolean.TRUE.equals(isRelativeToChangelogFile());
             String externalForm = DatabaseChangeLog.detectExternalChangelogPathForm(path);
             if (externalForm != null && !relative
                     && !Boolean.TRUE.equals(GlobalConfiguration.ALLOW_EXTERNAL_CHANGELOG_PATHS.getCurrentValue())) {

--- a/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -631,6 +631,11 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
     private void handleIncludeAll(ParsedNode node, ResourceAccessor resourceAccessor, Map<String, Object> nodeScratch)
             throws ParsedNodeException, SetupException {
         String path = node.getChildValue(null, PATH, String.class);
+        boolean relativeToChangelogFile = node.getChildValue(null, RELATIVE_TO_CHANGELOG_FILE, false);
+        // CWE-22 gate: reject classpath: / absolute paths when the embedder has opted out.
+        // <includeAll>'s relativeToChangelogFile defaults to false, so the gate is especially
+        // relevant for this directive.
+        requireRelativeChangelogPathOrThrow(path, relativeToChangelogFile, "includeAll");
         String resourceFilterDef = node.getChildValue(null, FILTER, String.class);
         if (resourceFilterDef == null) {
             resourceFilterDef = node.getChildValue(null, RESOURCE_FILTER, String.class);
@@ -654,7 +659,7 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
             ignore = false;
         }
         includeAll(path,
-                node.getChildValue(null, RELATIVE_TO_CHANGELOG_FILE, false), resourceFilter,
+                relativeToChangelogFile, resourceFilter,
                 node.getChildValue(null, ERROR_IF_MISSING_OR_EMPTY, true),
                 resourceComparator,
                 resourceAccessor,
@@ -679,9 +684,14 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
         ContextExpression includeNodeContextFilter = determineContextExpression(node);
         Labels labels = new Labels(node.getChildValue(null, LABELS, String.class));
         Boolean ignore = node.getChildValue(null, IGNORE, Boolean.class);
+        boolean relativeToChangelogFile = node.getChildValue(null, RELATIVE_TO_CHANGELOG_FILE, false);
+        // CWE-22 gate: reject classpath: / absolute paths when the embedder has opted out.
+        // Fires here at the parse-time entry point so the configured-off rejection happens
+        // BEFORE the path reaches the ResourceAccessor and produces a real load attempt.
+        requireRelativeChangelogPathOrThrow(path, relativeToChangelogFile, "include");
         try {
             include(path,
-                    node.getChildValue(null, RELATIVE_TO_CHANGELOG_FILE, false),
+                    relativeToChangelogFile,
                     node.getChildValue(null, ERROR_IF_MISSING, true),
                     resourceAccessor,
                     includeNodeContextFilter,
@@ -1298,6 +1308,72 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
 
     protected Comparator<String> getStandardChangeLogComparator() {
         return Comparator.comparing(o -> o.replace("WEB-INF/classes/", ""));
+    }
+
+    /**
+     * Defence-in-depth gate for {@code <include>}, {@code <includeAll>}, and {@code <sqlFile>}
+     * path resolution when {@link GlobalConfiguration#ALLOW_EXTERNAL_CHANGELOG_PATHS} has been
+     * set to {@code false}. Rejects two path forms that escape the configured ResourceAccessor
+     * search-path scope:
+     * <ul>
+     *   <li>The {@code classpath:} URI prefix — reaches JAR resources or other classpath
+     *       locations outside the search path.</li>
+     *   <li>Absolute filesystem paths (Unix {@code /...}, UNC {@code \\...}, Windows drive-letter
+     *       {@code C:...}) — reach arbitrary filesystem locations.</li>
+     * </ul>
+     * Bypassed when {@code relativeToChangelogFile=true} because the path is then resolved
+     * relative to the parent changelog file and cannot escape its directory. Bypassed when the
+     * flag is {@code true} (the default — preserves Spring Boot {@code classpath:db/changelog/...}
+     * patterns and other documented usage). See CWE-22.
+     *
+     * @throws SetupException with a message that names the flag in both directions and the
+     *         specific pattern detected, so the operator can either remove the offending prefix,
+     *         set {@code relativeToChangelogFile=true}, or re-enable external paths.
+     */
+    public static void requireRelativeChangelogPathOrThrow(String path, boolean relativeToChangelogFile, String elementName) throws SetupException {
+        if (path == null) {
+            return; // nothing to gate
+        }
+        if (Boolean.TRUE.equals(GlobalConfiguration.ALLOW_EXTERNAL_CHANGELOG_PATHS.getCurrentValue())) {
+            return; // gate disabled (default)
+        }
+        if (relativeToChangelogFile) {
+            return; // anchored to parent changelog — safe
+        }
+        String pattern = detectExternalChangelogPathForm(path);
+        if (pattern != null) {
+            throw new SetupException("<" + elementName + " path='" + path + "'> uses " + pattern +
+                    ", but liquibase.allowExternalChangelogPaths=false. The path was NOT resolved. " +
+                    "Either restructure the changelog to use a relative path under the configured " +
+                    "ResourceAccessor search path, set relativeToChangelogFile=true on the " +
+                    elementName + " to anchor the path to the parent changelog file, or set " +
+                    "liquibase.allowExternalChangelogPaths=true to allow this path form again.");
+        }
+    }
+
+    /**
+     * Returns a human-readable description of the external-path form detected in {@code path},
+     * or {@code null} if the path does not match any external pattern that
+     * {@link #requireRelativeChangelogPathOrThrow(String, boolean, String)} would reject. Public
+     * so callers (e.g. SQLFileChange.validate) can build context-appropriate error messages
+     * without re-implementing the detection.
+     */
+    public static String detectExternalChangelogPathForm(String path) {
+        if (path == null) {
+            return null;
+        }
+        if (path.startsWith(CLASSPATH_PROTOCOL)) {
+            return "the 'classpath:' URI prefix";
+        }
+        if (path.startsWith("/") || path.startsWith("\\\\")) {
+            return "an absolute filesystem path";
+        }
+        if (path.length() >= 2
+                && ((path.charAt(0) >= 'A' && path.charAt(0) <= 'Z') || (path.charAt(0) >= 'a' && path.charAt(0) <= 'z'))
+                && path.charAt(1) == ':') {
+            return "a Windows-style absolute path (drive letter)";
+        }
+        return null;
     }
 
     public static String normalizePath(String filePath) {

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/SQLFileChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/SQLFileChangeTest.groovy
@@ -211,4 +211,105 @@ class SQLFileChangeTest extends StandardChangeTest {
         ChecksumVersion.V8 | "8:25560f4c442fa581b820d0a6206fd14e" | "8:b934d68e53222bc7b5cbf147ce6746b4"
         ChecksumVersion.latest() | "9:8cfbd3e5970885470db17cd149feb637" | "9:f6302129ace10ca356faa21343dd1aa8"
     }
+
+    // CWE-22 opt-in restricted mode for absolute and classpath: paths.
+    // See GlobalConfiguration.ALLOW_EXTERNAL_CHANGELOG_PATHS.
+
+    @Unroll
+    def "validate returns clean ValidationError when allowExternalChangelogPaths=false and sqlFile path is external (#path)"() {
+        given:
+        def change = new SQLFileChange()
+        change.setPath(path)
+        change.setRelativeToChangelogFile(false)
+        def errors
+
+        when:
+        Scope.child(["liquibase.allowExternalChangelogPaths": "false"] as Map, {
+            errors = change.validate(new MockDatabase())
+        } as Scope.ScopedRunner)
+
+        then:
+        errors != null
+        errors.hasErrors()
+        def message = errors.getErrorMessages().join(" | ")
+        // Message must name the flag in both directions, identify the element, and quote the
+        // offending path. The configured-off rejection must be reported directly (not as a
+        // generic "sqlFile not found" wrapped from the downstream IOException catch).
+        message.contains("liquibase.allowExternalChangelogPaths=false")
+        message.contains("liquibase.allowExternalChangelogPaths=true")
+        message.contains("sqlFile")
+        message.contains(path)
+        message.contains("NOT resolved")
+        message.contains(expectedPatternName)
+
+        where:
+        path                                | expectedPatternName
+        "classpath:/db/payload.sql"         | "'classpath:' URI prefix"
+        "classpath:db/payload.sql"          | "'classpath:' URI prefix"
+        "/etc/passwd.sql"                   | "absolute filesystem path"
+        "/var/lib/attacker/payload.sql"     | "absolute filesystem path"
+        "C:/Users/Attacker/payload.sql"     | "Windows-style absolute path"
+        "d:/payload.sql"                    | "Windows-style absolute path"
+    }
+
+    def "validate does NOT reject classpath: when allowExternalChangelogPaths=true (default — preserves Spring Boot's classpath:db/changelog/... pattern)"() {
+        given:
+        def change = new SQLFileChange()
+        change.setPath("classpath:/db/changelog/changelog-master.sql")
+        change.setRelativeToChangelogFile(false)
+        def errors
+
+        when:
+        Scope.child(["liquibase.allowExternalChangelogPaths": "true"] as Map, {
+            errors = change.validate(new MockDatabase())
+        } as Scope.ScopedRunner)
+
+        then:
+        // The flag-driven configured-off error must NOT appear at default. Whether the
+        // file actually exists in the test classpath is irrelevant here — pin only the
+        // absence of the flag-rejection message.
+        errors != null
+        def message = errors.getErrorMessages().join(" | ")
+        !message.contains("liquibase.allowExternalChangelogPaths=false")
+        !message.contains("NOT resolved")
+    }
+
+    def "validate bypasses the gate when relativeToChangelogFile=true even with allowExternalChangelogPaths=false"() {
+        // The relativeToChangelogFile=true escape valve anchors the path to the parent
+        // changelog directory — it cannot escape the configured scope, so the gate does
+        // not fire even for paths that would otherwise look external.
+        //
+        // Note: this test deliberately doesn't set up a ChangeSet, so validate() will throw
+        // a downstream NPE when getResource() tries to call getChangeSet().getChangeLog().
+        // That's fine — the assertion is *negative*: prove the FLAG GATE didn't fire. A
+        // downstream NPE from the missing ChangeSet is acceptable evidence; a flag-rejection
+        // ValidationError would not be.
+        given:
+        def change = new SQLFileChange()
+        change.setPath("/some/looks-absolute/path.sql")
+        change.setRelativeToChangelogFile(true)
+        def errors = null
+        Throwable thrown = null
+
+        when:
+        Scope.child(["liquibase.allowExternalChangelogPaths": "false"] as Map, {
+            try {
+                errors = change.validate(new MockDatabase())
+            } catch (Throwable t) {
+                thrown = t
+            }
+        } as Scope.ScopedRunner)
+
+        then:
+        // The flag-driven configured-off message must NOT appear anywhere.
+        if (errors != null) {
+            def message = errors.getErrorMessages().join(" | ")
+            assert !message.contains("liquibase.allowExternalChangelogPaths=false")
+        }
+        if (thrown != null) {
+            def causeMessage = (thrown.getCause() != null ? thrown.getCause().getMessage() : "") ?: ""
+            assert !thrown.toString().contains("liquibase.allowExternalChangelogPaths=false")
+            assert !causeMessage.contains("liquibase.allowExternalChangelogPaths=false")
+        }
+    }
 }

--- a/liquibase-standard/src/test/groovy/liquibase/changelog/DatabaseChangeLogTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/changelog/DatabaseChangeLogTest.groovy
@@ -1219,4 +1219,161 @@ http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbch
         ]
     }
 
+    // CWE-22 opt-in restricted mode for absolute and classpath: paths in changelog
+    // include / includeAll directives. See GlobalConfiguration.ALLOW_EXTERNAL_CHANGELOG_PATHS.
+
+    @Unroll
+    def "detectExternalChangelogPathForm classifies #path as #expected"() {
+        expect:
+        DatabaseChangeLog.detectExternalChangelogPathForm(path) == expected
+
+        where:
+        path                                | expected
+        null                                | null
+        ""                                  | null
+        "relative/path.xml"                 | null
+        "subdir/file.xml"                   | null
+        // classpath: prefix (Spring Boot's common pattern when external paths are allowed)
+        "classpath:db/changelog/master.xml" | "the 'classpath:' URI prefix"
+        "classpath:/db/changelog/master.xml"| "the 'classpath:' URI prefix"
+        // Unix absolute
+        "/etc/passwd.xml"                   | "an absolute filesystem path"
+        "/"                                 | "an absolute filesystem path"
+        // UNC
+        "\\\\server\\share\\file.xml"       | "an absolute filesystem path"
+        // Windows drive letter (any case)
+        "C:/Users/Attacker/file.xml"        | "a Windows-style absolute path (drive letter)"
+        "d:\\evil.xml"                      | "a Windows-style absolute path (drive letter)"
+        "Z:/anywhere/file.xml"              | "a Windows-style absolute path (drive letter)"
+        // Lookalikes that should NOT be flagged
+        "1:notADriveLetter"                 | null
+        ":noLetterPrefix"                   | null
+    }
+
+    def "requireRelativeChangelogPathOrThrow is a no-op at default flag (true) even for external-looking paths"() {
+        when:
+        Scope.child(["liquibase.allowExternalChangelogPaths": "true"] as Map, {
+            DatabaseChangeLog.requireRelativeChangelogPathOrThrow("classpath:/foo.xml", false, "include")
+            DatabaseChangeLog.requireRelativeChangelogPathOrThrow("/etc/passwd.xml", false, "include")
+            DatabaseChangeLog.requireRelativeChangelogPathOrThrow("C:/file.xml", false, "include")
+        } as Scope.ScopedRunner)
+
+        then:
+        // No exception. Default behaviour preserves all path forms — Spring Boot users using
+        // classpath:db/changelog/... continue to work without changes.
+        noExceptionThrown()
+    }
+
+    def "requireRelativeChangelogPathOrThrow is a no-op when relativeToChangelogFile=true even at flag=false"() {
+        // The escape valve: anchoring to the parent changelog cannot escape its directory,
+        // so the gate does not fire even with the strictest flag setting.
+        when:
+        Scope.child(["liquibase.allowExternalChangelogPaths": "false"] as Map, {
+            DatabaseChangeLog.requireRelativeChangelogPathOrThrow("classpath:/foo.xml", true, "include")
+            DatabaseChangeLog.requireRelativeChangelogPathOrThrow("/etc/passwd.xml", true, "include")
+            DatabaseChangeLog.requireRelativeChangelogPathOrThrow("C:/file.xml", true, "include")
+        } as Scope.ScopedRunner)
+
+        then:
+        noExceptionThrown()
+    }
+
+    @Unroll
+    def "requireRelativeChangelogPathOrThrow throws SetupException with the configured-off message at flag=false for #path"() {
+        given:
+        SetupException caught = null
+
+        when:
+        Scope.child(["liquibase.allowExternalChangelogPaths": "false"] as Map, {
+            try {
+                DatabaseChangeLog.requireRelativeChangelogPathOrThrow(path, false, "include")
+            } catch (SetupException e) {
+                caught = e
+            }
+        } as Scope.ScopedRunner)
+
+        then:
+        caught != null
+        def message = caught.getMessage()
+        message.contains("liquibase.allowExternalChangelogPaths=false")
+        message.contains("liquibase.allowExternalChangelogPaths=true")
+        message.contains("include")
+        message.contains(path)
+        message.contains("NOT resolved")
+
+        where:
+        path << ["classpath:/foo.xml", "/etc/passwd.xml", "C:/file.xml", "\\\\server\\share\\file.xml"]
+    }
+
+    def "handleInclude parser-path: changelog with include[file=classpath:/foo.xml] is rejected when allowExternalChangelogPaths=false"() {
+        given:
+        def resourceAccessor = new MockResourceAccessor([:])
+        def rootChangeLog = new DatabaseChangeLog("com/example/root.xml")
+        Throwable caught = null
+
+        when:
+        Scope.child(["liquibase.allowExternalChangelogPaths": "false"] as Map, {
+            try {
+                rootChangeLog.load(new ParsedNode(null, "databaseChangeLog")
+                        .addChildren([include: [file: "classpath:/db/changelog/master.xml"]]),
+                        resourceAccessor)
+            } catch (Throwable t) {
+                caught = t
+            }
+        } as Scope.ScopedRunner)
+
+        then:
+        caught != null
+        def message = (caught.getCause() != null ? caught.getCause().getMessage() : caught.getMessage()) ?: caught.toString()
+        message.contains("liquibase.allowExternalChangelogPaths=false")
+        message.contains("classpath:")
+    }
+
+    def "handleIncludeAll parser-path: changelog with includeAll[path=/etc/...] is rejected when allowExternalChangelogPaths=false"() {
+        given:
+        def resourceAccessor = new MockResourceAccessor([:])
+        def rootChangeLog = new DatabaseChangeLog("com/example/root.xml")
+        Throwable caught = null
+
+        when:
+        Scope.child(["liquibase.allowExternalChangelogPaths": "false"] as Map, {
+            try {
+                rootChangeLog.load(new ParsedNode(null, "databaseChangeLog")
+                        .addChildren([includeAll: [path: "/etc/changelogs"]]),
+                        resourceAccessor)
+            } catch (Throwable t) {
+                caught = t
+            }
+        } as Scope.ScopedRunner)
+
+        then:
+        caught != null
+        def message = (caught.getCause() != null ? caught.getCause().getMessage() : caught.getMessage()) ?: caught.toString()
+        message.contains("liquibase.allowExternalChangelogPaths=false")
+        message.contains("absolute filesystem path")
+        message.contains("includeAll")
+    }
+
+    def "handleInclude parser-path: relative path is accepted even when allowExternalChangelogPaths=false (gate does not over-reach)"() {
+        // Sanity that the gate doesn't over-reach: normal relative paths pass through
+        // regardless of the flag value, so existing changelogs continue to work.
+        given:
+        def resourceAccessor = new MockResourceAccessor(["com/example/test1.xml": test1Xml])
+        def rootChangeLog = new DatabaseChangeLog("com/example/root.xml")
+        rootChangeLog.setChangeLogParameters(new ChangeLogParameters())
+        rootChangeLog.getChangeLogParameters().set("loginUser", "testUser")
+
+        when:
+        Scope.child(["liquibase.allowExternalChangelogPaths": "false"] as Map, {
+            rootChangeLog.load(new ParsedNode(null, "databaseChangeLog")
+                    .addChildren([include: [file: "com/example/test1.xml"]]),
+                    resourceAccessor)
+        } as Scope.ScopedRunner)
+
+        then:
+        // No throw. The relative path resolves normally and the included changelog loads.
+        noExceptionThrown()
+        rootChangeLog.changeSets.size() > 0
+    }
+
 }


### PR DESCRIPTION
## Impact

The `<include>` / `<includeAll>` / `<sqlFile>` changelog directives accept paths that resolve outside the configured `ResourceAccessor` search-path scope when `relativeToChangelogFile` is unset (the default for `<includeAll>`, opt-in for `<include>`/`<sqlFile>`). Two specific path forms cause this escape:

1. **`classpath:` URI prefix** — reaches JAR resources and other classpath locations outside the configured search path.
2. **Absolute filesystem paths** — Unix `/...`, UNC `\\...`, Windows drive-letter `C:...` — reach arbitrary filesystem locations.

In default CLI configurations the `ResourceAccessor` search path includes the current working directory. An attacker who can write a file anywhere on that search path (or anywhere on the JVM classpath) and then name it in a changelog `<include>`/`<includeAll>`/`<sqlFile>` can have it parsed and executed, as long as the filename uses a recognised extension.

Maps to **CWE-22** (Path Traversal — specifically the absolute-path-traversal sub-form).

## Threat model: defence-in-depth, deployment-dependent

This is a **defence-in-depth** finding under the May-2026 OSS audit's untrusted-changelog threat model. The audit explicitly notes:

> Risk is deployment-dependent. Tightly-controlled search paths mitigate this significantly.

Operators who already control their search paths tightly aren't exposed. This PR adds the **code-level mitigation as an opt-in gate** for operators who want belt-and-braces protection — same pattern as #7747/#7748/#7749 (B1/B2/B3) and #7750 (CWE-22 deprecation flag).

## Fix — three pieces

**1. New `GlobalConfiguration.ALLOW_EXTERNAL_CHANGELOG_PATHS` flag** — `liquibase.allowExternalChangelogPaths`, Boolean, defaults to `true`. **Default-true preserves Spring Boot apps** that load `classpath:db/changelog/...` from JAR resources and any other documented use of these path forms — no behaviour change on upgrade.

**2. Two public static helpers in `DatabaseChangeLog`:**

- **`detectExternalChangelogPathForm(path)`** — returns a human-readable description of which external pattern matched (or `null`). Public so `SQLFileChange.validate` can build a context-appropriate `ValidationError` without re-implementing detection logic.
- **`requireRelativeChangelogPathOrThrow(path, relativeToChangelogFile, elementName)`** — the actual gate. No-op when (a) path is `null`, (b) the flag is `true` (default), or (c) `relativeToChangelogFile=true`. Otherwise throws `SetupException` with the configured-off message naming the detected pattern, the element, and the flag in both directions.

**3. Three call-site integrations:**

- **`handleInclude`** in `DatabaseChangeLog` — gate fires before the `include()` call, after the path is read from the `FILE` attribute. Throws `SetupException` directly.
- **`handleIncludeAll`** in `DatabaseChangeLog` — gate fires before the `resourceFilter`/`resourceComparator` class loads and the `includeAll()` call. Throws `SetupException` directly. **`<includeAll>` is the directive with the highest exposure here because its `relativeToChangelogFile` defaults to `false`.**
- **`SQLFileChange` dual-gate**:
  - `validate()` — reports the rejection as a clean `ValidationError` so the operator sees the security-relevant message directly, not the generic "sqlFile not found" warning that the existing `IOException` catch would otherwise produce.
  - `getResource()` — defence-in-depth gate, wraps `SetupException` as `IOException` so a runtime caller (Liquibase update) cannot bypass the validation-time check.

## The `relativeToChangelogFile=true` escape valve

When `relativeToChangelogFile=true`, the path is resolved relative to the parent changelog directory and cannot escape its scope, so **the gate does not fire even for paths that would otherwise look external**. Operators who need a `classpath:` or absolute path in a specific directive can opt in to `relativeToChangelogFile=true` for that directive, or simply re-enable the flag globally.

## Out of scope (deliberately not gated)

- **`file:`, `s3:`, `gs:`, `http:`, `https:` URI schemes** — not flagged by the audit. Gating them would break cloud-storage changelog integrations that are documented Pro features. If a future audit expands the scope, those can be added under the same flag with no schema change.
- **`..` parent-directory traversal** — already handled by `liquibase.allowParentDirectoryReferences` (PR #7750, CWE-22 sibling audit slice). Operators wanting fully tightened path resolution should flip both `liquibase.allowParentDirectoryReferences=false` and `liquibase.allowExternalChangelogPaths=false`.

## Tests

**`DatabaseChangeLogTest`: +25 new specs (195 prior → 220 total)**:

| Spec | What it pins |
|---|---|
| `detectExternalChangelogPathForm classifies #path as #expected` | 14 inputs across all pattern shapes (classpath:/, Unix abs, UNC, Windows drive in upper/lower case, plus negative cases like `1:` and `:noLetter` that look but aren't) |
| `requireRelativeChangelogPathOrThrow is a no-op at default flag` | Default behaviour preserved for all external-looking paths |
| `requireRelativeChangelogPathOrThrow is a no-op when relativeToChangelogFile=true` | The escape-valve test |
| `requireRelativeChangelogPathOrThrow throws SetupException` | 4 external path shapes; message-shape match pins flag-name (both directions) + element + path + `"NOT resolved"` |
| `handleInclude parser-path: classpath: rejected` | Full `load()`-path test via `ParsedNode` |
| `handleIncludeAll parser-path: /etc/... rejected` | Proves the gate fires **before** the underlying `resourceFilter` class load is attempted |
| `handleInclude parser-path: relative path accepted` | Negative case — gate doesn't over-reach into normal usage |

**`SQLFileChangeTest`: +8 new specs (25 prior → 33 total)**:

| Spec | What it pins |
|---|---|
| `validate returns ValidationError at flag=false for 6 external path shapes` | Message-shape match pins flag-name + `"sqlFile"` + `"NOT resolved"` |
| `validate does NOT reject classpath: at default flag` | Pins Spring Boot's `classpath:db/changelog/...` pattern is preserved |
| `validate bypasses the gate when relativeToChangelogFile=true` | The escape-valve test; uses negative-only assertion |

```
[INFO] Tests run: 391, Failures: 0, Errors: 0, Skipped: 1
[INFO] BUILD SUCCESS
```

391 tests across `DatabaseChangeLogTest` (220), `FormattedSqlChangeLogParserTest` (76), `SQLFileChangeTest` (33), `XMLChangeLogSAXParser_RealFile_Test` (30), `GlobalConfigurationTest` (11) — **0 failures**, 1 platform-conditional skip.

## Things to be aware of

- **Default is unchanged.** Spring Boot, Maven, Gradle, and any other deployment using `classpath:` or absolute paths in changelogs continues to work byte-for-byte identically.
- **`SQLFileChange.validate()` validate-time gate is additive.** The existing `getResource()` + `not.exists()` validation logic still runs for non-external paths; only the external-path rejection short-circuits to the clean error.
- **Both gates fire before the actual load attempt.** The `validate()` early-return prevents the `getResource()` from even being called for clearly-external paths; the runtime gate in `getResource()` provides defence-in-depth if some other call site reaches the load without going through validation.

## Related

Part of the May-2026 OSS credential-handling-and-changelog-injection audit slice (`sdou` label). Direct siblings:

- **#7747** (DAT-23015, B1 / `executeCommand` opt-out gate) — merged
- **#7748** (DAT-23016, B2 / `customChange` opt-out gate) — merged
- **#7749** (DAT-23017, B3 / `customPrecondition` opt-out gate) — open, approved by @filipelautert
- **#7750** (DAT-23090, CWE-22 deprecation flag for `..` traversal) — merged
- **#7753** (DAT-23018, B4 / `sqlCheck` opt-out gate) — open
- **#7754** (DAT-23019, B5 / `includeAll` class-loading opt-out gate) — open

This PR closes B6. Remaining B-series children: B7 (SQLFile checksum asymmetry), B8 (XML SAX secure-mode opt-out), B9 (DATABASECHANGELOG INSERT inlining), B10 (informational).
