### PR TITLE
Widen LockService SPI throws clauses to LiquibaseException (ADR-0005 pilot)

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/database/LiquibaseTableNames.java
+++ b/liquibase-standard/src/main/java/liquibase/database/LiquibaseTableNames.java
@@ -1,6 +1,6 @@
 package liquibase.database;
 
-import liquibase.exception.DatabaseException;
+import liquibase.exception.LiquibaseException;
 
 import java.util.List;
 
@@ -12,7 +12,18 @@ public interface LiquibaseTableNames {
      */
     List<String> getLiquibaseGeneratedTableNames(Database database);
 
-    void destroy(Database database) throws DatabaseException;
+    /**
+     * Drops the Liquibase-generated tables this modifier knows about.
+     *
+     * <p>ADR-0005 (INT-2205 phase 2): the clause is widened from {@code DatabaseException} to
+     * {@code LiquibaseException} so a classified business/system failure raised deeper in the
+     * teardown chain (e.g. {@link liquibase.lockservice.LockService#destroy()}) can flow through
+     * unwrapped. Existing implementors may keep a narrower {@code throws DatabaseException} override
+     * unchanged (source-compatible) — {@code ProLiquibaseTableNames} does exactly that.
+     *
+     * @throws LiquibaseException if the teardown fails
+     */
+    void destroy(Database database) throws LiquibaseException;
 
     /**
      * Returns the order in which modifiers should be run. Modifiers with a higher order will run after modifiers with a lower order value.

--- a/liquibase-standard/src/main/java/liquibase/database/LiquibaseTableNamesFactory.java
+++ b/liquibase-standard/src/main/java/liquibase/database/LiquibaseTableNamesFactory.java
@@ -2,7 +2,7 @@ package liquibase.database;
 
 import liquibase.Scope;
 import liquibase.SingletonObject;
-import liquibase.exception.DatabaseException;
+import liquibase.exception.LiquibaseException;
 import liquibase.servicelocator.ServiceLocator;
 
 import java.util.Comparator;
@@ -25,7 +25,10 @@ public class LiquibaseTableNamesFactory implements SingletonObject {
         return generators.stream().flatMap(f -> f.getLiquibaseGeneratedTableNames(database).stream()).collect(Collectors.toList());
     }
 
-    public void destroy(Database abstractJdbcDatabase) throws DatabaseException {
+    // ADR-0005 (INT-2205 phase 2): widened to LiquibaseException in lockstep with the
+    // LiquibaseTableNames.destroy SPI it fans out to; Database.dropDatabaseObjects already
+    // declares throws LiquibaseException, so the widening terminates one level up.
+    public void destroy(Database abstractJdbcDatabase) throws LiquibaseException {
         for (LiquibaseTableNames generator : generators) {
             generator.destroy(abstractJdbcDatabase);
             abstractJdbcDatabase.commit();

--- a/liquibase-standard/src/main/java/liquibase/database/StandardLiquibaseTableNames.java
+++ b/liquibase-standard/src/main/java/liquibase/database/StandardLiquibaseTableNames.java
@@ -2,7 +2,7 @@ package liquibase.database;
 
 import liquibase.Scope;
 import liquibase.changelog.ChangeLogHistoryServiceFactory;
-import liquibase.exception.DatabaseException;
+import liquibase.exception.LiquibaseException;
 import liquibase.lockservice.LockServiceFactory;
 
 import java.util.Arrays;
@@ -15,7 +15,7 @@ public class StandardLiquibaseTableNames implements LiquibaseTableNames {
     }
 
     @Override
-    public void destroy(Database database) throws DatabaseException {
+    public void destroy(Database database) throws LiquibaseException {
         Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).getChangeLogService(database).destroy();
         LockServiceFactory.getInstance().getLockService(database).destroy();
     }

--- a/liquibase-standard/src/main/java/liquibase/lockservice/LockService.java
+++ b/liquibase-standard/src/main/java/liquibase/lockservice/LockService.java
@@ -1,7 +1,7 @@
 package liquibase.lockservice;
 
 import liquibase.database.Database;
-import liquibase.exception.DatabaseException;
+import liquibase.exception.LiquibaseException;
 import liquibase.exception.LockException;
 import liquibase.servicelocator.PrioritizedService;
 
@@ -26,16 +26,24 @@ public interface LockService extends PrioritizedService {
     DatabaseChangeLogLock[] listLocks() throws LockException;
 
     /**
-     * Releases whatever locks are on the database change log table
+     * Releases whatever locks are on the database change log table.
+     *
+     * <p>ADR-0005 (INT-2205 phase 2): the clause is widened from {@code DatabaseException} to
+     * {@code LiquibaseException} so a classified business/system failure can flow through this SPI.
+     * {@code LockException} stays explicit for the documented lock-specific contract. Existing
+     * implementors may keep a narrower {@code throws DatabaseException} override unchanged
+     * (source-compatible); only strict {@code catch (DatabaseException)} callers must widen.
      */
-    void forceReleaseLock() throws LockException, DatabaseException;
+    void forceReleaseLock() throws LockException, LiquibaseException;
 
     /**
      * Clears information the lock handler knows about the tables.  Should only be called by Liquibase internal calls
      */
     void reset();
 
-    void init() throws DatabaseException;
+    /** @throws LiquibaseException if the lock table cannot be created or initialized (ADR-0005: widened from {@code DatabaseException}). */
+    void init() throws LiquibaseException;
 
-    void destroy() throws DatabaseException;
+    /** @throws LiquibaseException if the lock table cannot be dropped (ADR-0005: widened from {@code DatabaseException}). */
+    void destroy() throws LiquibaseException;
 }


