### PR TITLE
[DAT-23022] Unconditional XXE hardening in XMLChangeLogSAXParser

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/parser/core/xml/XMLChangeLogSAXParser.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/core/xml/XMLChangeLogSAXParser.java
@@ -42,19 +42,28 @@ public class XMLChangeLogSAXParser extends AbstractChangeLogParser {
         saxParserFactory = SAXParserFactory.newInstance();
         saxParserFactory.setValidating(GlobalConfiguration.VALIDATE_XML_CHANGELOG_FILES.getCurrentValue());
         saxParserFactory.setNamespaceAware(true);
+        // Unconditional XXE hardening — Liquibase changelogs validate against XSD, not DTD,
+        // so DOCTYPE has no legitimate use. Applied regardless of secureParsing to provide
+        // defense-in-depth even when users opt out of secure mode.
+        trySetFactoryFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        trySetFactoryFeature("http://xml.org/sax/features/external-general-entities", false);
+        trySetFactoryFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        trySetFactoryFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
         if (GlobalConfiguration.SECURE_PARSING.getCurrentValue()) {
             try {
                 saxParserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             } catch (Throwable e) {
                 Scope.getCurrentScope().getLog(getClass()).fine("Cannot enable FEATURE_SECURE_PROCESSING: " + e.getMessage(), e);
             }
-            try {
-                // Changelogs are validated against XSD, not DTD. DOCTYPE has no legitimate use here;
-                // disabling it eliminates XXE entity-expansion as an attack surface.
-                saxParserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            } catch (Throwable e) {
-                Scope.getCurrentScope().getLog(getClass()).fine("Cannot enable disallow-doctype-decl: " + e.getMessage(), e);
-            }
+        }
+    }
+
+    private void trySetFactoryFeature(String feature, boolean value) {
+        try {
+            saxParserFactory.setFeature(feature, value);
+        } catch (Throwable e) {
+            Scope.getCurrentScope().getLog(getClass()).fine(
+                    "Cannot set SAX parser factory feature " + feature + "=" + value + ": " + e.getMessage(), e);
         }
     }
 
