### PR TITLE
CWE-470: opt-in restricted mode for customPrecondition changelog element

### DIFF
--- a/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineTest.groovy
+++ b/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineTest.groovy
@@ -22,17 +22,18 @@ Command-specific help: "liquibase <command-name> --help"
 
 Global Options
       --allow-custom-change=PARAM
-                             If false, the customChange changelog change is
-                               rejected before its named class is loaded.
-                               Defaults to true to preserve the documented
-                               customChange feature for the standard trust
-                               model (team-authored, team-reviewed changelogs).
-                               Set to false in environments that execute
-                               changelogs from less-trusted sources
-                               (multi-tenant SaaS running customer changelogs,
-                               downloaded change-packs, contributor PRs prior
-                               to review): customChange loads an arbitrary JVM
-                               class by FQCN via Class.forName
+                             If false, the customChange and customPrecondition
+                               changelog elements are rejected before the named
+                               class is loaded. Defaults to true to preserve
+                               the documented custom-Java features for the
+                               standard trust model (team-authored,
+                               team-reviewed changelogs). Set to false in
+                               environments that execute changelogs from
+                               less-trusted sources (multi-tenant SaaS running
+                               customer changelogs, downloaded change-packs,
+                               contributor PRs prior to review): both
+                               customChange and customPrecondition load an
+                               arbitrary JVM class by FQCN via Class.forName
                                (initialize=true), which fires the class's
                                static <clinit> initializer at load time —
                                before any cast or marker-interface check could

--- a/liquibase-standard/src/main/java/liquibase/GlobalConfiguration.java
+++ b/liquibase-standard/src/main/java/liquibase/GlobalConfiguration.java
@@ -53,6 +53,7 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
     public static final ConfigurationDefinition<Boolean> STRICT;
     public static final ConfigurationDefinition<Integer> DDL_LOCK_TIMEOUT;
     public static final ConfigurationDefinition<Boolean> SECURE_PARSING;
+    public static final ConfigurationDefinition<Boolean> ALLOW_CUSTOM_CHANGE;
     public static final ConfigurationDefinition<String> SEARCH_PATH;
 
     public static final ConfigurationDefinition<UIServiceEnum> UI_SERVICE;
