### PR TITLE
fix(release-notes): skip prereleases on auto-fire + add concurrency block [TECHOPS-498]

### DIFF
--- a/.github/workflows/release-notes-aggregate.yml
+++ b/.github/workflows/release-notes-aggregate.yml
@@ -45,8 +45,25 @@ permissions:
   id-token: write
   contents: write
 
+# Serialize runs against the same release so concurrent triggers
+# (auto-fire from `release: [published]` + manual `workflow_dispatch`
+# on the same tag, two reruns racing, etc.) don't clobber each other
+# through the `gh release edit` step. cancel-in-progress: false lets
+# both runs complete in order rather than killing the first.
+concurrency:
+  group: release-notes-${{ github.event.release.tag_name || inputs.release_tag || inputs.version }}
+  cancel-in-progress: false
+
 jobs:
   derive:
+    # Skip prereleases on the auto-publish path. `release: [published]`
+    # fires for ANY release type (GA, prerelease, draft-being-published),
+    # but only GA releases should have their body auto-augmented with
+    # Jira release notes — an `v5.2.0-RC8` tag shouldn't pollute the RC
+    # release body with an empty completeness report.
+    # workflow_dispatch runs are unaffected (`github.event.release` is
+    # absent on dispatch, so the expression evaluates true).
+    if: ${{ github.event_name != 'release' || !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.compute.outputs.version }}


### PR DESCRIPTION
Follow-up on #7771. Two fixes from [@v-petrovych](https://github.com/v-petrovych)'s review on the [liquibase-pro twin PR](https://github.com/liquibase/liquibase-pro/pull/3895#issuecomment-4563779007):

## 1. Skip prereleases on the auto-fire path

`release: [published]` fires for **any** release type — GA, prerelease, even a draft-being-published. An RC tag (`v5.0.4-RC1`) would auto-trigger this workflow with `version='Community 5.0.4-RC1'`, find zero matching Jira Fix Versions, and pollute the RC release body with an empty completeness report.

Added `if: github.event_name != 'release' || !github.event.release.prerelease` to the `derive` job. Skip cascades to `aggregate` via `needs:`. `workflow_dispatch` is unaffected since `github.event.release` is absent on dispatch (the expression evaluates true).

## 2. Concurrency control

No `concurrency:` block meant an auto-fire + manual dispatch race on the same tag could both read the current body, compute different new bodies, then race on `gh release edit` — last write wins, the other's update lost. Added:

```yaml
concurrency:
  group: release-notes-${{ github.event.release.tag_name || inputs.release_tag || inputs.version }}
  cancel-in-progress: false
```

`cancel-in-progress: false` so both runs complete in order rather than the first being killed.

## Companion fix

The "append to release body" step had a separate idempotency bug — even single concurrent run, a re-publish or workflow re-run would have appended a second copy of the aggregator output. Fixed on the reusable-workflow side in [build-logic#604](https://github.com/liquibase/build-logic/pull/604) (HTML comment marker-based replace).