### PR TITLE
TECHOPS-646: Pin step-level GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/auto-create-jira-on-merge.yml
+++ b/.github/workflows/auto-create-jira-on-merge.yml
@@ -57,20 +57,20 @@ jobs:
          (github.event.action == 'milestoned' && github.event.pull_request.merged == true)))
     steps:
       - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6
         with:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Get Jira service-account credentials from vault
-        uses: aws-actions/aws-secretsmanager-get-secrets@v3
+        uses: aws-actions/aws-secretsmanager-get-secrets@2cb1a461cbd4865ac4299648312e4704c646cd53 # v3
         with:
           secret-ids: |
             ,/vault/liquibase
           parse-json-secrets: true
 
       - name: Auto-create / update tickets
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           JIRA_BASE_URL: https://datical.atlassian.net
           JIRA_EMAIL: ${{ env.JIRA_USER }}

--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Invoke Create Release
         id: trigger-step
-        uses: liquibase/build-logic/.github/actions/dispatch-and-wait@main
+        uses: liquibase/build-logic/.github/actions/dispatch-and-wait@a220b5f9914de6995d944c33587da54d24088d64 # main
         with:
           workflow: create-release.yml
           ref: main
@@ -202,7 +202,7 @@ jobs:
           permission-actions: write
 
       - name: Trigger release-published-orchestrator workflow
-        uses: liquibase/build-logic/.github/actions/dispatch-and-wait@main
+        uses: liquibase/build-logic/.github/actions/dispatch-and-wait@a220b5f9914de6995d944c33587da54d24088d64 # main
         with:
           workflow: release-published-orchestrator.yml
           ref: main


### PR DESCRIPTION
## 📋 Overview
Pins **step-level** `uses:` references to full-length commit SHAs, per the enterprise Actions SHA-pinning policy. Tracked in [TECHOPS-646](https://datical.atlassian.net/browse/TECHOPS-646) (relates to [TECHOPS-81](https://datical.atlassian.net/browse/TECHOPS-81)).

Step-level action references are enforced by **"Require actions to be pinned to a full-length commit SHA"**; job-level reusable-workflow refs (`*.yml@main`) are exempt. These refs were still pinned to tags/branches and would fail once enforcement is enabled.

## 🔧 Changes
- Replaced tag/branch refs with the resolved full commit SHA.
- Original ref preserved as a trailing `# <ref>` comment.
- Only active (non-commented) step-level references changed.

## ✅ Testing
- SHAs resolved via the GitHub API against current tag/branch HEAD.
- Post-change verification confirmed no remaining unpinned step-level refs in the edited files.

## ⚠️ Notes
- No functional change: same action code, now immutably referenced.
- `dispatch-and-wait@main` is pinned to build-logic's current `main` HEAD and will need periodic bumps (Dependabot can manage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECHOPS-646]: https://datical.atlassian.net/browse/TECHOPS-646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TECHOPS-81]: https://datical.atlassian.net/browse/TECHOPS-81?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