### PR TITLE
Fix uppercase acronym parameters being dropped in customChange

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/util/ObjectMethods.java
+++ b/liquibase-standard/src/main/java/liquibase/util/ObjectMethods.java
@@ -35,7 +35,14 @@ final class ObjectMethods {
 
   private String propertyName(String methodName, String prefix) {
     int length = prefix.length();
-    return methodName.substring(length, length + 1).toLowerCase(ROOT) + methodName.substring(length + 1);
+    String remainder = methodName.substring(length);
+    if (remainder.length() > 1
+        && Character.isUpperCase(remainder.charAt(0))
+        && Character.isUpperCase(remainder.charAt(1))) {
+      // Preserve uppercase acronyms (e.g. setGET -> "GET"), matching java.beans.Introspector.decapitalize
+      return remainder;
+    }
+    return remainder.substring(0, 1).toLowerCase(ROOT) + remainder.substring(1);
   }
 
   Method getReadMethod(String propertyName) {

--- a/liquibase-standard/src/main/java/liquibase/util/ObjectMethods.java
+++ b/liquibase-standard/src/main/java/liquibase/util/ObjectMethods.java
@@ -1,8 +1,8 @@
 package liquibase.util;
 
-import static java.util.Locale.ROOT;
 import static java.util.stream.Collectors.toMap;
 
+import java.beans.Introspector;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -34,15 +34,7 @@ final class ObjectMethods {
   }
 
   private String propertyName(String methodName, String prefix) {
-    int length = prefix.length();
-    String remainder = methodName.substring(length);
-    if (remainder.length() > 1
-        && Character.isUpperCase(remainder.charAt(0))
-        && Character.isUpperCase(remainder.charAt(1))) {
-      // Preserve uppercase acronyms (e.g. setGET -> "GET"), matching java.beans.Introspector.decapitalize
-      return remainder;
-    }
-    return remainder.substring(0, 1).toLowerCase(ROOT) + remainder.substring(1);
+    return Introspector.decapitalize(methodName.substring(prefix.length()));
   }
 
   Method getReadMethod(String propertyName) {

--- a/liquibase-standard/src/test/java/liquibase/util/ObjectMethodsTest.java
+++ b/liquibase-standard/src/test/java/liquibase/util/ObjectMethodsTest.java
@@ -23,6 +23,17 @@ class ObjectMethodsTest {
     assertThat(objectMethods.getWriteMethod("human")).isNull();
   }
 
+  @Test
+  void writeMethodsPreserveUppercaseAcronyms() {
+    ObjectMethods objectMethods = new ObjectMethods(Acronyms.class);
+    // Uppercase acronyms (first two chars both uppercase) must be kept as the property name so that
+    // <param name="GET">/<param name="URL"> resolve to setGET/setURL (issue #7582, regression since 4.29.0).
+    assertThat(objectMethods.getWriteMethod("GET").getName()).isEqualTo("setGET");
+    assertThat(objectMethods.getWriteMethod("URL").getName()).isEqualTo("setURL");
+    // Regular camelCase names are still lowercased as before.
+    assertThat(objectMethods.getWriteMethod("name").getName()).isEqualTo("setName");
+  }
+
   static class User {
     private final String name;
     private int age;
@@ -43,6 +54,17 @@ class ObjectMethodsTest {
 
     public boolean isHuman() {
       return true;
+    }
+  }
+
+  static class Acronyms {
+    public void setGET(String value) {
+    }
+
+    public void setURL(String value) {
+    }
+
+    public void setName(String value) {
     }
   }
 }


### PR DESCRIPTION
## Impact
- [x] Bug fix (non-breaking change which fixes expected existing functionality)

## Description

Since 4.29.0, `<param>` elements whose name is an uppercase acronym (e.g. `GET`, `POST`, `PUT`, `URL`) are silently dropped when mapped to `customChange` setter methods named `setGET`, `setPOST`, etc. Reported in #7582.

### Root cause

`ObjectMethods.propertyName()` derives the property name from the getter/setter method name by removing the `get`/`set`/`is` prefix and **unconditionally lowercasing the first character**:

```java
return methodName.substring(length, length + 1).toLowerCase(ROOT) + methodName.substring(length + 1);
```

So `setGET` is stored under key `gET` (not `GET`). When `<param name="GET">` is processed, the lookup `getWriteMethod("GET")` misses and returns `null`, so the parameter value is never set.

This contradicts the JavaBeans convention implemented by `java.beans.Introspector.decapitalize`, which keeps a name unchanged when its first two characters are both uppercase (acronyms like `URL`, `GET`). Pre-4.29 liquibase built the method name from the param name (`"set" + "GET"` → `setGET`) and found it directly, so acronym parameters worked.

### Fix

Align `propertyName` with `Introspector.decapitalize`: when the remainder's first two characters are both uppercase, keep the name unchanged; otherwise lowercase the first character as before. This restores the pre-4.29 behavior for acronym parameters (`setGET` → `GET`) without affecting regular camelCase names (`setAge` → `age`, `setName` → `name`).

## Testing
- New `ObjectMethodsTest#writeMethodsPreserveUppercaseAcronyms` verifies `setGET`/`setURL` resolve via `getWriteMethod("GET")`/`getWriteMethod("URL")`, while `setName` still resolves via `getWriteMethod("name")`. Fails before the fix (`getWriteMethod("GET")` returns `null` → NPE), passes after.
- Existing `ObjectMethodsTest` (read/write methods) still pass.
- `ObjectUtilTest` (82 tests) still pass — `ObjectUtil` uses `ObjectMethods` for property mapping, confirming regular camelCase mapping is unaffected.

Fixes #7582
