### PR TITLE
CWE-89: opt-in restricted mode for sqlCheck changelog precondition

### DIFF
--- a/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineTest.groovy
+++ b/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineTest.groovy
@@ -120,6 +120,35 @@ Global Options
                                variable:
                                'LIQUIBASE_ALLOW_PARENT_DIRECTORY_REFERENCES')
 
+      --allow-sql-precondition=PARAM
+                             If false, the sqlCheck changelog precondition is
+                               rejected at validation and check time without
+                               executing its SQL body. Defaults to true to
+                               preserve the documented sqlCheck feature for the
+                               standard trust model (team-authored,
+                               team-reviewed changelogs). Set to false in
+                               environments that execute changelogs from
+                               less-trusted sources (multi-tenant SaaS running
+                               customer changelogs, downloaded change-packs,
+                               contributor PRs prior to review): sqlCheck runs
+                               the literal SQL body from the changelog against
+                               the live JDBC connection during precondition
+                               evaluation, before the change body is reached.
+                               On drivers permitting multi-statement execution
+                               (e.g. MySQL/MariaDB with
+                               allowMultiQueries=true), additional DDL or DML
+                               can be batched into the sqlCheck body and run
+                               regardless of the expectedResult comparison; the
+                               SQL also executes through a less-reviewed code
+                               path that bypasses the change-execution audit
+                               trail, and an onFail=MARK_RAN precondition can
+                               hide the change body from being applied while
+                               the precondition SQL has already run (CWE-89).
+                             DEFAULT: true
+                             (defaults file: 'liquibase.allowSqlPrecondition',
+                               environment variable:
+                               'LIQUIBASE_ALLOW_SQL_PRECONDITION')
+
       --always-drop-instead-of-replace=PARAM
                              If true, drop and recreate a view instead of
                                replacing it.

--- a/liquibase-standard/src/main/java/liquibase/GlobalConfiguration.java
+++ b/liquibase-standard/src/main/java/liquibase/GlobalConfiguration.java
@@ -56,6 +56,7 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
     public static final ConfigurationDefinition<Boolean> ALLOW_CUSTOM_CHANGE;
     public static final ConfigurationDefinition<Boolean> ALLOW_EXECUTE_COMMAND;
     public static final ConfigurationDefinition<Boolean> ALLOW_PARENT_DIRECTORY_REFERENCES;
+    public static final ConfigurationDefinition<Boolean> ALLOW_SQL_PRECONDITION;
     public static final ConfigurationDefinition<String> SEARCH_PATH;
 
     public static final ConfigurationDefinition<UIServiceEnum> UI_SERVICE;
@@ -265,6 +266,24 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
                         "window; a future major release will flip the default to false, at which point " +
                         "callers depending on parent-directory traversal must either restructure their " +
                         "layout or explicitly opt in via this flag (CWE-22).")
+                .setDefaultValue(true)
+                .build();
+
+        ALLOW_SQL_PRECONDITION = builder.define("allowSqlPrecondition", Boolean.class)
+                .setDescription("If false, the sqlCheck changelog precondition is rejected at validation " +
+                        "and check time without executing its SQL body. Defaults to true to preserve the " +
+                        "documented sqlCheck feature for the standard trust model (team-authored, team-" +
+                        "reviewed changelogs). Set to false in environments that execute changelogs from " +
+                        "less-trusted sources (multi-tenant SaaS running customer changelogs, downloaded " +
+                        "change-packs, contributor PRs prior to review): sqlCheck runs the literal SQL body " +
+                        "from the changelog against the live JDBC connection during precondition " +
+                        "evaluation, before the change body is reached. On drivers permitting multi-" +
+                        "statement execution (e.g. MySQL/MariaDB with allowMultiQueries=true), additional " +
+                        "DDL or DML can be batched into the sqlCheck body and run regardless of the " +
+                        "expectedResult comparison; the SQL also executes through a less-reviewed code " +
+                        "path that bypasses the change-execution audit trail, and an onFail=MARK_RAN " +
+                        "precondition can hide the change body from being applied while the precondition " +
+                        "SQL has already run (CWE-89).")
                 .setDefaultValue(true)
                 .build();
 

