### PR TITLE
INT-2141: add Postgres-family capability methods (behavior-neutral)

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/database/core/AbstractPostgresDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/AbstractPostgresDatabase.java
@@ -194,22 +194,25 @@ public abstract class AbstractPostgresDatabase extends AbstractJdbcDatabase {
     // ---------------------------------------------------------------------------------------------
 
     /**
-     * Whether this database supports PostgreSQL-style enumerated types
-     * ({@code CREATE TYPE ... AS ENUM (...)}).
+     * Whether PostgreSQL-style enumerated types ({@code CREATE TYPE ... AS ENUM (...)}) on this
+     * database can be read by the standard enum-type snapshot generator. Named for
+     * <em>snapshot-ability</em>, not raw SQL capability.
      *
-     * @return true if enum types can be created and snapshotted on this database
+     * @return true if enum types on this database are snapshot-able via the standard generator
      */
-    public boolean supportsEnumTypes() {
+    public boolean supportsEnumTypeSnapshot() {
         return false;
     }
 
     /**
-     * Whether this database supports PostgreSQL-style composite types
-     * ({@code CREATE TYPE ... AS (...)}).
+     * Whether PostgreSQL-style composite types ({@code CREATE TYPE ... AS (...)}) on this database
+     * can be read by the standard composite-type snapshot generator. Named for
+     * <em>snapshot-ability</em>, not raw SQL capability: a variant may accept the DDL yet return
+     * {@code false} here because the standard generator cannot read its catalog.
      *
-     * @return true if composite types can be created and snapshotted on this database
+     * @return true if composite types on this database are snapshot-able via the standard generator
      */
-    public boolean supportsCompositeTypes() {
+    public boolean supportsCompositeTypeSnapshot() {
         return false;
     }
 

--- a/liquibase-standard/src/main/java/liquibase/database/core/AbstractPostgresDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/AbstractPostgresDatabase.java
@@ -181,4 +181,59 @@ public abstract class AbstractPostgresDatabase extends AbstractJdbcDatabase {
         }
         super.setDefaultCatalogName(defaultCatalogName);
     }
+
+    // ---------------------------------------------------------------------------------------------
+    // Explicit Postgres-family capabilities (INT-2139).
+    //
+    // The class-level contract: default to the safe/minimal value here, real PostgresDatabase opts
+    // in, and variants that lack the feature opt down. This replaces the fragile
+    // "inherit-by-default, override-to-disable" pattern (and the off-classpath short-name checks
+    // such as getShortName().equalsIgnoreCase("redshift")) that previously lived in the snapshot
+    // generators. These live on the Postgres-family SPI for now; they may be promoted to the core
+    // Database interface once the model is proven and generalized to other families (6.1+).
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Whether this database supports PostgreSQL-style enumerated types
+     * ({@code CREATE TYPE ... AS ENUM (...)}).
+     *
+     * @return true if enum types can be created and snapshotted on this database
+     */
+    public boolean supportsEnumTypes() {
+        return false;
+    }
+
+    /**
+     * Whether this database supports PostgreSQL-style composite types
+     * ({@code CREATE TYPE ... AS (...)}).
+     *
+     * @return true if composite types can be created and snapshotted on this database
+     */
+    public boolean supportsCompositeTypes() {
+        return false;
+    }
+
+    /**
+     * Whether check constraints on this database can be read by the standard check-constraint
+     * snapshot service. Named for <em>snapshot-ability</em>, not enforcement: e.g. Redshift accepts
+     * {@code CHECK} in DDL but never enforces it and exposes no usable catalog for it, so it returns
+     * {@code false}. (Cross-family concept; non-Postgres families still gate via {@code instanceof}
+     * in {@code StandardCheckConstraintService} until the 6.1+ sweep.)
+     *
+     * @return true if check constraints on this database are snapshot-able via the standard service
+     */
+    public boolean supportsCheckConstraintSnapshot() {
+        return false;
+    }
+
+    /**
+     * Whether stored database logic (functions, procedures, packages, triggers) can be snapshotted
+     * from this database via the standard stored-logic snapshot generators. (Cross-family concept;
+     * non-Postgres families still gate via {@code instanceof} until the 6.1+ sweep.)
+     *
+     * @return true if stored logic on this database is snapshot-able via the standard generators
+     */
+    public boolean supportsStoredLogicSnapshot() {
+        return false;
+    }
 }

--- a/liquibase-standard/src/main/java/liquibase/database/core/CockroachDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/CockroachDatabase.java
@@ -151,11 +151,13 @@ public class CockroachDatabase extends PostgresDatabase {
     }
 
     /**
-     * CockroachDB has no composite types (no {@code pg_collation}); it must not be treated as
-     * real PostgreSQL for composite-type snapshotting. Opts down from {@link PostgresDatabase}.
+     * The standard composite-type snapshot generator reads composite types via {@code pg_type}/
+     * {@code typrelid}, which CockroachDB does not populate for user-defined composite types, so it
+     * must not be treated as real PostgreSQL for composite-type snapshotting. Opts down from
+     * {@link PostgresDatabase}.
      */
     @Override
-    public boolean supportsCompositeTypes() {
+    public boolean supportsCompositeTypeSnapshot() {
         return false;
     }
 

--- a/liquibase-standard/src/main/java/liquibase/database/core/CockroachDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/CockroachDatabase.java
@@ -149,4 +149,22 @@ public class CockroachDatabase extends PostgresDatabase {
     public boolean supportsCreateIfNotExists(Class<? extends DatabaseObject> type) {
         return type.isAssignableFrom(Table.class);
     }
+
+    /**
+     * CockroachDB has no composite types (no {@code pg_collation}); it must not be treated as
+     * real PostgreSQL for composite-type snapshotting. Opts down from {@link PostgresDatabase}.
+     */
+    @Override
+    public boolean supportsCompositeTypes() {
+        return false;
+    }
+
+    /**
+     * CockroachDB does not expose the stored-logic catalog the standard generators rely on.
+     * Opts down from {@link PostgresDatabase}.
+     */
+    @Override
+    public boolean supportsStoredLogicSnapshot() {
+        return false;
+    }
 }

--- a/liquibase-standard/src/main/java/liquibase/database/core/EnterpriseDBDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/EnterpriseDBDatabase.java
@@ -77,11 +77,13 @@ public class EnterpriseDBDatabase extends PostgresDatabase {
     }
 
     /**
-     * EnterpriseDB does not support composite types for snapshotting; opts down from
-     * {@link PostgresDatabase}.
+     * EnterpriseDB (Advanced Server) accepts {@code CREATE TYPE ... AS (...)}, but the standard
+     * composite-type snapshot generator does not read composite types on it, so it opts down from
+     * {@link PostgresDatabase}. This preserves today's behavior, where the generator explicitly
+     * excludes EnterpriseDB.
      */
     @Override
-    public boolean supportsCompositeTypes() {
+    public boolean supportsCompositeTypeSnapshot() {
         return false;
     }
 }

--- a/liquibase-standard/src/main/java/liquibase/database/core/EnterpriseDBDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/EnterpriseDBDatabase.java
@@ -75,4 +75,13 @@ public class EnterpriseDBDatabase extends PostgresDatabase {
     public boolean supportsCreateIfNotExists(Class<? extends DatabaseObject> type) {
         return false;
     }
+
+    /**
+     * EnterpriseDB does not support composite types for snapshotting; opts down from
+     * {@link PostgresDatabase}.
+     */
+    @Override
+    public boolean supportsCompositeTypes() {
+        return false;
+    }
 }

--- a/liquibase-standard/src/main/java/liquibase/database/core/PostgresDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/PostgresDatabase.java
@@ -286,4 +286,24 @@ public class PostgresDatabase extends AbstractPostgresDatabase {
     public boolean supportsDatabaseChangeLogHistory() {
         return true;
     }
+
+    @Override
+    public boolean supportsEnumTypes() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsCompositeTypes() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsCheckConstraintSnapshot() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsStoredLogicSnapshot() {
+        return true;
+    }
 }

--- a/liquibase-standard/src/main/java/liquibase/database/core/PostgresDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/PostgresDatabase.java
@@ -288,12 +288,12 @@ public class PostgresDatabase extends AbstractPostgresDatabase {
     }
 
     @Override
-    public boolean supportsEnumTypes() {
+    public boolean supportsEnumTypeSnapshot() {
         return true;
     }
 
     @Override
-    public boolean supportsCompositeTypes() {
+    public boolean supportsCompositeTypeSnapshot() {
         return true;
     }
 

--- a/liquibase-standard/src/test/groovy/liquibase/database/core/CockroachDatabaseTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/database/core/CockroachDatabaseTest.groovy
@@ -47,10 +47,10 @@ class CockroachDatabaseTest extends Specification {
 
         expect:
         verifyAll {
-            database.supportsEnumTypes()                // inherited from PostgresDatabase
-            !database.supportsCompositeTypes()          // CockroachDB has no composite types
-            database.supportsCheckConstraintSnapshot()  // inherited from PostgresDatabase
-            !database.supportsStoredLogicSnapshot()     // no stored-logic catalog
+            database.supportsEnumTypeSnapshot()              // inherited from PostgresDatabase
+            !database.supportsCompositeTypeSnapshot()        // not snapshot-able on CockroachDB
+            database.supportsCheckConstraintSnapshot()       // inherited from PostgresDatabase
+            !database.supportsStoredLogicSnapshot()          // no stored-logic catalog
         }
     }
 

--- a/liquibase-standard/src/test/groovy/liquibase/database/core/CockroachDatabaseTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/database/core/CockroachDatabaseTest.groovy
@@ -41,6 +41,19 @@ class CockroachDatabaseTest extends Specification {
         QUOTE_ALL_OBJECTS         || 'col with space' | Column     || 'col with space' | '"col with space"'
     }
 
+    def "postgres-family capabilities"() {
+        given:
+        def database = new CockroachDatabase()
+
+        expect:
+        verifyAll {
+            database.supportsEnumTypes()                // inherited from PostgresDatabase
+            !database.supportsCompositeTypes()          // CockroachDB has no composite types
+            database.supportsCheckConstraintSnapshot()  // inherited from PostgresDatabase
+            !database.supportsStoredLogicSnapshot()     // no stored-logic catalog
+        }
+    }
+
     def useSerialDatatypes() {
         when:
         def db = new CockroachDatabase()

--- a/liquibase-standard/src/test/groovy/liquibase/database/core/EnterpriseDBDatabaseTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/database/core/EnterpriseDBDatabaseTest.groovy
@@ -44,6 +44,19 @@ class EnterpriseDBDatabaseTest extends Specification {
         QUOTE_ALL_OBJECTS         || 'col with space' | Column     || 'col with space' | '"col with space"'
     }
 
+    def "postgres-family capabilities"() {
+        given:
+        def database = new EnterpriseDBDatabase()
+
+        expect:
+        verifyAll {
+            database.supportsEnumTypes()                // inherited from PostgresDatabase
+            !database.supportsCompositeTypes()          // EnterpriseDB has no composite types
+            database.supportsCheckConstraintSnapshot()  // inherited from PostgresDatabase
+            database.supportsStoredLogicSnapshot()      // inherited from PostgresDatabase
+        }
+    }
+
     @Unroll
     def "isCorrectDatabaseImplementation"() {
         when:

--- a/liquibase-standard/src/test/groovy/liquibase/database/core/EnterpriseDBDatabaseTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/database/core/EnterpriseDBDatabaseTest.groovy
@@ -50,10 +50,10 @@ class EnterpriseDBDatabaseTest extends Specification {
 
         expect:
         verifyAll {
-            database.supportsEnumTypes()                // inherited from PostgresDatabase
-            !database.supportsCompositeTypes()          // EnterpriseDB has no composite types
-            database.supportsCheckConstraintSnapshot()  // inherited from PostgresDatabase
-            database.supportsStoredLogicSnapshot()      // inherited from PostgresDatabase
+            database.supportsEnumTypeSnapshot()              // inherited from PostgresDatabase
+            !database.supportsCompositeTypeSnapshot()        // not snapshot-able on EnterpriseDB
+            database.supportsCheckConstraintSnapshot()       // inherited from PostgresDatabase
+            database.supportsStoredLogicSnapshot()           // inherited from PostgresDatabase
         }
     }
 

--- a/liquibase-standard/src/test/java/liquibase/database/core/PostgresDatabaseTest.java
+++ b/liquibase-standard/src/test/java/liquibase/database/core/PostgresDatabaseTest.java
@@ -46,8 +46,8 @@ public class PostgresDatabaseTest extends AbstractJdbcDatabaseTest {
     public void postgresFamilyCapabilities() {
         // Real PostgreSQL opts in to every Postgres-family capability (INT-2139).
         PostgresDatabase database = new PostgresDatabase();
-        assertTrue(database.supportsEnumTypes());
-        assertTrue(database.supportsCompositeTypes());
+        assertTrue(database.supportsEnumTypeSnapshot());
+        assertTrue(database.supportsCompositeTypeSnapshot());
         assertTrue(database.supportsCheckConstraintSnapshot());
         assertTrue(database.supportsStoredLogicSnapshot());
     }

--- a/liquibase-standard/src/test/java/liquibase/database/core/PostgresDatabaseTest.java
+++ b/liquibase-standard/src/test/java/liquibase/database/core/PostgresDatabaseTest.java
@@ -42,6 +42,16 @@ public class PostgresDatabaseTest extends AbstractJdbcDatabaseTest {
         assertTrue(getDatabase().supportsInitiallyDeferrableColumns());
     }
 
+    @Test
+    public void postgresFamilyCapabilities() {
+        // Real PostgreSQL opts in to every Postgres-family capability (INT-2139).
+        PostgresDatabase database = new PostgresDatabase();
+        assertTrue(database.supportsEnumTypes());
+        assertTrue(database.supportsCompositeTypes());
+        assertTrue(database.supportsCheckConstraintSnapshot());
+        assertTrue(database.supportsStoredLogicSnapshot());
+    }
+
     @Override
     @Test
     public void getCurrentDateTimeFunction() {


### PR DESCRIPTION
## Impact
Phase 2 of the Postgres-family inheritance refactor (INT-2139). Introduces explicit **capability methods** on `AbstractPostgresDatabase`, replacing the fragile *inherit-by-default, override-to-disable* pattern that has repeatedly let Postgres features leak into non-substitutable variants (Redshift, CockroachDB, EnterpriseDB, YugabyteDB).

## Changes
New methods on `AbstractPostgresDatabase`, each defaulting to the conservative `false` on the family SPI:
- `supportsEnumTypes()`
- `supportsCompositeTypes()`
- `supportsCheckConstraintSnapshot()` — snapshot-ability, **not** enforcement
- `supportsStoredLogicSnapshot()`

`PostgresDatabase` opts in (`true`); variants opt down where they lack the feature — CockroachDB (composite types, stored-logic), EnterpriseDB (composite types).

## Behavior-neutral
No variant is reparented yet, so every subclass inherits its current values. Consumers (the Pro snapshot generators) are converted separately once this lands. Unit tests added for Postgres / Cockroach / EDB capability values.

## Related
- Epic: INT-2139
- Builds on: INT-2140 (AbstractPostgresDatabase extraction)
