### PR TITLE
Fix fast check cache after rollback

### DIFF
--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/UpdateCommandStepIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/UpdateCommandStepIntegrationTest.groovy
@@ -65,6 +65,7 @@ class UpdateCommandStepIntegrationTest extends Specification {
         liquibase.rollback(1, contexts, labels)
 
         then:
+        !fastCheckService.isUpToDateFastCheck(null, database, liquibase.getDatabaseChangeLog(), contexts, labels)
         executor.queryForInt(new RawParameterizedSqlStatement(
                 "select count(1) from databasechangelog where id = ? and author = ? and filename = ?",
                 "1", "Liquibase User", "liquibase/update-tests.yml")) == 0

--- a/liquibase-integration-tests/src/test/groovy/liquibase/command/UpdateCommandStepIntegrationTest.groovy
+++ b/liquibase-integration-tests/src/test/groovy/liquibase/command/UpdateCommandStepIntegrationTest.groovy
@@ -49,6 +49,38 @@ class UpdateCommandStepIntegrationTest extends Specification {
         Scope.currentScope.getSingleton(FastCheckService.class).isUpToDateFastCheck(null, h2.getDatabaseFromFactory(), liquibase.getDatabaseChangeLog(), context, label)
     }
 
+    def "rollback invalidates the fast check cache before a subsequent update"() {
+        given:
+        def database = h2.getDatabaseFromFactory()
+        def liquibase = new Liquibase("liquibase/update-tests.yml", new ClassLoaderResourceAccessor(), database)
+        def contexts = new Contexts()
+        def labels = new LabelExpression()
+        def fastCheckService = Scope.currentScope.getSingleton(FastCheckService.class)
+        def executor = Scope.currentScope.getSingleton(ExecutorService.class).getExecutor("jdbc", database)
+        fastCheckService.clearCache()
+        liquibase.update(contexts, labels)
+        assert fastCheckService.isUpToDateFastCheck(null, database, liquibase.getDatabaseChangeLog(), contexts, labels)
+
+        when:
+        liquibase.rollback(1, contexts, labels)
+
+        then:
+        executor.queryForInt(new RawParameterizedSqlStatement(
+                "select count(1) from databasechangelog where id = ? and author = ? and filename = ?",
+                "1", "Liquibase User", "liquibase/update-tests.yml")) == 0
+
+        when:
+        liquibase.update(contexts, labels)
+
+        then:
+        executor.queryForInt(new RawParameterizedSqlStatement(
+                "select count(1) from databasechangelog where id = ? and author = ? and filename = ?",
+                "1", "Liquibase User", "liquibase/update-tests.yml")) == 1
+
+        cleanup:
+        fastCheckService.clearCache()
+    }
+
     def "validate update is successfully executed even when there is by a context mismatch and a non-existent file is referenced in a changeSet"() {
         when:
         def resourceAccessor = new SearchPathResourceAccessor(".,target/test-classes")

--- a/liquibase-standard/src/main/java/liquibase/command/core/AbstractRollbackCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/AbstractRollbackCommandStep.java
@@ -85,6 +85,7 @@ public abstract class AbstractRollbackCommandStep extends AbstractCommandStep {
             handleRollbackException(defineCommandNames()[0][0], rollbackReportParameters);
             throw t;
         } finally {
+            Scope.getCurrentScope().getSingleton(FastCheckService.class).clearCache();
             Scope.getCurrentScope().getMdcManager().remove(MdcKey.CHANGESETS_ROLLED_BACK);
         }
     }


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Fixes #7549.

A successful fast check is cached for the lifetime of the JVM. After a rollback changes DATABASECHANGELOG, that cached result can make the next update report that the database is already up to date and skip the rolled-back change set.

This change invalidates the fast-check cache when a rollback command finishes. The integration test reproduces the full sequence: update, cache the up-to-date result, rollback, verify the history row was removed, update again, and verify the row was restored.

## Release note

Fixed an issue where an update in the same Java process could be skipped after a rollback because Liquibase retained a stale up-to-date result.

## Things to be aware of

The invalidation is in the common rollback command path, so rollback by tag, count, and date receive the same behavior. It also runs from the command's finally block so a partially completed rollback cannot leave a known stale result cached.

## Things to worry about

None known.

## Additional Context

Verified with JDK 17:

- UpdateCommandStepIntegrationTest: 5 tests, 0 failures
- UpdateCommandStepIntegrationTest, RollbackIntegrationTest, and UpdateTestingRollbackCommandsIntegrationTest: 12 tests, 0 failures
- liquibase-standard full test suite: 6,435 tests, 0 failures, 12 skipped