### PR TITLE
feat(ui): console-only formatter and typed message (enables colored output)

### DIFF
--- a/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
+++ b/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
@@ -424,7 +424,7 @@ public class LiquibaseCommandLine {
                                 }
                                 final List<CommandLine> commandList = commandLine.getParseResult().asCommandLineList();
                                 final String commandName = StringUtil.join(getCommandNames(commandList.get(commandList.size() - 1)), " ");
-                                Scope.getCurrentScope().getUI().sendMessage("Liquibase command '" + commandName + "' was executed successfully.");
+                                Scope.getCurrentScope().getUI().sendMessage("Liquibase command '" + commandName + "' was executed successfully.", liquibase.ui.UIService.MessageType.SUCCESS);
                             }
                         }
                         return response;
@@ -938,8 +938,12 @@ public class LiquibaseCommandLine {
         for (Handler handler : rootLogger.getHandlers()) {
             if (handler instanceof ConsoleHandler) {
                 handler.setLevel(cliLogLevel);
+                // Apply the console-specific formatter (may include ANSI colour in Pro).
+                // This keeps the file handler on the plain formatter path — ANSI never reaches log files.
+                JavaLogService.setConsoleFormatterOnHandler(logService, handler);
+            } else {
+                JavaLogService.setFormatterOnHandler(logService, handler);
             }
-            JavaLogService.setFormatterOnHandler(logService, handler);
         }
     }
 

