### PR TITLE
ci: drop the external environment gate from fork PR workflows

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -25,7 +25,6 @@ on:
 jobs:
 
   authorize:
-    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
     runs-on: ubuntu-latest
     steps:
       - run: true

--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -22,7 +22,6 @@ permissions:
 jobs:
 
   authorize:
-    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
     runs-on: ubuntu-latest
     steps:
       - run: true

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -37,7 +37,6 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref == 'main' && (github.event_name == 'push' && 'push-to-main' || github.event_name == 'pull_request' && 'merge-to-main') || github.event_name == 'pull_request_target' && github.event.pull_request.number || github.run_id }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' && github.base_ref == 'main' }}
-    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
     runs-on: ubuntu-latest
     steps:
       - run: true


### PR DESCRIPTION
## Impact

- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

A fork PR currently needs the approval clicked several times: once on the PR page (Approve workflows to run) and then again per workflow, because run-tests, build-branch and run-test-harness each put their authorize job behind the external environment and each environment gate is its own deployment approval. They arrive at different moments, so they show up in waves.

Both gates protect the same moment with the same decision from the same person. The repository setting is Require approval for all outside collaborators, which already blocks the whole run before any step executes, so the environment adds nothing but clicks.

The authorize jobs stay in place: the one in run-tests.yml also carries the concurrency group, and the needs: authorize edges are untouched.

## Testing

This cannot be exercised by its own CI. pull_request_target reads the workflow from the base branch, and this PR is from an internal branch anyway, so authorize resolves to internal either way and nothing here runs the changed path.

The check is the first fork PR after this merges: one approval on the PR page should carry the whole pipeline, with no deployment approval left on the jobs. Reverting is three lines if it does not.

## Things to be aware of

With the environment gone, the authorize job in build-branch.yml and run-test-harness.yml is a plain no-op. Removing them means touching every needs: authorize, so I left that out of a security change.

The enable_external_environment flag for this repo still exists in liquibase-infrastructure. It can be dropped separately once this is confirmed working.