### PR TITLE
fix: give each command execution its own CommandStep instances

### DIFF
--- a/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
+++ b/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseCommandLine.java
@@ -377,13 +377,27 @@ public class LiquibaseCommandLine {
 
             Main.setRunningFromNewCli(true);
 
-            final List<ConfigurationValueProvider> valueProviders = registerValueProviders(finalArgs);
-            LogService newLogService = Scope.child(Collections.singletonMap(REGISTERED_VALUE_PROVIDERS_KEY, true), () -> {
+            // The per-execution providers live in the scope, not in the shared LiquibaseConfiguration:
+            // concurrent executions used to see (and unregister) each other's argument values (#6927)
+            final CommandLineArgumentValueProvider argumentProvider =
+                    new CommandLineArgumentValueProvider(commandLine.parseArgs(finalArgs));
+            final List<ConfigurationValueProvider> valueProviders = Scope.child(
+                    Collections.singletonMap(LiquibaseConfiguration.SCOPED_VALUE_PROVIDERS_KEY,
+                            Collections.singletonList(argumentProvider)),
+                    () -> resolveValueProviders(argumentProvider));
+
+            final Map<String, Object> providerScopeValues = new HashMap<>();
+            providerScopeValues.put(LiquibaseConfiguration.SCOPED_VALUE_PROVIDERS_KEY, valueProviders);
+            providerScopeValues.put(REGISTERED_VALUE_PROVIDERS_KEY, true);
+
+            LogService newLogService = Scope.child(providerScopeValues, () -> {
                 // Get a new log service after registering the value providers, since the log service might need to load parameters using newly registered value providers.
                 return Scope.getCurrentScope().getSingleton(LogServiceFactory.class).getDefaultLogService();
             });
 
-            return Scope.child(Collections.singletonMap(Scope.Attr.logService.name(), newLogService), () -> {
+            final Map<String, Object> executionScopeValues = new HashMap<>(providerScopeValues);
+            executionScopeValues.put(Scope.Attr.logService.name(), newLogService);
+            return Scope.child(executionScopeValues, () -> {
                 addEmptyMdcValues();
                 try {
                     return Scope.child(configureScope(args), () -> {
@@ -430,12 +444,7 @@ public class LiquibaseCommandLine {
                         return response;
                     });
                 } finally {
-                    final LiquibaseConfiguration liquibaseConfiguration = Scope.getCurrentScope().getSingleton(LiquibaseConfiguration.class);
-
-                    for (ConfigurationValueProvider provider : valueProviders) {
-                        liquibaseConfiguration.unregisterProvider(provider);
-                    }
-
+                    // scoped value providers simply fall out of scope, there is nothing to unregister
                     LogUtil.setPersistedMdcKeysToEmptyString();
                 }
             });
@@ -704,12 +713,14 @@ public class LiquibaseCommandLine {
         return returnList.toArray(new String[0]);
     }
 
-    private List<ConfigurationValueProvider> registerValueProviders(String[] args) throws IOException {
-        final LiquibaseConfiguration liquibaseConfiguration = Scope.getCurrentScope().getSingleton(LiquibaseConfiguration.class);
+    /**
+     * Builds the per-execution value providers (argument values, defaults file, local defaults file).
+     * Callers make them visible through {@link LiquibaseConfiguration#SCOPED_VALUE_PROVIDERS_KEY}; nothing is
+     * registered on the shared {@link LiquibaseConfiguration}. Must run inside a scope that already exposes
+     * the given argument provider so the defaults file location can be resolved from the command line.
+     */
+    private List<ConfigurationValueProvider> resolveValueProviders(CommandLineArgumentValueProvider argumentProvider) throws IOException {
         List<ConfigurationValueProvider> returnList = new ArrayList<>();
-
-        final CommandLineArgumentValueProvider argumentProvider = new CommandLineArgumentValueProvider(commandLine.parseArgs(args));
-        liquibaseConfiguration.registerProvider(argumentProvider);
         returnList.add(argumentProvider);
 
         final ConfiguredValue<String> defaultsFileConfig = LiquibaseCommandLineConfiguration.DEFAULTS_FILE.getCurrentConfiguredValue();
@@ -738,7 +749,6 @@ public class LiquibaseCommandLine {
             try (InputStream defaultsStream = resource.openInputStream()) {
                 if (defaultsStream != null) {
                     final DefaultsFileValueProvider fileProvider = new DefaultsFileValueProvider(defaultsStream, "File exists at path " + defaultsFileConfigValue);
-                    liquibaseConfiguration.registerProvider(fileProvider);
                     returnList.add(fileProvider);
                 }
             }
@@ -757,7 +767,6 @@ public class LiquibaseCommandLine {
                 }
             } else {
                 final DefaultsFileValueProvider fileProvider = new DefaultsFileValueProvider(inputStreamOnClasspath, "File in classpath " + defaultsFileConfigValue);
-                liquibaseConfiguration.registerProvider(fileProvider);
                 returnList.add(fileProvider);
             }
         }
@@ -771,7 +780,6 @@ public class LiquibaseCommandLine {
                     return super.getPrecedence() + 1;
                 }
             };
-            liquibaseConfiguration.registerProvider(fileProvider);
             returnList.add(fileProvider);
         } else {
             Scope.getCurrentScope().getLog(getClass()).fine("Cannot find local defaultsFile " + defaultsFile.getAbsolutePath());

--- a/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineThreadingTest.groovy
+++ b/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineThreadingTest.groovy
@@ -10,7 +10,7 @@ class LiquibaseCommandLineThreadingTest extends Specification {
         given:
         // Reproduces #6927: commands running at the same time used to share the cached
         // CommandDefinition's step instances, letting one thread clean up the other's run.
-        def startGate = new java.util.concurrent.CountDownLatch(1)
+        def startGate = new java.util.concurrent.CyclicBarrier(2)
         def results = Collections.synchronizedList([])
         // start from a cold cache so the test also covers two threads racing the first
         // computation of the definition, not only the steady-state execution
@@ -19,17 +19,17 @@ class LiquibaseCommandLineThreadingTest extends Specification {
         when:
         def threads = (1..2).collect { n ->
             Thread.start {
-                startGate.await()
+                startGate.await(30, java.util.concurrent.TimeUnit.SECONDS)
                 3.times {
                     results.add(new LiquibaseCommandLine().execute("update", "--show-summary=OFF",
                             "--url=jdbc:h2:mem:liquibaseConcurrent" + n, "--changeLogFile=changelog.xml"))
                 }
             }
         }
-        startGate.countDown()
-        threads*.join()
+        threads.each { it.join(java.util.concurrent.TimeUnit.MINUTES.toMillis(3)) }
 
         then:
+        threads.every { !it.alive }
         results.size() == 6
         results.every { it == 0 }
     }

--- a/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineThreadingTest.groovy
+++ b/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineThreadingTest.groovy
@@ -12,6 +12,9 @@ class LiquibaseCommandLineThreadingTest extends Specification {
         // CommandDefinition's step instances, letting one thread clean up the other's run.
         def startGate = new java.util.concurrent.CountDownLatch(1)
         def results = Collections.synchronizedList([])
+        // start from a cold cache so the test also covers two threads racing the first
+        // computation of the definition, not only the steady-state execution
+        liquibase.Scope.currentScope.getSingleton(liquibase.command.CommandFactory).resetCommandDefinitions()
 
         when:
         def threads = (1..2).collect { n ->

--- a/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineThreadingTest.groovy
+++ b/liquibase-cli/src/test/groovy/liquibase/integration/commandline/LiquibaseCommandLineThreadingTest.groovy
@@ -6,6 +6,31 @@ import spock.lang.Unroll
 
 class LiquibaseCommandLineThreadingTest extends Specification {
 
+    def "2 concurrent updates do not interfere with each other" () {
+        given:
+        // Reproduces #6927: commands running at the same time used to share the cached
+        // CommandDefinition's step instances, letting one thread clean up the other's run.
+        def startGate = new java.util.concurrent.CountDownLatch(1)
+        def results = Collections.synchronizedList([])
+
+        when:
+        def threads = (1..2).collect { n ->
+            Thread.start {
+                startGate.await()
+                3.times {
+                    results.add(new LiquibaseCommandLine().execute("update", "--show-summary=OFF",
+                            "--url=jdbc:h2:mem:liquibaseConcurrent" + n, "--changeLogFile=changelog.xml"))
+                }
+            }
+        }
+        startGate.countDown()
+        threads*.join()
+
+        then:
+        results.size() == 6
+        results.every { it == 0 }
+    }
+
     @Unroll
     def "2 threads global flags" () {
         given:

--- a/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
+++ b/liquibase-maven-plugin/src/main/java/org/liquibase/maven/plugins/AbstractLiquibaseMojo.java
@@ -8,6 +8,7 @@ import liquibase.changelog.visitor.ChangeExecListener;
 import liquibase.changelog.visitor.DefaultChangeExecListener;
 import liquibase.command.CommandScope;
 import liquibase.command.core.helpers.DbUrlConnectionCommandStep;
+import liquibase.configuration.ConfigurationValueProvider;
 import liquibase.configuration.LiquibaseConfiguration;
 import liquibase.configuration.core.DefaultsFileValueProvider;
 import liquibase.database.Database;
@@ -585,95 +586,102 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
 
                     configureFieldsAndValues();
 
-                    if (showBanner) {
-                        getLog().info(CommandLineUtils.getBanner());
-                    }
+                    // The property-file provider is visible only to this execution's scope: registering it
+                    // on the shared LiquibaseConfiguration leaked one module's properties into other goals
+                    // and into parallel executions (#6927)
+                    List<ConfigurationValueProvider> mojoValueProviders = buildPropertyFileValueProviders();
+                    Scope.child(Collections.singletonMap(LiquibaseConfiguration.SCOPED_VALUE_PROVIDERS_KEY, mojoValueProviders), () -> {
 
-                    // Displays the settings for the Mojo depending on verbosity mode.
-                    displayMojoSettings();
+                        if (showBanner) {
+                            getLog().info(CommandLineUtils.getBanner());
+                        }
 
-                    // Check that all the parameters that must be specified have been by the user.
-                    checkRequiredParametersAreSpecified();
+                        // Displays the settings for the Mojo depending on verbosity mode.
+                        displayMojoSettings();
 
-                    Database database = null;
-                    try {
-                        if (databaseConnectionRequired()) {
-                            String dbPassword = (emptyPassword || (password == null)) ? "" : password;
-                            String driverPropsFile = (driverPropertiesFile == null) ? null : driverPropertiesFile.getAbsolutePath();
-                            database = CommandLineUtils.createDatabaseObject(mavenClassLoader,
-                                    url,
-                                    username,
-                                    dbPassword,
-                                    driver,
-                                    defaultCatalogName,
-                                    defaultSchemaName,
-                                    outputDefaultCatalog,
-                                    outputDefaultSchema,
-                                    databaseClass,
-                                    driverPropsFile,
-                                    propertyProviderClass,
-                                    changelogCatalogName,
-                                    changelogSchemaName,
-                                    databaseChangeLogTableName,
-                                    databaseChangeLogLockTableName);
-                            DbUrlConnectionCommandStep.logMdc(url, database);
-                            liquibase = createLiquibase(database);
+                        // Check that all the parameters that must be specified have been by the user.
+                        checkRequiredParametersAreSpecified();
 
-                            configureChangeLogProperties();
+                        Database database = null;
+                        try {
+                            if (databaseConnectionRequired()) {
+                                String dbPassword = (emptyPassword || (password == null)) ? "" : password;
+                                String driverPropsFile = (driverPropertiesFile == null) ? null : driverPropertiesFile.getAbsolutePath();
+                                database = CommandLineUtils.createDatabaseObject(mavenClassLoader,
+                                        url,
+                                        username,
+                                        dbPassword,
+                                        driver,
+                                        defaultCatalogName,
+                                        defaultSchemaName,
+                                        outputDefaultCatalog,
+                                        outputDefaultSchema,
+                                        databaseClass,
+                                        driverPropsFile,
+                                        propertyProviderClass,
+                                        changelogCatalogName,
+                                        changelogSchemaName,
+                                        databaseChangeLogTableName,
+                                        databaseChangeLogLockTableName);
+                                DbUrlConnectionCommandStep.logMdc(url, database);
+                                liquibase = createLiquibase(database);
 
-                            ChangeExecListener listener = ChangeExecListenerUtils.getChangeExecListener(
-                                    liquibase.getDatabase(), liquibase.getResourceAccessor(),
-                                    changeExecListenerClass, changeExecListenerPropertiesFile);
-                            defaultChangeExecListener = new DefaultChangeExecListener(listener);
-                            liquibase.setChangeExecListener(defaultChangeExecListener);
+                                configureChangeLogProperties();
 
-                            getLog().debug("expressionVars = " + expressionVars);
+                                ChangeExecListener listener = ChangeExecListenerUtils.getChangeExecListener(
+                                        liquibase.getDatabase(), liquibase.getResourceAccessor(),
+                                        changeExecListenerClass, changeExecListenerPropertiesFile);
+                                defaultChangeExecListener = new DefaultChangeExecListener(listener);
+                                liquibase.setChangeExecListener(defaultChangeExecListener);
 
-                            if (expressionVars != null) {
-                                for (Map.Entry<Object, Object> var : expressionVars.entrySet()) {
-                                    this.liquibase.setChangeLogParameter(var.getKey().toString(), var.getValue());
-                                }
-                            }
+                                getLog().debug("expressionVars = " + expressionVars);
 
-                            getLog().debug("expressionVariables = " + expressionVariables);
-                            if (expressionVariables != null) {
-                                for (Map.Entry var : (Set<Map.Entry>) expressionVariables.entrySet()) {
-                                    if (var.getValue() != null) {
+                                if (expressionVars != null) {
+                                    for (Map.Entry<Object, Object> var : expressionVars.entrySet()) {
                                         this.liquibase.setChangeLogParameter(var.getKey().toString(), var.getValue());
                                     }
                                 }
-                            }
 
-                            if (clearCheckSums) {
-                                getLog().info("Clearing the Liquibase checksums on the database");
-                                liquibase.clearCheckSums();
-                            }
+                                getLog().debug("expressionVariables = " + expressionVariables);
+                                if (expressionVariables != null) {
+                                    for (Map.Entry var : (Set<Map.Entry>) expressionVariables.entrySet()) {
+                                        if (var.getValue() != null) {
+                                            this.liquibase.setChangeLogParameter(var.getKey().toString(), var.getValue());
+                                        }
+                                    }
+                                }
 
-                            getLog().info("Executing on Database: " + url);
+                                if (clearCheckSums) {
+                                    getLog().info("Clearing the Liquibase checksums on the database");
+                                    liquibase.clearCheckSums();
+                                }
 
-                            if (isPromptOnNonLocalDatabase()) {
-                                getLog().info("NOTE: The promptOnLocalDatabase functionality has been removed");
+                                getLog().info("Executing on Database: " + url);
+
+                                if (isPromptOnNonLocalDatabase()) {
+                                    getLog().info("NOTE: The promptOnLocalDatabase functionality has been removed");
+                                }
                             }
+                            setupBindInfoPackage();
+
+                            //
+                            // Add another scope child with a map so that
+                            // we can set the preserveSchemaCase property,
+                            // which might have been specified in a defaults file
+                            //
+                            Map<String, Object> innerScopeValues = new HashMap<>();
+                            innerScopeValues.put(key, preserveSchemaCase);
+                            innerScopeValues.put(LiquibaseCommandLineConfiguration.SUPPRESS_LIQUIBASE_SQL.getKey(), suppressLiquibaseSql);
+                            Scope.child(innerScopeValues, () -> performLiquibaseTask(liquibase));
+                        } catch (LiquibaseException e) {
+                            cleanup(database);
+                            throw new MojoExecutionException("\nError setting up or running Liquibase:\n" + e.getMessage(), e);
                         }
-                        setupBindInfoPackage();
 
-                        //
-                        // Add another scope child with a map so that
-                        // we can set the preserveSchemaCase property,
-                        // which might have been specified in a defaults file
-                        //
-                        Map<String, Object> innerScopeValues = new HashMap<>();
-                        innerScopeValues.put(key, preserveSchemaCase);
-                        innerScopeValues.put(LiquibaseCommandLineConfiguration.SUPPRESS_LIQUIBASE_SQL.getKey(), suppressLiquibaseSql);
-                        Scope.child(innerScopeValues, () -> performLiquibaseTask(liquibase));
-                    } catch (LiquibaseException e) {
                         cleanup(database);
-                        throw new MojoExecutionException("\nError setting up or running Liquibase:\n" + e.getMessage(), e);
-                    }
-
-                    cleanup(database);
-                    getLog().info(MavenUtils.LOG_SEPARATOR);
-                    getLog().info("");
+                        getLog().info(MavenUtils.LOG_SEPARATOR);
+                        getLog().info("");
+                    });
                 });
             });
         } catch (Exception e) {
@@ -801,13 +809,22 @@ public abstract class AbstractLiquibaseMojo extends AbstractMojo {
             } catch (IOException | MojoFailureException e) {
                 throw new UnexpectedLiquibaseException(e);
             }
-            try (InputStream is = handlePropertyFileInputStream(propertyFile)) {
-                LiquibaseConfiguration liquibaseConfiguration = Scope.getCurrentScope().getSingleton(LiquibaseConfiguration.class);
-                final DefaultsFileValueProvider fileProvider = new DefaultsFileValueProvider(is, "Property file " + propertyFile);
-                liquibaseConfiguration.registerProvider(fileProvider);
-            } catch (IOException | MojoFailureException e) {
-                throw new UnexpectedLiquibaseException(e);
-            }
+        }
+    }
+
+    /**
+     * Builds the value providers backed by the configured property file, if any. They are exposed through
+     * {@link LiquibaseConfiguration#SCOPED_VALUE_PROVIDERS_KEY} for this execution only instead of being
+     * registered on the shared {@link LiquibaseConfiguration}.
+     */
+    private List<ConfigurationValueProvider> buildPropertyFileValueProviders() throws MojoExecutionException {
+        if (propertyFile == null) {
+            return Collections.emptyList();
+        }
+        try (InputStream is = handlePropertyFileInputStream(propertyFile)) {
+            return Collections.singletonList(new DefaultsFileValueProvider(is, "Property file " + propertyFile));
+        } catch (IOException | MojoFailureException e) {
+            throw new UnexpectedLiquibaseException(e);
         }
     }
 

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogParameters.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogParameters.java
@@ -479,7 +479,7 @@ public class ChangeLogParameters {
      */
     public void addDefaultFileProperties() {
         final LiquibaseConfiguration liquibaseConfiguration = Scope.getCurrentScope().getSingleton(LiquibaseConfiguration.class);
-        for (ConfigurationValueProvider cvp : liquibaseConfiguration.getProviders()) {
+        for (ConfigurationValueProvider cvp : liquibaseConfiguration.getEffectiveProviders()) {
             if (cvp instanceof DefaultsFileValueProvider) {
                 DefaultsFileValueProvider dfvp = (DefaultsFileValueProvider) cvp;
                 dfvp.getMap().entrySet().stream()

--- a/liquibase-standard/src/main/java/liquibase/command/CommandDefinition.java
+++ b/liquibase-standard/src/main/java/liquibase/command/CommandDefinition.java
@@ -51,6 +51,31 @@ public class CommandDefinition implements Comparable<CommandDefinition> {
     }
 
     /**
+     * Copies the template's metadata but instantiates a fresh {@link CommandStep} pipeline, so each
+     * {@link CommandScope} executes on its own step instances and never shares their state.
+     */
+    protected CommandDefinition(CommandDefinition template) {
+        this(template.name);
+        for (CommandStep step : template.pipeline) {
+            try {
+                this.pipeline.add(step.getClass().getConstructor().newInstance());
+            } catch (ReflectiveOperationException e) {
+                throw new IllegalArgumentException(e);
+            }
+        }
+        this.arguments.putAll(template.arguments);
+        this.longDescription = template.longDescription;
+        this.shortDescription = template.shortDescription;
+        this.internal = template.internal;
+        this.hidden = template.hidden;
+        this.footer = template.footer;
+        this.groupFooter = template.groupFooter;
+        this.groupLongDescription.putAll(template.groupLongDescription);
+        this.groupShortDescription.putAll(template.groupShortDescription);
+        this.aliases = new ArrayList<>(template.aliases);
+    }
+
+    /**
      * The fully qualified name of this command.
      */
     public String[] getName() {

--- a/liquibase-standard/src/main/java/liquibase/command/CommandDefinition.java
+++ b/liquibase-standard/src/main/java/liquibase/command/CommandDefinition.java
@@ -55,7 +55,7 @@ public class CommandDefinition implements Comparable<CommandDefinition> {
      * {@link CommandScope} executes on its own step instances and never shares their state.
      */
     protected CommandDefinition(CommandDefinition template) {
-        this(template.name);
+        this(template.name.clone());
         for (CommandStep step : template.pipeline) {
             try {
                 this.pipeline.add(step.getClass().getConstructor().newInstance());
@@ -72,7 +72,10 @@ public class CommandDefinition implements Comparable<CommandDefinition> {
         this.groupFooter = template.groupFooter;
         this.groupLongDescription.putAll(template.groupLongDescription);
         this.groupShortDescription.putAll(template.groupShortDescription);
-        this.aliases = new ArrayList<>(template.aliases);
+        this.aliases = new ArrayList<>(template.aliases.size());
+        for (String[] alias : template.aliases) {
+            this.aliases.add(alias.clone());
+        }
     }
 
     /**

--- a/liquibase-standard/src/main/java/liquibase/command/CommandFactory.java
+++ b/liquibase-standard/src/main/java/liquibase/command/CommandFactory.java
@@ -280,7 +280,7 @@ public class CommandFactory implements SingletonObject {
      * @return a map with key of the CommandStep intended to override and value of the valid overriding command step
      * @throws RuntimeException if more than one command step overrides another command step
      */
-    private Map<Class<? extends CommandStep>, CommandStep> findAllOverrides(Collection<CommandStep> allCommandSteps) throws RuntimeException {
+    private synchronized Map<Class<? extends CommandStep>, CommandStep> findAllOverrides(Collection<CommandStep> allCommandSteps) throws RuntimeException {
         if (commandOverrides == null) { //If we have not already found any overrides
             Map<Class<? extends CommandStep>, List<CommandStep>> overrides = new HashMap<>();
             allCommandSteps.stream()

--- a/liquibase-standard/src/main/java/liquibase/command/CommandFactory.java
+++ b/liquibase-standard/src/main/java/liquibase/command/CommandFactory.java
@@ -45,14 +45,16 @@ public class CommandFactory implements SingletonObject {
      */
     public CommandDefinition getCommandDefinition(String... commandName) throws IllegalArgumentException{
         String commandNameKey = StringUtil.join(commandName, " ");
-        CommandDefinition commandDefinition = COMMAND_DEFINITIONS.get(commandNameKey);
-        if (commandDefinition == null) { //Check if we have already computed arguments, dependencies, pipeline and adjusted definition
-            commandDefinition = new CommandDefinition(commandName);
-            computePipelineForCommandDefinition(commandDefinition);
-            consolidateCommandArgumentsForCommand(commandDefinition);
-            adjustCommandDefinitionForSteps(commandDefinition);
-            COMMAND_DEFINITIONS.put(commandNameKey, commandDefinition);
-        }
+        // computeIfAbsent so two threads asking for the same command on first use do not build it
+        // concurrently: the plain get/put idiom let one thread consolidate arguments while the other
+        // was still registering them through the step classes' static initializers (#6927)
+        CommandDefinition commandDefinition = COMMAND_DEFINITIONS.computeIfAbsent(commandNameKey, key -> {
+            CommandDefinition template = new CommandDefinition(commandName);
+            computePipelineForCommandDefinition(template);
+            consolidateCommandArgumentsForCommand(template);
+            adjustCommandDefinitionForSteps(template);
+            return template;
+        });
         // Return a copy with fresh CommandStep instances: the cached definition is a shared template,
         // and handing out its steps would let concurrent executions interfere with each other (#6927)
         return new CommandDefinition(commandDefinition);

--- a/liquibase-standard/src/main/java/liquibase/command/CommandFactory.java
+++ b/liquibase-standard/src/main/java/liquibase/command/CommandFactory.java
@@ -53,7 +53,9 @@ public class CommandFactory implements SingletonObject {
             adjustCommandDefinitionForSteps(commandDefinition);
             COMMAND_DEFINITIONS.put(commandNameKey, commandDefinition);
         }
-        return commandDefinition;
+        // Return a copy with fresh CommandStep instances: the cached definition is a shared template,
+        // and handing out its steps would let concurrent executions interfere with each other (#6927)
+        return new CommandDefinition(commandDefinition);
     }
 
     /**

--- a/liquibase-standard/src/main/java/liquibase/command/CommandScope.java
+++ b/liquibase-standard/src/main/java/liquibase/command/CommandScope.java
@@ -242,7 +242,7 @@ public class CommandScope {
     }
 
     public void validate() throws CommandValidationException {
-        for (ConfigurationValueProvider provider : Scope.getCurrentScope().getSingleton(LiquibaseConfiguration.class).getProviders()) {
+        for (ConfigurationValueProvider provider : Scope.getCurrentScope().getSingleton(LiquibaseConfiguration.class).getEffectiveProviders()) {
             provider.validate(this);
         }
 

--- a/liquibase-standard/src/main/java/liquibase/command/core/init/InitProjectCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/init/InitProjectCommandStep.java
@@ -140,6 +140,19 @@ public class InitProjectCommandStep extends AbstractCommandStep {
             Optional<ConfigurationValueProvider> providerOpt = lbConf.getProviders().stream().filter(vp -> vp instanceof DefaultsFileValueProvider).findFirst();
             providerOpt.ifPresent(lbConf::unregisterProvider);
 
+            // Integrations keep their defaults file provider in the scope instead of registering it, so the
+            // scoped list has to be shadowed too for init project to ignore an already existing defaults file.
+            List<?> scopedProviders = Scope.getCurrentScope().get(LiquibaseConfiguration.SCOPED_VALUE_PROVIDERS_KEY, List.class);
+            if (scopedProviders != null) {
+                List<ConfigurationValueProvider> withoutDefaultsFile = new ArrayList<>();
+                for (Object provider : scopedProviders) {
+                    if (!(provider instanceof DefaultsFileValueProvider)) {
+                        withoutDefaultsFile.add((ConfigurationValueProvider) provider);
+                    }
+                }
+                scopeValues.put(LiquibaseConfiguration.SCOPED_VALUE_PROVIDERS_KEY, withoutDefaultsFile);
+            }
+
             Scope.child(scopeValues, () -> {
                 internalRun(resultsBuilder);
             });

--- a/liquibase-standard/src/main/java/liquibase/configuration/LiquibaseConfiguration.java
+++ b/liquibase-standard/src/main/java/liquibase/configuration/LiquibaseConfiguration.java
@@ -40,6 +40,9 @@ public class LiquibaseConfiguration implements SingletonObject {
      * children. Integrations that run executions side by side (CLI, maven) put their per-execution providers
      * here instead of {@link #registerProvider(ConfigurationValueProvider)}, so one execution's arguments never
      * leak into or vanish from another running in parallel.
+     * <p>
+     * A nested scope that sets this key shadows the outer list rather than combining with it; integrations set
+     * it once per execution.
      */
     public static final String SCOPED_VALUE_PROVIDERS_KEY = "liquibase.scopedValueProviders";
 

--- a/liquibase-standard/src/main/java/liquibase/configuration/LiquibaseConfiguration.java
+++ b/liquibase-standard/src/main/java/liquibase/configuration/LiquibaseConfiguration.java
@@ -21,7 +21,30 @@ import java.util.*;
  */
 public class LiquibaseConfiguration implements SingletonObject {
 
-    private final SortedSet<ConfigurationValueProvider> configurationValueProviders;
+    /**
+     * Orders providers by ascending {@link ConfigurationValueProvider#getPrecedence()}: resolution walks the
+     * list in order and later values override earlier ones, so the last provider wins.
+     */
+    private static final Comparator<ConfigurationValueProvider> PROVIDER_ORDER = (o1, o2) -> {
+        if (o1.getPrecedence() < o2.getPrecedence()) {
+            return -1;
+        } else if (o1.getPrecedence() > o2.getPrecedence()) {
+            return 1;
+        }
+
+        return o1.getClass().getName().compareTo(o2.getClass().getName());
+    };
+
+    /**
+     * Scope key holding a {@code List<ConfigurationValueProvider>} visible only to the current scope and its
+     * children. Integrations that run executions side by side (CLI, maven) put their per-execution providers
+     * here instead of {@link #registerProvider(ConfigurationValueProvider)}, so one execution's arguments never
+     * leak into or vanish from another running in parallel.
+     */
+    public static final String SCOPED_VALUE_PROVIDERS_KEY = "liquibase.scopedValueProviders";
+
+    // Immutable snapshot replaced on every mutation, so resolution never sees a half-updated set.
+    private volatile SortedSet<ConfigurationValueProvider> configurationValueProviders;
     private final static SortedSet<ConfigurationDefinition<?>> definitions = new TreeSet<>();
     public static final String REGISTERED_VALUE_PROVIDERS_KEY = "REGISTERED_VALUE_PROVIDERS";
 
@@ -33,16 +56,7 @@ public class LiquibaseConfiguration implements SingletonObject {
     private final Map<String, String> lastLoggedKeyValues = new HashMap<>();
 
     protected LiquibaseConfiguration() {
-        configurationValueProviders = new TreeSet<>((o1, o2) -> {
-            if (o1.getPrecedence() < o2.getPrecedence()) {
-                return -1;
-            } else if (o1.getPrecedence() > o2.getPrecedence()) {
-                return 1;
-            }
-
-            return o1.getClass().getName().compareTo(o2.getClass().getName());
-        });
-
+        configurationValueProviders = new TreeSet<>(PROVIDER_ORDER);
     }
 
     /**
@@ -55,22 +69,25 @@ public class LiquibaseConfiguration implements SingletonObject {
     /**
      * Finishes configuration of this service. Called as the root scope is set up, should not be called elsewhere.
      */
-    public void init(Scope scope) {
-        configurationValueProviders.clear();
+    public synchronized void init(Scope scope) {
         ServiceLocator serviceLocator = scope.getServiceLocator();
         final List<AutoloadedConfigurations> containers = serviceLocator.findInstances(AutoloadedConfigurations.class);
         for (AutoloadedConfigurations container : containers) {
             Scope.getCurrentScope().getLog(getClass()).fine("Found ConfigurationDefinitions in " + container.getClass().getName());
         }
 
-        configurationValueProviders.addAll(serviceLocator.findInstances(ConfigurationValueProvider.class));
+        SortedSet<ConfigurationValueProvider> replacement = new TreeSet<>(PROVIDER_ORDER);
+        replacement.addAll(serviceLocator.findInstances(ConfigurationValueProvider.class));
+        this.configurationValueProviders = replacement;
     }
 
     /**
      * Adds a new {@link ConfigurationValueProvider} to the active collection of providers.
      */
-    public void registerProvider(ConfigurationValueProvider valueProvider) {
-        this.configurationValueProviders.add(valueProvider);
+    public synchronized void registerProvider(ConfigurationValueProvider valueProvider) {
+        SortedSet<ConfigurationValueProvider> replacement = new TreeSet<>(this.configurationValueProviders);
+        replacement.add(valueProvider);
+        this.configurationValueProviders = replacement;
     }
 
     /**
@@ -78,8 +95,11 @@ public class LiquibaseConfiguration implements SingletonObject {
      *
      * @return true if the given provider was previously registered.
      */
-    public boolean unregisterProvider(ConfigurationValueProvider valueProvider) {
-        return this.configurationValueProviders.remove(valueProvider);
+    public synchronized boolean unregisterProvider(ConfigurationValueProvider valueProvider) {
+        SortedSet<ConfigurationValueProvider> replacement = new TreeSet<>(this.configurationValueProviders);
+        boolean removed = replacement.remove(valueProvider);
+        this.configurationValueProviders = replacement;
+        return removed;
     }
 
     /**
@@ -87,8 +107,8 @@ public class LiquibaseConfiguration implements SingletonObject {
      *
      * @return true if the provider was removed.
      */
-    public boolean removeProvider(ConfigurationValueProvider provider) {
-        return this.configurationValueProviders.remove(provider);
+    public synchronized boolean removeProvider(ConfigurationValueProvider provider) {
+        return unregisterProvider(provider);
     }
 
     /**
@@ -104,6 +124,11 @@ public class LiquibaseConfiguration implements SingletonObject {
 
     public SortedSet<ConfigurationValueProvider> getProviders() {
         return Collections.unmodifiableSortedSet(this.configurationValueProviders);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<ConfigurationValueProvider> getScopedValueProviders() {
+        return Scope.getCurrentScope().get(SCOPED_VALUE_PROVIDERS_KEY, List.class);
     }
 
     public ConfigurationValueProvider getProvider(ConfigurationValueProvider provider) {
@@ -136,6 +161,12 @@ public class LiquibaseConfiguration implements SingletonObject {
         ConfiguredValue<DataType> details = new ConfiguredValue<>(keyAndAliases[0], converter, obfuscator);
 
         List<ConfigurationValueProvider> finalValueProviders = new ArrayList<>(configurationValueProviders);
+        List<ConfigurationValueProvider> scopedValueProviders = getScopedValueProviders();
+        if (scopedValueProviders != null) {
+            // merge and re-sort so a scoped provider ranks by its own precedence, exactly as if registered
+            finalValueProviders.addAll(scopedValueProviders);
+            finalValueProviders.sort(PROVIDER_ORDER);
+        }
         if (additionalValueProviders != null) {
             finalValueProviders.addAll(Arrays.asList(additionalValueProviders));
         }

--- a/liquibase-standard/src/main/java/liquibase/configuration/LiquibaseConfiguration.java
+++ b/liquibase-standard/src/main/java/liquibase/configuration/LiquibaseConfiguration.java
@@ -125,8 +125,26 @@ public class LiquibaseConfiguration implements SingletonObject {
         }
     }
 
+    /**
+     * Returns only the globally registered providers. Callers that need everything resolution would see,
+     * including the current scope's per-execution providers, want {@link #getEffectiveProviders()}.
+     */
     public SortedSet<ConfigurationValueProvider> getProviders() {
         return Collections.unmodifiableSortedSet(this.configurationValueProviders);
+    }
+
+    /**
+     * Returns the globally registered providers merged with the current scope's ones, ordered by
+     * {@link ConfigurationValueProvider#getPrecedence()} exactly as {@link #getCurrentConfiguredValue} resolves them.
+     */
+    public List<ConfigurationValueProvider> getEffectiveProviders() {
+        List<ConfigurationValueProvider> effective = new ArrayList<>(this.configurationValueProviders);
+        List<ConfigurationValueProvider> scoped = getScopedValueProviders();
+        if (scoped != null) {
+            effective.addAll(scoped);
+            effective.sort(PROVIDER_ORDER);
+        }
+        return Collections.unmodifiableList(effective);
     }
 
     @SuppressWarnings("unchecked")
@@ -163,13 +181,7 @@ public class LiquibaseConfiguration implements SingletonObject {
 
         ConfiguredValue<DataType> details = new ConfiguredValue<>(keyAndAliases[0], converter, obfuscator);
 
-        List<ConfigurationValueProvider> finalValueProviders = new ArrayList<>(configurationValueProviders);
-        List<ConfigurationValueProvider> scopedValueProviders = getScopedValueProviders();
-        if (scopedValueProviders != null) {
-            // merge and re-sort so a scoped provider ranks by its own precedence, exactly as if registered
-            finalValueProviders.addAll(scopedValueProviders);
-            finalValueProviders.sort(PROVIDER_ORDER);
-        }
+        List<ConfigurationValueProvider> finalValueProviders = new ArrayList<>(getEffectiveProviders());
         if (additionalValueProviders != null) {
             finalValueProviders.addAll(Arrays.asList(additionalValueProviders));
         }

--- a/liquibase-standard/src/test/groovy/liquibase/changelog/ChangeLogParametersTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/changelog/ChangeLogParametersTest.groovy
@@ -6,6 +6,8 @@ import liquibase.database.core.MySQLDatabase
 import liquibase.exception.ChangeLogParseException
 import liquibase.exception.UnexpectedLiquibaseException
 import liquibase.exception.UnknownChangeLogParameterException
+import liquibase.configuration.LiquibaseConfiguration
+import liquibase.configuration.core.DefaultsFileValueProvider
 import liquibase.parser.ChangeLogParserConfiguration
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -160,5 +162,22 @@ class ChangeLogParametersTest extends Specification {
 
         cleanup:
         System.clearProperty("SOME_PROPERTY")
+    }
+
+    def "parameter entries of a scoped defaults file provider become changelog parameters"() {
+        given:
+        // integrations keep the defaults file provider in the scope rather than registering it (#6927),
+        // so reading only the registered providers here silently dropped every parameter.* entry
+        def provider = new DefaultsFileValueProvider(
+                new ByteArrayInputStream("parameter.mytable=CUSTOM_TABLE_NAME".getBytes()), "test defaults")
+        def changeLogParameters = new ChangeLogParameters()
+
+        when:
+        Scope.child([(LiquibaseConfiguration.SCOPED_VALUE_PROVIDERS_KEY): [provider]], {
+            changeLogParameters.addDefaultFileProperties()
+        } as Scope.ScopedRunner)
+
+        then:
+        changeLogParameters.getValue("mytable", null) == "CUSTOM_TABLE_NAME"
     }
 }

--- a/liquibase-standard/src/test/groovy/liquibase/command/CommandFactoryTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/command/CommandFactoryTest.groovy
@@ -20,8 +20,22 @@ class CommandFactoryTest extends Specification {
         def command1 = Scope.currentScope.getSingleton(CommandFactory).getCommandDefinition("update")
         def command2 = Scope.currentScope.getSingleton(CommandFactory).getCommandDefinition("update")
 
+        then: "definitions are equal and carry the same metadata"
+        command1 == command2
+        command1.arguments.keySet() == command2.arguments.keySet()
+        command1.pipeline*.class == command2.pipeline*.class
+    }
+
+    def "getCommandDefinition returns isolated pipeline step instances"() {
+        // Two concurrent CommandScopes must never share CommandStep instances: steps hold execution
+        // state, and a shared instance lets one thread's cleanUp tear down another thread's run (#6927)
+        when:
+        def factory = Scope.currentScope.getSingleton(CommandFactory)
+        def command1 = factory.getCommandDefinition("update")
+        def command2 = factory.getCommandDefinition("update")
+
         then:
-        System.identityHashCode(command1) == System.identityHashCode(command2)
+        command1.pipeline.every { s1 -> !command2.pipeline.any { s2 -> s1.is(s2) } }
     }
 
     def "getCommand for an invalid command"() {

--- a/liquibase-standard/src/test/groovy/liquibase/configuration/LiquibaseConfigurationTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/configuration/LiquibaseConfigurationTest.groovy
@@ -147,6 +147,29 @@ class LiquibaseConfigurationTest extends Specification {
         (1..2).every { n -> (0..49).every { results[n + "-" + it] == "value" + n } }
     }
 
+    def "getEffectiveProviders merges the scoped providers into the registered ones"() {
+        given:
+        def config = Scope.currentScope.getSingleton(LiquibaseConfiguration)
+        def registered = new TestValueProvider([:], 400)
+        def scoped = new TestValueProvider([:], 50)
+        config.registerProvider(registered)
+
+        when:
+        def inside = Scope.child([(LiquibaseConfiguration.SCOPED_VALUE_PROVIDERS_KEY): [scoped]], {
+            return config.getEffectiveProviders()
+        } as Scope.ScopedRunnerWithReturn)
+
+        then:
+        inside.contains(scoped)
+        inside.contains(registered)
+        inside.indexOf(scoped) < inside.indexOf(registered)   // sorted by precedence, not appended
+        !config.getEffectiveProviders().contains(scoped)
+        !config.getProviders().contains(scoped)               // getProviders stays registered-only
+
+        cleanup:
+        config.unregisterProvider(registered)
+    }
+
     class TestValueProvider extends liquibase.configuration.AbstractMapConfigurationValueProvider {
         private final Map<String, Object> values
         private final int precedence

--- a/liquibase-standard/src/test/groovy/liquibase/configuration/LiquibaseConfigurationTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/configuration/LiquibaseConfigurationTest.groovy
@@ -83,6 +83,89 @@ class LiquibaseConfigurationTest extends Specification {
         Scope.getCurrentScope().getSingleton(ConfiguredValueModifierFactory.class).unregister(higherModifier)
     }
 
+    def "scoped value provider is visible inside its scope and gone outside"() {
+        given:
+        def config = Scope.currentScope.getSingleton(LiquibaseConfiguration)
+        def provider = new TestValueProvider(["test.scopedKey": "scoped value"], 300)
+
+        when:
+        def insideValue = Scope.child([(LiquibaseConfiguration.SCOPED_VALUE_PROVIDERS_KEY): [provider]], {
+            return config.getCurrentConfiguredValue(null, null, "test.scopedKey").getValue()
+        } as Scope.ScopedRunnerWithReturn)
+
+        then:
+        insideValue == "scoped value"
+        config.getCurrentConfiguredValue(null, null, "test.scopedKey").getValue() == null
+    }
+
+    def "scoped provider ranks by its own precedence against registered providers"() {
+        given:
+        def config = Scope.currentScope.getSingleton(LiquibaseConfiguration)
+        def registered = new TestValueProvider(["test.precedenceKey": "from registered"], registeredPrecedence)
+        def scoped = new TestValueProvider(["test.precedenceKey": "from scoped"], scopedPrecedence)
+        config.registerProvider(registered)
+
+        when:
+        def value = Scope.child([(LiquibaseConfiguration.SCOPED_VALUE_PROVIDERS_KEY): [scoped]], {
+            return config.getCurrentConfiguredValue(null, null, "test.precedenceKey").getValue()
+        } as Scope.ScopedRunnerWithReturn)
+
+        then:
+        value == expected
+
+        cleanup:
+        config.unregisterProvider(registered)
+
+        where:
+        registeredPrecedence | scopedPrecedence | expected
+        400                  | 50               | "from registered"
+        50                   | 400              | "from scoped"
+    }
+
+    def "concurrent scopes only see their own scoped providers"() {
+        given:
+        def config = Scope.currentScope.getSingleton(LiquibaseConfiguration)
+        def results = Collections.synchronizedMap([:])
+        def gate = new java.util.concurrent.CountDownLatch(1)
+
+        when:
+        def threads = (1..2).collect { n ->
+            Thread.start {
+                def provider = new TestValueProvider(["test.concurrentKey": "value" + n], 300)
+                Scope.child([(LiquibaseConfiguration.SCOPED_VALUE_PROVIDERS_KEY): [provider]], {
+                    gate.await()
+                    50.times {
+                        results.put(n + "-" + it, config.getCurrentConfiguredValue(null, null, "test.concurrentKey").getValue())
+                    }
+                } as Scope.ScopedRunner)
+            }
+        }
+        gate.countDown()
+        threads*.join()
+
+        then:
+        (1..2).every { n -> (0..49).every { results[n + "-" + it] == "value" + n } }
+    }
+
+    class TestValueProvider extends liquibase.configuration.AbstractMapConfigurationValueProvider {
+        private final Map<String, Object> values
+        private final int precedence
+
+        TestValueProvider(Map<String, Object> values, int precedence) {
+            this.values = values
+            this.precedence = precedence
+        }
+
+        @Override
+        protected Map<?, ?> getMap() { return values }
+
+        @Override
+        protected String getSourceDescription() { return "Test provider" }
+
+        @Override
+        int getPrecedence() { return precedence }
+    }
+
     def "autoRegisters and sorts providers"() {
         expect:
         Scope.getCurrentScope().getSingleton(LiquibaseConfiguration).configurationValueProviders*.getClass()*.getName().contains("liquibase.configuration.core.SystemPropertyValueProvider")


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Fixes #6927.

Three separate concurrency defects, all reproduced by the new concurrent CLI test (two parallel updates from a cold start used to fail almost every run, now green):

1. COMMAND_DEFINITIONS handed the same cached CommandDefinition to every caller, so parallel executions shared the pipeline CommandStep instances and one thread could clean up another thread's command. Regression from #6222 once #6872 made the cache key match. The cache now works as a template and getCommandDefinition returns a copy with fresh steps.
2. The definition build itself was not atomic, two threads missing the cache together could consolidate arguments while step classes were still registering them. Now computeIfAbsent.
3. CLI and maven registered their per-execution value providers (argument values, defaults/property files) on the shared LiquibaseConfiguration, so parallel executions resolved each other's values (one thread even migrating the other thread's database) and lost their own arguments when the first execution finished and unregistered. Providers now travel in the execution's scope via LiquibaseConfiguration.SCOPED_VALUE_PROVIDERS_KEY, and the global provider set became a volatile snapshot. This also fixes the maven provider never being unregistered, which leaked one module's properties into later goals of the same JVM.

The single computation that #6222 needed is kept, so the picocli "Unknown option" problem from #6076 stays fixed. Verified with the full liquibase-standard, liquibase-cli and liquibase-maven-plugin suites plus a 5x cold-start stress run of the concurrent test.
