### PR TITLE
CWE-693 follow-up: scope generic JDBC userinfo matcher to authority-position only

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/database/jvm/JdbcConnectionPatterns.java
+++ b/liquibase-standard/src/main/java/liquibase/database/jvm/JdbcConnectionPatterns.java
@@ -68,10 +68,33 @@ public class JdbcConnectionPatterns extends ConnectionPatterns {
 
         // Generic JDBC userinfo fallback for any jdbc: URL not covered by the dialect
         // patterns above (postgresql, sqlserver, third-party drivers; CWE-693).
-        // See git blame / PR for design rationale and the dialect-vs-generic tradeoff.
-        final Pattern anyJdbcUrl = Pattern.compile("(?i)jdbc:.*");
-        addJdbcBlankPatterns(PatternPair.of(anyJdbcUrl, Pattern.compile(FILTER_CREDS)));
-        addJdbcBlankToObfuscatePatterns(PatternPair.of(anyJdbcUrl, Pattern.compile(FILTER_CREDS_MYSQL_TO_OBFUSCATE)));
-        addJdbcBlankToObfuscatePatternsReplaceWithEmpty(PatternPair.of(anyJdbcUrl, Pattern.compile(FILTER_CREDS_MYSQL_TO_OBFUSCATE_EMPTY)));
+        //
+        // The matcher is anchored to "@ follows :// with only authority-shaped characters
+        // between them" — specifically, no '/', ';', or '?'. This prevents the userinfo
+        // filter from firing on URLs where the '@' is NOT in the authority position:
+        //
+        //   * jdbc:sqlserver://host:1433;databaseName=mydb;...;user=admin@tenant.com;password=pass
+        //     — Azure-AD UPN inside a ';property=value' string. The '@' is in a property
+        //       value, not in userinfo. With the original "(?i)jdbc:.*" matcher this URL
+        //       false-matched, and the greedy FILTER_CREDS_MYSQL_TO_OBFUSCATE_EMPTY then
+        //       stripped 'jdbc:sqlserver://host:1433;...;user=admin@' from the front,
+        //       leaving 'tenant.com;password=pass' (later stripped further to 'tenant.com'
+        //       by the dialect's sanitizeAndStripParams) — a real LLT regression
+        //       discovered via MSSQLDatabaseTest.getTargetUniquenessAttributes_allAuthMethods_
+        //       produceSameUrl on the liquibase-pro subtree-sync.
+        //
+        //   * jdbc:postgresql://host:5432/db?user=admin@tenant.com&password=p
+        //     — '@' inside a query-string value. The dedicated FILTER_CREDS_USER /
+        //       FILTER_CREDS_PASSWORD obfuscation filters handle this correctly; the
+        //       userinfo filter has no business here.
+        //
+        // URLs WITH genuine userinfo (jdbc:postgresql://user:pass@host/db,
+        // jdbc:sqlserver://user:pass@host/db, third-party drivers in the same shape)
+        // are unchanged by this scoping — the userinfo characters never include '/',
+        // ';', or '?', so the new matcher still matches them.
+        final Pattern anyJdbcUrlWithAuthorityUserinfo = Pattern.compile("(?i)jdbc:[^/]+://[^/;?]+@.*");
+        addJdbcBlankPatterns(PatternPair.of(anyJdbcUrlWithAuthorityUserinfo, Pattern.compile(FILTER_CREDS)));
+        addJdbcBlankToObfuscatePatterns(PatternPair.of(anyJdbcUrlWithAuthorityUserinfo, Pattern.compile(FILTER_CREDS_MYSQL_TO_OBFUSCATE)));
+        addJdbcBlankToObfuscatePatternsReplaceWithEmpty(PatternPair.of(anyJdbcUrlWithAuthorityUserinfo, Pattern.compile(FILTER_CREDS_MYSQL_TO_OBFUSCATE_EMPTY)));
     }
 }

