### PR TITLE
fix(TECHOPS-620): fix test-harness dispatch ref and harden dry-run artifact selection

### DIFF
--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -27,13 +27,34 @@ jobs:
       - name: Get run-tests.yml runId
         id: get_run_id
         run: |
-          # Fetch the list of workflow runs
+          # Find the most recent run-tests.yml run on main that has a valid (non-expired) liquibase-artifacts artifact.
+          # We scan up to 20 recent runs regardless of conclusion, so a single unrelated failing job
+          # (e.g. test-harness dispatch) cannot starve the dry-run of fresh build artifacts.
           response=$(curl -s \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/liquibase/liquibase/actions/workflows/run-tests.yml/runs?branch=main&status=success&per_page=1")
-            # Extract the last successful run ID
-          run_id=$(echo "$response" | jq -r '.workflow_runs[0].id')
+            "https://api.github.com/repos/liquibase/liquibase/actions/workflows/run-tests.yml/runs?branch=main&per_page=20")
+
+          run_id=""
+          while IFS= read -r candidate_id; do
+            artifacts=$(curl -sf \
+              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              "https://api.github.com/repos/liquibase/liquibase/actions/runs/${candidate_id}/artifacts") || continue
+            valid=$(echo "$artifacts" | jq -r '[.artifacts[] | select(.name == "liquibase-artifacts" and (.expired | not))] | length')
+            valid="${valid:-0}"
+            if [ "$valid" -gt 0 ]; then
+              run_id="$candidate_id"
+              echo "Found valid liquibase-artifacts in run-tests run $run_id"
+              break
+            fi
+          done < <(echo "$response" | jq -r '.workflow_runs[].id')
+
+          if [ -z "$run_id" ]; then
+            echo "ERROR: No run-tests.yml run found with a valid liquibase-artifacts artifact in the last 20 runs on main"
+            exit 1
+          fi
+
           echo "dry_run_id=$run_id" >> $GITHUB_OUTPUT
           echo "dry_run_branch_name=${{ github.ref_name }}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -99,7 +99,7 @@ jobs:
         id: return_dispatch
         with:
           token: ${{ steps.get-token.outputs.token }}
-          ref: "develop"
+          ref: "main"
           repo: liquibase-test-harness
           owner: liquibase
           workflow: main.yml


### PR DESCRIPTION
## Summary

- **Fix A (root cause):** `run-test-harness.yml` was dispatching to `ref: "develop"` on `liquibase-test-harness`, which no longer exists. Changed to `ref: "main"`. This caused `HttpError: Not Found` / "Timeout exceeded while attempting to get Run ID" on every `run-tests.yml` run on `main` since 2026-05-19, marking all builds as failed despite the build artifacts being valid.
- **Fix B (resilience):** `dry-run-release.yml` `setup` job previously filtered for `status=success` runs when selecting which run's artifacts to use. Changed to scan the 20 most recent runs (any conclusion) and pick the first one with a non-expired `liquibase-artifacts` artifact. This decouples the dry-run from unrelated red jobs so artifact expiration cannot happen again.

## Root cause (TECHOPS-620)

The `liquibase-test-harness` `develop` branch was removed; `main` is the default. Every `run-tests.yml` run on `main` since 2026-05-19 failed at the test-harness dispatch step with `HttpError: Not Found`, making the only `status=success` run a 21-day-old run whose artifacts had since expired — which caused the weekly dry-run release to fail on 2026-06-10.

## Test plan

- [ ] After merge, verify the next `run-tests.yml` push to `main` no longer fails at "Dispatch an action and get the run ID" — the test-harness `main.yml` workflow on `main` should dispatch successfully.
- [ ] Re-run or wait for the next weekly **Dry run release** — confirm `create-release.yml` "Download liquibase-artifacts" step succeeds and the run_id selected is recent (not the 21-day-old one).
- [ ] If all `run-tests.yml` runs in the last 20 have expired artifacts, the dry-run will now exit with a clear error message instead of silently downloading an expired artifact.

Closes TECHOPS-620

🤖 Generated with [Claude Code](https://claude.com/claude-code)