--- a/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineLoggingTest.groovy
+++ b/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineLoggingTest.groovy
@@ -1,0 +1,168 @@
+package liquibase.integration.commandline
+
+import liquibase.logging.LogService
+import liquibase.logging.core.JavaLogService
+import spock.lang.Specification
+
+import java.util.logging.ConsoleHandler
+import java.util.logging.Formatter
+import java.util.logging.SimpleFormatter
+import java.util.logging.StreamHandler
+
+/**
+ * A-3: Verifies per-sink formatter routing:
+ *  - ConsoleHandler receives the console-specific formatter from getConsoleFormatter()
+ *  - Non-console handlers (FileHandler / StreamHandler) stay on the plain formatter path
+ *
+ * RED phase: fails until A-4 wires setConsoleFormatterOnHandler into the handler loop
+ * in LiquibaseCommandLine.configureLogging().
+ *
+ * NOTE: A-3 also covers the static helper setConsoleFormatterOnHandler introduced in A-2,
+ * which is a prerequisite for the A-4 wiring test below.
+ */
+class LiquibaseCommandLineLoggingTest extends Specification {
+
+    // ── Helpers ─────────────────────────────────────────────────────────────────
+
+    /** A JavaLogService subclass that returns a distinct console formatter. */
+    static class ColorLogService extends JavaLogService {
+        final Formatter consoleFormatter = new SimpleFormatter() {
+            @Override String toString() { return "CONSOLE_FORMATTER" }
+        }
+
+        @Override
+        Formatter getConsoleFormatter() { return consoleFormatter }
+
+        // getCustomFormatter() stays null (file handler must stay plain)
+        @Override
+        Formatter getCustomFormatter() { return null }
+    }
+
+    // ── setConsoleFormatterOnHandler unit tests (A-2 helper, exercised here) ──
+
+    def "setConsoleFormatterOnHandler applies console formatter to ConsoleHandler"() {
+        given:
+        def logService = new ColorLogService()
+        def handler = new ConsoleHandler()
+
+        when:
+        JavaLogService.setConsoleFormatterOnHandler(logService, handler)
+
+        then:
+        handler.formatter.is(logService.consoleFormatter)
+    }
+
+    def "setConsoleFormatterOnHandler does NOT change a non-console handler when getCustomFormatter is null"() {
+        given:
+        def logService = new ColorLogService() // getCustomFormatter == null
+        def outputStream = new ByteArrayOutputStream()
+        def fileHandler = new StreamHandler(outputStream, new SimpleFormatter())
+        def originalFormatter = fileHandler.formatter
+
+        when:
+        // Simulate what configureLogging does for file handlers: use setFormatterOnHandler
+        JavaLogService.setFormatterOnHandler(logService, fileHandler)
+
+        then: "file handler formatter is unchanged because getCustomFormatter() returns null"
+        fileHandler.formatter.is(originalFormatter)
+    }
+
+    def "setConsoleFormatterOnHandler falls back to getCustomFormatter when getConsoleFormatter is null"() {
+        given: "a log service where getConsoleFormatter returns null but getCustomFormatter is non-null"
+        def customFmt = new SimpleFormatter()
+        def logService = new JavaLogService() {
+            @Override Formatter getConsoleFormatter() { return null }
+            @Override Formatter getCustomFormatter() { return customFmt }
+        }
+        def handler = new ConsoleHandler()
+
+        when:
+        JavaLogService.setConsoleFormatterOnHandler(logService, handler)
+
+        then: "falls back to getCustomFormatter"
+        handler.formatter.is(customFmt)
+    }
+
+    def "setConsoleFormatterOnHandler is a no-op for null logService"() {
+        given:
+        def handler = new ConsoleHandler()
+        def original = handler.formatter
+
+        when:
+        JavaLogService.setConsoleFormatterOnHandler(null, handler)
+
+        then:
+        noExceptionThrown()
+        handler.formatter.is(original)
+    }
+
+    def "setConsoleFormatterOnHandler is a no-op for null handler"() {
+        given:
+        def logService = new ColorLogService()
+
+        when:
+        JavaLogService.setConsoleFormatterOnHandler(logService, null)
+
+        then:
+        noExceptionThrown()
+    }
+
+    // ── configureLogging handler-loop integration test (A-4 gate) ──────────────
+
+    /**
+     * Exercises the actual LiquibaseCommandLine.configureLogging handler loop via reflection to
+     * verify that AFTER A-4:
+     *  - ConsoleHandler receives the colour formatter from getConsoleFormatter()
+     *  - A non-console StreamHandler keeps its original plain formatter
+     *
+     * BEFORE A-4 (current state) the loop calls setFormatterOnHandler() for ALL handlers —
+     * so ConsoleHandler does NOT get the colour formatter (getConsoleFormatter returns non-null
+     * but is ignored).  This test will go RED until A-4 patches the loop.
+     */
+    def "configureLogging loop applies console formatter to ConsoleHandler but not to file handler"() {
+        given: "a LiquibaseCommandLine instance and a ColorLogService in Scope"
+        def cli = new LiquibaseCommandLine()
+        def colorLogService = new ColorLogService()
+
+        def rootLogger = java.util.logging.Logger.getLogger("")
+        def consoleHandler = new ConsoleHandler()
+        def plainFormatter = new SimpleFormatter()
+        def fileHandler = new StreamHandler(new ByteArrayOutputStream(), plainFormatter)
+
+        // Remove all existing root handlers to have a clean slate; restore in cleanup
+        def savedHandlers = rootLogger.handlers.toList()
+        savedHandlers.each { rootLogger.removeHandler(it) }
+        rootLogger.addHandler(consoleHandler)
+        rootLogger.addHandler(fileHandler)
+
+        when: "configureLogging runs under the ColorLogService scope (via reflection)"
+        def invokeError = null
+        try {
+            liquibase.Scope.child(
+                [(liquibase.Scope.Attr.logService.name()): colorLogService],
+                { ->
+                    def method = LiquibaseCommandLine.class.getDeclaredMethod(
+                        "configureLogging",
+                        java.util.logging.Level.class, String.class, boolean.class)
+                    method.accessible = true
+                    method.invoke(cli, java.util.logging.Level.INFO, null, false)
+                } as liquibase.Scope.ScopedRunner
+            )
+        } catch (Throwable t) {
+            invokeError = t
+        } finally {
+            rootLogger.removeHandler(consoleHandler)
+            rootLogger.removeHandler(fileHandler)
+            savedHandlers.each { rootLogger.addHandler(it) }
+        }
+
+        then: "no exception during configureLogging"
+        invokeError == null
+
+        and: "ConsoleHandler gets the colour formatter (A-4 patched loop)"
+        consoleHandler.formatter.is(colorLogService.consoleFormatter)
+
+        and: "file-style StreamHandler keeps the plain formatter (getCustomFormatter is null → unchanged)"
+        fileHandler.formatter.is(plainFormatter)
+    }
+}

--- a/liquibase-standard/src/main/java/liquibase/logging/LogService.java
+++ b/liquibase-standard/src/main/java/liquibase/logging/LogService.java
@@ -3,6 +3,8 @@ package liquibase.logging;
 import liquibase.logging.core.JavaLogService;
 import liquibase.plugin.Plugin;
 
