### PR TITLE
Fix: acquire changelog lock lazily for updateCount/updateSql, after the fast-check

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/command/core/AbstractUpdateCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/AbstractUpdateCommandStep.java
@@ -146,12 +146,13 @@ public abstract class AbstractUpdateCommandStep extends AbstractCommandStep impl
             throw e;
         } finally {
             // Check the lock's actual live state rather than trusting isDBLocked's bookkeeping: for
-            // UpdateCommandStep (the one subclass with no pipeline-managed LockServiceCommandStep,
-            // see requiredDependencies() below) isDBLocked is only true once this method has actually
-            // acquired the lock above. For the other subclasses, the pipeline already acquired the lock
-            // before this method ran, so isDBLocked's true default doesn't reflect whether *this* call
-            // should release it -- hasChangeLogLock() does. This also keeps releasing here (rather than
-            // only in LockServiceCommandStep#cleanUp) so that Sql-output commands still capture the
+            // UpdateCommandStep, UpdateCountCommandStep and UpdateSqlCommandStep (plus UpdateCountSqlCommandStep,
+            // which inherits from UpdateCountCommandStep) -- the subclasses with no pipeline-managed
+            // LockServiceCommandStep, see requiredDependencies() below -- isDBLocked is only true once this
+            // method has actually acquired the lock above. For the other subclasses, the pipeline already
+            // acquired the lock before this method ran, so isDBLocked's true default doesn't reflect whether
+            // *this* call should release it -- hasChangeLogLock() does. This also keeps releasing here (rather
+            // than only in LockServiceCommandStep#cleanUp) so that Sql-output commands still capture the
             // "Release Database Lock" statement while their LoggingExecutor is still active; see #5438.
             try {
                 LockService lockService = LockServiceFactory.getInstance().getLockService(database);

--- a/liquibase-standard/src/main/java/liquibase/command/core/UpdateCountCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/UpdateCountCommandStep.java
@@ -9,6 +9,7 @@ import liquibase.changelog.filter.*;
 import liquibase.command.*;
 import liquibase.database.Database;
 import liquibase.exception.DatabaseException;
+import liquibase.lockservice.LockService;
 import liquibase.logging.mdc.MdcKey;
 
 import java.util.ArrayList;
@@ -100,9 +101,17 @@ public class UpdateCountCommandStep extends AbstractUpdateCommandStep {
 
     @Override
     public List<Class<?>> requiredDependencies() {
+        // Lock is acquired lazily in run(), only if the fast-check finds pending changes -- see #6102.
         List<Class<?>> deps = new ArrayList<>(super.requiredDependencies());
+        deps.remove(LockService.class);
         deps.add(UpdateSummaryEnum.class);
         return deps;
+    }
+
+    @Override
+    public void run(CommandResultsBuilder resultsBuilder) throws Exception {
+        setDBLock(false);
+        super.run(resultsBuilder);
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/command/core/UpdateSqlCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/UpdateSqlCommandStep.java
@@ -4,6 +4,7 @@ import liquibase.UpdateSummaryEnum;
 import liquibase.command.*;
 import liquibase.command.core.helpers.DatabaseChangelogCommandStep;
 import liquibase.database.Database;
+import liquibase.lockservice.LockService;
 import liquibase.util.LoggingExecutorTextUtil;
 
 import java.io.Writer;
@@ -46,9 +47,11 @@ public class UpdateSqlCommandStep extends AbstractUpdateCommandStep {
 
     @Override
     public List<Class<?>> requiredDependencies() {
+        // Lock is acquired lazily in run(), only if the fast-check finds pending changes -- see #6102.
         List<Class<?>> dependencies = new ArrayList<>();
         dependencies.add(Writer.class);
         dependencies.addAll(super.requiredDependencies());
+        dependencies.remove(LockService.class);
         return dependencies;
     }
 
@@ -58,6 +61,7 @@ public class UpdateSqlCommandStep extends AbstractUpdateCommandStep {
         final Database database = (Database) commandScope.getDependency(Database.class);
         final String changelogFile = commandScope.getArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_FILE_ARG);
         LoggingExecutorTextUtil.outputHeader("Update Database Script", database, changelogFile);
+        setDBLock(false);
         super.run(resultsBuilder);
     }
 

--- a/liquibase-standard/src/test/groovy/liquibase/command/CommandFactoryTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/command/CommandFactoryTest.groovy
@@ -73,4 +73,15 @@ class CommandFactoryTest extends Specification {
         command.pipeline*.class*.name == ["liquibase.command.core.helpers.DbUrlConnectionArgumentsCommandStep", "liquibase.command.core.helpers.DbUrlConnectionCommandStep", "liquibase.command.core.helpers.LockServiceCommandStep", "liquibase.command.core.TagCommandStep"]
 
     }
+
+    def "#commandName does not pre-acquire the changelog lock via the pipeline, so it can be acquired lazily after the fast-check (#6102)"() {
+        when:
+        def command = Scope.currentScope.getSingleton(CommandFactory).getCommandDefinition(commandName)
+
+        then:
+        !command.pipeline*.class*.name.contains("liquibase.command.core.helpers.LockServiceCommandStep")
+
+        where:
+        commandName << ["update", "updateCount", "updateSql"]
+    }
 }

--- a/liquibase-standard/src/test/groovy/liquibase/command/core/UpdateSqlCommandStepTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/command/core/UpdateSqlCommandStepTest.groovy
@@ -24,19 +24,27 @@ import java.sql.DriverManager
 class UpdateSqlCommandStepTest extends Specification {
 
     private java.sql.Connection jdbcConnection
+    private Database database
 
     def cleanup() {
         LockServiceFactory.reset()
+        if (database != null) {
+            Scope.getCurrentScope().getSingleton(ExecutorService.class).clearExecutor("logging", database)
+        }
         jdbcConnection?.close()
     }
 
     /**
      * Bypasses the real FastCheckService/DB round-trip, standing in for the case where the fast-check finds pending changes.
+     * Records completion so the test can assert the lock is acquired only after the fast-check runs, not before it.
      */
     private static class FastCheckPendingUpdateSqlCommandStep extends UpdateSqlCommandStep {
+        boolean fastCheckCompleted = false
+
         @Override
         boolean isUpToDate(CommandScope commandScope, Database database, DatabaseChangeLog databaseChangeLog,
                             Contexts contexts, LabelExpression labelExpression, OutputStream outputStream) {
+            fastCheckCompleted = true
             return false
         }
     }
@@ -48,9 +56,11 @@ class UpdateSqlCommandStepTest extends Specification {
         // A real (fresh, empty) H2 database: run() queries the changelog history/snapshot tables as
         // part of building the status summary, which a plain mock Database can't satisfy.
         jdbcConnection = DriverManager.getConnection("jdbc:h2:mem:" + UUID.randomUUID(), "sa", "")
-        Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(jdbcConnection))
+        database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(jdbcConnection))
 
-        def mockLockService = Mock(LockService)
+        def mockLockService = Mock(LockService) {
+            hasChangeLogLock() >> true
+        }
         def mockFactory = Mock(LockServiceFactory) {
             getLockService(database) >> mockLockService
         }
@@ -71,7 +81,10 @@ class UpdateSqlCommandStepTest extends Specification {
         when: "run() proceeds past the fast-check since there are pending changes"
         step.run(resultsBuilder)
 
-        then: "the lock is acquired here, not by a LockServiceCommandStep that was never wired into the pipeline"
-        1 * mockLockService.waitForLock()
+        then: "the lock is acquired only after the fast-check completes, not by a pipeline-managed LockServiceCommandStep beforehand"
+        1 * mockLockService.waitForLock() >> { assert step.fastCheckCompleted }
+
+        and: "the lock this call acquired is also released before run() returns"
+        1 * mockLockService.releaseLock()
     }
 }

--- a/liquibase-standard/src/test/groovy/liquibase/command/core/UpdateSqlCommandStepTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/command/core/UpdateSqlCommandStepTest.groovy
@@ -11,64 +11,67 @@ import liquibase.changelog.visitor.DefaultChangeExecListener
 import liquibase.command.CommandResultsBuilder
 import liquibase.command.CommandScope
 import liquibase.database.Database
-import liquibase.database.DatabaseConnection
+import liquibase.database.DatabaseFactory
+import liquibase.database.jvm.JdbcConnection
 import liquibase.executor.ExecutorService
 import liquibase.executor.LoggingExecutor
 import liquibase.lockservice.LockService
 import liquibase.lockservice.LockServiceFactory
 import spock.lang.Specification
 
+import java.sql.DriverManager
+
 class UpdateSqlCommandStepTest extends Specification {
+
+    private java.sql.Connection jdbcConnection
 
     def cleanup() {
         LockServiceFactory.reset()
+        jdbcConnection?.close()
     }
 
     /**
-     * Bypasses the real FastCheckService/DB round-trip, standing in for the case where the fast-check finds nothing pending.
+     * Bypasses the real FastCheckService/DB round-trip, standing in for the case where the fast-check finds pending changes.
      */
-    private static class FastCheckUpToDateUpdateSqlCommandStep extends UpdateSqlCommandStep {
+    private static class FastCheckPendingUpdateSqlCommandStep extends UpdateSqlCommandStep {
         @Override
         boolean isUpToDate(CommandScope commandScope, Database database, DatabaseChangeLog databaseChangeLog,
                             Contexts contexts, LabelExpression labelExpression, OutputStream outputStream) {
-            return true
+            return false
         }
     }
 
-    def "run() must not touch the changelog lock when the fast-check finds nothing pending (#6102)"() {
-        given: "updateSql, like update, now acquires the lock lazily instead of via the pipeline"
-        def step = new FastCheckUpToDateUpdateSqlCommandStep()
+    def "run() acquires the changelog lock itself exactly once when the fast-check finds pending changes (#6102)"() {
+        given: "updateSql now owns lock acquisition instead of relying on a pipeline-managed LockServiceCommandStep"
+        def step = new FastCheckPendingUpdateSqlCommandStep()
+
+        // A real (fresh, empty) H2 database: run() queries the changelog history/snapshot tables as
+        // part of building the status summary, which a plain mock Database can't satisfy.
+        jdbcConnection = DriverManager.getConnection("jdbc:h2:mem:" + UUID.randomUUID(), "sa", "")
+        Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(jdbcConnection))
+
         def mockLockService = Mock(LockService)
-        def mockDatabase = Mock(Database) {
-            getConnection() >> Mock(DatabaseConnection) {
-                getVisibleUrl() >> "jdbc:test"
-                getURL() >> "jdbc:test"
-                getConnectionUserName() >> "test"
-            }
-            getLineComment() >> "--"
-        }
         def mockFactory = Mock(LockServiceFactory) {
-            getLockService(mockDatabase) >> mockLockService
+            getLockService(database) >> mockLockService
         }
         LockServiceFactory.setInstance(mockFactory)
 
         def commandScope = new CommandScope(UpdateSqlCommandStep.COMMAND_NAME)
                 .addArgumentValue(UpdateSqlCommandStep.CHANGELOG_FILE_ARG, "changelog.xml")
-                .provideDependency(Database.class, mockDatabase)
+                .provideDependency(Database.class, database)
                 .provideDependency(DatabaseChangeLog.class, new DatabaseChangeLog("changelog.xml"))
                 .provideDependency(ChangeExecListener.class, new DefaultChangeExecListener())
                 .provideDependency(ChangeLogParameters.class, new ChangeLogParameters())
         def resultsBuilder = new CommandResultsBuilder(commandScope, new ByteArrayOutputStream())
 
         // In the real pipeline, AbstractOutputWriterCommandStep sets this up before UpdateSqlCommandStep runs.
-        Scope.getCurrentScope().getSingleton(ExecutorService.class).setExecutor("logging", mockDatabase,
-                new LoggingExecutor(null, new OutputStreamWriter(resultsBuilder.getOutputStream()), mockDatabase))
+        Scope.getCurrentScope().getSingleton(ExecutorService.class).setExecutor("logging", database,
+                new LoggingExecutor(null, new OutputStreamWriter(resultsBuilder.getOutputStream()), database))
 
-        when: "run() takes the fast-check early-return path"
+        when: "run() proceeds past the fast-check since there are pending changes"
         step.run(resultsBuilder)
 
-        then: "in SQL-output mode waitForLock() is what writes the lock statements, so 0 calls means none were written"
-        0 * mockLockService.waitForLock()
-        0 * mockLockService.releaseLock()
+        then: "the lock is acquired here, not by a LockServiceCommandStep that was never wired into the pipeline"
+        1 * mockLockService.waitForLock()
     }
 }

--- a/liquibase-standard/src/test/groovy/liquibase/command/core/UpdateSqlCommandStepTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/command/core/UpdateSqlCommandStepTest.groovy
@@ -1,0 +1,74 @@
+package liquibase.command.core
+
+import liquibase.Contexts
+import liquibase.LabelExpression
+import liquibase.Scope
+import liquibase.UpdateSummaryEnum
+import liquibase.changelog.ChangeLogParameters
+import liquibase.changelog.DatabaseChangeLog
+import liquibase.changelog.visitor.ChangeExecListener
+import liquibase.changelog.visitor.DefaultChangeExecListener
+import liquibase.command.CommandResultsBuilder
+import liquibase.command.CommandScope
+import liquibase.database.Database
+import liquibase.database.DatabaseConnection
+import liquibase.executor.ExecutorService
+import liquibase.executor.LoggingExecutor
+import liquibase.lockservice.LockService
+import liquibase.lockservice.LockServiceFactory
+import spock.lang.Specification
+
+class UpdateSqlCommandStepTest extends Specification {
+
+    def cleanup() {
+        LockServiceFactory.reset()
+    }
+
+    /**
+     * Bypasses the real FastCheckService/DB round-trip, standing in for the case where the fast-check finds nothing pending.
+     */
+    private static class FastCheckUpToDateUpdateSqlCommandStep extends UpdateSqlCommandStep {
+        @Override
+        boolean isUpToDate(CommandScope commandScope, Database database, DatabaseChangeLog databaseChangeLog,
+                            Contexts contexts, LabelExpression labelExpression, OutputStream outputStream) {
+            return true
+        }
+    }
+
+    def "run() must not touch the changelog lock when the fast-check finds nothing pending (#6102)"() {
+        given: "updateSql, like update, now acquires the lock lazily instead of via the pipeline"
+        def step = new FastCheckUpToDateUpdateSqlCommandStep()
+        def mockLockService = Mock(LockService)
+        def mockDatabase = Mock(Database) {
+            getConnection() >> Mock(DatabaseConnection) {
+                getVisibleUrl() >> "jdbc:test"
+                getURL() >> "jdbc:test"
+                getConnectionUserName() >> "test"
+            }
+            getLineComment() >> "--"
+        }
+        def mockFactory = Mock(LockServiceFactory) {
+            getLockService(mockDatabase) >> mockLockService
+        }
+        LockServiceFactory.setInstance(mockFactory)
+
+        def commandScope = new CommandScope(UpdateSqlCommandStep.COMMAND_NAME)
+                .addArgumentValue(UpdateSqlCommandStep.CHANGELOG_FILE_ARG, "changelog.xml")
+                .provideDependency(Database.class, mockDatabase)
+                .provideDependency(DatabaseChangeLog.class, new DatabaseChangeLog("changelog.xml"))
+                .provideDependency(ChangeExecListener.class, new DefaultChangeExecListener())
+                .provideDependency(ChangeLogParameters.class, new ChangeLogParameters())
+        def resultsBuilder = new CommandResultsBuilder(commandScope, new ByteArrayOutputStream())
+
+        // In the real pipeline, AbstractOutputWriterCommandStep sets this up before UpdateSqlCommandStep runs.
+        Scope.getCurrentScope().getSingleton(ExecutorService.class).setExecutor("logging", mockDatabase,
+                new LoggingExecutor(null, new OutputStreamWriter(resultsBuilder.getOutputStream()), mockDatabase))
+
+        when: "run() takes the fast-check early-return path"
+        step.run(resultsBuilder)
+
+        then: "in SQL-output mode waitForLock() is what writes the lock statements, so 0 calls means none were written"
+        0 * mockLockService.waitForLock()
+        0 * mockLockService.releaseLock()
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #6102 - `updateCount`/`updateSql` block on acquiring the changelog lock even when the fast-check finds nothing pending, so a stale/held lock blocks startup even when no migration would run.

`updateCommandStep` (plain `update`) already avoids this: it drops `LockService.class` from `requiredDependencies()` so the pipeline never pre-acquires the lock, and only acquires it lazily in `AbstractUpdateCommandStep.run()` after `isUpToDate()`'s fast-check confirms there's real work. `updateCount`/`updateSql` still declared `LockService.class` as required, so `LockServiceCommandStep` grabbed the lock unconditionally before the fast-check ran.

This extends the same lazy-acquire pattern (already proven for `update`) to `updateCount` and `updateSql`. `updateToTag` was intentionally left out - it calls `setFastCheckEnabled(false)`, so there's no fast-check path for this fix to help.

## Test plan
- [x] New parameterized test in `CommandFactoryTest` asserting `LockServiceCommandStep` is absent from the `update`/`updateCount`/`updateSql` pipelines
- [x] `liquibase.command.**` unit tests pass
- [x] `LiquibaseCoreExtensionTests` h2 suite (400 tests) passes, including the `updateCountSql`/`updateSql` "Happy path with output file" cases that capture the release-lock SQL statement (regression surface from #5438/#7886)