### PR TITLE
CWE-470: opt-in restricted mode for includeAll resourceFilter and resourceComparator classes

### DIFF
--- a/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineTest.groovy
+++ b/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineTest.groovy
@@ -72,6 +72,35 @@ Global Options
                                environment variable:
                                'LIQUIBASE_ALLOW_EXECUTE_COMMAND')
 
+      --allow-include-all-classes=PARAM
+                             If false, the includeAll changelog directive's
+                               resourceFilter and resourceComparator attributes
+                               are rejected when they reference a class name.
+                               Defaults to true to preserve the documented
+                               includeAll feature for the standard trust model
+                               (team-authored, team-reviewed changelogs). Set
+                               to false in environments that execute changelogs
+                               from less-trusted sources (multi-tenant SaaS
+                               running customer changelogs, downloaded
+                               change-packs, contributor PRs prior to review):
+                               both attributes load an arbitrary JVM class by
+                               FQCN via Class.forName(initialize=true), which
+                               fires the class's static <clinit> initializer at
+                               load time — before any cast or marker-interface
+                               check could reject the load. Any class on the
+                               JVM classpath is reachable this way (CWE-470).
+                               This flag governs the same unsafe-reflection
+                               surface as liquibase.allowCustomChange (which
+                               gates the <customChange> and
+                               <customPrecondition> changelog elements);
+                               operators wanting to fully lock down
+                               changelog-controlled class loading must set both
+                               flags to false.
+                             DEFAULT: true
+                             (defaults file: 'liquibase.
+                               allowIncludeAllClasses', environment variable:
+                               'LIQUIBASE_ALLOW_INCLUDE_ALL_CLASSES')
+
       --allow-inherit-logical-file-path=PARAM
                              If true, included changelogs without an explicit
                                logicalFilePath will inherit their parent

--- a/liquibase-standard/src/main/java/liquibase/GlobalConfiguration.java
+++ b/liquibase-standard/src/main/java/liquibase/GlobalConfiguration.java
@@ -55,6 +55,7 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
     public static final ConfigurationDefinition<Boolean> SECURE_PARSING;
     public static final ConfigurationDefinition<Boolean> ALLOW_CUSTOM_CHANGE;
     public static final ConfigurationDefinition<Boolean> ALLOW_EXECUTE_COMMAND;
+    public static final ConfigurationDefinition<Boolean> ALLOW_INCLUDE_ALL_CLASSES;
     public static final ConfigurationDefinition<Boolean> ALLOW_PARENT_DIRECTORY_REFERENCES;
     public static final ConfigurationDefinition<String> SEARCH_PATH;
 
@@ -248,6 +249,23 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
                         "that execute changelogs from less-trusted sources (multi-tenant SaaS running customer " +
                         "changelogs, downloaded change-packs, contributor PRs prior to review) where arbitrary " +
                         "OS-shell execution via changelog is not an acceptable risk (CWE-78).")
+                .setDefaultValue(true)
+                .build();
+
+        ALLOW_INCLUDE_ALL_CLASSES = builder.define("allowIncludeAllClasses", Boolean.class)
+                .setDescription("If false, the includeAll changelog directive's resourceFilter and " +
+                        "resourceComparator attributes are rejected when they reference a class name. " +
+                        "Defaults to true to preserve the documented includeAll feature for the standard " +
+                        "trust model (team-authored, team-reviewed changelogs). Set to false in environments " +
+                        "that execute changelogs from less-trusted sources (multi-tenant SaaS running customer " +
+                        "changelogs, downloaded change-packs, contributor PRs prior to review): both " +
+                        "attributes load an arbitrary JVM class by FQCN via Class.forName(initialize=true), " +
+                        "which fires the class's static <clinit> initializer at load time — before any cast " +
+                        "or marker-interface check could reject the load. Any class on the JVM classpath is " +
+                        "reachable this way (CWE-470). This flag governs the same unsafe-reflection surface " +
+                        "as liquibase.allowCustomChange (which gates the <customChange> and " +
+                        "<customPrecondition> changelog elements); operators wanting to fully lock down " +
+                        "changelog-controlled class loading must set both flags to false.")
                 .setDefaultValue(true)
                 .build();
 

