### PR TITLE
fix(postgres): preserve PARTITION BY in diff-changelog (#6885)

### DIFF
--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/pgsql/PostgreSQLIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/pgsql/PostgreSQLIntegrationTest.java
@@ -497,6 +497,9 @@ public class PostgreSQLIntegrationTest extends AbstractIntegrationTest {
     @Test
     public void testSnapshotPartitionedTableCapturesPartitionBy() throws Exception {
         assumeNotNull(this.getDatabase());
+        // Declarative partitioning syntax (PARTITION BY) requires PostgreSQL 10+.
+        // Matches the version-guard pattern used elsewhere in this file. Suggested by CodeRabbit on PR #7759.
+        assumeTrue(getDatabase().getDatabaseMajorVersion() >= 10);
         Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", getDatabase())
                 .execute(new RawParameterizedSqlStatement(
                         "CREATE TABLE part_test (id BIGINT, sold_at DATE NOT NULL) PARTITION BY RANGE (sold_at)"));

--- a/liquibase-integration-tests/src/test/java/liquibase/dbtest/pgsql/PostgreSQLIntegrationTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/dbtest/pgsql/PostgreSQLIntegrationTest.java
@@ -488,6 +488,56 @@ public class PostgreSQLIntegrationTest extends AbstractIntegrationTest {
         Assert.assertTrue("Using index function should be \"" + using + "\"", found);
     }
 
+    /**
+     * Regression test for #6885: diff-changelog and generate-changelog now capture the
+     * PARTITION BY clause for declaratively-partitioned PostgreSQL tables. Pre-fix, this
+     * test would have asserted false (the CreateTableChange would have no partitionBy
+     * attribute and the parent table would have been emitted as a plain heap table).
+     */
+    @Test
+    public void testSnapshotPartitionedTableCapturesPartitionBy() throws Exception {
+        assumeNotNull(this.getDatabase());
+        Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", getDatabase())
+                .execute(new RawParameterizedSqlStatement(
+                        "CREATE TABLE part_test (id BIGINT, sold_at DATE NOT NULL) PARTITION BY RANGE (sold_at)"));
+        try {
+            DiffResult diffResult = DiffGeneratorFactory.getInstance().compare(getDatabase(), null, new CompareControl());
+            DiffToChangeLog changeLogWriter = new DiffToChangeLog(diffResult,
+                    new DiffOutputControl(false, false, false, null));
+            List<ChangeSet> changeSets = changeLogWriter.generateChangeSets();
+
+            String capturedPartitionBy = null;
+            for (ChangeSet changeSet : changeSets) {
+                for (Change change : changeSet.getChanges()) {
+                    if (!(change instanceof CreateTableChange)) {
+                        continue;
+                    }
+                    CreateTableChange ctc = (CreateTableChange) change;
+                    if ("part_test".equalsIgnoreCase(ctc.getTableName())) {
+                        capturedPartitionBy = ctc.getPartitionBy();
+                        break;
+                    }
+                }
+                if (capturedPartitionBy != null) {
+                    break;
+                }
+            }
+
+            Assert.assertNotNull("CreateTableChange for the partitioned table 'part_test' should carry a partitionBy attribute",
+                    capturedPartitionBy);
+            // pg_get_partkeydef typically returns lowercase "range (sold_at)" but exact case is version-dependent.
+            // We assert on the meaningful tokens (RANGE strategy + sold_at column) case-insensitively rather than on the literal string.
+            String normalized = capturedPartitionBy.toUpperCase();
+            Assert.assertTrue("partitionBy should mention the RANGE strategy; got: " + capturedPartitionBy,
+                    normalized.contains("RANGE"));
+            Assert.assertTrue("partitionBy should reference the sold_at key column; got: " + capturedPartitionBy,
+                    normalized.contains("SOLD_AT"));
+        } finally {
+            Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", getDatabase())
+                    .execute(new RawParameterizedSqlStatement("DROP TABLE IF EXISTS part_test"));
+        }
+    }
+
     @Test
     public void rollbackRestoresSearchPathForNumericSchema() throws Exception {
         final String numericSchema = "4b5d63f449304c05a291c4c27136ebb5";

--- a/liquibase-standard/src/main/java/liquibase/change/core/CreateTableChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/CreateTableChange.java
@@ -62,6 +62,8 @@ public class CreateTableChange extends AbstractChange implements ChangeWithColum
     private Boolean ifNotExists;
     @Setter
     private Boolean rowDependencies;
+    @Setter
+    private String partitionBy;
 
     public CreateTableChange() {
         super();
@@ -191,7 +193,8 @@ public class CreateTableChange extends AbstractChange implements ChangeWithColum
     }
 
     protected CreateTableStatement generateCreateTableStatement() {
-        return new CreateTableStatement(getCatalogName(), getSchemaName(), getTableName(), getRemarks(), getTableType(), Boolean.TRUE.equals(getIfNotExists()), Boolean.TRUE.equals(getRowDependencies()));
+        return new CreateTableStatement(getCatalogName(), getSchemaName(), getTableName(), getRemarks(), getTableType(), Boolean.TRUE.equals(getIfNotExists()), Boolean.TRUE.equals(getRowDependencies()))
+                .setPartitionBy(getPartitionBy());
     }
 
     @Override
@@ -315,10 +318,25 @@ public class CreateTableChange extends AbstractChange implements ChangeWithColum
         return rowDependencies;
     }
 
+    @DatabaseChangeProperty(
+            description = "PostgreSQL partition definition, e.g. 'RANGE (created_at)' or 'LIST (region)'. " +
+                    "Causes CREATE TABLE to be emitted as a partitioned parent table.",
+            supportsDatabase = "postgresql"
+    )
+    public String getPartitionBy() {
+        return partitionBy;
+    }
+
     @Override
     public String[] getExcludedFieldFilters(ChecksumVersion version) {
-        return new String[] {
-                "ifNotExists", "rowDependencies"
-        };
+        // For checksum versions before V9, partitionBy must be excluded so that pre-existing
+        // <createTable> changesets (which never had this field) keep the same checksum after
+        // upgrading to a Liquibase version that knows about partitionBy. From V9 onward,
+        // partitionBy contributes to the checksum so that changes to the partition spec are
+        // caught by validation. Mirrors the version-gating pattern in CreateViewChange.
+        if (version.lowerOrEqualThan(ChecksumVersion.V8)) {
+            return new String[] { "ifNotExists", "rowDependencies", "partitionBy" };
+        }
+        return new String[] { "ifNotExists", "rowDependencies" };
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/change/core/CreateTableChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/CreateTableChange.java
@@ -37,6 +37,7 @@ import liquibase.structure.core.Table;
 import liquibase.util.ObjectUtil;
 import liquibase.util.StringUtil;
 import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Creates a new table.
@@ -193,8 +194,11 @@ public class CreateTableChange extends AbstractChange implements ChangeWithColum
     }
 
     protected CreateTableStatement generateCreateTableStatement() {
+        // Trim-to-null on partitionBy mirrors how tablespace is normalized below in generateStatements;
+        // prevents a whitespace-only attribute from being forwarded into the SQL generator and emitting
+        // an invalid trailing "PARTITION BY ". Reported by CodeRabbit on PR #7759.
         return new CreateTableStatement(getCatalogName(), getSchemaName(), getTableName(), getRemarks(), getTableType(), Boolean.TRUE.equals(getIfNotExists()), Boolean.TRUE.equals(getRowDependencies()))
-                .setPartitionBy(getPartitionBy());
+                .setPartitionBy(StringUtils.trimToNull(getPartitionBy()));
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/diff/output/changelog/core/ChangedTableChangeGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/diff/output/changelog/core/ChangedTableChangeGenerator.java
@@ -55,10 +55,19 @@ public class ChangedTableChangeGenerator extends AbstractChangeGenerator impleme
         }
 
         Difference changedTablespace = differences.getDifference("tablespace");
-        
+
         if (changedTablespace != null) {
             // TODO: Implement moveTableToDifferentTablespace change type!
             Scope.getCurrentScope().getLog(getClass()).warning("A change of the tablespace was detected, however, Liquibase does not currently generate statements to move a table between tablespaces.");
+        }
+
+        Difference changedPartitionBy = differences.getDifference("partitionBy");
+
+        if (changedPartitionBy != null) {
+            // PostgreSQL declarative partitioning cannot be added/removed/modified via ALTER TABLE;
+            // the parent table has to be dropped and recreated. Warn the operator rather than
+            // silently producing a changelog that would no-op the partition-key change at apply time.
+            Scope.getCurrentScope().getLog(getClass()).warning("A change to the PostgreSQL partitionBy specification was detected, however, Liquibase does not currently generate statements to alter declarative partitioning; the parent table would need to be dropped and recreated to change its partition key.");
         }
 
         return null;

--- a/liquibase-standard/src/main/java/liquibase/diff/output/changelog/core/MissingTableChangeGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/diff/output/changelog/core/MissingTableChangeGenerator.java
@@ -138,6 +138,14 @@ public class MissingTableChangeGenerator extends AbstractChangeGenerator impleme
                 change.setTableType("GLOBAL TEMPORARY");
         }
 
+        if (referenceDatabase instanceof PostgresDatabase && missingTable.getPartitionBy() != null) {
+            // Postgres declarative partitioning: surface the PARTITION BY (<strategy> (<keys>))
+            // clause captured by TableSnapshotGenerator / JdbcDatabaseSnapshot.enrichPostgresqlTablesResult
+            // so it makes it into the generated changelog. Without this, diff-changelog silently
+            // produces a plain CREATE TABLE for partitioned-table parents (#6885).
+            change.setPartitionBy(missingTable.getPartitionBy());
+        }
+
         for (Column column : missingTable.getColumns()) {
             ColumnConfig columnConfig = new ColumnConfig();
             columnConfig.setName(column.getName());

--- a/liquibase-standard/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -1361,8 +1361,8 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                  * Postgres-side enrichment that backfills a {@code PARTITION_BY} column onto each
                  * row in {@code rows} whose parent table is declaratively partitioned
                  * ({@code pg_class.relkind = 'p'}). The string stored is whatever
-                 * {@link } returns — verbatim, valid PostgreSQL syntax for the right-hand
-                 * side of a {@code PARTITION BY} clause. JDBC's {@code DatabaseMetaData.getTables}
+                 * {@code pg_get_partkeydef(oid)} returns — verbatim, valid PostgreSQL syntax for
+                 * the right-hand side of a {@code PARTITION BY} clause. JDBC's {@code DatabaseMetaData.getTables}
                  * already lists partitioned-table rows (via {@code TABLE_TYPE = 'PARTITIONED TABLE'})
                  * but does not expose the partition strategy or key columns, so this enrichment is
                  * the only path by which {@link liquibase.snapshot.jvm.TableSnapshotGenerator}

--- a/liquibase-standard/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -1348,12 +1348,60 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                     return executeAndExtract(database, sql, parameters.toArray());
                 }
 
-                private List<CachedRow> queryPostgres(CatalogAndSchema catalogAndSchema, String tableName) throws SQLException {
+                private List<CachedRow> queryPostgres(CatalogAndSchema catalogAndSchema, String tableName) throws SQLException, DatabaseException {
                     String catalog = ((AbstractJdbcDatabase) database).getJdbcCatalogName(catalogAndSchema);
                     String schema = ((AbstractJdbcDatabase) database).getJdbcSchemaName(catalogAndSchema);
-                    return extract(databaseMetaData.getTables(catalog, escapeForLike(schema, database), ((tableName == null) ?
+                    List<CachedRow> rows = extract(databaseMetaData.getTables(catalog, escapeForLike(schema, database), ((tableName == null) ?
                             SQL_FILTER_MATCH_ALL : escapeForLike(tableName, database)), new String[]{"TABLE", "PARTITIONED TABLE"}));
+                    enrichPostgresqlTablesResult(catalogAndSchema, tableName, rows);
+                    return rows;
+                }
 
+                /**
+                 * Postgres-side enrichment that backfills a {@code PARTITION_BY} column onto each
+                 * row in {@code rows} whose parent table is declaratively partitioned
+                 * ({@code pg_class.relkind = 'p'}). The string stored is whatever
+                 * {@link } returns — verbatim, valid PostgreSQL syntax for the right-hand
+                 * side of a {@code PARTITION BY} clause. JDBC's {@code DatabaseMetaData.getTables}
+                 * already lists partitioned-table rows (via {@code TABLE_TYPE = 'PARTITIONED TABLE'})
+                 * but does not expose the partition strategy or key columns, so this enrichment is
+                 * the only path by which {@link liquibase.snapshot.jvm.TableSnapshotGenerator}
+                 * can recover that information.
+                 *
+                 * <p>Mirrors the index-USING enrichment added in PR #6901 (which lives in the
+                 * {@code getIndexInfo} extractor in this same file).
+                 */
+                private void enrichPostgresqlTablesResult(CatalogAndSchema catalogAndSchema, String tableName, List<CachedRow> rows) throws DatabaseException, SQLException {
+                    if (!(database instanceof PostgresDatabase) || rows.isEmpty()) {
+                        return;
+                    }
+                    String schemaName = database.correctObjectName(catalogAndSchema.getSchemaName(), Schema.class);
+                    StringBuilder sql = new StringBuilder(
+                            "SELECT ns.nspname AS TABLE_SCHEM, " +
+                            "       c.relname AS TABLE_NAME, " +
+                            "       pg_get_partkeydef(c.oid) AS PARTITION_BY " +
+                            "FROM pg_class c " +
+                            "JOIN pg_namespace ns ON ns.oid = c.relnamespace " +
+                            "JOIN pg_partitioned_table pt ON pt.partrelid = c.oid " +
+                            "WHERE c.relkind = 'p'");
+                    if (schemaName != null) {
+                        sql.append(" AND ns.nspname = '").append(database.escapeStringForDatabase(schemaName)).append("'");
+                    }
+                    if (tableName != null) {
+                        sql.append(" AND c.relname = '").append(database.escapeStringForDatabase(tableName)).append("'");
+                    }
+                    List<CachedRow> partitionRows = executeAndExtract(sql.toString(), database);
+                    for (CachedRow source : partitionRows) {
+                        for (CachedRow target : rows) {
+                            String tName = target.getString("TABLE_NAME");
+                            String tSchem = target.getString("TABLE_SCHEM");
+                            if (tName != null && tName.equalsIgnoreCase(source.getString("TABLE_NAME"))
+                                    && tSchem != null && tSchem.equalsIgnoreCase(source.getString("TABLE_SCHEM"))) {
+                                target.set("PARTITION_BY", source.getString("PARTITION_BY"));
+                                break;
+                            }
+                        }
+                    }
                 }
             });
         }

--- a/liquibase-standard/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -1372,7 +1372,16 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                  * {@code getIndexInfo} extractor in this same file).
                  */
                 private void enrichPostgresqlTablesResult(CatalogAndSchema catalogAndSchema, String tableName, List<CachedRow> rows) throws DatabaseException, SQLException {
-                    if (!(database instanceof PostgresDatabase) || rows.isEmpty()) {
+                    // CockroachDatabase extends PostgresDatabase but does not expose pg_partitioned_table /
+                    // pg_get_partkeydef as standard PG-compatible catalogs (Cockroach has its own partitioning
+                    // model). Exclude it explicitly so the enrichment query doesn't fail the entire snapshot
+                    // on a Cockroach target. Reported by CodeRabbit on PR #7759.
+                    // (Note: the index-USING enrichment a few methods up in this file has the identical guard
+                    // gap — same root cause, same fix-shape. Out of scope for #6885; should land as a separate
+                    // follow-up PR against the getIndexInfo extractor.)
+                    if (!(database instanceof PostgresDatabase)
+                            || (database instanceof CockroachDatabase)
+                            || rows.isEmpty()) {
                         return;
                     }
                     String schemaName = database.correctObjectName(catalogAndSchema.getSchemaName(), Schema.class);

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/TableSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/TableSnapshotGenerator.java
@@ -3,6 +3,7 @@ package liquibase.snapshot.jvm;
 import liquibase.CatalogAndSchema;
 import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.Database;
+import liquibase.database.core.PostgresDatabase;
 import liquibase.exception.DatabaseException;
 import liquibase.snapshot.CachedRow;
 import liquibase.snapshot.DatabaseSnapshot;
@@ -90,6 +91,15 @@ public class TableSnapshotGenerator extends JdbcSnapshotGenerator {
         table.setRemarks(remarks);
         table.setTablespace(tablespace);
         table.setDefaultTablespace(BooleanUtil.isTrue(Boolean.parseBoolean(defaultTablespaceString)));
+
+        if (database instanceof PostgresDatabase) {
+            // PARTITION_BY is stamped onto the row by JdbcDatabaseSnapshot.enrichPostgresqlTablesResult
+            // (pg_get_partkeydef on pg_partitioned_table) for relkind='p' parent tables.
+            String partitionBy = StringUtil.trimToNull(tableMetadataResultSet.getString("PARTITION_BY"));
+            if (partitionBy != null) {
+                table.setPartitionBy(partitionBy);
+            }
+        }
 
         CatalogAndSchema schemaFromJdbcInfo = ((AbstractJdbcDatabase) database).getSchemaFromJdbcInfo(rawCatalogName, rawSchemaName);
         table.setSchema(new Schema(schemaFromJdbcInfo.getCatalogName(), schemaFromJdbcInfo.getSchemaName()));

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/TableSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/TableSnapshotGenerator.java
@@ -14,6 +14,7 @@ import liquibase.structure.core.Schema;
 import liquibase.structure.core.Table;
 import liquibase.util.BooleanUtil;
 import liquibase.util.StringUtil;
+import org.apache.commons.lang3.StringUtils;
 
 import java.sql.SQLException;
 import java.util.List;
@@ -95,7 +96,10 @@ public class TableSnapshotGenerator extends JdbcSnapshotGenerator {
         if (database instanceof PostgresDatabase) {
             // PARTITION_BY is stamped onto the row by JdbcDatabaseSnapshot.enrichPostgresqlTablesResult
             // (pg_get_partkeydef on pg_partitioned_table) for relkind='p' parent tables.
-            String partitionBy = StringUtil.trimToNull(tableMetadataResultSet.getString("PARTITION_BY"));
+            // Uses org.apache.commons.lang3.StringUtils.trimToNull (the non-deprecated variant);
+            // surrounding reads still use the deprecated liquibase.util.StringUtil.trimToNull for
+            // consistency with the rest of this method and are out of scope for #6885.
+            String partitionBy = StringUtils.trimToNull(tableMetadataResultSet.getString("PARTITION_BY"));
             if (partitionBy != null) {
                 table.setPartitionBy(partitionBy);
             }

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateTableGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateTableGenerator.java
@@ -44,7 +44,7 @@ public class CreateTableGenerator extends AbstractSqlGenerator<CreateTableStatem
     public Warnings warn(CreateTableStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
         Warnings warnings = super.warn(statement, database, sqlGeneratorChain);
         if (!(database instanceof PostgresDatabase) && statement.getPartitionBy() != null) {
-            warnings.addWarning("partitionBy clause is only supported on PostgreSQL; " + database + " will silently ignore it");
+            warnings.addWarning("partitionBy is only supported on PostgreSQL; the clause will be dropped from the generated SQL for " + database);
         }
         return warnings;
     }

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateTableGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateTableGenerator.java
@@ -355,6 +355,19 @@ public class CreateTableGenerator extends AbstractSqlGenerator<CreateTableStatem
             sql += " " + ((MySQLDatabase) database).getTableOptionAutoIncrementStartWithClause(mysqlTableOptionStartWith);
         }
 
+        // PARTITION BY must come BEFORE TABLESPACE per PostgreSQL grammar:
+        //   (columns) [PARTITION BY ...] [USING ...] [WITH ...] [ON COMMIT ...] [TABLESPACE ...]
+        // Emitting them in the reverse order causes a syntax error when both are set on the same
+        // statement. Flagged by @filipelautert on PR #7759.
+        //
+        // Defense-in-depth even though CreateTableChange.generateCreateTableStatement already
+        // trims-to-null: a CreateTableStatement constructed programmatically (or by a future change-
+        // type) could still arrive with whitespace-only partitionBy. Reported by CodeRabbit on PR #7759.
+        String partitionBy = StringUtils.trimToNull(statement.getPartitionBy());
+        if (database instanceof PostgresDatabase && partitionBy != null) {
+            sql += " PARTITION BY " + partitionBy;
+        }
+
         if ((statement.getTablespace() != null) && database.supportsTablespaces()) {
             if ((database instanceof MSSQLDatabase) || (database instanceof SybaseASADatabase)) {
                 sql += " ON " + database.escapeTablespaceName(statement.getTablespace());
@@ -363,14 +376,6 @@ public class CreateTableGenerator extends AbstractSqlGenerator<CreateTableStatem
             } else {
                 sql += " TABLESPACE " + statement.getTablespace();
             }
-        }
-
-        // Defense-in-depth even though CreateTableChange.generateCreateTableStatement already
-        // trims-to-null: a CreateTableStatement constructed programmatically (or by a future change-
-        // type) could still arrive with whitespace-only partitionBy. Reported by CodeRabbit on PR #7759.
-        String partitionBy = StringUtils.trimToNull(statement.getPartitionBy());
-        if (database instanceof PostgresDatabase && partitionBy != null) {
-            sql += " PARTITION BY " + partitionBy;
         }
 
         if ((database instanceof MySQLDatabase) && (statement.getRemarks() != null)) {

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateTableGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateTableGenerator.java
@@ -365,8 +365,12 @@ public class CreateTableGenerator extends AbstractSqlGenerator<CreateTableStatem
             }
         }
 
-        if (database instanceof PostgresDatabase && statement.getPartitionBy() != null) {
-            sql += " PARTITION BY " + statement.getPartitionBy();
+        // Defense-in-depth even though CreateTableChange.generateCreateTableStatement already
+        // trims-to-null: a CreateTableStatement constructed programmatically (or by a future change-
+        // type) could still arrive with whitespace-only partitionBy. Reported by CodeRabbit on PR #7759.
+        String partitionBy = StringUtils.trimToNull(statement.getPartitionBy());
+        if (database instanceof PostgresDatabase && partitionBy != null) {
+            sql += " PARTITION BY " + partitionBy;
         }
 
         if ((database instanceof MySQLDatabase) && (statement.getRemarks() != null)) {

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateTableGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateTableGenerator.java
@@ -6,6 +6,7 @@ import liquibase.database.core.*;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.ValidationErrors;
+import liquibase.exception.Warnings;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
@@ -37,6 +38,15 @@ public class CreateTableGenerator extends AbstractSqlGenerator<CreateTableStatem
             }
         }
         return validationErrors;
+    }
+
+    @Override
+    public Warnings warn(CreateTableStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+        Warnings warnings = super.warn(statement, database, sqlGeneratorChain);
+        if (!(database instanceof PostgresDatabase) && statement.getPartitionBy() != null) {
+            warnings.addWarning("partitionBy clause is only supported on PostgreSQL; " + database + " will silently ignore it");
+        }
+        return warnings;
     }
 
     @Override
@@ -353,6 +363,10 @@ public class CreateTableGenerator extends AbstractSqlGenerator<CreateTableStatem
             } else {
                 sql += " TABLESPACE " + statement.getTablespace();
             }
+        }
+
+        if (database instanceof PostgresDatabase && statement.getPartitionBy() != null) {
+            sql += " PARTITION BY " + statement.getPartitionBy();
         }
 
         if ((database instanceof MySQLDatabase) && (statement.getRemarks() != null)) {

--- a/liquibase-standard/src/main/java/liquibase/statement/core/CreateTableStatement.java
+++ b/liquibase-standard/src/main/java/liquibase/statement/core/CreateTableStatement.java
@@ -11,6 +11,7 @@ public class CreateTableStatement extends AbstractSqlStatement implements Compou
 
     private String tablespace;
     private String remarks;
+    private String partitionBy;
     private final List<String> columns = new ArrayList<>();
     private final Set<AutoIncrementConstraint> autoIncrementConstraints = new HashSet<>();
     private final Map<String, LiquibaseDataType> columnTypes = new HashMap<>();
@@ -94,6 +95,15 @@ public class CreateTableStatement extends AbstractSqlStatement implements Compou
 
     public CreateTableStatement setTablespace(String tablespace) {
         this.tablespace = tablespace;
+        return this;
+    }
+
+    public String getPartitionBy() {
+        return partitionBy;
+    }
+
+    public CreateTableStatement setPartitionBy(String partitionBy) {
+        this.partitionBy = partitionBy;
         return this;
     }
 

--- a/liquibase-standard/src/main/java/liquibase/structure/core/Table.java
+++ b/liquibase-standard/src/main/java/liquibase/structure/core/Table.java
@@ -106,4 +106,19 @@ public class Table extends Relation {
         Boolean b = getAttribute("default_tablespace",Boolean.class);
         return BooleanUtil.isTrue(b);
     }
+
+    /**
+     * For declaratively-partitioned PostgreSQL tables, holds the partition-key definition as
+     * returned verbatim by {@code pg_get_partkeydef()} — e.g. {@code "RANGE (created_at)"},
+     * {@code "LIST (region)"}, {@code "HASH (id)"}. Null for non-partitioned tables and on
+     * databases that do not support declarative partitioning.
+     */
+    public String getPartitionBy() {
+        return getAttribute("partitionBy", String.class);
+    }
+
+    public Table setPartitionBy(String partitionBy) {
+        setAttribute("partitionBy", partitionBy);
+        return this;
+    }
 }

--- a/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-5.0.xsd
+++ b/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-5.0.xsd
@@ -1031,6 +1031,7 @@
             <xsd:attribute name="remarks" type="xsd:string"/>
             <xsd:attribute name="ifNotExists" type="xsd:boolean"/>
             <xsd:attribute name="rowDependencies" type="xsd:boolean" default="false"/>
+            <xsd:attribute name="partitionBy" type="xsd:string"/>
             <xsd:anyAttribute namespace="##other" processContents="lax"/>
         </xsd:complexType>
     </xsd:element>

--- a/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
+++ b/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
@@ -1031,6 +1031,7 @@
             <xsd:attribute name="remarks" type="xsd:string"/>
             <xsd:attribute name="ifNotExists" type="xsd:boolean"/>
             <xsd:attribute name="rowDependencies" type="xsd:boolean" default="false"/>
+            <xsd:attribute name="partitionBy" type="xsd:string"/>
             <xsd:anyAttribute namespace="##other" processContents="lax"/>
         </xsd:complexType>
     </xsd:element>

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/CreateTableChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/CreateTableChangeTest.groovy
@@ -1,6 +1,7 @@
 package liquibase.change.core
 
 
+import liquibase.ChecksumVersion
 import liquibase.change.ChangeStatus
 import liquibase.change.ColumnConfig
 import liquibase.change.ConstraintsConfig
@@ -372,5 +373,45 @@ public class CreateTableChangeTest extends StandardChangeTest {
         "int" | true    | new OracleDatabase()       | "CREATE TABLE test_table (id INTEGER)"
         "int" | true    | new SybaseASADatabase()    | "CREATE TABLE test_table (id INTEGER NULL)"
         "int" | true    | new SybaseDatabase()       | "CREATE TABLE test_table (id INT NULL)"
+    }
+
+    def "partitionBy round-trips through setter/getter"() {
+        when:
+        def change = new CreateTableChange()
+        change.setPartitionBy("RANGE (created_at)")
+
+        then:
+        change.getPartitionBy() == "RANGE (created_at)"
+    }
+
+    def "generateStatements threads partitionBy onto the CreateTableStatement"() {
+        when:
+        def change = new CreateTableChange()
+        change.setTableName("test_tbl_part")
+        def col = new ColumnConfig()
+        col.setName("test_date_int")
+        col.setType("int")
+        change.addColumn(col)
+        change.setPartitionBy("RANGE (test_date_int)")
+
+        then:
+        def stmt = (CreateTableStatement) change.generateStatements(new PostgresDatabase())[0]
+        stmt.getPartitionBy() == "RANGE (test_date_int)"
+    }
+
+    @Unroll
+    def "getExcludedFieldFilters version-gating for partitionBy: V#version.version excludes=#shouldExclude"() {
+        expect:
+        // Pre-V9 checksums must keep partitionBy out of the hash so existing changesets
+        // (which never had this field) keep their stored checksums after upgrade. V9+
+        // includes partitionBy so changes to the partition spec are caught by validation.
+        def excluded = new CreateTableChange().getExcludedFieldFilters(version) as List
+        excluded.contains("partitionBy") == shouldExclude
+
+        where:
+        version            | shouldExclude
+        ChecksumVersion.V7 | true
+        ChecksumVersion.V8 | true
+        ChecksumVersion.V9 | false
     }
 }

--- a/liquibase-standard/src/test/groovy/liquibase/diff/output/changelog/core/MissingTableChangeGeneratorTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/diff/output/changelog/core/MissingTableChangeGeneratorTest.groovy
@@ -2,6 +2,7 @@ package liquibase.diff.output.changelog.core
 
 import liquibase.change.core.CreateTableChange
 import liquibase.database.core.MockDatabase
+import liquibase.database.core.PostgresDatabase
 import liquibase.diff.output.DiffOutputControl
 import liquibase.diff.output.changelog.ChangeGeneratorChain
 import liquibase.structure.core.Column
@@ -46,5 +47,39 @@ class MissingTableChangeGeneratorTest extends Specification {
         includeCatalog | includeSchema | includeTablespace | expectedCatalog | expectedSchema | expectedTablespace
         false          | false         | false             | null            | null           | null
         true           | true          | true              | "my_catalog"    | "my_schema"    | "my_tablespace"
+    }
+
+    def "fixMissing propagates partitionBy from Postgres reference Table onto CreateTableChange"() {
+        when:
+        def generator = new MissingTableChangeGenerator()
+        def control = new DiffOutputControl(false, false, false, null)
+
+        def table = new Table(null, "public", "test_tbl_part")
+        table.addColumn(new Column("test_date_int").setType(new DataType("int")))
+        table.setPartitionBy("RANGE (test_date_int)")
+
+        def referenceDatabase = new PostgresDatabase()
+        def comparisonDatabase = new PostgresDatabase()
+
+        def changes = generator.fixMissing(table, control, referenceDatabase, comparisonDatabase, new ChangeGeneratorChain(null))
+
+        then:
+        changes.length == 1
+        ((CreateTableChange) changes[0]).getPartitionBy() == "RANGE (test_date_int)"
+    }
+
+    def "fixMissing leaves partitionBy null when reference Table has no partition spec"() {
+        when:
+        def generator = new MissingTableChangeGenerator()
+        def control = new DiffOutputControl(false, false, false, null)
+
+        def table = new Table(null, "public", "plain_tbl")
+        table.addColumn(new Column("id").setType(new DataType("int")))
+        // no setPartitionBy(...) call
+
+        def changes = generator.fixMissing(table, control, new PostgresDatabase(), new PostgresDatabase(), new ChangeGeneratorChain(null))
+
+        then:
+        ((CreateTableChange) changes[0]).getPartitionBy() == null
     }
 }

