### PR TITLE
Fix grouped context expression parsing

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/ContextExpression.java
+++ b/liquibase-standard/src/main/java/liquibase/ContextExpression.java
@@ -74,10 +74,34 @@ public class ContextExpression {
         if (contexts == null) {
             return;
         }
-        for (String context : StringUtil.splitAndTrim(contexts, ",")) {
+        for (String context : splitAndTrimContextExpressions(contexts)) {
             this.contexts.add(context.toLowerCase());
         }
 
+    }
+
+    static List<String> splitAndTrimContextExpressions(String contexts) {
+        List<String> splitContexts = new ArrayList<>();
+        int parenthesesDepth = 0;
+        int start = 0;
+
+        for (int i = 0; i < contexts.length(); i++) {
+            char currentChar = contexts.charAt(i);
+            if (currentChar == '(') {
+                parenthesesDepth++;
+            } else if (currentChar == ')' && parenthesesDepth > 0) {
+                parenthesesDepth--;
+            } else if (currentChar == ',' && parenthesesDepth == 0) {
+                splitContexts.add(contexts.substring(start, i).trim());
+                start = i + 1;
+            }
+        }
+
+        splitContexts.add(contexts.substring(start).trim());
+        while (!splitContexts.isEmpty() && splitContexts.get(splitContexts.size() - 1).isEmpty()) {
+            splitContexts.remove(splitContexts.size() - 1);
+        }
+        return splitContexts;
     }
 
     public boolean add(String context) {
@@ -106,7 +130,7 @@ public class ContextExpression {
         // If there are required runtime contexts, we need to evaluate those match as well
         boolean noRequiredRuntime = runtimeContexts.getContexts()
                 .stream()
-                .noneMatch(context -> context.startsWith("@"));
+                .noneMatch(ContextExpression::isRequiredRuntimeContext);
 
         if (this.contexts.isEmpty() && noRequiredRuntime) {
             // Legacy behaviour: an empty context expression matches anything when no required
@@ -123,6 +147,14 @@ public class ContextExpression {
             }
         }
         return false;
+    }
+
+    private static boolean isRequiredRuntimeContext(String context) {
+        String normalizedContext = context.trim();
+        while (normalizedContext.startsWith("(")) {
+            normalizedContext = normalizedContext.substring(1).trim();
+        }
+        return normalizedContext.startsWith("@");
     }
 
     private boolean matches(String expression, Contexts runtimeContexts) {

--- a/liquibase-standard/src/main/java/liquibase/Contexts.java
+++ b/liquibase-standard/src/main/java/liquibase/Contexts.java
@@ -53,7 +53,7 @@ public class Contexts {
         if (contexts == null) {
             return;
         }
-        for (String context : StringUtil.splitAndTrim(contexts, ",")) {
+        for (String context : ContextExpression.splitAndTrimContextExpressions(contexts)) {
             this.contextStore.add(context.toLowerCase());
         }
 

--- a/liquibase-standard/src/test/java/liquibase/changelog/filter/ContextChangeSetFilterTest.java
+++ b/liquibase-standard/src/test/java/liquibase/changelog/filter/ContextChangeSetFilterTest.java
@@ -3,6 +3,7 @@ package liquibase.changelog.filter;
 import liquibase.ContextExpression;
 import liquibase.Contexts;
 import liquibase.changelog.ChangeSet;
+import liquibase.changelog.DatabaseChangeLog;
 import liquibase.database.Database;
 import liquibase.sql.visitor.AbstractSqlVisitor;
 import org.junit.Test;
@@ -155,6 +156,17 @@ public class ContextChangeSetFilterTest {
             assertTrue(filter.accepts(new ChangeSet(null, null, false, false, null, "test3, @TEST1", null, null)).isAccepted());
             assertTrue(filter.accepts(new ChangeSet(null, null, false, false, null, "@test3, @TEST1", null, null)).isAccepted());
         }
+    }
+
+    @Test
+    public void groupedInheritedContextDoesNotMatchChangesetContextByFragment() {
+        DatabaseChangeLog changeLog = new DatabaseChangeLog();
+        changeLog.setContextFilter(new ContextExpression("a,b,c"));
+
+        ChangeSet changeSet = new ChangeSet("1", "example", false, false, "test.xml", "a", null, changeLog);
+        ContextChangeSetFilter filter = new ContextChangeSetFilter(new Contexts("b"));
+
+        assertFalse(filter.accepts(changeSet).isAccepted());
     }
 
 


### PR DESCRIPTION
## Impact

* [x] Bug fix (non-breaking change which fixes expected existing functionality)
* [ ] Enhancement/New feature (adds functionality without impacting existing logic)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Fixes #7783.

This fixes grouped context expressions containing comma-separated values, such as `(a,b,c)`, being split into invalid fragments before expression matching.

Previously, context parsing split on every comma. That could split a grouped expression like `(a,b,c) AND a` into separate fragments such as `(a`, `b`, and `c) AND a`, allowing runtime context `b` to match incorrectly.

This changes context splitting to split only on commas at parenthesis depth zero, while preserving existing top-level comma-list behavior.

Changes:

* Added a regression test for inherited/root changelog context `a,b,c`, changeset context `a`, and runtime context filter `b`
* Made context splitting parenthesis-depth-aware
* Reused the same splitting logic for `ContextExpression` and `Contexts`
* Preserved required runtime context handling for grouped required contexts such as `(@test1, @test2)`

Testing:

```bash
./mvnw.cmd -pl liquibase-standard -Dtest=ContextChangeSetFilterTest test
```

Result:

```text
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

## Release note

Fixed grouped context expressions such as `(a,b,c)` so comma-separated values inside parentheses are evaluated correctly instead of being split into invalid context fragments.

## Things to be aware of

This change keeps existing top-level comma-list behavior while only preventing commas inside parentheses from being treated as top-level separators.

## Things to worry about

The change touches shared context parsing logic, so reviewers may want to confirm that existing context expression behavior remains compatible.

## Additional Context

This directly covers the reported case where a changelog-level context like `a,b,c` combined with a changeset context `a` could incorrectly allow runtime context `b` to match.
