### PR TITLE
Update LiquibaseCommandLineTest expectedHelpOutput for the three new ALLOW_* audit flags

### DIFF
--- a/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineTest.groovy
+++ b/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineTest.groovy
@@ -21,6 +21,28 @@ Usage: liquibase [GLOBAL OPTIONS] [COMMAND] [COMMAND OPTIONS]
 Command-specific help: "liquibase <command-name> --help"
 
 Global Options
+      --allow-custom-change=PARAM
+                             If false, the customChange changelog change is
+                               rejected before its named class is loaded.
+                               Defaults to true to preserve the documented
+                               customChange feature for the standard trust
+                               model (team-authored, team-reviewed changelogs).
+                               Set to false in environments that execute
+                               changelogs from less-trusted sources
+                               (multi-tenant SaaS running customer changelogs,
+                               downloaded change-packs, contributor PRs prior
+                               to review): customChange loads an arbitrary JVM
+                               class by FQCN via Class.forName
+                               (initialize=true), which fires the class's
+                               static <clinit> initializer at load time —
+                               before any cast or marker-interface check could
+                               reject the load. Any class on the JVM classpath
+                               is reachable this way (CWE-470).
+                             DEFAULT: true
+                             (defaults file: 'liquibase.allowCustomChange',
+                               environment variable:
+                               'LIQUIBASE_ALLOW_CUSTOM_CHANGE')
+
       --allow-duplicated-changeset-identifiers=PARAM
                              Allows duplicated changeset identifiers without
                                failing Liquibase execution.
@@ -30,6 +52,25 @@ Global Options
                                environment variable:
                                'LIQUIBASE_ALLOW_DUPLICATED_CHANGESET_IDENTIFIERS
                                ')
+
+      --allow-execute-command=PARAM
+                             If false, the executeCommand changelog change is
+                               rejected at validation time with a clear error
+                               instead of being allowed to invoke an OS shell
+                               command. Defaults to true to preserve the
+                               documented executeCommand feature for the
+                               standard trust model (team-authored,
+                               team-reviewed changelogs). Set to false in
+                               environments that execute changelogs from
+                               less-trusted sources (multi-tenant SaaS running
+                               customer changelogs, downloaded change-packs,
+                               contributor PRs prior to review) where arbitrary
+                               OS-shell execution via changelog is not an
+                               acceptable risk (CWE-78).
+                             DEFAULT: true
+                             (defaults file: 'liquibase.allowExecuteCommand',
+                               environment variable:
+                               'LIQUIBASE_ALLOW_EXECUTE_COMMAND')
 
       --allow-inherit-logical-file-path=PARAM
                              If true, included changelogs without an explicit
@@ -48,6 +89,36 @@ Global Options
                                allowInheritLogicalFilePath', environment
                                variable:
                                'LIQUIBASE_ALLOW_INHERIT_LOGICAL_FILE_PATH')
+
+      --allow-parent-directory-references=PARAM
+                             If true (the default),
+                               AbstractPathResourceAccessor allows path
+                               payloads containing '..' segments and symbolic
+                               links that resolve outside the configured root
+                               directory. This preserves the behaviour that
+                               existed before the CWE-22 path-containment fix
+                               landed, for legitimate multi-changelog layouts
+                               that depend on parent-directory traversal — for
+                               example a shared 'dbarepo' at the project root
+                               referenced as '../shared/foo.xml' from
+                               per-environment changelogs underneath it, or a
+                               custom-check SCRIPT_PATH like '../checks/policy.
+                               py'. Set to false to enforce strict containment:
+                               any '..' that resolves outside the accessor
+                               root, or any symbolic link whose canonical real
+                               path escapes the canonical root, is rejected
+                               with IOException. The default is true for one
+                               major release as a deprecation window; a future
+                               major release will flip the default to false, at
+                               which point callers depending on
+                               parent-directory traversal must either
+                               restructure their layout or explicitly opt in
+                               via this flag (CWE-22).
+                             DEFAULT: true
+                             (defaults file: 'liquibase.
+                               allowParentDirectoryReferences', environment
+                               variable:
+                               'LIQUIBASE_ALLOW_PARENT_DIRECTORY_REFERENCES')
 
       --always-drop-instead-of-replace=PARAM
                              If true, drop and recreate a view instead of


### PR DESCRIPTION
## TL;DR

Three audit-batch PRs that landed in `main` recently — #7747 (CWE-78 `allowExecuteCommand`), #7748 (CWE-470 `allowCustomChange`), #7750 (CWE-22 `allowParentDirectoryReferences`) — each added a new `GlobalConfiguration.builder.define()` entry that picocli auto-renders into `--help` output. None of those PRs updated the byte-exact `expectedHelpOutput` snapshot in `LiquibaseCommandLineTest.groovy`. This PR adds the three missing stanzas at the alphabetical positions picocli actually emits.

Captured the stanzas verbatim from a local `mvn test -Dtest='LiquibaseCommandLineTest#help output'` run; not hand-written, so the wrap points exactly match what picocli renders.

## Why this regression wasn't caught at PR-author time

picocli reflects over `LiquibaseConfiguration.getRegisteredDefinitions()` at CLI startup (see `LiquibaseCommandLine.addGlobalArguments` line 1203) and adds an `OptionSpec` per registered definition automatically. Authors of new flags get the `--help` rendering "for free" without touching CLI code, which is exactly when it's easy to forget there's a downstream snapshot test pinning every byte of that output.

The snapshot is a single ~691-line inline string literal in `LiquibaseCommandLineTest`, which doesn't show up in IDE call-graphs of `GlobalConfiguration.ALLOW_CUSTOM_CHANGE` (it's literally just a string). Each of the three authors (same author, three different PRs) missed the linkage three times in a row.

