### PR TITLE
INT-2142: widen Postgres-family instanceof to AbstractPostgresDatabase (core)

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/change/core/AddNotNullConstraintChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/AddNotNullConstraintChange.java
@@ -3,7 +3,6 @@ package liquibase.change.core;
 import liquibase.change.*;
 import liquibase.database.Database;
 import liquibase.database.core.DB2Database;
-import liquibase.database.core.PostgresDatabase;
 import liquibase.database.core.AbstractPostgresDatabase;
 import liquibase.database.core.SQLiteDatabase.AlterTableVisitor;
 import liquibase.datatype.DataTypeFactory;

--- a/liquibase-standard/src/main/java/liquibase/change/core/AddNotNullConstraintChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/AddNotNullConstraintChange.java
@@ -4,6 +4,7 @@ import liquibase.change.*;
 import liquibase.database.Database;
 import liquibase.database.core.DB2Database;
 import liquibase.database.core.PostgresDatabase;
+import liquibase.database.core.AbstractPostgresDatabase;
 import liquibase.database.core.SQLiteDatabase.AlterTableVisitor;
 import liquibase.datatype.DataTypeFactory;
 import liquibase.datatype.LiquibaseDataType;
@@ -142,7 +143,7 @@ public class AddNotNullConstraintChange extends AbstractChange {
                         }
                     }
 
