### PR TITLE
fix: default-schema-name not working when runInTransaction is false

### DIFF
--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/SearchPathIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/SearchPathIntegrationTest.groovy
@@ -93,6 +93,47 @@ class SearchPathIntegrationTest extends Specification {
         } catch (Exception e) {}
     }
 
+    def "defaultSchemaName works when runInTransaction is false (#7791)"() {
+        given:
+        def customSchema = "concurrent_idx_" + System.currentTimeMillis()
+        def database = postgres.getDatabaseFromFactory()
+        def connection = database.getConnection()
+        connection.createStatement().execute("CREATE SCHEMA IF NOT EXISTS " + customSchema)
+        connection.commit()
+
+        when:
+        def resourceAccessor = new SearchPathResourceAccessor(".,target/test-classes")
+        def scopeSettings = [
+                (Scope.Attr.resourceAccessor.name()): resourceAccessor
+        ]
+        Scope.child(scopeSettings, {
+            CommandScope commandScope = new CommandScope(UpdateCommandStep.COMMAND_NAME)
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.URL_ARG, postgres.getConnectionUrl())
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.USERNAME_ARG, postgres.getUsername())
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.PASSWORD_ARG, postgres.getPassword())
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.DEFAULT_SCHEMA_NAME_ARG, customSchema)
+            commandScope.addArgumentValue(UpdateCommandStep.CHANGELOG_FILE_ARG, "changelogs/pgsql/update/default-schema-name-run-in-transaction-false.xml")
+            commandScope.execute()
+        } as Scope.ScopedRunner)
+
+        then:
+        noExceptionThrown()
+
+        // Verify the concurrent index was actually created in the custom schema
+        def rs = connection.createStatement().executeQuery("""
+            SELECT COUNT(*) FROM pg_indexes
+            WHERE schemaname = '${customSchema}'
+              AND indexname = 'idx_test_id'
+        """)
+        rs.next()
+        rs.getInt(1) == 1
+
+        cleanup:
+        try {
+            connection.createStatement().execute("DROP SCHEMA IF EXISTS " + customSchema + " CASCADE")
+        } catch (Exception e) {}
+    }
+
     def "SET LOCAL search_path reverts after transaction completes"() {
         given:
         def customSchema = "local_test_" + System.currentTimeMillis()

--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/SearchPathIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/SearchPathIntegrationTest.groovy
@@ -134,6 +134,58 @@ class SearchPathIntegrationTest extends Specification {
         } catch (Exception e) {}
     }
 
