### PR TITLE
Fix --output-default-schema/--output-default-catalog being ignored by update-sql and other SQL output commands

### DIFF
--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/UpdateCommandsIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/UpdateCommandsIntegrationTest.groovy
@@ -145,4 +145,36 @@ class UpdateCommandsIntegrationTest extends Specification {
         cleanup:
         outputFile.delete()
     }
+
+    @Unroll
+    def "run UpdateSql with outputDefaultSchema=#outputDefaultSchema qualifies objects in the default schema accordingly"() {
+        given:
+        def outputStream = new ByteArrayOutputStream()
+        def resourceAccessor = new SearchPathResourceAccessor(".,target/test-classes")
+        def scopeSettings = [
+                (Scope.Attr.resourceAccessor.name()): resourceAccessor
+        ]
+
+        when:
+        Scope.child(scopeSettings, {
+            CommandScope commandScope = new CommandScope(UpdateSqlCommandStep.COMMAND_NAME)
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.URL_ARG, h2.getConnectionUrl())
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.USERNAME_ARG, h2.getUsername())
+            commandScope.addArgumentValue(DbUrlConnectionArgumentsCommandStep.PASSWORD_ARG, h2.getPassword())
+            commandScope.addArgumentValue(UpdateSqlCommandStep.CHANGELOG_FILE_ARG, "liquibase/update-tests.yml")
+            commandScope.addArgumentValue(UpdateSqlCommandStep.OUTPUT_DEFAULT_SCHEMA_ARG, outputDefaultSchema)
+            commandScope.addArgumentValue(UpdateSqlCommandStep.OUTPUT_DEFAULT_CATALOG_ARG, outputDefaultSchema)
+            commandScope.setOutput(outputStream)
+
+            commandScope.execute()
+        } as Scope.ScopedRunner)
+
+        then:
+        def output = outputStream.toString().toLowerCase()
+        output.contains("create table public.example_table") == outputDefaultSchema
+        output.contains("create table example_table") == !outputDefaultSchema
+
+        where:
+        outputDefaultSchema << [true, false]
+    }
 }

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/DbUrlConnectionCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/DbUrlConnectionCommandStep.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 /**
  * Internal command step to be used on CommandStep pipeline to manage the database connection.
@@ -125,11 +126,32 @@ public class DbUrlConnectionCommandStep extends AbstractDatabaseConnectionComman
             } catch (Exception e) {
                 throw new DatabaseException(e);
             }
+            applyCommandBooleanArgument(commandScope, "outputDefaultSchema", database.get()::setOutputDefaultSchema);
+            applyCommandBooleanArgument(commandScope, "outputDefaultCatalog", database.get()::setOutputDefaultCatalog);
         }
         String urlForLogging = url == null ? database.get().getConnection().getURL() : url;
         logMdc(urlForLogging, database.get());
         logLicenseUsage(urlForLogging, database.get(), true, false);
         return database.get();
+    }
+
+    /**
+     * Applies a command-specific boolean argument (e.g. "outputDefaultSchema", "outputDefaultCatalog") to the
+     * database that was just created, if the currently running command declares that argument. This connection
+     * step is shared by every command, but only some (updateSql, rollbackSql, changelogSyncSql, ...) expose
+     * these output-qualification flags, and {@link #createDatabaseObject} otherwise always leaves the database
+     * with outputDefaultSchema/outputDefaultCatalog set to true.
+     */
+    @SuppressWarnings("unchecked")
+    private static void applyCommandBooleanArgument(CommandScope commandScope, String argumentName, Consumer<Boolean> setter) {
+        CommandArgumentDefinition<?> argument = commandScope.getCommand().getArgument(argumentName);
+        if (argument == null) {
+            return;
+        }
+        Boolean value = commandScope.getArgumentValue((CommandArgumentDefinition<Boolean>) argument);
+        if (value != null) {
+            setter.accept(value);
+        }
     }
 
     private static String getDriver(CommandScope commandScope) {


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Fixes #6944 (also previously reported as #2547).

`updateSql` — and every other SQL-output command that declares these arguments (`rollbackSql`, `rollbackCountSql`, `rollbackToDateSql`, `changelogSyncSql`, `futureRollbackSql`, `futureRollbackCountSql`, `futureRollbackFromTagSql`, `updateCountSql`, `updateToTagSql`) — exposes `--output-default-schema` / `--output-default-catalog` arguments, documented as "If false, only objects outside the default schema are fully qualified". Setting either to `false` has no effect: objects in the default schema are always fully qualified (e.g. `CREATE TABLE PUBLIC.example_table` on H2, `CREATE TABLE ORAUSER.TABLENAME` on Oracle).

**Root cause:** the arguments are declared but never read. The `Database` object used to generate SQL is created by `AbstractDatabaseConnectionCommandStep#createDatabaseObject`, which unconditionally sets:

```java
database.setOutputDefaultCatalog(true);
database.setOutputDefaultSchema(true);
```

Nothing in the command pipeline ever applies the declared argument values afterwards. (The downstream qualification logic in `AbstractJdbcDatabase#escapeObjectName` already checks `isDefaultSchema(...) && !getOutputDefaultSchema()` correctly, so only the wiring is missing.)

**Fix:** after `DbUrlConnectionCommandStep#obtainDatabase` creates the `Database`, look up whether the currently running command declares an `outputDefaultSchema` / `outputDefaultCatalog` argument, and if so apply its configured value to the new `Database` instance.

- Commands that don't declare these arguments (the majority) are untouched — the database keeps the existing hardcoded `true`/`true`.
- Both arguments default to `true`, so commands that declare them but where the user doesn't pass a value also keep today's behavior.
- When the caller supplies a pre-built `Database` via `DATABASE_ARG` (API usage), nothing is overridden.
- `diff`/`diffChangelog`/`generateChangelog` are unaffected: they don't declare these argument names and keep using their own `DiffOutputControl`/`includeSchema` handling.

**Repro:** run `liquibase updateSql --output-default-schema=false` with a table-creating changelog against any database whose connection has a default schema; the generated `CREATE TABLE` is schema-qualified even though the doc says it shouldn't be. Verified on Oracle (per #6944, maintainer also reproduced on H2), and independently on PostgreSQL 5.0.x via CLI flag and `LIQUIBASE_COMMAND_UPDATE_SQL_OUTPUT_DEFAULT_SCHEMA=false`.

An integration test (`UpdateCommandsIntegrationTest`, H2) is included that runs `updateSql` with `outputDefaultSchema` set to `true` and `false` and asserts the generated `CREATE TABLE` qualification.

## Release note

Fixed `--output-default-schema` / `--output-default-catalog` being ignored by `update-sql`, `rollback-sql`, `changelog-sync-sql`, `future-rollback-sql`, and the other SQL-output commands. Setting them to `false` now omits the default schema/catalog prefix from generated SQL as documented.

## Things to be aware of

- The fix is placed in `DbUrlConnectionCommandStep#obtainDatabase` (the shared connection step) rather than in each of the ten command steps, and applies by argument name lookup so any command declaring `outputDefaultSchema`/`outputDefaultCatalog` — including extensions — gets the wiring for free.
- Only the database-creation path is affected; a `Database` passed in through `DATABASE_ARG` is never modified.

## Things to worry about

- If an extension declares an argument named `outputDefaultSchema`/`outputDefaultCatalog` of type `Boolean` but intends different semantics, it would now also be applied to the database. This seems desirable rather than harmful, but flagging it.

## Additional Context

Issue #6944 was closed by the stale-issue triage after 30 days of inactivity, but was reproduced and confirmed by @tati-qalified, who asked for a community PR. Please consider reopening it alongside this PR.
