### PR TITLE
ci: restore fork PR checkout under pull_request_target for actions/checkout v7

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -44,6 +44,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha || github.event.after}}
+          allow-unsafe-pr-checkout: true
 
       - name: Get Latest Merge Commit SHA
         id: get-sha
@@ -82,6 +83,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha || github.event.after}}
+          allow-unsafe-pr-checkout: true
       - name: Set up Java for publishing to GitHub Repository
         uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha || github.event.after}}
+          allow-unsafe-pr-checkout: true
       - name: Get Latest Merge Commit SHA
         id: get-sha
         run: |
@@ -98,6 +99,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha || github.event.after}}
+          allow-unsafe-pr-checkout: true
       # this includes all the tar files included in the previous runs. So in the next step we deploy what was previously build
       - name: Download Artifacts for build.yml
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -45,6 +45,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha || github.event.after}} #sets the Git reference (commit or branch) to be checked out in the workflow
+          allow-unsafe-pr-checkout: true
 
   run-test-harness-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -56,6 +56,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          allow-unsafe-pr-checkout: true
 
       - name: Get current date
         id: get-date
@@ -104,6 +105,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha || github.event.after}}
+          allow-unsafe-pr-checkout: true
 
       - name: Built Code Cache
         if: ${{ matrix.java == 17}}
@@ -210,6 +212,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha || github.event.after}}
+          allow-unsafe-pr-checkout: true
 
       - name: Prepare
         id: prepare


### PR DESCRIPTION
## Problem

Every external contributor (fork) PR is failing at the very first step — checkout — before any code is built. Example: [PR #7708 run](https://github.com/liquibase/liquibase/actions/runs/29023049006/job/86135310681?pr=7708#step:2:19):

> `Refusing to check out fork pull request code from a 'pull_request_target' workflow… set 'allow-unsafe-pr-checkout: true'`

## Root cause

Dependabot PR #7819 bumped `actions/checkout` from v6.0.3 to **v7.0.0**. v7 introduced a breaking security change: it refuses to check out fork PR head code when the workflow runs as `pull_request_target`, unless `allow-unsafe-pr-checkout: true` is explicitly set.

Our CI depends on exactly this pattern — `pull_request_target` workflows check out `github.event.pull_request.head.sha` (fork code) so tests can access the vault/secrets. Internal-branch PRs don't hit this path, which is why only fork PRs broke.

## Fix

Set `allow-unsafe-pr-checkout: true` on the 8 fork-head checkouts across the `pull_request_target` workflows:

| Workflow | checkouts |
|---|---|
| `run-tests.yml` | 3 |
| `build.yml` | 2 |
| `build-branch.yml` | 2 |
| `run-test-harness.yml` | 1 |

This restores the pre-v7 behavior. The "pwn request" risk v7 warns about is already mitigated by the `external` environment gate, which requires manual approval before a fork PR's deployment runs.

## Validation

Because these are `pull_request_target` workflows, GitHub executes the base-branch version — so this fix only takes effect **after it lands on main**, and a fork PR's own run can't exercise it. Validated via `workflow_dispatch` on this branch; re-run #7708 CI after merge to confirm.