### PR TITLE
Fix formatted SQL precondition messages

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
@@ -105,10 +105,20 @@ public class FormattedSqlChangeLogParser extends AbstractFormattedChangeLogParse
         }
     }
 
+    /**
+     * Parses a string attribute without treating attribute-like text inside quoted values as a new token. A quote
+     * starts a quoted value only when it immediately follows the attribute separator. Unquoted values are returned
+     * as-is, while quoted values retain their surrounding quotes for the caller to remove.
+     *
+     * @param body The preconditions body
+     * @param attributeName The attribute to parse
+     * @return The attribute value, or {@code null} when the attribute is missing or empty
+     */
     private String parseStringAttribute(String body, String attributeName) {
         int tokenStart = -1;
         char quote = 0;
 
+        // The synthetic trailing space flushes the final token when the body has no trailing whitespace.
         for (int i = 0; i <= body.length(); i++) {
             char current = i < body.length() ? body.charAt(i) : ' ';
             if (quote != 0) {
@@ -123,7 +133,11 @@ public class FormattedSqlChangeLogParser extends AbstractFormattedChangeLogParse
                     String token = body.substring(tokenStart, i);
                     int separator = token.indexOf(':');
                     if ((separator > 0) && attributeName.equalsIgnoreCase(token.substring(0, separator))) {
-                        return StringUtil.trimToNull(token.substring(separator + 1));
+                        String value = StringUtil.trimToNull(token.substring(separator + 1));
+                        if (value != null) {
+                            logMatch(attributeName, value, getClass());
+                        }
+                        return value;
                     }
                     tokenStart = -1;
                 }

--- a/liquibase-standard/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
@@ -82,7 +82,15 @@ public class FormattedSqlChangeLogParser extends AbstractFormattedChangeLogParse
 
             PreconditionContainer pc = new PreconditionContainer();
             pc.setOnFail(StringUtil.trimToNull(parseString(onFailMatcher, ON_FAIL)));
+            String onFailMessage = parseStringAttribute(body, "onFailMessage");
+            if (onFailMessage != null) {
+                pc.setOnFailMessage(StringUtil.stripEnclosingQuotes(onFailMessage));
+            }
             pc.setOnError(StringUtil.trimToNull(parseString(onErrorMatcher, ON_ERROR)));
+            String onErrorMessage = parseStringAttribute(body, "onErrorMessage");
+            if (onErrorMessage != null) {
+                pc.setOnErrorMessage(StringUtil.stripEnclosingQuotes(onErrorMessage));
+            }
 
             if (onSqlOutputMatcher.matches() && onUpdateSqlMatcher.matches()) {
                 throw new IllegalArgumentException("Please modify the changelog to have preconditions set with either " +
@@ -95,6 +103,35 @@ public class FormattedSqlChangeLogParser extends AbstractFormattedChangeLogParse
             }
             changeSet.setPreconditions(pc);
         }
+    }
+
+    private String parseStringAttribute(String body, String attributeName) {
+        int tokenStart = -1;
+        char quote = 0;
+
+        for (int i = 0; i <= body.length(); i++) {
+            char current = i < body.length() ? body.charAt(i) : ' ';
+            if (quote != 0) {
+                if (current == quote) {
+                    quote = 0;
+                }
+            } else if (((current == '\"') || (current == '\'')) &&
+                    (tokenStart >= 0) && (i > tokenStart) && (body.charAt(i - 1) == ':')) {
+                quote = current;
+            } else if (Character.isWhitespace(current)) {
+                if (tokenStart >= 0) {
+                    String token = body.substring(tokenStart, i);
+                    int separator = token.indexOf(':');
+                    if ((separator > 0) && attributeName.equalsIgnoreCase(token.substring(0, separator))) {
+                        return StringUtil.trimToNull(token.substring(separator + 1));
+                    }
+                    tokenStart = -1;
+                }
+            } else if (tokenStart < 0) {
+                tokenStart = i;
+            }
+        }
+        return null;
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
+++ b/liquibase-standard/src/main/java/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParser.java
@@ -12,6 +12,7 @@ import liquibase.precondition.core.SqlPrecondition;
 import liquibase.precondition.core.TableExistsPrecondition;
 import liquibase.precondition.core.ViewExistsPrecondition;
 import liquibase.util.StringUtil;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -133,7 +134,7 @@ public class FormattedSqlChangeLogParser extends AbstractFormattedChangeLogParse
                     String token = body.substring(tokenStart, i);
                     int separator = token.indexOf(':');
                     if ((separator > 0) && attributeName.equalsIgnoreCase(token.substring(0, separator))) {
-                        String value = StringUtil.trimToNull(token.substring(separator + 1));
+                        String value = StringUtils.trimToNull(token.substring(separator + 1));
                         if (value != null) {
                             logMatch(attributeName, value, getClass());
                         }

--- a/liquibase-standard/src/test/groovy/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.groovy
@@ -802,8 +802,44 @@ create table table1 (
 
         then:
         PreconditionContainer preconditions = changeLog.getChangeSets().first().getPreconditions()
+        preconditions.getOnFail() == PreconditionContainer.FailOption.HALT
         preconditions.getOnFailMessage() == "Application 'value' not found. Skipping insertion."
+        preconditions.getOnError() == PreconditionContainer.ErrorOption.HALT
         preconditions.getOnErrorMessage() == "Unable to verify application."
+    }
+
+    def "leave precondition messages unset when not specified"() throws Exception {
+        given:
+        String changeLogWithoutPreconditionMessages = "--liquibase formatted sql\n" +
+                "--changeset test:test\n" +
+                "--preconditions onFail:HALT onError:HALT\n" +
+                "select 1;\n"
+
+        when:
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithoutPreconditionMessages)
+                .parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+
+        then:
+        PreconditionContainer preconditions = changeLog.getChangeSets().first().getPreconditions()
+        preconditions.getOnFailMessage() == null
+        preconditions.getOnErrorMessage() == null
+    }
+
+    def "parse precondition message with onSqlOutput"() throws Exception {
+        given:
+        String changeLogWithMessageAndOnSqlOutput = "--liquibase formatted sql\n" +
+                "--changeset test:test\n" +
+                "--preconditions onFail:HALT onFailMessage:\"Application missing.\" onSqlOutput:TEST\n" +
+                "select 1;\n"
+
+        when:
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithMessageAndOnSqlOutput)
+                .parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+
+        then:
+        PreconditionContainer preconditions = changeLog.getChangeSets().first().getPreconditions()
+        preconditions.getOnFailMessage() == "Application missing."
+        preconditions.getOnSqlOutput() == PreconditionContainer.OnSqlOutputOption.TEST
     }
 
     def "do not parse message attribute names from inside quoted messages"() throws Exception {

--- a/liquibase-standard/src/test/groovy/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/parser/core/formattedsql/FormattedSqlChangeLogParserTest.groovy
@@ -786,6 +786,61 @@ create table table1 (
         assert changeLog.getPreconditions().getOnSqlOutput() == PreconditionContainer.OnSqlOutputOption.TEST
     }
 
+    def "parse quoted precondition messages"() throws Exception {
+        given:
+        String changeLogWithPreconditionMessages = "--liquibase formatted sql\n" +
+                "--changeset test:test\n" +
+                "--preconditions onFail:HALT " +
+                "onFailMessage:\"Application 'value' not found. Skipping insertion.\" " +
+                "onError:HALT onErrorMessage:\"Unable to verify application.\"\n" +
+                "--precondition-sql-check expectedResult:1 select count(*) from application;\n" +
+                "select 1;\n"
+
+        when:
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithPreconditionMessages)
+                .parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+
+        then:
+        PreconditionContainer preconditions = changeLog.getChangeSets().first().getPreconditions()
+        preconditions.getOnFailMessage() == "Application 'value' not found. Skipping insertion."
+        preconditions.getOnErrorMessage() == "Unable to verify application."
+    }
+
+    def "do not parse message attribute names from inside quoted messages"() throws Exception {
+        given:
+        String changeLogWithAttributeNamesInMessages = "--liquibase formatted sql\n" +
+                "--changeset test:test\n" +
+                "--preconditions onErrorMessage:\"No onFailMessage:configured.\" " +
+                "onFailMessage:\"First onFailMessage:second.\"\n" +
+                "select 1;\n"
+
+        when:
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithAttributeNamesInMessages)
+                .parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+
+        then:
+        PreconditionContainer preconditions = changeLog.getChangeSets().first().getPreconditions()
+        preconditions.getOnFailMessage() == "First onFailMessage:second."
+        preconditions.getOnErrorMessage() == "No onFailMessage:configured."
+    }
+
+    def "parse unquoted message attributes containing apostrophes"() throws Exception {
+        given:
+        String changeLogWithUnquotedMessages = "--liquibase formatted sql\n" +
+                "--changeset test:test\n" +
+                "--preconditions onErrorMessage:can't-connect onFailMessage:plain\n" +
+                "select 1;\n"
+
+        when:
+        DatabaseChangeLog changeLog = new MockFormattedSqlChangeLogParser(changeLogWithUnquotedMessages)
+                .parse("asdf.sql", new ChangeLogParameters(), new JUnitResourceAccessor())
+
+        then:
+        PreconditionContainer preconditions = changeLog.getChangeSets().first().getPreconditions()
+        preconditions.getOnFailMessage() == "plain"
+        preconditions.getOnErrorMessage() == "can't-connect"
+    }
+
     def "parse error when changeset with both 'onSqlOutput' and 'onUpdateSql' preconditions set"() throws Exception {
         when:
         final String changeLogWithOnSqlOutputPrecondition = "--liquibase formatted sql\n" +


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Fixes #7816.

Formatted SQL changelogs recognized the `onFail` and `onError` actions, but did not copy their `onFailMessage` and `onErrorMessage` attributes into the `PreconditionContainer`. As a result, precondition failures always displayed the generated default message.

This change parses message attributes as quote-aware top-level tokens, preserving messages with spaces, apostrophes, and attribute-like text inside the value. It maps both message attributes to the existing container fields.

Regression coverage includes the reported quoted `onFailMessage` form, the symmetric error message, embedded attribute names, and unquoted apostrophes.

## Release note

Formatted SQL preconditions now display custom `onFailMessage` and `onErrorMessage` text.

## Things to be aware of

The parser only treats a quote immediately after an attribute colon as an opening delimiter. Quotes inside an unquoted token remain part of that token.

## Things to worry about

None known.

## Additional Context

Verification with JDK 17:

- `FormattedSqlChangeLogParserTest`: 79 tests, 0 failures
- `liquibase-standard` unit suite: 6,179 tests, 0 failures, 12 skipped
- `git diff --check`