### PR TITLE
INT-2211: reference-scoped configuration for two-connection commands

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/ReferenceDbUrlConnectionCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/ReferenceDbUrlConnectionCommandStep.java
@@ -3,6 +3,7 @@ package liquibase.command.core.helpers;
 import liquibase.Scope;
 import liquibase.command.*;
 import liquibase.command.providers.ReferenceDatabase;
+import liquibase.configuration.ConfigurationDefinition;
 import liquibase.configuration.ConfigurationValueObfuscator;
 import liquibase.database.Database;
 import liquibase.database.jvm.JdbcConnection;
@@ -91,6 +92,9 @@ public class ReferenceDbUrlConnectionCommandStep extends AbstractDatabaseConnect
             logMdc(url, username, defaultSchemaName, defaultCatalogName);
             Map<String, Object> scopeValues = new HashMap<>();
             scopeValues.put(Database.IGNORE_MISSING_REFERENCES_KEY, commandScope.getArgumentValue(DiffArgumentsCommandStep.IGNORE_MISSING_REFERENCES));
+            // Flag this connection as the reference connection so reference-scoped configuration definitions
+            // resolve from their `.reference.` sibling keys while it is opened.
+            scopeValues.put(ConfigurationDefinition.IS_REFERENCE_CONNECTION_SCOPE_KEY, Boolean.TRUE);
             AtomicReference<Database> database = new AtomicReference<>();
             try {
                 Scope.child(scopeValues, () -> {

--- a/liquibase-standard/src/main/java/liquibase/configuration/ConfigurationDefinition.java
+++ b/liquibase-standard/src/main/java/liquibase/configuration/ConfigurationDefinition.java
@@ -404,7 +404,9 @@ public class ConfigurationDefinition<DataType> implements Comparable<Configurati
          * synchronously in {@code DatabaseConnection.open(...)} (a later/async read sees the primary value);
          * only the canonical key is scoped, not aliases; and it does not apply to auth activated by the
          * credential value itself (e.g. a {@code referencePassword} resolved by a {@link ConfiguredValueModifier}),
-         * which is already per-connection.
+         * which is already per-connection. Intended for {@code String}-typed selectors: the
+         * {@link #REFERENCE_DEFAULT_SENTINEL} opt-out is matched on the raw sibling value before type
+         * conversion, so a non-{@code String} {@code DataType} (e.g. an enum) would not see the sentinel honored.
          */
         public Building<DataType> referenceScoped() {
             final String fullKey = definition.getKey();

--- a/liquibase-standard/src/main/java/liquibase/configuration/ConfigurationDefinition.java
+++ b/liquibase-standard/src/main/java/liquibase/configuration/ConfigurationDefinition.java
@@ -35,9 +35,25 @@ public class ConfigurationDefinition<DataType> implements Comparable<Configurati
     private boolean internal;
     private ConfigurationValueConverter<DataType> valueConverter;
     private ConfigurationValueObfuscator<DataType> valueObfuscator;
+    private String referenceKey;
 
     private static final String ALLOWED_KEY_REGEX = "[a-zA-Z0-9._]+";
     private static final Pattern ALLOWED_KEY_PATTERN = Pattern.compile(ALLOWED_KEY_REGEX);
+
+    /**
+     * Scope key set to {@link Boolean#TRUE} while the reference connection of a two-connection command
+     * (e.g. {@code diff} / {@code diff-changelog}) is being opened. Reference-scoped definitions
+     * (see {@link Builder.Building#referenceScoped()}) resolve from their {@code .reference.} sibling
+     * key while this is set. Unset (the primary connection and every single-connection command) preserves
+     * the standard resolution.
+     */
+    public static final String IS_REFERENCE_CONNECTION_SCOPE_KEY = "liquibase.connection.isReference";
+
+    /**
+     * Value of a {@code .reference.} sibling key that explicitly opts the reference connection out of an
+     * inherited mechanism, resolving the definition as if unset (i.e. to its default). Case-insensitive.
+     */
+    public static final String REFERENCE_DEFAULT_SENTINEL = "DEFAULT";
 
     private boolean loggedUsingDefault = false;
     private boolean hidden = false;
@@ -99,12 +115,45 @@ public class ConfigurationDefinition<DataType> implements Comparable<Configurati
     public ConfiguredValue<DataType> getCurrentConfiguredValue(ConfigurationValueProvider... additionalValueProviders) {
         final LiquibaseConfiguration liquibaseConfiguration = Scope.getCurrentScope().getSingleton(LiquibaseConfiguration.class);
 
+        // Reference-scoped resolution: while the reference connection of a two-connection command is being
+        // opened, a flagged definition resolves from its `.reference.` sibling. This lets diff/diff-changelog
+        // use a different auth mechanism on the reference side than on the primary. The value still flows
+        // through this definition, so its type conversion, default, and obfuscator all apply unchanged.
+        if (referenceKey != null && isReferenceConnectionScope()) {
+            ConfiguredValue<?> referenceValue = liquibaseConfiguration.getCurrentConfiguredValue(valueConverter, valueObfuscator, additionalValueProviders, referenceKey);
+            if (referenceValue.found()) {
+                if (isReferenceDefaultSentinel(referenceValue.getProvidedValue().getValue())) {
+                    // Explicit opt-out: resolve as if unset for this connection (→ this definition's default).
+                    return applyDefaultAndConvert(new ConfiguredValue<>(key, valueConverter, valueObfuscator));
+                }
+                return applyDefaultAndConvert(referenceValue);
+            }
+            // No `.reference.` value set → fall through and inherit the primary value below.
+        }
+
         List<String> keyList = new ArrayList<>();
         keyList.add(this.getKey());
         keyList.addAll(this.getAliasKeys());
 
         ConfiguredValue<?> configurationValue = liquibaseConfiguration.getCurrentConfiguredValue(valueConverter, valueObfuscator, additionalValueProviders, keyList.toArray(new String[0]));
 
+        return applyDefaultAndConvert(configurationValue);
+    }
+
+    private static boolean isReferenceConnectionScope() {
+        return Boolean.TRUE.equals(Scope.getCurrentScope().get(IS_REFERENCE_CONNECTION_SCOPE_KEY, Boolean.FALSE));
+    }
+
+    private static boolean isReferenceDefaultSentinel(Object value) {
+        return value != null && REFERENCE_DEFAULT_SENTINEL.equalsIgnoreCase(String.valueOf(value).trim());
+    }
+
+    /**
+     * Applies this definition's default value (when nothing was configured) and its value converter to a
+     * resolved {@link ConfiguredValue}, returning the final typed value. Shared by the standard and the
+     * reference-scoped resolution paths.
+     */
+    private ConfiguredValue<DataType> applyDefaultAndConvert(ConfiguredValue<?> configurationValue) {
         if (!configurationValue.found()) {
             defaultValue = this.getDefaultValue();
             if (defaultValue != null) {
@@ -339,6 +388,24 @@ public class ConfigurationDefinition<DataType> implements Comparable<Configurati
 
         public Building<DataType> setHidden(boolean hidden) {
             definition.hidden = hidden;
+
+            return this;
+        }
+
+        /**
+         * Marks this definition reference-scopable. While the reference connection of a two-connection command
+         * (e.g. {@code diff} / {@code diff-changelog}) is opened, the definition resolves from its
+         * {@code <namespace>.reference.<suffix>} sibling key when that sibling is set — enabling a different
+         * value (e.g. a different auth mechanism) on the reference connection than on the primary. When the
+         * sibling is unset the primary value is inherited; a sibling value of {@link #REFERENCE_DEFAULT_SENTINEL}
+         * opts out (resolves as if unset). No behavior changes for single-connection commands or the primary
+         * connection.
+         */
+        public Building<DataType> referenceScoped() {
+            final String fullKey = definition.getKey();
+            // define() always prepends "defaultKeyPrefix.", so the sibling is prefix + ".reference." + suffix.
+            final String suffix = fullKey.substring(defaultKeyPrefix.length() + 1);
+            definition.referenceKey = defaultKeyPrefix + ".reference." + suffix;
 
             return this;
         }

--- a/liquibase-standard/src/main/java/liquibase/configuration/ConfigurationDefinition.java
+++ b/liquibase-standard/src/main/java/liquibase/configuration/ConfigurationDefinition.java
@@ -394,28 +394,17 @@ public class ConfigurationDefinition<DataType> implements Comparable<Configurati
         }
 
         /**
-         * Marks this definition reference-scopable. While the reference connection of a two-connection command
-         * (e.g. {@code diff} / {@code diff-changelog}) is opened, the definition resolves from its
-         * {@code <namespace>.reference.<suffix>} sibling key when that sibling is set — enabling a different
-         * value (e.g. a different auth mechanism) on the reference connection than on the primary. When the
-         * sibling is unset the primary value is inherited; a sibling value of {@link #REFERENCE_DEFAULT_SENTINEL}
-         * opts out (resolves as if unset). No behavior changes for single-connection commands or the primary
-         * connection.
-         *
-         * <p><b>Read synchronously during connection open.</b> Reference scoping is active only while the
-         * reference connection is being opened (see {@link #IS_REFERENCE_CONNECTION_SCOPE_KEY}). A value read
-         * outside that window — lazy initialization, a token/credential refresh after {@code open()} returns,
-         * connection-pool re-authentication — resolves the <i>primary</i> value with no error. Consumers must
-         * read reference-scoped configuration synchronously inside their {@code DatabaseConnection.open(...)}.
-         *
-         * <p><b>Primary key only.</b> Only the definition's canonical key gets a {@code .reference.} sibling;
-         * alias keys are not reference-scoped. Apply this to non-aliased definitions (as the auth selectors are).
-         *
-         * <p><b>Not for value-activated auth.</b> This mechanism is for a selector/companion read at open time.
-         * Authentication activated by the credential <i>value</i> itself (e.g. a password reference resolved by a
-         * {@link ConfiguredValueModifier} on the distinct {@code referencePassword} command argument) is already
-         * per-connection via its own key and must not use this flag — the scope marker is not set during
-         * value-modifier resolution, so it would have no effect there.
+         * Marks this definition reference-scopable: while the reference connection of a two-connection command
+         * (e.g. {@code diff}) is opening, it resolves from its {@code <namespace>.reference.<suffix>} sibling
+         * instead of the primary key. An unset sibling inherits the primary value; a sibling of
+         * {@link #REFERENCE_DEFAULT_SENTINEL} opts out (resolves as if unset). No effect on single-connection
+         * commands or the primary connection.
+         * <p>
+         * Caveats: the reference value resolves only while the reference connection is opening, so read it
+         * synchronously in {@code DatabaseConnection.open(...)} (a later/async read sees the primary value);
+         * only the canonical key is scoped, not aliases; and it does not apply to auth activated by the
+         * credential value itself (e.g. a {@code referencePassword} resolved by a {@link ConfiguredValueModifier}),
+         * which is already per-connection.
          */
         public Building<DataType> referenceScoped() {
             final String fullKey = definition.getKey();

--- a/liquibase-standard/src/main/java/liquibase/configuration/ConfigurationDefinition.java
+++ b/liquibase-standard/src/main/java/liquibase/configuration/ConfigurationDefinition.java
@@ -155,19 +155,20 @@ public class ConfigurationDefinition<DataType> implements Comparable<Configurati
      */
     private ConfiguredValue<DataType> applyDefaultAndConvert(ConfiguredValue<?> configurationValue) {
         if (!configurationValue.found()) {
-            defaultValue = this.getDefaultValue();
-            if (defaultValue != null) {
+            // Use a local rather than writing the shared instance field on this read path.
+            final DataType resolvedDefault = this.getDefaultValue();
+            if (resolvedDefault != null) {
                 DataType obfuscatedValue;
                 if (valueObfuscator == null) {
-                    obfuscatedValue = defaultValue;
+                    obfuscatedValue = resolvedDefault;
                 } else {
-                    obfuscatedValue = valueObfuscator.obfuscate(defaultValue);
+                    obfuscatedValue = valueObfuscator.obfuscate(resolvedDefault);
                 }
                 if (!loggedUsingDefault) {
                     Scope.getCurrentScope().getLog(getClass()).fine("Configuration " + key + " is using the default value of " + obfuscatedValue);
                     loggedUsingDefault = true;
                 }
-                configurationValue.override(new DefaultValueProvider(this.getDefaultValue()).getProvidedValue(key));
+                configurationValue.override(new DefaultValueProvider(resolvedDefault).getProvidedValue(key));
             }
         }
 
@@ -400,11 +401,32 @@ public class ConfigurationDefinition<DataType> implements Comparable<Configurati
          * sibling is unset the primary value is inherited; a sibling value of {@link #REFERENCE_DEFAULT_SENTINEL}
          * opts out (resolves as if unset). No behavior changes for single-connection commands or the primary
          * connection.
+         *
+         * <p><b>Read synchronously during connection open.</b> Reference scoping is active only while the
+         * reference connection is being opened (see {@link #IS_REFERENCE_CONNECTION_SCOPE_KEY}). A value read
+         * outside that window — lazy initialization, a token/credential refresh after {@code open()} returns,
+         * connection-pool re-authentication — resolves the <i>primary</i> value with no error. Consumers must
+         * read reference-scoped configuration synchronously inside their {@code DatabaseConnection.open(...)}.
+         *
+         * <p><b>Primary key only.</b> Only the definition's canonical key gets a {@code .reference.} sibling;
+         * alias keys are not reference-scoped. Apply this to non-aliased definitions (as the auth selectors are).
+         *
+         * <p><b>Not for value-activated auth.</b> This mechanism is for a selector/companion read at open time.
+         * Authentication activated by the credential <i>value</i> itself (e.g. a password reference resolved by a
+         * {@link ConfiguredValueModifier} on the distinct {@code referencePassword} command argument) is already
+         * per-connection via its own key and must not use this flag — the scope marker is not set during
+         * value-modifier resolution, so it would have no effect there.
          */
         public Building<DataType> referenceScoped() {
             final String fullKey = definition.getKey();
             // define() always prepends "defaultKeyPrefix.", so the sibling is prefix + ".reference." + suffix.
-            final String suffix = fullKey.substring(defaultKeyPrefix.length() + 1);
+            // Assert that invariant explicitly so a future change fails loudly instead of deriving a wrong key.
+            final String expectedPrefix = defaultKeyPrefix + ".";
+            if (!fullKey.startsWith(expectedPrefix)) {
+                throw new IllegalStateException("referenceScoped() requires a key under the builder prefix '"
+                        + defaultKeyPrefix + "', but was '" + fullKey + "'.");
+            }
+            final String suffix = fullKey.substring(expectedPrefix.length());
             definition.referenceKey = defaultKeyPrefix + ".reference." + suffix;
 
             return this;

--- a/liquibase-standard/src/test/groovy/liquibase/configuration/ConfigurationDefinitionTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/configuration/ConfigurationDefinitionTest.groovy
@@ -230,6 +230,34 @@ class ConfigurationDefinitionTest extends Specification {
         false       | null    | "OAUTH"   | null    // primary side with no primary value
     }
 
+    @Unroll
+    def "referenceScoped DEFAULT sentinel resolves to the definition's default value when one is set"() {
+        when:
+        def definition = new ConfigurationDefinition.Builder("test.refScopeDefault")
+                .define("auth.type", String)
+                .setDefaultValue("PWD")
+                .referenceScoped()
+                .buildTemporary()
+
+        def scopeVars = new HashMap<String, Object>()
+        scopeVars.put("test.refScopeDefault.auth.type", "PKI") // primary is set to a non-default value
+        if (reference != null) {
+            scopeVars.put("test.refScopeDefault.reference.auth.type", reference)
+        }
+        scopeVars.put(ConfigurationDefinition.IS_REFERENCE_CONNECTION_SCOPE_KEY, Boolean.TRUE)
+
+        def value = Scope.child(scopeVars, { definition.getCurrentValue() } as Scope.ScopedRunnerWithReturn)
+
+        then:
+        value == expected
+
+        where:
+        reference | expected
+        "OAUTH"   | "OAUTH" // explicit reference value wins over the default
+        null      | "PKI"   // unset reference inherits the primary (not the default)
+        "DEFAULT" | "PWD"   // sentinel opts out -> the definition's default, NOT the primary and NOT null
+    }
+
     def "referenceScoped is inert for definitions that were not flagged"() {
         when:
         def definition = new ConfigurationDefinition.Builder("test.refScopeUnflagged")

--- a/liquibase-standard/src/test/groovy/liquibase/configuration/ConfigurationDefinitionTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/configuration/ConfigurationDefinitionTest.groovy
@@ -194,4 +194,55 @@ class ConfigurationDefinitionTest extends Specification {
         "SHOULD.RUN"           | true
         null                   | false
     }
+
+    @Unroll
+    def "referenceScoped resolves from the .reference. sibling only while the reference-connection scope is set"() {
+        when:
+        def definition = new ConfigurationDefinition.Builder("test.refScope")
+                .define("auth.type", String)
+                .referenceScoped()
+                .buildTemporary()
+
+        def scopeVars = new HashMap<String, Object>()
+        if (primary != null) {
+            scopeVars.put("test.refScope.auth.type", primary)
+        }
+        if (reference != null) {
+            scopeVars.put("test.refScope.reference.auth.type", reference)
+        }
+        if (isReference) {
+            scopeVars.put(ConfigurationDefinition.IS_REFERENCE_CONNECTION_SCOPE_KEY, Boolean.TRUE)
+        }
+
+        def value = Scope.child(scopeVars, { definition.getCurrentValue() } as Scope.ScopedRunnerWithReturn)
+
+        then:
+        value == expected
+
+        where:
+        isReference | primary | reference | expected
+        false       | "PKI"   | "OAUTH"   | "PKI"   // primary connection ignores the reference sibling
+        true        | "PKI"   | null      | "PKI"   // unset reference inherits the primary value
+        true        | "PKI"   | "OAUTH"   | "OAUTH" // reference sibling overrides the primary
+        true        | "PKI"   | "DEFAULT" | null    // sentinel opts out -> resolves as unset (no default)
+        true        | "PKI"   | "default" | null    // sentinel is case-insensitive
+        true        | null    | "OAUTH"   | "OAUTH" // reference-only configuration
+        false       | null    | "OAUTH"   | null    // primary side with no primary value
+    }
+
+    def "referenceScoped is inert for definitions that were not flagged"() {
+        when:
+        def definition = new ConfigurationDefinition.Builder("test.refScopeUnflagged")
+                .define("auth.type", String)
+                .buildTemporary()
+
+        def value = Scope.child([
+                "test.refScopeUnflagged.auth.type"          : "PKI",
+                "test.refScopeUnflagged.reference.auth.type" : "OAUTH",
+                (ConfigurationDefinition.IS_REFERENCE_CONNECTION_SCOPE_KEY): Boolean.TRUE
+        ], { definition.getCurrentValue() } as Scope.ScopedRunnerWithReturn)
+
+        then:
+        value == "PKI"
+    }
 }


### PR DESCRIPTION
  ## What

  Adds opt-in **reference scoping** to `ConfigurationDefinition` so two-connection commands (`diff`, `diff-changelog`) can resolve a configuration definition differently on the **reference** connection than on the **primary** one.

  Today the primary/reference distinction exists only in the command-step layer and is erased before `connection.open()`, so any auth/connection selector read via `getCurrentValue()` binds *both* connections. This change threads a lightweight signal so a flagged definition can be resolved per-connection.

  ## How
  
  - **`ConfigurationDefinition.Builder.referenceScoped()`** — marks a definition reference-scopable. While the reference connection is being opened, the definition resolves from its `<namespace>.reference.<suffix>` sibling key:
    - sibling **unset** → inherit the primary value (fully backward compatible),
    - sibling **set** → use it,
    - sibling = **`DEFAULT`** (case-insensitive sentinel) → resolve as if unset (→ the definition's default).
    The value is resolved *through the base definition*, so its type conversion, default value, and obfuscator all still apply — secrets stay masked.
  - **`ConfigurationDefinition.IS_REFERENCE_CONNECTION_SCOPE_KEY`** — a `Scope` marker set to `TRUE` only while the reference connection opens. `ReferenceDbUrlConnectionCommandStep` sets it inside the existing `Scope.child(...)` block that wraps
  `createDatabaseObject(...)`.
  - The default+convert tail of `getCurrentConfiguredValue` was extracted into a private `applyDefaultAndConvert(...)` helper (pure refactor), shared by the standard and reference-scoped paths.

  ## Compatibility

  Fully inert unless a definition is explicitly flagged `referenceScoped()`. Unflagged definitions, single-connection commands, and the primary connection of two-connection commands behave exactly as before (`referenceKey == null` short-circuits the new branch).

  ## Tests

  `ConfigurationDefinitionTest` gains cases for: inherit-when-unset, sibling-override, `DEFAULT` opt-out (incl. case-insensitivity), reference-only config, primary-connection-ignores-sibling, and unflagged-definition-is-inert. Full `liquibase.configuration` test package is green.

  ## Context
  
  Enables downstream (commercial) database extensions to offer per-connection auth for `diff`/`diff-changelog` (e.g. target on PKI/OAuth/OIDC, reference on password). Tracked as INT-2211.