+import java.util.logging.Formatter;
+
 /**
  * This service is used to create named {@link Logger} instances through a {@link LogService}.
  * <p>
@@ -11,6 +13,24 @@ import liquibase.plugin.Plugin;
 public interface LogService extends Plugin {
 
     int getPriority();
+
+    /**
+     * Returns the {@link Formatter} to be applied specifically to the console (stdout/stderr) handler.
+     * <p>
+     * Returning {@code null} here means the console handler receives no override and falls back to whatever
+     * the JUL infrastructure provides (typically {@link java.util.logging.SimpleFormatter}).  Subclasses
+     * that wish to apply per-sink formatting — for example to inject ANSI colour codes on the console
+     * without affecting file handlers — should override this method.
+     * <p>
+     * The default implementation returns {@code null}, preserving existing behaviour for all
+     * {@link LogService} implementations that do not override this method.
+     *
+     * @return a {@link Formatter} for the console handler, or {@code null} to use the JUL default
+     * @since 5.2
+     */
+    default Formatter getConsoleFormatter() {
+        return null;
+    }
 
     /**
      * Creates a logger for logging from the given class.

--- a/liquibase-standard/src/main/java/liquibase/logging/core/JavaLogService.java
+++ b/liquibase-standard/src/main/java/liquibase/logging/core/JavaLogService.java
@@ -133,6 +133,23 @@ public class JavaLogService extends AbstractLogService {
         return null;
     }
 
+    /**
+     * Returns the {@link Formatter} to be applied to the console (stdout/stderr) handler only.
+     * <p>
+     * Overrides the {@link liquibase.logging.LogService} interface default to return the value of
+     * {@link #getCustomFormatter()}, preserving current OSS behaviour: when no custom formatter is set
+     * both the console handler and any file handler continue to use the JUL default ({@link java.util.logging.SimpleFormatter}).
+     * <p>
+     * Pro subclasses may override this method to return a colour-capable formatter for the console
+     * while leaving {@link #getCustomFormatter()} returning {@code null} (so file handlers stay plain).
+     *
+     * @return the console-specific {@link Formatter}, or {@code null}
+     * @since 5.2
+     */
+    @Override
+    public Formatter getConsoleFormatter() {
+        return getCustomFormatter();
+    }
 
     /**
      * Set the formatter for the supplied handler if the supplied log service
@@ -140,6 +157,39 @@ public class JavaLogService extends AbstractLogService {
      */
     public static void setFormatterOnHandler(LogService logService, Handler handler) {
         if (logService instanceof JavaLogService && handler != null) {
+            Formatter customFormatter = ((JavaLogService) logService).getCustomFormatter();
+            if (customFormatter != null) {
+                handler.setFormatter(customFormatter);
+            }
+        }
+    }
+
+    /**
+     * Set the <em>console-specific</em> formatter on the supplied handler.
+     * <p>
+     * Unlike {@link #setFormatterOnHandler(LogService, Handler)} (which uses {@link #getCustomFormatter()}),
+     * this method reads {@link LogService#getConsoleFormatter()}.  When the console formatter is {@code null}
+     * it falls back to {@link #getCustomFormatter()} so that existing behaviour is preserved for any
+     * {@link LogService} implementation that does not override {@link LogService#getConsoleFormatter()}.
+     * <p>
+     * Intended to be called in {@code configureLogging()} exclusively for {@link java.util.logging.ConsoleHandler}
+     * instances, keeping file handlers on the plain formatter path.
+     *
+     * @param logService the active log service (may be any implementation)
+     * @param handler    the handler to configure (must be non-{@code null})
+     * @since 5.2
+     */
+    public static void setConsoleFormatterOnHandler(LogService logService, Handler handler) {
+        if (logService == null || handler == null) {
+            return;
+        }
+        Formatter consoleFormatter = logService.getConsoleFormatter();
+        if (consoleFormatter != null) {
+            handler.setFormatter(consoleFormatter);
+            return;
+        }
+        // Fall back to the existing custom-formatter path so existing impls are unchanged.
+        if (logService instanceof JavaLogService) {
             Formatter customFormatter = ((JavaLogService) logService).getCustomFormatter();
             if (customFormatter != null) {
                 handler.setFormatter(customFormatter);

--- a/liquibase-standard/src/main/java/liquibase/ui/CompositeUIService.java
+++ b/liquibase-standard/src/main/java/liquibase/ui/CompositeUIService.java
@@ -35,6 +35,11 @@ public class CompositeUIService extends AbstractExtensibleObject implements UISe
     }
 
     @Override
+    public void sendMessage(String message, MessageType type) {
+        outputServices.forEach(service -> service.sendMessage(message, type));
+    }
+
+    @Override
     public void sendErrorMessage(String message) {
         outputServices.forEach(service -> service.sendErrorMessage(message));
     }

--- a/liquibase-standard/src/main/java/liquibase/ui/UIService.java
+++ b/liquibase-standard/src/main/java/liquibase/ui/UIService.java
@@ -8,12 +8,47 @@ import liquibase.plugin.Plugin;
  */
 public interface UIService extends ExtensibleObject, Plugin {
 
+    /**
+     * Semantic type for a message, allowing UI implementations to apply
+     * presentation-layer treatment (e.g. colour) without the caller needing
+     * to know how or whether the terminal supports it.
+     *
+     * <p>The set of values is intentionally small.  Only distinct visual
+     * outcomes that are broadly useful across all CLI commands are listed here.
+     * A plain/untyped message should use {@link #sendMessage(String)} directly.
+     *
+     * @since 5.2
+     */
+    enum MessageType {
+        /**
+         * A command completed without errors.  Rendered green when the
+         * terminal supports colour and colour output is enabled.
+         */
+        SUCCESS
+    }
+
     int getPriority();
 
     /**
      * Send a "normal" message to the user.
      */
     void sendMessage(String message);
+
+    /**
+     * Send a typed message to the user.
+     *
+     * <p>Implementations that support coloured or otherwise styled output may
+     * use the {@code type} hint to apply the appropriate presentation.  The
+     * default implementation simply delegates to {@link #sendMessage(String)}
+     * so that existing {@link UIService} implementations are unaffected.
+     *
+     * @param message the text to display
+     * @param type    the semantic classification of the message
+     * @since 5.2
+     */
+    default void sendMessage(String message, MessageType type) {
+        sendMessage(message);
+    }
 
     /**
      * Send an "error" message to the user.

--- a/liquibase-standard/src/test/groovy/liquibase/logging/LogServiceConsoleFormatterTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/logging/LogServiceConsoleFormatterTest.groovy
@@ -1,0 +1,48 @@
+package liquibase.logging
+
+import liquibase.logging.core.AbstractLogService
+import liquibase.logging.core.JavaLogService
+import spock.lang.Specification
+
+/**
+ * A-1: Verifies the getConsoleFormatter() seam on LogService and JavaLogService.
+ *
+ * RED phase: these tests fail until A-2 adds the method to LogService / JavaLogService.
+ */
+class LogServiceConsoleFormatterTest extends Specification {
+
+    /** Minimal concrete LogService that does NOT override getConsoleFormatter — gets the interface default. */
+    static class MinimalLogService extends AbstractLogService {
+        @Override int getPriority() { return 0 }
+        @Override liquibase.logging.Logger getLog(Class clazz) { return null }
+    }
+
+    def "LogService default getConsoleFormatter returns null"() {
+        given: "a LogService that does not override getConsoleFormatter"
+        def svc = new MinimalLogService()
+
+        expect:
+        svc.getConsoleFormatter() == null
+    }
+
+    def "JavaLogService getConsoleFormatter returns same value as getCustomFormatter"() {
+        given:
+        def svc = new JavaLogService()
+
+        expect: "both return null when no custom formatter is set"
+        svc.getConsoleFormatter() == svc.getCustomFormatter()
+    }
+
+    def "JavaLogService getConsoleFormatter still matches getCustomFormatter after a subclass override"() {
+        given: "a subclass that overrides getCustomFormatter to return a custom formatter"
+        def formatter = new java.util.logging.SimpleFormatter()
+        def svc = new JavaLogService() {
+            @Override
+            java.util.logging.Formatter getCustomFormatter() { return formatter }
+        }
+
+        expect:
+        svc.getConsoleFormatter() == formatter
+        svc.getConsoleFormatter() == svc.getCustomFormatter()
+    }
+}

--- a/liquibase-standard/src/test/groovy/liquibase/ui/CompositeUIServiceTypedMessageTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/ui/CompositeUIServiceTypedMessageTest.groovy
@@ -1,0 +1,27 @@
+package liquibase.ui
+
+import spock.lang.Specification
+
+/**
+ * Verifies that {@link CompositeUIService} forwards the typed
+ * {@link UIService#sendMessage(String, UIService.MessageType)} call to every
+ * output service, rather than letting the interface default flatten it to the
+ * untyped {@link UIService#sendMessage(String)}. Without this, a wrapping
+ * CompositeUIService (as installed by the CLI) would strip the MessageType
+ * before it reaches a styling UIService implementation.
+ */
+class CompositeUIServiceTypedMessageTest extends Specification {
+
+    def "typed sendMessage forwards the MessageType to every output service"() {
+        given:
+        UIService member = Mock()
+        def composite = new CompositeUIService(member, [member])
+
+        when:
+        composite.sendMessage("done", UIService.MessageType.SUCCESS)
+
+        then:
+        1 * member.sendMessage("done", UIService.MessageType.SUCCESS)
+        0 * member.sendMessage("done")
+    }
+}

--- a/liquibase-standard/src/test/groovy/liquibase/ui/UIServiceTypedSendMessageTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/ui/UIServiceTypedSendMessageTest.groovy
@@ -1,0 +1,52 @@
+package liquibase.ui
+
+import liquibase.ExtensibleObject
+import liquibase.ExtensibleObjectAttribute
+import spock.lang.Specification
+
+/**
+ * A-5: Verifies that UIService.sendMessage(String, MessageType) default delegates to
+ * the plain sendMessage(String) overload, keeping existing UIService impls unaffected.
+ *
+ * RED phase: fails until A-6 adds MessageType + the default method to UIService.
+ */
+class UIServiceTypedSendMessageTest extends Specification {
+
+    /**
+     * Spy-style class: only overrides sendMessage(String) so we can verify it was called.
+     * Does NOT override sendMessage(String, MessageType) — relies on the interface default.
+     *
+     * Extends ConsoleUIService because UIService requires many method impls and ExtensibleObject
+     * plumbing that ConsoleUIService already provides.
+     */
+    static class SpyUIService extends ConsoleUIService {
+        final List<String> received = []
+
+        @Override
+        void sendMessage(String message) {
+            received << message
+        }
+    }
+
+    def "sendMessage(String, MessageType.SUCCESS) default delegates to sendMessage(String)"() {
+        given:
+        def svc = new SpyUIService()
+
+        when:
+        svc.sendMessage("command was executed successfully.", UIService.MessageType.SUCCESS)
+
+        then: "the plain sendMessage(String) was invoked with the original string"
+        svc.received == ["command was executed successfully."]
+    }
+
+    def "sendMessage(String, MessageType) does not alter the message"() {
+        given:
+        def svc = new SpyUIService()
+
+        when:
+        svc.sendMessage("some other message", UIService.MessageType.SUCCESS)
+
+        then:
+        svc.received == ["some other message"]
+    }
+}


### PR DESCRIPTION
# Enable colored console output (the plumbing)

## The problem
Liquibase prints everything in one color. Anything built on top of Liquibase — like Liquibase Secure — has no clean, supported way to highlight errors or success in the console. Today the only options are hacks that risk leaking color codes into log files.

## What this does
Adds a small, safe set of extension points so an add-on **can** color console output — and nothing more. On its own, this change does nothing you'd notice. **Default Liquibase output looks exactly the same.**

## The result
- Add-ons can style console text (e.g. color).
- Log files stay clean — color can't leak in.
- A message can be marked "success."
- 100% backward compatible by default.

## Why it's safe
Every addition is a no-op unless an add-on opts in. Existing behavior, log files, and output are untouched. Tests lock in the "nothing changes by default" guarantee.

## Companion PR
This is only the plumbing. The actual colors ship in Liquibase Secure: **liquibase/liquibase-pro#3920**.

---

## Under the hood (for reviewers)
Two seams, both inert until something overrides them:

- **Console-only formatter.** `LogService.getConsoleFormatter()` (default `null`) lets a service style *only* the console handler; `JavaLogService.setConsoleFormatterOnHandler(...)` + `LiquibaseCommandLine.configureLogging()` apply it to the `ConsoleHandler` while file handlers keep the plain formatter — so ANSI never reaches log files.
- **Typed message.** `UIService.MessageType` (currently just `SUCCESS`) plus a default `sendMessage(String, MessageType)` that delegates to the existing `sendMessage(String)`; `CompositeUIService` forwards it to all output services. The "executed successfully" message now passes `MessageType.SUCCESS`.

**Tests:** default no-op behavior, per-sink formatter routing (console styled, file handler stays plain), and typed-message delegation/forwarding. `liquibase-standard` and `liquibase-cli` suites pass.

> **Note for the downstream sync.** This PR currently carries the original two seams (above). As more outputs were colored, the Secure PR (#3920) grew the seam further; those additions live on the Pro branch's `core/` but are **not yet in this PR**. They should land here so the next `core/` subtree sync reconciles cleanly:
> - `UIService.MessageType` values `RUNNING`, `BANNER`, and `ERROR` (alongside `SUCCESS`), plus the `sendMessage(..., type)` call-site tags that use them.
> - `UIService.formatMessage(String, MessageType)` (default returns the text unchanged) and `CompositeUIService` delegation — lets picocli print a pre-styled `--version` banner.
> - a console-only `ShowSummaryGenerator.colorizeForConsole(...)` hook for the update summary.
>
> Each is backward-compatible and a no-op unless an implementation overrides it — same as the seams above.

