### PR TITLE
fix the ChangeSet checksum cache to recalculate when a different checksum version is requested

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeSet.java
@@ -396,7 +396,10 @@ public class ChangeSet implements Conditional, ChangeLogChild {
     public CheckSum generateCheckSum(ChecksumVersion version) {
         try {
             return Scope.child(Collections.singletonMap(Scope.Attr.checksumVersion.name(), version), () -> {
-                if (checkSum == null) {
+                // The cached value can only be reused when it was calculated with the checksum version that is
+                // in effect now. Otherwise a caller asking for a different version would silently get back a
+                // checksum belonging to the previously requested one, including its version number.
+                if (checkSum == null || checkSum.getVersion() != getCurrentScope().getChecksumVersion().getVersion()) {
                     StringBuilder stringToMD5 = new StringBuilder();
                     for (Change change : this.getChanges()) {
                         // checksum v8 requires changes that are applied even to other databases to be calculated

--- a/liquibase-standard/src/test/groovy/liquibase/changelog/ChangeSetTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/changelog/ChangeSetTest.groovy
@@ -1,6 +1,7 @@
 package liquibase.changelog
 
 
+import liquibase.ChecksumVersion
 import liquibase.Scope
 import liquibase.change.CheckSum
 import liquibase.change.ColumnConfig
@@ -91,6 +92,64 @@ class ChangeSetTest extends Specification {
         assert !md5Sum1.equals(md5Sum2)
     }
 
+    @Unroll
+    def "generateCheckSum honors the requested version after another version was already calculated"() {
+        when:
+        def changeSet = new ChangeSet("testId", "testAuthor", false, false, "com/example/test.xml", null, null, null)
+        changeSet.addChange(createTableChangeWithPartitionBy())
+
+        def firstCheckSum = changeSet.generateCheckSum(firstVersion)
+        def secondCheckSum = changeSet.generateCheckSum(secondVersion)
+
+        then:
+        firstCheckSum.getVersion() == firstVersion.getVersion()
+        secondCheckSum.getVersion() == secondVersion.getVersion()
+        firstCheckSum != secondCheckSum
+
+        where:
+        firstVersion          | secondVersion
+        ChecksumVersion.V8    | ChecksumVersion.V9
+        ChecksumVersion.V9    | ChecksumVersion.V8
+    }
+
+    def "generateCheckSum keeps caching the result when the same version is requested again"() {
+        when:
+        def changeSet = new ChangeSet("testId", "testAuthor", false, false, "com/example/test.xml", null, null, null)
+        changeSet.addChange(createTableChangeWithPartitionBy())
+
+        def firstCall = changeSet.generateCheckSum(ChecksumVersion.V9)
+        def secondCall = changeSet.generateCheckSum(ChecksumVersion.V9)
+
+        then:
+        firstCall.is(secondCall)
+    }
+
+    def "isCheckSumValid compares against the stored version even when a newer checksum was calculated first"() {
+        when:
+        def storedChangeSet = new ChangeSet("testId", "testAuthor", false, false, "com/example/test.xml", null, null, null)
+        storedChangeSet.addChange(createTableChangeWithPartitionBy())
+        def storedCheckSum = storedChangeSet.generateCheckSum(ChecksumVersion.V8)
+
+        // mimics the runtime order of ChangeSetStatus/RanChangeSet/MarkChangeSetRanGenerator, which
+        // materialize the checksum at the latest version before validation reaches the stored one
+        def changeSet = new ChangeSet("testId", "testAuthor", false, false, "com/example/test.xml", null, null, null)
+        changeSet.addChange(createTableChangeWithPartitionBy())
+        changeSet.generateCheckSum(ChecksumVersion.V9)
+
+        then:
+        changeSet.isCheckSumValid(storedCheckSum)
+    }
+
+    private static CreateTableChange createTableChangeWithPartitionBy() {
+        def change = new CreateTableChange()
+        change.setTableName("TABLE_NAME")
+        // partitionBy is excluded from the checksum up to V8 and included from V9 on, so the two
+        // versions produce different checksums for the very same change
+        change.setPartitionBy("RANGE (created_at)")
+        change.addColumn(new ColumnConfig().setName("COLUMN_NAME").setType("INT"))
+        return change
+    }
+
     def isCheckSumValid_validCheckSum() {
         when:
         def changeSet = new ChangeSet("1", "2", false, false, "/test.xml", null, null, null)
@@ -113,7 +172,9 @@ class ChangeSetTest extends Specification {
         CheckSum checkSum = CheckSum.parse("8:asdf")
 
         ChangeSet changeSet = new ChangeSet("1", "2", false, false, "/test.xml", null, null, null)
-        changeSet.addValidCheckSum(changeSet.generateCheckSum().toString())
+        // isCheckSumValid calculates the current checksum with the version of the stored one, so the
+        // valid checksum has to be registered for that same version to be comparable
+        changeSet.addValidCheckSum(changeSet.generateCheckSum(ChecksumVersion.V8).toString())
 
         then:
         assert changeSet.isCheckSumValid(checkSum)


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Fixes #7863.

`ChangeSet.generateCheckSum(ChecksumVersion)` caches its result in the `checkSum` field and recalculated only when that field was `null`:

```java
return Scope.child(Collections.singletonMap(Scope.Attr.checksumVersion.name(), version), () -> {
    if (checkSum == null) {
        ...
        checkSum = CheckSum.compute(stringToMD5.toString());
    }
    return checkSum;   // returned regardless of the requested version
});
```

So the first calculated value was returned for every later call on that instance, whatever version was asked for, until `clearCheckSum()` was called. `CheckSum.compute` stamps the version that is in effect at calculation time, so the returned object also carried the wrong version number, and `generateCheckSum(version).getVersion()` did not match `version.getVersion()`. No exception, no log message.

This is reachable without a caller that deliberately asks for two versions. The version is picked at runtime from the stored checksum in `ShouldRunChangeSetFilter.checksumChanged`, `AbstractChangeLogHistoryService.getRunStatus`, `ChangeSetStatus` and `RanChangeSet`, while `MarkChangeSetRanGenerator` and `UpdateChangeSetChecksumGenerator` ask for `ChecksumVersion.latest()` when writing `MD5SUM`, so a single `ChangeSet` instance can be asked for two different versions inside one run. `UpdateVisitor.updateCheckSumIfRequired`, `ValidatingVisitorUtil.validateSqlFileChangeAndExpandExpressions` and `ValidatingVisitorUtil.validateCreateFunctionChangeV8ChecksumVariant` already call `clearCheckSum()` immediately before recalculating, which is this behaviour being worked around one call site at a time.

The fix reuses the cache only when it holds a checksum for the version that is currently in effect:

```java
if (checkSum == null || checkSum.getVersion() != getCurrentScope().getChecksumVersion().getVersion()) {
```

The comparison is against the scope value rather than the `version` parameter, because that is exactly the value `CheckSum.compute` will stamp on the result, and because `Scope` falls through to the parent when a child value is `null` (several existing tests call the method through Groovy with no argument, which passes `null` and therefore means "latest").

Reproduction from the issue, run against `liquibase-standard` built from this branch and from `main` at 9a9ea95a2 (JDK 21.0.9):

```
main                                          this branch
Call 1 - requested V8:  8:b967cdcf22ae...     Call 1 - requested V8:  8:b967cdcf22ae...
Call 2 - requested V9:  8:b967cdcf22ae...     Call 2 - requested V9:  9:6a68455a2c7f...
  -> version returned:  8                       -> version returned:  9
  -> same object?       true                    -> same object?       false
Call 3 - after clear:   9:6a68455a2c7f...     Call 3 - after clear:   9:6a68455a2c7f...
```

## Release note

Fixed `ChangeSet.generateCheckSum` returning a checksum that was calculated for a different checksum version. A checksum requested for a specific version is now always calculated for that version, instead of reusing whatever was calculated first for that changeset.

## Things to be aware of

Three tests were added to `ChangeSetTest` and one existing test was adjusted.

The new tests use a `createTable` change with `partitionBy` set, because `CreateTableChange.getExcludedFieldFilters` excludes that field up to V8 and includes it from V9, so the two versions produce genuinely different digests rather than only a different version prefix. On `main` at 9a9ea95a2 the three new tests fail and the rest of `ChangeSetTest` passes:

| test | main | this branch |
| --- | --- | --- |
| `generateCheckSum honors the requested version after another version was already calculated` (V8 then V9) | fail: returned `8:3cf71e88...` for V9 | pass |
| `generateCheckSum honors the requested version after another version was already calculated` (V9 then V8) | fail: returned `9:451d3d83...` for V8 | pass |
| `isCheckSumValid compares against the stored version even when a newer checksum was calculated first` | fail: `isCheckSumValid` returned false | pass |
| `generateCheckSum keeps caching the result when the same version is requested again` | pass | pass |

The adjusted test is `isCheckSumValid_differentButValidCheckSum`. It registered the valid checksum through `changeSet.generateCheckSum()`, which Groovy calls with `null` and therefore evaluates at the latest version, while the stored checksum it then validates against is `8:asdf`. `isCheckSumValid` calculates the current checksum with the version of the stored one, so the version 9 valid checksum only ever matched because the stale cache handed it back for the version 8 request. It now registers the valid checksum for V8. With that single line changed and the production change reverted, it still passes on `main`, so it is not being loosened to accommodate the fix; any fix for this issue invalidates the original cross-version assertion.

Repeatedly alternating versions on the same instance now recalculates each time instead of returning the first value. The call sites above ask for a stable version per run, so this is not a hot path, and correctness of the returned version seemed worth more than keeping a cache hit that returns the wrong answer.

## Things to worry about

Whether `validCheckSum` entries are meant to be comparable across checksum versions. Today `isCheckSumValid` compares them against a checksum calculated at the stored version, so an entry recorded for a different version cannot match. This PR does not change that logic, it only stops the stale cache from making such a match happen by accident. If cross-version matching of `validCheckSum` is wanted, that looks like a separate change to `isCheckSumValid`.

## Additional Context

Verification, all on JDK 21.0.9 (Temurin), macOS arm64:

- `mvn -pl liquibase-standard test` on this branch: `Tests run: 6227, Failures: 0, Errors: 0, Skipped: 12`
- `./mvnw -B -P 'skip-integration-tests' test` for the whole reactor, which is what the unit test workflow runs: BUILD SUCCESS, `6227 / 115 / 77 / 20 / 44 / 400` tests across the modules, 0 failures and 0 errors.

Integration tests against the real databases were not run locally.
