### PR TITLE
fix(snapshot): close owning Statement in ResultSetCache.extract to prevent JDBC Statement leak

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/snapshot/ResultSetCache.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/ResultSetCache.java
@@ -16,6 +16,7 @@ import liquibase.util.StringUtil;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -317,7 +318,19 @@ public class ResultSetCache {
                     returnList.add(new CachedRow(row));
                 }
             } finally {
-                JdbcUtil.closeResultSet(resultSet);
+                // This ResultSet is often obtained directly from a DatabaseMetaData call
+                // (e.g. getColumns/getTables/getImportedKeys), so the caller keeps no reference
+                // to the Statement that produced it. Closing the ResultSet alone leaks that
+                // Statement until the connection is closed (see #7780), so close its owning
+                // Statement too. getStatement() may legitimately return null for such ResultSets
+                // per the JDBC spec, which JdbcUtil.close handles.
+                Statement statement = null;
+                try {
+                    statement = resultSet.getStatement();
+                } catch (SQLException ignored) {
+                    // Some drivers may not support getStatement() here; fall back to closing the ResultSet only.
+                }
+                JdbcUtil.close(resultSet, statement);
             }
             return returnList;
         }

--- a/liquibase-standard/src/test/java/liquibase/snapshot/ResultSetCacheTest.java
+++ b/liquibase-standard/src/test/java/liquibase/snapshot/ResultSetCacheTest.java
@@ -1,32 +1,64 @@
 package liquibase.snapshot;
 
+import liquibase.database.Database;
+import org.junit.jupiter.api.Test;
+
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 public class ResultSetCacheTest {
 
-//    @Test
-//    public void permutations() {
-//        assertEquals(4, new ResultSetCache().permutations(new String[]{"a", "b"}).length);
-//        assertEquals(8, new ResultSetCache().permutations(new String[]{"a", "b", "c"}).length);
-//        assertEquals(16, new ResultSetCache().permutations(new String[]{"a", "b", "c", "d"}).length);
-//        assertEquals(32, new ResultSetCache().permutations(new String[]{"a", "b", "c", "d", "e"}).length);
-//
-//        assertThat(Arrays.asList(new ResultSetCache().permutations(new String[]{"a"})), containsInAnyOrder(new String[] {"a"}, new String[] {null}));
-//
-//        assertThat(Arrays.asList(new ResultSetCache().permutations(new String[]{"a", "b"})), containsInAnyOrder(
-//                new String[]{"a", "b"},
-//                new String[]{null, "b"},
-//                new String[]{"a", null},
-//                new String[]{null, null}
-//        ));
-//
-//        assertThat(Arrays.asList(new ResultSetCache().permutations(new String[]{"a", "b", "c"})), containsInAnyOrder(
-//                new String[]{"a", "b", "c"},
-//                new String[]{"a", "b", null},
-//                new String[]{"a", null, "c"},
-//                new String[]{null, "b", "c"},
-//                new String[]{null, null, "c"},
-//                new String[]{"a", null, null},
-//                new String[]{null, "b", null},
-//                new String[]{null, null, null}
-//        ));
-//    }
+    /**
+     * Regression test for <a href="https://github.com/liquibase/liquibase/issues/7780">#7780</a>:
+     * {@link ResultSetCache.ResultSetExtractor#extract(ResultSet)} is frequently fed a {@link ResultSet}
+     * obtained directly from a {@link java.sql.DatabaseMetaData} call (e.g. {@code getColumns}/{@code getTables}),
+     * so the caller keeps no reference to the producing {@link Statement}. Closing only the ResultSet
+     * leaks that Statement until the connection is closed. extract() must close the owning Statement too.
+     */
+    @Test
+    public void extractClosesOwningStatement() throws Exception {
+        Database database = mock(Database.class);
+
+        Statement statement = mock(Statement.class);
+        ResultSet resultSet = mock(ResultSet.class);
+        when(resultSet.getStatement()).thenReturn(statement);
+        when(resultSet.next()).thenReturn(false);
+
+        ResultSetCache.ResultSetExtractor extractor = new ResultSetCache.ResultSetExtractor(database) {
+            @Override
+            public boolean bulkContainsSchema(String schemaKey) {
+                return false;
+            }
+
+            @Override
+            public ResultSetCache.RowData rowKeyParameters(CachedRow row) {
+                return null;
+            }
+
+            @Override
+            public ResultSetCache.RowData wantedKeyParameters() {
+                return null;
+            }
+
+            @Override
+            public List<CachedRow> fastFetch() {
+                return null;
+            }
+
+            @Override
+            public List<CachedRow> bulkFetch() {
+                return null;
+            }
+        };
+
+        extractor.extract(resultSet);
+
+        verify(resultSet).close();
+        verify(statement).close();
+    }
 }


### PR DESCRIPTION
Fixes #7780

## Root cause
\`ResultSetCache.ResultSetExtractor#extract(ResultSet)\` is frequently fed a \`ResultSet\` obtained directly from a \`DatabaseMetaData\` call (\`getColumns\`/\`getTables\`/\`getImportedKeys\`/\`getPrimaryKeys\`, e.g. \`JdbcDatabaseSnapshot.java:501,877,1243,...\`), so the caller keeps no reference to the \`Statement\` that produced the result set. Per the JDBC contract, closing a \`ResultSet\` does **not** close its \`Statement\`, and many drivers (e.g. MySQL Connector/J) implement \`DatabaseMetaData.getXxx()\` by creating an internal \`Statement\` that is registered with the connection. The \`finally\` block closed only the \`ResultSet\`, so that owning \`Statement\` leaked until the connection was closed. This surfaces downstream as JDBC statement leaks (see quarkusio/quarkus#44042: "18 ResultSet(s) and 0 Statement(s)").

## Change
In \`extract(ResultSet, boolean)\`, capture the owning \`Statement\` via \`ResultSet.getStatement()\` (while the result set is still open) and close it alongside the \`ResultSet\` using the existing \`JdbcUtil.close(ResultSet, Statement)\` helper — mirroring how the sibling \`executeAndExtract\` method already closes both. \`getStatement()\` may return \`null\` for metadata result sets per the JDBC spec, which \`JdbcUtil.close\` already null-checks; a defensive \`catch (SQLException)\` falls back to closing the \`ResultSet\` only for drivers that do not support \`getStatement()\` here.

## Test evidence
Added a regression test \`ResultSetCacheTest#extractClosesOwningStatement\` that drives \`extract\` with a mocked \`ResultSet\` whose \`getStatement()\` returns a mock \`Statement\`, and verifies both are closed. It **fails before** this change (\`statement.close()\` is never invoked) and **passes after**.

Verification done: built and ran the new test against `liquibase-standard` with `./mvnw -pl liquibase-standard -am test -Dtest=ResultSetCacheTest` — 1 passed with the fix, 1 failed with the fix reverted (confirming it is a true regression test).