## Why it surfaced in CI now, not before

Maven's reactor stops at the first module-level test failure. On the liquibase-pro subtree-sync runs, `liquibase-standard`'s `MSSQLDatabaseTest.getTargetUniquenessAttributes_allAuthMethods_produceSameUrl` was failing first (the regression fixed in #7756). The reactor never advanced to `liquibase-cli`, so this fixture gap stayed invisible. After #7756 merged and the subtree-sync was retried, the reactor advanced past `liquibase-standard`, and `LiquibaseCommandLineTest.'help output':854` immediately tripped.

## The fix

Three new stanzas inserted at the alphabetical positions picocli emits:

| Position | New stanza |
|---|---|
| Before `--allow-duplicated-changeset-identifiers` | `--allow-custom-change=PARAM` (#7748 / CWE-470) |
| Between `--allow-duplicated-…` and `--allow-inherit-logical-file-path` | `--allow-execute-command=PARAM` (#7747 / CWE-78) |
| Between `--allow-inherit-logical-file-path` and `--always-drop-instead-of-replace` | `--allow-parent-directory-references=PARAM` (#7750 / CWE-22) |

Alphabetical ordering rationale:
- Within `allow-*`: `c` < `d` < `e` < `i` < `p` — so `custom-change` comes **first**, `parent-directory-references` comes **last**.
- `allow-*` (`a-l-l-o-w`) < `always-*` (`a-l-w-a-y-s`) because `l` < `w` at position 2 of the suffix.

Each stanza is the verbatim output of picocli's `.usage()` renderer for that flag, including picocli's specific line-wrap points. **The stanzas are NOT hand-written.** Hand-editing risks drifting from picocli's rendering on the next build — capturing them as picocli emits them is the only way to keep this snapshot stable.

## Captured-output methodology (for future fixture updates)

For anyone adding a new `GlobalConfiguration` flag and needing to update this fixture:

1. Temporarily add `new File("target/help-output-actual.txt").text = bytes.toString()` to the `'help output'` test's `when:` block.
2. Run `mvn test -Dtest='LiquibaseCommandLineTest#help output'` — it'll fail, but `target/help-output-actual.txt` will contain the full picocli output.
3. Extract the new flag's stanza from that file verbatim (option header + description + DEFAULT + defaults-file/env-var trailer).
4. Insert at the alphabetical position in `expectedHelpOutput`.
5. Revert the diagnostic line.
6. Re-run the test to confirm green.

This is the procedure I used to generate this PR.

## Test plan

```
[INFO] Tests run: 115, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS  (liquibase-cli reactor)
```

Full `liquibase-cli` reactor passes (115/115 specs across `ParameterUtilTest`, `CommandLineArgumentValueProviderTest`, `LiquibaseCommandLineProCommandTest`, `LiquibaseCommandLineTest` 40 incl. `'help output'`, `LiquibaseCommandLineThreadingTest`, `LiquibaseLauncherTest`, `ProCommandErrorMessageTest`).

## Things to be aware of

- **Fixture-only change.** No production behaviour change. The three flags themselves (their actual gating logic) were merged via #7747/#7748/#7750.
- **No new tests.** This PR adds 71 lines to the existing snapshot literal; it doesn't add new specs. The existing 'help output' spec is the only consumer of `expectedHelpOutput`.
- **Forward-looking risk**: the same fixture-drift gap will reappear when the remaining audit-batch PRs land in main, because each introduces a new `GlobalConfiguration` entry:
  - #7749 (B3 `customPrecondition`) — updates description of existing `ALLOW_CUSTOM_CHANGE`, will drift the stanza I added in this PR
  - #7753 (B4 `sqlCheck` → `ALLOW_SQL_PRECONDITION`)
  - #7754 (B5 `includeAll` filter/comparator → `ALLOW_INCLUDE_ALL_CLASSES`)
  - #7755 (B6 absolute/classpath: paths → `ALLOW_EXTERNAL_CHANGELOG_PATHS`)

  Each should ideally include its own fixture update before merging. If any merge without one, a follow-up of this PR's shape will be needed for it. Adding a release-process note / PR-template checkbox to enforce this is filed as a separate TECHOPS follow-up.

## Coordination

- **liquibase-pro#3860** (the subtree-sync PR currently red on this test) will go green on `LiquibaseCommandLineTest.'help output'` after this PR merges and a follow-up subtree-sync pulls it in.
- The remaining red check on #3860 (`PostgreSQLIntegrationTest.testStatusRunDuringUpdate` NPE in `AlternateConnectionExecutor.<init>`) is a pre-existing test-fixture wiring issue, unrelated to this PR.

## Related

- PR liquibase/liquibase#7747 — `allowExecuteCommand` (the original PR that should have updated the fixture)
- PR liquibase/liquibase#7748 — `allowCustomChange` (same)
- PR liquibase/liquibase#7750 — `allowParentDirectoryReferences` (same)
- PR liquibase/liquibase-pro#3860 — subtree-sync currently red on this fixture gap
- liquibase/liquibase#7756 — the upstream-most MSSQL regression that was hiding this issue until reactor advanced
- Sibling regression-fix tickets: DAT-23090 (PR #7729 over-restriction), DAT-23093 (PR #7740 MSSQL Azure-AD over-strip). Pattern across the three: each May-2026 audit fix that touched externally-observable behaviour introduced a downstream test/fixture gap. Worth a retro on the audit-batch process before the remaining tickets in DAT-23006 land.

Part of the May-2026 OSS credential-handling-and-changelog-injection audit slice (`sdou` label).