@@ -221,6 +222,20 @@ public class GlobalConfiguration implements AutoloadedConfigurations {
 
         SECURE_PARSING = builder.define("secureParsing", Boolean.class)
                 .setDescription("If true, remove functionality from file parsers which could be used insecurely. Examples include (but not limited to) disabling remote XML entity support.")
+                .setDefaultValue(true)
+                .build();
+
+        ALLOW_CUSTOM_CHANGE = builder.define("allowCustomChange", Boolean.class)
+                .setDescription("If false, the customChange and customPrecondition changelog elements are " +
+                        "rejected before the named class is loaded. Defaults to true to preserve the " +
+                        "documented custom-Java features for the standard trust model (team-authored, " +
+                        "team-reviewed changelogs). Set to false in environments that execute changelogs " +
+                        "from less-trusted sources (multi-tenant SaaS running customer changelogs, " +
+                        "downloaded change-packs, contributor PRs prior to review): both customChange " +
+                        "and customPrecondition load an arbitrary JVM class by FQCN via " +
+                        "Class.forName(initialize=true), which fires the class's static <clinit> " +
+                        "initializer at load time — before any cast or marker-interface check could " +
+                        "reject the load. Any class on the JVM classpath is reachable this way (CWE-470).")
                 .setDefaultValue(true)
                 .build();
 

--- a/liquibase-standard/src/main/java/liquibase/precondition/CustomPreconditionWrapper.java
+++ b/liquibase-standard/src/main/java/liquibase/precondition/CustomPreconditionWrapper.java
@@ -1,5 +1,6 @@
 package liquibase.precondition;
 
+import liquibase.GlobalConfiguration;
 import liquibase.Scope;
 import liquibase.changelog.ChangeSet;
 import liquibase.changelog.visitor.ChangeExecListener;
@@ -54,12 +55,47 @@ public class CustomPreconditionWrapper extends AbstractPrecondition {
 
     @Override
     public ValidationErrors validate(Database database) {
+        // CWE-470 hard gate, paired with the defense-in-depth gate inside check().
+        // Hard error so the operator sees a clean pre-execution failure when the
+        // embedder has disabled custom-Java elements via
+        // liquibase.allowCustomChange=false. Naming-note: the flag is shared with
+        // customChange (see GlobalConfiguration.ALLOW_CUSTOM_CHANGE) because both
+        // elements expose identical Class.forName(initialize=true) load surfaces.
+        if (Boolean.FALSE.equals(GlobalConfiguration.ALLOW_CUSTOM_CHANGE.getCurrentValue())) {
+            return new ValidationErrors().addError(
+                    "customPrecondition is disabled by configuration " +
+                            "(liquibase.allowCustomChange=false). To run customPrecondition (and " +
+                            "customChange) elements, set liquibase.allowCustomChange=true (the default). " +
+                            "This flag is provided for environments that execute changelogs from " +
+                            "less-trusted sources, where loading an arbitrary JVM class by name via " +
+                            "changelog is not an acceptable risk.");
+        }
         return new ValidationErrors();
     }
 
     @Override
     public void check(Database database, DatabaseChangeLog changeLog, ChangeSet changeSet, ChangeExecListener changeExecListener)
             throws PreconditionFailedException, PreconditionErrorException {
+        // CWE-470 defense-in-depth gate: fire BEFORE any of the two Class.forName
+        // call sites below. The audit notes that preconditions are evaluated
+        // before changes execute, providing a separate class-load trigger point
+        // that fires even if the change body is never reached — e.g. an
+        // onFail=MARK_RAN precondition that "always passes" but whose load-time
+        // static <clinit> already ran. Throwing PreconditionErrorException
+        // (not PreconditionFailedException) bypasses onFail handling — we do NOT
+        // want MARK_RAN to silently swallow the embedder's configured-off intent.
+        if (Boolean.FALSE.equals(GlobalConfiguration.ALLOW_CUSTOM_CHANGE.getCurrentValue())) {
+            throw new PreconditionErrorException(new ErrorPrecondition(
+                    new CustomPreconditionErrorException(
+                            "customPrecondition is disabled by configuration " +
+                                    "(liquibase.allowCustomChange=false). To run customPrecondition (and " +
+                                    "customChange) elements, set liquibase.allowCustomChange=true (the " +
+                                    "default). This flag is provided for environments that execute " +
+                                    "changelogs from less-trusted sources, where loading an arbitrary " +
+                                    "JVM class by name via changelog is not an acceptable risk."),
+                    changeLog, this));
+        }
+
         CustomPrecondition customPrecondition;
         try {
 //            System.out.println(classLoader.toString());

--- a/liquibase-standard/src/test/groovy/liquibase/precondition/CustomPreconditionWrapperTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/precondition/CustomPreconditionWrapperTest.groovy
@@ -67,12 +67,18 @@ class CustomPreconditionWrapperTest extends Specification {
     def "validate returns no errors by default — customPrecondition is intentional under the standard trust model (CWE-470 opt-out gate)"() {
         // CWE-470 regression: the default is liquibase.allowCustomChange=true so
         // existing users see no behaviour change.
+        //
+        // Explicitly scope the flag to "true" instead of reading the ambient default
+        // (per @coderabbitai's hermetic-test nit on #7749): another test, the runner,
+        // or a stale system property could leave the flag at "false" and turn the
+        // intended default-true path into a spurious failure.
         given:
         def precondition = new CustomPreconditionWrapper()
         precondition.setClassName("liquibase.precondition.ExampleCustomPrecondition")
 
         when:
-        def errors = precondition.validate(new MockDatabase())
+        def errors = Scope.child([(GlobalConfiguration.ALLOW_CUSTOM_CHANGE.getKey()): "true"],
+                { return precondition.validate(new MockDatabase()) } as Scope.ScopedRunnerWithReturn)
 
         then:
         !errors.hasErrors()
@@ -135,12 +141,18 @@ class CustomPreconditionWrapperTest extends Specification {
         // fixture used in the load-correctness specs above; it's known to load
         // cleanly and its check() body doesn't have side effects against
         // MockDatabase.
+        //
+        // Explicitly scope the flag to "true" (per @coderabbitai's hermetic-test
+        // nit on #7749) — see the same note on the "validate returns no errors
+        // by default" spec above.
         given:
         def precondition = new CustomPreconditionWrapper()
         precondition.setClassName("liquibase.precondition.ExampleCustomPrecondition")
 
-        when: "the flag is at its default (true)"
-        precondition.check(new MockDatabase(), null, null, null)
+        when: "the flag is enabled"
+        Scope.child([(GlobalConfiguration.ALLOW_CUSTOM_CHANGE.getKey()): "true"], {
+            precondition.check(new MockDatabase(), null, null, null)
+        } as Scope.ScopedRunner)
 
         then: "no exception thrown by the gate; ExampleCustomPrecondition.check ran normally"
         noExceptionThrown()

--- a/liquibase-standard/src/test/groovy/liquibase/precondition/CustomPreconditionWrapperTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/precondition/CustomPreconditionWrapperTest.groovy
@@ -1,5 +1,9 @@
 package liquibase.precondition
 
+import liquibase.GlobalConfiguration
+import liquibase.Scope
+import liquibase.database.core.MockDatabase
+import liquibase.exception.PreconditionErrorException
 import liquibase.parser.core.ParsedNode
 import liquibase.parser.core.ParsedNodeException
 import liquibase.sdk.supplier.resource.ResourceSupplier
@@ -60,4 +64,85 @@ class CustomPreconditionWrapperTest extends Specification {
         precondition.getParamValue("param 3") == "param 3 value"
     }
 
+    def "validate returns no errors by default — customPrecondition is intentional under the standard trust model (CWE-470 opt-out gate)"() {
+        // CWE-470 regression: the default is liquibase.allowCustomChange=true so
+        // existing users see no behaviour change.
+        given:
+        def precondition = new CustomPreconditionWrapper()
+        precondition.setClassName("liquibase.precondition.ExampleCustomPrecondition")
+
+        when:
+        def errors = precondition.validate(new MockDatabase())
+
+        then:
+        !errors.hasErrors()
+    }
+
+    def "validate fails when liquibase.allowCustomChange=false — embedder opt-out path"() {
+        // CWE-470 regression: when the embedder disables custom-Java elements via
+        // liquibase.allowCustomChange=false, validate() returns a hard error that
+        // names the flag in both =false and =true directions. The flag is shared
+        // with customChange (per the audit's "same flag" guidance).
+        given:
+        def precondition = new CustomPreconditionWrapper()
+        precondition.setClassName("liquibase.precondition.ExampleCustomPrecondition")
+
+        when:
+        def errors = Scope.child([(GlobalConfiguration.ALLOW_CUSTOM_CHANGE.getKey()): "false"],
+                { return precondition.validate(new MockDatabase()) } as Scope.ScopedRunnerWithReturn)
+
+        then:
+        errors.hasErrors()
+        errors.getErrorMessages().any { it.contains("liquibase.allowCustomChange=false") }
+        errors.getErrorMessages().any { it.contains("liquibase.allowCustomChange=true") }
+        // Spells out customPrecondition specifically, so the error message points at
+        // the offending element rather than reading like a generic 'custom' message.
+        errors.getErrorMessages().any { it.contains("customPrecondition") }
+    }
+
+    def "check throws PreconditionErrorException BEFORE Class.forName when allowCustomChange=false"() {
+        // CWE-470 defense-in-depth regression: check() is the per-evaluation entry
+        // point where Class.forName(initialize=true) actually fires. Even if a
+        // caller bypasses validate(), check() must reject the load BEFORE the
+        // class is loaded — proving this by using a class name that does NOT
+        // exist on the classpath. The PRE-fix code would attempt the load and
+        // wrap ClassNotFoundException into PreconditionFailedException; AFTER the
+        // fix, the gate short-circuits with PreconditionErrorException (NOT
+        // PreconditionFailedException — Error bypasses onFail handling so a
+        // crafted onFail=MARK_RAN cannot silently swallow the configured-off
+        // intent, which is the specific attack vector flagged in the audit).
+        given:
+        def precondition = new CustomPreconditionWrapper()
+        precondition.setClassName("com.example.definitely.not.a.real.CustomPrecondition")
+
+        when:
+        Scope.child([(GlobalConfiguration.ALLOW_CUSTOM_CHANGE.getKey()): "false"], {
+            precondition.check(new MockDatabase(), null, null, null)
+        } as Scope.ScopedRunner)
+
+        then:
+        PreconditionErrorException e = thrown()
+        // The thrown error mentions the configured-off cause, NOT a
+        // ClassNotFoundException — which proves the gate ran first.
+        e.errorPreconditions != null
+        !e.errorPreconditions.isEmpty()
+        e.errorPreconditions[0].toString().contains("liquibase.allowCustomChange=false")
+    }
+
+    def "check default-true path still executes the existing load logic (sanity)"() {
+        // Sanity that the new gate's short-circuit does not block the normal
+        // default-true behaviour. ExampleCustomPrecondition is the existing test
+        // fixture used in the load-correctness specs above; it's known to load
+        // cleanly and its check() body doesn't have side effects against
+        // MockDatabase.
+        given:
+        def precondition = new CustomPreconditionWrapper()
+        precondition.setClassName("liquibase.precondition.ExampleCustomPrecondition")
+
+        when: "the flag is at its default (true)"
+        precondition.check(new MockDatabase(), null, null, null)
+
+        then: "no exception thrown by the gate; ExampleCustomPrecondition.check ran normally"
+        noExceptionThrown()
+    }
 }


### PR DESCRIPTION
## Impact

`CustomPreconditionWrapper.check(...)` (`CustomPreconditionWrapper.java:67-69`) loads an arbitrary JVM class by FQCN via the same `Class.forName(className, true, ...)` pattern as `customChange`:

```java
customPrecondition = (CustomPrecondition) Class.forName(className, true,
        Scope.getCurrentScope().getClassLoader()).getConstructor().newInstance();
//                                              ^ static <clinit> fires here, before the cast
```

Same Unsafe-Reflection attack surface as B2 (DAT-23016 / PR #7748) — **CWE-470**.

**An additional attack vector unique to this PR**, called out explicitly in the audit ticket: preconditions are evaluated **before** the change body executes. An attacker can craft a precondition with `onFail=MARK_RAN` that *"always passes"* and the change body is never reached — but the load-time `<clinit>` already ran. So the fix must reject the load **before** `Class.forName`, **not** rely on the precondition's pass/fail logic.

## Cross-PR coordination (please read)

This PR is the **third sibling** in a B1/B2/B3 pattern:

| PR | Element | Flag |
|---|---|---|
| #7747 | `<executeCommand>` | `liquibase.allowExecuteCommand` |
| #7748 | `<customChange>` | `liquibase.allowCustomChange` |
| **THIS** | **`<customPrecondition>`** | **`liquibase.allowCustomChange` (same as #7748)** |

The audit ticket's exact words: *"Covered by the same `liquibase.execution.allowCustomClassLoad=false` opt-in flag proposed for B2."* Both `customChange` and `customPrecondition` are "load arbitrary FQCN" surfaces with identical risk — one flag covers both.

### Expected merge conflict with #7748

Both this PR and #7748 declare `GlobalConfiguration.ALLOW_CUSTOM_CHANGE`. The declarations are byte-identical for the constant; the **description text** differs:

- **#7748's description** mentions only `customChange`.
- **THIS PR's description** mentions both `customChange` AND `customPrecondition` (the larger surface that's accurate after both PRs are in `main`).

**Recommended merge resolution:** when merging the second of the two PRs, keep this PR's broader description text and discard #7748's narrower one. The constant declaration itself dedupes mechanically (1-line edit). I considered stacking this PR on #7748's branch to avoid the conflict but chose independent PRs to keep each one reviewable in any merge order — the conflict is mechanical and 1-line.

## Fix — three pieces

**1. `GlobalConfiguration.ALLOW_CUSTOM_CHANGE`** — Boolean, defaults to `true`. Description covers both `customChange` and `customPrecondition` surfaces and ties them to CWE-470.

**2. Dual gate inside `CustomPreconditionWrapper`:**

   **(a) Hard error in `validate(Database)`.** The pre-fix `validate()` was a trivial no-op (`return new ValidationErrors();`). This PR replaces that body with a configured-off check, so the operator sees a pre-execution failure during the standard validation pass.

   **(b) Defense-in-depth gate at the top of `check(...)`** — fires BEFORE either of the two `Class.forName` call sites at lines 67/69. Throws `PreconditionErrorException`, **not** `PreconditionFailedException`. The choice is deliberate: `Error` bypasses `onFail` handling, so a crafted `onFail=MARK_RAN` precondition cannot silently swallow the embedder's configured-off intent — which is the specific attack vector the audit calls out.

**3. Four new Spock specs in `CustomPreconditionWrapperTest`** (2 pre-existing → 6 total):

| Spec | What it pins |
|---|---|
| `validate returns no errors by default` | Default-true path preserves existing behaviour |
| `validate fails when liquibase.allowCustomChange=false — embedder opt-out path` | Hard error, names the flag in both directions AND names `customPrecondition` specifically so the message points at the offending element |
| `check throws PreconditionErrorException BEFORE Class.forName when allowCustomChange=false` | Sets a non-existent class name to prove the gate ran first (no wrapped `ClassNotFoundException` appears). Asserts `PreconditionErrorException` not `Failed` — pins the audit's `onFail=MARK_RAN`-bypass requirement |
| `check default-true path still executes the existing load logic (sanity)` | Default-true short-circuit doesn't skip downstream behaviour |

```
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0 -- in CustomPreconditionWrapperTest
[INFO] BUILD SUCCESS
```

## Things to be aware of

- **Default is unchanged.** Existing `customPrecondition` users see byte-for-byte identical behaviour.
- **Both gates fire before any static initializer.** The defense-in-depth design specifically prevents the load-time side effect — not just the cast or constructor invocation.
- **PreconditionErrorException (not Failed) is the intentional choice** at the `check()` gate. A `PreconditionFailedException` would respect `onFail` handling, allowing `onFail=MARK_RAN` to silently swallow the embedder's configured-off intent — exactly the attack vector the audit calls out. The unit test pins this.
- **Chain 3 status:** with this PR (B3) landing alongside #7747 (B1) and #7748 (B2), **all three RCE primitives flagged in DAT-23027 (the env-var command-injection chain) now have embedder opt-out gates.** B10 (env-var substitution behaviour on changeset properties) is a separate child ticket; closing the chain fully requires B10 to land too.

## Related

Part of the May-2026 OSS credential-handling-and-changelog-injection audit slice (`sdou` label).

- **Direct sibling**: #7748 (DAT-23016, B2 / `customChange` opt-out gate) — same flag, parallel implementation. The two are designed to land together.
- **Cousin**: #7747 (DAT-23015, B1 / `executeCommand` opt-out gate) — same opt-in restricted-mode shape, different flag and different change tag.
- Other audit slice PRs: #7739, #7740, #7741, #7742, #7743, #7744, #7746. Merged: #7737, #7738.