### PR TITLE
ci: copy liquibase-core artifacts at branch version after -am rebuild

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,11 +192,11 @@ jobs:
 
           cp liquibase-dist/target/liquibase-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT.tar.gz artifacts
           cp liquibase-dist/target/liquibase-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT.zip artifacts
-          cp liquibase-core/target/liquibase-core-0-SNAPSHOT.jar artifacts/liquibase-core-0-SNAPSHOT.jar
+          cp liquibase-core/target/liquibase-core-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT.jar artifacts/liquibase-core-0-SNAPSHOT.jar
           #cp liquibase-dist/target/liquibase-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT/internal/lib/liquibase-core.jar artifacts/liquibase-core-0-SNAPSHOT.jar
 
-          cp liquibase-core/target/liquibase-core-0-SNAPSHOT-sources.jar artifacts/liquibase-core-0-SNAPSHOT-sources.jar
-          cp target/liquibase-0-SNAPSHOT-javadoc.jar artifacts/liquibase-core-0-SNAPSHOT-javadoc.jar
+          cp liquibase-core/target/liquibase-core-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT-sources.jar artifacts/liquibase-core-0-SNAPSHOT-sources.jar
+          cp target/liquibase-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT-javadoc.jar artifacts/liquibase-core-0-SNAPSHOT-javadoc.jar
 
           ##create installer - disabled here but run as nightly job and as part of release workflow
           #cp liquibase-dist/target/liquibase-*-installer-* artifacts


### PR DESCRIPTION
## Summary

Follow-up to #7775. That PR added `-am` to the `Artifacts - Build & Sign` step so `liquibase-dist` can resolve its reactor dependencies after `Version Artifact` renames every module pom to `<branch>-SNAPSHOT`. That fixed the Maven dependency resolution, but it changed what lands in `liquibase-core/target/`: with `-am` + `clean package`, `liquibase-core` is now **rebuilt locally under the branch version**, so its jars are named `liquibase-core-<branch>-SNAPSHOT*.jar`.

The artifact copy step a few lines later still referenced the hardcoded `0-SNAPSHOT` source names, so every branch-versioned build now fails one step downstream of where it used to:

```
cp: cannot stat 'liquibase-core/target/liquibase-core-0-SNAPSHOT.jar': No such file or directory
```

## Fix

Point the three `cp` **sources** at `${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT` — matching the `liquibase-dist` tar.gz/zip lines immediately above them, which already use the branch version. The `artifacts/...-0-SNAPSHOT*.jar` **destination** names are left unchanged so downstream consumers see no difference.

```diff
- cp liquibase-core/target/liquibase-core-0-SNAPSHOT.jar artifacts/liquibase-core-0-SNAPSHOT.jar
+ cp liquibase-core/target/liquibase-core-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT.jar artifacts/liquibase-core-0-SNAPSHOT.jar
```
(same change to the `-sources.jar` and `-javadoc.jar` lines)

## Why main wasn't affected

On `main` the version stays `0-SNAPSHOT` (no branch rename), so the hardcoded `cp` names matched and the failure was masked. It only surfaces on branch-versioned PR builds — and only became reachable once `-am` let the build get past dependency resolution.

## Blocking right now

The four in-flight audit PRs (#7765, #7766, #7767, #7768) all fail `Artifacts - Build & Package` on this exact `cp` error. This change unblocks all four.

## Test plan

- [ ] This PR's own `Artifacts - Build & Package` job runs the updated workflow — expected to pass (`liquibase-core-<branch>-SNAPSHOT.jar` now exists and is what the `cp` looks for).
- [ ] After merge: re-update #7765/#7766/#7767/#7768 and confirm their `Artifacts - Build & Package` jobs flip green.
- [ ] `main` SNAPSHOT build continues to pass (branch name resolves to its own value; the dist lines above already use the same variable).
