### PR TITLE
ci: add -am to Artifacts - Build & Sign so dist resolves liquibase-core on branch-versioned builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,7 +168,7 @@ jobs:
           ## save install4j code signing keys
           mkdir -p liquibase-dist/target/keys
         
-          ./mvnw -B -pl liquibase-dist source:jar clean package failsafe:integration-test failsafe:verify \
+          ./mvnw -B -pl liquibase-dist -am source:jar clean package failsafe:integration-test failsafe:verify \
           "-Dbuild.repository.owner=liquibase" \
           "-Dbuild.repository.name=liquibase" \
           "-Dbuild.branch=${{ needs.setup.outputs.thisBranchName }}" \


### PR DESCRIPTION
## Summary

One-character workflow fix to `.github/workflows/build.yml`: add `-am` (also-make) to the `Artifacts - Build & Sign` step's `mvnw` command so that `liquibase-dist` can resolve its reactor dependencies after the prior `Version Artifact` step renames pom versions to `<branch>-SNAPSHOT`.

```diff
-          ./mvnw -B -pl liquibase-dist source:jar clean package failsafe:integration-test failsafe:verify \
+          ./mvnw -B -pl liquibase-dist -am source:jar clean package failsafe:integration-test failsafe:verify \
```

## Why this is needed (and why it isn't visible on `main` pushes)

Step sequence in the `run-build-publish-file / Artifacts - Build & Package` job:

1. **Download Artifacts for build.yml** — downloads pre-built JARs at the *original* version (currently `5.2.0-SNAPSHOT`).
2. **Version Artifact** — runs `./mvnw versions:set -DnewVersion="$version"` where `$version` is `${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT`. Renames every module's pom to the branch-named SNAPSHOT.
3. **Artifacts - Build & Sign** — runs `./mvnw -B -pl liquibase-dist source:jar clean package ...`.

Without `-am`, Maven only builds `liquibase-dist` in step 3. It then tries to resolve `liquibase-dist`'s reactor deps (`liquibase-core`, etc.) at the post-`versions:set` coordinate `liquibase-core:jar:<branch>-SNAPSHOT`. That coordinate exists nowhere reachable:

- local m2 holds `liquibase-core` only at `5.2.0-SNAPSHOT` (downloaded in step 1, before the rename)
- GPM (`maven.pkg.github.com/liquibase/liquibase`) holds `liquibase-core` only at `main-SNAPSHOT`, deployed by prior pushes to `main`
- no other reachable repo has the branch-named coordinate

Failure on every long-lived branch PR:

```
[ERROR] Could not find artifact org.liquibase:liquibase-core:jar:<branch>-SNAPSHOT
        in liquibase (https://maven.pkg.github.com/liquibase/liquibase)
```

**Why `main` pushes don't trip this**: for them `<branch>-SNAPSHOT == main-SNAPSHOT`, and that coordinate *is* in GPM (deployed by prior main runs). The failure is masked on `main` by accidental cache state — not by correctness.

## Concretely blocking right now

Four in-flight audit PRs are all wedged on this single deterministic failure:

| PR | Branch | Failure |
|---|---|---|
| #7765 | `cwe-22-external-changelog-paths-flag` | `Artifacts - Build & Package` |
| #7766 | `cwe-470-include-all-classes-opt-out-gate` | `Artifacts - Build & Package` |
| #7767 | `cwe-89-sql-check-opt-out-gate` | `Artifacts - Build & Package` |
| #7768 | `cwe-470-custom-precondition-opt-out-gate` | `Artifacts - Build & Package` |

All four are otherwise green: 26/26 checks pass (incl. all JVM unit-test matrix slots and all 10 integration-test DBs including `Integration Test (postgresql)`). The only red across all four is this same job, with the same error pattern. Reruns do not clear it — the bug is deterministic.

This `-am` change unblocks all four simultaneously without any per-PR change. It is also a trap that will catch every future PR touching `liquibase-dist` or anything downstream of `liquibase-core`, so it's worth fixing in its own focused PR rather than per-branch workarounds.

## Trade-off

Adding `-am` makes the Artifacts step build `liquibase-core` (plus other reactor deps) locally before building `liquibase-dist`. This adds a small amount of build time (~30–60s on a fresh runner). In exchange, dist resolution becomes correct by construction rather than depending on which SNAPSHOT happens to be cached in GPM at the moment.

## Test plan

- [x] Diff is the single one-character addition shown above; `git diff --check` is clean.
- [ ] This PR's own `Artifacts - Build & Package` job runs the new workflow — expected to pass (`liquibase-core` is now built locally before dist resolves it).
- [ ] After merge: push an empty commit to each of #7765/#7766/#7767/#7768 (or rerun their Artifacts jobs). Expected: all four `Artifacts - Build & Package` flip to green, `mergeStateStatus` becomes `CLEAN` modulo review.
- [ ] Push-to-`main` runs continue to succeed (the `-am` is additive — it can only build *more* than before, never less).

## Related (internal)

Internal tracking ticket: [SECURE-209](https://datical.atlassian.net/browse/SECURE-209) — same-parent audit work as the four PRs above.

[SECURE-209]: https://datical.atlassian.net/browse/SECURE-209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