### PR TITLE
Fix service discovery aborting when a provider fails to load

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/servicelocator/StandardServiceLocator.java
+++ b/liquibase-standard/src/main/java/liquibase/servicelocator/StandardServiceLocator.java
@@ -21,8 +21,12 @@ public class StandardServiceLocator implements ServiceLocator {
 
         final Logger log = Scope.getCurrentScope().getLog(getClass());
         final Iterator<T> services = ServiceLoader.load(interfaceType, Scope.getCurrentScope().getClassLoader(true)).iterator();
-        while (services.hasNext()) {
+        // Guard hasNext() too: ServiceLoader may throw LinkageError (e.g. NoClassDefFoundError) from it.
+        while (true) {
             try {
+                if (!services.hasNext()) {
+                    break;
+                }
                 final T service = services.next();
                 log.fine("Loaded "+interfaceType.getName()+" instance "+service.getClass().getName());
                 allInstances.add(service);

--- a/liquibase-standard/src/test/groovy/liquibase/servicelocator/StandardServiceLocatorTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/servicelocator/StandardServiceLocatorTest.groovy
@@ -1,8 +1,8 @@
 package liquibase.servicelocator
 
+import liquibase.Scope
 import liquibase.change.Change
 import liquibase.changelog.ChangeLogHistoryService
-import liquibase.command.CommandStep
 import liquibase.database.Database
 import liquibase.database.DatabaseConnection
 import liquibase.datatype.LiquibaseDataType
@@ -23,9 +23,18 @@ import liquibase.structure.DatabaseObject
 import liquibase.util.TestUtil
 import org.junit.Assume
 import spock.lang.Specification
+import spock.lang.TempDir
 import spock.lang.Unroll
 
+import javax.tools.ToolProvider
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+
 class StandardServiceLocatorTest extends Specification {
+
+    @TempDir
+    Path tempDir
 
     @Unroll("#featureName: #type.name")
     def "all classes are listed in service loader files"() {
@@ -67,5 +76,128 @@ class StandardServiceLocatorTest extends Specification {
                 Executor.class,
                 DatabaseConnection.class,
         ]
+    }
+
+    def "findInstances continues after NoClassDefFoundError from ServiceLoader.hasNext"() {
+        given:
+        def compiler = ToolProvider.getSystemJavaCompiler()
+        Assume.assumeNotNull("JDK JavaCompiler required to build broken provider fixtures", compiler)
+
+        def classesDir = tempDir.resolve("classes")
+        Files.createDirectories(classesDir)
+        compileServiceFixtures(classesDir)
+        Files.delete(classesDir.resolve("servicelocator/testfixture/MissingDependency.class"))
+
+        URLClassLoader serviceClassLoader = new URLClassLoader(
+                [classesDir.toUri().toURL()] as URL[],
+                getClass().getClassLoader()
+        )
+        def serviceType = serviceClassLoader.loadClass("servicelocator.testfixture.OptionalDependencyService")
+
+        when:
+        def instances = Scope.child([(Scope.Attr.classLoader.name()): serviceClassLoader], {
+            return new StandardServiceLocator().findInstances(serviceType)
+        } as Scope.ScopedRunnerWithReturn)
+
+        then:
+        instances.size() == 2
+        instances*.getClass().name as Set == [
+                "servicelocator.testfixture.GoodProviderBefore",
+                "servicelocator.testfixture.GoodProviderAfter",
+        ] as Set
+
+        cleanup:
+        serviceClassLoader?.close()
+    }
+
+    def "findInstances returns empty list when every provider fails to load"() {
+        given:
+        def compiler = ToolProvider.getSystemJavaCompiler()
+        Assume.assumeNotNull("JDK JavaCompiler required to build broken provider fixtures", compiler)
+
+        def classesDir = tempDir.resolve("classes-all-bad")
+        Files.createDirectories(classesDir)
+        compileServiceFixtures(classesDir)
+        Files.delete(classesDir.resolve("servicelocator/testfixture/MissingDependency.class"))
+
+        def servicesFile = classesDir.resolve("META-INF/services/servicelocator.testfixture.OptionalDependencyService")
+        Files.write(servicesFile, "servicelocator.testfixture.BadProvider\n".getBytes(StandardCharsets.UTF_8))
+
+        URLClassLoader serviceClassLoader = new URLClassLoader(
+                [classesDir.toUri().toURL()] as URL[],
+                getClass().getClassLoader()
+        )
+        def serviceType = serviceClassLoader.loadClass("servicelocator.testfixture.OptionalDependencyService")
+
+        when:
+        def instances = Scope.child([(Scope.Attr.classLoader.name()): serviceClassLoader], {
+            return new StandardServiceLocator().findInstances(serviceType)
+        } as Scope.ScopedRunnerWithReturn)
+
+        then:
+        instances.isEmpty()
+
+        cleanup:
+        serviceClassLoader?.close()
+    }
+
+    private void compileServiceFixtures(Path classesDir) {
+        def srcDir = tempDir.resolve("src-" + classesDir.fileName)
+        def pkgDir = srcDir.resolve("servicelocator/testfixture")
+        Files.createDirectories(pkgDir)
+
+        writeJava(pkgDir.resolve("OptionalDependencyService.java"), """
+            package servicelocator.testfixture;
+            public interface OptionalDependencyService {
+            }
+            """)
+        writeJava(pkgDir.resolve("MissingDependency.java"), """
+            package servicelocator.testfixture;
+            public class MissingDependency {
+            }
+            """)
+        writeJava(pkgDir.resolve("GoodProviderBefore.java"), """
+            package servicelocator.testfixture;
+            public class GoodProviderBefore implements OptionalDependencyService {
+                public GoodProviderBefore() {}
+            }
+            """)
+        writeJava(pkgDir.resolve("BadProvider.java"), """
+            package servicelocator.testfixture;
+            public class BadProvider extends MissingDependency implements OptionalDependencyService {
+                public BadProvider() {}
+            }
+            """)
+        writeJava(pkgDir.resolve("GoodProviderAfter.java"), """
+            package servicelocator.testfixture;
+            public class GoodProviderAfter implements OptionalDependencyService {
+                public GoodProviderAfter() {}
+            }
+            """)
+
+        def sources = Files.walk(srcDir)
+                .filter { Files.isRegularFile(it) && it.toString().endsWith(".java") }
+                .map { it.toFile() }
+                .toList()
+
+        def compiler = ToolProvider.getSystemJavaCompiler()
+        def fileManager = compiler.getStandardFileManager(null, null, StandardCharsets.UTF_8)
+        def compilationUnits = fileManager.getJavaFileObjectsFromFiles(sources)
+        def options = ["-d", classesDir.toAbsolutePath().toString()]
+        def task = compiler.getTask(null, fileManager, null, options, null, compilationUnits)
+        assert task.call() : "Failed to compile service locator test fixtures"
+        fileManager.close()
+
+        def servicesDir = classesDir.resolve("META-INF/services")
+        Files.createDirectories(servicesDir)
+        Files.write(servicesDir.resolve("servicelocator.testfixture.OptionalDependencyService"), """
+            servicelocator.testfixture.GoodProviderBefore
+            servicelocator.testfixture.BadProvider
+            servicelocator.testfixture.GoodProviderAfter
+            """.stripIndent().trim().getBytes(StandardCharsets.UTF_8))
+    }
+
+    private static void writeJava(Path path, String source) {
+        Files.write(path, source.stripIndent().trim().getBytes(StandardCharsets.UTF_8))
     }
 }


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Fixes #7757.

`StandardServiceLocator` only caught failures from `iterator.next()`. On newer JDKs, `ServiceLoader` can throw `NoClassDefFoundError` from `hasNext()` when a provider class has a missing dependency (for example liquibase-hibernate Spring classes without Spring on the classpath). That stopped discovery entirely, so later providers never loaded either.

Both `hasNext()` and `next()` are now inside the try/catch. A bad provider is logged and skipped; the rest continue to load.

## Release note

Fixed a bug where Liquibase could fail to start if an extension registered a service that referenced a missing optional dependency.

## Things to be aware of

Same failure handling path as before — we just also cover errors thrown from `hasNext()`.

## Things to worry about

None.

## Additional Context

Added unit tests that build a small ServiceLoader fixture with a broken provider between two good ones and check that discovery continues.