### PR TITLE
Detect Firebird-compatible RedDatabase servers as Firebird

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/database/core/FirebirdDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/core/FirebirdDatabase.java
@@ -23,7 +23,8 @@ public class FirebirdDatabase extends AbstractJdbcDatabase {
 
     @Override
     public boolean isCorrectDatabaseImplementation(DatabaseConnection conn) throws DatabaseException {
-        return conn.getDatabaseProductName().startsWith("Firebird");
+        String productName = conn.getDatabaseProductName();
+        return productName.startsWith("Firebird") || productName.startsWith("RedDatabase");
     }
 
     @Override

--- a/liquibase-standard/src/test/groovy/liquibase/database/core/FirebirdDatabaseTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/database/core/FirebirdDatabaseTest.groovy
@@ -1,5 +1,6 @@
 package liquibase.database.core
 
+import liquibase.database.DatabaseConnection
 import liquibase.structure.core.Column
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -8,6 +9,26 @@ import static liquibase.database.ObjectQuotingStrategy.QUOTE_ALL_OBJECTS
 import static liquibase.database.ObjectQuotingStrategy.QUOTE_ONLY_RESERVED_WORDS
 
 class FirebirdDatabaseTest extends Specification {
+
+    @Unroll
+    def "isCorrectDatabaseImplementation for #productName"() {
+        given:
+        def connection = Mock(DatabaseConnection) {
+            getDatabaseProductName() >> productName
+        }
+
+        expect:
+        new FirebirdDatabase().isCorrectDatabaseImplementation(connection) == expected
+
+        where:
+        productName                    || expected
+        'Firebird'                     || true
+        'Firebird 5.0'                 || true
+        'RedDatabase'                  || true
+        'RedDatabase 5.1 (abcdef01)'   || true
+        'PostgreSQL'                   || false
+        'H2'                           || false
+    }
 
     @Unroll("#featureName [#quotingStrategy], [#objectName, #objectType], [#expectedCorrect, #expectedEscape]")
     def "correctObjectName, escapeObjectName"() {


### PR DESCRIPTION
## Impact

- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

RedDatabase is an actively maintained Firebird fork (same engine lineage,
SQL-compatible, works with the standard Jaybird JDBC driver), but it reports
its own product name, e.g. `RedDatabase 5.1 (abcdef01...)`.
`FirebirdDatabase.isCorrectDatabaseImplementation()` only matches product
names starting with `Firebird`, so such connections fall through to
`UnsupportedDatabase` and Liquibase generates generic SQL that the server
rejects.

#### Steps To Reproduce

1. Run `liquibase update` (or Spring Boot with Liquibase) against a
   RedDatabase server using the Jaybird driver.
2. Liquibase attempts to create its tracking table.

#### Expected Behavior

The connection is detected as Firebird and Firebird-compatible SQL is
generated.

#### Actual Behavior

The connection is treated as `UnsupportedDatabase` and the update fails:

CREATE TABLE DATABASECHANGELOG failed; SQL error code = -607;
Specified domain or source column DATETIME does not exist

#### Fix

Accept product names starting with `RedDatabase` in addition to `Firebird`
in `FirebirdDatabase.isCorrectDatabaseImplementation()`. This follows the
existing pattern in `SybaseASADatabase`, which matches several product names
of compatible servers in a single class. The short name stays `firebird`,
so existing changelogs with `dbms="firebird"` apply as-is.

Unit tests added to `FirebirdDatabaseTest` covering detection of Firebird
and RedDatabase product names plus negative cases.

## Release note

Liquibase now detects Firebird-compatible RedDatabase servers as Firebird,
so `update` and other commands work against RedDatabase out of the box.

## Things to be aware of

- Detection-only change: two lines in `isCorrectDatabaseImplementation()`;
  no SQL generation logic is touched and behavior for all other databases
  is unchanged.
- Verified against a live RedDatabase 5.1 server: the tracking tables are
  created and updates run successfully.

## Additional Context

RedDatabase: https://reddatabase.ru/en/ - a Firebird-based DBMS; the same
Jaybird driver and Firebird SQL dialect are used, only the reported product
name differs.