### PR TITLE
ci: drop the vestigial authorize job from fork PR workflows

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -24,14 +24,8 @@ on:
 
 jobs:
 
-  authorize:
-    runs-on: ubuntu-latest
-    steps:
-      - run: true
-
   setup:
     name: Setup
-    needs: authorize
     runs-on: ubuntu-22.04
     outputs:
       timeStamp: ${{ steps.get-timestamp.outputs.timestamp }}

--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -21,13 +21,7 @@ permissions:
   
 jobs:
 
-  authorize:
-    runs-on: ubuntu-latest
-    steps:
-      - run: true
-
   test-harness-build:
-    needs: authorize
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'runFunctional&HarnessTests') || (github.event_name != 'pull_request' && github.event_name != 'pull_request_target')
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,19 +31,13 @@ on:
       - '**.md'
 
 jobs:
-  authorize:
+  setup:
+    name: setup
     #concurrent runs for pull requests from forked repositories will be canceled, while runs for pull requests from the main repository won't be affected.
     #for a pull_request against main: the concurrency check will cancel commit A so that commit B check can run.
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref == 'main' && (github.event_name == 'push' && 'push-to-main' || github.event_name == 'pull_request' && 'merge-to-main') || github.event_name == 'pull_request_target' && github.event.pull_request.number || github.run_id }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' && github.base_ref == 'main' }}
-    runs-on: ubuntu-latest
-    steps:
-      - run: true
-
-  setup:
-    name: setup
-    needs: [authorize]
     runs-on: ubuntu-24.04
     outputs:
       timestamp: ${{ steps.get-date.outputs.date }}


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)

## Description

Follow-up to #7902. The `authorize` job only existed to carry `environment: external`, which
was the second approval gate on fork PRs. #7902 removed the environment and left the job
behind as a bare `run: true`, so it still shows up as a check and still blocks `setup`.

Removed it from run-tests.yml, build-branch.yml and run-test-harness.yml.

The `concurrency` block in run-tests.yml was the only real content of that job. It moved to
`setup` unchanged, so cancel-in-progress behaviour is the same.

## Release note

## Things to be aware of

`authorize` is not a required status check (the ruleset only requires `mergefreeze`), so
dropping it does not block existing PRs.

The repo setting "Require approval for all external contributors" stays on. Fork PRs still
need one approval, which is the point.

## Things to worry about

## Additional Context
