### PR TITLE
CWE-316: make CommandScope.clearCredentialArguments() opt-in (fixes #7761)

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/command/CommandScope.java
+++ b/liquibase-standard/src/main/java/liquibase/command/CommandScope.java
@@ -52,9 +52,23 @@ public class CommandScope {
 
     /**
      * Substring tokens (lowercase) that mark an argument key as credential-bearing.
-     * Values for matching keys are overwritten with {@code "*****"} at the end of
-     * {@link #execute()} so the original credential Strings become GC-eligible and
-     * do not linger in heap for the rest of the JVM lifetime (CWE-316).
+     * Values for matching keys are overwritten with {@code "*****"} when the
+     * (public) {@link #clearCredentialArguments()} method is invoked by a caller.
+     * That makes the original credential Strings GC-eligible so they do not linger
+     * in heap for the rest of the JVM lifetime in long-running embedded scenarios
+     * (CWE-316).
+     * <p>
+     * <b>Caller-invoked, not auto-invoked from {@link #execute()}</b>. Calling it
+     * from an outer {@code finally} block in {@code execute()} (as the original
+     * CWE-316 fix did) breaks any caller that calls {@code execute()} more than
+     * once on the same {@code CommandScope} — the second call reads {@code "*****"}
+     * instead of the real credential and the JDBC driver rejects the connection.
+     * The CLI in {@code Main} wraps its single-use scopes in try-finally to call
+     * this method after each {@code execute()}; programmatic / library callers
+     * who reuse a {@code CommandScope} (e.g. status-before / update / status-after
+     * patterns) should call it once after the final {@code execute()}, never
+     * between executions. Discovered via
+     * {@code PostgreSQLIntegrationTest.testStatusRunDuringUpdate}.
      * <p>
      * Matching is intentionally substring-based on the lowercased key: keys like
      * {@code "argument__bearerToken"} are caught by {@code "token"};
@@ -379,22 +393,30 @@ public class CommandScope {
             throw e;
         } catch (Exception e) {
             throw new CommandExecutionException(e);
-        } finally {
-            clearCredentialArguments();
         }
     }
 
     /**
-     * Overwrite the values of any credential-bearing argument keys with
-     * {@code "*****"} so the original credential Strings stop being referenced by
-     * this scope. Strings are immutable and cannot be wiped in-place, but dropping
-     * the reference here makes them GC-eligible (assuming no other references hold
-     * the same String) instead of letting them live for the rest of the JVM in
-     * long-running embedded scenarios (CWE-316: Cleartext Storage of Sensitive
-     * Information in Memory). Called from {@link #execute()}'s outer finally so
-     * it runs regardless of command outcome; package-private for direct testing.
+     * Overwrite the values of any credential-bearing argument keys (per
+     * {@link #CREDENTIAL_KEY_TOKENS}) with {@code "*****"} so the original
+     * credential Strings stop being referenced by this scope. Strings are
+     * immutable and cannot be wiped in-place, but dropping the reference here
+     * makes them GC-eligible (assuming no other references hold the same String)
+     * instead of letting them live for the rest of the JVM in long-running
+     * embedded scenarios (CWE-316: Cleartext Storage of Sensitive Information
+     * in Memory).
+     * <p>
+     * <b>Caller-invoked.</b> This method must NOT be auto-invoked from
+     * {@link #execute()} — doing so (as the original CWE-316 fix did) breaks any
+     * caller that calls {@code execute()} more than once on the same scope, since
+     * the second call reads {@code "*****"} instead of the real credential.
+     * Callers that reuse a scope (e.g. status-before / update / status-after
+     * patterns) must call this method <b>after the final</b> {@code execute()},
+     * never between executions. Callers that use a scope only once (such as the
+     * CLI in {@code Main}) typically wrap the {@code execute()} call in a
+     * try-finally and call this in the {@code finally}.
      */
-    void clearCredentialArguments() {
+    public void clearCredentialArguments() {
         if (argumentValues.isEmpty()) {
             return;
         }

--- a/liquibase-standard/src/main/java/liquibase/integration/commandline/Main.java
+++ b/liquibase-standard/src/main/java/liquibase/integration/commandline/Main.java
@@ -1478,7 +1478,7 @@ public class Main {
                 // otherwise, we will print the output
                 //
                 Writer outputWriter = getOutputWriter();
-                CommandResults commandResults = snapshotCommand.execute();
+                CommandResults commandResults = executeAndClearCredentials(snapshotCommand);
                 String result = InternalSnapshotCommandStep.printSnapshot(snapshotCommand, commandResults);
                 outputWriter.write(result);
                 outputWriter.flush();
@@ -1521,7 +1521,7 @@ public class Main {
                         .addArgumentValue(DropAllCommandStep.CATALOG_AND_SCHEMAS_ARG, InternalSnapshotCommandStep.parseSchemas(database, getSchemaParams(database)))
                         .addArgumentValue(GenerateChangelogCommandStep.CHANGELOG_FILE_ARG, changeLogFile);
 
-                dropAllCommand.execute();
+                executeAndClearCredentials(dropAllCommand);
                 return;
             } else if (COMMANDS.STATUS.equalsIgnoreCase(command)) {
                 boolean runVerbose = false;
@@ -1558,7 +1558,7 @@ public class Main {
                         .addArgumentValue(CalculateChecksumCommandStep.CHANGESET_IDENTIFIER_ARG, getCommandParam(OPTIONS.CHANGE_SET_IDENTIFIER, null))
                         .addArgumentValue(CalculateChecksumCommandStep.CHANGELOG_FILE_ARG, this.changeLogFile);
 
-                calculateChecksumCommand.execute();
+                executeAndClearCredentials(calculateChecksumCommand);
                 return;
             } else if (COMMANDS.DB_DOC.equalsIgnoreCase(command)) {
                 if (commandParams.isEmpty()) {
@@ -1704,7 +1704,7 @@ public class Main {
                     historyCommand.addArgumentValue(HistoryCommandStep.FORMAT_ARG, HistoryFormat.valueOf(format));
                     historyCommand.setOutput(getOutputStream());
 
-                    historyCommand.execute();
+                    executeAndClearCredentials(historyCommand);
                 } else {
                     throw new CommandLineParsingException(
                             String.format(coreBundle.getString("command.unknown"), command));
@@ -1782,13 +1782,13 @@ public class Main {
         if (outputWriter != null) {
             commandScope.setOutput(new WriterOutputStream(outputWriter, GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()));
         }
-        commandScope.execute();
+        executeAndClearCredentials(commandScope);
     }
 
     private void runReleaseLocksCommand() throws CommandExecutionException {
         CommandScope commandScope = new CommandScope(ReleaseLocksCommandStep.COMMAND_NAME[0]);
         this.setDatabaseArgumentsToCommand(commandScope);
-        commandScope.execute();
+        executeAndClearCredentials(commandScope);
     }
 
     private void runGenerateChangelogCommandStep() throws LiquibaseException, IOException, CommandLineParsingException {
@@ -1827,7 +1827,7 @@ public class Main {
         this.setDatabaseArgumentsToCommand(diffChangelogCommand);
         this.setReferenceDatabaseArgumentsToCommand(diffChangelogCommand);
 
-        diffChangelogCommand.execute();
+        executeAndClearCredentials(diffChangelogCommand);
     }
 
     private void runDiffCommandStep() throws CommandLineParsingException, CommandExecutionException, IOException {
@@ -1839,7 +1839,7 @@ public class Main {
         this.setDatabaseArgumentsToCommand(diffCommand);
         this.setReferenceDatabaseArgumentsToCommand(diffCommand);
 
-        diffCommand.execute();
+        executeAndClearCredentials(diffCommand);
     }
 
     private void runUpdateCommandStep() throws CommandLineParsingException, CommandExecutionException, IOException {
@@ -1850,7 +1850,7 @@ public class Main {
         updateCommand.addArgumentValue(ChangeExecListenerCommandStep.CHANGE_EXEC_LISTENER_CLASS_ARG, changeExecListenerClass);
         updateCommand.addArgumentValue(ChangeExecListenerCommandStep.CHANGE_EXEC_LISTENER_PROPERTIES_FILE_ARG, changeExecListenerPropertiesFile);
         setDatabaseArgumentsToCommand(updateCommand);
-        updateCommand.execute();
+        executeAndClearCredentials(updateCommand);
     }
 
     private void runRollbackOneChangeSetCommandStep() throws CommandExecutionException, CommandLineParsingException {
@@ -1865,7 +1865,7 @@ public class Main {
                 .addArgumentValue("force", getCommandParam(OPTIONS.FORCE, null));
         String internalCommand = "rollbackOneChangeset";
         Scope.getCurrentScope().addMdcValue(MdcKey.LIQUIBASE_INTERNAL_COMMAND, internalCommand);
-        rollbackOneChangeSet.execute();
+        executeAndClearCredentials(rollbackOneChangeSet);
     }
 
     private void runRollbackOneChangeSetSqlCommandStep() throws CommandExecutionException, CommandLineParsingException, IOException {
@@ -1881,7 +1881,7 @@ public class Main {
         String internalCommand = "rollbackOneChangeset";
         Scope.getCurrentScope().addMdcValue(MdcKey.LIQUIBASE_INTERNAL_COMMAND, internalCommand);
         rollbackOneChangeSet.setOutput(new WriterOutputStream(getOutputWriter(), GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()));
-        rollbackOneChangeSet.execute();
+        executeAndClearCredentials(rollbackOneChangeSet);
     }
 
     private void runRollbackOneUpdateCommandStep() throws CommandExecutionException, CommandLineParsingException {
@@ -1894,7 +1894,7 @@ public class Main {
                 .addArgumentValue("force", getCommandParam(OPTIONS.FORCE, null));
         String internalCommand = "rollbackOneUpdate";
         Scope.getCurrentScope().addMdcValue(MdcKey.LIQUIBASE_INTERNAL_COMMAND, internalCommand);
-        rollbackOneUpdate.execute();
+        executeAndClearCredentials(rollbackOneUpdate);
     }
 
     private void runRollbackOneUpdateSqlCommandStep() throws CommandExecutionException, CommandLineParsingException, IOException {
@@ -1908,7 +1908,7 @@ public class Main {
         String internalCommand = "rollbackOneUpdate";
         Scope.getCurrentScope().addMdcValue(MdcKey.LIQUIBASE_INTERNAL_COMMAND, internalCommand);
         rollbackOneUpdate.setOutput(new WriterOutputStream(getOutputWriter(), GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue()));
-        rollbackOneUpdate.execute();
+        executeAndClearCredentials(rollbackOneUpdate);
     }
 
     /**
@@ -1989,7 +1989,7 @@ public class Main {
         executeSql.addArgumentValue(ExecuteSqlCommandStep.SQLFILE_ARG, getCommandParam("sqlFile", null));
         executeSql.addArgumentValue(ExecuteSqlCommandStep.DELIMITER_ARG, getCommandParam("delimiter", ";"));
         setDatabaseArgumentsToCommand(executeSql);
-        executeSql.execute();
+        executeAndClearCredentials(executeSql);
     }
 
     /**
@@ -2067,6 +2067,29 @@ public class Main {
     }
 
     /**
+     * Execute the given {@link CommandScope} and unconditionally call
+     * {@link CommandScope#clearCredentialArguments()} on it afterwards (CWE-316:
+     * Cleartext Storage of Sensitive Information in Memory). Used in place of a
+     * bare {@code commandScope.execute()} at every CLI command-runner site so
+     * that single-use scopes drop their credential references before this method
+     * returns, regardless of command outcome.
+     * <p>
+     * The clearing was originally inlined into {@link CommandScope#execute()}'s
+     * outer {@code finally}, but that broke any caller that calls {@code execute()}
+     * more than once on the same scope (the second call sees {@code "*****"} and
+     * the JDBC driver rejects). Moving the clearing to the CLI entry points
+     * preserves the CWE-316 intent here without imposing single-use semantics on
+     * programmatic / library callers.
+     */
+    private static CommandResults executeAndClearCredentials(CommandScope commandScope) throws CommandExecutionException {
+        try {
+            return commandScope.execute();
+        } finally {
+            commandScope.clearCredentialArguments();
+        }
+    }
+
+    /**
      * Return the first "parameter" from the command line that does NOT have the form of parameter=value. A parameter
      * is a command line argument that follows the main action (e.g. update/rollback/...). Example:
      * For the main action "updateToTagSQL &lt;tag&gt;", &lt;tag&gt; would be the command argument.
@@ -2137,7 +2160,7 @@ public class Main {
             commandScope.addArgumentValue("exception", exception);
             commandScope.addArgumentValue("listener", defaultChangeExecListener);
             commandScope.addArgumentValue("rollbackOnError", rollbackOnError);
-            commandScope.execute();
+            executeAndClearCredentials(commandScope);
         } catch (IllegalArgumentException ignoredCommandNotFound) {
             throw exception;
         }

--- a/liquibase-standard/src/test/groovy/liquibase/command/CommandScopeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/command/CommandScopeTest.groovy
@@ -196,13 +196,19 @@ class CommandScopeTest extends Specification {
         Locale.setDefault(savedDefault)
     }
 
-    def "execute invokes credential clearing in its outer finally on the success path"() {
-        // CWE-316 wiring check: confirms the outer finally added to execute()
-        // actually calls clearCredentialArguments(). Pre-supplies the 'requiredArg'
-        // value so this test is order-independent w.r.t. the 'execute with failing
-        // argument validation' spec that registers requiredArg as required on
-        // 'mock' (Spock test order in a single Specification is declaration-order,
-        // but the side effect of CommandBuilder is global to the JVM).
+    def "execute does NOT clear credential arguments automatically — opt-in semantics"() {
+        // Regression: PR #7741 originally clamped clearCredentialArguments() into
+        // execute()'s outer finally to satisfy CWE-316. That broke any caller that
+        // re-uses a CommandScope (see PostgreSQLIntegrationTest.testStatusRunDuringUpdate
+        // which executes 3× on the same scope: first call succeeded; second/third saw
+        // "*****" in argumentValues["password"] and got "FATAL: password authentication
+        // failed for user 'lbuser'" from the JDBC driver). The fix moved the clearing
+        // out of execute() and made it caller-invoked via the (now public)
+        // clearCredentialArguments() method. This spec pins that execute() alone does
+        // NOT touch credential argument values, so re-use cases continue to work.
+        // Pre-supplies 'requiredArg' so the test is order-independent w.r.t. the
+        // 'execute with failing argument validation' spec above which registers
+        // requiredArg as required on 'mock'.
         given:
         def scope = new CommandScope("mock")
         scope.addArgumentValue("requiredArg", "anything")
@@ -212,7 +218,7 @@ class CommandScopeTest extends Specification {
         MockCommandStep.logic = new MockCommandStep() {
             @Override
             void run(CommandResultsBuilder resultsBuilder) throws Exception {
-                // no-op pipeline body — we are testing the finally-block wiring, not the step.
+                // no-op pipeline body — we are pinning the absence of auto-clearing, not the step.
             }
         }
 
@@ -220,13 +226,51 @@ class CommandScopeTest extends Specification {
         scope.execute()
 
         then:
-        scope.@argumentValues["password"]    == "*****"
+        scope.@argumentValues["password"]    == "supersecret-pw-12345"
         scope.@argumentValues["requiredArg"] == "anything"
         scope.@argumentValues["username"]    == "regular-user"
     }
 
-    def "execute invokes credential clearing in its outer finally even when the pipeline throws"() {
-        // CWE-316 wiring check: the outer finally must run on the failure path too.
+    def "execute called twice on the same scope reads original credentials both times — regression for PostgreSQLIntegrationTest.testStatusRunDuringUpdate"() {
+        // The canary scenario that surfaced the auto-clear regression. A caller
+        // creates a CommandScope, executes it (e.g., 'status'), then re-executes
+        // the SAME scope (e.g., 'update', or 'status' again after a concurrent
+        // update). With the old auto-clear in execute()'s finally, the second
+        // execute() would see argumentValues["password"] == "*****" and the JDBC
+        // driver would reject the connection with "password authentication failed".
+        // Post-fix: both executions see the original credential.
+        given:
+        def scope = new CommandScope("mock")
+        scope.addArgumentValue("requiredArg", "anything")
+        scope.addArgumentValue("password",    "supersecret-pw-12345")
+
+        def passwordsObservedByPipeline = []
+        MockCommandStep.logic = new MockCommandStep() {
+            @Override
+            void run(CommandResultsBuilder resultsBuilder) throws Exception {
+                // Capture what the pipeline would have read at execute() time.
+                passwordsObservedByPipeline << resultsBuilder.getCommandScope().@argumentValues["password"]
+            }
+        }
+
+        when:
+        scope.execute()
+        scope.execute()
+        scope.execute()
+
+        then:
+        // All three executions saw the same original credential — none was redacted
+        // between calls. This is the contract that re-use callers depend on.
+        passwordsObservedByPipeline == ["supersecret-pw-12345", "supersecret-pw-12345", "supersecret-pw-12345"]
+        scope.@argumentValues["password"] == "supersecret-pw-12345"
+    }
+
+    def "execute does NOT clear credentials even when the pipeline throws — opt-in semantics also apply on the failure path"() {
+        // Counterpart to the success-path spec above: under the new opt-in semantics,
+        // execute() must NOT auto-clear on exception either. If a caller needs the
+        // CWE-316 protection on the failure path, they wrap the execute() call in
+        // try-finally and call clearCredentialArguments() themselves (see
+        // Main.executeAndClearCredentials()).
         given:
         def scope = new CommandScope("mock")
         scope.addArgumentValue("requiredArg", "anything")
@@ -244,6 +288,37 @@ class CommandScopeTest extends Specification {
 
         then:
         thrown(liquibase.exception.CommandExecutionException)
+        scope.@argumentValues["password"] == "supersecret-pw-12345"
+    }
+
+    def "caller-invoked try-finally pattern around execute clears credentials post-execution (CWE-316 wiring documented for CLI integrators)"() {
+        // The pattern recommended for CLI / single-use callers: wrap execute() in
+        // try-finally and call clearCredentialArguments() in the finally. This spec
+        // documents the contract: the pipeline sees the original credential during
+        // execute(), and the credential is wiped immediately after the call returns.
+        // Main.executeAndClearCredentials() is the canonical implementation.
+        given:
+        def scope = new CommandScope("mock")
+        scope.addArgumentValue("requiredArg", "anything")
+        scope.addArgumentValue("password",    "supersecret-pw-12345")
+
+        def passwordSeenByPipeline = null
+        MockCommandStep.logic = new MockCommandStep() {
+            @Override
+            void run(CommandResultsBuilder resultsBuilder) throws Exception {
+                passwordSeenByPipeline = resultsBuilder.getCommandScope().@argumentValues["password"]
+            }
+        }
+
+        when:
+        try {
+            scope.execute()
+        } finally {
+            scope.clearCredentialArguments()
+        }
+
+        then:
+        passwordSeenByPipeline == "supersecret-pw-12345"
         scope.@argumentValues["password"] == "*****"
     }
 


### PR DESCRIPTION
## TL;DR

PR #7741 ("CWE-316: clear password memory after use in legacy CLI + CommandScope") added a `finally { clearCredentialArguments(); }` block to `CommandScope.execute()`. **That breaks every caller that calls `execute()` more than once on the same `CommandScope`** — the second call reads `"*****"` and the JDBC driver rejects the connection.

This PR implements **Option A** from issue #7761: remove the auto-clearing in `execute()`, make `clearCredentialArguments()` public so callers can opt in explicitly, and wire the CLI's single-use call sites in `Main.java` to call it via a small `executeAndClearCredentials()` helper. Adds three new `CommandScopeTest` specs — including the **unit-level regression coverage for `PostgreSQLIntegrationTest.testStatusRunDuringUpdate`** — so future re-introductions are caught at PR-author time without needing a live postgres in the loop.

Closes #7761.

## The concrete regression

```java
public CommandResults execute() throws CommandExecutionException {
    ...
    } finally {
        clearCredentialArguments();   // <-- auto-clear after every execute()
    }
}
```

`clearCredentialArguments()` overwrites every credential-bearing argument value (`password`, `passwd`, `secret`, `token`, `apikey`, `accesskey`, `licensekey`) in the scope's `argumentValues` map with `"*****"`. A caller that reuses the same scope:

```java
CommandScope statusScope = new CommandScope("status")
    .addArgumentValue("password", realPassword);

statusScope.execute();   // 1st call: OK, uses realPassword. After: argumentValues["password"] = "*****"
// ... concurrent liquibase.update() runs ...
statusScope.execute();   // 2nd call: argumentValues["password"] is now "*****"
                          //   → JDBC driver sees "*****" → "FATAL: password authentication failed"
```

`liquibase.dbtest.pgsql.PostgreSQLIntegrationTest.testStatusRunDuringUpdate` (line 93) does exactly that — three executions on the same scope to check status before / during / after a concurrent update. First call succeeds; second/third fail with:

```
liquibase.exception.DatabaseException: Connection could not be created to
jdbc:postgresql://localhost:48822/lbcat?loggerLevel=OFF with driver
org.postgresql.Driver. FATAL: password authentication failed for user "lbuser"
```

Upstream main has been red on this test since 2026-05-21 12:15 UTC (when #7741 merged). [The failing run linked from issue #7761](https://github.com/liquibase/liquibase/actions/runs/26402847894/job/77720530913).

## Why the regression sat in upstream main for four days

PR #7741 was authored from a fork (`v-petrovych/liquibase`). Upstream's `run-tests.yml` workflow gates its `authorize` job on `environment: external` whenever the PR's head repo differs from `github.repository`. That gate requires a maintainer to click **"Review deployments → Approve and run"** before the workflow can proceed.

The gate was never approved on #7741's pre-merge build. The workflow sat in `status: waiting`. No `Run Test for (Java N <OS>)` or `Integration Test (<db>)` jobs ever materialised. The PR's 9 green checks were all from non-gated workflows (CodeQL, label, claude-review). **The merge button did not block on a workflow that never produced any check at all.**

After merge, the post-merge `push` to `main` triggered the workflow with the `internal` environment (no manual approval needed) — but by then the merge was already in. Same shape for PR #7760 (the fixture fix that finally let the reactor advance past `liquibase-standard` to `liquibase-integration-tests`).

I've filed validation guidance for the next contributor in the upstream issue so this gate doesn't continue to hide regressions on fork-authored PRs. The five checks are summarised at the bottom of this PR description.

## Option A — opt-in clearing

Three options were discussed in issue #7761:

| Option | Description | Verdict |
|---|---|---|
| **A** | Make clearing opt-in: public method on `CommandScope`; remove finally; call explicitly at single-use sites. | **Chosen.** Preserves CWE-316 intent at CLI call sites; doesn't break re-use. |
| B | Gate clearing on a `markSingleUse()` flag (backwards-compat default). | Possible, but adds API surface and a state machine that's easy to forget. |
| C | Clear on scope `close()` rather than per-execute (`AutoCloseable`). | Bigger refactor; same forget-to-close risk as B. |

## Changes

### 1. `CommandScope.java`

- **Removed** the outer `finally { clearCredentialArguments(); }` block from `execute()`.
- **Changed** `clearCredentialArguments()` from package-private to **`public`** so external callers can invoke it explicitly.
- **Updated** both the `CREDENTIAL_KEY_TOKENS` doc comment and the `clearCredentialArguments()` method doc to document the new caller-invoked contract, including the specific re-use scenario the auto-finally broke and the recommended try-finally pattern for single-use callers.

### 2. `Main.java`

- **Added** a private static helper:
  ```java
  private static CommandResults executeAndClearCredentials(CommandScope commandScope) throws CommandExecutionException {
      try {
          return commandScope.execute();
      } finally {
          commandScope.clearCredentialArguments();
      }
  }
  ```
- **Replaced** every CLI `commandScope.execute()` callsite with `executeAndClearCredentials(commandScope)`. 15 sites: `snapshotCommand`, `dropAllCommand`, `calculateChecksumCommand`, `historyCommand`, `diffCommand`, `diffChangelogCommand`, `updateCommand`, `rollbackOneChangeSet` (×2), `rollbackOneUpdate` (×2), `executeSql`, plus three bare `commandScope.execute()` calls.

Net effect: CLI users get the same CWE-316 protection they had before #7741's regression-causing fix landed, but the protection now lives at the call site (where the single-use assumption is true) rather than inside `execute()` (where the assumption was false for the integration test and any library/programmatic caller that reuses a scope).

### 3. `CommandScopeTest.groovy`

- **Updated** the two existing specs (`"execute invokes credential clearing in its outer finally..."`) to assert the new opt-in semantics: `execute()` alone does NOT touch credential values; explicit `clearCredentialArguments()` does.
- **Added** the key regression spec:
  > `"execute called twice on the same scope reads original credentials both times — regression for PostgreSQLIntegrationTest.testStatusRunDuringUpdate"`

  Calls `execute()` three times on the same scope and uses a `MockCommandStep` that captures `argumentValues["password"]` each time the pipeline runs. All three captured values must equal the original credential. **This is the unit-level regression coverage for the integration-test scenario that surfaced the bug** — running it at unit speed means future re-introductions are caught at PR-author time without needing a live postgres in the loop.
- **Added** a documentation spec for the recommended `try-finally` usage pattern.

## Tests

All passing locally on this branch (pre-merge validation):

```
CommandScopeTest                      22 / 22   (3 new specs)
LiquibaseCommandLineTest              40 / 40   (incl. 'help output' snapshot)
liquibase-cli full reactor           115 / 115
liquibase-standard Command*-related  204 / 204
MainTest                              32 / 32
```

**413 specs across the directly-impacted set, 0 failures.** Did not run the live-postgres integration tests locally — Docker not available in my setup. Pre-merge CI will need to run them; see the **Validation** section below.

## Validation (please read before merging)

Verbatim from the [Validation section](https://datical.atlassian.net/browse/DAT-23097) of the internal regression ticket — mirrored upstream as context for anyone in the org or external who authors / reviews fork PRs against `liquibase/liquibase`. The deep root cause of why both #7741 and #7760 merged without their tests running is the `environment: external` gate on the fork PR's `run-tests.yml`:

1. **Before celebrating CI-green, check the actual workflow run.** After opening the PR, go to the Actions tab → filter by branch → confirm `Unit and Integration Tests` has `conclusion: success`. If you see `status: waiting`, the tests did NOT run.
2. **If it's waiting, ask a maintainer to approve it.** Comment on the PR: *"Could a maintainer hit 'Review deployments → Approve and run' on the run-tests.yml workflow run for this PR? It's waiting on the `external` environment gate."* Don't ask for merge until that workflow has actually run and is green.
3. **If you have push access to `liquibase/liquibase` directly, prefer branching inside the org repo** rather than working from your fork. That avoids the gate entirely (the workflow picks `internal` environment and runs immediately).
4. **Run the snapshot tests locally before opening a fork PR**, especially anything touching `GlobalConfiguration`, `LiquibaseCommandLine`, or `CommandScope`. Five seconds locally beats four days of upstream-main red.
5. **When reviewing or merging a fork PR**, scan the rollup for `authorize` jobs in pending/null state — that's the explicit signal the test matrix was gated and never ran.

For this PR specifically: I'll watch the Actions tab after pushing. If the `Unit and Integration Tests` workflow lands in `status: waiting`, I'll comment asking for deployment approval before requesting merge.

## Related

- Issue liquibase/liquibase#7761 — the upstream issue this PR closes
- PR liquibase/liquibase#7741 — the original CWE-316 fix that introduced the regression (commit `4850342ae7`)
- PR liquibase/liquibase#7760 — the DAT-23096 fixture fix that finally let the reactor advance past `liquibase-standard` so this regression became visible on main
- Pro subtree-sync PR liquibase/liquibase-pro#3860 — held until this PR lands and a fresh subtree-sync picks it up

Part of the May-2026 OSS credential-handling-and-changelog-injection audit slice (`sdou` label).
