### PR TITLE
ci: build maven-plugin and extension-testing so their artifacts can be copied

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,9 +202,9 @@ jobs:
           #cp liquibase-dist/target/liquibase-*-installer-* artifacts
 
           for i in 'liquibase-maven-plugin' 'liquibase-cli'; do
-            cp $i/target/$i-0-SNAPSHOT.jar artifacts
-            cp $i/target/$i-0-SNAPSHOT-sources.jar artifacts
-            cp $i/target/$i-0-SNAPSHOT-javadoc.jar artifacts
+            cp $i/target/$i-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT.jar artifacts/$i-0-SNAPSHOT.jar
+            cp $i/target/$i-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT-sources.jar artifacts/$i-0-SNAPSHOT-sources.jar
+            cp $i/target/$i-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT-javadoc.jar artifacts/$i-0-SNAPSHOT-javadoc.jar
           done
 
           .github/util/sign-artifacts.sh artifacts
@@ -213,10 +213,10 @@ jobs:
           mkdir artifacts-named
 
           cp liquibase-dist/target/liquibase-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT.tar.gz artifacts-named/liquibase-${{ needs.setup.outputs.thisBranchName }}.tar.gz
-          cp liquibase-extension-testing/target/liquibase-extension-testing-0-SNAPSHOT-deps.jar artifacts-named/liquibase-extension-testing-${{ needs.setup.outputs.thisBranchName }}-deps.jar
+          cp liquibase-extension-testing/target/liquibase-extension-testing-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT-deps.jar artifacts-named/liquibase-extension-testing-${{ needs.setup.outputs.thisBranchName }}-deps.jar
 
           for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-extension-testing'; do
-            cp $i/target/$i-0-SNAPSHOT.jar artifacts-named/$i-${{ needs.setup.outputs.thisBranchName }}.jar
+            cp $i/target/$i-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT.jar artifacts-named/$i-${{ needs.setup.outputs.thisBranchName }}.jar
           done
 
       - name: Archive Packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,7 +168,7 @@ jobs:
           ## save install4j code signing keys
           mkdir -p liquibase-dist/target/keys
         
-          ./mvnw -B -pl liquibase-dist -am source:jar clean package failsafe:integration-test failsafe:verify \
+          ./mvnw -B -pl liquibase-dist,liquibase-maven-plugin,liquibase-extension-testing -am source:jar clean package failsafe:integration-test failsafe:verify \
           "-Dbuild.repository.owner=liquibase" \
           "-Dbuild.repository.name=liquibase" \
           "-Dbuild.branch=${{ needs.setup.outputs.thisBranchName }}" \


### PR DESCRIPTION
Follow-up to #7775 / #7777.

#7775 changed the Artifacts build to `-pl liquibase-dist -am`. That only builds `liquibase-dist` and its dependency subgraph (core, cli, snowflake, ...). `liquibase-maven-plugin` and `liquibase-extension-testing` are **not** dependencies of `liquibase-dist`, so `-am` never builds them — and the artifact-copy loops then fail with `cp: cannot stat '.../liquibase-maven-plugin-<version>.jar'` (seen on #7762 after #7777 fixed the cli/core filenames).

This adds both modules to the `-pl` list so `-am` builds them alongside dist.

Verified locally — the reactor now produces every jar the copy loops expect, including `liquibase-extension-testing-*-deps.jar`:
```
liquibase-maven-plugin/target/liquibase-maven-plugin-*-{,, -sources, -javadoc}.jar
liquibase-extension-testing/target/liquibase-extension-testing-*-{,, -sources, -javadoc, -deps}.jar
```

Note: like #7775/#7777 this can only be validated in CI after merge, because `run-tests.yml` runs via `pull_request_target` (workflow definition resolved from the base branch).