--- a/liquibase-standard/src/test/groovy/liquibase/snapshot/jvm/TableSnapshotGeneratorTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/snapshot/jvm/TableSnapshotGeneratorTest.groovy
@@ -1,0 +1,79 @@
+package liquibase.snapshot.jvm
+
+import liquibase.database.core.MySQLDatabase
+import liquibase.database.core.PostgresDatabase
+import liquibase.snapshot.CachedRow
+import spock.lang.Specification
+
+class TableSnapshotGeneratorTest extends Specification {
+
+    def "readTable picks up PARTITION_BY enrichment column when database is PostgresDatabase"() {
+        given:
+        def row = new CachedRow([
+                "TABLE_NAME"         : "test_tbl_part",
+                "TABLE_SCHEM"        : "public",
+                "TABLE_CAT"          : "lbtest",
+                "PARTITION_BY"       : "RANGE (test_date_int)",
+                "REMARKS"            : null,
+                "TABLESPACE_NAME"    : null,
+                "DEFAULT_TABLESPACE" : null,
+                "TEMPORARY"          : null,
+        ] as Map<String, Object>)
+        def generator = new TableSnapshotGenerator()
+        def database = new PostgresDatabase()
+
+        when:
+        def table = generator.readTable(row, database)
+
+        then:
+        table.getName() == "test_tbl_part"
+        table.getPartitionBy() == "RANGE (test_date_int)"
+    }
+
+    def "readTable does not set partitionBy when PARTITION_BY column is absent"() {
+        given:
+        def row = new CachedRow([
+                "TABLE_NAME"         : "plain_tbl",
+                "TABLE_SCHEM"        : "public",
+                "TABLE_CAT"          : "lbtest",
+                "REMARKS"            : null,
+                "TABLESPACE_NAME"    : null,
+                "DEFAULT_TABLESPACE" : null,
+                "TEMPORARY"          : null,
+        ] as Map<String, Object>)
+        def generator = new TableSnapshotGenerator()
+        def database = new PostgresDatabase()
+
+        when:
+        def table = generator.readTable(row, database)
+
+        then:
+        table.getName() == "plain_tbl"
+        table.getPartitionBy() == null
+    }
+
+    def "readTable ignores PARTITION_BY column on non-Postgres databases (safety guard)"() {
+        given:
+        // A stray PARTITION_BY column on a CachedRow from a non-Postgres path must not
+        // accidentally end up on the Table model. This guards against schema-name collisions
+        // with future enrichment paths in other dialects.
+        def row = new CachedRow([
+                "TABLE_NAME"         : "test_tbl",
+                "TABLE_SCHEM"        : "public",
+                "TABLE_CAT"          : "lbtest",
+                "PARTITION_BY"       : "RANGE (col)",
+                "REMARKS"            : null,
+                "TABLESPACE_NAME"    : null,
+                "DEFAULT_TABLESPACE" : null,
+                "TEMPORARY"          : null,
+        ] as Map<String, Object>)
+        def generator = new TableSnapshotGenerator()
+        def database = new MySQLDatabase()
+
+        when:
+        def table = generator.readTable(row, database)
+
+        then:
+        table.getPartitionBy() == null
+    }
+}

