### PR TITLE
Fix: Resolve concurrency issue in Scope.removeMdcObjectWhenScopeExits

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/Scope.java
+++ b/liquibase-standard/src/main/java/liquibase/Scope.java
@@ -34,21 +34,30 @@ import java.nio.charset.Charset;
 import java.text.DecimalFormat;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
- * This scope object is used to hold configuration and other parameters within a call without needing complex method signatures.
- * It also allows new parameters to be added by extensions without affecting standard method signatures.
- * Scope objects can be created in a hierarchical manner with the {@link #child(Map, ScopedRunner)} or {@link #child(String, Object, ScopedRunner)} methods.
- * Values set in parent scopes are visible in child scopes, but values in child scopes are not visible to parent scopes.
- * Values with the same key in different scopes "mask" each other with the value furthest down the scope chain being returned.
+ * This scope object is used to hold configuration and other parameters within a
+ * call without needing complex method signatures.
+ * It also allows new parameters to be added by extensions without affecting
+ * standard method signatures.
+ * Scope objects can be created in a hierarchical manner with the
+ * {@link #child(Map, ScopedRunner)} or
+ * {@link #child(String, Object, ScopedRunner)} methods.
+ * Values set in parent scopes are visible in child scopes, but values in child
+ * scopes are not visible to parent scopes.
+ * Values with the same key in different scopes "mask" each other with the value
+ * furthest down the scope chain being returned.
  */
 public class Scope {
 
-    public static final String AZURE_MESSAGE =
-            "The Liquibase Azure Extension 1.0.0 or higher is required to use Azure Storage. " +
-                    "Visit https://docs.liquibase.com/pro-extensions to acquire the Azure Extension.";
+    public static final String AZURE_MESSAGE = "The Liquibase Azure Extension 1.0.0 or higher is required to use Azure Storage. "
+            +
+            "Visit https://docs.liquibase.com/pro-extensions to acquire the Azure Extension.";
+
     /**
-     * Enumeration containing standard attributes. Normally use methods like convenience {@link #getResourceAccessor()} or {@link #getDatabase()}
+     * Enumeration containing standard attributes. Normally use methods like
+     * convenience {@link #getResourceAccessor()} or {@link #getDatabase()}
      */
     public enum Attr {
         logService,
@@ -75,13 +84,15 @@ public class Scope {
         checksumVersion,
         latestChecksumVersion,
         /**
-         * A <code>Map<String, String></code> of arguments/configuration properties used in the maven invocation of Liquibase.
+         * A <code>Map<String, String></code> of arguments/configuration properties used
+         * in the maven invocation of Liquibase.
          */
         mavenConfigurationProperties,
         analyticsEvent,
         integrationDetails,
         /**
-         * The maximum number of analytics events that should be cached in memory before sent in a batch.
+         * The maximum number of analytics events that should be cached in memory before
+         * sent in a batch.
          */
         maxAnalyticsCacheSize,
         licenseTrackList,
@@ -92,9 +103,12 @@ public class Scope {
 
     /**
      * Lazily initialized scope manager ThreadLocal.
-     * Uses double-checked locking pattern with volatile for thread-safe lazy initialization.
-     * The volatile keyword ensures visibility of the initialized object across threads.
-     * Once initialized, this field is never modified, making it effectively immutable.
+     * Uses double-checked locking pattern with volatile for thread-safe lazy
+     * initialization.
+     * The volatile keyword ensures visibility of the initialized object across
+     * threads.
+     * Once initialized, this field is never modified, making it effectively
+     * immutable.
      */
     @SuppressWarnings("java:S3077")
     private static volatile InheritableThreadLocal<ScopeManager> scopeManager;
@@ -154,12 +168,13 @@ public class Scope {
             if (overrideLogService != null) {
                 rootScope.values.put(Attr.logService.name(), overrideLogService);
             } else {
-                rootScope.getLog(Scope.class).warning("Could not find log service via LogServiceFactory. Using JavaLogService as default.");
+                rootScope.getLog(Scope.class)
+                        .warning("Could not find log service via LogServiceFactory. Using JavaLogService as default.");
             }
 
             rootScope.getSingleton(LiquibaseConfiguration.class).init(rootScope);
 
-            //check for higher-priority serviceLocator
+            // check for higher-priority serviceLocator
             ServiceLocator serviceLocator = rootScope.getServiceLocator();
             for (ServiceLocator possibleLocator : serviceLocator.findInstances(ServiceLocator.class)) {
                 if (possibleLocator.getPriority() > serviceLocator.getPriority()) {
@@ -189,12 +204,14 @@ public class Scope {
     }
 
     /**
-     * @param parent      The new Scopes parent in the hierarchy of Scopes, not null.
+     * @param parent      The new Scopes parent in the hierarchy of Scopes, not
+     *                    null.
      * @param scopeValues The values for the new Scope.
      */
     protected Scope(Scope parent, Map<String, Object> scopeValues) {
         if (parent == null) {
-            throw new UnexpectedLiquibaseException("Cannot pass a null parent to a new Scope. Use Scope.child to correctly create a nested scope");
+            throw new UnexpectedLiquibaseException(
+                    "Cannot pass a null parent to a new Scope. Use Scope.child to correctly create a nested scope");
         }
         this.parent = parent;
         scopeId = generateScopeId();
@@ -224,13 +241,15 @@ public class Scope {
     /**
      * Creates a new scope that is a child of this scope.
      */
-    public static <ReturnType> ReturnType child(Map<String, Object> scopeValues, ScopedRunnerWithReturn<ReturnType> runner) throws Exception {
+    public static <ReturnType> ReturnType child(Map<String, Object> scopeValues,
+            ScopedRunnerWithReturn<ReturnType> runner) throws Exception {
         return child(null, scopeValues, runner);
     }
 
     /**
      * Creates a new child scope that includes the given {@link LiquibaseListener}.
-     * You cannot unassign a listener, they simply fall out of scope when the Scope does.
+     * You cannot unassign a listener, they simply fall out of scope when the Scope
+     * does.
      *
      * @see #getListeners(Class)
      */
@@ -238,14 +257,16 @@ public class Scope {
         child(listener, null, runner);
     }
 
-    public static void child(LiquibaseListener listener, Map<String, Object> scopeValues, ScopedRunner runner) throws Exception {
+    public static void child(LiquibaseListener listener, Map<String, Object> scopeValues, ScopedRunner runner)
+            throws Exception {
         child(listener, scopeValues, () -> {
             runner.run();
             return null;
         });
     }
 
-    public static <T> T child(LiquibaseListener listener, Map<String, Object> scopeValues, ScopedRunnerWithReturn<T> runner) throws Exception {
+    public static <T> T child(LiquibaseListener listener, Map<String, Object> scopeValues,
+            ScopedRunnerWithReturn<T> runner) throws Exception {
         String scopeId = enter(listener, scopeValues);
 
         try {
@@ -256,7 +277,8 @@ public class Scope {
     }
 
     /**
-     * Convenience version of {@link #enter(LiquibaseListener, Map)} with no {@link LiquibaseListener}
+     * Convenience version of {@link #enter(LiquibaseListener, Map)} with no
+     * {@link LiquibaseListener}
      */
     public static String enter(Map<String, Object> scopeValues) throws Exception {
         return enter(null, scopeValues);
@@ -282,12 +304,14 @@ public class Scope {
     /**
      * Exits the scope started with {@link #enter(LiquibaseListener, Map)}
      *
-     * @param scopeId The id of the scope to exit. Throws an exception if the name does not match the current scope.
+     * @param scopeId The id of the scope to exit. Throws an exception if the name
+     *                does not match the current scope.
      */
     public static void exit(String scopeId) throws Exception {
         Scope currentScope = getCurrentScope();
         if (!currentScope.scopeId.equals(scopeId)) {
-            throw new RuntimeException("Cannot end scope " + scopeId + " when currently at scope " + currentScope.scopeId);
+            throw new RuntimeException(
+                    "Cannot end scope " + scopeId + " when currently at scope " + currentScope.scopeId);
         }
 
         // clear the MDC values added in this scope
@@ -327,7 +351,6 @@ public class Scope {
         return has(key.name());
     }
 
-
     public synchronized <T> T get(Enum key, Class<T> type) {
         return get(key.name(), type);
     }
@@ -337,15 +360,17 @@ public class Scope {
     }
 
     /**
-     * Return the value associated with the given key in this scope or any parent scope.
-     * The value is converted to the given type if necessary using {@link liquibase.util.ObjectUtil#convert(Object, Class)}.
+     * Return the value associated with the given key in this scope or any parent
+     * scope.
+     * The value is converted to the given type if necessary using
+     * {@link liquibase.util.ObjectUtil#convert(Object, Class)}.
      * Returns null if key is not defined in this or any parent scopes.
      */
     public <T> T get(String key, Class<T> type) {
         T value = values.get(key, type);
         if (value == null && values.containsKey(JAVA_PROPERTIES)) {
             Map javaProperties = values.get(JAVA_PROPERTIES, Map.class);
-            value = (T)javaProperties.get(key);
+            value = (T) javaProperties.get(key);
         }
         if (value == null && parent != null) {
             value = parent.get(key, type);
@@ -355,9 +380,11 @@ public class Scope {
     }
 
     /**
-     * Return the value associated with the given key in this scope or any parent scope.
+     * Return the value associated with the given key in this scope or any parent
+     * scope.
      * If the value is not defined, the passed defaultValue is returned.
-     * The value is converted to the given type if necessary using {@link liquibase.util.ObjectUtil#convert(Object, Class)}.
+     * The value is converted to the given type if necessary using
+     * {@link liquibase.util.ObjectUtil#convert(Object, Class)}.
      */
     public synchronized <T> T get(String key, T defaultValue) {
         Class type;
@@ -375,8 +402,10 @@ public class Scope {
     }
 
     /**
-     * Looks up the singleton object of the given type. If the singleton has not been created yet, it will be instantiated.
-     * The singleton is a singleton based on the root scope and the same object will be returned for all child scopes of the root.
+     * Looks up the singleton object of the given type. If the singleton has not
+     * been created yet, it will be instantiated.
+     * The singleton is a singleton based on the root scope and the same object will
+     * be returned for all child scopes of the root.
      */
     public synchronized <T extends SingletonObject> T getSingleton(Class<T> type) {
         if (getParent() != null) {
@@ -391,7 +420,7 @@ public class Scope {
                     Constructor<T> constructor = type.getDeclaredConstructor(Scope.class);
                     constructor.setAccessible(true);
                     singleton = constructor.newInstance(this);
-                } catch (NoSuchMethodException e) { //try without scope
+                } catch (NoSuchMethodException e) { // try without scope
                     Constructor<T> constructor = type.getDeclaredConstructor();
                     constructor.setAccessible(true);
                     singleton = constructor.newInstance();
@@ -417,7 +446,9 @@ public class Scope {
         return get(Attr.database, Database.class);
     }
 
-    public String getDeploymentId() { return get(Attr.deploymentId, String.class); }
+    public String getDeploymentId() {
+        return get(Attr.deploymentId, String.class);
+    }
 
     public ClassLoader getClassLoader() {
         return get(Attr.classLoader, Thread.currentThread().getContextClassLoader());
@@ -464,7 +495,8 @@ public class Scope {
     }
 
     /**
-     * Add a key value pair to the MDC using the MDC manager. This key value pair will be automatically removed from the
+     * Add a key value pair to the MDC using the MDC manager. This key value pair
+     * will be automatically removed from the
      * MDC when this scope exits.
      */
     public MdcObject addMdcValue(String key, String value) {
@@ -473,8 +505,11 @@ public class Scope {
 
     /**
      * Add a key value pair to the MDC using the MDC manager.
-     * @param removeWhenScopeExits if true, this key value pair will be automatically removed from the MDC when this
-     *                             scope exits. If there is not a demonstrable reason for setting this parameter to false
+     * 
+     * @param removeWhenScopeExits if true, this key value pair will be
+     *                             automatically removed from the MDC when this
+     *                             scope exits. If there is not a demonstrable
+     *                             reason for setting this parameter to false
      *                             then it should be set to true.
      */
     public MdcObject addMdcValue(String key, String value, boolean removeWhenScopeExits) {
@@ -488,14 +523,14 @@ public class Scope {
         if (removeWhenScopeExits) {
             Scope currentScope = getCurrentScope();
             addedMdcEntries
-                    .computeIfAbsent(currentScope.scopeId, k -> new ArrayList<>())
+                    .computeIfAbsent(currentScope.scopeId, k -> new CopyOnWriteArrayList<>())
                     .add(mdcObject);
         }
     }
 
-
     /**
-     * Add a key value pair to the MDC using the MDC manager. This key value pair will be automatically removed from the
+     * Add a key value pair to the MDC using the MDC manager. This key value pair
+     * will be automatically removed from the
      * MDC when this scope exits.
      */
     public MdcObject addMdcValue(String key, Map<String, Object> value) {
@@ -504,8 +539,11 @@ public class Scope {
 
     /**
      * Add a key value pair to the MDC using the MDC manager.
-     * @param removeWhenScopeExits if true, this key value pair will be automatically removed from the MDC when this
-     *                             scope exits. If there is not a demonstrable reason for setting this parameter to false
+     * 
+     * @param removeWhenScopeExits if true, this key value pair will be
+     *                             automatically removed from the MDC when this
+     *                             scope exits. If there is not a demonstrable
+     *                             reason for setting this parameter to false
      *                             then it should be set to true.
      */
     public MdcObject addMdcValue(String key, Map<String, Object> value, boolean removeWhenScopeExits) {
@@ -516,7 +554,8 @@ public class Scope {
     }
 
     /**
-     * Add a key value pair to the MDC using the MDC manager. This key value pair will be automatically removed from the
+     * Add a key value pair to the MDC using the MDC manager. This key value pair
+     * will be automatically removed from the
      * MDC when this scope exits.
      */
     public MdcObject addMdcValue(String key, CustomMdcObject customMdcObject) {
@@ -525,8 +564,11 @@ public class Scope {
 
     /**
      * Add a key value pair to the MDC using the MDC manager.
-     * @param removeWhenScopeExits if true, this key value pair will be automatically removed from the MDC when this
-     *                             scope exits. If there is not a demonstrable reason for setting this parameter to false
+     * 
+     * @param removeWhenScopeExits if true, this key value pair will be
+     *                             automatically removed from the MDC when this
+     *                             scope exits. If there is not a demonstrable
+     *                             reason for setting this parameter to false
      *                             then it should be set to true.
      */
     public MdcObject addMdcValue(String key, CustomMdcObject customMdcObject, boolean removeWhenScopeExits) {
@@ -538,6 +580,7 @@ public class Scope {
 
     /**
      * Check if the provided mdc key is present
+     * 
      * @return true if there is an existing key, false otherwise
      */
     @Beta
@@ -547,7 +590,8 @@ public class Scope {
     }
 
     /**
-     * Returns {@link LiquibaseListener}s defined in this scope and/or all its parents that are of the given type.
+     * Returns {@link LiquibaseListener}s defined in this scope and/or all its
+     * parents that are of the given type.
      */
     public <T extends LiquibaseListener> Collection<T> getListeners(Class<T> type) {
         List<T> returnList = new ArrayList<>();
@@ -564,7 +608,9 @@ public class Scope {
     }
 
     /**
-     * Get the current analytics event. This can return null if analytics is not enabled.
+     * Get the current analytics event. This can return null if analytics is not
+     * enabled.
+     * 
      * @return
      */
     public Event getAnalyticsEvent() {
@@ -579,8 +625,7 @@ public class Scope {
         long time = (new Date()).getTime();
         String dateString = String.valueOf(time);
         DecimalFormat decimalFormat = new DecimalFormat("0000000000");
-        return dateString.length() > 9 ? dateString.substring(dateString.length() - 10) :
-                decimalFormat.format(time);
+        return dateString.length() > 9 ? dateString.substring(dateString.length() - 10) : decimalFormat.format(time);
     }
 
     public void setLpmArgs(String args) {


### PR DESCRIPTION
## Description
This PR resolves #[7563](https://github.com/liquibase/liquibase/issues/7563).

During parallel database migrations (e.g., against multiple Docker databases in JUnit tests), a concurrency issue could occur when multiple threads shared the same `scopeId`. This resulted in concurrent `.add()` calls on a non-thread-safe `ArrayList` in `Scope.removeMdcObjectWhenScopeExits`, causing an `ArrayIndexOutOfBoundsException`.

## Changes Made
Replaced `new ArrayList<>()` with `new CopyOnWriteArrayList<>()` inside the `computeIfAbsent` block for `addedMdcEntries`. Since the consumer at line 292 iterates over this list after detaching it from the map, `CopyOnWriteArrayList` safely handles concurrent modifications during scope resolution without risking `ConcurrentModificationException`.

## Testing
- Verified successful compilation.
- Passed all unit tests in `liquibase-standard`.

Signed-off-by: om7057 <kulkarniom7057@gmail.com>