--- a/liquibase-standard/src/test/groovy/liquibase/database/jvm/JdbcConnectionTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/database/jvm/JdbcConnectionTest.groovy
@@ -42,6 +42,20 @@ class JdbcConnectionTest extends Specification {
         "jdbc:postgresql://liquibaseuser:secret@host:5432/db"                                | "jdbc:postgresql:@host:5432/db"
         "jdbc:sqlserver://user:secret@host:1433/db"                                          | "jdbc:sqlserver:@host:1433/db"
         "jdbc:vendor-x://liquibaseuser:secret@host:9999/db"                                  | "jdbc:vendor-x:@host:9999/db"
+        // CWE-693 follow-up: the generic userinfo matcher is now scoped to authority-position
+        // '@' only — these three URLs put '@' in a property value or query string, NOT in
+        // userinfo, and must NOT trigger the generic strip. The dedicated property/query
+        // filters (FILTER_CREDS_PW_TO_BLANK, FILTER_CREDS_USER_TO_BLANK) handle them.
+        // Without the scoped matcher fix, the MSSQL case below stripped 'host:1433;...;user=admin@'
+        // leaving 'tenant.com;password=pass' — caught by liquibase-pro MSSQLDatabaseTest.
+        "jdbc:sqlserver://host:1433;databaseName=mydb;authentication=ActiveDirectoryPassword;user=admin@tenant.com;password=pass" | "jdbc:sqlserver://host:1433;databaseName=mydb;authentication=ActiveDirectoryPassword"
+        // Password value is deliberately longer than 1 char to avoid a pre-existing literal-
+        // replace collision in FILTER_CREDS_PASSWORD where ':p' would match 'jdbc:p[ostgresql]'.
+        // That collision exists independently of this CWE-693 follow-up; tracked as a separate
+        // latent issue in the sanitizeUrl obfuscation step. Use 'secret123' here so the test
+        // pins the regression-of-interest (authority-position scoping) cleanly.
+        "jdbc:postgresql://host:5432/db?user=admin@tenant.com&password=secret123"            | "jdbc:postgresql://host:5432/db"
+        "jdbc:somevendor://host:5432/db;property=value@with-at-sign;password=p"              | "jdbc:somevendor://host:5432/db;property=value@with-at-sign"
         null                                                                                 | null
     }
 
@@ -84,6 +98,12 @@ class JdbcConnectionTest extends Specification {
         "jdbc:postgresql://liquibaseuser:secret@host:5432/db"                                | "jdbc:postgresql://*****:*****@host:5432/db"
         "jdbc:sqlserver://user:secret@host:1433/db"                                          | "jdbc:sqlserver://*****:*****@host:1433/db"
         "jdbc:vendor-x://liquibaseuser:secret@host:9999/db"                                  | "jdbc:vendor-x://*****:*****@host:9999/db"
+        // CWE-693 follow-up: '@' inside property value / query string must NOT trigger the
+        // userinfo obfuscator. Authority preserved; user/password obfuscated by dedicated
+        // property filters.
+        "jdbc:sqlserver://host:1433;databaseName=mydb;authentication=ActiveDirectoryPassword;user=admin@tenant.com;password=pass" | "jdbc:sqlserver://host:1433;databaseName=mydb;authentication=ActiveDirectoryPassword;user=*****;password=*****"
+        "jdbc:postgresql://host:5432/db?user=admin@tenant.com&password=secret123"            | "jdbc:postgresql://host:5432/db?user=*****&password=*****"
+        "jdbc:somevendor://host:5432/db;property=value@with-at-sign;password=p"              | "jdbc:somevendor://host:5432/db;property=value@with-at-sign;password=*****"
         null                                                                                 | null
     }
 
@@ -125,6 +145,15 @@ class JdbcConnectionTest extends Specification {
         "jdbc:postgresql://liquibaseuser:secret@host:5432/db"                                | "jdbc:postgresql://host:5432/db"
         "jdbc:sqlserver://user:secret@host:1433/db"                                          | "jdbc:sqlserver://host:1433/db"
         "jdbc:vendor-x://liquibaseuser:secret@host:9999/db"                                  | "jdbc:vendor-x://host:9999/db"
+        // CWE-693 follow-up — the strongest regression assertion in this set. Without the
+        // scoped-matcher fix the MSSQL Azure-AD URL had 'host:1433' replaced by 'tenant.com'
+        // here (the buggy generic strip left 'tenant.com;password=pass' which then got
+        // further trimmed by MSSQLDatabase.sanitizeAndStripParams to 'jdbc:sqlserver://tenant.com').
+        // The fix means 'host:1433' is preserved; only the user/password property values
+        // are masked.
+        "jdbc:sqlserver://host:1433;databaseName=mydb;authentication=ActiveDirectoryPassword;user=admin@tenant.com;password=pass" | "jdbc:sqlserver://host:1433;databaseName=mydb;authentication=ActiveDirectoryPassword;user=*****;password=*****"
+        "jdbc:postgresql://host:5432/db?user=admin@tenant.com&password=secret123"            | "jdbc:postgresql://host:5432/db?user=*****&password=*****"
+        "jdbc:somevendor://host:5432/db;property=value@with-at-sign;password=p"              | "jdbc:somevendor://host:5432/db;property=value@with-at-sign;password=*****"
         null                                                                                 | null
     }
 }


### PR DESCRIPTION
## TL;DR

