### PR TITLE
fix: carry the index relation down to its columns

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/structure/core/Index.java
+++ b/liquibase-standard/src/main/java/liquibase/structure/core/Index.java
@@ -92,6 +92,21 @@ public class Index extends AbstractDatabaseObject {
 
     public Index setRelation(Relation relation) {
     	this.setAttribute("table", relation);
+        // setColumns() only propagates the relation when the table is already known. Restoring a snapshot
+        // builds the index first and resolves its table reference afterwards, so the columns would keep a
+        // null relation and stop comparing equal to the same index read from a live database (#7895).
+        if (relation != null) {
+            List<?> columns = getAttribute("columns", List.class);
+            if (columns != null) {
+                for (Object column : columns) {
+                    // Read the raw attribute: while a snapshot is being restored a column's relation can still
+                    // be an unresolved reference String, and getRelation() would fail casting it to Relation.
+                    if ((column instanceof Column) && (((Column) column).getAttribute("relation", Object.class) == null)) {
+                        ((Column) column).setRelation(relation);
+                    }
+                }
+            }
+        }
         return this;
     }
 

--- a/liquibase-standard/src/test/groovy/liquibase/diff/compare/core/IndexComparatorTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/diff/compare/core/IndexComparatorTest.groovy
@@ -4,6 +4,7 @@ import liquibase.diff.compare.DatabaseObjectComparatorFactory
 import liquibase.database.core.MockDatabase
 import liquibase.structure.core.Column
 import liquibase.structure.core.Index
+import liquibase.structure.core.Table
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -35,5 +36,36 @@ class IndexComparatorTest extends Specification {
         new Index(null, null, null, "table_name", new Column("col1"))                          | new Index(null, null, null, "table_name", new Column("col1"))                          | true //They should be the same object if they have no name but the same columns
         new Index(null, null, null, "table_name", new Column("col1"), new Column("col2"))      | new Index(null, null, null, "table_name", new Column("col1"))                          | false //Different if no name and different columns
         new Index(null, null, null, "table_name", new Column("col1"), new Column("col2"))      | new Index("uq_test", null, null, "table_name", new Column("col1"))                     | false //Different if one has no name name but different columns
+    }
+
+    def "an index whose columns were set before its relation still matches the same index (issue #7895)"() {
+        given: "an index built the way restoring a snapshot does it - columns first, table reference resolved after"
+        def table = new Table(null, "my_schema", "table_name")
+        def restored = new Index()
+        restored.setColumns([new Column("col1"), new Column("col2")])
+        restored.setRelation(table)
+
+        and: "the same index read from a live database, where the relation is known up front"
+        def live = new Index(null, null, "my_schema", "table_name", new Column("col1"), new Column("col2"))
+
+        expect: "the restored index carries the relation down to its columns, so both compare equal"
+        restored.getColumns().every { it.getRelation() != null }
+        DatabaseObjectComparatorFactory.instance.isSameObject(restored, live, null, new MockDatabase())
+        DatabaseObjectComparatorFactory.instance.isSameObject(live, restored, null, new MockDatabase())
+    }
+
+    def "setting the relation does not overwrite a relation the column already had"() {
+        given:
+        def ownTable = new Table(null, "my_schema", "own_table")
+        def column = new Column("col1")
+        column.setRelation(ownTable)
+        def index = new Index()
+        index.setColumns([column])
+
+        when:
+        index.setRelation(new Table(null, "my_schema", "table_name"))
+
+        then:
+        column.getRelation().getName() == "own_table"
     }
 }


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Fixes #7895.

Offline diff-changelog emitted dropPrimaryKey/addPrimaryKey twice for the same PK. ChangedPrimaryKeyChangeGenerator marks the backing index as handled by building an Index from the PK's own columns, and that no longer matched the index restored from the snapshot: setColumns() only propagates the relation when the table is already known, but restoring resolves the table reference after the index is built, so the index columns kept a null relation.

setRelation() now propagates it to columns that do not have one yet, which makes the index consistent whatever order the attributes arrive in. Columns that already carry a relation are left alone.

## Testing

MariaDB, two schemas whose composite PK differs only in column order, captured as offline snapshots:

```
offline before: 4 changesets
offline after:  2
online:         2
```

liquibase-standard 6461 green, integration h2 846, postgresql 54, mariadb 41.

## Things to be aware of

Unique constraints were never affected - ChangedUniqueConstraintChangeGenerator passes the real backing index to the dedup rather than building one, so it never saw the mismatch. Verified: the same offline scenario for a unique constraint already emitted 2 changesets before this change.

The first version of this fix called column.getRelation() and broke JsonSnapshotParserTest: while a snapshot is being restored a column's relation can still be an unresolved reference String, which fails the cast. It reads the raw attribute now.