@@ -144,6 +153,12 @@ public class XMLChangeLogSAXParser extends AbstractChangeLogParser {
             throw new ChangeLogParseException("Error Reading Changelog File: " + e.getMessage(), e);
         } catch (SAXParseException e) {
             String errMsg = e.getMessage();
+            if (errMsg != null && errMsg.contains("DOCTYPE")) {
+                throw new ChangeLogParseException(
+                        "Changelog '" + physicalChangeLogLocation + "' contains a DOCTYPE declaration, which is not supported. " +
+                        "Liquibase changelogs validate against XSD schemas and do not support DOCTYPE/DTD declarations. " +
+                        "Remove the <!DOCTYPE> block from your changelog.", e);
+            }
             try {
                 Boolean isDatabaseChangeLogRootElement = isDatabaseChangeLogTagTheFirstElement(physicalChangeLogLocation, resourceAccessor);
                 if (isDatabaseChangeLogRootElement != null && !isDatabaseChangeLogRootElement) {

--- a/liquibase-standard/src/test/groovy/liquibase/parser/core/xml/XMLChangeLogSAXParserTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/parser/core/xml/XMLChangeLogSAXParserTest.groovy
@@ -113,13 +113,9 @@ class XMLChangeLogSAXParserTest extends Specification {
         new XMLChangeLogSAXParser().parse("com/example/insecure.xml", new ChangeLogParameters(), resourceAccessor)
 
         then:
-        // Under SECURE_PARSING=true the parser now rejects DOCTYPE declarations outright
-        // (defense in depth on top of the LiquibaseEntityResolver's remote-lookup block).
-        // JAXP wording is stable across recent JDKs but assertion is intentionally
-        // loose against the keywords to survive future parser-version changes.
         def e = thrown(ChangeLogParseException)
         e.message.contains("DOCTYPE")
-        e.message.contains("disallow")
+        e.message.contains("not supported")
     }
 
     def "DOCTYPE with path-traversal entity SYSTEM URI is rejected"() {
@@ -134,16 +130,12 @@ class XMLChangeLogSAXParserTest extends Specification {
         new XMLChangeLogSAXParser().parse("com/example/xxe.xml", new ChangeLogParameters(), resourceAccessor)
 
         then:
-        // DOCTYPE rejection fires before entity expansion, so the path-traversal
-        // entity URI never reaches the (now-confined) AbstractPathResourceAccessor.
-        // Both defences are exercised: this test for DOCTYPE rejection,
-        // DirectoryResourceAccessorTest for accessor containment.
         def e = thrown(ChangeLogParseException)
         e.message.contains("DOCTYPE")
-        e.message.contains("disallow")
+        e.message.contains("not supported")
     }
 
-    def "allows liquibase.secureParsing=false to disable secure parsing"() {
+    def "DOCTYPE is rejected unconditionally even when secureParsing=false"() {
         when:
         def resourceAccessor = new MockResourceAccessor(["com/example/insecure.xml": INSECURE_XML])
 
@@ -151,10 +143,12 @@ class XMLChangeLogSAXParserTest extends Specification {
             new XMLChangeLogSAXParser().parse("com/example/insecure.xml", new ChangeLogParameters(), resourceAccessor)
         })
 
-
         then:
+        // disallow-doctype-decl is unconditional — DOCTYPE is blocked before entity resolution
+        // even when secureParsing=false, so the file-system entity URI is never reached.
         def e = thrown(ChangeLogParseException)
-        e.message.contains("Error Reading Changelog File: " + File.separator + "invalid.txt")
+        e.message.contains("DOCTYPE")
+        e.message.contains("not supported")
     }
 
     def "by default validate XML file based on XSD files"() {


### PR DESCRIPTION
## Summary

- **`XMLChangeLogSAXParser.java`**: Moves `disallow-doctype-decl` out of the `secureParsing` guard and adds three additional XXE-hardening features (`external-general-entities=false`, `external-parameter-entities=false`, `load-external-dtd=false`) unconditionally. Introduces a private `trySetFactoryFeature` helper to keep each feature attempt independent. `FEATURE_SECURE_PROCESSING` remains `secureParsing`-gated (schema loading restriction, not entity-expansion surface). Intercepts `SAXParseException` caused by DOCTYPE and throws a clear `ChangeLogParseException` explaining that DOCTYPE/DTD is not supported and the block should be removed.
- **`XMLChangeLogSAXParserTest.groovy`**: Updates the `"allows secureParsing=false"` test — previously it asserted that the entity resolver was reached (file-system open of `invalid.txt`); after the fix `disallow-doctype-decl` fires first, so the assertion now checks for the DOCTYPE rejection message. Updates all three DOCTYPE test assertions from the raw Xerces `"disallow"` keyword to the new user-facing `"not supported"` message.

## Why

When `LIQUIBASE_SECURE_PARSING=false`, all four explicit XXE features were previously skipped. `LiquibaseEntityResolver` would return `null` on any entity-resolution miss, causing the SAX parser to fall through to network/filesystem fetching — enabling classic XXE and SSRF (DAT-23022 / Sec-Audit B8).

Changelogs validate against XSD, not DTD; `<!DOCTYPE>` has no legitimate use here. The four features are now applied regardless of `secureParsing` to provide defence-in-depth even when users opt out of secure mode for compatibility reasons.

## Test plan

- [x] `XMLChangeLogSAXParserTest` — 16 tests pass, including the renamed regression test `"DOCTYPE is rejected unconditionally even when secureParsing=false"`
- [x] `LiquibaseEntityResolverTest` — 28 tests pass unchanged (entity resolver behaviour for XSD schema lookups is unaffected)
- [x] Full build with all tests executed successfully

## Related

- Parent epic: DAT-23006 (Security Audit: Credential Handling and Changelog Injection)
- Related chain ticket: DAT-23029 (XXE via Search-Path Plant — depends on B6+B8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Related Ticket:** [DAT-23022](https://datical.atlassian.net/browse/DAT-23022)

[DAT-23022]: https://datical.atlassian.net/browse/DAT-23022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