### PR TITLE
fix: emit valid timestamp with time zone syntax

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/datatype/core/TimestampType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/TimestampType.java
@@ -155,21 +155,15 @@ public class TimestampType extends DateTimeType {
             type = new DatabaseDataType("TIMESTAMP");
         }
 
-        if ((originalDefinition.toUpperCase().startsWith("JAVA.SQL.TYPES.TIMESTAMP_WITH_TIMEZONE")
+        if (isTimezoneAware
             && (database instanceof AbstractPostgresDatabase
             || database instanceof OracleDatabase
             || database instanceof H2Database
             || database instanceof HsqlDatabase
-            || database instanceof SybaseASADatabase)) || isTimezoneAware) {
+            || database instanceof SybaseASADatabase)) {
 
-            if (database instanceof AbstractPostgresDatabase
-                    || database instanceof H2Database
-                    || database instanceof SybaseASADatabase
-                    || database instanceof OracleDatabase) {
-                type.addAdditionalInformation("WITH TIME ZONE");
-            } else {
-                type.addAdditionalInformation("WITH TIMEZONE");
-            }
+            type.addAdditionalInformation("WITH TIME ZONE");
+
             return type;
         }
 

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/TimestampType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/TimestampType.java
@@ -160,7 +160,7 @@ public class TimestampType extends DateTimeType {
             || database instanceof OracleDatabase
             || database instanceof H2Database
             || database instanceof HsqlDatabase
-            || database instanceof SybaseASADatabase)) || (originalDefinition.toLowerCase().startsWith("timestamptz"))) {
+            || database instanceof SybaseASADatabase)) || isTimezoneAware) {
 
             if (database instanceof AbstractPostgresDatabase
                     || database instanceof H2Database

--- a/liquibase-standard/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
@@ -304,6 +304,8 @@ class DataTypeFactoryTest extends Specification {
         "timestamptz"                                  | new DerbyDatabase()    | "TIMESTAMP"                                    | TimestampType | false
         "timestamp"                                    | new HsqlDatabase()     | "TIMESTAMP"                                    | TimestampType | false
         "timestamptz"                                  | new HsqlDatabase()     | "TIMESTAMP WITH TIME ZONE"                     | TimestampType | false
+        "TIMESTAMP WITH TIMEZONE"                      | new HsqlDatabase()     | "TIMESTAMP WITH TIME ZONE"                     | TimestampType | false
+        "timestamptz"                                  | new InformixDatabase() | "DATETIME YEAR TO FRACTION(5)"                 | TimestampType | false
     }
 
     @Unroll("#featureName: #object for #database")

--- a/liquibase-standard/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
@@ -299,6 +299,11 @@ class DataTypeFactoryTest extends Specification {
         "uuid"                                         | new MariaDBDatabase()  | "UUID"                                         | UUIDType      | false
         "timestamp"                                    | new FirebirdDatabase() | "TIMESTAMP"                                    | TimestampType | false
         "timestamp(6)"                                 | new FirebirdDatabase() | "TIMESTAMP"                                    | TimestampType | false
+        "timestamptz"                                  | new FirebirdDatabase() | "TIMESTAMP"                                    | TimestampType | false
+        "timestamp"                                    | new DerbyDatabase()    | "TIMESTAMP"                                    | TimestampType | false
+        "timestamptz"                                  | new DerbyDatabase()    | "TIMESTAMP"                                    | TimestampType | false
+        "timestamp"                                    | new HsqlDatabase()     | "TIMESTAMP"                                    | TimestampType | false
+        "timestamptz"                                  | new HsqlDatabase()     | "TIMESTAMP WITH TIME ZONE"                     | TimestampType | false
     }
 
     @Unroll("#featureName: #object for #database")

--- a/liquibase-standard/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
@@ -237,9 +237,9 @@ class DataTypeFactoryTest extends Specification {
         "xmltype"                                      | new OracleDatabase()   | "XMLTYPE"                                      | XMLType       | false
         "timestamp"                                    | new OracleDatabase()   | "TIMESTAMP"                                    | TimestampType | false
         "timestamp(6)"                                 | new OracleDatabase()   | "TIMESTAMP(6)"                                 | TimestampType | false
-        "TIMESTAMP WITH TIMEZONE"                      | new OracleDatabase()   | "TIMESTAMP WITH TIME ZONE"                     | TimestampType | false
-        "TIMESTAMP(6) WITH TIMEZONE"                   | new OracleDatabase()   | "TIMESTAMP(6) WITH TIME ZONE"                  | TimestampType | false
-        "TIMESTAMP(6) WITH TIMEZONE(13)"               | new OracleDatabase()   | "TIMESTAMP(6) WITH TIME ZONE"                  | TimestampType | false
+        "TIMESTAMP WITH TIME ZONE"                     | new OracleDatabase()   | "TIMESTAMP WITH TIME ZONE"                     | TimestampType | false
+        "TIMESTAMP(6) WITH TIME ZONE"                  | new OracleDatabase()   | "TIMESTAMP(6) WITH TIME ZONE"                  | TimestampType | false
+        "TIMESTAMP(6) WITH TIME ZONE(13)"              | new OracleDatabase()   | "TIMESTAMP(6) WITH TIME ZONE"                  | TimestampType | false
         "timestamp without timezone"                   | new OracleDatabase()   | "TIMESTAMP"                                    | TimestampType | false
         "timestamp(6) without timezone"                | new OracleDatabase()   | "TIMESTAMP(6)"                                 | TimestampType | false
         "timestamptz"                                  | new OracleDatabase()   | "TIMESTAMP WITH TIME ZONE"                     | TimestampType | false

--- a/liquibase-standard/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
@@ -237,6 +237,8 @@ class DataTypeFactoryTest extends Specification {
         "xmltype"                                      | new OracleDatabase()   | "XMLTYPE"                                      | XMLType       | false
         "timestamp"                                    | new OracleDatabase()   | "TIMESTAMP"                                    | TimestampType | false
         "timestamp(6)"                                 | new OracleDatabase()   | "TIMESTAMP(6)"                                 | TimestampType | false
+        "TIMESTAMP WITH TIMEZONE"                      | new OracleDatabase()   | "TIMESTAMP WITH TIME ZONE"                     | TimestampType | false
+        "TIMESTAMP(6) WITH TIMEZONE"                   | new OracleDatabase()   | "TIMESTAMP(6) WITH TIME ZONE"                  | TimestampType | false
         "TIMESTAMP WITH TIME ZONE"                     | new OracleDatabase()   | "TIMESTAMP WITH TIME ZONE"                     | TimestampType | false
         "TIMESTAMP(6) WITH TIME ZONE"                  | new OracleDatabase()   | "TIMESTAMP(6) WITH TIME ZONE"                  | TimestampType | false
         "TIMESTAMP(6) WITH TIME ZONE(13)"              | new OracleDatabase()   | "TIMESTAMP(6) WITH TIME ZONE"                  | TimestampType | false

--- a/liquibase-standard/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/datatype/DataTypeFactoryTest.groovy
@@ -239,6 +239,7 @@ class DataTypeFactoryTest extends Specification {
         "timestamp(6)"                                 | new OracleDatabase()   | "TIMESTAMP(6)"                                 | TimestampType | false
         "TIMESTAMP WITH TIMEZONE"                      | new OracleDatabase()   | "TIMESTAMP WITH TIME ZONE"                     | TimestampType | false
         "TIMESTAMP(6) WITH TIMEZONE"                   | new OracleDatabase()   | "TIMESTAMP(6) WITH TIME ZONE"                  | TimestampType | false
+        "TIMESTAMP(6) WITH TIMEZONE(13)"               | new OracleDatabase()   | "TIMESTAMP(6) WITH TIME ZONE"                  | TimestampType | false
         "timestamp without timezone"                   | new OracleDatabase()   | "TIMESTAMP"                                    | TimestampType | false
         "timestamp(6) without timezone"                | new OracleDatabase()   | "TIMESTAMP(6)"                                 | TimestampType | false
         "timestamptz"                                  | new OracleDatabase()   | "TIMESTAMP WITH TIME ZONE"                     | TimestampType | false


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->

## Description

With PR #6929 the datatype "TIMESTAMP WITH TIMEZONE" is not captured any more. The reason is two-fold:

1. Oracle reports the datatype as "TIMESTAMP(6) WITH TIME ZONE(13)" with an additional data size at the end.
2. The above change was actually checking whether the type contains the string "WITH TIMEZONE", but the result stored to local variable `isTimezoneAware` was not used.

This patch makes use of the variable `isTimezoneAware` and adds a test case for the Oracle column type "TIMESTAMP(6) WITH TIME ZONE(13)".

## Release note

<!--
RECOMMENDED — one or two sentences for customers. What's better now from
the user's perspective? Plain language, no implementation detail.

Examples:
  ✓ "Aurora Serverless v2 is now a first-class target — add
     `db: aurora-serverless-v2` to liquibase.properties, no driver
     path needed."
  ✓ "Fixed a regression where the diff command silently dropped
     UNIQUE constraints on Oracle databases."
  ✗ "Refactored DatabaseFactory to use the new SPI loader." (too internal)

Where this goes: on merge, an auto-created Jira ticket (TECHOPS-497)
lands in the docs-review queue with this text. Empty → docs sees
`[Release note needed]` and will chase you to fill it in.

Not customer-facing (CI, internal refactor, dep bump)? Leave this blank
AND apply the `skipReleaseNotes` label — no ticket gets created.

Convention: https://github.com/liquibase/liquibase-infrastructure/blob/main/jira/docs/description-conventions.md
-->


## Things to be aware of

<!--
- Describe the technical choices you made
- Describe impacts on the codebase
-->

## Things to worry about

<!--
- List any questions or concerns you have with the change
- List unknowns you have 
-->

## Additional Context

<!--
Add any other context about the problem here.
-->