--- a/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/CreateTableGeneratorPostgresTest.java
+++ b/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/CreateTableGeneratorPostgresTest.java
@@ -47,6 +47,64 @@ public class CreateTableGeneratorPostgresTest {
     }
 
     @Test
+    public void testGenerateSqlEmitsVerbatimForMultiColumnRangeKey() {
+        // pg_get_partkeydef returns multi-column keys as "RANGE (a, b)"; must round-trip verbatim.
+        CreateTableStatement statement = new CreateTableStatement(null, "public", "multi_col_part")
+                .setPartitionBy("RANGE (a, b)");
+        statement.addColumn("a", new IntType());
+        statement.addColumn("b", new IntType());
+
+        Sql[] result = new CreateTableGenerator().generateSql(statement, new PostgresDatabase(), null);
+
+        Assert.assertEquals(
+                "CREATE TABLE public.multi_col_part (a INTEGER, b INTEGER) PARTITION BY RANGE (a, b)",
+                result[0].toSql()
+        );
+    }
+
+    @Test
+    public void testGenerateSqlEmitsVerbatimForFunctionalKey() {
+        // Functional partition keys (RANGE (lower(email))) must pass through unchanged — we trust
+        // pg_get_partkeydef output rather than parsing/reformatting it.
+        CreateTableStatement statement = new CreateTableStatement(null, "public", "func_part")
+                .setPartitionBy("RANGE (lower(email))");
+        statement.addColumn("email", new IntType()); // type doesn't matter for this assertion
+
+        Sql[] result = new CreateTableGenerator().generateSql(statement, new PostgresDatabase(), null);
+
+        Assert.assertTrue("expected PARTITION BY RANGE (lower(email)); got: " + result[0].toSql(),
+                result[0].toSql().endsWith("PARTITION BY RANGE (lower(email))"));
+    }
+
+    @Test
+    public void testGenerateSqlEmitsVerbatimForQuotedIdentifier() {
+        // Case-sensitive identifiers are emitted by pg_get_partkeydef with double quotes preserved.
+        CreateTableStatement statement = new CreateTableStatement(null, "public", "quoted_part")
+                .setPartitionBy("RANGE (\"MixedCaseCol\")");
+        statement.addColumn("MixedCaseCol", new IntType());
+
+        Sql[] result = new CreateTableGenerator().generateSql(statement, new PostgresDatabase(), null);
+
+        Assert.assertTrue("quoted identifier must survive verbatim; got: " + result[0].toSql(),
+                result[0].toSql().endsWith("PARTITION BY RANGE (\"MixedCaseCol\")"));
+    }
+
+    @Test
+    public void testGenerateSqlEmitsListAndHashStrategiesVerbatim() {
+        // LIST and HASH strategies (alongside RANGE) all round-trip identically.
+        for (String spec : new String[]{"LIST (region)", "HASH (user_id)"}) {
+            CreateTableStatement statement = new CreateTableStatement(null, "public", "tbl")
+                    .setPartitionBy(spec);
+            statement.addColumn("c", new IntType());
+
+            Sql[] result = new CreateTableGenerator().generateSql(statement, new PostgresDatabase(), null);
+
+            Assert.assertTrue("expected ... PARTITION BY " + spec + "; got: " + result[0].toSql(),
+                    result[0].toSql().endsWith("PARTITION BY " + spec));
+        }
+    }
+
+    @Test
     public void testWarnEmittedForPartitionByOnNonPostgresDatabase() {
         // Given a statement with partitionBy targeting a non-Postgres database
         CreateTableStatement statement = new CreateTableStatement(null, "public", "tbl")

--- a/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/CreateTableGeneratorPostgresTest.java
+++ b/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/CreateTableGeneratorPostgresTest.java
@@ -122,6 +122,33 @@ public class CreateTableGeneratorPostgresTest {
     }
 
     @Test
+    public void testGenerateSqlEmitsPartitionByBeforeTablespace() {
+        // Per Postgres grammar:
+        //   (columns) [PARTITION BY ...] [USING ...] [WITH ...] [ON COMMIT ...] [TABLESPACE ...]
+        // The PARTITION BY clause must precede the TABLESPACE clause when both are present.
+        // Regression guard for @filipelautert's review on PR #7759.
+        CreateTableStatement statement = new CreateTableStatement(null, "public", "part_with_ts")
+                .setPartitionBy("RANGE (created_at)")
+                .setTablespace("my_ts");
+        statement.addColumn("id", new IntType());
+        statement.addColumn("created_at", new IntType());
+
+        Sql[] result = new CreateTableGenerator().generateSql(statement, new PostgresDatabase(), null);
+
+        String sql = result[0].toSql();
+        Assert.assertEquals(
+                "CREATE TABLE public.part_with_ts (id INTEGER, created_at INTEGER) PARTITION BY RANGE (created_at) TABLESPACE my_ts",
+                sql
+        );
+        // Defensive: verify both clauses present in the right order, in case the exact-string
+        // assertion drifts on whitespace in the future.
+        int partIdx = sql.indexOf("PARTITION BY");
+        int tsIdx = sql.indexOf("TABLESPACE");
+        Assert.assertTrue("PARTITION BY must appear before TABLESPACE; got: " + sql,
+                partIdx > 0 && tsIdx > 0 && partIdx < tsIdx);
+    }
+
+    @Test
     public void testWarnEmittedForPartitionByOnNonPostgresDatabase() {
         // Given a statement with partitionBy targeting a non-Postgres database
         CreateTableStatement statement = new CreateTableStatement(null, "public", "tbl")

--- a/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/CreateTableGeneratorPostgresTest.java
+++ b/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/CreateTableGeneratorPostgresTest.java
@@ -1,0 +1,63 @@
+package liquibase.sqlgenerator.core;
+
+import liquibase.database.core.MySQLDatabase;
+import liquibase.database.core.PostgresDatabase;
+import liquibase.datatype.core.IntType;
+import liquibase.sql.Sql;
+import liquibase.exception.Warnings;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.statement.core.CreateTableStatement;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.TreeSet;
+
+public class CreateTableGeneratorPostgresTest {
+
+    @Test
+    public void testGenerateSqlAppendsPartitionByClauseForPostgres() {
+        // Given a CreateTableStatement with a partitionBy spec, against PostgresDatabase
+        CreateTableStatement statement = new CreateTableStatement(null, "public", "test_tbl_part")
+                .setPartitionBy("RANGE (test_date_int)");
+        statement.addColumn("test_date_int", new IntType());
+
+        // When the base CreateTableGenerator produces SQL for Postgres
+        Sql[] result = new CreateTableGenerator().generateSql(statement, new PostgresDatabase(), null);
+
+        // Then the PARTITION BY clause is appended verbatim, after the column list
+        Assert.assertEquals(
+                "CREATE TABLE public.test_tbl_part (test_date_int INTEGER) PARTITION BY RANGE (test_date_int)",
+                result[0].toSql()
+        );
+    }
+
+    @Test
+    public void testGenerateSqlWithoutPartitionByOnPostgresProducesPlainCreateTable() {
+        // Given a statement with NO partitionBy
+        CreateTableStatement statement = new CreateTableStatement(null, "public", "plain_tbl");
+        statement.addColumn("id", new IntType());
+
+        // When generating SQL for Postgres
+        Sql[] result = new CreateTableGenerator().generateSql(statement, new PostgresDatabase(), null);
+
+        // Then no PARTITION BY clause appears
+        String sql = result[0].toSql();
+        Assert.assertFalse("plain create-table must not emit PARTITION BY: " + sql,
+                sql.contains("PARTITION BY"));
+    }
+
+    @Test
+    public void testWarnEmittedForPartitionByOnNonPostgresDatabase() {
+        // Given a statement with partitionBy targeting a non-Postgres database
+        CreateTableStatement statement = new CreateTableStatement(null, "public", "tbl")
+                .setPartitionBy("RANGE (dt)");
+        statement.addColumn("dt", new IntType());
+
+        // When CreateTableGenerator validates against MySQL (empty downstream chain — we test the leaf generator's contribution)
+        Warnings warnings = new CreateTableGenerator().warn(statement, new MySQLDatabase(), new SqlGeneratorChain<>(new TreeSet<>()));
+
+        // Then a warning is produced — partitionBy is silently dropped if we don't warn
+        Assert.assertTrue("expected a warning about partitionBy not supported on MySQL; got: " + warnings.getMessages(),
+                warnings.getMessages().stream().anyMatch(m -> m.toLowerCase().contains("partition")));
+    }
+}

--- a/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/CreateTableGeneratorPostgresTest.java
+++ b/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/CreateTableGeneratorPostgresTest.java
@@ -32,6 +32,23 @@ public class CreateTableGeneratorPostgresTest {
     }
 
     @Test
+    public void testGenerateSqlNormalizesBlankPartitionByToNull() {
+        // Whitespace-only partitionBy must not emit a stray "PARTITION BY " — confirmed by
+        // the trim-to-null guard added in response to CodeRabbit on PR #7759.
+        for (String blank : new String[]{"", " ", "   ", "\t", "\n", " \n\t "}) {
+            CreateTableStatement statement = new CreateTableStatement(null, "public", "blank_tbl")
+                    .setPartitionBy(blank);
+            statement.addColumn("id", new IntType());
+
+            Sql[] result = new CreateTableGenerator().generateSql(statement, new PostgresDatabase(), null);
+
+            Assert.assertFalse("blank partitionBy (\"" + blank.replace("\n", "\\n").replace("\t", "\\t")
+                            + "\") must not emit PARTITION BY: " + result[0].toSql(),
+                    result[0].toSql().contains("PARTITION BY"));
+        }
+    }
+
+    @Test
     public void testGenerateSqlWithoutPartitionByOnPostgresProducesPlainCreateTable() {
         // Given a statement with NO partitionBy
         CreateTableStatement statement = new CreateTableStatement(null, "public", "plain_tbl");

--- a/liquibase-standard/src/test/resources/liquibase/change/ChangeDefinitionTest.yaml
+++ b/liquibase-standard/src/test/resources/liquibase/change/ChangeDefinitionTest.yaml
@@ -446,6 +446,9 @@ createTable: |
   ifNotExists boolean 
     Description: If true, creates the table only if it does not already exist. Appends IF NOT EXISTS syntax to SQL query
     Supported: all
+  partitionBy string 
+    Description: PostgreSQL partition definition, e.g. 'RANGE (created_at)' or 'LIST (region)'. Causes CREATE TABLE to be emitted as a partitioned parent table.
+    Supported: postgresql
   remarks string 
     Description: A brief descriptive comment to store in the table metadata
     Supported: all


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change

## Description

PostgreSQL `diff-changelog` and `generate-changelog` silently dropped the
`PARTITION BY` clause on declaratively-partitioned tables. The generated
changelog described a plain heap table; applying it to a fresh database produced
a non-partitioned copy of the source. Structural divergence not visible in the
changelog text.

This PR adds first-class support for the parent-table `PARTITION BY <strategy> (<keys>)`
clause via a new optional `partitionBy` attribute on `<createTable>`. Captured
verbatim from `pg_get_partkeydef(c.oid)` at snapshot time, round-tripped through
the diff and SQL-generation paths, emitted in the changelog XML, and re-applied
on `liquibase update`.

Fixes #6885
Closes #1874
Refs #7215

### Structural template

PR #6901 (`CREATE INDEX ... USING <method>`) is the exact same shape — an
optional Postgres-specific clause captured from a system catalog and emitted in
DDL. @filipelautert explicitly named #6901 as the template in the #6885 thread,
with pointers to `TableSnapshotGenerator.java:83` and
`CreateTableGenerator.java:357`. This PR follows that template across 5 commits
(the remaining 3 are documented under "Drive-by fixes" below).

### Verification

Before (current `main`, postgres:16 in colima):
```xml
<createTable tableName="test_tbl_part">
  <column name="test_date_int" type="INTEGER">
    <constraints nullable="false" primaryKey="true"/>
  </column>
</createTable>
```

After:
```xml
<createTable partitionBy="RANGE (test_date_int)" tableName="test_tbl_part">
  <column name="test_date_int" type="INTEGER">
    <constraints nullable="false" primaryKey="true"/>
  </column>
</createTable>
```

`liquibase-standard`: **6080 unit tests, 0 failures**, 12 environment-dependent
skips. `PostgreSQLIntegrationTest` against postgres:15 via TestSystemFactory:
**54/54 passing**, 1 environment-dependent skip. Includes a new
`testSnapshotPartitionedTableCapturesPartitionBy` integration regression test
that fails on `main` before this PR and passes after.

## Release note

PostgreSQL `diff-changelog` and `generate-changelog` now preserve the
`PARTITION BY` clause on declaratively-partitioned tables. Previously the
partition strategy was silently dropped from the generated changelog,
producing a non-partitioned copy when applied to a target database. The new
behaviour is also expressible directly in handwritten changelogs via the
`partitionBy` attribute on `<createTable>` — for example
`<createTable tableName="orders" partitionBy="RANGE (created_at)">`.

## Things to be aware of

### Checksum stability

The new `partitionBy` field is **version-gated** in
`CreateTableChange.getExcludedFieldFilters(ChecksumVersion)`:

- `V8` and earlier: excluded from the checksum. Pre-existing `<createTable>`
  changesets that have already been applied keep their stored checksum after
  upgrading — no `Validation Failed: Stored checksum ...` errors and no
  forced `clear-checksums` runs.
- `V9` (current latest, since Liquibase 4.22.0): included in the checksum.
  Changes to the partition specification on V9-era changesets are caught by
  validation rather than silently slipping through.

Mirrors the version-gating pattern in `CreateViewChange.java:165-180` (added
alongside the V8→V9 bump). This is a more thoughtful approach than the simple
`always-exclude` chosen for `using` in PR #6901; happy to align with that
precedent if reviewers prefer.

### Verbatim partition spec storage

The string stored in `partitionBy` is whatever `pg_get_partkeydef(c.oid)`
returns — `"RANGE (created_at)"`, `"LIST (region)"`, `"HASH (id)"`,
`"RANGE (lower(email))"` (functional), `"RANGE (\"MixedCaseCol\")"` (quoted),
multi-column `"RANGE (a, b)"`. No upper-casing, normalization, or parsing.
The output is already valid Postgres syntax for the right-hand side of
`PARTITION BY`. Tests in `CreateTableGeneratorPostgresTest` cover all five
shapes.

### Postgres-specific snapshot enrichment

`JdbcDatabaseSnapshot.queryPostgres` already requested
`TABLE_TYPE = 'PARTITIONED TABLE'` from JDBC metadata, so partitioned-table
rows were in the cache — but JDBC does not expose the partition strategy or
key columns. A new `enrichPostgresqlTablesResult` joins `pg_class`,
`pg_namespace`, `pg_partitioned_table` and projects `pg_get_partkeydef(c.oid)`
as a synthetic `PARTITION_BY` column on matching rows, keyed on
`(TABLE_SCHEM, TABLE_NAME)`. Mirrors PR #6901's index-USING enrichment in the
same file's `getIndexInfo` extractor.

The schema filter (and table filter, when scoped) are applied at SQL time
before the Java-side matching loop runs, so the matching is N×M with both
sides bounded by the partitioned-parent count in the schema — typically <10
even on large databases. No measurable cost.

## Things to worry about (pre-emptive answers to common review prompts)

### "Missing escape on `statement.getPartitionBy()` in the SQL append"

`partitionBy` is a clause-tail expression
(`"RANGE (a, b)"`, `"LIST (region)"`, `"HASH (lower(email))"`), not an
identifier. The existing identifier-escapers
(`escapeColumnName`, `escapeTableName`, `escapeTablespaceName`) don't apply;
there is no expression-level parser/sanitizer in the codebase. Precedent for
verbatim concatenation of clause-tail expressions:

- `CreateIndexGeneratorPostgres.generateSql:53-55` —
  `buffer.append(" USING ").append(statement.getUsing())` (PR #6901, merged
  April 2025, no escape requested at review)
- `CreateTableGenerator.generateSql:362,364` —
  `sql += " TABLESPACE " + statement.getTablespace()` (long-standing)

Trust boundary: `partitionBy` is set either by `pg_get_partkeydef()` at diff
time (a trusted PG-internal source) or by a changelog author writing
`<createTable partitionBy="...">` (the same trust level that allows arbitrary
`<sql>` blocks). No new attack surface introduced.

### "ChangedTableChangeGenerator no-ops for partition-spec changes"

Postgres declarative partitioning cannot be added, removed, or modified via
ALTER TABLE — the parent table has to be dropped and recreated. The
`ChangedTableChangeGenerator` mirrors the existing tablespace behaviour:
a `warning` is logged when a `partitionBy` difference is detected, no change
is emitted. This is consistent with how `tablespace` changes are handled in
the same generator.

### "Why not a separate `CreateTableGeneratorPostgres`?"

The base `CreateTableGenerator.generateSql` is already heavily branched per
database (`MSSQLDatabase`, `SybaseASADatabase`, `AbstractDb2Database`,
`InformixDatabase`, `MySQLDatabase`, `OracleDatabase`). A one-line
`if (database instanceof PostgresDatabase) sql += " PARTITION BY ..."`
joins those rather than spawning a new class — consistent with existing
precedent.

## Scope (deliberate exclusions)

**Child partitions (`CREATE TABLE child PARTITION OF parent FOR VALUES ...`)**
are out of scope for this PR. They remain as raw `<sql>` change sets — the
same workaround users already employ. A follow-up PR can add `pg_inherits` +
`pg_get_expr(relpartbound, oid)` enumeration plus a `partitionOf`/`partitionBound`
attribute pair (or a new `<createPartition>` change type). Doubling the
surface area into one PR would significantly increase the review burden and
risk "let's discuss the architecture" deferral — keeping V1 tight per the
maintainer guidance in #6885.

## Drive-by fixes (cleanly cherry-pickable)

Two commits unrelated to #6885 — surfaced because they were blocking the
local pre-push test run, and isolating them into separate PRs would have
delayed shipping the load-bearing fix. If maintainers prefer, both are
self-contained:

- `cc332c791 test(cli): refresh LiquibaseCommandLineTest 'help output' fixture`
  — three new `--allow-*` global options (CWE-22/-78/-470 deprecation flags)
  were added on `main` recently but the hardcoded `expectedHelpOutput` in
  `LiquibaseCommandLineTest.groovy` was not regenerated. The test fails on a
  clean `main` checkout. Verified by stashing this branch's changes before
  running the test. Mechanical regeneration from the live `liquibase --help`
  output.

- `a2dd2af06 test(postgres): fix testStatusRunDuringUpdate regression from CWE-316`
  — `PostgreSQLIntegrationTest.testStatusRunDuringUpdate` calls
  `commandScope.execute()` three times on the same `CommandScope` instance.
  PR #7741 (CWE-316, May 21) added a finally block in `CommandScope.execute()`
  that overwrites credential argument values with `"*****"` after the
  pipeline runs — making a single `CommandScope` instance single-use. Second
  call gets `FATAL: password authentication failed for user "lbuser"`. Fix
  is one line per call site: build a fresh `CommandScope` per snapshot via
  the existing `getStatusCommandScope(...)` helper. Test logic, assertions,
  and timing semantics are otherwise unchanged.

## Additional Context

- Local verification environment: macOS + Colima + postgres:16/postgres:15.
- Manual reproduction harness in colima documented in the commit body of
  `afe00c4a4`.
- Maintainer guidance from #6885: filipelautert pointed at the splice points
  in `TableSnapshotGenerator.java:83` and `CreateTableGenerator.java:357-356`
  and named PR #6901 as the structural template. Both pointers are honored
  verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

The contributor stays accountable for all architecture and scope decisions on this PR. (this line typed without AI assistance, just to be clear 🙃) — @Khromushkin