### PR TITLE
ci: stop appending -SNAPSHOT to build.commit so releases on SHAs ending in 0 don't fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,7 +175,7 @@ jobs:
           "-Dbuild.repository.name=liquibase" \
           "-Dbuild.branch=${{ needs.setup.outputs.thisBranchName }}" \
           "-Dbuild.number=${{ github.run_number }}" \
-          "-Dbuild.commit=${{ needs.setup.outputs.latestMergeSha }}-SNAPSHOT" \
+          "-Dbuild.commit=${{ needs.setup.outputs.latestMergeSha }}" \
           "-Dbuild.timestamp=${{ needs.setup.outputs.timeStamp }}"
 
           # Extract the tarball to allow us to upload the liquibase installation files to our


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

The `Artifacts - Build & Sign` step in `build.yml` passed the commit SHA as
`-Dbuild.commit=<sha>-SNAPSHOT`, baking a bogus suffix into
`liquibase.build.properties` in every published artifact:

```
build.commit=deab096cd346bc1e454889f770ea66c9015c8210-SNAPSHOT
```

This **fails the release** whenever the release commit's last hex digit is `0`.
`re-version.sh` guards its output by grepping each jar for leftover
`0-SNAPSHOT` versions, and `...c8210-SNAPSHOT` contains that literal substring —
so it reports an unreplaced version that is actually a commit SHA:

```
Found '0-SNAPSHOT' in .../re-version/out/liquibase-core-5.0.4.jar
```

That is what broke the 5.0.4 release: [run 31621677975](https://github.com/liquibase/liquibase/actions/runs/31621677975/job/94197835038).

### Why now, and not before

The suffix itself dates to #4780 (Dec 2023), where it was pasted from the
adjacent `-Dliquibase-pro.version=...-SNAPSHOT` argument on the same line. It
was **dead code** for 18 months: without `-am` the step built only
`liquibase-dist`, so the `liquibase-core` jar copied into `artifacts/` was the
pristine one restored from `temp-artifact` — built earlier in `run-tests.yml`
with a *clean* `-Dbuild.commit` and no `-Dbuild.timestamp`.

#7775 added `-am` (so `liquibase-core`/`liquibase-standard` are now rebuilt in
that step) and #7776 repointed the `cp` at the freshly built branch-versioned
jars. Since **2026-05-29** the poisoned properties are the ones that ship.

The shipped artifacts show the transition — note the timestamp format flip,
which is the fingerprint of a different mvn invocation (`HH:mmZ` is Maven's own
`maven.build.timestamp.format`, i.e. nothing passed on the CLI):

| | `build.commit` | `build.timestamp` |
|---|---|---|
| `liquibase-core-5.0.3.jar` (released) | `4d815ea8…fcb` — clean | `2026-05-13 17:55+0000` |
| 5.0.4 candidate | `…c8210-SNAPSHOT` | `2026-08-12 15:06:29 UTC` |

v5.0.3 (May 13) is the last real release tag, and every `create-release` run
since #7775 has been a scheduled dry-run — so 5.0.4 is the first genuine
release after the change, and the first to draw a SHA ending in `0`. The one
dry-run that could have caught it (June 3, tip `c8c5f80…f0e40`) dodged it
because the selector then was `status=success&per_page=1` and that commit's
`run-tests` run had failed, so it fell back to a SHA ending in `3`.

## Release note

<!-- CI-only fix, not customer-facing. Applying skipReleaseNotes. -->

## Things to be aware of

Every other place that sets this property already passes a bare SHA
(`build.yml:248`/`255`, `build-main.yml:59`, `build-branch.yml:104`,
`run-tests.yml:136`, `release-publish-github-packages.yml:86`); this line was
the sole outlier. `LiquibaseUtilTest.groovy:22` also asserts against a bare
SHA, confirming the clean value is what was always intended.

The bad suffix was cosmetically invisible at runtime because
`LiquibaseUtil.java:40` renders the commit as `buildCommit.substring(0, 6)`,
which truncates it away — which is why it went unnoticed while still corrupting
the metadata.

### Verification

Ran `.github/util/re-version.sh` locally against the real 5.0.4 input artifacts
(from `run-tests` build `31608660806`):

- **unmodified** → exits 1 with exactly the CI failure, same file
- **with only `build.commit` corrected** → exits 0, all 11 artifacts produced
  (`liquibase-core-5.0.4.jar`, `.tar.gz`, `.zip`, javadoc/sources)

So this one value is the sole blocker; no other leftovers were hiding behind it.

## Things to worry about

This fixes the producer, so it does **not** repair the artifacts already in run
`31608660806`. Shipping 5.0.4 needs a fresh `run-tests` build on `main` after
merge, then re-dispatching `create-release` with the new `runId`.

Separately worth considering (deliberately **not** in this PR): the guard in
`re-version.sh:158` greps for a bare `0-SNAPSHOT` substring, so any SHA ending
in `0` can trip it. Anchoring it to `<version>0-SNAPSHOT<` / `=0-SNAPSHOT`
would make it robust, but that changes release-gating behavior and shouldn't
ride along with an unblocking fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
