### PR TITLE
fix: ship commons-text and commons-collections4 in the distribution again

### DIFF
--- a/liquibase-dist/expected-distribution-contents.txt
+++ b/liquibase-dist/expected-distribution-contents.txt
@@ -37,8 +37,9 @@ lib/liquibase_autocomplete.zsh
 lib/liquibase_autocomplete_mac.bash
 licenses/oss/README.txt
 licenses/oss/apache-2.0.txt
-licenses/oss/epl-1.0.txt
 licenses/oss/epl-2.0.txt
+licenses/oss/FSL-1.1-ALv2.txt
+licenses/oss/gpl-2.0-classpath-exception.txt
 licenses/oss/usage-data.txt
 liquibase
 liquibase.bat

--- a/liquibase-dist/pom.xml
+++ b/liquibase-dist/pom.xml
@@ -70,6 +70,18 @@
             </exclusions>
         </dependency>
 
+        <!-- excluded from opencsv above so the version stays under our control -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>${commons-text.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>${commons-collections4.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
@@ -152,6 +164,37 @@
                         <phase/>
                     </execution>
                 </executions>
+            </plugin>
+            <!-- this module is packaging:pom, so test sources need an explicit compile step -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- ZipIT/TarIT compare the generated archives against expected-distribution-contents.txt -->
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <systemPropertyVariables>
+                        <expected.distribution.contents.filename>${expected-distribution-contents-filename}</expected.distribution.contents.filename>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.liquibase.ext</groupId>

--- a/liquibase-dist/src/main/assembly/component-minimal-deps.xml
+++ b/liquibase-dist/src/main/assembly/component-minimal-deps.xml
@@ -56,6 +56,8 @@
                 <include>com.opencsv:opencsv:</include>
                 <include>org.yaml:snakeyaml:jar:</include>
                 <include>info.picocli:picocli:jar:</include>
+                <include>org.apache.commons:commons-text:jar:</include>
+                <include>org.apache.commons:commons-collections4:jar:</include>
             </includes>
 
             <!-- some libraries lie about compile vs. runtime dependencies. Or we don't hit code that uses these. So exclude them manually. -->


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)

Fixes #7904

## Description

The 5.0.4 draft ships 7 jars in `internal/lib`, 5.0.3 shipped 9. `commons-collections4` and
`commons-text` are gone, so `AnalyticsBatch` hits `NoClassDefFoundError` and update / rollback /
changelog-sync crash out of the box.

Root cause is the `-am` added to the dist build in build.yml by #7778. Without it the dist
resolved `liquibase-core` from the published repository, and that pom is the shade
dependency-reduced one: `promoteTransitiveDependencies` lifts both commons artifacts to first
level dependencies of `liquibase-core`, which is one of the assembly's includes, so they land in
`internal/lib`. With `-am` the core comes from the reactor with its original pom, where they sit
behind `liquibase-standard`, and the assembly excludes `liquibase-standard` with
`useTransitiveFiltering` on, which drops them too.

Reverting the `-am` is not an option, it is what makes the maven-plugin and extension-testing
artifacts get built at all. So `liquibase-dist` now declares both, the way `liquibase-standard`
and `liquibase-core` already do, and the assembly names them. Declaring alone is not enough:
`useTransitiveFiltering` drops a direct dependency that is not in `<includes>`. Verified the jars
come out at 1.15.0 / 4.6.0, from the properties. Dropping the opencsv exclusions instead would
have pulled opencsv's 1.13.1 / 4.5.0 and lost the version control the exclusions exist for.

Verified by building the current main unchanged, once with `-am` and once without: 7 jars and 9
jars respectively.

## Release note

Fixed a regression where the Liquibase distribution was missing two dependency jars, making
update, rollback and changelog-sync fail with `NoClassDefFoundError`.

## Things to be aware of

`ZipIT` and `TarIT` compare the archives against `expected-distribution-contents.txt` and should
have caught this. They never ran: `liquibase-dist` is `packaging:pom`, so its test sources need an
explicit compile step, and that step lived in the `liquibase-commercial` profile removed by #7247.
Since then `failsafe:integration-test` answers "No tests to run" and the build stays green.
Restored both plugins in the normal build section, since there is no pro profile in this repo
anymore.

The same #7247 swapped the license files without updating the expected contents, so that file
needed a refresh for the tests to pass.

Confirmed the guard-rail works: with the dependencies removed and the plugins in place, both
tests fail; with the fix, both pass.

## Things to worry about

`liquibase-pro/core/liquibase-dist` still carries the old profile, so it has been running these
tests all along. Worth syncing that subtree at some point.

## Additional Context