-                    if (database instanceof PostgresDatabase) {
+                    if (database instanceof AbstractPostgresDatabase) {
                         if (finalDefaultNullValue.equals(0)) {
                             finalDefaultNullValue = new DatabaseFunction( "B'0'");
                         } else if (finalDefaultNullValue.equals(1)) {

--- a/liquibase-standard/src/main/java/liquibase/change/core/LoadDataChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/LoadDataChange.java
@@ -9,7 +9,6 @@ import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.Database;
 import liquibase.database.core.MSSQLDatabase;
 import liquibase.database.core.MySQLDatabase;
-import liquibase.database.core.PostgresDatabase;
 import liquibase.database.core.AbstractPostgresDatabase;
 import liquibase.datatype.DataTypeFactory;
 import liquibase.datatype.LiquibaseDataType;

--- a/liquibase-standard/src/main/java/liquibase/change/core/LoadDataChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/LoadDataChange.java
@@ -10,6 +10,7 @@ import liquibase.database.Database;
 import liquibase.database.core.MSSQLDatabase;
 import liquibase.database.core.MySQLDatabase;
 import liquibase.database.core.PostgresDatabase;
+import liquibase.database.core.AbstractPostgresDatabase;
 import liquibase.datatype.DataTypeFactory;
 import liquibase.datatype.LiquibaseDataType;
 import liquibase.exception.*;
@@ -497,7 +498,7 @@ public class LoadDataChange extends AbstractTableChange implements ChangeWithCol
      * should we use prepared statements as a default?
      */
     private boolean preferPreparedStatements(Database database) {
-        if (database instanceof PostgresDatabase) {
+        if (database instanceof AbstractPostgresDatabase) {
             return false; //postgresql seems surprisingly slow with prepared statements
         }
         return supportsBatchUpdates(database);
@@ -874,7 +875,7 @@ public class LoadDataChange extends AbstractTableChange implements ChangeWithCol
         if (rows.stream().anyMatch(LoadDataRowConfig::needsPreparedStatement)) {
             // If we have only prepared statements and the database supports batching, let's roll
             if (supportsBatchUpdates(database) && !preparedStatements.isEmpty()) {
-                if (database instanceof PostgresDatabase || database instanceof MySQLDatabase) {
+                if (database instanceof AbstractPostgresDatabase || database instanceof MySQLDatabase) {
                     // we don't do batch updates for Postgres but we still send as a prepared statement, see LB-744
                     // mysql supports batch updates, but the performance vs. the big insert is worse
                     return preparedStatements.toArray(SqlStatement.EMPTY_SQL_STATEMENT);
@@ -904,7 +905,7 @@ public class LoadDataChange extends AbstractTableChange implements ChangeWithCol
             }
 
             if ((database instanceof MSSQLDatabase) || (database instanceof MySQLDatabase) || (database
-                    instanceof PostgresDatabase)) {
+                    instanceof AbstractPostgresDatabase)) {
                 List<InsertStatement> innerStatements = statementSet.getStatements();
                 if ((innerStatements != null) && (!innerStatements.isEmpty()) && (innerStatements.get(0)
                         instanceof InsertOrUpdateStatement)) {

--- a/liquibase-standard/src/main/java/liquibase/command/core/InternalSnapshotCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/InternalSnapshotCommandStep.java
@@ -124,7 +124,7 @@ public class InternalSnapshotCommandStep extends AbstractCommandStep {
                     || database instanceof OracleDatabase
                     || database instanceof MySQLDatabase
                     || database instanceof DB2Database
-                    || database instanceof PostgresDatabase
+                    || database instanceof AbstractPostgresDatabase
                     || database.getShortName().equalsIgnoreCase("bigquery")
                     || database.getShortName().equalsIgnoreCase("snowflake"))) { //TODO: Update to use SnowflakeDatabase once the liquibase-snowflake module is fully integrated into liquibase-core
                 Scope.getCurrentScope().getUI().sendMessage("INFO This command might not yet capture Liquibase Pro additional object types on " + database.getShortName());

--- a/liquibase-standard/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -566,7 +566,7 @@ public abstract class AbstractJdbcDatabase implements Database {
 
             if (generateIncrementBy) {
                 if (generateStartWith) {
-                    if(!(this instanceof PostgresDatabase)) {
+                    if(!(this instanceof AbstractPostgresDatabase)) {
                         autoIncrementClause += ", ";
                     }
                     else {
@@ -770,7 +770,7 @@ public abstract class AbstractJdbcDatabase implements Database {
     @Override
     public boolean supportsDropTableCascadeConstraints() {
         return ((this instanceof SQLiteDatabase) || (this instanceof SybaseDatabase) || (this instanceof
-                SybaseASADatabase) || (this instanceof PostgresDatabase) || (this instanceof OracleDatabase));
+                SybaseASADatabase) || (this instanceof AbstractPostgresDatabase) || (this instanceof OracleDatabase));
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/BigIntType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/BigIntType.java
@@ -53,8 +53,8 @@ public class BigIntType extends LiquibaseDataType {
                 || (database instanceof SybaseASADatabase) || (database instanceof H2Database)) {
             return new DatabaseDataType("BIGINT");
         }
-        if (database instanceof AbstractPostgresDatabase) {
-            if (isAutoIncrement() && ((AbstractPostgresDatabase) database).useSerialDatatypes()) {
+        if (database instanceof AbstractPostgresDatabase postgresDatabase) {
+            if (isAutoIncrement() && postgresDatabase.useSerialDatatypes()) {
                 return new DatabaseDataType("BIGSERIAL");
             } else {
                 if (GlobalConfiguration.CONVERT_DATA_TYPES.getCurrentValue() || this.getRawDefinition() == null) {

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/BigIntType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/BigIntType.java
@@ -53,8 +53,8 @@ public class BigIntType extends LiquibaseDataType {
                 || (database instanceof SybaseASADatabase) || (database instanceof H2Database)) {
             return new DatabaseDataType("BIGINT");
         }
-        if (database instanceof AbstractPostgresDatabase postgresDatabase) {
-            if (isAutoIncrement() && postgresDatabase.useSerialDatatypes()) {
+        if (database instanceof AbstractPostgresDatabase postgresLike) {
+            if (isAutoIncrement() && postgresLike.useSerialDatatypes()) {
                 return new DatabaseDataType("BIGSERIAL");
             } else {
                 if (GlobalConfiguration.CONVERT_DATA_TYPES.getCurrentValue() || this.getRawDefinition() == null) {

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/BigIntType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/BigIntType.java
@@ -53,8 +53,8 @@ public class BigIntType extends LiquibaseDataType {
                 || (database instanceof SybaseASADatabase) || (database instanceof H2Database)) {
             return new DatabaseDataType("BIGINT");
         }
-        if (database instanceof PostgresDatabase) {
-            if (isAutoIncrement() && ((PostgresDatabase) database).useSerialDatatypes()) {
+        if (database instanceof AbstractPostgresDatabase) {
+            if (isAutoIncrement() && ((AbstractPostgresDatabase) database).useSerialDatatypes()) {
                 return new DatabaseDataType("BIGSERIAL");
             } else {
                 if (GlobalConfiguration.CONVERT_DATA_TYPES.getCurrentValue() || this.getRawDefinition() == null) {

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/BlobType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/BlobType.java
@@ -87,7 +87,7 @@ public class BlobType extends LiquibaseDataType {
             }
         }
 
-        if (database instanceof PostgresDatabase) {
+        if (database instanceof AbstractPostgresDatabase) {
             if (blob) {
                 // There are two ways of handling byte arrays ("BLOBs") in pgsql. For consistency with Hibernate ORM
                 // (see upstream bug https://liquibase.jira.com/browse/CORE-1863) we choose the oid variant.

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/BooleanType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/BooleanType.java
@@ -88,7 +88,7 @@ public class BooleanType extends LiquibaseDataType {
 				return new DatabaseDataType("SMALLINT");
         } else if (database instanceof HsqlDatabase) {
             return new DatabaseDataType("BOOLEAN");
-        } else if (database instanceof PostgresDatabase) {
+        } else if (database instanceof AbstractPostgresDatabase) {
             if (originalDefinition.toLowerCase(Locale.US).startsWith("bit")) {
                 return new DatabaseDataType("BIT", getParameters());
             }
@@ -114,7 +114,7 @@ public class BooleanType extends LiquibaseDataType {
             } else if ("false".equals(((String) value).toLowerCase(Locale.US)) || "0".equals(value) || "b'0'".equals(
                     ((String) value).toLowerCase(Locale.US)) || "f".equals(((String) value).toLowerCase(Locale.US)) || ((String) value).toLowerCase(Locale.US).equals(this.getFalseBooleanValue(database).toLowerCase(Locale.US))) {
                 returnValue = this.getFalseBooleanValue(database);
-            } else if (database instanceof PostgresDatabase && Pattern.matches("b?([01])\\1*(::bit|::\"bit\")?", (String) value)) {
+            } else if (database instanceof AbstractPostgresDatabase && Pattern.matches("b?([01])\\1*(::bit|::\"bit\")?", (String) value)) {
                 returnValue = "b'" 
                         + value.toString()
                                 .replace("b", "")

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/CharType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/CharType.java
@@ -7,6 +7,7 @@ import liquibase.database.core.H2Database;
 import liquibase.database.core.MSSQLDatabase;
 import liquibase.database.core.OracleDatabase;
 import liquibase.database.core.PostgresDatabase;
+import liquibase.database.core.AbstractPostgresDatabase;
 import liquibase.datatype.DataTypeInfo;
 import liquibase.datatype.DatabaseDataType;
 import liquibase.datatype.LiquibaseDataType;
@@ -52,7 +53,7 @@ public class CharType extends LiquibaseDataType {
             DatabaseDataType type = new DatabaseDataType(database.escapeDataTypeName("char"), parameters);
             type.addAdditionalInformation(getAdditionalInformation());
             return type;
-        } else if (database instanceof PostgresDatabase){
+        } else if (database instanceof AbstractPostgresDatabase){
             final Object[] parameters = getParameters();
             if ((parameters != null) && (parameters.length == 1)) {
                 // PostgreSQL only supports (n) syntax but not (n CHAR) syntax, so we need to remove CHAR.

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/CharType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/CharType.java
@@ -6,7 +6,6 @@ import liquibase.database.Database;
 import liquibase.database.core.H2Database;
 import liquibase.database.core.MSSQLDatabase;
 import liquibase.database.core.OracleDatabase;
-import liquibase.database.core.PostgresDatabase;
 import liquibase.database.core.AbstractPostgresDatabase;
 import liquibase.datatype.DataTypeInfo;
 import liquibase.datatype.DatabaseDataType;

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/ClobType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/ClobType.java
@@ -100,7 +100,7 @@ public class ClobType extends LiquibaseDataType {
             } else {
                 return new DatabaseDataType("CLOB");
             }
-        } else if ((database instanceof PostgresDatabase) || (database instanceof SQLiteDatabase) || (database
+        } else if ((database instanceof AbstractPostgresDatabase) || (database instanceof SQLiteDatabase) || (database
             instanceof SybaseDatabase)) {
             return new DatabaseDataType("TEXT");
         } else if (database instanceof OracleDatabase) {

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/DateTimeType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/DateTimeType.java
@@ -95,7 +95,7 @@ public class DateTimeType extends LiquibaseDataType {
 
             return new DatabaseDataType("DATETIME YEAR TO FRACTION", 5);
         }
-        if (database instanceof PostgresDatabase) {
+        if (database instanceof AbstractPostgresDatabase) {
             String rawDefinition = originalDefinition.toLowerCase(Locale.US);
             Object[] params = getParameters();
             if (rawDefinition.contains("tz") || rawDefinition.contains("with time zone")) {

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/DoubleType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/DoubleType.java
@@ -39,7 +39,7 @@ public class DoubleType  extends LiquibaseDataType {
         if ((database instanceof AbstractDb2Database) || (database instanceof DerbyDatabase) || (database instanceof HsqlDatabase) || (database instanceof SybaseASADatabase)) {
             return new DatabaseDataType("DOUBLE");
         }
-        if ((database instanceof H2Database) || (database instanceof OracleDatabase) || (database instanceof PostgresDatabase)
+        if ((database instanceof H2Database) || (database instanceof OracleDatabase) || (database instanceof AbstractPostgresDatabase)
               || (database instanceof InformixDatabase) || (database instanceof FirebirdDatabase)) {
             return new DatabaseDataType("DOUBLE PRECISION");
         }

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/FloatType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/FloatType.java
@@ -41,7 +41,7 @@ public class FloatType  extends LiquibaseDataType {
         }
         if ((database instanceof FirebirdDatabase) || (database instanceof InformixDatabase)) {
             return new DatabaseDataType("FLOAT");
-        } else if (database instanceof PostgresDatabase) {
+        } else if (database instanceof AbstractPostgresDatabase) {
             if ("real".equals(originalDefinition.toLowerCase(Locale.US))) {
                 return new DatabaseDataType("REAL");
             }

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/IntType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/IntType.java
@@ -38,9 +38,9 @@ public class IntType extends LiquibaseDataType {
             return new DatabaseDataType("INTEGER");
         }
 
-        if (database instanceof PostgresDatabase) {
+        if (database instanceof AbstractPostgresDatabase) {
             if (isAutoIncrement()) {
-                if (((PostgresDatabase) database).useSerialDatatypes()) {
+                if (((AbstractPostgresDatabase) database).useSerialDatatypes()) {
                     return new DatabaseDataType("SERIAL");
                 } else {
                     if (GlobalConfiguration.CONVERT_DATA_TYPES.getCurrentValue() || this.getRawDefinition() == null) {

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/IntType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/IntType.java
@@ -38,9 +38,9 @@ public class IntType extends LiquibaseDataType {
             return new DatabaseDataType("INTEGER");
         }
 
-        if (database instanceof AbstractPostgresDatabase postgresDatabase) {
+        if (database instanceof AbstractPostgresDatabase postgresLike) {
             if (isAutoIncrement()) {
-                if (postgresDatabase.useSerialDatatypes()) {
+                if (postgresLike.useSerialDatatypes()) {
                     return new DatabaseDataType("SERIAL");
                 } else {
                     if (GlobalConfiguration.CONVERT_DATA_TYPES.getCurrentValue() || this.getRawDefinition() == null) {

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/IntType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/IntType.java
@@ -38,9 +38,9 @@ public class IntType extends LiquibaseDataType {
             return new DatabaseDataType("INTEGER");
         }
 
-        if (database instanceof AbstractPostgresDatabase) {
+        if (database instanceof AbstractPostgresDatabase postgresDatabase) {
             if (isAutoIncrement()) {
-                if (((AbstractPostgresDatabase) database).useSerialDatatypes()) {
+                if (postgresDatabase.useSerialDatatypes()) {
                     return new DatabaseDataType("SERIAL");
                 } else {
                     if (GlobalConfiguration.CONVERT_DATA_TYPES.getCurrentValue() || this.getRawDefinition() == null) {

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/NVarcharType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/NVarcharType.java
@@ -19,7 +19,7 @@ public class NVarcharType extends CharType {
         if ((getRawDefinition() != null) && getRawDefinition().toLowerCase(Locale.US).contains("national character varying")) {
             setAdditionalInformation(null); //just go to nvarchar
         }
-        if ((database instanceof HsqlDatabase) || (database instanceof PostgresDatabase) || (database instanceof
+        if ((database instanceof HsqlDatabase) || (database instanceof AbstractPostgresDatabase) || (database instanceof
             DerbyDatabase)) {
 
             return new DatabaseDataType("VARCHAR", getParameters());

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/NumberType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/NumberType.java
@@ -46,7 +46,7 @@ public class NumberType extends LiquibaseDataType {
             } else {
                 return new DatabaseDataType("NUMBER", getParameters());
             }
-        } else if (database instanceof PostgresDatabase) {
+        } else if (database instanceof AbstractPostgresDatabase) {
             if ((getParameters().length > 0)) {
                 try {
                     if ((Integer.parseInt(getParameters()[0].toString()) > 1000)) {

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/SmallIntType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/SmallIntType.java
@@ -47,9 +47,9 @@ public class SmallIntType extends LiquibaseDataType {
         }
 
 
-        if (database instanceof AbstractPostgresDatabase) {
+        if (database instanceof AbstractPostgresDatabase postgresDatabase) {
             if (isAutoIncrement()) {
-                if (((AbstractPostgresDatabase) database).useSerialDatatypes()) {
+                if (postgresDatabase.useSerialDatatypes()) {
                     return new DatabaseDataType("SMALLSERIAL");
                 }
             } else {

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/SmallIntType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/SmallIntType.java
@@ -47,9 +47,9 @@ public class SmallIntType extends LiquibaseDataType {
         }
 
 
-        if (database instanceof AbstractPostgresDatabase postgresDatabase) {
+        if (database instanceof AbstractPostgresDatabase postgresLike) {
             if (isAutoIncrement()) {
-                if (postgresDatabase.useSerialDatatypes()) {
+                if (postgresLike.useSerialDatatypes()) {
                     return new DatabaseDataType("SMALLSERIAL");
                 }
             } else {

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/SmallIntType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/SmallIntType.java
@@ -47,9 +47,9 @@ public class SmallIntType extends LiquibaseDataType {
         }
 
 
-        if (database instanceof PostgresDatabase) {
+        if (database instanceof AbstractPostgresDatabase) {
             if (isAutoIncrement()) {
-                if (((PostgresDatabase) database).useSerialDatatypes()) {
+                if (((AbstractPostgresDatabase) database).useSerialDatatypes()) {
                     return new DatabaseDataType("SMALLSERIAL");
                 }
             } else {

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/TimeType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/TimeType.java
@@ -59,7 +59,7 @@ public class TimeType extends LiquibaseDataType {
             return new DatabaseDataType("DATE");
         }
 
-        if (database instanceof PostgresDatabase) {
+        if (database instanceof AbstractPostgresDatabase) {
             DatabaseDataType datatype = new DatabaseDataType(getName(), getValidatedParameters());
             String rawDefinition = originalDefinition.toLowerCase(Locale.US);
 

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/TimestampType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/TimestampType.java
@@ -156,13 +156,13 @@ public class TimestampType extends DateTimeType {
         }
 
         if ((originalDefinition.toUpperCase().startsWith("JAVA.SQL.TYPES.TIMESTAMP_WITH_TIMEZONE")
-            && (database instanceof PostgresDatabase
+            && (database instanceof AbstractPostgresDatabase
             || database instanceof OracleDatabase
             || database instanceof H2Database
             || database instanceof HsqlDatabase
             || database instanceof SybaseASADatabase)) || (originalDefinition.toLowerCase().startsWith("timestamptz"))) {
 
-            if (database instanceof PostgresDatabase
+            if (database instanceof AbstractPostgresDatabase
                     || database instanceof H2Database
                     || database instanceof SybaseASADatabase
                     || database instanceof OracleDatabase) {
@@ -176,7 +176,7 @@ public class TimestampType extends DateTimeType {
 
 
         if (getAdditionalInformation() != null
-                && (database instanceof PostgresDatabase
+                && (database instanceof AbstractPostgresDatabase
                 || database instanceof OracleDatabase
                 || database instanceof H2Database
                 || database instanceof HsqlDatabase
@@ -186,7 +186,7 @@ public class TimestampType extends DateTimeType {
             if (additionalInformation != null) {
                 String additionInformation = additionalInformation.toUpperCase(Locale.US);
                 // Normalize "TIMEZONE" to "TIME ZONE" for databases that require it
-                if ((database instanceof PostgresDatabase || database instanceof H2Database || database instanceof SybaseASADatabase || database instanceof OracleDatabase)
+                if ((database instanceof AbstractPostgresDatabase || database instanceof H2Database || database instanceof SybaseASADatabase || database instanceof OracleDatabase)
                         && additionInformation.contains("TIMEZONE")) {
                     additionalInformation = additionInformation.replace("TIMEZONE", "TIME ZONE");
                 }
@@ -217,7 +217,7 @@ public class TimestampType extends DateTimeType {
         // Firebird doesn't support TIMESTAMP(precision) syntax, so let it fall through to super
         if (getParameters().length > 0
                 && !(database instanceof SybaseASADatabase)
-                && !(database instanceof PostgresDatabase)
+                && !(database instanceof AbstractPostgresDatabase)
                 && !(database instanceof FirebirdDatabase)) {
             return type;
         }

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/TinyIntType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/TinyIntType.java
@@ -30,7 +30,7 @@ public class TinyIntType extends LiquibaseDataType {
         if (database instanceof MSSQLDatabase) {
             return new DatabaseDataType(database.escapeDataTypeName("tinyint"));
         }
-        if ((database instanceof DerbyDatabase) || (database instanceof PostgresDatabase) || (database instanceof
+        if ((database instanceof DerbyDatabase) || (database instanceof AbstractPostgresDatabase) || (database instanceof
                 FirebirdDatabase) || (database instanceof AbstractDb2Database)) {
             return new DatabaseDataType("SMALLINT");
         }

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/VarcharType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/VarcharType.java
@@ -53,7 +53,7 @@ public class VarcharType extends CharType {
             DatabaseDataType type = new DatabaseDataType(database.escapeDataTypeName("varchar"), parameters);
             type.addAdditionalInformation(getAdditionalInformation());
             return type;
-        } else if (database instanceof PostgresDatabase) {
+        } else if (database instanceof AbstractPostgresDatabase) {
             final Object[] parameters = getParameters();
             if ((parameters != null) && (parameters.length == 1)) {
                 // PostgreSQL only supports (n) syntax but not (n CHAR) syntax, so we need to remove CHAR.

--- a/liquibase-standard/src/main/java/liquibase/datatype/core/XMLType.java
+++ b/liquibase-standard/src/main/java/liquibase/datatype/core/XMLType.java
@@ -19,7 +19,7 @@ public class XMLType extends LiquibaseDataType {
         String val = value.toString();
         if ((database instanceof MSSQLDatabase) && !StringUtil.isAscii(val)) {
             return "N'" + database.escapeStringForDatabase(val) + "'";
-        } else if (database instanceof PostgresDatabase) {
+        } else if (database instanceof AbstractPostgresDatabase) {
             try {
                 if ((database.getDatabaseMajorVersion() <= 7) // 8.2 or earlier
                     || ((database.getDatabaseMajorVersion() == 8) && (database.getDatabaseMinorVersion() <= 2))) {
@@ -43,7 +43,7 @@ public class XMLType extends LiquibaseDataType {
               parameters = new Object[] { parameters[0] };
             }
             return new DatabaseDataType(database.escapeDataTypeName("xml"), parameters);
-        } else if (database instanceof PostgresDatabase) {
+        } else if (database instanceof AbstractPostgresDatabase) {
             try {
                 if ((database.getDatabaseMajorVersion() <= 7) // 8.2 or earlier
                     || ((database.getDatabaseMajorVersion() == 8) && (database.getDatabaseMinorVersion() <= 2))) {

--- a/liquibase-standard/src/main/java/liquibase/diff/output/changelog/DiffToChangeLog.java
+++ b/liquibase-standard/src/main/java/liquibase/diff/output/changelog/DiffToChangeLog.java
@@ -215,7 +215,7 @@ public class DiffToChangeLog {
     private Database determineDatabase(DatabaseSnapshot snapshot) {
         Database database = snapshot.getDatabase();
         DatabaseConnection connection = database.getConnection();
-        if (! (connection instanceof OfflineConnection) && database instanceof PostgresDatabase) {
+        if (! (connection instanceof OfflineConnection) && database instanceof AbstractPostgresDatabase) {
             return database;
         }
         return null;
@@ -458,7 +458,7 @@ public class DiffToChangeLog {
                         //
                         // For Postgres, make tables appear before stored logic
                         //
-                        if (database instanceof PostgresDatabase) {
+                        if (database instanceof AbstractPostgresDatabase) {
                             Integer x = determineOrderingForTablesAndStoredLogic(o1, o2);
                             if (x != null) {
                                 return x;
@@ -525,7 +525,7 @@ public class DiffToChangeLog {
      */
     private static String convertStoredLogicObjectName(String schemaName, String objectName, Database database) {
         String name = schemaName + "." + objectName;
-        if (! (database instanceof PostgresDatabase) || ! (objectName.contains("(") && objectName.contains(")"))) {
+        if (! (database instanceof AbstractPostgresDatabase) || ! (objectName.contains("(") && objectName.contains(")"))) {
             return name;
         }
         Pattern p = Pattern.compile(".*?[(]+(.*)?[)]+[\\s]*?$");
@@ -584,7 +584,7 @@ public class DiffToChangeLog {
             return false;
         }
         return (database instanceof AbstractDb2Database) || (database instanceof MSSQLDatabase) || (database instanceof
-                OracleDatabase) || database instanceof PostgresDatabase;
+                OracleDatabase) || database instanceof AbstractPostgresDatabase;
     }
 
     /**
@@ -701,7 +701,7 @@ public class DiffToChangeLog {
                     }
                 }
             }
-        } else if (database instanceof PostgresDatabase) {
+        } else if (database instanceof AbstractPostgresDatabase) {
             final String sql = queryForDependenciesPostgreSql(schemas);
             final Executor executor = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database);
             final List<Map<String, ?>> queryForListResult = executor.queryForList(new RawParameterizedSqlStatement(sql));

--- a/liquibase-standard/src/main/java/liquibase/diff/output/changelog/core/ChangedColumnChangeGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/diff/output/changelog/core/ChangedColumnChangeGenerator.java
@@ -8,7 +8,6 @@ import liquibase.database.Database;
 import liquibase.database.core.MSSQLDatabase;
 import liquibase.database.core.OracleDatabase;
 import liquibase.database.core.AbstractPostgresDatabase;
-import liquibase.database.core.PostgresDatabase;
 import liquibase.datatype.DataTypeFactory;
 import liquibase.datatype.LiquibaseDataType;
 import liquibase.datatype.core.BooleanType;
@@ -293,7 +292,7 @@ public class ChangedColumnChangeGenerator extends AbstractChangeGenerator implem
     }
 
     /**
-     * For {@link PostgresDatabase} if column is of autoIncrement/SERIAL type we can ignore 'defaultValue' differences
+     * For {@link AbstractPostgresDatabase} if column is of autoIncrement/SERIAL type we can ignore 'defaultValue' differences
      * (because its execution of sequence.next() anyway)
      */
     private boolean shouldTriggerAddDefaultChange(Column column, Difference difference, Database comparisonDatabase) {

--- a/liquibase-standard/src/main/java/liquibase/diff/output/changelog/core/ChangedColumnChangeGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/diff/output/changelog/core/ChangedColumnChangeGenerator.java
@@ -7,6 +7,7 @@ import liquibase.change.core.*;
 import liquibase.database.Database;
 import liquibase.database.core.MSSQLDatabase;
 import liquibase.database.core.OracleDatabase;
+import liquibase.database.core.AbstractPostgresDatabase;
 import liquibase.database.core.PostgresDatabase;
 import liquibase.datatype.DataTypeFactory;
 import liquibase.datatype.LiquibaseDataType;
@@ -296,7 +297,7 @@ public class ChangedColumnChangeGenerator extends AbstractChangeGenerator implem
      * (because its execution of sequence.next() anyway)
      */
     private boolean shouldTriggerAddDefaultChange(Column column, Difference difference, Database comparisonDatabase) {
-        if (!(comparisonDatabase instanceof PostgresDatabase)) {
+        if (!(comparisonDatabase instanceof AbstractPostgresDatabase)) {
             return true;
         }
         return column.getAutoIncrementInformation() == null || !(difference.getReferenceValue() instanceof DatabaseFunction);

--- a/liquibase-standard/src/main/java/liquibase/precondition/core/ColumnExistsPrecondition.java
+++ b/liquibase-standard/src/main/java/liquibase/precondition/core/ColumnExistsPrecondition.java
@@ -6,6 +6,7 @@ import liquibase.changelog.visitor.ChangeExecListener;
 import liquibase.database.Database;
 import liquibase.database.core.FirebirdDatabase;
 import liquibase.database.core.PostgresDatabase;
+import liquibase.database.core.AbstractPostgresDatabase;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.*;
 import liquibase.precondition.AbstractPrecondition;
@@ -134,7 +135,7 @@ public class ColumnExistsPrecondition extends AbstractPrecondition {
             String tableName = getTableName();
             String columnName = getColumnName();
 
-            if (database instanceof PostgresDatabase) {
+            if (database instanceof AbstractPostgresDatabase) {
                 makeSureColumnExistsInPostgres(database, changeLog, schemaName, tableName, columnName);
             } else {
                 makeSureColumnExistsInOtherDBs(database, changeLog, schemaName, tableName, columnName);

--- a/liquibase-standard/src/main/java/liquibase/precondition/core/ColumnExistsPrecondition.java
+++ b/liquibase-standard/src/main/java/liquibase/precondition/core/ColumnExistsPrecondition.java
@@ -5,7 +5,6 @@ import liquibase.changelog.DatabaseChangeLog;
 import liquibase.changelog.visitor.ChangeExecListener;
 import liquibase.database.Database;
 import liquibase.database.core.FirebirdDatabase;
-import liquibase.database.core.PostgresDatabase;
 import liquibase.database.core.AbstractPostgresDatabase;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.*;

--- a/liquibase-standard/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/JdbcDatabaseSnapshot.java
@@ -1847,7 +1847,7 @@ public class JdbcDatabaseSnapshot extends DatabaseSnapshot {
                         if (tableName != null) {
                             sql += " and table_name='" + tableName + "'";
                         }
-                    } else if (database instanceof PostgresDatabase) {
+                    } else if (database instanceof AbstractPostgresDatabase) {
                         sql = "select CONSTRAINT_NAME, TABLE_NAME "
                                 + "from " + database.getSystemSchema() + ".table_constraints "
                                 + "where constraint_catalog='" + jdbcCatalogName + "' "

--- a/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotGeneratorFactory.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotGeneratorFactory.java
@@ -8,7 +8,6 @@ import liquibase.database.*;
 import liquibase.database.core.MSSQLDatabase;
 import liquibase.database.core.MariaDBDatabase;
 import liquibase.database.core.MockDatabase;
-import liquibase.database.core.PostgresDatabase;
 import liquibase.database.core.AbstractPostgresDatabase;
 import liquibase.diff.compare.DatabaseObjectComparatorFactory;
 import liquibase.exception.DatabaseException;

--- a/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotGeneratorFactory.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/SnapshotGeneratorFactory.java
@@ -9,6 +9,7 @@ import liquibase.database.core.MSSQLDatabase;
 import liquibase.database.core.MariaDBDatabase;
 import liquibase.database.core.MockDatabase;
 import liquibase.database.core.PostgresDatabase;
+import liquibase.database.core.AbstractPostgresDatabase;
 import liquibase.diff.compare.DatabaseObjectComparatorFactory;
 import liquibase.exception.DatabaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
@@ -171,7 +172,7 @@ public class SnapshotGeneratorFactory {
                                         database.getLiquibaseSchemaName(), example.getName(), Table.class))));
                 return true;
             } catch (DatabaseException e) {
-                if (database instanceof PostgresDatabase) {
+                if (database instanceof AbstractPostgresDatabase) {
                     database.rollback(); // throws "current transaction is aborted" unless we roll back the connection
                 }
                 return false;

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/ColumnSnapshotGenerator.java
@@ -92,7 +92,7 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
 
             example.setAttribute(LIQUIBASE_COMPLETE, null);
 
-            if (column == null && database instanceof PostgresDatabase && looksLikeFunction(example.getName())) {
+            if (column == null && database instanceof AbstractPostgresDatabase && looksLikeFunction(example.getName())) {
                 ((Column) example).setComputed(true);
                 return example;
             }
@@ -378,7 +378,7 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
                 // NOTE:  I am commenting this line out currently to fix an issue with older snapshots
                 // columnMetadataResultSet.set("COLUMN_SIZE", null);
             }
-        } else if (database instanceof PostgresDatabase) {
+        } else if (database instanceof AbstractPostgresDatabase) {
             columnTypeName = database.unescapeDataTypeName(columnTypeName);
             // https://www.postgresql.org/message-id/20061016193942.GF23302%40svana.org says that internally array datatypes are defined with an underscore prefix.
             if (columnTypeName.startsWith("_")) {
@@ -437,7 +437,7 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
             columnSize = columnMetadataResultSet.getInt("COLUMN_SIZE");
             decimalDigits = columnMetadataResultSet.getInt("DECIMAL_DIGITS");
             if ((decimalDigits != null) && decimalDigits.equals(0)) {
-                if (dataType == Types.TIME && database instanceof PostgresDatabase) {
+                if (dataType == Types.TIME && database instanceof AbstractPostgresDatabase) {
                     //that is allowed
                 } else {
                     decimalDigits = null;
@@ -463,7 +463,7 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
             }
         }
 
-        if ((database instanceof PostgresDatabase) && columnSize != null) {
+        if ((database instanceof AbstractPostgresDatabase) && columnSize != null) {
             if (columnSize.equals(Integer.MAX_VALUE)) {
                 columnSize = null;
             } else if (columnTypeName.equalsIgnoreCase("numeric") && columnSize.equals(0)) {
@@ -567,7 +567,7 @@ public class ColumnSnapshotGenerator extends JdbcSnapshotGenerator {
             }
         }
 
-        if (database instanceof PostgresDatabase) {
+        if (database instanceof AbstractPostgresDatabase) {
             readDefaultValueForPostgresDatabase(columnMetadataResultSet, columnInfo);
         }
 

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/IndexSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/IndexSnapshotGenerator.java
@@ -81,7 +81,7 @@ public class IndexSnapshotGenerator extends JdbcSnapshotGenerator {
                     } else {
                         ascOrDesc = row.getString("ASC_OR_DESC");
                     }
-                    if (database instanceof PostgresDatabase) {
+                    if (database instanceof AbstractPostgresDatabase) {
                         String indexType = row.getString("INDEX_TYPE");
                         index.setUsing(indexType);
                     }
@@ -293,7 +293,7 @@ public class IndexSnapshotGenerator extends JdbcSnapshotGenerator {
 
                         // Is this column a simple column (definition == null)
                         // or is it a computed expression (definition != null)
-                        if (definition == null || database instanceof PostgresDatabase ||  database instanceof MSSQLDatabase) {
+                        if (definition == null || database instanceof AbstractPostgresDatabase ||  database instanceof MSSQLDatabase) {
                             String ascOrDesc;
                             if (database instanceof Db2zDatabase) {
                                 ascOrDesc = row.getString("ORDER");

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/JdbcSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/JdbcSnapshotGenerator.java
@@ -4,7 +4,6 @@ import liquibase.Scope;
 import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.Database;
 import liquibase.database.core.InformixDatabase;
-import liquibase.database.core.PostgresDatabase;
 import liquibase.database.core.AbstractPostgresDatabase;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.diff.DiffStatusListener;

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/JdbcSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/JdbcSnapshotGenerator.java
@@ -5,6 +5,7 @@ import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.Database;
 import liquibase.database.core.InformixDatabase;
 import liquibase.database.core.PostgresDatabase;
+import liquibase.database.core.AbstractPostgresDatabase;
 import liquibase.database.jvm.JdbcConnection;
 import liquibase.diff.DiffStatusListener;
 import liquibase.exception.DatabaseException;
@@ -112,7 +113,7 @@ public abstract class JdbcSnapshotGenerator implements SnapshotGenerator {
         if (!(database instanceof InformixDatabase)) {
             objectName = objectName.trim();
         }
-        if (database instanceof PostgresDatabase) {
+        if (database instanceof AbstractPostgresDatabase) {
             return objectName.replaceAll("\"", "");
         }
         return objectName;

--- a/liquibase-standard/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/snapshot/jvm/UniqueConstraintSnapshotGenerator.java
@@ -177,7 +177,7 @@ public class UniqueConstraintSnapshotGenerator extends JdbcSnapshotGenerator {
                 }
                 sql.append("order by ordinal_position");
                 rawSql = sql.toString();
-            } else if (database instanceof PostgresDatabase) {
+            } else if (database instanceof AbstractPostgresDatabase) {
                 List<String> conditions = new ArrayList<>();
                 StringBuilder sql = new StringBuilder("select const.CONSTRAINT_NAME, COLUMN_NAME, const.constraint_schema as CONSTRAINT_CONTAINER ")
                         .append(String.format("from %s.table_constraints const ", database.getSystemSchema()))

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateTableGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateTableGenerator.java
@@ -441,7 +441,7 @@ public class CreateTableGenerator extends AbstractSqlGenerator<CreateTableStatem
     private String generateTableName(Database database, CreateTableStatement statement) {
         // In Postgresql, temp tables get their own schema and each session (connection) gets
         //its own temp schema. So - don't qualify them by schema.
-        if (!(database instanceof PostgresDatabase) || StringUtils.isEmpty(statement.getTableType()) || !statement.getTableType().trim().toLowerCase().contains("temp")) {
+        if (!(database instanceof AbstractPostgresDatabase) || StringUtils.isEmpty(statement.getTableType()) || !statement.getTableType().trim().toLowerCase().contains("temp")) {
             return database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName());
         } else {
             return database.escapeObjectName(statement.getTableName(), Table.class);

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateViewGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateViewGenerator.java
@@ -152,7 +152,7 @@ public class CreateViewGenerator extends AbstractSqlGenerator<CreateViewStatemen
             dropIfCannotReplace = GlobalConfiguration.ALWAYS_DROP_INSTEAD_OF_REPLACE.getCurrentValue();
         } 
         return database instanceof HsqlDatabase ||
-              (database instanceof PostgresDatabase && dropIfCannotReplace);
+              (database instanceof AbstractPostgresDatabase && dropIfCannotReplace);
     }
 
     //

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/DropDefaultValueGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/DropDefaultValueGenerator.java
@@ -66,7 +66,7 @@ public class DropDefaultValueGenerator extends AbstractSqlGenerator<DropDefaultV
         	sql = "ALTER TABLE " + escapedTableName + " MODIFY (" + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " " + statement.getColumnDataType() + ")";
         } else if (database instanceof AbstractDb2Database) {
             sql = "ALTER TABLE " + escapedTableName + " ALTER COLUMN " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " DROP DEFAULT";
-        } else if (database instanceof PostgresDatabase) {
+        } else if (database instanceof AbstractPostgresDatabase) {
             sql = "ALTER TABLE " + escapedTableName + " ALTER COLUMN " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " DROP DEFAULT";
         } else {
             sql = "ALTER TABLE " + escapedTableName + " ALTER COLUMN  " + database.escapeColumnName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), statement.getColumnName()) + " SET DEFAULT NULL";

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/DropPrimaryKeyGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/DropPrimaryKeyGenerator.java
@@ -47,7 +47,7 @@ public class DropPrimaryKeyGenerator extends AbstractSqlGenerator<DropPrimaryKey
             } else {
                 sql = "ALTER TABLE " + escapedTableName + " DROP CONSTRAINT " + database.escapeConstraintName(statement.getConstraintName());
             }
-        } else if (database instanceof PostgresDatabase) {
+        } else if (database instanceof AbstractPostgresDatabase) {
 			if (statement.getConstraintName() == null) {
 				String schemaName = (statement.getSchemaName() != null) ? statement.getSchemaName() : database
                     .getDefaultSchemaName();

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/GetViewDefinitionGeneratorPostgres.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/GetViewDefinitionGeneratorPostgres.java
@@ -2,7 +2,6 @@ package liquibase.sqlgenerator.core;
 
 import liquibase.CatalogAndSchema;
 import liquibase.database.Database;
-import liquibase.database.core.PostgresDatabase;
 import liquibase.database.core.AbstractPostgresDatabase;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/GetViewDefinitionGeneratorPostgres.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/GetViewDefinitionGeneratorPostgres.java
@@ -3,6 +3,7 @@ package liquibase.sqlgenerator.core;
 import liquibase.CatalogAndSchema;
 import liquibase.database.Database;
 import liquibase.database.core.PostgresDatabase;
+import liquibase.database.core.AbstractPostgresDatabase;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
@@ -16,7 +17,7 @@ public class GetViewDefinitionGeneratorPostgres extends GetViewDefinitionGenerat
 
     @Override
     public boolean supports(GetViewDefinitionStatement statement, Database database) {
-        return database instanceof PostgresDatabase;
+        return database instanceof AbstractPostgresDatabase;
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/ModifyDataTypeGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/ModifyDataTypeGenerator.java
@@ -62,7 +62,7 @@ public class ModifyDataTypeGenerator extends AbstractSqlGenerator<ModifyDataType
 
         alterTable += newDataType;
 
-        if (database instanceof PostgresDatabase) {
+        if (database instanceof AbstractPostgresDatabase) {
             alterTable += " USING ("+columnName+"::"+newDataType+")";
         }
 

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/RenameTableGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/RenameTableGenerator.java
@@ -34,7 +34,7 @@ public class RenameTableGenerator extends AbstractSqlGenerator<RenameTableStatem
             sql = "exec sp_rename '" + statement.getOldTableName() + "', '" + statement.getNewTableName() + '\'';
         } else if (database instanceof MySQLDatabase) {
             sql = "ALTER TABLE " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getOldTableName()) + " RENAME " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getNewTableName());
-        } else if (database instanceof PostgresDatabase) {
+        } else if (database instanceof AbstractPostgresDatabase) {
             sql = "ALTER TABLE " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getOldTableName()) + " RENAME TO " + database.escapeObjectName(statement.getNewTableName(), Table.class);
         } else if (database instanceof SybaseASADatabase) {
             sql = "ALTER TABLE " + database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getOldTableName()) + " RENAME " + database.escapeObjectName(statement.getNewTableName(), Table.class);

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/RenameViewGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/RenameViewGenerator.java
@@ -38,7 +38,7 @@ public class RenameViewGenerator extends AbstractSqlGenerator<RenameViewStatemen
             sql = "exec sp_rename '" + database.escapeViewName(statement.getCatalogName(), statement.getSchemaName(), statement.getOldViewName()) + "', '" + statement.getNewViewName() + '\'';
         } else if (database instanceof MySQLDatabase) {
             sql = "RENAME TABLE " + database.escapeViewName(statement.getCatalogName(), statement.getSchemaName(), statement.getOldViewName()) + " TO " + database.escapeViewName(statement.getCatalogName(), statement.getSchemaName(), statement.getNewViewName());
-        } else if (database instanceof PostgresDatabase) {
+        } else if (database instanceof AbstractPostgresDatabase) {
             sql = "ALTER TABLE " + database.escapeViewName(statement.getCatalogName(), statement.getSchemaName(), statement.getOldViewName()) + " RENAME TO " + database.escapeObjectName(statement.getNewViewName(), View.class);
         } else if (database instanceof OracleDatabase) {
             sql = "RENAME " + database.escapeObjectName(statement.getOldViewName(), View.class) + " TO " + database.escapeObjectName(statement.getNewViewName(), View.class);

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/SelectFromDatabaseChangeLogGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/SelectFromDatabaseChangeLogGenerator.java
@@ -71,7 +71,7 @@ public class SelectFromDatabaseChangeLogGenerator extends AbstractSqlGenerator<S
                     } else {
                         sql += " AND ROWNUM="+statement.getLimit();
                     }
-                } else if ((database instanceof MySQLDatabase) || (database instanceof PostgresDatabase)) {
+                } else if ((database instanceof MySQLDatabase) || (database instanceof AbstractPostgresDatabase)) {
                     sql += " LIMIT "+statement.getLimit();
                 } else if (database instanceof AbstractDb2Database) {
                     sql += " FETCH FIRST "+statement.getLimit()+" ROWS ONLY";

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/SetColumnRemarksGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/SetColumnRemarksGenerator.java
@@ -22,7 +22,7 @@ public class SetColumnRemarksGenerator extends AbstractSqlGenerator<SetColumnRem
 
     @Override
     public boolean supports(SetColumnRemarksStatement statement, Database database) {
-        return (database instanceof OracleDatabase) || (database instanceof PostgresDatabase) || (database instanceof
+        return (database instanceof OracleDatabase) || (database instanceof AbstractPostgresDatabase) || (database instanceof
                 AbstractDb2Database) || (database instanceof MSSQLDatabase) || (database instanceof H2Database) || (database
                 instanceof SybaseASADatabase) || (database instanceof MySQLDatabase);
     }

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/SetViewRemarksGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/SetViewRemarksGenerator.java
@@ -15,7 +15,7 @@ public class SetViewRemarksGenerator extends AbstractSqlGenerator<SetViewRemarks
 
     @Override
     public boolean supports(SetViewRemarksStatement statement, Database database) {
-        return (database instanceof OracleDatabase) || (database instanceof PostgresDatabase) || (database instanceof MSSQLDatabase) || (database instanceof DB2Database)
+        return (database instanceof OracleDatabase) || (database instanceof AbstractPostgresDatabase) || (database instanceof MSSQLDatabase) || (database instanceof DB2Database)
                 || (database instanceof SybaseASADatabase);
     }
 
@@ -30,7 +30,7 @@ public class SetViewRemarksGenerator extends AbstractSqlGenerator<SetViewRemarks
     public Sql[] generateSql(SetViewRemarksStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
         String sql = "";
         String remarksEscaped = database.escapeStringForDatabase(StringUtil.trimToEmpty(statement.getRemarks()));
-        if (database instanceof OracleDatabase || database instanceof PostgresDatabase || database instanceof DB2Database || database instanceof SybaseASADatabase) {
+        if (database instanceof OracleDatabase || database instanceof AbstractPostgresDatabase || database instanceof DB2Database || database instanceof SybaseASADatabase) {
             String sqlPlaceholder = "COMMENT ON %s %s IS '%s'";
             String targetNameEscaped = database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getViewName());
             String targetObject;

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/TagDatabaseGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/TagDatabaseGenerator.java
@@ -44,7 +44,7 @@ public class TagDatabaseGenerator extends AbstractSqlGenerator<TagDatabaseStatem
                                         "ON C." + orderColumnNameEscaped + " = D." + orderColumnNameEscaped + " " +
                                         "SET C." + tagColumnNameEscaped + " = " + tagEscaped)
                 };
-            } else if (database instanceof PostgresDatabase) {
+            } else if (database instanceof AbstractPostgresDatabase) {
                 return new Sql[]{
                         new UnparsedSql(
                                 "UPDATE " + tableNameEscaped + " t SET TAG=" + tagEscaped +

--- a/liquibase-standard/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
+++ b/liquibase-standard/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
@@ -8,7 +8,6 @@ import liquibase.database.Database;
 import liquibase.database.PreparedStatementFactory;
 import liquibase.database.core.MariaDBDatabase;
 import liquibase.database.core.MySQLDatabase;
-import liquibase.database.core.PostgresDatabase;
 import liquibase.database.core.AbstractPostgresDatabase;
 import liquibase.database.core.SQLiteDatabase;
 import liquibase.datatype.DataTypeFactory;

--- a/liquibase-standard/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
+++ b/liquibase-standard/src/main/java/liquibase/statement/ExecutablePreparedStatementBase.java
@@ -9,6 +9,7 @@ import liquibase.database.PreparedStatementFactory;
 import liquibase.database.core.MariaDBDatabase;
 import liquibase.database.core.MySQLDatabase;
 import liquibase.database.core.PostgresDatabase;
+import liquibase.database.core.AbstractPostgresDatabase;
 import liquibase.database.core.SQLiteDatabase;
 import liquibase.datatype.DataTypeFactory;
 import liquibase.datatype.LiquibaseDataType;
@@ -182,7 +183,7 @@ public abstract class ExecutablePreparedStatementBase implements ExecutablePrepa
     }
 
     protected void executePreparedStatement(PreparedStatement stmt) throws SQLException {
-        if (database instanceof PostgresDatabase) {
+        if (database instanceof AbstractPostgresDatabase) {
             //postgresql's default prepared statement setup is slow for normal liquibase usage. Calling with QUERY_ONESHOT seems faster, even when we keep re-calling the same prepared statement for many rows in loadData
             try {
                 if (EXECUTE_WITH_FLAGS_METHOD.get() == null) {
@@ -255,7 +256,7 @@ public abstract class ExecutablePreparedStatementBase implements ExecutablePrepa
                 stmt.setBlob(i, new ByteArrayInputStream(Base64.getDecoder().decode(col.getValue())));
             } else if (LoadDataChange.LOAD_DATA_TYPE.CLOB.name().equalsIgnoreCase(col.getType())) {
                 try {
-                    if (database instanceof PostgresDatabase || database instanceof SQLiteDatabase) {
+                    if (database instanceof AbstractPostgresDatabase || database instanceof SQLiteDatabase) {
                         // JDBC driver does not have the .createClob() call implemented yet
                         stmt.setString(i, col.getValue());
                     } else {
@@ -315,7 +316,7 @@ public abstract class ExecutablePreparedStatementBase implements ExecutablePrepa
             try {
                 LOBContent<InputStream> lob = toBinaryStream(col.getValueBlobFile());
 
-                if (database instanceof PostgresDatabase) {
+                if (database instanceof AbstractPostgresDatabase) {
                     String snapshotKeyName = String.format("%s-%s-%s-%s", getCatalogName(), getSchemaName(), getTableName(), col.getName());
                     Column snapshot = (Column) this.getScratchData(snapshotKeyName);
                     if (snapshot == null) {


### PR DESCRIPTION
Foundation for the INT-2139 Postgres-family reparent. Widens `instanceof PostgresDatabase` → `instanceof AbstractPostgresDatabase` at sites gating behavior shared by the whole Postgres wire family (data types, DDL, comments, snapshot, dependency sorting).

**Safe / behavior-neutral:** today the only subclasses of `AbstractPostgresDatabase` are `PostgresDatabase` and its descendants (Redshift/Cockroach/EDB), so each widened check matches the exact same set of databases as before. Nothing new is included until a variant is reparented later — per-variant, behind its own integration tests — at which point that variant correctly keeps this shared behavior instead of silently losing it.

Real-Postgres-only sites (sequences, generated columns, partition catalogs, sequence-quoting) are intentionally left as `instanceof PostgresDatabase`. Also folds the 3 `useSerialDatatypes()` casts into a pattern binding. Compiles; 77 Postgres-family tests green.