### PR DESCRIPTION
> **Draft / RFC pilot.** Pairs with the Liquibase Secure PR that consumes this (`liquibase-pro#4435`) and is gated on ADR-0005 landing. Opening upstream-first per the core-subtree ordering rule — the Secure side re-lands this via subtree sync rather than editing `core/` directly.

## What

Widens the lock-teardown SPI so a classified business/system failure (a `LiquibaseException` subclass) can propagate through it **unwrapped**, instead of being flattened into a `DatabaseException` carrier at the boundary:

| Method | Before | After |
|---|---|---|
| `LockService.forceReleaseLock()` | `throws LockException, DatabaseException` | `throws LockException, LiquibaseException` |
| `LockService.init()` | `throws DatabaseException` | `throws LiquibaseException` |
| `LockService.destroy()` | `throws DatabaseException` | `throws LiquibaseException` |

`destroy()` follows the one teardown chain that propagates it — `LiquibaseTableNames.destroy` (SPI) and its concrete fan-out `LiquibaseTableNamesFactory.destroy` — terminating at `Database.dropDatabaseObjects`, which already declares `throws LiquibaseException`.

## Compatibility

Checked-exception clauses are a compile-time construct, so widening `throws`:
- **Binary-compatible** — existing compiled callers/implementors keep linking.
- **Source-compatible for implementors** — an override may keep a narrower `throws DatabaseException` clause; every in-tree `LockService` impl does, unchanged.
- **Source-incompatible only for strict callers** — code that handles *only* `catch (DatabaseException e)` must widen to `catch (LiquibaseException e)`. `forceReleaseLock`'s caller propagates via `throws`, so nothing in-tree breaks.

## Why

Smallest-first pilot of a per-interface campaign so Liquibase's typed business/system exception hierarchy can flow through the database SPIs (enables per-vendor `…UserErrorException` / `…InfrastructureException` and exit-code routing by classification). Note: `LiquibaseTableNamesFactory.destroy` is a concrete fan-out, **not** an SPI — downstream slices should not widen concrete methods by reflex.

`liquibase-standard` compiles clean with the change.