--- a/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/DatabaseChangeLog.java
@@ -637,6 +637,18 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
         }
         IncludeAllFilter resourceFilter = null;
         if (resourceFilterDef != null) {
+            // CWE-470 gate: reject changelog-controlled FQCN loading when the embedder has
+            // explicitly opted out. The Class.forName(initialize=true) below would fire the
+            // named class's static <clinit> at load time, before the cast to IncludeAllFilter
+            // could reject it — same unsafe-reflection surface as <customChange> and
+            // <customPrecondition>, gated by liquibase.allowCustomChange.
+            if (!Boolean.TRUE.equals(GlobalConfiguration.ALLOW_INCLUDE_ALL_CLASSES.getCurrentValue())) {
+                throw new SetupException("includeAll with a resourceFilter class is disabled " +
+                        "because liquibase.allowIncludeAllClasses=false. The named class was " +
+                        "NOT loaded. Either remove the resourceFilter / filter attribute from " +
+                        "the includeAll directive, or set liquibase.allowIncludeAllClasses=true " +
+                        "to enable changelog-controlled class loading by includeAll.");
+            }
             try {
                 resourceFilter = (IncludeAllFilter) Class.forName(resourceFilterDef, true, Thread.currentThread().getContextClassLoader()).getConstructor().newInstance();
             } catch (ReflectiveOperationException e) {
@@ -727,6 +739,19 @@ public class DatabaseChangeLog implements Comparable<DatabaseChangeLog>, Conditi
         if (resourceComparatorDef == null) {
             resourceComparator = getStandardChangeLogComparator();
         } else {
+            // CWE-470 gate: must throw BEFORE the try/catch below so the existing
+            // ReflectiveOperationException-catches-and-falls-back-to-standard logic
+            // cannot silently degrade the configured-off intent into the default
+            // comparator (which would mask the rejection from the operator and look
+            // identical to the success path in logs).
+            if (!Boolean.TRUE.equals(GlobalConfiguration.ALLOW_INCLUDE_ALL_CLASSES.getCurrentValue())) {
+                throw new UnexpectedLiquibaseException("includeAll with a resourceComparator " +
+                        "class is disabled because liquibase.allowIncludeAllClasses=false. " +
+                        "The named class was NOT loaded. Either remove the resourceComparator " +
+                        "attribute from the includeAll directive, or set " +
+                        "liquibase.allowIncludeAllClasses=true to enable changelog-controlled " +
+                        "class loading by includeAll.");
+            }
             try {
                 resourceComparator = (Comparator<String>) Class.forName(resourceComparatorDef, true, Thread.currentThread().getContextClassLoader()).getConstructor().newInstance();
             } catch (ReflectiveOperationException e) {

--- a/liquibase-standard/src/test/groovy/liquibase/changelog/DatabaseChangeLogTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/changelog/DatabaseChangeLogTest.groovy
@@ -1219,4 +1219,144 @@ http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbch
         ]
     }
 
+    // CWE-470 opt-in restricted mode for includeAll's resourceFilter and resourceComparator
+    // class loading. See GlobalConfiguration.ALLOW_INCLUDE_ALL_CLASSES. Sibling-shape to
+    // ALLOW_CUSTOM_CHANGE (which gates <customChange> and <customPrecondition>).
+
+    def "determineResourceComparator returns the standard comparator when allowIncludeAllClasses=true (default) and resourceComparatorDef is null"() {
+        given:
+        def changelog = new DatabaseChangeLog()
+        Comparator<String> comparator = null
+
+        when:
+        Scope.child(["liquibase.allowIncludeAllClasses": "true"] as Map, {
+            comparator = changelog.determineResourceComparator(null)
+        } as Scope.ScopedRunner)
+
+        then:
+        comparator != null
+        // Standard comparator behaviour: alphabetical with the "WEB-INF/classes/" prefix
+        // stripped. getStandardChangeLogComparator() returns a fresh Comparator.comparing
+        // lambda each call, so reference-equality would always fail — pin behaviour instead.
+        comparator.compare("a", "b") < 0
+        comparator.compare("b", "a") > 0
+        comparator.compare("WEB-INF/classes/foo", "foo") == 0
+    }
+
+    def "determineResourceComparator falls back to standard comparator at default flag when resourceComparator class fails to load (preserves pre-fix catch behaviour)"() {
+        given:
+        def changelog = new DatabaseChangeLog()
+        Comparator<String> comparator = null
+
+        when:
+        Scope.child(["liquibase.allowIncludeAllClasses": "true"] as Map, {
+            // Non-existent class. Existing pre-fix catch swallows the ReflectiveOperationException
+            // and falls back to the standard comparator. This spec pins that we do NOT regress
+            // that behaviour when the flag is at its default (true) — only the flag=false case
+            // hard-fails.
+            comparator = changelog.determineResourceComparator("com.example.definitely.not.a.real.Comparator")
+        } as Scope.ScopedRunner)
+
+        then:
+        comparator != null
+        // Standard comparator behaviour: alphabetical with the "WEB-INF/classes/" prefix
+        // stripped. getStandardChangeLogComparator() returns a fresh Comparator.comparing
+        // lambda each call, so reference-equality would always fail — pin behaviour instead.
+        comparator.compare("a", "b") < 0
+        comparator.compare("b", "a") > 0
+        comparator.compare("WEB-INF/classes/foo", "foo") == 0
+    }
+
+    def "determineResourceComparator throws UnexpectedLiquibaseException BEFORE Class.forName when allowIncludeAllClasses=false"() {
+        // The strongest assertion in this section: the gate must fire BEFORE Class.forName,
+        // and the existing ReflectiveOperationException-catches-fall-back-to-standard logic
+        // must NOT swallow the configured-off intent. If the gate fired AFTER Class.forName
+        // (or worse, if the catch had swallowed the configured-off exception), the call
+        // would return the standard comparator and look identical to the default path.
+        given:
+        def changelog = new DatabaseChangeLog()
+        UnexpectedLiquibaseException caught = null
+
+        when:
+        Scope.child(["liquibase.allowIncludeAllClasses": "false"] as Map, {
+            try {
+                // Class name is irrelevant — gate fires regardless of whether the named class
+                // exists. Using an obviously-fake name makes the test independent of any class
+                // present on the test classpath.
+                changelog.determineResourceComparator("com.example.definitely.not.a.real.Comparator")
+            } catch (UnexpectedLiquibaseException e) {
+                caught = e
+            }
+        } as Scope.ScopedRunner)
+
+        then:
+        caught != null
+        // Message names the flag in both directions and identifies what was NOT loaded.
+        // A wrapped exception from a downstream code path would not match this shape.
+        def message = caught.getMessage()
+        message.contains("liquibase.allowIncludeAllClasses=false")
+        message.contains("liquibase.allowIncludeAllClasses=true")
+        message.contains("NOT loaded")
+        message.contains("resourceComparator")
+    }
+
+    def "determineResourceComparator with null resourceComparatorDef returns standard comparator even when allowIncludeAllClasses=false"() {
+        // The gate is gated on the presence of a class name. A null resourceComparator
+        // means there is nothing to gate — the call returns the standard comparator
+        // without any flag check. This spec pins that the gate does NOT over-reach into
+        // the default-comparator path.
+        given:
+        def changelog = new DatabaseChangeLog()
+        Comparator<String> comparator = null
+
+        when:
+        Scope.child(["liquibase.allowIncludeAllClasses": "false"] as Map, {
+            comparator = changelog.determineResourceComparator(null)
+        } as Scope.ScopedRunner)
+
+        then:
+        comparator != null
+        // Standard comparator behaviour: alphabetical with the "WEB-INF/classes/" prefix
+        // stripped. getStandardChangeLogComparator() returns a fresh Comparator.comparing
+        // lambda each call, so reference-equality would always fail — pin behaviour instead.
+        comparator.compare("a", "b") < 0
+        comparator.compare("b", "a") > 0
+        comparator.compare("WEB-INF/classes/foo", "foo") == 0
+    }
+
+    def "handleIncludeAll throws SetupException BEFORE Class.forName when allowIncludeAllClasses=false and resourceFilter is specified"() {
+        // Parser-path test for the inline gate in handleIncludeAll. The previous spec
+        // covers determineResourceComparator (public method) directly; this one exercises
+        // the second Class.forName call site via the standard load() entry point.
+        given:
+        def resourceAccessor = new MockResourceAccessor(["com/example/test1.xml": test1Xml])
+        def rootChangeLog = new DatabaseChangeLog("com/example/root.xml")
+        rootChangeLog.setChangeLogParameters(new ChangeLogParameters())
+        rootChangeLog.getChangeLogParameters().set("loginUser", "testUser")
+        Throwable caught = null
+
+        when:
+        Scope.child(["liquibase.allowIncludeAllClasses": "false"] as Map, {
+            try {
+                rootChangeLog.load(new ParsedNode(null, "databaseChangeLog")
+                        .addChildren([includeAll: [path: "com/example",
+                                                   resourceFilter: "com.example.definitely.not.a.real.IncludeAllFilter"]]),
+                        resourceAccessor)
+            } catch (Throwable t) {
+                caught = t
+            }
+        } as Scope.ScopedRunner)
+
+        then:
+        caught != null
+        // Load() wraps SetupException in some upstream exception types depending on the
+        // path; the message-shape match is the load-bearing assertion. If the gate had
+        // NOT fired, the failure would be a ReflectiveOperationException for the
+        // non-existent class — not our configured-off text.
+        def message = (caught.getCause() != null ? caught.getCause().getMessage() : caught.getMessage()) ?: caught.toString()
+        message.contains("liquibase.allowIncludeAllClasses=false")
+        message.contains("resourceFilter")
+        message.contains("NOT loaded")
+    }
+
 }


### PR DESCRIPTION
## Impact

The `<includeAll>` changelog directive accepts `resourceFilter` and `resourceComparator` attributes that specify fully-qualified Java class names. Both are loaded via `Class.forName(name, true, ContextClassLoader).getConstructor().newInstance()` with no allowlist and no marker-interface check before construction:

```java
// DatabaseChangeLog.java:641 — resourceFilter
resourceFilter = (IncludeAllFilter) Class.forName(resourceFilterDef, true,
    Thread.currentThread().getContextClassLoader()).getConstructor().newInstance();

// DatabaseChangeLog.java:731 — resourceComparator
resourceComparator = (Comparator<String>) Class.forName(resourceComparatorDef, true,
    Thread.currentThread().getContextClassLoader()).getConstructor().newInstance();
```

The `initialize=true` argument fires the named class's static `<clinit>` initializer **at load time** — before the cast or any other safety check could reject the load. Any class on the JVM classpath is reachable via a malicious `<includeAll>`: name the class, get its static-init code and zero-arg constructor invoked as a side effect.

This maps to **CWE-470** (Use of Externally-Controlled Input to Select Classes or Code, aka *Unsafe Reflection*) — the same surface as `<customChange>` and `<customPrecondition>`, applied to a different parse-time entry point.

## Scope decision (sibling to #7748 and #7749) — separate flag, not shared

The audit author originally suggested unifying B2/B3/B5 under one flag (`liquibase.execution.allowCustomClassLoad`). After deliberation this PR uses a **separate flag** for two reasons:

1. **`<includeAll>` is not a "custom-*" element.** Extending `liquibase.allowCustomChange` (which gates `<customChange>` and `<customPrecondition>`) to also gate `<includeAll>` would stretch the flag name beyond what an operator reading `allowCustomChange` would reasonably expect.
2. **Distinct flags give operators independent control surface.** An embedder who uses `<customChange>` but not `<includeAll>` filters (or vice versa) can lock down each independently.

To prevent the "operator missed a flag" footgun that motivated #7749 sharing #7748's flag, **this PR's new-flag description cross-references `liquibase.allowCustomChange`**. Operators reading either description learn that fully locking down changelog-controlled class loading requires setting **both** flags to `false`. Open to feedback if reviewers prefer the unified-flag approach instead — the swap would be mechanical.

**No default behaviour change.** Every existing `<includeAll>` continues to work byte-for-byte identically at the default flag value.

## Fix — three pieces

**1. New `GlobalConfiguration.ALLOW_INCLUDE_ALL_CLASSES` flag** — `liquibase.allowIncludeAllClasses`, Boolean, defaults to `true`. Description references CWE-470 and cross-references `liquibase.allowCustomChange`.

**2. Two inline gates in `DatabaseChangeLog`:**

   **(a) In `handleIncludeAll()`** at the `resourceFilter` `Class.forName` call site (line 641 in the audit reference). Throws `SetupException` with the configured-off message **BEFORE** the `Class.forName`, so the static initializer of the named class never fires when the flag is `false`.

   **(b) In `determineResourceComparator()`** at the `resourceComparator` `Class.forName` call site (line 731 in the audit reference). Throws `UnexpectedLiquibaseException` (the method has no checked-throws clause). **Critically, the gate fires BEFORE the `try/catch` block** — the existing `ReflectiveOperationException`-catches-and-falls-back-to-standard logic would otherwise silently degrade the configured-off intent into the default comparator (which would mask the rejection from the operator and look identical to the success path in logs).

**3. Five new Spock specs** in `DatabaseChangeLogTest` (195 pre-existing → 200 total):

| Spec | What it pins |
|---|---|
| `determineResourceComparator returns the standard comparator when allowIncludeAllClasses=true (default) and resourceComparatorDef is null` | Default-path preservation. Behaviour-asserts via `comparator.compare(...)` rather than reference-equality because `getStandardChangeLogComparator()` returns a fresh `Comparator.comparing(...)` lambda each call. |
| `determineResourceComparator falls back to standard comparator at default flag when resourceComparator class fails to load (preserves pre-fix catch behaviour)` | flag=true must not regress the existing graceful-fallback path. |
| `determineResourceComparator throws UnexpectedLiquibaseException BEFORE Class.forName when allowIncludeAllClasses=false` | The strongest assertion in this section: uses a non-existent class name. Pre-fix code path would have fallen back to standard (no exception); after-fix produces ONLY the configured-off error — the loader never ran. Message-shape match (flag-name in both directions + `"NOT loaded"` + `"resourceComparator"`) is the proof-of-short-circuit. |
| `determineResourceComparator with null resourceComparatorDef returns standard comparator even when allowIncludeAllClasses=false` | Pins that the gate does NOT over-reach into the default-comparator path when there's nothing to gate. |
| `handleIncludeAll throws SetupException BEFORE Class.forName when allowIncludeAllClasses=false and resourceFilter is specified` | Parser-path test exercising the inline gate at line 641 via the standard `load()` entry point with a `ParsedNode`-based changelog. |

```
[INFO] Tests run: 200, Failures: 0, Errors: 0, Skipped: 0 -- in DatabaseChangeLogTest
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0 -- in GlobalConfigurationTest
[INFO] BUILD SUCCESS
```

Broader sanity sweep: **262 tests** across `DatabaseChangeLogTest` (200), `XMLChangeLogSAXParser_RealFile_Test` (30), and `GlobalConfigurationTest` (11) — **0 failures**, 1 platform-conditional skip.

## Things to be aware of

- **Default is unchanged.** Existing `<includeAll>` users see no behaviour change.
- **Both gates fire before any static initializer runs.** The defense-in-depth design specifically prevents the load-time side effect.
- **`determineResourceComparator` is `public`.** External callers passing a class name will now hit the gate; null-comparator callers are unaffected. This is intentional — any code path that passes a changelog-controlled FQCN to this method should respect the flag.
- **Cross-reference convention.** This PR adds the cross-reference only one-way (the new flag's description points at `liquibase.allowCustomChange`). The reverse cross-reference (updating `liquibase.allowCustomChange` to point at this new flag) is deferred to avoid stacking yet another description-text conflict on top of the #7748 → #7749 merge sequence already in flight. Happy to do that cleanup pass after both PRs land if useful.

## Related

Part of the May-2026 OSS credential-handling-and-changelog-injection audit slice (`sdou` label). Direct siblings:

- **#7747** (DAT-23015, B1 / `executeCommand` opt-out gate) — merged
- **#7748** (DAT-23016, B2 / `customChange` opt-out gate) — merged
- **#7749** (DAT-23017, B3 / `customPrecondition` opt-out gate) — open, approved by @filipelautert
- **#7750** (DAT-23090, CWE-22 deprecation flag) — merged
- **#7753** (DAT-23018, B4 / `sqlCheck` opt-out gate) — open

This PR closes B5. Remaining B-series children: B6 (sqlFile/include classpath URIs), B7 (SQLFile checksum), B8 (XML SAX secure-mode opt-out), B9 (DATABASECHANGELOG INSERT inlining), B10 (informational).