### PR TITLE
fix: share a single root scope across threads

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -265,7 +265,7 @@ jobs:
 
   sonar:
     needs: [ setup, build_tests, integration-test ]
-    uses: liquibase/build-logic/.github/workflows/sonar-coverage-merge.yml@main
+    uses: liquibase/build-logic/.github/workflows/sonar-coverage-merge.yml@fix/sonar-pr-mode-on-pull-request-target
     permissions:
       pull-requests: write
       id-token: write

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -265,7 +265,7 @@ jobs:
 
   sonar:
     needs: [ setup, build_tests, integration-test ]
-    uses: liquibase/build-logic/.github/workflows/sonar-coverage-merge.yml@fix/sonar-pr-mode-on-pull-request-target
+    uses: liquibase/build-logic/.github/workflows/sonar-coverage-merge.yml@main
     permissions:
       pull-requests: write
       id-token: write

--- a/liquibase-standard/src/main/java/liquibase/Scope.java
+++ b/liquibase-standard/src/main/java/liquibase/Scope.java
@@ -100,6 +100,14 @@ public class Scope {
     private static volatile InheritableThreadLocal<ScopeManager> scopeManager;
 
     /**
+     * The first fully-built root scope of the JVM. Threads that never inherited a scope manager (pool
+     * threads created before Liquibase initialized, or from another thread lineage) adopt this root
+     * instead of bootstrapping a second one with their own context classloader, which produced
+     * "not a subtype" ServiceLoader failures and split-brain singletons (#6880).
+     */
+    private static volatile Scope rootScope;
+
+    /**
      * Lazily initializes and returns the scopeManager ThreadLocal.
      */
     private static InheritableThreadLocal<ScopeManager> getScopeManagerThreadLocal() {
@@ -134,42 +142,58 @@ public class Scope {
     public static Scope getCurrentScope() {
         InheritableThreadLocal<ScopeManager> manager = getScopeManagerThreadLocal();
         if (manager.get() == null) {
-            manager.set(new SingletonScopeManager());
+            SingletonScopeManager newManager = new SingletonScopeManager();
+            Scope existingRoot = rootScope;
+            if (existingRoot != null) {
+                newManager.setCurrentScope(existingRoot);
+            }
+            manager.set(newManager);
         }
         if (manager.get().getCurrentScope() == null) {
-            Scope rootScope = new Scope();
-            manager.get().setCurrentScope(rootScope);
+            // Serialize root construction so the whole JVM shares a single root scope. The bootstrap
+            // below re-enters getCurrentScope() on the same thread, which is safe because the partially
+            // built root is set on the manager before the bootstrap runs.
+            synchronized (Scope.class) {
+                if (rootScope != null) {
+                    manager.get().setCurrentScope(rootScope);
+                    return manager.get().getCurrentScope();
+                }
+                Scope newRootScope = new Scope();
+                manager.get().setCurrentScope(newRootScope);
 
-            rootScope.values.put(Attr.logService.name(), new JavaLogService());
-            rootScope.values.put(Attr.serviceLocator.name(), new StandardServiceLocator());
-            rootScope.values.put(Attr.resourceAccessor.name(), new ClassLoaderResourceAccessor());
-            rootScope.values.put(Attr.latestChecksumVersion.name(), ChecksumVersion.V9);
-            rootScope.values.put(Attr.checksumVersion.name(), ChecksumVersion.latest());
+                newRootScope.values.put(Attr.logService.name(), new JavaLogService());
+                newRootScope.values.put(Attr.serviceLocator.name(), new StandardServiceLocator());
+                newRootScope.values.put(Attr.resourceAccessor.name(), new ClassLoaderResourceAccessor());
+                newRootScope.values.put(Attr.latestChecksumVersion.name(), ChecksumVersion.V9);
+                newRootScope.values.put(Attr.checksumVersion.name(), ChecksumVersion.latest());
 
-            rootScope.values.put(Attr.ui.name(), new ConsoleUIService());
+                newRootScope.values.put(Attr.ui.name(), new ConsoleUIService());
 
-            // Discover custom LogService early, before LiquibaseConfiguration.init(),
-            // so that logging during configuration setup uses the correct LogService.
-            LogService overrideLogService = rootScope.getSingleton(LogServiceFactory.class).getDefaultLogService();
-            if (overrideLogService != null) {
-                rootScope.values.put(Attr.logService.name(), overrideLogService);
-            } else {
-                rootScope.getLog(Scope.class).warning("Could not find log service via LogServiceFactory. Using JavaLogService as default.");
+                // Discover custom LogService early, before LiquibaseConfiguration.init(),
+                // so that logging during configuration setup uses the correct LogService.
+                LogService overrideLogService = newRootScope.getSingleton(LogServiceFactory.class).getDefaultLogService();
+                if (overrideLogService != null) {
+                newRootScope.values.put(Attr.logService.name(), overrideLogService);
+                } else {
+                newRootScope.getLog(Scope.class).warning("Could not find log service via LogServiceFactory. Using JavaLogService as default.");
             }
 
-            rootScope.getSingleton(LiquibaseConfiguration.class).init(rootScope);
+                newRootScope.getSingleton(LiquibaseConfiguration.class).init(newRootScope);
 
-            //check for higher-priority serviceLocator
-            ServiceLocator serviceLocator = rootScope.getServiceLocator();
-            for (ServiceLocator possibleLocator : serviceLocator.findInstances(ServiceLocator.class)) {
+                //check for higher-priority serviceLocator
+                ServiceLocator serviceLocator = newRootScope.getServiceLocator();
+                for (ServiceLocator possibleLocator : serviceLocator.findInstances(ServiceLocator.class)) {
                 if (possibleLocator.getPriority() > serviceLocator.getPriority()) {
                     serviceLocator = possibleLocator;
                 }
             }
 
-            rootScope.values.put(Attr.serviceLocator.name(), serviceLocator);
-            rootScope.values.put(Attr.osgiPlatform.name(), ContainerChecker.isOsgiPlatform());
-            rootScope.values.put(Attr.deploymentId.name(), generateDeploymentId());
+                newRootScope.values.put(Attr.serviceLocator.name(), serviceLocator);
+                newRootScope.values.put(Attr.osgiPlatform.name(), ContainerChecker.isOsgiPlatform());
+                newRootScope.values.put(Attr.deploymentId.name(), generateDeploymentId());
+
+                Scope.rootScope = newRootScope;
+            }
         }
         return manager.get().getCurrentScope();
     }

--- a/liquibase-standard/src/main/java/liquibase/Scope.java
+++ b/liquibase-standard/src/main/java/liquibase/Scope.java
@@ -173,20 +173,20 @@ public class Scope {
                 // so that logging during configuration setup uses the correct LogService.
                 LogService overrideLogService = newRootScope.getSingleton(LogServiceFactory.class).getDefaultLogService();
                 if (overrideLogService != null) {
-                newRootScope.values.put(Attr.logService.name(), overrideLogService);
+                    newRootScope.values.put(Attr.logService.name(), overrideLogService);
                 } else {
-                newRootScope.getLog(Scope.class).warning("Could not find log service via LogServiceFactory. Using JavaLogService as default.");
-            }
+                    newRootScope.getLog(Scope.class).warning("Could not find log service via LogServiceFactory. Using JavaLogService as default.");
+                }
 
                 newRootScope.getSingleton(LiquibaseConfiguration.class).init(newRootScope);
 
                 //check for higher-priority serviceLocator
                 ServiceLocator serviceLocator = newRootScope.getServiceLocator();
                 for (ServiceLocator possibleLocator : serviceLocator.findInstances(ServiceLocator.class)) {
-                if (possibleLocator.getPriority() > serviceLocator.getPriority()) {
-                    serviceLocator = possibleLocator;
+                    if (possibleLocator.getPriority() > serviceLocator.getPriority()) {
+                        serviceLocator = possibleLocator;
+                    }
                 }
-            }
 
                 newRootScope.values.put(Attr.serviceLocator.name(), serviceLocator);
                 newRootScope.values.put(Attr.osgiPlatform.name(), ContainerChecker.isOsgiPlatform());

--- a/liquibase-standard/src/test/groovy/liquibase/ScopeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/ScopeTest.groovy
@@ -161,6 +161,34 @@ class ScopeTest extends Specification {
         deploymentIdScope == deploymentIdService2;
     }
 
+    def "a thread without a scope manager attaches to the existing root scope"() {
+        given:
+        // A pool thread created before Liquibase initialized (or from another lineage) gets no
+        // manager from the InheritableThreadLocal. It must adopt the already-built root instead of
+        // bootstrapping a second one with its own context classloader (#6880).
+        def mainRoot = rootOf(Scope.getCurrentScope())
+        def orphanRoot = null
+
+        when:
+        def thread = new Thread({
+            Scope.setScopeManager(null)   // simulate a thread that never inherited a manager
+            orphanRoot = rootOf(Scope.getCurrentScope())
+        })
+        thread.start()
+        thread.join(30_000)
+
+        then:
+        !thread.alive
+        orphanRoot.is(mainRoot)
+    }
+
+    private static Scope rootOf(Scope scope) {
+        while (scope.getParent() != null) {
+            scope = scope.getParent()
+        }
+        return scope
+    }
+
     def "lazy initialization of scope manager for GraalVM compatibility"() {
         when:
         // Reset scope manager to test lazy initialization


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Fixes #6880.

A thread that never inherited a scope manager (a pool thread created before Liquibase initialized, or from another thread lineage) used to bootstrap a second root scope using its own context classloader. With a different classloader the ServiceLoader pass fails with "X not a subtype" for AutoloadedConfigurations, LogService, ConfigurationValueProvider and ServiceLocator, and the JVM ends up with split-brain singletons.

The first fully-built root scope is now kept and threads without a manager adopt it, exactly what @varrob112 suggested in the issue. Per-thread child scope stacks are unchanged: each thread still gets its own SingletonScopeManager, so the LB-1359 "Cannot end scope X" scenario stays fixed, and root initialization still works whichever ScopeManager an integration sets (PR #1768 behavior preserved).

Verified with the reproduction project from the issue: 26 "not a subtype" errors on the bundled jar, 28 on a core built from current main, 0 on this branch across 3 runs. Full liquibase-standard suite green, including ScopeTest and ThreadLocalScopeManagerTest.
