### PR TITLE
[DAT-23023] audit DATABASECHANGELOG escaping with real DB instances

### DIFF
--- a/liquibase-standard/src/test/groovy/liquibase/datatype/core/CharTypeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/datatype/core/CharTypeTest.groovy
@@ -41,4 +41,28 @@ class CharTypeTest extends Specification {
         thrown UnexpectedLiquibaseException
 
     }
+
+    @Unroll
+    def "objectToSql escapes values to prevent SQL injection - #desc"() {
+        when:
+        def charType = new CharType()
+
+        then:
+        charType.objectToSql(input, database) == expected
+
+        where:
+        desc                                          | input                                | database               | expected
+        "plain string"                                | "simple"                             | new H2Database()       | "'simple'"
+        "single quote doubled - H2"                   | "O'Brien"                            | new H2Database()       | "'O''Brien'"
+        "single quote doubled - PostgreSQL"           | "O'Brien"                            | new PostgresDatabase() | "'O''Brien'"
+        "single quote doubled - Oracle"               | "O'Brien"                            | new OracleDatabase()   | "'O''Brien'"
+        "single quote doubled - MSSQL"                | "O'Brien"                            | new MSSQLDatabase()    | "'O''Brien'"
+        "single quote doubled - MySQL"                | "O'Brien"                            | new MySQLDatabase()    | "'O''Brien'"
+        "injection: statement terminator - H2"        | "'; DROP TABLE DATABASECHANGELOG--"  | new H2Database()       | "'''; DROP TABLE DATABASECHANGELOG--'"
+        "injection: statement terminator - MySQL"     | "'; DROP TABLE DATABASECHANGELOG--"  | new MySQLDatabase()    | "'''; DROP TABLE DATABASECHANGELOG--'"
+        "injection: boolean bypass - H2"              | "' OR '1'='1"                        | new H2Database()       | "''' OR ''1''=''1'"
+        "MySQL backslash is escaped"                  | "foo\\bar"                           | new MySQLDatabase()    | "'foo\\\\bar'"
+        "null returns null"                           | null                                 | new H2Database()       | null
+        "literal null string returns null"            | "null"                               | new H2Database()       | null
+    }
 }

--- a/liquibase-standard/src/test/groovy/liquibase/sqlgenerator/core/MarkChangeSetRanGeneratorEscapingTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/sqlgenerator/core/MarkChangeSetRanGeneratorEscapingTest.groovy
@@ -1,0 +1,89 @@
+package liquibase.sqlgenerator.core
+
+import liquibase.Scope
+import liquibase.changelog.ChangeSet
+import liquibase.database.core.*
+import liquibase.sdk.resource.MockResourceAccessor
+import liquibase.sqlgenerator.MockSqlGeneratorChain
+import liquibase.statement.core.MarkChangeSetRanStatement
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class MarkChangeSetRanGeneratorEscapingTest extends Specification {
+
+    String generateInsertSql(ChangeSet changeSet, database) {
+        def scopeValues = [(Scope.Attr.resourceAccessor.name()): new MockResourceAccessor()]
+        Scope.child(scopeValues, {
+            new MarkChangeSetRanGenerator().generateSql(
+                    new MarkChangeSetRanStatement(changeSet, ChangeSet.ExecType.EXECUTED),
+                    database,
+                    new MockSqlGeneratorChain())[0].toSql()
+        } as Scope.ScopedRunnerWithReturn<String>)
+    }
+
+    @Unroll
+    def "INSERT SQL escapes single quotes in changeset fields - #databaseName"() {
+        given:
+        def changeSet = new ChangeSet("it's-an-id", "dev'author", false, false, "path/my'file.xml", null, null, null)
+
+        when:
+        String sql = generateInsertSql(changeSet, database)
+
+        then:
+        sql.contains("'it''s-an-id'")
+        sql.contains("'dev''author'")
+        sql.contains("'path/my''file.xml'")
+
+        where:
+        database               | databaseName
+        new H2Database()       | "H2"
+        new PostgresDatabase() | "PostgreSQL"
+        new OracleDatabase()   | "Oracle"
+        new MSSQLDatabase()    | "MSSQL"
+        new MySQLDatabase()    | "MySQL"
+        new MariaDBDatabase()  | "MariaDB"
+    }
+
+    @Unroll
+    def "INSERT SQL neutralizes statement terminator injection in changeset id - #databaseName"() {
+        given:
+        def changeSet = new ChangeSet("'; DROP TABLE DATABASECHANGELOG--", "author", false, false, "changelog.xml", null, null, null)
+
+        when:
+        String sql = generateInsertSql(changeSet, database)
+
+        then:
+        // The injected quote is doubled — the whole value becomes a safe SQL string literal with no statement break
+        sql.contains("'''; DROP TABLE DATABASECHANGELOG--'")
+
+        where:
+        database               | databaseName
+        new H2Database()       | "H2"
+        new PostgresDatabase() | "PostgreSQL"
+        new OracleDatabase()   | "Oracle"
+        new MSSQLDatabase()    | "MSSQL"
+        new MySQLDatabase()    | "MySQL"
+        new MariaDBDatabase()  | "MariaDB"
+    }
+
+    @Unroll
+    def "INSERT SQL neutralizes boolean bypass injection in changeset author - #databaseName"() {
+        given:
+        def changeSet = new ChangeSet("id", "' OR '1'='1", false, false, "changelog.xml", null, null, null)
+
+        when:
+        String sql = generateInsertSql(changeSet, database)
+
+        then:
+        sql.contains("''' OR ''1''=''1'")
+
+        where:
+        database               | databaseName
+        new H2Database()       | "H2"
+        new PostgresDatabase() | "PostgreSQL"
+        new OracleDatabase()   | "Oracle"
+        new MSSQLDatabase()    | "MSSQL"
+        new MySQLDatabase()    | "MySQL"
+        new MariaDBDatabase()  | "MariaDB"
+    }
+}


### PR DESCRIPTION
## Summary

- Adds escaping correctness tests to cover security audit finding B9: `DATABASECHANGELOG` INSERT values are inlined via `objectToSql` string concatenation rather than JDBC bound parameters
- `CharTypeTest.groovy`: 12 new parametrized `objectToSql` cases verifying single-quote doubling, statement-terminator injection, boolean-bypass injection, and MySQL backslash escaping across H2, PostgreSQL, Oracle, MSSQL, and MySQL
- `MarkChangeSetRanGeneratorEscapingTest.groovy`: new Spock spec with 3 `@Unroll` test methods (single-quote escaping, statement-terminator injection, boolean-bypass injection) parametrized across H2, PostgreSQL, Oracle, MSSQL, MySQL, and MariaDB using real database instances

No production code changes. The audit finding is addressed by confirming and locking in the correctness of the existing `escapeStringForDatabase` chain (`AbstractJdbcDatabase` doubles single quotes; `MySQLDatabase` additionally doubles backslashes).

## Test plan

- [x] `CharTypeTest` — 23 tests pass (8 existing + 12 new `objectToSql` escaping cases)
- [x] `MarkChangeSetRanGeneratorEscapingTest` — 21 tests pass (3 scenarios × 6 real database dialects + 3 unroll count)
- [x] `mvn test -pl liquibase-standard -Dtest="CharTypeTest,MarkChangeSetRanGeneratorEscapingTest"` — BUILD SUCCESS, 0 failures