### PR TITLE
Fix Redshift snapshot failure: skip pg_partitioned_table enrichment on pre-PG10 servers

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -53,6 +53,13 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
         return cachingDatabaseMetaData;
     }
 
+    public static boolean supportsPartitionKeyCatalog(Database database) throws DatabaseException {
+        // Cockroach reports PG 10+ but ships its own catalog subset without pg_partitioned_table.
+        return database instanceof PostgresDatabase
+                && !(database instanceof CockroachDatabase)
+                && database.getDatabaseMajorVersion() >= 10;
+    }
+
     public class CachingDatabaseMetaData {
         private static final String SQL_FILTER_MATCH_ALL = "%";
         private final DatabaseMetaData databaseMetaData;
@@ -1372,16 +1379,7 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                  * {@code getIndexInfo} extractor in this same file).
                  */
                 private void enrichPostgresqlTablesResult(CatalogAndSchema catalogAndSchema, String tableName, List<CachedRow> rows) throws DatabaseException, SQLException {
-                    // CockroachDatabase extends PostgresDatabase but does not expose pg_partitioned_table /
-                    // pg_get_partkeydef as standard PG-compatible catalogs (Cockroach has its own partitioning
-                    // model). Exclude it explicitly so the enrichment query doesn't fail the entire snapshot
-                    // on a Cockroach target. Reported by CodeRabbit on PR #7759.
-                    // (Note: the index-USING enrichment a few methods up in this file has the identical guard
-                    // gap — same root cause, same fix-shape. Out of scope for #6885; should land as a separate
-                    // follow-up PR against the getIndexInfo extractor.)
-                    if (!(database instanceof PostgresDatabase)
-                            || (database instanceof CockroachDatabase)
-                            || rows.isEmpty()) {
+                    if (rows.isEmpty() || !supportsPartitionKeyCatalog(database)) {
                         return;
                     }
                     String schemaName = database.correctObjectName(catalogAndSchema.getSchemaName(), Schema.class);

--- a/liquibase-standard/src/test/groovy/liquibase/snapshot/jvm/TableSnapshotGeneratorTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/snapshot/jvm/TableSnapshotGeneratorTest.groovy
@@ -1,9 +1,13 @@
 package liquibase.snapshot.jvm
 
+import liquibase.database.Database
+import liquibase.database.core.CockroachDatabase
 import liquibase.database.core.MySQLDatabase
 import liquibase.database.core.PostgresDatabase
 import liquibase.snapshot.CachedRow
+import liquibase.snapshot.JdbcDatabaseSnapshot
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class TableSnapshotGeneratorTest extends Specification {
 
@@ -75,5 +79,29 @@ class TableSnapshotGeneratorTest extends Specification {
 
         then:
         table.getPartitionBy() == null
+    }
+
+    @Unroll
+    def "supportsPartitionKeyCatalog is #expected for #desc"() {
+        expect:
+        JdbcDatabaseSnapshot.supportsPartitionKeyCatalog(database) == expected
+
+        where:
+        desc                        | database                     || expected
+        "PostgreSQL 10"             | postgresWithVersion(10)      || true
+        "PostgreSQL 15"             | postgresWithVersion(15)      || true
+        "PostgreSQL 9 (pre-10)"     | postgresWithVersion(9)       || false
+        "Redshift-like PG 8.0.2"    | postgresWithVersion(8)       || false
+        "CockroachDB"               | new CockroachDatabase()      || false
+        "non-Postgres (MySQL)"      | new MySQLDatabase()          || false
+    }
+
+    // RedshiftDatabase lives in an extension off core's classpath, so a PostgresDatabase pinned to major
+    // version 8 stands in for it — the guard only sees `instanceof PostgresDatabase` and the reported version.
+    private static Database postgresWithVersion(int major) {
+        new PostgresDatabase() {
+            @Override
+            int getDatabaseMajorVersion() { major }
+        }
     }
 }


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

On Amazon Redshift, every DB-touching command (`status`, `update`, `snapshot`, `diff`, `generate-changelog`) aborts with `ERROR: relation "pg_partitioned_table" does not exist`.

**Root cause:** regression from #7759, which added `PARTITION_BY` snapshot enrichment that unconditionally queries the `pg_partitioned_table` / `pg_get_partkeydef` catalogs. Those are PostgreSQL 10+; Redshift runs on the PG 8.0.2 engine and lacks them, so the query fails the whole snapshot — reached even during `checkLiquibaseTables` at startup, hence virtually every command breaks.

**Fix:** gate the enrichment on a new `supportsPartitionKeyCatalog()` predicate — Postgres-family, **not** Cockroach, major version ≥ 10. This also skips any pre-10 real PostgreSQL while keeping EnterpriseDB and YugabyteDB (PG 10+/11) enriching. Cockroach keeps its explicit exclusion (reports PG 10+ but ships its own catalog subset).

> Companion PR in the commercial repo: liquibase/liquibase-pro#4232 (identical change; opened separately because the subtree sync was paused for the release).

## Release note

Fixed a regression where Liquibase commands failed against Amazon Redshift with `relation "pg_partitioned_table" does not exist`.

## Things to be aware of

The sibling index-USING enrichment (`enrichPostgresqlResult`) needs no equivalent guard: it queries `pg_index` / `pg_class` / `pg_am` / `pg_namespace` — all PG ≤ 8 catalogs that Redshift retains — so it runs cleanly (confirmed on a live cluster). Only the PG 10+ partition catalogs were absent.

## Testing

- **Live Redshift (QA cluster):** reproduced the exact error on an unfixed #7759 build; after the fix, `snapshot` / `status` / `generate-changelog` all succeed (FINE logs confirm the partition query is skipped, version reads 8).
- **EDB 12** (Test Harness `ChangeObjectTests`): postgres driver → `PostgresDatabase` 60/0/0; edb driver → `EnterpriseDBDatabase` 64/0/0. FINE logs confirm the partition query still runs (version 12).
- **YugabyteDB 2.16** (Test Harness): base suite 80/0/0, `ChangeObjectTests` 75/0/0. FINE logs confirm the partition query still runs (version 11).
- **Unit:** `TableSnapshotGeneratorTest` — 6 new cases (PG 10/15 allowed; PG 9 / Redshift-like PG 8 / Cockroach / MySQL skipped), 10/10 green.