### PR TITLE
fix: preserve case for quoted index names so indexExists works on Oracle

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/database/AbstractJdbcDatabase.java
+++ b/liquibase-standard/src/main/java/liquibase/database/AbstractJdbcDatabase.java
@@ -288,6 +288,12 @@ public abstract class AbstractJdbcDatabase implements Database {
         } else if ((getObjectQuotingStrategy() == ObjectQuotingStrategy.QUOTE_ALL_OBJECTS) || (unquotedObjectsAreUppercased == null) ||
                 (objectName == null) || (objectName.startsWith(getQuotingStartCharacter()) && objectName.endsWith(getQuotingEndCharacter()))) {
             return objectName;
+        } else if ((objectType == Index.class) && mustQuoteObjectName(objectName, objectType)) {
+            // Index names that need quoting (e.g. they contain a "-") are quoted with their case preserved
+            // by escapeObjectName()/quoteObject() when generated, so correcting them to the database's default
+            // case here would make them impossible to find again, e.g. by the indexExists precondition
+            // (see https://github.com/liquibase/liquibase/issues/3876).
+            return objectName;
         } else if (Boolean.TRUE.equals(unquotedObjectsAreUppercased)) {
             return objectName.toUpperCase(Locale.US);
         } else {

--- a/liquibase-standard/src/test/groovy/liquibase/database/core/OracleDatabaseSpec.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/database/core/OracleDatabaseSpec.groovy
@@ -1,6 +1,7 @@
 package liquibase.database.core
 
 import liquibase.structure.core.Column
+import liquibase.structure.core.Index
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -47,5 +48,9 @@ class OracleDatabaseSpec extends Specification {
         null                      || 'internalPhoneNumber'   | Column     || 'INTERNALPHONENUMBER'   | 'internalPhoneNumber'
         null                      || 'internal_payload_id'   | Column     || 'INTERNAL_PAYLOAD_ID'   | 'internal_payload_id'
         null                      || 'integration_type'      | Column     || 'INTEGRATION_TYPE'      | 'integration_type'
+        // #3876: index names that must be quoted keep original case so indexExists can find them
+        null                      || 'index_-id'             | Index      || 'index_-id'             | '"index_-id"'
+        null                      || 'my_index'              | Index      || 'MY_INDEX'              | 'my_index'
+        null                      || 'INDEX_-ID'             | Index      || 'INDEX_-ID'             | '"INDEX_-ID"'
     }
 }

--- a/liquibase-standard/src/test/java/liquibase/database/core/OracleDatabaseTest.java
+++ b/liquibase-standard/src/test/java/liquibase/database/core/OracleDatabaseTest.java
@@ -15,6 +15,8 @@ import liquibase.sql.visitor.SqlVisitor;
 import liquibase.statement.SequenceNextValueFunction;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.UpdateStatement;
+import liquibase.structure.core.Index;
+import liquibase.structure.core.Table;
 import liquibase.test.JUnitResourceAccessor;
 import org.junit.jupiter.api.Test;
 
@@ -184,6 +186,15 @@ public class OracleDatabaseTest extends AbstractJdbcDatabaseTest {
         }
         String primaryKeyName = spyDatabase.generatePrimaryKeyName(tableName);
         assertEquals(expectedPrimaryKeyName, primaryKeyName, assertMessage);
+    }
+
+    @Test
+    public void correctObjectNamePreservesCaseForIndexNamesThatMustBeQuoted() {
+        // #3876: createIndex quotes names like index_-id, so correctObjectName must not uppercase them
+        final Database database = getDatabase();
+        assertEquals("index_-id", database.correctObjectName("index_-id", Index.class));
+        assertEquals("MY_INDEX", database.correctObjectName("my_index", Index.class));
+        assertEquals("MY-TABLE", database.correctObjectName("my-table", Table.class));
     }
 }
 


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Fixes #3876

On Oracle (and other databases that uppercase unquoted identifiers), `createIndex` quotes index names that need quoting (for example names containing `-`) and preserves the original case:

```sql
CREATE INDEX ADMIN."index_-id" ON ADMIN.test_table(name)
```

But `indexExists` looked up the index via `database.correctObjectName(indexName, Index.class)`, which uppercased the name to `INDEX_-ID`. The snapshot therefore never found the index, the precondition passed, and a second run of a `runAlways` changeset failed with ORA-00955.

This change skips case normalization in `correctObjectName` when the object is an `Index` and `mustQuoteObjectName()` is true, so create and lookup use the same stored case. Unquoted index names (and other object types) still use the previous upper/lower behavior.

Matches the approach suggested by @nvoxland on the issue and the patch reported as working by the issue author.

## Release note

Fixed `indexExists` failing to detect Oracle indexes whose names require quoting (for example names containing `-`), which caused second-run failures for conditional `createIndex` changesets.

## Things to be aware of

- Fix is in shared `AbstractJdbcDatabase.correctObjectName`, scoped to `Index` only when quoting is required, so it does not change table/column/schema case correction.
- Covered with unit tests only (no Oracle Docker required).

## Things to worry about

- None expected; unquoted index names still normalize as before.

## Additional Context

**Tests run (JDK 17):**
- `OracleDatabaseTest` — 34 tests, 0 failures
- `OracleDatabaseSpec` — 23 tests, 0 failures (includes new index name cases for #3876)