### PR TITLE
ci: add release-notes aggregator caller workflow [TECHOPS-498]

### DIFF
--- a/.github/workflows/release-notes-aggregate.yml
+++ b/.github/workflows/release-notes-aggregate.yml
@@ -1,0 +1,86 @@
+name: "Release notes: aggregate from Jira"
+
+# Thin caller for the reusable workflow in liquibase/build-logic.
+# Aggregates `## Release note` H2 blocks from every Done Jira ticket
+# in a Community Fix Version, renders a markdown report, and either
+# previews it in the run summary (dry run) or appends it to the
+# GitHub Release body (publish).
+#
+# Two triggers:
+#   release: [published]     Auto-fires when a Community release is
+#                            published. Derives Jira Fix Version from
+#                            the release tag (strip leading 'v',
+#                            prepend 'Community '). dry_run is false,
+#                            release body gets the notes appended.
+#   workflow_dispatch        Manual. User enters the Fix Version name
+#                            directly. dry_run defaults to true,
+#                            preview-only.
+#
+# Per TECHOPS-498. Logic lives in liquibase/build-logic.
+#
+# Security: every workflow input and event payload field is consumed
+# via env vars in run: blocks. Never interpolated directly into shell.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Jira Fix Version name (e.g. 'Community 5.0.4')"
+        required: true
+        type: string
+      dry_run:
+        description: "Preview only — do not post to the GitHub Release body"
+        required: false
+        type: boolean
+        default: true
+      release_tag:
+        description: "GitHub Release tag to update when dry_run=false (e.g. 'v5.0.4')"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  derive:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.compute.outputs.version }}
+      dry_run: ${{ steps.compute.outputs.dry_run }}
+      release_tag: ${{ steps.compute.outputs.release_tag }}
+    steps:
+      - id: compute
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MANUAL_VERSION: ${{ inputs.version }}
+          MANUAL_DRY_RUN: ${{ inputs.dry_run }}
+          MANUAL_RELEASE_TAG: ${{ inputs.release_tag }}
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [[ "$EVENT_NAME" == "release" ]]; then
+            stripped="${EVENT_TAG#v}"
+            {
+              echo "version=Community ${stripped}"
+              echo "dry_run=false"
+              echo "release_tag=${EVENT_TAG}"
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo "version=${MANUAL_VERSION}"
+              echo "dry_run=${MANUAL_DRY_RUN}"
+              echo "release_tag=${MANUAL_RELEASE_TAG}"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+  aggregate:
+    needs: derive
+    uses: liquibase/build-logic/.github/workflows/release-notes-aggregate.yml@main
+    with:
+      version: ${{ needs.derive.outputs.version }}
+      dry_run: ${{ needs.derive.outputs.dry_run == 'true' }}
+      release_tag: ${{ needs.derive.outputs.release_tag }}
+    secrets: inherit


### PR DESCRIPTION
## The problem

Every Community release forces a manual H2-extraction pass across dozens of Jira tickets to assemble the release notes. Tickets without the heading or an opt-out label get silently dropped — no visibility for the release manager, no fix path for the engineer.

## What we did

Adds a thin (~85-line) caller for the new reusable workflow in [`liquibase/build-logic#602`](https://github.com/liquibase/build-logic/pull/602). Two triggers:

- **`release: [published]` auto-fire** — when a Community release is published, the workflow derives the Jira Fix Version from the release tag (`v5.0.4` → `Community 5.0.4`) and appends the aggregated notes to the GH Release body. Existing Release Drafter content is preserved with a `---` separator.
- **`workflow_dispatch` manual** — release manager enters the Fix Version directly. Defaults to `dry_run=true` — preview-only in the step summary + downloadable artifact, GH Release untouched. Uncheck `dry_run` (and provide a `release_tag`) to publish.

## The result

Once `build-logic#602` lands and this caller merges, every Community release auto-publishes its Jira release notes alongside Release Drafter's output. Release manager runs the manual dispatch first in dry-run to preview before the real release goes out.

## Under the hood

All logic — Python aggregator script, ADF visitor, 70 pytest tests, completeness report renderer, `gh release edit --notes-file` — lives in `build-logic`. This caller does three things:

1. Derives the inputs from either the release event or manual input.
2. Calls the reusable workflow with `secrets: inherit` (uses org-level `LIQUIBASE_VAULT_OIDC_ROLE_ARN` for Jira auth).
3. Returns the run summary back to the user.

## Security

Every workflow input and event payload field (`inputs.version`, `inputs.release_tag`, `github.event.release.tag_name`) is consumed via env vars in `run:` blocks — never interpolated directly into shell. Follows [GitHub's workflow-injection guide](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/).

## Dependencies

- **`liquibase/build-logic#602`** — must land first. This caller `uses: liquibase/build-logic/.github/workflows/release-notes-aggregate.yml@main`.