### PR TITLE
TECHOPS-683: Skip Claude Code Review on forked PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,7 +19,10 @@ permissions:
 
 jobs:
   claude-review:
-    if: ${{ !endsWith(github.actor, '[bot]') }}
+    # Skip PRs from forks: GitHub withholds secrets and downgrades id-token to
+    # read-only for fork-triggered pull_request runs, so the vault/OIDC auth step
+    # cannot succeed and the job fails instead of reviewing (TECHOPS-683).
+    if: ${{ !endsWith(github.actor, '[bot]') && github.event.pull_request.head.repo.full_name == github.repository }}
     uses: liquibase/build-logic/.github/workflows/claude-code-review.yml@main
     permissions:
       contents: read


### PR DESCRIPTION
## What

Skip the **Claude Code Review** job for pull requests opened from forks.

```yaml
if: ${{ !endsWith(github.actor, '[bot]') && github.event.pull_request.head.repo.full_name == github.repository }}
```

## Why

Fork-triggered `pull_request` runs do not receive repository secrets and have `id-token` downgraded to read-only. The reusable workflow's `Configure AWS credentials for vault access` step (OIDC → vault) therefore cannot authenticate, so the job fails with `Could not load credentials from any providers` on **every community PR**.

This is the failure tracked in [TECHOPS-683](https://datical.atlassian.net/browse/TECHOPS-683). Running the review on forks isn't viable safely (it would require `pull_request_target` executing untrusted code with full secrets + write token), so the sanctioned fallback is to skip rather than fail.

Example failing run: https://github.com/liquibase/liquibase/actions/runs/27845492342 (PR #7566, from fork `jstastny`).

## Behavior after this change

| PR source | Before | After |
|---|---|---|
| Fork / community PR | ❌ job fails at vault auth | ⏭️ job skipped (no failure, no API cost) |
| Internal branch PR (same repo) | ✅ review runs | ✅ review runs (unchanged) |

`claude-review` is **not** a required status check (the `main` ruleset only requires `mergefreeze`), so skipping does not block or stall any PR.

## Scope

Scoped to the `liquibase/liquibase` caller workflow. Other repos that call `build-logic`'s reusable `claude-code-review.yml` will still hit the same fork failure; a central fix in build-logic would be the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[TECHOPS-683]: https://datical.atlassian.net/browse/TECHOPS-683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