+    def "session-level search_path set for runInTransaction=false changeset is restored (#7791)"() {
+        given:
+        def customSchema = "restore_path_" + System.currentTimeMillis()
+        def database = postgres.getDatabaseFromFactory()
+        def connection = database.getConnection()
+        connection.createStatement().execute("CREATE SCHEMA IF NOT EXISTS " + customSchema)
+        connection.commit()
+        database.setDefaultSchemaName(customSchema)
+
+        when:
+        def resourceAccessor = new SearchPathResourceAccessor(".,target/test-classes")
+        def scopeSettings = [
+                (Scope.Attr.resourceAccessor.name()): resourceAccessor
+        ]
+        Scope.child(scopeSettings, {
+            CommandScope commandScope = new CommandScope(UpdateCommandStep.COMMAND_NAME)
+            // pass the database object so the search_path can be inspected on the same
+            // session the update ran on
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.DATABASE_ARG, database)
+            commandScope.addArgumentValue(UpdateCommandStep.CHANGELOG_FILE_ARG, "changelogs/pgsql/update/default-schema-name-run-in-transaction-false.xml")
+            commandScope.execute()
+        } as Scope.ScopedRunner)
+
+        // End any transaction left open by the update so transaction-scoped SET LOCAL values are
+        // discarded and SHOW reflects the session-level value the next pool client would inherit
+        connection.rollback()
+        def searchPathRs = connection.createStatement().executeQuery("SHOW SEARCH_PATH")
+        searchPathRs.next()
+        def currentSearchPath = searchPathRs.getString(1)
+
+        then:
+        noExceptionThrown()
+
+        // The concurrent index from the runInTransaction=false changeset was created in the custom schema
+        def rs = connection.createStatement().executeQuery("""
+            SELECT COUNT(*) FROM pg_indexes
+            WHERE schemaname = '${customSchema}'
+              AND indexname = 'idx_test_id'
+        """)
+        rs.next()
+        rs.getInt(1) == 1
+
+        // The session-level SET SEARCH_PATH issued for the runInTransaction=false changeset
+        // must not linger on the connection after the changeset completes
+        !currentSearchPath.contains(customSchema)
+
+        cleanup:
+        try {
+            connection.createStatement().execute("DROP SCHEMA IF EXISTS " + customSchema + " CASCADE")
+        } catch (Exception e) {}
+    }
+
     def "SET LOCAL search_path reverts after transaction completes"() {
         given:
         def customSchema = "local_test_" + System.currentTimeMillis()

--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/SearchPathIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/SearchPathIntegrationTest.groovy
@@ -131,6 +131,7 @@ class SearchPathIntegrationTest extends Specification {
         cleanup:
         try {
             connection.createStatement().execute("DROP SCHEMA IF EXISTS " + customSchema + " CASCADE")
+            connection.commit()
         } catch (Exception e) {}
     }
 
@@ -183,6 +184,7 @@ class SearchPathIntegrationTest extends Specification {
         cleanup:
         try {
             connection.createStatement().execute("DROP SCHEMA IF EXISTS " + customSchema + " CASCADE")
+            connection.commit()
         } catch (Exception e) {}
     }
 

--- a/liquibase-integration-tests/src/test/resources/changelogs/pgsql/update/default-schema-name-run-in-transaction-false.xml
+++ b/liquibase-integration-tests/src/test/resources/changelogs/pgsql/update/default-schema-name-run-in-transaction-false.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="create-test-table" author="test">
+        <createTable tableName="test_table">
+            <column name="id" type="int">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="data" type="varchar(255)"/>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="create-index-test-table" author="test" runInTransaction="false">
+        <sql>CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_test_id ON test_table (data)</sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeSet.java
@@ -15,6 +15,7 @@ import liquibase.configuration.LiquibaseConfiguration;
 import liquibase.database.Database;
 import liquibase.database.DatabaseList;
 import liquibase.database.ObjectQuotingStrategy;
+import liquibase.database.core.PostgresDatabase;
 import liquibase.exception.*;
 import liquibase.executor.Executor;
 import liquibase.executor.ExecutorService;
@@ -923,6 +924,7 @@ public class ChangeSet implements Conditional, ChangeLogChild {
             // restore auto-commit to false if this ChangeSet was not run in a transaction,
             // but only if the database supports DDL in transactions
             if (!runInTransaction && database.supportsDDLInTransaction()) {
+                restoreSearchPath(database);
                 try {
                     database.setAutoCommit(false);
                 } catch (DatabaseException e) {
@@ -1089,6 +1091,7 @@ public class ChangeSet implements Conditional, ChangeLogChild {
             // but only if the database supports DDL in transactions
             getCurrentScope().getSingleton(ExecutorService.class).setExecutor("jdbc", database, originalExecutor);
             if (!runInTransaction && database.supportsDDLInTransaction()) {
+                restoreSearchPath(database);
                 try {
                     database.setAutoCommit(false);
                 } catch (DatabaseException e) {
@@ -1097,6 +1100,16 @@ public class ChangeSet implements Conditional, ChangeLogChild {
             }
         }
 
+    }
+
+    private void restoreSearchPath(Database database) {
+        if (database instanceof PostgresDatabase pgDatabase) {
+            try {
+                pgDatabase.restoreSearchPath();
+            } catch (DatabaseException e) {
+                getCurrentScope().getLog(getClass()).warning("Could not restore search_path", e);
+            }
+        }
     }
 
     private void addSqlFileMdc(SQLFileChange change) {

--- a/liquibase-standard/src/main/java/liquibase/database/core/DatabaseUtils.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/DatabaseUtils.java
@@ -10,6 +10,7 @@ import liquibase.executor.ExecutorService;
 import liquibase.statement.core.RawParameterizedSqlStatement;
 import liquibase.structure.core.Schema;
 import liquibase.util.StringUtil;
+import org.apache.commons.lang3.StringUtils;
 
 public class DatabaseUtils {
     /**
@@ -50,7 +51,7 @@ public class DatabaseUtils {
                         finalSearchPath = defaultSchemaName;
                     }
 
-                    if (StringUtil.isNotEmpty(searchPath)) {
+                    if (StringUtils.isNotEmpty(searchPath)) {
                         //If existing search path entries are not quoted, quote them. Some databases do not show them as quoted even though they need to be (like $user or case sensitive schemas)
                         finalSearchPath += ", " + StringUtil.join(StringUtil.splitAndTrim(searchPath, ","), ",", (StringUtil.StringUtilFormatter<String>) obj -> {
                             if (obj.startsWith("\"")) {
@@ -60,7 +61,8 @@ public class DatabaseUtils {
                         });
                     }
 
-                    executor.execute(new RawParameterizedSqlStatement(String.format("SET LOCAL SEARCH_PATH TO %s", finalSearchPath)));
+                    String setSearchPathSql = isInTransaction(database) ? "SET LOCAL SEARCH_PATH TO %s" : "SET SEARCH_PATH TO %s";
+                    executor.execute(new RawParameterizedSqlStatement(String.format(setSearchPathSql, finalSearchPath)));
                 }
 
             } else if (database instanceof AbstractDb2Database) {
@@ -76,11 +78,19 @@ public class DatabaseUtils {
                 }
                 executor.execute(new RawParameterizedSqlStatement(String.format("USE %s", schema)));
             } else if (database instanceof MSSQLDatabase) {
-                    defaultCatalogName = StringUtil.trimToNull(defaultCatalogName);
-                    if (defaultCatalogName != null) {
-                        executor.execute(new RawParameterizedSqlStatement(String.format("USE %s", defaultCatalogName)));
-                    }
+                defaultCatalogName = StringUtils.trimToNull(defaultCatalogName);
+                if (defaultCatalogName != null) {
+                    executor.execute(new RawParameterizedSqlStatement(String.format("USE %s", defaultCatalogName)));
+                }
             }
+        }
+    }
+
+    private static boolean isInTransaction(Database database) {
+        try {
+            return !database.isAutoCommit();
+        } catch (DatabaseException e) {
+            return true;
         }
     }
 
@@ -90,10 +100,10 @@ public class DatabaseUtils {
      */
     public static String buildCatalogAndSchemaString(String catalog, String schema) {
         String info = "";
-        if (StringUtil.isNotEmpty(catalog)) {
+        if (StringUtils.isNotEmpty(catalog)) {
             info += catalog;
         }
-        if (StringUtil.isNotEmpty(schema)) {
+        if (StringUtils.isNotEmpty(schema)) {
             if (!info.endsWith(".")) {
                 info += ".";
             }

--- a/liquibase-standard/src/main/java/liquibase/database/core/DatabaseUtils.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/DatabaseUtils.java
@@ -37,7 +37,7 @@ public class DatabaseUtils {
                 }
                 executor.execute(
                         new RawParameterizedSqlStatement(String.format("ALTER SESSION SET CURRENT_SCHEMA=%s", database.escapeObjectName(schema, Schema.class))));
-            } else if (database instanceof PostgresDatabase && defaultSchemaName != null) {
+            } else if (database instanceof PostgresDatabase pgDataBase && defaultSchemaName != null) {
                 String searchPath = executor.queryForObject(new RawParameterizedSqlStatement("SHOW SEARCH_PATH"), String.class);
 
                 if (!searchPath.equals(defaultCatalogName) && !searchPath.equals(defaultSchemaName) && !searchPath.equals("\"" + defaultSchemaName + "\"") && !searchPath.startsWith(defaultSchemaName + ",") && !searchPath.startsWith("\"" + defaultSchemaName + "\",")) {
@@ -46,23 +46,31 @@ public class DatabaseUtils {
                     //
                     String finalSearchPath;
                     if (Boolean.TRUE.equals(GlobalConfiguration.PRESERVE_SCHEMA_CASE.getCurrentValue()) || defaultSchemaName.contains("@")) {
-                        finalSearchPath = ((PostgresDatabase) database).quoteObject(defaultSchemaName, Schema.class);
+                        finalSearchPath = pgDataBase.quoteObject(defaultSchemaName, Schema.class);
                     } else {
                         finalSearchPath = defaultSchemaName;
                     }
 
+                    String quotedSearchPath = null;
                     if (StringUtils.isNotEmpty(searchPath)) {
                         //If existing search path entries are not quoted, quote them. Some databases do not show them as quoted even though they need to be (like $user or case sensitive schemas)
-                        finalSearchPath += ", " + StringUtil.join(StringUtil.splitAndTrim(searchPath, ","), ",", (StringUtil.StringUtilFormatter<String>) obj -> {
+                        quotedSearchPath = StringUtil.join(StringUtil.splitAndTrim(searchPath, ","), ",", (StringUtil.StringUtilFormatter<String>) obj -> {
                             if (obj.startsWith("\"")) {
                                 return obj;
                             }
-                            return ((PostgresDatabase) database).quoteObject(obj, Schema.class);
+                            return pgDataBase.quoteObject(obj, Schema.class);
                         });
+                        finalSearchPath += ", " + quotedSearchPath;
                     }
 
-                    String setSearchPathSql = isInTransaction(database) ? "SET LOCAL SEARCH_PATH TO %s" : "SET SEARCH_PATH TO %s";
-                    executor.execute(new RawParameterizedSqlStatement(String.format(setSearchPathSql, finalSearchPath)));
+                    if (isInTransaction(database)) {
+                        executor.execute(new RawParameterizedSqlStatement(String.format("SET LOCAL SEARCH_PATH TO %s", finalSearchPath)));
+                    } else {
+                        if (quotedSearchPath != null) {
+                            pgDataBase.saveSearchPath(quotedSearchPath);
+                        }
+                        executor.execute(new RawParameterizedSqlStatement(String.format("SET SEARCH_PATH TO %s", finalSearchPath)));
+                    }
                 }
 
             } else if (database instanceof AbstractDb2Database) {

--- a/liquibase-standard/src/main/java/liquibase/database/core/PostgresDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/PostgresDatabase.java
@@ -8,8 +8,6 @@ import liquibase.exception.DatabaseException;
 import liquibase.executor.Executor;
 import liquibase.executor.ExecutorService;
 import liquibase.logging.Logger;
-import liquibase.statement.SqlStatement;
-import liquibase.statement.core.RawCallStatement;
 import liquibase.statement.core.RawParameterizedSqlStatement;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.Catalog;

--- a/liquibase-standard/src/main/java/liquibase/database/core/PostgresDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/PostgresDatabase.java
@@ -50,10 +50,6 @@ public class PostgresDatabase extends AbstractPostgresDatabase {
     private static final int PGSQL_DEFAULT_TCP_PORT_NUMBER = 5432;
     private static final Logger LOG = Scope.getCurrentScope().getLog(PostgresDatabase.class);
 
-    private final Set<String> systemTablesAndViews = new HashSet<>();
-
-    private final Set<String> reservedWords = new HashSet<>();
-
     /**
      * The search_path in effect before it was changed session-level for a runInTransaction="false"
      * changeset, or null if no restore is pending. See {@link #restoreSearchPath()}.
@@ -292,14 +288,6 @@ public class PostgresDatabase extends AbstractPostgresDatabase {
         Executor executor = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", this);
         executor.execute(new RawParameterizedSqlStatement(String.format("SET SEARCH_PATH TO %s", searchPathToRestore)));
         searchPathToRestore = null;
-    }
-
-    @Override
-    public void setDefaultCatalogName(String defaultCatalogName) {
-        if (StringUtils.isNotEmpty(defaultCatalogName)) {
-            Scope.getCurrentScope().getUI().sendMessage("WARNING: Postgres does not support catalogs, so the values set in 'defaultCatalogName' and 'referenceDefaultCatalogName' will be ignored.");
-        }
-        super.setDefaultCatalogName(defaultCatalogName);
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/database/core/PostgresDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/PostgresDatabase.java
@@ -14,6 +14,7 @@ import liquibase.executor.ExecutorService;
 import liquibase.logging.Logger;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.RawCallStatement;
+import liquibase.statement.core.RawParameterizedSqlStatement;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.Catalog;
 import liquibase.structure.core.Schema;
@@ -56,6 +57,12 @@ public class PostgresDatabase extends AbstractJdbcDatabase {
     private final Set<String> systemTablesAndViews = new HashSet<>();
 
     private final Set<String> reservedWords = new HashSet<>();
+
+    /**
+     * The search_path in effect before it was changed session-level for a runInTransaction="false"
+     * changeset, or null if no restore is pending. See {@link #restoreSearchPath()}.
+     */
+    private String searchPathToRestore;
 
     public PostgresDatabase() {
         super.setCurrentDateTimeFunction("NOW()");
@@ -420,9 +427,24 @@ public class PostgresDatabase extends AbstractJdbcDatabase {
         }
     }
 
+    public void saveSearchPath(String searchPath) {
+        if (this.searchPathToRestore == null) {
+            this.searchPathToRestore = searchPath;
+        }
+    }
+
+    public void restoreSearchPath() throws DatabaseException {
+        if (searchPathToRestore == null) {
+            return;
+        }
+        Executor executor = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", this);
+        executor.execute(new RawParameterizedSqlStatement(String.format("SET SEARCH_PATH TO %s", searchPathToRestore)));
+        searchPathToRestore = null;
+    }
+
     @Override
     public void setDefaultCatalogName(String defaultCatalogName) {
-        if (StringUtil.isNotEmpty(defaultCatalogName)) {
+        if (StringUtils.isNotEmpty(defaultCatalogName)) {
             Scope.getCurrentScope().getUI().sendMessage("WARNING: Postgres does not support catalogs, so the values set in 'defaultCatalogName' and 'referenceDefaultCatalogName' will be ignored.");
         }
         super.setDefaultCatalogName(defaultCatalogName);


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description
Only apply `LOCAL` to `SEARCH_PATH` when not running in transaction. Fixes default-schema-name when changelog not running in transaction 

## Release note
Fixed defaultSchemaName not applying to runInTransaction=false changesets

## Things to be aware of
First time committer to Liquibase; not sure about the `isInTransaction` and the fallback to `true`.

## Additional Context
Introduced by #7488
Closes #7791
