### PR TITLE
Route deprecated-AWS-extension warning to System.err

### DIFF
--- a/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseLauncher.java
+++ b/liquibase-cli/src/main/java/liquibase/integration/commandline/LiquibaseLauncher.java
@@ -203,7 +203,7 @@ public class LiquibaseLauncher {
                     "extension is present. To suppress this message, remove the following stand-alone AWS extension" +
                     plural + " from the classpath: " + StringUtil.join(removedJars, ", ")
                     + ". Learn more at https://docs.liquibase.com/pro-extensions";
-            System.out.println(message);
+            System.err.println(message);
         }
     }
 


### PR DESCRIPTION
## Summary

- `removeIncompatibleAwsExtensions()` in `LiquibaseLauncher` was printing its deprecation warning to `System.out` instead of `System.err`
- This is a pre-`Scope` bootstrap diagnostic with no machine payload — it belongs on STDERR per standard Unix convention
- Note: `buildDupsMessage()` already correctly routes through `Scope.getCurrentScope().getUI().sendMessage()` and is unaffected

## Test plan

- [ ] Existing `LiquibaseLauncherTest` passes unchanged (it covers `checkForDuplicatedJars`/`buildDupsMessage`, not `removeIncompatibleAwsExtensions`)
- [ ] Manual: configure both `liquibase-aws-extension` and a deprecated standalone AWS extension on the classpath; verify the warning appears on STDERR and not STDOUT

🤖 Generated with [Claude Code](https://claude.com/claude-code)