### PR TITLE
fix(TECHOPS-650): replace actions/cache with upload/download-artifact; simplify dry-run artifact scan

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -177,11 +177,12 @@ jobs:
           (cd re-version/out/ && zip liquibase-additional-${{ needs.setup.outputs.version }}.zip *)
           mv re-version/out/liquibase-additional-${{ needs.setup.outputs.version }}.zip re-version/final
 
-      - name: Cache Completed Artifacts
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Upload Completed Artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          key: completed-artifacts-${{ github.run_number }}-${{ github.run_attempt }}
+          name: completed-artifacts-${{ github.run_number }}-${{ github.run_attempt }}
           path: re-version/final
+          retention-days: 1
 
       - name: Set repository tags
         if: ${{ inputs.standalone_zip == false && inputs.dry_run == false }}
@@ -221,10 +222,10 @@ jobs:
             echo "GPG_EOF"
           } >> $GITHUB_ENV
 
-      - name: Restore Completed Artifacts
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Download Completed Artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          key: completed-artifacts-${{ github.run_number }}-${{ github.run_attempt }}
+          name: completed-artifacts-${{ github.run_number }}-${{ github.run_attempt }}
           path: re-version/final
 
        # https://github.com/actions/setup-java/tree/v4/?tab=readme-ov-file#install-multiple-jdks   

--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -26,24 +26,19 @@ jobs:
     steps:
       - name: Get run-tests.yml runId
         id: get_run_id
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Find the most recent run-tests.yml run on main that has a valid (non-expired) liquibase-artifacts artifact.
-          # We scan up to 20 recent runs regardless of conclusion, so a single unrelated failing job
+          # We scan up to 20 recent completed runs, so a single unrelated failing job
           # (e.g. test-harness dispatch) cannot starve the dry-run of fresh build artifacts.
-          response=$(curl -s \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/liquibase/liquibase/actions/workflows/run-tests.yml/runs?branch=main&per_page=20")
+          response=$(gh api "repos/${{ github.repository }}/actions/workflows/run-tests.yml/runs?branch=main&status=completed&per_page=20")
 
           run_id=""
           while IFS= read -r candidate_id; do
-            artifacts=$(curl -sf \
-              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-              -H "Accept: application/vnd.github.v3+json" \
-              "https://api.github.com/repos/liquibase/liquibase/actions/runs/${candidate_id}/artifacts") || continue
-            valid=$(echo "$artifacts" | jq -r '[.artifacts[] | select(.name == "liquibase-artifacts" and (.expired | not))] | length')
-            valid="${valid:-0}"
-            if [ "$valid" -gt 0 ]; then
+            valid=$(gh api "repos/${{ github.repository }}/actions/runs/${candidate_id}/artifacts" \
+              --jq 'any(.artifacts[]; .name == "liquibase-artifacts" and (.expired | not))') || continue
+            if [ "$valid" = "true" ]; then
               run_id="$candidate_id"
               echo "Found valid liquibase-artifacts in run-tests run $run_id"
               break
@@ -51,7 +46,7 @@ jobs:
           done < <(echo "$response" | jq -r '.workflow_runs[].id')
 
           if [ -z "$run_id" ]; then
-            echo "ERROR: No run-tests.yml run found with a valid liquibase-artifacts artifact in the last 20 runs on main"
+            echo "ERROR: No run-tests.yml run found with a valid liquibase-artifacts artifact in the last 20 completed runs on main"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

### `create-release.yml` — fix cache race (TECHOPS-650)
- `actions/cache` was used to transfer `re-version/final/` from the `reversion` job to `build-installers`. It is eventually-consistent — not a reliable inter-job transport. A 15-second save→restore window on identical code/version produced a HIT on 2026-06-03 and a MISS on 2026-06-17, failing every dry-run and production release with `tar: Cannot open: No such file or directory`.
- Replaced `Cache Completed Artifacts` (reversion job) with `actions/upload-artifact@043fb46d...` (v7.0.1) and `Restore Completed Artifacts` (build-installers job) with `actions/download-artifact@3e5f45b...` (v8.0.1). Both SHAs were already pinned in this file.
- `download-artifact` blocks until the named artifact is available, eliminating the race by design. Directory layout (`re-version/final/<file>`) is unchanged.

### `dry-run-release.yml` — simplify artifact-validity scan
- Replaced two `curl -s -H "Authorization: token ..."` calls with `gh api` + `GH_TOKEN` env var, matching the pattern already used in `installer-build-check.yml` and peers.
- Added `status=completed` to the runs query to skip in-progress runs that can't have stable artifacts.
- Dropped `valid="${valid:-0}"` (dead code — `jq length` never returns empty string).
- Collapsed `valid=$(... | length)` + numeric comparison into `gh api --jq 'any(...)'` + string compare against `"true"`.
- Used `${{ github.repository }}` instead of hardcoded `liquibase/liquibase`.

## Root cause context

The `create-release.yml` bug is a 4-year-old latent nondeterministic race in GitHub's cache backend (introduced 2022-03-25 by `41b1e2fcf`), not a recent regression. It was masked by TECHOPS-620 failures dying earlier in the pipeline; run `27695042493` (2026-06-17) was the first to reach `build-installers` since 06-03, surfacing it.

## Test Plan

**`create-release.yml` fix** — trigger directly on this branch (dry-run-release.yml dispatches create-release.yml with `ref: main`, so it won't exercise this change):
- [ ] `gh workflow run create-release.yml --ref TECHOPS-650 --field version=dry-run-test --field branch=main --field runId=<recent-run-tests-run-id> --field dry_run=true --field standalone_zip=false`
- [ ] `reversion` "Upload Completed Artifacts" succeeds
- [ ] `build-installers` "Download Completed Artifacts" populates `re-version/final/` (no "Cache not found")
- [ ] "Build Unsigned Windows Installer" opens the tar.gz successfully (was the failure point)
- [ ] Run 2-3x to confirm determinism

**`dry-run-release.yml` simplification** — trigger on this branch:
- [ ] `gh workflow run dry-run-release.yml --ref TECHOPS-650`
- [ ] "Get run-tests.yml runId" step logs `Found valid liquibase-artifacts in run-tests run <id>` and exits 0

Fixes: TECHOPS-650
Related: TECHOPS-620

🤖 Generated with [Claude Code](https://claude.com/claude-code)