### PR TITLE
DEVX-1545: Update the CLI banner to point at Liquibase Secure

### DIFF
--- a/liquibase-standard/src/main/resources/liquibase/banner.txt
+++ b/liquibase-standard/src/main/resources/liquibase/banner.txt
@@ -8,7 +8,7 @@
 ##              | |                               ##
 ##              |_|                               ##
 ##                                                ## 
-##  Get documentation at docs.liquibase.com       ##
-##  Get certified courses at learn.liquibase.com  ## 
+##  Taking Liquibase to production?               ##
+##  liquibase.com/liquibase-secure                ## 
 ##                                                ##
 ####################################################

--- a/liquibase-standard/src/test/groovy/liquibase/integration/commandline/CommandLineUtilsTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/integration/commandline/CommandLineUtilsTest.groovy
@@ -17,7 +17,8 @@ class CommandLineUtilsTest extends Specification {
         } as Scope.ScopedRunnerWithReturn<String>)
 
         then:
-        banner.contains("Get documentation at docs.liquibase.com")
+        banner.contains("Taking Liquibase to production?")
+        banner.contains("liquibase.com/liquibase-secure")
         banner.contains(coreBundle.getString("starting.liquibase.at.timestamp").replace("%s using Java %s", ""))
         banner.contains(coreBundle.getString("liquibase.version.builddate").replaceFirst("%s.*", ""))
     }
@@ -29,7 +30,8 @@ class CommandLineUtilsTest extends Specification {
         } as Scope.ScopedRunnerWithReturn<String>)
 
         then:
-        !banner.contains("Get documentation at docs.liquibase.com")
+        !banner.contains("Taking Liquibase to production?")
+        !banner.contains("liquibase.com/liquibase-secure")
         banner.contains(coreBundle.getString("starting.liquibase.at.timestamp").replace("%s using Java %s", ""))
         banner.contains(coreBundle.getString("liquibase.version.builddate").replaceFirst("%s.*", ""))
     }


### PR DESCRIPTION
## Impact

- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Updates the two promotional lines in the Liquibase CLI banner, per [DEVX-1545](https://datical.atlassian.net/browse/DEVX-1545). Aimed at the Liquibase Community 5.0.4 release.

Before:

```
##                                                ##
##  Get documentation at docs.liquibase.com       ##
##  Get certified courses at learn.liquibase.com  ##
##                                                ##
####################################################
```

After:

```
##                                                ##
##  Taking Liquibase to production?               ##
##  liquibase.com/liquibase-secure                ##
##                                                ##
####################################################
```

The change is confined to `liquibase-standard/src/main/resources/liquibase/banner.txt` — two lines, and no other content in the file is touched.

`CommandLineUtilsTest` asserted on the old text in both directions (present when the banner is enabled, absent when it is disabled), so both assertions were updated to the new lines.

## Release note

The Liquibase CLI banner now points to liquibase.com/liquibase-secure instead of the documentation and training links.

## Things to be aware of

- **Alignment is verified, not eyeballed.** The banner box is 52 characters wide, and lines 10 and 12 carry a single trailing space. Rather than hand-padding, the replacement lines were generated against the border width and then diffed character-for-character against the mockup in the ticket. The result matches exactly, trailing space included, so the frame cannot drift. `git diff` shows exactly two changed lines and no end-of-file change.
- **Nothing else depends on the banner's shape.** `Banner.toString()` reads `banner.txt` verbatim via `IOUtils.toString` and appends the timestamp and version lines beneath it, so there is no padding, wrapping or line-count logic to keep in sync.
- **The test covers the real code path.** `CommandLineUtilsTest` goes through `CommandLineUtils.getBanner()`, which loads the resource exactly as the CLI does, so the assertions confirm resource loading rather than just the file contents.

## Things to worry about

The same promotional text appears in **eight other files** that this PR deliberately leaves alone, because they are a different block from the one in the ticket — no box frame, and a third line the ticket's replacement does not mention:

```
##  Get documentation at docs.liquibase.com       ##
##  Get certified courses at learn.liquibase.com  ##
##  Get support at liquibase.com/support         ##
```

Shipped examples, which users will still see the old text in:

- `liquibase-standard/src/main/resources/liquibase/examples/yaml/liquibase.properties`
- `liquibase-standard/src/main/resources/liquibase/examples/sql/liquibase.properties`
- `liquibase-standard/src/main/resources/liquibase/examples/xml/liquibase.properties`
- `liquibase-standard/src/main/resources/liquibase/examples/json/liquibase.properties`

Test fixtures, not user-facing:

- `liquibase-integration-tests/src/test/resources/liquibase.{sample,sql,xml,yaml}.properties`

The ticket's before/after block matches `banner.txt`'s 14 lines exactly, so I read it as scoped to the CLI banner. If the intent is broader — stop advertising docs and courses, advertise Secure everywhere — the four shipped examples should probably follow, and we would need a decision on what happens to the `Get support at liquibase.com/support` line (keep, drop, or replace all three). Happy to extend this PR if @mariochampion confirms the wording.

## Additional Context

Verified locally: `CommandLineUtilsTest`, `LiquibaseEntityResolverTest` (which references `banner.txt` as a resolver fixture) — 30 tests, all passing.


[DEVX-1545]: https://datical.atlassian.net/browse/DEVX-1545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