### PR TITLE
fix: drop the backtick expectation for description on mysql and mariadb

### DIFF
--- a/liquibase-integration-tests/src/test/java/liquibase/statementexecute/MarkChangeSetRanExecutorTest.java
+++ b/liquibase-integration-tests/src/test/java/liquibase/statementexecute/MarkChangeSetRanExecutorTest.java
@@ -83,13 +83,13 @@ public class MarkChangeSetRanExecutorTest extends AbstractExecutorTest {
                         " '%s')", deploymentId),
                 SybaseASADatabase.class);
         assertCorrect(String.format("insert into databasechangelog (id, author, filename, dateexecuted, orderexecuted, " +
-                        "md5sum, `description`, comments, exectype, contexts, labels, liquibase, deployment_id) values " +
+                        "md5sum, description, comments, exectype, contexts, labels, liquibase, deployment_id) values " +
                         "('a', 'b', 'c', now(), 1, " +
                         "'9:d41d8cd98f00b204e9800998ecf8427e', 'empty', '', 'executed', 'e', null, '" + version + "'," +
                         " '%s')", deploymentId),
                 MySQLDatabase.class);
         assertCorrect(String.format("insert into databasechangelog (id, author, filename, dateexecuted, orderexecuted, " +
-                        "md5sum, `description`, comments, exectype, contexts, labels, liquibase, deployment_id) values " +
+                        "md5sum, description, comments, exectype, contexts, labels, liquibase, deployment_id) values " +
                         "('a', 'b', 'c', now(), 1, " +
                         "'9:d41d8cd98f00b204e9800998ecf8427e', 'empty', '', 'executed', 'e', null, '" + version + "'," +
                         " '%s')", deploymentId),


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

main is red since #7560. All 10 integration suites fail on the same assertion:

```
MarkChangeSetRanExecutorTest.generateSql_insert
expected: ... md5sum, `description`, comments ...
but was:  ... md5sum, description, comments ...
```

#7560 removed DESCRIPTION from the MySQL and MariaDB reserved word lists, which is right, it is a non-reserved keyword there. The insert stopped quoting it. This expectation is in liquibase-integration-tests and that PR only touched liquibase-standard, so it never showed up in its own diff.

Ran the h2 integration suite on main with this: 843 tests, 0 failures. It was 843 with 1 failure before.

## Things to be aware of

The mysql, mariadb and postgres/h2/cockroach/enterprisedb blocks are now identical and could be merged into one assertCorrect. Left alone to keep this to the fix.