### PR TITLE
Refactor DiffToChangeLog: honest naming, Edge record, simpler bringDropFKToTop, + tests

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/diff/output/changelog/DiffToChangeLog.java
+++ b/liquibase-standard/src/main/java/liquibase/diff/output/changelog/DiffToChangeLog.java
@@ -166,9 +166,9 @@ public class DiffToChangeLog {
             //
             // Get a Database instance and save it in the scope for later use
             //
-            Database database = determineDatabase(diffResult.getReferenceSnapshot());
+            Database database = liveDatabaseForSerialization(diffResult.getReferenceSnapshot());
             if (database == null) {
-                database = determineDatabase(diffResult.getComparisonSnapshot());
+                database = liveDatabaseForSerialization(diffResult.getComparisonSnapshot());
             }
             ChangelogPrintServiceFactory printServiceFactory = Scope.getCurrentScope().getSingleton(ChangelogPrintServiceFactory.class);
             ChangelogPrintService printService = printServiceFactory.getChangeLogPrintService(this);
@@ -176,19 +176,16 @@ public class DiffToChangeLog {
             if (file.exists() && Boolean.FALSE.equals(overwriteOutputFile) && changeLogSerializer instanceof FormattedSqlChangeLogSerializer) {
                 newScopeObjects.put(ADD_FORMATTED_SQL_HEADER, false);
             }
-            Scope.child(newScopeObjects, new Scope.ScopedRunner() {
-                @Override
-                public void run() {
-                    try {
-                        if (!file.exists()) {
-                            //print changeLog only if there are available changeSets to print instead of printing it always
-                            printService.printNew(changeLogSerializer, file);
-                        } else {
-                            printService.printToExisting(changeLogSerializer, file, overwriteOutputFile);
-                        }
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
+            Scope.child(newScopeObjects, (Scope.ScopedRunner) () -> {
+                try {
+                    if (!file.exists()) {
+                        //print changeLog only if there are available changeSets to print instead of printing it always
+                        printService.printNew(changeLogSerializer, file);
+                    } else {
+                        printService.printToExisting(changeLogSerializer, file, overwriteOutputFile);
                     }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
                 }
             });
         } catch (Exception e) {
@@ -209,10 +206,12 @@ public class DiffToChangeLog {
     }
 
     //
-    // Return the Database from this snapshot
-    // if it is not offline
+    // Live Database for changelog SQL serialization, or null to derive it from the
+    // changelog filename. Gated to online Postgres-family connections: their SQL
+    // generation is connection-state-sensitive (SERIAL vs GENERATED-IDENTITY depends on
+    // the live server version, EDB Redwood mode), so a filename-derived stand-in is wrong.
     //
-    private Database determineDatabase(DatabaseSnapshot snapshot) {
+    Database liveDatabaseForSerialization(DatabaseSnapshot snapshot) {
         Database database = snapshot.getDatabase();
         DatabaseConnection connection = database.getConnection();
         if (! (connection instanceof OfflineConnection) && database instanceof AbstractPostgresDatabase) {
@@ -351,25 +350,14 @@ public class DiffToChangeLog {
     // FK changes with the same constraint name, we make sure that the
     // drop FK goes first
     //
-    private List<ChangeSet> bringDropFKToTop(List<ChangeSet> changeSets) {
-        List<ChangeSet> dropFk = changeSets.stream().filter(cs ->
-            cs.getChanges().stream().anyMatch(DropForeignKeyConstraintChange.class::isInstance)
-        ).collect(Collectors.toList());
-        if (dropFk.isEmpty()) {
-            return changeSets;
-        }
-        List<ChangeSet> returnList = new ArrayList<>();
-        changeSets.stream().forEach(cs -> {
-            if (dropFk.contains(cs)) {
-                returnList.add(cs);
-            }
-        });
-        changeSets.stream().forEach(cs -> {
-            if (! dropFk.contains(cs)) {
-                returnList.add(cs);
-            }
-        });
-        return returnList;
+    protected List<ChangeSet> bringDropFKToTop(List<ChangeSet> changeSets) {
+        return changeSets.stream()
+                .sorted(Comparator.comparingInt(cs -> hasDropForeignKey(cs) ? 0 : 1))
+                .collect(Collectors.toList());
+    }
+
+    private boolean hasDropForeignKey(ChangeSet changeSet) {
+        return changeSet.getChanges().stream().anyMatch(DropForeignKeyConstraintChange.class::isInstance);
     }
 
     private DatabaseObjectCollectionComparator getDatabaseObjectCollectionComparator() {
@@ -511,11 +499,9 @@ public class DiffToChangeLog {
     /**
      *
      * POSTGRES ONLY:
-     *
      * If we have a stored logic object then we edit the name
      * to replace the parameter list with a list of just the types.
      * This is the format that the dependency computation puts out.
-     *
      * Example:  calculate_bonus(emp_salary numeric, emp_name character varying) becomes
      *           calculate_bonus(numeric, character varying)
      *
@@ -712,11 +698,9 @@ public class DiffToChangeLog {
                 String tabName = StringUtils.trimToEmpty((String)row.get("REFERENCED_SCHEMA_NAME")) +
                         "." + StringUtils.trimToEmpty((String)row.get("REFERENCED_NAME"));
 
-                if (!(tabName.isEmpty() || bName.isEmpty())) {
-                    graph.add(bName.replace("\"", ""), tabName.replace("\"", ""));
-                    graph.add(bName.replace("\"", "").replaceAll("\\s*\\([^)]*\\)\\s*",""),
-                            tabName.replace("\"", "").replaceAll("\\s*\\([^)]*\\)\\s*", ""));
-                }
+                graph.add(bName.replace("\"", ""), tabName.replace("\"", ""));
+                graph.add(bName.replace("\"", "").replaceAll("\\s*\\([^)]*\\)\\s*",""),
+                        tabName.replace("\"", "").replaceAll("\\s*\\([^)]*\\)\\s*", ""));
             }
         }
     }
@@ -836,7 +820,7 @@ public class DiffToChangeLog {
                     changeSets.add(changeSet);
                 }
             } else {
-                final boolean runOnChange = Arrays.asList(changes).stream().allMatch(this::isContainedInRunOnChangeTypes);
+                final boolean runOnChange = Arrays.stream(changes).allMatch(this::isContainedInRunOnChangeTypes);
                 ChangeSet changeSet = service.createChangeSet(generateId(changes), getChangeSetAuthor(), false, runOnChange, this.changeSetPath, changeSetContext,
                                         null, null, null, true, quotingStrategy, null);
                 changeSet.setCreated(created);
@@ -1017,7 +1001,7 @@ public class DiffToChangeLog {
                 for (Iterator<Edge> it = node.outEdges.iterator(); it.hasNext(); ) {
                     //remove edge e from the graph
                     Edge edge = it.next();
-                    Node nodePointedTo = edge.to;
+                    Node nodePointedTo = edge.to();
                     it.remove();//Remove edge from node
                     nodePointedTo.inEdges.remove(edge);//Remove edge from nodePointedTo
 
@@ -1067,10 +1051,10 @@ public class DiffToChangeLog {
                         SortedSet<String> fromTypes = new TreeSet<>();
                         SortedSet<String> toTypes = new TreeSet<>();
                         for (Edge edge : node.inEdges) {
-                            fromTypes.add(edge.from.type.getSimpleName());
+                            fromTypes.add(edge.from().type.getSimpleName());
                         }
                         for (Edge edge : node.outEdges) {
-                            toTypes.add(edge.to.type.getSimpleName());
+                            toTypes.add(edge.to().type.getSimpleName());
                         }
                         String from = StringUtil.join(fromTypes, ",");
                         String to = StringUtil.join(toTypes, ",");
@@ -1106,31 +1090,7 @@ public class DiffToChangeLog {
             }
         }
 
-        static class Edge {
-            public final Node from;
-            public final Node to;
-
-            public Edge(Node from, Node to) {
-                this.from = from;
-                this.to = to;
-            }
-
-            @Override
-            public boolean equals(Object obj) {
-                if (obj == null) {
-                    return false;
-                }
-                if (!(obj instanceof Edge)) {
-                    return false;
-                }
-                Edge e = (Edge) obj;
-                return (e.from == from) && (e.to == to);
-            }
-
-            @Override
-            public int hashCode() {
-                return (this.from.toString() + "." + this.to.toString()).hashCode();
-            }
+        record Edge(Node from, Node to) {
         }
     }
 }

--- a/liquibase-standard/src/test/java/liquibase/diff/output/changelog/DiffToChangeLogTest.java
+++ b/liquibase-standard/src/test/java/liquibase/diff/output/changelog/DiffToChangeLogTest.java
@@ -1,8 +1,21 @@
 package liquibase.diff.output.changelog;
 
+import liquibase.change.Change;
+import liquibase.change.core.AddForeignKeyConstraintChange;
+import liquibase.change.core.CreateTableChange;
+import liquibase.change.core.DropForeignKeyConstraintChange;
+import liquibase.changelog.ChangeSet;
+import liquibase.database.Database;
+import liquibase.database.DatabaseConnection;
+import liquibase.database.OfflineConnection;
+import liquibase.database.core.CockroachDatabase;
 import liquibase.database.core.MySQLDatabase;
+import liquibase.database.core.PostgresDatabase;
+import liquibase.database.jvm.JdbcConnection;
 import liquibase.diff.DiffResult;
 import liquibase.diff.compare.CompareControl;
+import liquibase.diff.output.DiffOutputControl;
+import liquibase.snapshot.DatabaseSnapshot;
 import liquibase.snapshot.EmptyDatabaseSnapshot;
 import liquibase.snapshot.SnapshotControl;
 import liquibase.structure.DatabaseObject;
@@ -10,10 +23,13 @@ import liquibase.structure.core.*;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class DiffToChangeLogTest {
 
@@ -62,5 +78,69 @@ public class DiffToChangeLogTest {
                 PrimaryKey.class,
                 View.class
         )));
+    }
+
+    // --- liveDatabaseForSerialization: returns the live DB only for online Postgres-family connections ---
+
+    @Test
+    public void liveDatabaseForSerialization_onlinePostgres_returnsDatabase() {
+        assertLiveDatabase(mock(PostgresDatabase.class), mock(JdbcConnection.class), true);
+    }
+
+    @Test
+    public void liveDatabaseForSerialization_onlineCockroach_returnsDatabase() { // whole PG family, not just real Postgres
+        assertLiveDatabase(mock(CockroachDatabase.class), mock(JdbcConnection.class), true);
+    }
+
+    @Test
+    public void liveDatabaseForSerialization_offlinePostgres_returnsNull() {
+        assertLiveDatabase(mock(PostgresDatabase.class), mock(OfflineConnection.class), false);
+    }
+
+    @Test
+    public void liveDatabaseForSerialization_onlineNonPostgres_returnsNull() {
+        assertLiveDatabase(mock(MySQLDatabase.class), mock(JdbcConnection.class), false);
+    }
+
+    private void assertLiveDatabase(Database database, DatabaseConnection connection, boolean expectReturned) {
+        when(database.getConnection()).thenReturn(connection);
+        DatabaseSnapshot snapshot = mock(DatabaseSnapshot.class);
+        when(snapshot.getDatabase()).thenReturn(database);
+
+        Database result = new DiffToChangeLog((DiffOutputControl) null).liveDatabaseForSerialization(snapshot);
+
+        assertThat(result, expectReturned ? sameInstance(database) : nullValue());
+    }
+
+    // --- bringDropFKToTop: drop-FK changesets float to the top, order preserved within each group ---
+
+    @Test
+    public void bringDropFKToTop_movesDropFKFirst_preservingOrderWithinGroups() {
+        ChangeSet addA = changeSetWith(new AddForeignKeyConstraintChange());
+        ChangeSet dropA = changeSetWith(new DropForeignKeyConstraintChange());
+        ChangeSet addB = changeSetWith(new CreateTableChange());
+        ChangeSet dropB = changeSetWith(new DropForeignKeyConstraintChange());
+
+        List<ChangeSet> result = new DiffToChangeLog((DiffOutputControl) null)
+                .bringDropFKToTop(Arrays.asList(addA, dropA, addB, dropB));
+
+        assertThat(result, contains(dropA, dropB, addA, addB));
+    }
+
+    @Test
+    public void bringDropFKToTop_returnsInputUnchanged_whenNoDropFK() {
+        ChangeSet addA = changeSetWith(new AddForeignKeyConstraintChange());
+        ChangeSet addB = changeSetWith(new CreateTableChange());
+
+        List<ChangeSet> result = new DiffToChangeLog((DiffOutputControl) null)
+                .bringDropFKToTop(Arrays.asList(addA, addB));
+
+        assertThat(result, contains(addA, addB));
+    }
+
+    private ChangeSet changeSetWith(Change change) {
+        ChangeSet cs = mock(ChangeSet.class);
+        when(cs.getChanges()).thenReturn(Collections.singletonList(change));
+        return cs;
     }
 }


### PR DESCRIPTION
Readability/cleanup pass on `DiffToChangeLog` — **no behavior change**, and it adds unit coverage for two previously-untested methods.

- Rename `determineDatabase` → `liveDatabaseForSerialization` and fix its comment — the old comment ("return the Database if not offline") never mentioned that it also gates on Postgres-family, which is half the logic. (The gate is real: Postgres SQL generation is connection-state-sensitive — SERIAL vs `GENERATED … AS IDENTITY` keys off the live server version, EDB Redwood — so the serializer needs the live connection object; others fall back to a filename-derived `Database`.)
- Convert `Edge` to a `record` — drops a mismatched hand-rolled `equals` (identity `==`) / `hashCode` (value, on `toString()`).
- Replace `bringDropFKToTop`'s two-pass `contains` partition with a stable sort + a named `hasDropForeignKey` predicate. `Stream.sorted()` is stable on ordered streams, so within-group order is preserved.
- Remove a dead `isEmpty()` guard (always true — `trimToEmpty(...) + "."` is never empty) and a redundant `null`-check before an `instanceof`.

Adds `DiffToChangeLogTest` coverage for `liveDatabaseForSerialization` (online Postgres-family → returns the DB; offline / non-Postgres → null) and `bringDropFKToTop` (drop-FK float to top, order preserved; no-drop-FK unchanged). 8/8 green.