--- a/liquibase-standard/src/main/java/liquibase/precondition/core/SqlPrecondition.java
+++ b/liquibase-standard/src/main/java/liquibase/precondition/core/SqlPrecondition.java
@@ -1,5 +1,6 @@
 package liquibase.precondition.core;
 
+import liquibase.GlobalConfiguration;
 import liquibase.Scope;
 import liquibase.changelog.ChangeSet;
 import liquibase.changelog.DatabaseChangeLog;
@@ -39,12 +40,34 @@ public class SqlPrecondition extends AbstractPrecondition {
 
     @Override
     public ValidationErrors validate(Database database) {
-        return new ValidationErrors();
+        ValidationErrors errors = new ValidationErrors();
+        if (!Boolean.TRUE.equals(GlobalConfiguration.ALLOW_SQL_PRECONDITION.getCurrentValue())) {
+            errors.addError("sqlCheck preconditions are disabled because " +
+                    "liquibase.allowSqlPrecondition=false. Either remove the sqlCheck " +
+                    "precondition from the changelog, or set " +
+                    "liquibase.allowSqlPrecondition=true to enable it.");
+        }
+        return errors;
     }
 
     @Override
     public void check(Database database, DatabaseChangeLog changeLog, ChangeSet changeSet, ChangeExecListener changeExecListener)
             throws PreconditionFailedException, PreconditionErrorException {
+        // Defense-in-depth gate, ahead of the JDBC executor lookup and queryForObject below.
+        // Throws PreconditionErrorException (NOT PreconditionFailedException) deliberately:
+        // PreconditionErrorException bypasses onFail handling (MARK_RAN / CONTINUE / WARN),
+        // so a crafted onFail=MARK_RAN sqlCheck cannot silently swallow the embedder's
+        // configured-off intent — the SQL body must never reach the executor when the flag
+        // is false, regardless of the precondition author's onFail choice (CWE-89).
+        if (!Boolean.TRUE.equals(GlobalConfiguration.ALLOW_SQL_PRECONDITION.getCurrentValue())) {
+            throw new PreconditionErrorException(
+                    new RuntimeException("sqlCheck preconditions are disabled because " +
+                            "liquibase.allowSqlPrecondition=false. The SQL body in this " +
+                            "sqlCheck was NOT executed. Set liquibase.allowSqlPrecondition=true " +
+                            "to enable sqlCheck, or remove the sqlCheck precondition from the " +
+                            "changelog."),
+                    changeLog, this);
+        }
         try {
             Object oResult = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database).queryForObject(new RawParameterizedSqlStatement(getSql().replaceFirst(";$","")), String.class);
             if (oResult == null) {

--- a/liquibase-standard/src/test/groovy/liquibase/precondition/core/SqlPreconditionTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/precondition/core/SqlPreconditionTest.groovy
@@ -1,5 +1,8 @@
 package liquibase.precondition.core
 
+import liquibase.Scope
+import liquibase.database.Database
+import liquibase.exception.PreconditionErrorException
 import liquibase.parser.core.ParsedNodeException
 import liquibase.sdk.supplier.resource.ResourceSupplier
 import spock.lang.Shared
@@ -20,5 +23,114 @@ class SqlPreconditionTest extends Specification {
         then:
         precondition.expectedResult == "5"
         precondition.sql == "select count(*) from test"
+    }
+
+    def "validate returns no errors by default — sqlCheck is intentional under the standard trust model (CWE-89 opt-out gate)"() {
+        given:
+        def precondition = new SqlPrecondition()
+        precondition.sql = "select 1"
+        precondition.expectedResult = "1"
+
+        when:
+        // Wrap default-true explicitly so a stale system property or test-ordering quirk
+        // can't turn this default-pass into a spurious failure.
+        def errors
+        Scope.child(["liquibase.allowSqlPrecondition": "true"] as Map, {
+            errors = precondition.validate(null)
+        } as Scope.ScopedRunner)
+
+        then:
+        errors != null
+        !errors.hasErrors()
+    }
+
+    def "validate fails with the configured-off hard error when allowSqlPrecondition=false — embedder opt-out path"() {
+        given:
+        def precondition = new SqlPrecondition()
+        precondition.sql = "select 1"
+        precondition.expectedResult = "1"
+
+        when:
+        def errors
+        Scope.child(["liquibase.allowSqlPrecondition": "false"] as Map, {
+            errors = precondition.validate(null)
+        } as Scope.ScopedRunner)
+
+        then:
+        errors != null
+        errors.hasErrors()
+        // Message must name the flag in both directions and identify the element so
+        // operators know which precondition is rejected and how to flip the gate.
+        def joined = errors.getErrorMessages().join(" | ")
+        joined.contains("sqlCheck")
+        joined.contains("liquibase.allowSqlPrecondition=false")
+        joined.contains("liquibase.allowSqlPrecondition=true")
+    }
+
+    def "check throws PreconditionErrorException BEFORE any SQL execution when allowSqlPrecondition=false"() {
+        // The strongest assertion in this PR: the gate must fire before the SQL body
+        // reaches the JDBC executor, regardless of onFail handling on the precondition.
+        // We mock Database; if the gate did NOT fire, the executor lookup would proceed
+        // and the configured-off message would NOT appear. The message-shape match is
+        // the proof-of-short-circuit.
+        given:
+        def precondition = new SqlPrecondition()
+        precondition.sql = "INSERT INTO admins VALUES ('attacker', 'hash'); SELECT 1"
+        precondition.expectedResult = "1"
+        def database = Mock(Database)
+        PreconditionErrorException caught = null
+
+        when:
+        Scope.child(["liquibase.allowSqlPrecondition": "false"] as Map, {
+            try {
+                precondition.check(database, null, null, null)
+            } catch (PreconditionErrorException e) {
+                caught = e
+            }
+        } as Scope.ScopedRunner)
+
+        then:
+        caught != null
+        // PreconditionErrorException.getMessage() returns the fixed string "Precondition Error";
+        // the configured-off message lives in the wrapped cause. Same convention as the
+        // pre-existing DatabaseException catch path in check() — kept for consistency. If
+        // the gate had NOT fired and the SQL had reached the executor, the cause would be
+        // a DatabaseException with a JDBC/driver error message — not the configured-off
+        // text below. The string-shape match is the proof-of-short-circuit.
+        caught.getCause() != null
+        def causeMessage = caught.getCause().getMessage()
+        causeMessage.contains("liquibase.allowSqlPrecondition=false")
+        causeMessage.contains("NOT executed")
+        causeMessage.contains("sqlCheck")
+    }
+
+    def "check throws PreconditionErrorException — not PreconditionFailedException — so onFail=MARK_RAN cannot swallow configured-off intent"() {
+        // Pins the audit ticket's specific concern: PreconditionErrorException bypasses
+        // onFail handling whereas PreconditionFailedException respects it. A crafted
+        // onFail=MARK_RAN sqlCheck would otherwise allow the precondition SQL to run
+        // (or be reported as having run) without the embedder's intent being honored.
+        given:
+        def precondition = new SqlPrecondition()
+        precondition.sql = "select 1"
+        precondition.expectedResult = "1"
+        def database = Mock(Database)
+        Throwable thrown = null
+
+        when:
+        Scope.child(["liquibase.allowSqlPrecondition": "false"] as Map, {
+            try {
+                precondition.check(database, null, null, null)
+            } catch (Throwable t) {
+                thrown = t
+            }
+        } as Scope.ScopedRunner)
+
+        then:
+        thrown != null
+        thrown.getClass().getName() == "liquibase.exception.PreconditionErrorException"
+        // Not PreconditionFailedException — Error vs Failed is the load-bearing distinction
+        // for onFail handling. Pin it with a strict class-name check (not instanceof, which
+        // would pass for either if one extends the other).
+        thrown.getClass().getSimpleName() != "PreconditionFailedException"
     }
 }


### PR DESCRIPTION
## Impact

`SqlPrecondition.check()` ([`liquibase-standard/src/main/java/liquibase/precondition/core/SqlPrecondition.java:49`](https://github.com/liquibase/liquibase/blob/main/liquibase-standard/src/main/java/liquibase/precondition/core/SqlPrecondition.java#L49)) executes the literal SQL body from the changelog against the live JDBC connection via `RawParameterizedSqlStatement`. The body is `${...}`-expanded by the global `ChangeLogParameters.expandExpressions` pass before execution. The only "gate" is the `expectedResult` attribute — which the changelog author also controls.

This maps to **CWE-89** (SQL Injection — multi-statement batch is the canonical case). Defense-in-depth finding: the same author who can write a `<sqlCheck>` can also write a `<sql>` change, so this isn't a privilege-escalation novelty — but the precondition evaluation path is a less-reviewed code path that bypasses the change execution audit trail, and it carries two specific attack vectors:

### Attack vector 1: MARK_RAN bypass

A precondition with `onFail="MARK_RAN"` records the changeset as applied *without applying the change body*. With a crafted `<sqlCheck>` whose `expectedResult` always "fails":

```xml
<preConditions onFail="MARK_RAN">
  <sqlCheck expectedResult="impossible_value">
    INSERT INTO admins VALUES ('attacker', 'hash'); SELECT 1
  </sqlCheck>
</preConditions>
<changeSet id="innocent-looking-noop" author="x">
  <comment>cosmetic update, nothing to see here</comment>
</changeSet>
```

The precondition SQL **executes** (precondition evaluation runs SQL *before* the `expectedResult` comparison). The precondition then "fails" (`SELECT 1` ≠ `"impossible_value"`). `onFail="MARK_RAN"` records the changeset as applied. The attacker's `INSERT INTO admins` has run; the changeset body shows nothing suspicious; the changelog and DATABASECHANGELOG both look innocuous.

This is the **same Error-vs-Failed attack vector @filipelautert flagged as the right design call on #7749** for `<customPrecondition>` — same shape, applied to a different precondition primitive.

### Attack vector 2: Multi-statement injection

On JDBC drivers that permit batched-statement execution (MySQL/MariaDB with `allowMultiQueries=true`, some PostgreSQL drivers in legacy modes), additional DDL or DML statements can be packed into the `sqlCheck` body. They execute as part of the precondition SELECT and are **not gated by the `expectedResult` comparison at all** — the comparison runs against the result of the *batch*, after the entire batch has already executed.

## Scope decision (sibling to #7747, #7748, #7749)

Same opt-in restricted-mode pattern as DAT-23015 / #7747 (B1, `executeCommand`), DAT-23016 / #7748 (B2, `customChange`), and DAT-23017 / #7749 (B3, `customPrecondition`):

- Add a Boolean flag, default `true` (preserves the documented `<sqlCheck>` feature for the standard trust model — team-authored, team-reviewed changelogs).
- Opt-out for embedders running changelogs from less-trusted sources (multi-tenant SaaS running customer changelogs, downloaded change-packs, contributor PRs prior to review).

**No default behaviour change.** Every existing `<sqlCheck>` continues to work byte-for-byte identically at the default flag value.

## Fix — three pieces

**1. New `GlobalConfiguration.ALLOW_SQL_PRECONDITION` flag** — `liquibase.allowSqlPrecondition`, Boolean, defaults to `true`. Description spells out both attack vectors (MARK_RAN + multi-statement) so a future maintainer sees *why* the gate exists.

**2. Dual gate inside `SqlPrecondition`:**

   **(a) Hard error in `validate(Database)`** — the pre-fix `validate()` was a trivial no-op (returned empty `ValidationErrors`); the gate replaces that body with a configured-off check. Operator sees a clean pre-execution failure during the standard validation pass, with a message naming the flag in both directions.

   **(b) Defense-in-depth gate at the top of `check(...)`** — fires **BEFORE** the `ExecutorService.getExecutor("jdbc", database)` lookup and `queryForObject` call. Throws **`PreconditionErrorException` (NOT `PreconditionFailedException`)** deliberately:

> `PreconditionErrorException` bypasses `onFail` handling (`MARK_RAN` / `CONTINUE` / `WARN`); `PreconditionFailedException` respects it. A crafted `onFail="MARK_RAN"` `<sqlCheck>` would otherwise allow the embedder's configured-off intent to be silently swallowed — Error vs Failed is the load-bearing distinction.

This is the same Error-vs-Failed design call as #7749 — same threat model, same primitive choice.

**3. Four new Spock specs** in `SqlPreconditionTest` (1 pre-existing → 5 total):

| Spec | What it pins |
|---|---|
| `validate returns no errors by default — sqlCheck is intentional under the standard trust model (CWE-89 opt-out gate)` | Default-true path: zero behaviour change for existing users. Explicit `Scope.child("...=true")` so a stale system property or test-ordering quirk can't turn this into a spurious failure. |
| `validate fails with the configured-off hard error when allowSqlPrecondition=false — embedder opt-out path` | Hard error; message names the flag in both `=false`/`=true` directions AND names `"sqlCheck"` specifically so operators know which element triggered the message. |
| `check throws PreconditionErrorException BEFORE any SQL execution when allowSqlPrecondition=false` | Uses a deliberately malicious-looking SQL body (`INSERT INTO admins VALUES (...); SELECT 1`) to demonstrate the multi-statement attack vector being blocked. Database is `Mock`; the assertion is on the cause-message shape — if the gate had NOT fired, the cause would be a `DatabaseException` with a JDBC/driver error, not our configured-off text. String-shape match (flag-name + `"NOT executed"` + `"sqlCheck"`) is the proof-of-short-circuit. |
| `check throws PreconditionErrorException — not PreconditionFailedException — so onFail=MARK_RAN cannot swallow configured-off intent` | Pins the audit ticket's specific attack vector with a strict class-name check (not `instanceof`, which would pass for either if one extended the other). |

```
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0 -- in SqlPreconditionTest
[INFO] Tests run: 16, Failures: 0, Errors: 0, Skipped: 0 (incl. GlobalConfigurationTest)
[INFO] BUILD SUCCESS
```

Broader sanity sweep: 338 tests across `DatabaseChangeLogTest` (195), `FormattedSqlChangeLogParserTest` (76), `XMLChangeLogSAXParser_RealFile_Test` (30), `YamlChangeLogParser_RealFile_Test`, and the targeted specs — **0 failures, 1 skipped** (the platform-conditional spec already present in the suite).

## Things to be aware of

- **Default is unchanged.** Existing `<sqlCheck>` users see no behaviour change. Flag must be explicitly set to `false` (via `liquibase.properties`, env-var, system property, or any standard `ConfigurationDefinition` source) to flip the gate.
- **`PreconditionErrorException` cause-message convention.** The outer `PreconditionErrorException.getMessage()` returns the fixed string `"Precondition Error"`; the configured-off text lives in `getCause().getMessage()`. This matches the convention used by the pre-existing `DatabaseException` catch path in `check()` — kept for consistency. The third test pins this explicitly so future refactors that change the wrapping shape would flag the spec.
- **Both gates fire before any SQL reaches the executor.** The defense-in-depth design specifically prevents the multi-statement batch attack — the SQL body is not seen by the JDBC layer at all when the flag is `false`.

## Related

Part of the May-2026 OSS credential-handling-and-changelog-injection audit slice (`sdou` label). Direct siblings:

- **#7747** (DAT-23015, B1 / `executeCommand` opt-out gate) — same opt-in restricted-mode shape applied to the OS-shell RCE primitive (merged).
- **#7748** (DAT-23016, B2 / `customChange` opt-out gate) — same shape applied to `<customChange>` (merged).
- **#7749** (DAT-23017, B3 / `customPrecondition` opt-out gate) — same shape applied to `<customPrecondition>`; same `PreconditionErrorException`-vs-`Failed` design call as this PR (open, approved by @filipelautert).
- **#7750** (DAT-23090, CWE-22 deprecation flag) — separate audit-regression fix (merged).