### PR TITLE
Fix MariaDB enum null default snapshot

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
@@ -610,6 +610,11 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
     }
 
     private void readDefaultValueForMysqlDatabase(CachedRow columnMetadataResultSet, Column column, Database database) {
+        if (isMysqlEnumNullDefaultValue(columnMetadataResultSet, column)) {
+            columnMetadataResultSet.set(COLUMN_DEF_COL, new DatabaseFunction("NULL"));
+            return;
+        }
+        
         try {
             StringBuilder selectQuery = new StringBuilder("SELECT EXTRA FROM INFORMATION_SCHEMA.COLUMNS\n")
                     .append("WHERE TABLE_SCHEMA = ?\n")
@@ -627,6 +632,20 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
         } catch (DatabaseException e) {
             Scope.getCurrentScope().getLog(getClass()).warning("Error fetching extra values", e);
         }
+    }
+
+    private boolean isMysqlEnumNullDefaultValue(CachedRow columnMetadataResultSet, Column column) {
+        Object defaultValue = columnMetadataResultSet.get(COLUMN_DEF_COL);
+
+        if (!(defaultValue instanceof String) || !StringUtil.equalsWordNull((String) defaultValue)) {
+            return false;
+        }
+
+        if (column.getType() == null || column.getType().getTypeName() == null) {
+            return false;
+        }
+
+        return StringUtils.startsWithIgnoreCase(column.getType().getTypeName(), "ENUM");
     }
 
     private void readDefaultValueForPostgresDatabase(CachedRow columnMetadataResultSet, Column columnInfo) {

--- a/liquibase-standard/src/test/groovy/liquibase/snapshot/jvm/ColumnSnapshotGeneratorTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/snapshot/jvm/ColumnSnapshotGeneratorTest.groovy
@@ -1,5 +1,6 @@
 package liquibase.snapshot.jvm
 
+import liquibase.database.core.MariaDBDatabase
 import liquibase.database.core.MSSQLDatabase
 import liquibase.database.core.MySQLDatabase
 import liquibase.database.core.PostgresDatabase
@@ -72,13 +73,14 @@ class ColumnSnapshotGeneratorTest extends Specification {
         columnSnapshotGenerator.readDefaultValue(new CachedRow(["COLUMN_DEF": columnValue]), new Column("col").setType(new DataType(datatype)), db) == expected
 
         where:
-        columnValue          | datatype  | db                     | expected
-        null                 | "varchar" | new MSSQLDatabase()    | null
-        "(NULL)"             | "varchar" | new MSSQLDatabase()    | new DatabaseFunction("null")
-        "3"                  | "int"     | new PostgresDatabase() | 3
-        3                    | "int"     | new PostgresDatabase() | 3
-        "(3)::real"          | "float"   | new PostgresDatabase() | 3
-        "3::real"            | "float"   | new PostgresDatabase() | 3
-        "'a value'::varchar" | "varchar" | new PostgresDatabase() | "a value"
+        columnValue          | datatype           | db                     | expected
+        null                 | "varchar"          | new MSSQLDatabase()    | null
+        "(NULL)"             | "varchar"          | new MSSQLDatabase()    | new DatabaseFunction("null")
+        "3"                  | "int"              | new PostgresDatabase() | 3
+        3                    | "int"              | new PostgresDatabase() | 3
+        "(3)::real"          | "float"            | new PostgresDatabase() | 3
+        "3::real"            | "float"            | new PostgresDatabase() | 3
+        "'a value'::varchar" | "varchar"          | new PostgresDatabase() | "a value"
+        "null"               | "ENUM('yo', 'lo')" | new MariaDBDatabase()  | new DatabaseFunction("NULL")
     }
 }


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

Fix MariaDB enum NULL default value handling when generating changelogs.

When generating a changelog from a MariaDB table with an enum column using `DEFAULT NULL`, Liquibase could previously serialize the default as `defaultValue="null"`. This could later produce invalid SQL such as `DEFAULT 'null' NULL`.

This change normalizes MariaDB/MySQL enum default values equal to `NULL` as a computed database value, so the generated changelog can use `defaultValueComputed="NULL"` instead of treating `null` as a literal string.

A regression test was added to verify that an enum column default value of `null` is converted to `DatabaseFunction("NULL")`.

Fixes #3444


## Release note

Fixed MariaDB enum columns with `DEFAULT NULL` being generated as a literal string default value in changelogs.


## Things to be aware of

This change is intentionally limited to MySQL/MariaDB enum columns whose default value is reported as `NULL`.

The fix converts the enum `NULL` default to a `DatabaseFunction("NULL")`, which allows changelog generation to serialize it as a computed default value instead of a quoted string default.


## Things to worry about

The main assumption is that a MariaDB/MySQL enum column default reported as `null` represents SQL `NULL`, not a literal enum value named `null`.

If maintainers prefer a stricter distinction between SQL `NULL` and a literal enum value `'null'`, this may need additional metadata handling from `INFORMATION_SCHEMA.COLUMNS`.


## Additional Context

This addresses the behavior described in #3444, where a MariaDB enum column like:

```sql
CREATE TABLE `test_with_enum` (
  `id` int(11) NOT NULL,
  `enumerateur` enum('yo','lo') DEFAULT NULL
) ENGINE=InnoDB DEFAULT CHARSET=latin1;
```

Testing performed:

```powershell
.\mvnw.cmd -pl liquibase-standard -Dtest=ColumnSnapshotGeneratorTest test
```