PR #7740 ("CWE-693: add generic JDBC userinfo fallback to sanitizeUrl coverage", merged 2026-05-20) introduced a regression I missed in its own test set. The generic matcher `(?i)jdbc:.*` is too coarse: it fires on URLs whose `@` sits **inside a property value or query string** rather than in the URL authority. The position-blind MySQL-style filter then strips across the property/query boundary and removes content the URL needs to keep — most notably for MSSQL Azure-AD URLs with `user=<upn>@<tenant>` properties.

This PR tightens the matcher to fire **only** when `@` follows `://` with authority-shaped characters in between:

```java
// before  (too broad)
Pattern.compile("(?i)jdbc:.*")

// after   (authority-position only)
Pattern.compile("(?i)jdbc:[^/]+://[^/;?]+@.*")
```

The original CWE-693 coverage (`jdbc:postgresql://user:pass@host/db`, `jdbc:sqlserver://user:pass@host/db`, third-party drivers in the same shape) is fully preserved — userinfo characters never contain `/`, `;`, or `?`, so the scoped matcher still matches them.

## The concrete regression

Caught by upstream-side `MSSQLDatabaseTest.getTargetUniquenessAttributes_allAuthMethods_produceSameUrl` when the subtree-sync PR liquibase/liquibase-pro#3860 tried to bring #7740 into Pro:

```java
MSSQLDatabase dbAzureAd = new MSSQLDatabase();
dbAzureAd.setConnection(mockMssqlConnection(
    "jdbc:sqlserver://host:1433;databaseName=mydb;authentication=ActiveDirectoryPassword;user=admin@tenant.com;password=pass",
    "mydb", "dbo"));

assertThat(dbAzureAd.getTargetUniquenessAttributes().getSanitizedUrl())
    .isEqualTo("jdbc:sqlserver://host:1433"); // FAILED pre-fix
```

```
expected: "jdbc:sqlserver://host:1433"
 but was: "jdbc:sqlserver://tenant.com"
```

**Why it matters (LLT correctness, not just cosmetic):** `MSSQLDatabase.getTargetUniquenessAttributes()` computes a `targetId` from the sanitized URL. With the bug, the same MSSQL database connected via SQL auth, Integrated auth, and Azure-AD auth produces THREE different sanitized URLs (`host:1433`, `host:1433`, and `tenant.com`), and therefore three different `targetId`s. The same database then counts multiple times against the customer's licensed-target budget.

## Root cause

The MySQL-style filter `(?i).+://(.*?)([:])(.*?@)` with `String.replace` literal-substitution semantics:

For the Azure-AD URL:
- `.+://` greedy matches `jdbc:sqlserver://`
- `(.*?):` lazy matches `host:` → group 1 = `host`, group 2 = `:`
- `(.*?@)` lazy reaches to the FIRST `@` in the URL, which is `admin@` in the property value
- group 3 = `1433;databaseName=mydb;authentication=ActiveDirectoryPassword;user=admin@`

`jdbcUrl.replace(group1 + group2 + group3, "")` strips `host:1433;databaseName=mydb;authentication=ActiveDirectoryPassword;user=admin@`. What's left: `jdbc:sqlserver://tenant.com;password=pass`. After `sanitizeAndStripParams` trims trailing `;password=...`: `jdbc:sqlserver://tenant.com`.

The filter itself is correct for its intended dialect-specific use (MySQL/MariaDB userinfo). The bug is the **generic matcher** that triggered the filter on a URL shape it wasn't designed for.

## Why #7740's own tests didn't catch this

#7740 added test cases for `jdbc:postgresql://user:pass@host`, `jdbc:sqlserver://user:pass@host`, and a synthetic third-party dialect — **all with host-position userinfo**, where the filter is correct. No test exercised an `@` inside a property value or query string. My miss; filing this ticket on myself.

## Fix — design

Scope-by-position. The new matcher:

```java
Pattern.compile("(?i)jdbc:[^/]+://[^/;?]+@.*")
```

- `jdbc:` — literal prefix
- `[^/]+` — driver scheme (anything except `/`)
- `://` — authority opener
- `[^/;?]+` — authority body: no `/`, `;`, or `?` in between
- `@` — userinfo separator (required for this filter to even be relevant)
- `.*` — rest of URL

Behaviour for the three cases the audit ticket identified, plus #7740's existing fixtures:

