### PR TITLE
fix: do not hoist a foreign key column ahead of its own table

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/diff/output/changelog/DiffToChangeLog.java
+++ b/liquibase-standard/src/main/java/liquibase/diff/output/changelog/DiffToChangeLog.java
@@ -494,6 +494,9 @@ public class DiffToChangeLog {
      * The one exception is a column referenced by a sorted {@link ForeignKey}. The foreign key constraint cannot be
      * added before the column it constrains exists, so those specific columns are hoisted ahead of the sorted block
      * while every other unsortable object keeps its position after it.
+     * A column is only hoisted when its own table is not being created by this same changelog. When the table is
+     * also missing it has to be created first, otherwise the hoisted column turns into an ALTER TABLE against a
+     * table that does not exist yet. The table can sit in either list, so both are checked.
      */
     private List<DatabaseObject> mergeSortedObjectsHoistingForeignKeyColumns(List<DatabaseObject> toSort, List<DatabaseObject> toNotSort) {
         Set<String> foreignKeyColumnNames = new HashSet<>();
@@ -511,11 +514,24 @@ public class DiffToChangeLog {
             return mergedObjects;
         }
 
+        Set<String> tablesBeingCreated = new HashSet<>();
+        for (DatabaseObject object : toSort) {
+            if (object instanceof Relation) {
+                tablesBeingCreated.add(relationIdentifier((Relation) object));
+            }
+        }
+        for (DatabaseObject object : toNotSort) {
+            if (object instanceof Relation) {
+                tablesBeingCreated.add(relationIdentifier((Relation) object));
+            }
+        }
+
         List<DatabaseObject> hoistedColumns = new ArrayList<>();
         List<DatabaseObject> remainingObjects = new ArrayList<>(toNotSort.size());
         for (DatabaseObject unsortedObject : toNotSort) {
             if (unsortedObject instanceof Column
-                    && foreignKeyColumnNames.contains(foreignKeyColumnIdentifier(((Column) unsortedObject).getRelation(), (Column) unsortedObject))) {
+                    && foreignKeyColumnNames.contains(foreignKeyColumnIdentifier(((Column) unsortedObject).getRelation(), (Column) unsortedObject))
+                    && !tablesBeingCreated.contains(relationIdentifier(((Column) unsortedObject).getRelation()))) {
                 hoistedColumns.add(unsortedObject);
             } else {
                 remainingObjects.add(unsortedObject);
@@ -530,12 +546,16 @@ public class DiffToChangeLog {
     }
 
     private static String foreignKeyColumnIdentifier(Relation table, Column column) {
+        return relationIdentifier(table) + "." + column.getName();
+    }
+
+    private static String relationIdentifier(Relation table) {
         String schemaName = null;
         if (table != null && table.getSchema() != null) {
             schemaName = table.getSchema().getName();
         }
         String tableName = (table == null) ? null : table.getName();
-        return schemaName + "." + tableName + "." + column.getName();
+        return schemaName + "." + tableName;
     }
 
     private static Integer determineOrderingForTablesAndStoredLogic(DatabaseObject o1, DatabaseObject o2) {

--- a/liquibase-standard/src/test/java/liquibase/diff/output/changelog/DiffToChangeLogTest.java
+++ b/liquibase-standard/src/test/java/liquibase/diff/output/changelog/DiffToChangeLogTest.java
@@ -239,4 +239,70 @@ public class DiffToChangeLogTest {
         assertThat(firstChange, instanceOf(AddColumnChange.class));
         assertThat(secondChange, instanceOf(AddForeignKeyConstraintChange.class));
     }
+
+    @Test
+    public void generateChangeSets_doesNotHoistAForeignKeyColumnAheadOfItsOwnTableCreation() throws Exception {
+        MSSQLDatabase referenceDatabase = new MSSQLDatabase();
+        referenceDatabase.setConnection(new MockDatabaseConnection());
+
+        MSSQLDatabase comparisonDatabase = new MSSQLDatabase();
+        comparisonDatabase.setConnection(new MockDatabaseConnection());
+
+        SnapshotControl control = new SnapshotControl(referenceDatabase, Table.class, Column.class, PrimaryKey.class, Index.class, UniqueConstraint.class, ForeignKey.class);
+        EmptyDatabaseSnapshot referenceSnapshot = new EmptyDatabaseSnapshot(referenceDatabase, control);
+        EmptyDatabaseSnapshot comparisonSnapshot = new EmptyDatabaseSnapshot(comparisonDatabase, control);
+
+        DiffResult diffResult = new DiffResult(referenceSnapshot, comparisonSnapshot, new CompareControl());
+
+        Table baseTable = new Table(null, "dbo", "Test");
+        baseTable.setSnapshotId(SnapshotIdService.getInstance().generateId());
+        Table foreignKeyTable = new Table(null, "dbo", "Test2");
+        foreignKeyTable.setSnapshotId(SnapshotIdService.getInstance().generateId());
+
+        Column missingColumn = new Column("testID")
+                .setRelation(foreignKeyTable)
+                .setType(new DataType("bigint"))
+                .setNullable(false);
+
+        ForeignKey missingForeignKey = new ForeignKey("FK__Test2__testID__267ABA7A");
+        missingForeignKey.setForeignKeyTable(foreignKeyTable);
+        missingForeignKey.addForeignKeyColumn(new Column("testID"));
+        missingForeignKey.setPrimaryKeyTable(baseTable);
+        missingForeignKey.addPrimaryKeyColumn(new Column("ID"));
+
+        // Unlike the test above, the table holding the foreign key column is missing too, so it is created by this
+        // same changelog. Hoisting the column ahead of the sorted block would emit ALTER TABLE before CREATE TABLE.
+        diffResult.addMissingObject(foreignKeyTable);
+        diffResult.addMissingObject(missingColumn);
+        diffResult.addMissingObject(missingForeignKey);
+
+        DiffToChangeLog diffToChangeLog = new DiffToChangeLog(diffResult, new DiffOutputControl()) {
+            @Override
+            protected void addDependencies(DependencyUtil.DependencyGraph<String> graph, List<String> schemas, liquibase.database.Database database) {
+                graph.add("dbo.Test", "dbo.FK__Test2__testID__267ABA7A");
+            }
+        };
+
+        List<ChangeSet> changeSets = diffToChangeLog.generateChangeSets();
+
+        int createTableIndex = indexOfFirstChange(changeSets, CreateTableChange.class);
+        int addColumnIndex = indexOfFirstChange(changeSets, AddColumnChange.class);
+
+        assertThat("the table must be created by this changelog", createTableIndex, greaterThanOrEqualTo(0));
+        if (addColumnIndex >= 0) {
+            assertThat("a column cannot be added before its own table is created",
+                    addColumnIndex, greaterThan(createTableIndex));
+        }
+    }
+
+    private static int indexOfFirstChange(List<ChangeSet> changeSets, Class<? extends Change> changeType) {
+        for (int i = 0; i < changeSets.size(); i++) {
+            for (Change change : changeSets.get(i).getChanges()) {
+                if (changeType.isInstance(change)) {
+                    return i;
+                }
+            }
+        }
+        return -1;
+    }
 }


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

main is red on Integration Test (mssql) since #7801. First failing commit is 0aae0cbac, mssql was green on c41f4c73b right before it.

```
testRerunDiffChangeLog
Cannot find the object "fkexists_table2" because it does not exist
[Failed SQL: ALTER TABLE fkexists_table2 ADD id int;]
```

#7801 hoists columns referenced by a sorted foreign key ahead of the sorted block, so the constraint is never added before the column exists. It did not check whether the column's own table is created by the same changelog: for fkexists_table2 both the table and its column are missing, so the hoisted column produced an ALTER TABLE before the CREATE TABLE.

Hoisting is now skipped when the column's table is among the objects being created. The table can land in either list, so both are checked - toSort only receives objects present in dependencyOrder, and in this scenario the table is not one of them.

## Testing

MSSQL, the fkexists fixture from common.tests.changelog.xml, generating a changelog and then applying it:

```
before: Cannot find the object "fkexists_table2"
after:  update completed successfully
```

The #1792 case #7801 was written for still works - a table that already exists on the target still gets its column hoisted ahead of the foreign key. Also checked a mixed scenario (one existing table needing an FK column plus a brand new table with one) and a composite two-column FK; both generate changelogs that apply cleanly.

liquibase-standard 6465 green, integration h2 846, postgresql 54, mariadb 41.

## Things to be aware of

MssqlIntegrationTest cannot be pointed at an external SQL Server: MSSQLTestSystem:40 casts the wrapper to DockerDatabaseWrapper, so it only works with a container it starts itself. The scenario above was reproduced through the CLI instead.

Unrelated to this change, fkexists_table2 is still created before fkexists_table1 despite the foreign key between them. It applies because the constraint is emitted as a separate addForeignKeyConstraint, but the creation order ignores that dependency. Same before #7801.