### PR TITLE
ci: copy cli/maven-plugin/extension-testing artifacts at branch version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,9 +202,9 @@ jobs:
           #cp liquibase-dist/target/liquibase-*-installer-* artifacts
 
           for i in 'liquibase-maven-plugin' 'liquibase-cli'; do
-            cp $i/target/$i-0-SNAPSHOT.jar artifacts
-            cp $i/target/$i-0-SNAPSHOT-sources.jar artifacts
-            cp $i/target/$i-0-SNAPSHOT-javadoc.jar artifacts
+            cp $i/target/$i-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT.jar artifacts/$i-0-SNAPSHOT.jar
+            cp $i/target/$i-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT-sources.jar artifacts/$i-0-SNAPSHOT-sources.jar
+            cp $i/target/$i-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT-javadoc.jar artifacts/$i-0-SNAPSHOT-javadoc.jar
           done
 
           .github/util/sign-artifacts.sh artifacts
@@ -213,10 +213,10 @@ jobs:
           mkdir artifacts-named
 
           cp liquibase-dist/target/liquibase-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT.tar.gz artifacts-named/liquibase-${{ needs.setup.outputs.thisBranchName }}.tar.gz
-          cp liquibase-extension-testing/target/liquibase-extension-testing-0-SNAPSHOT-deps.jar artifacts-named/liquibase-extension-testing-${{ needs.setup.outputs.thisBranchName }}-deps.jar
+          cp liquibase-extension-testing/target/liquibase-extension-testing-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT-deps.jar artifacts-named/liquibase-extension-testing-${{ needs.setup.outputs.thisBranchName }}-deps.jar
 
           for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-extension-testing'; do
-            cp $i/target/$i-0-SNAPSHOT.jar artifacts-named/$i-${{ needs.setup.outputs.thisBranchName }}.jar
+            cp $i/target/$i-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT.jar artifacts-named/$i-${{ needs.setup.outputs.thisBranchName }}.jar
           done
 
       - name: Archive Packages


### PR DESCRIPTION
Follow-up to #7775 / #7776. Those PRs fixed `liquibase-core` artifact copying on branch-versioned builds (version = `<branchName>-SNAPSHOT`), but the `liquibase-maven-plugin` / `liquibase-cli` / `liquibase-extension-testing` copy loops still read from the hardcoded `$i-0-SNAPSHOT.jar` source path and fail with `cp: cannot stat`. This applies the same branch-version source pattern to those loops.

Unblocks the `Artifacts - Build & Package` step seen failing on #7762.