| URL | Matcher matches? | Filter runs? | Outcome |
|---|---|---|---|
| `jdbc:postgresql://user:pass@host:5432/db` | yes | yes (correct) | userinfo stripped — preserved coverage |
| `jdbc:sqlserver://user:pass@host:1433/db` | yes | yes (correct) | userinfo stripped — preserved coverage |
| `jdbc:vendor-x://user:pass@host:9999/db` | yes | yes (correct) | userinfo stripped — preserved coverage |
| `jdbc:sqlserver://host:1433;...;user=admin@tenant.com;password=pass` | **no** (`;` between `://` and `@`) | no | **FIXED** — authority preserved |
| `jdbc:postgresql://host:5432/db?user=admin@tenant.com&password=p` | **no** (`/?` between `://` and `@`) | no | **FIXED** — authority preserved |
| `jdbc:somevendor://host:5432/db;property=value@with-at-sign;password=p` | **no** (`/;` between `://` and `@`) | no | **FIXED** — authority preserved |

The non-matching cases still get their password / user property values obfuscated by the dedicated `FILTER_CREDS_PASSWORD` and `FILTER_CREDS_USER` filters (which target `<delim>password=value` / `<delim>user=value` shapes directly and don't depend on `@` position).

## Why I rejected the audit ticket's Option B and Option C

The Jira ticket I filed against myself proposed three options. After reading the actual code in `JdbcConnection.obfuscateCredentialsPropFromJdbcUrl` (the filter operates on the **full URL**, not on the matcher's match substring), the analysis below justifies Option A:

- **Option B** (anchor the userinfo filter regex itself): the filter is shared between the dialect-specific paths (MySQL, MariaDB) and the new generic path. Changes there risk collateral on the working MySQL/MariaDB cases. The audit ticket flagged this as "more fiddly"; agreed.
- **Option C** (explicit dialect exclusion list — skip generic fallback for `sqlserver`, `jtds`, `databricks`, `snowflake`): operationally cumbersome and fragile against new dialects with property-string syntax.
- **Option A** (scope the matcher by position): minimal, addresses the root cause, doesn't touch the working filter regex, and naturally covers any future dialect with property-value `@`.

## Tests

6 new regression cases in `JdbcConnectionTest.groovy` — 2 per `@Unroll` block (`sanitizeUrl`, `sanitizeUrl, replacing with empty`, `getUrl`):

- **MSSQL Azure-AD URL** with `user=upn@tenant.com` inside the property string. Pinned outputs verify authority (`host:1433`), `databaseName`, and `authentication` properties are preserved; user and password values are masked.
- **PostgreSQL URL** with `@` inside a `?user=...` query-string value. Pinned outputs verify authority + path preserved; user and password masked by dedicated property filters, NOT by the userinfo filter.
- **Generic third-party URL** with `@` inside a `;property=value` property string. Pinned outputs verify authority + path + the literal property containing `@` preserved; only the password property value is masked.

```
[INFO] Tests run: 76, Failures: 0 -- in JdbcConnectionTest
[INFO] Tests run: 30, Failures: 0 -- in MSSQLDatabaseTest
[INFO] Tests run: 10, Failures: 0 -- in DatabaseFactoryTest
[INFO] Tests run: 17, Failures: 0 -- in OfflineConnectionTest
[INFO] Tests run: 133, Failures: 0
[INFO] BUILD SUCCESS
```

## Test-data note for reviewers

The regression test for the postgres `?@` case uses `password=secret123` rather than `password=p` (the audit ticket's example). A single-char password value (`p`) triggers a SEPARATE pre-existing collision in `FILTER_CREDS_PASSWORD`'s obfuscation step:

```java
jdbcUrl.replace(":" + actualMatcher.group(2), ":*****");
```

Literal `":p"` substring-matches inside `"jdbc:postgresql"` too — so a 1-char password causes `jdbc:postgresql` to become `jdbc:*****ostgresql` in the obfuscated output. That collision exists independently of the matcher-scoping fix in this PR; it's a candidate for a separate follow-up cleanup of the literal-replace pattern in `FILTER_CREDS_PASSWORD`. Using a longer password value keeps this PR's tests focused on the regression-of-interest.

## Coordination

- **liquibase-pro#3860** (the subtree-sync PR) was red on the MSSQL test that caused this ticket. After this PR merges and a follow-up subtree refresh pulls it in, #3860's CI for the MSSQL test should flip green automatically.
- **The other red check on #3860** (`Integration Tests (postgresql)` — `AlternateConnectionExecutor` `ServiceConfigurationError` with `this.wrapper` null) is unrelated to this regression and not in #3860's diff. Tracked separately as a pre-existing test-fixture issue.

## Related

- PR liquibase/liquibase#7740 — the CWE-693 fix that introduced this regression
- DAT-23012 — the original audit ticket that requested broader sanitizeUrl coverage
- DAT-23093 — the regression-tracking ticket I filed on myself
- liquibase-pro#3860 — the subtree-sync PR that surfaced the regression in CI
- Part of the May-2026 OSS credential-handling-and-changelog-injection audit slice (`sdou` label).
