### PR TITLE
fix: scope per-database service cleanup so parallel Maven reactor builds no longer corrupt each other's state

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryServiceFactory.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryServiceFactory.java
@@ -90,6 +90,10 @@ public class ChangeLogHistoryServiceFactory extends AbstractPluginFactory<Change
             }
     }
 
+    /**
+     * Removes the given service from the plugin registry, so it is no longer a candidate for
+     * {@link #getChangeLogService(Database)} lookups that have not already been cached.
+     */
     public synchronized void unregister(final ChangeLogHistoryService service) {
         removeInstance(service);
     }
@@ -112,10 +116,19 @@ public class ChangeLogHistoryServiceFactory extends AbstractPluginFactory<Change
         }
     }
 
+    /**
+     * Resets and drops every database's {@link ChangeLogHistoryService}, discovered and
+     * {@link #registerForDatabase} registered alike. This is a full JVM-wide teardown; cleanup paths
+     * belonging to a single execution should use {@link #resetDatabase(Database)} instead, so they
+     * don't discard other concurrently running executions' services.
+     */
     public synchronized void resetAll() {
         for (ChangeLogHistoryService changeLogHistoryService : findAllInstances()) {
             changeLogHistoryService.reset();
         }
+        // Services registered for a database never enter the plugin registry, so findAllInstances()
+        // above does not cover them. reset() is idempotent, so overlap between the two is harmless.
+        services.values().forEach(ChangeLogHistoryService::reset);
         services.clear();
         // unregister all self-registered
         explicitRegistered.forEach(this::removeInstance);

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryServiceFactory.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryServiceFactory.java
@@ -95,13 +95,21 @@ public class ChangeLogHistoryServiceFactory extends AbstractPluginFactory<Change
     }
 
     /**
-     * Clears the cached {@link ChangeLogHistoryService} for just the given database, as opposed to
-     * {@link #resetAll()} which clears every database's entry. Since this factory is a single JVM-wide
-     * singleton, resetAll() called from one execution's cleanup would otherwise drop other concurrently
-     * running executions' (different database's) cached services too.
+     * Invalidates the {@link ChangeLogHistoryService} cached for just the given database, as opposed to
+     * {@link #resetAll()} which invalidates and drops every database's entry. Since this factory is a
+     * single JVM-wide singleton, resetAll() called from one execution's cleanup would otherwise discard
+     * other concurrently running executions' (different database's) services too.
+     * <p>
+     * The entry is reset in place rather than removed: the service is bound to the database for that
+     * database's lifetime - {@link liquibase.database.OfflineConnection} registers one that
+     * {@link #getPlugin} cannot rebuild - whereas the stale data a finishing command wants dropped is
+     * exactly what {@link ChangeLogHistoryService#reset()} clears.
      */
     public synchronized void resetDatabase(Database database) {
-        services.remove(database);
+        ChangeLogHistoryService service = services.get(database);
+        if (service != null) {
+            service.reset();
+        }
     }
 
     public synchronized void resetAll() {

--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryServiceFactory.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeLogHistoryServiceFactory.java
@@ -48,6 +48,17 @@ public class ChangeLogHistoryServiceFactory extends AbstractPluginFactory<Change
     }
 
 
+    /**
+     * Registers a {@link ChangeLogHistoryService} that is already fully configured for the given database
+     * (e.g. an offline/simulated connection's history service), bypassing {@link #getPlugin(Object...)}'s
+     * generic type/priority-based lookup. That lookup can't distinguish between multiple pre-configured
+     * instances of the same class and priority registered concurrently for different databases - it only
+     * ever kept one, handing it out for every database.
+     */
+    public synchronized void registerForDatabase(Database database, ChangeLogHistoryService service) {
+        services.put(database, service);
+    }
+
     public synchronized ChangeLogHistoryService getChangeLogService(Database database) {
             if (services.containsKey(database)) {
                 return services.get(database);
@@ -81,6 +92,16 @@ public class ChangeLogHistoryServiceFactory extends AbstractPluginFactory<Change
 
     public synchronized void unregister(final ChangeLogHistoryService service) {
         removeInstance(service);
+    }
+
+    /**
+     * Clears the cached {@link ChangeLogHistoryService} for just the given database, as opposed to
+     * {@link #resetAll()} which clears every database's entry. Since this factory is a single JVM-wide
+     * singleton, resetAll() called from one execution's cleanup would otherwise drop other concurrently
+     * running executions' (different database's) cached services too.
+     */
+    public synchronized void resetDatabase(Database database) {
+        services.remove(database);
     }
 
     public synchronized void resetAll() {

--- a/liquibase-standard/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
@@ -80,6 +80,11 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
         this.ranChangeSetList = null;
         this.serviceInitialized = false;
         this.hasDatabaseChangeLogTable = null;
+        // Cached MAX(ORDEREXECUTED), incremented in memory by getNextSequenceValue(). Unlike
+        // databaseChecksumsCompatible it is not recomputed by init(), so it has to be dropped here or
+        // it would survive a reset and hand out sequence values based on a stale read - notably after
+        // acquiring the changelog lock, where another process may have written in the meantime.
+        this.lastChangeSetSequenceValue = null;
     }
 
     public boolean hasDatabaseChangeLogTable() {

--- a/liquibase-standard/src/main/java/liquibase/command/core/AbstractUpdateCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/AbstractUpdateCommandStep.java
@@ -209,8 +209,14 @@ public abstract class AbstractUpdateCommandStep extends AbstractCommandStep impl
     public void cleanUp(CommandResultsBuilder resultsBuilder) {
         isDBLocked.remove();
         LockServiceFactory.getInstance().resetAll();
-        Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).resetAll();
-        Scope.getCurrentScope().getSingleton(ExecutorService.class).reset();
+        // Scoped to this command's own database: ChangeLogHistoryServiceFactory and ExecutorService are
+        // single JVM-wide singletons, so a blanket resetAll()/reset() here would also drop other
+        // concurrently running commands' (different database's) cached services and executor overrides.
+        Database database = (Database) resultsBuilder.getCommandScope().getDependency(Database.class);
+        Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).resetDatabase(database);
+        ExecutorService executorService = Scope.getCurrentScope().getSingleton(ExecutorService.class);
+        executorService.clearExecutor("jdbc", database);
+        executorService.clearExecutor("logging", database);
     }
 
     private void logDeploymentOutcomeMdc(ChangeExecListener defaultListener, boolean success, UpdateReportParameters updateReportParameters,

--- a/liquibase-standard/src/main/java/liquibase/command/core/AbstractUpdateCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/AbstractUpdateCommandStep.java
@@ -209,9 +209,6 @@ public abstract class AbstractUpdateCommandStep extends AbstractCommandStep impl
     public void cleanUp(CommandResultsBuilder resultsBuilder) {
         isDBLocked.remove();
         LockServiceFactory.getInstance().resetAll();
-        // Scoped to this command's own database: ChangeLogHistoryServiceFactory and ExecutorService are
-        // single JVM-wide singletons, so a blanket resetAll()/reset() here would also drop other
-        // concurrently running commands' (different database's) cached services and executor overrides.
         Database database = (Database) resultsBuilder.getCommandScope().getDependency(Database.class);
         Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).resetDatabase(database);
         ExecutorService executorService = Scope.getCurrentScope().getSingleton(ExecutorService.class);

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/AbstractOutputWriterCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/AbstractOutputWriterCommandStep.java
@@ -18,6 +18,7 @@ import java.util.List;
 public abstract class AbstractOutputWriterCommandStep extends AbstractHelperCommandStep implements CleanUpCommandStep {
 
     private OutputStreamWriter outputStreamWriter;
+    private Database database;
 
     @Override
     public List<Class<?>> providedDependencies() {
@@ -45,7 +46,7 @@ public abstract class AbstractOutputWriterCommandStep extends AbstractHelperComm
         CommandScope commandScope = resultsBuilder.getCommandScope();
         String charsetName = GlobalConfiguration.OUTPUT_FILE_ENCODING.getCurrentValue();
         outputStreamWriter = new OutputStreamWriter(resultsBuilder.getOutputStream(), charsetName);
-        Database database = (Database) commandScope.getDependency(Database.class);
+        database = (Database) commandScope.getDependency(Database.class);
         Executor databaseExecutor = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database);
         LoggingExecutor loggingExecutor = new LoggingExecutor(databaseExecutor, outputStreamWriter, database);
         Scope.getCurrentScope().getSingleton(ExecutorService.class).setExecutor("jdbc", database, loggingExecutor);
@@ -63,7 +64,12 @@ public abstract class AbstractOutputWriterCommandStep extends AbstractHelperComm
     @Override
     public void cleanUp(CommandResultsBuilder resultsBuilder) {
         if (outputStreamWriter != null) {
-            Scope.getCurrentScope().getSingleton(ExecutorService.class).reset();
+            // Scoped to this command's own database - ExecutorService is a single JVM-wide singleton,
+            // so a blanket reset() here would also drop other concurrently running commands' (different
+            // database's) jdbc/logging executor overrides.
+            ExecutorService executorService = Scope.getCurrentScope().getSingleton(ExecutorService.class);
+            executorService.clearExecutor("jdbc", database);
+            executorService.clearExecutor("logging", database);
             try {
                 outputStreamWriter.close();
             } catch (IOException e) {

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/AbstractOutputWriterCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/AbstractOutputWriterCommandStep.java
@@ -64,9 +64,6 @@ public abstract class AbstractOutputWriterCommandStep extends AbstractHelperComm
     @Override
     public void cleanUp(CommandResultsBuilder resultsBuilder) {
         if (outputStreamWriter != null) {
-            // Scoped to this command's own database - ExecutorService is a single JVM-wide singleton,
-            // so a blanket reset() here would also drop other concurrently running commands' (different
-            // database's) jdbc/logging executor overrides.
             ExecutorService executorService = Scope.getCurrentScope().getSingleton(ExecutorService.class);
             executorService.clearExecutor("jdbc", database);
             executorService.clearExecutor("logging", database);

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/DatabaseChangelogCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/DatabaseChangelogCommandStep.java
@@ -231,9 +231,6 @@ public class DatabaseChangelogCommandStep extends AbstractHelperCommandStep impl
      */
     @Override
     public void cleanUp(CommandResultsBuilder resultsBuilder) {
-        // Scoped to this command's own database - ChangeLogHistoryServiceFactory is a single JVM-wide
-        // singleton, so a blanket resetAll() here would also drop other concurrently running commands'
-        // (different database's) cached ChangeLogHistoryService entries.
         Database database = (Database) resultsBuilder.getCommandScope().getDependency(Database.class);
         Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).resetDatabase(database);
     }

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/DatabaseChangelogCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/DatabaseChangelogCommandStep.java
@@ -231,7 +231,11 @@ public class DatabaseChangelogCommandStep extends AbstractHelperCommandStep impl
      */
     @Override
     public void cleanUp(CommandResultsBuilder resultsBuilder) {
-        Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).resetAll();
+        // Scoped to this command's own database - ChangeLogHistoryServiceFactory is a single JVM-wide
+        // singleton, so a blanket resetAll() here would also drop other concurrently running commands'
+        // (different database's) cached ChangeLogHistoryService entries.
+        Database database = (Database) resultsBuilder.getCommandScope().getDependency(Database.class);
+        Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).resetDatabase(database);
     }
 
     /**

--- a/liquibase-standard/src/main/java/liquibase/database/OfflineConnection.java
+++ b/liquibase-standard/src/main/java/liquibase/database/OfflineConnection.java
@@ -175,7 +175,7 @@ public class OfflineConnection implements DatabaseConnection {
             }
         }
 
-        Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).register(createChangeLogHistoryService(database));
+        Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).registerForDatabase(database, createChangeLogHistoryService(database));
     }
 
     protected ChangeLogHistoryService createChangeLogHistoryService(Database database) {

--- a/liquibase-standard/src/main/java/liquibase/lockservice/StandardLockService.java
+++ b/liquibase-standard/src/main/java/liquibase/lockservice/StandardLockService.java
@@ -349,7 +349,7 @@ public class StandardLockService implements LockService {
 
                 hasChangeLogLock = true;
 
-                Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).resetAll();
+                Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).resetDatabase(database);
                 database.setCanCacheLiquibaseTableInfo(true);
                 return true;
             }

--- a/liquibase-standard/src/test/groovy/liquibase/command/core/AbstractUpdateCommandStepTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/command/core/AbstractUpdateCommandStepTest.groovy
@@ -1,22 +1,39 @@
 package liquibase.command.core
 
+import liquibase.Scope
 import liquibase.UpdateSummaryEnum
+import liquibase.changelog.ChangeLogHistoryServiceFactory
 import liquibase.changelog.ChangeLogParameters
 import liquibase.changelog.DatabaseChangeLog
+import liquibase.changelog.StandardChangeLogHistoryService
 import liquibase.changelog.visitor.ChangeExecListener
 import liquibase.changelog.visitor.DefaultChangeExecListener
 import liquibase.command.CommandResultsBuilder
 import liquibase.command.CommandScope
 import liquibase.database.Database
 import liquibase.database.DatabaseConnection
+import liquibase.database.core.PostgresDatabase
+import liquibase.executor.Executor
+import liquibase.executor.ExecutorService
+import liquibase.executor.jvm.JdbcExampleExecutor
 import liquibase.lockservice.LockService
 import liquibase.lockservice.LockServiceFactory
 import spock.lang.Specification
 
 class AbstractUpdateCommandStepTest extends Specification {
 
+    def executorService = Scope.getCurrentScope().getSingleton(ExecutorService.class)
+    def changeLogHistoryServiceFactory = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class)
+
+    def setup() {
+        executorService.reset()
+        changeLogHistoryServiceFactory.resetAll()
+    }
+
     def cleanup() {
         LockServiceFactory.reset()
+        executorService.reset()
+        changeLogHistoryServiceFactory.resetAll()
     }
 
     /**
@@ -114,5 +131,45 @@ class AbstractUpdateCommandStepTest extends Specification {
         then: "the genuinely-held lock is still released here (not left for LockServiceCommandStep alone), so Sql-output commands still capture the release statement"
         0 * mockLockService.waitForLock()
         1 * mockLockService.releaseLock()
+    }
+
+    def "cleanUp only clears the executor override and ChangeLogHistoryService for its own database (regression for liquibase#6927)"() {
+        // Reproduces bug 2 from https://github.com/liquibase/liquibase/issues/6927: updateSql's
+        // cleanUp() used to call the blanket ExecutorService.reset() and
+        // ChangeLogHistoryServiceFactory.resetAll() unconditionally on every command completion.
+        // Since both factories are single JVM-wide singletons since #7877, one module's cleanUp()
+        // wiped out every other concurrently-running module's cached "jdbc"/"logging" Executor
+        // overrides (e.g. the SQL-writing LoggingExecutor installed by updateSql) and cached
+        // ChangeLogHistoryService too, not just its own. Exercised directly here (rather than via
+        // an actual -T Maven build) since the real race was intermittent.
+        given: "two independent executions (as concurrently-running Maven modules would each have) with their own executor override and cached history service"
+        def databaseA = new PostgresDatabase()
+        def databaseB = new PostgresDatabase()
+        Executor overrideA = new JdbcExampleExecutor()
+        Executor overrideB = new JdbcExampleExecutor()
+        executorService.setExecutor("jdbc", databaseA, overrideA)
+        executorService.setExecutor("jdbc", databaseB, overrideB)
+
+        def serviceA = new StandardChangeLogHistoryService()
+        serviceA.setDatabase(databaseA)
+        def serviceB = new StandardChangeLogHistoryService()
+        serviceB.setDatabase(databaseB)
+        changeLogHistoryServiceFactory.registerForDatabase(databaseA, serviceA)
+        changeLogHistoryServiceFactory.registerForDatabase(databaseB, serviceB)
+
+        def commandA = new CommandScope(UpdateSqlCommandStep.COMMAND_NAME)
+                .provideDependency(Database.class, databaseA)
+        def resultsBuilderA = new CommandResultsBuilder(commandA, new ByteArrayOutputStream())
+
+        when: "module A finishes and cleans up while module B is still in flight"
+        new UpdateSqlCommandStep().cleanUp(resultsBuilderA)
+
+        then: "module B's executor override and cached history service both survive module A's cleanup"
+        executorService.getExecutor("jdbc", databaseB).is(overrideB)
+        changeLogHistoryServiceFactory.getChangeLogService(databaseB).is(serviceB)
+
+        and: "module A's own state was cleared, as expected"
+        !executorService.getExecutor("jdbc", databaseA).is(overrideA)
+        !changeLogHistoryServiceFactory.getChangeLogService(databaseA).is(serviceA)
     }
 }

--- a/liquibase-standard/src/test/groovy/liquibase/command/core/AbstractUpdateCommandStepTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/command/core/AbstractUpdateCommandStepTest.groovy
@@ -150,9 +150,14 @@ class AbstractUpdateCommandStepTest extends Specification {
         executorService.setExecutor("jdbc", databaseA, overrideA)
         executorService.setExecutor("jdbc", databaseB, overrideB)
 
-        def serviceA = new StandardChangeLogHistoryService()
+        def resets = [:].withDefault { 0 }
+        def serviceA = new StandardChangeLogHistoryService() {
+            @Override void reset() { resets["A"]++; super.reset() }
+        }
         serviceA.setDatabase(databaseA)
-        def serviceB = new StandardChangeLogHistoryService()
+        def serviceB = new StandardChangeLogHistoryService() {
+            @Override void reset() { resets["B"]++; super.reset() }
+        }
         serviceB.setDatabase(databaseB)
         changeLogHistoryServiceFactory.registerForDatabase(databaseA, serviceA)
         changeLogHistoryServiceFactory.registerForDatabase(databaseB, serviceB)
@@ -164,12 +169,12 @@ class AbstractUpdateCommandStepTest extends Specification {
         when: "module A finishes and cleans up while module B is still in flight"
         new UpdateSqlCommandStep().cleanUp(resultsBuilderA)
 
-        then: "module B's executor override and cached history service both survive module A's cleanup"
+        then: "module B's executor override and history service are untouched by module A's cleanup"
         executorService.getExecutor("jdbc", databaseB).is(overrideB)
-        changeLogHistoryServiceFactory.getChangeLogService(databaseB).is(serviceB)
+        resets["B"] == 0
 
-        and: "module A's own state was cleared, as expected"
+        and: "module A's own executor override was dropped and its history service invalidated"
         !executorService.getExecutor("jdbc", databaseA).is(overrideA)
-        !changeLogHistoryServiceFactory.getChangeLogService(databaseA).is(serviceA)
+        resets["A"] == 1
     }
 }

--- a/liquibase-standard/src/test/groovy/liquibase/command/core/AbstractUpdateCommandStepTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/command/core/AbstractUpdateCommandStepTest.groovy
@@ -133,8 +133,8 @@ class AbstractUpdateCommandStepTest extends Specification {
         1 * mockLockService.releaseLock()
     }
 
-    def "cleanUp only clears the executor override and ChangeLogHistoryService for its own database (regression for liquibase#6927)"() {
-        // Reproduces bug 2 from https://github.com/liquibase/liquibase/issues/6927: updateSql's
+    def "cleanUp only clears the executor override and ChangeLogHistoryService for its own database"() {
+        // Cross-module state corruption in parallel (-T) Maven reactor builds, bug 2 of 3: updateSql's
         // cleanUp() used to call the blanket ExecutorService.reset() and
         // ChangeLogHistoryServiceFactory.resetAll() unconditionally on every command completion.
         // Since both factories are single JVM-wide singletons since #7877, one module's cleanUp()

--- a/liquibase-standard/src/test/groovy/liquibase/command/core/helpers/DatabaseChangelogCommandStepTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/command/core/helpers/DatabaseChangelogCommandStepTest.groovy
@@ -23,22 +23,26 @@ class DatabaseChangelogCommandStepTest extends Specification {
     def "cleanUp only resets the ChangeLogHistoryService for its own database (regression for liquibase#6927)"() {
         // Reproduces bug 3 from https://github.com/liquibase/liquibase/issues/6927: this helper
         // step's cleanUp() used to call the blanket ChangeLogHistoryServiceFactory.resetAll(),
-        // which - since the factory is a single JVM-wide singleton since #7877 - wiped out every
+        // which - since the factory is a single JVM-wide singleton since #7877 - discarded every
         // other concurrently-running Maven module's cached ChangeLogHistoryService too, not just
-        // the finishing module's own. That combined badly with the fix for bug 1: once wiped, a
-        // module's next lookup fell back to StandardChangeLogHistoryService (supports() always
-        // true) instead of its own offline-aware service, producing a raw ClassCastException.
-        // This bug only misfired in roughly 1 run in 15 under a real -T Maven build - too rare to
-        // rely on a threaded/looping test, so this exercises cleanUp() directly for two "modules"
-        // sharing the same JVM-wide factory instance instead.
+        // the finishing module's own. A module hit by that wipe fell back to
+        // StandardChangeLogHistoryService (supports() always true) instead of its own offline-aware
+        // service, producing a raw ClassCastException. This only misfired in roughly 1 run in 15
+        // under a real -T Maven build - too rare for a threaded/looping test - so this exercises
+        // cleanUp() directly for two "modules" sharing the same JVM-wide factory instance.
         given: "two independent executions (as concurrently-running Maven modules would each have) with their own cached ChangeLogHistoryService"
         def factory = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class)
         factory.resetAll()
         def databaseA = new MockDatabase()
         def databaseB = new MockDatabase()
-        def serviceA = new StandardChangeLogHistoryService()
+        def resets = [:].withDefault { 0 }
+        def serviceA = new StandardChangeLogHistoryService() {
+            @Override void reset() { resets["A"]++; super.reset() }
+        }
         serviceA.setDatabase(databaseA)
-        def serviceB = new StandardChangeLogHistoryService()
+        def serviceB = new StandardChangeLogHistoryService() {
+            @Override void reset() { resets["B"]++; super.reset() }
+        }
         serviceB.setDatabase(databaseB)
         factory.registerForDatabase(databaseA, serviceA)
         factory.registerForDatabase(databaseB, serviceB)
@@ -51,11 +55,13 @@ class DatabaseChangelogCommandStepTest extends Specification {
         when: "module A finishes and cleans up while module B is still in flight"
         step.cleanUp(resultsBuilderA)
 
-        then: "module B's cached service survives module A's cleanup"
-        factory.getChangeLogService(databaseB).is(serviceB)
+        then: "module A's own service was invalidated and module B's was left alone"
+        resets["A"] == 1
+        resets["B"] == 0
 
-        and: "module A's own cached service was cleared, as expected"
-        !factory.getChangeLogService(databaseA).is(serviceA)
+        and: "both modules keep their own service for any subsequent command"
+        factory.getChangeLogService(databaseA).is(serviceA)
+        factory.getChangeLogService(databaseB).is(serviceB)
 
         cleanup:
         factory.resetAll()

--- a/liquibase-standard/src/test/groovy/liquibase/command/core/helpers/DatabaseChangelogCommandStepTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/command/core/helpers/DatabaseChangelogCommandStepTest.groovy
@@ -20,8 +20,8 @@ import java.lang.reflect.Method
  */
 class DatabaseChangelogCommandStepTest extends Specification {
 
-    def "cleanUp only resets the ChangeLogHistoryService for its own database (regression for liquibase#6927)"() {
-        // Reproduces bug 3 from https://github.com/liquibase/liquibase/issues/6927: this helper
+    def "cleanUp only resets the ChangeLogHistoryService for its own database"() {
+        // Cross-module state corruption in parallel (-T) Maven reactor builds, bug 3 of 3: this helper
         // step's cleanUp() used to call the blanket ChangeLogHistoryServiceFactory.resetAll(),
         // which - since the factory is a single JVM-wide singleton since #7877 - discarded every
         // other concurrently-running Maven module's cached ChangeLogHistoryService too, not just

--- a/liquibase-standard/src/test/groovy/liquibase/command/core/helpers/DatabaseChangelogCommandStepTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/command/core/helpers/DatabaseChangelogCommandStepTest.groovy
@@ -1,7 +1,13 @@
 package liquibase.command.core.helpers
 
+import liquibase.Scope
+import liquibase.changelog.ChangeLogHistoryServiceFactory
 import liquibase.changelog.ChangeLogParameters
+import liquibase.changelog.StandardChangeLogHistoryService
+import liquibase.command.CommandResultsBuilder
 import liquibase.command.CommandScope
+import liquibase.database.Database
+import liquibase.database.core.MockDatabase
 import liquibase.database.core.PostgresDatabase
 import spock.lang.Specification
 
@@ -13,6 +19,47 @@ import java.lang.reflect.Method
  * ChangeLogParameters was passed via CommandScope.
  */
 class DatabaseChangelogCommandStepTest extends Specification {
+
+    def "cleanUp only resets the ChangeLogHistoryService for its own database (regression for liquibase#6927)"() {
+        // Reproduces bug 3 from https://github.com/liquibase/liquibase/issues/6927: this helper
+        // step's cleanUp() used to call the blanket ChangeLogHistoryServiceFactory.resetAll(),
+        // which - since the factory is a single JVM-wide singleton since #7877 - wiped out every
+        // other concurrently-running Maven module's cached ChangeLogHistoryService too, not just
+        // the finishing module's own. That combined badly with the fix for bug 1: once wiped, a
+        // module's next lookup fell back to StandardChangeLogHistoryService (supports() always
+        // true) instead of its own offline-aware service, producing a raw ClassCastException.
+        // This bug only misfired in roughly 1 run in 15 under a real -T Maven build - too rare to
+        // rely on a threaded/looping test, so this exercises cleanUp() directly for two "modules"
+        // sharing the same JVM-wide factory instance instead.
+        given: "two independent executions (as concurrently-running Maven modules would each have) with their own cached ChangeLogHistoryService"
+        def factory = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class)
+        factory.resetAll()
+        def databaseA = new MockDatabase()
+        def databaseB = new MockDatabase()
+        def serviceA = new StandardChangeLogHistoryService()
+        serviceA.setDatabase(databaseA)
+        def serviceB = new StandardChangeLogHistoryService()
+        serviceB.setDatabase(databaseB)
+        factory.registerForDatabase(databaseA, serviceA)
+        factory.registerForDatabase(databaseB, serviceB)
+
+        def step = new DatabaseChangelogCommandStep()
+        def commandA = new CommandScope(DatabaseChangelogCommandStep.COMMAND_NAME)
+                .provideDependency(Database.class, databaseA)
+        def resultsBuilderA = new CommandResultsBuilder(commandA, new ByteArrayOutputStream())
+
+        when: "module A finishes and cleans up while module B is still in flight"
+        step.cleanUp(resultsBuilderA)
+
+        then: "module B's cached service survives module A's cleanup"
+        factory.getChangeLogService(databaseB).is(serviceB)
+
+        and: "module A's own cached service was cleared, as expected"
+        !factory.getChangeLogService(databaseA).is(serviceA)
+
+        cleanup:
+        factory.resetAll()
+    }
 
     /**
      * Test that verifies the fix for issue #7602.

--- a/liquibase-standard/src/test/groovy/liquibase/database/OfflineConnectionTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/database/OfflineConnectionTest.groovy
@@ -1,5 +1,7 @@
 package liquibase.database
 
+import liquibase.Scope
+import liquibase.changelog.ChangeLogHistoryServiceFactory
 import liquibase.exception.UnexpectedLiquibaseException
 import liquibase.resource.ResourceAccessor
 import liquibase.database.core.MockDatabase
@@ -49,6 +51,38 @@ class OfflineConnectionTest extends Specification {
     def "Attached"() {
         expect:
         offlineConnection.attached new MockDatabase()
+    }
+
+    def "Attached registers an isolated ChangeLogHistoryService per database (regression for liquibase#6927)"() {
+        // Reproduces the scenario reported at https://github.com/liquibase/liquibase/issues/6927:
+        // two OfflineConnections (as concurrently-running Maven modules would each have their own)
+        // attaching to two different databases must each get their own OfflineChangeLogHistoryService.
+        // Before the fix, attached() registered through the generic, type/priority-based register()
+        // path, and AbstractPluginFactory.getPlugins()'s TreeSet - which orders candidates by
+        // (priority, class name), identical for every OfflineChangeLogHistoryService instance -
+        // silently collapsed both registrations into one, handing the same instance to both databases.
+        given:
+        def connectionA = new OfflineConnection(
+                "offline:mock?changeLogFile=changelogA.csv", resourceAccessor)
+        def connectionB = new OfflineConnection(
+                "offline:mock?changeLogFile=changelogB.csv", resourceAccessor)
+        def databaseA = new MockDatabase()
+        databaseA.setConnection(connectionA)
+        def databaseB = new MockDatabase()
+        databaseB.setConnection(connectionB)
+
+        when:
+        connectionA.attached(databaseA)
+        connectionB.attached(databaseB)
+
+        def factory = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class)
+        def serviceA = factory.getChangeLogService(databaseA)
+        def serviceB = factory.getChangeLogService(databaseB)
+
+        then:
+        serviceA.database.is(databaseA)
+        serviceB.database.is(databaseB)
+        !serviceA.is(serviceB)
     }
 
     def "GetDatabaseMajorVersion"() {

--- a/liquibase-standard/src/test/groovy/liquibase/database/OfflineConnectionTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/database/OfflineConnectionTest.groovy
@@ -53,8 +53,9 @@ class OfflineConnectionTest extends Specification {
         offlineConnection.attached new MockDatabase()
     }
 
-    def "Attached registers an isolated ChangeLogHistoryService per database (regression for liquibase#6927)"() {
-        // Reproduces the scenario reported at https://github.com/liquibase/liquibase/issues/6927:
+    def "Attached registers an isolated ChangeLogHistoryService per database"() {
+        // Cross-module state corruption in parallel (-T) Maven reactor builds, reproduced at
+        // https://github.com/pwielgolaski/liquibase-parallel-build-bug :
         // two OfflineConnections (as concurrently-running Maven modules would each have their own)
         // attaching to two different databases must each get their own OfflineChangeLogHistoryService.
         // Before the fix, attached() registered through the generic, type/priority-based register()

--- a/liquibase-standard/src/test/java/liquibase/changelog/ChangeLogHistoryServiceFactoryTest.java
+++ b/liquibase-standard/src/test/java/liquibase/changelog/ChangeLogHistoryServiceFactoryTest.java
@@ -18,7 +18,7 @@ public class ChangeLogHistoryServiceFactoryTest {
     }
 
     /**
-     * Regression test for https://github.com/liquibase/liquibase/issues/6927 (comment thread):
+     * Regression test for cross-module state corruption in parallel (-T) Maven reactor builds:
      * two pre-configured services registered for two different databases must resolve back to
      * their own database, not collapse into a single shared instance. Before the fix, registering
      * through the generic {@link ChangeLogHistoryServiceFactory#register(ChangeLogHistoryService)}

--- a/liquibase-standard/src/test/java/liquibase/changelog/ChangeLogHistoryServiceFactoryTest.java
+++ b/liquibase-standard/src/test/java/liquibase/changelog/ChangeLogHistoryServiceFactoryTest.java
@@ -88,6 +88,23 @@ public class ChangeLogHistoryServiceFactoryTest {
         assertThat(factory.getChangeLogService(database)).isSameAs(service);
     }
 
+    /**
+     * A service registered for a database never enters the plugin registry, so resetAll()'s loop over
+     * findAllInstances() does not reach it. It must still be reset before the map is cleared, or a full
+     * teardown would silently drop it without invalidating it.
+     */
+    @Test
+    public void resetAllResetsServicesRegisteredForADatabase() {
+        PostgresDatabase database = new PostgresDatabase();
+        RecordingChangeLogHistoryService registered = new RecordingChangeLogHistoryService();
+        registered.setDatabase(database);
+        factory.registerForDatabase(database, registered);
+
+        factory.resetAll();
+
+        assertThat(registered.resetCount).isEqualTo(1);
+    }
+
     private static class RecordingChangeLogHistoryService extends StandardChangeLogHistoryService {
         private int resetCount;
 

--- a/liquibase-standard/src/test/java/liquibase/changelog/ChangeLogHistoryServiceFactoryTest.java
+++ b/liquibase-standard/src/test/java/liquibase/changelog/ChangeLogHistoryServiceFactoryTest.java
@@ -45,20 +45,20 @@ public class ChangeLogHistoryServiceFactoryTest {
     }
 
     /**
-     * Regression test: {@link ChangeLogHistoryServiceFactory#resetDatabase} must only drop the
-     * given database's cached service, unlike {@link ChangeLogHistoryServiceFactory#resetAll()}
-     * which (correctly, by design) drops every database's entry. Several command-step cleanUp()
-     * paths used to call the blanket resetAll() on every command completion; since this factory
-     * is a single JVM-wide singleton (since #7877), that wiped out other concurrently-running
-     * Maven modules' cached services too.
+     * Regression test: {@link ChangeLogHistoryServiceFactory#resetDatabase} must invalidate only the
+     * given database's service, unlike {@link ChangeLogHistoryServiceFactory#resetAll()} which (by
+     * design) invalidates and drops every database's entry. Several command-step cleanUp() paths used
+     * to call the blanket resetAll() on every command completion; since this factory is a single
+     * JVM-wide singleton (since #7877), that discarded other concurrently-running Maven modules'
+     * cached services too.
      */
     @Test
     public void resetDatabaseOnlyAffectsGivenDatabase() {
         PostgresDatabase databaseA = new PostgresDatabase();
         PostgresDatabase databaseB = new PostgresDatabase();
-        ChangeLogHistoryService serviceA = new StandardChangeLogHistoryService();
+        RecordingChangeLogHistoryService serviceA = new RecordingChangeLogHistoryService();
         serviceA.setDatabase(databaseA);
-        ChangeLogHistoryService serviceB = new StandardChangeLogHistoryService();
+        RecordingChangeLogHistoryService serviceB = new RecordingChangeLogHistoryService();
         serviceB.setDatabase(databaseB);
 
         factory.registerForDatabase(databaseA, serviceA);
@@ -66,7 +66,35 @@ public class ChangeLogHistoryServiceFactoryTest {
 
         factory.resetDatabase(databaseA);
 
-        assertThat(factory.getChangeLogService(databaseB)).isSameAs(serviceB);
-        assertThat(factory.getChangeLogService(databaseA)).isNotSameAs(serviceA);
+        assertThat(serviceA.resetCount).isEqualTo(1);
+        assertThat(serviceB.resetCount).isZero();
+    }
+
+    /**
+     * resetDatabase() resets the service in place rather than evicting it. The binding survives, so a
+     * database used for more than one command in the same JVM run - e.g. an offline connection, whose
+     * service the generic plugin lookup cannot rebuild - keeps its own service for the next command
+     * instead of silently falling back to StandardChangeLogHistoryService.
+     */
+    @Test
+    public void resetDatabaseKeepsTheServiceBoundToItsDatabase() {
+        PostgresDatabase database = new PostgresDatabase();
+        ChangeLogHistoryService service = new StandardChangeLogHistoryService();
+        service.setDatabase(database);
+        factory.registerForDatabase(database, service);
+
+        factory.resetDatabase(database);
+
+        assertThat(factory.getChangeLogService(database)).isSameAs(service);
+    }
+
+    private static class RecordingChangeLogHistoryService extends StandardChangeLogHistoryService {
+        private int resetCount;
+
+        @Override
+        public void reset() {
+            resetCount++;
+            super.reset();
+        }
     }
 }

--- a/liquibase-standard/src/test/java/liquibase/changelog/ChangeLogHistoryServiceFactoryTest.java
+++ b/liquibase-standard/src/test/java/liquibase/changelog/ChangeLogHistoryServiceFactoryTest.java
@@ -1,0 +1,72 @@
+package liquibase.changelog;
+
+import liquibase.Scope;
+import liquibase.database.core.PostgresDatabase;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ChangeLogHistoryServiceFactoryTest {
+
+    private ChangeLogHistoryServiceFactory factory;
+
+    @Before
+    public void setUp() {
+        factory = Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class);
+        factory.resetAll();
+    }
+
+    /**
+     * Regression test for https://github.com/liquibase/liquibase/issues/6927 (comment thread):
+     * two pre-configured services registered for two different databases must resolve back to
+     * their own database, not collapse into a single shared instance. Before the fix, registering
+     * through the generic {@link ChangeLogHistoryServiceFactory#register(ChangeLogHistoryService)}
+     * path let {@link liquibase.plugin.AbstractPluginFactory#getPlugins} silently collapse both
+     * registrations into one, because its TreeSet orders candidates by (priority, class name) and
+     * both services share the same class and priority.
+     */
+    @Test
+    public void registerForDatabaseIsolatesInstancesPerDatabase() {
+        PostgresDatabase databaseA = new PostgresDatabase();
+        PostgresDatabase databaseB = new PostgresDatabase();
+        ChangeLogHistoryService serviceA = new StandardChangeLogHistoryService();
+        serviceA.setDatabase(databaseA);
+        ChangeLogHistoryService serviceB = new StandardChangeLogHistoryService();
+        serviceB.setDatabase(databaseB);
+
+        factory.registerForDatabase(databaseA, serviceA);
+        factory.registerForDatabase(databaseB, serviceB);
+
+        assertThat(factory.getChangeLogService(databaseA)).isSameAs(serviceA);
+        assertThat(factory.getChangeLogService(databaseB)).isSameAs(serviceB);
+        assertThat(factory.getChangeLogService(databaseA))
+                .isNotSameAs(factory.getChangeLogService(databaseB));
+    }
+
+    /**
+     * Regression test: {@link ChangeLogHistoryServiceFactory#resetDatabase} must only drop the
+     * given database's cached service, unlike {@link ChangeLogHistoryServiceFactory#resetAll()}
+     * which (correctly, by design) drops every database's entry. Several command-step cleanUp()
+     * paths used to call the blanket resetAll() on every command completion; since this factory
+     * is a single JVM-wide singleton (since #7877), that wiped out other concurrently-running
+     * Maven modules' cached services too.
+     */
+    @Test
+    public void resetDatabaseOnlyAffectsGivenDatabase() {
+        PostgresDatabase databaseA = new PostgresDatabase();
+        PostgresDatabase databaseB = new PostgresDatabase();
+        ChangeLogHistoryService serviceA = new StandardChangeLogHistoryService();
+        serviceA.setDatabase(databaseA);
+        ChangeLogHistoryService serviceB = new StandardChangeLogHistoryService();
+        serviceB.setDatabase(databaseB);
+
+        factory.registerForDatabase(databaseA, serviceA);
+        factory.registerForDatabase(databaseB, serviceB);
+
+        factory.resetDatabase(databaseA);
+
+        assertThat(factory.getChangeLogService(databaseB)).isSameAs(serviceB);
+        assertThat(factory.getChangeLogService(databaseA)).isNotSameAs(serviceA);
+    }
+}

--- a/liquibase-standard/src/test/java/liquibase/changelog/StandardChangeLogHistoryServiceTest.java
+++ b/liquibase-standard/src/test/java/liquibase/changelog/StandardChangeLogHistoryServiceTest.java
@@ -1,0 +1,33 @@
+package liquibase.changelog;
+
+import liquibase.database.DatabaseConnection;
+import liquibase.database.core.MockDatabase;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StandardChangeLogHistoryServiceTest {
+
+    /**
+     * getNextSequenceValue() caches MAX(ORDEREXECUTED) and increments it in memory, so reset() has to
+     * drop that cache: callers reset precisely when the database may have been written to by someone
+     * else - most sharply in StandardLockService.acquireLock(), where holding the lock is what makes
+     * the previous read stale. Unlike databaseChecksumsCompatible this value is not recomputed by
+     * init(), so nothing else would clear it.
+     */
+    @Test
+    public void resetClearsTheCachedSequenceValue() throws Exception {
+        MockDatabase database = new MockDatabase();
+        // No connection: getNextSequenceValue() then seeds from 0 instead of querying the database.
+        database.setConnection((DatabaseConnection) null);
+        StandardChangeLogHistoryService service = new StandardChangeLogHistoryService();
+        service.setDatabase(database);
+
+        assertThat(service.getNextSequenceValue()).isEqualTo(1);
+        assertThat(service.getNextSequenceValue()).isEqualTo(2);
+
+        service.reset();
+
+        assertThat(service.getNextSequenceValue()).isEqualTo(1);
+    }
+}

--- a/liquibase-standard/src/test/java/liquibase/executor/ExecutorServiceTest.java
+++ b/liquibase-standard/src/test/java/liquibase/executor/ExecutorServiceTest.java
@@ -32,4 +32,31 @@ public class ExecutorServiceTest {
 
     }
 
+    /**
+     * Regression test for https://github.com/liquibase/liquibase/issues/6927 (comment thread):
+     * {@link ExecutorService#clearExecutor(String, liquibase.database.Database)} must only remove
+     * the given database's override, unlike {@link ExecutorService#reset()} which (correctly, by
+     * design) clears every database's entry. Command-step cleanUp() paths used to call the blanket
+     * reset() on every command completion; since this factory is a single JVM-wide singleton
+     * (since #7877), that wiped out other concurrently-running Maven modules' "jdbc"/"logging"
+     * Executor overrides (e.g. the SQL-writing LoggingExecutor installed by updateSQL) too.
+     */
+    @Test
+    public void clearExecutorOnlyAffectsGivenDatabase() {
+        PostgresDatabase databaseA = new PostgresDatabase();
+        PostgresDatabase databaseB = new PostgresDatabase();
+        Executor overrideA = new JdbcExampleExecutor();
+        Executor overrideB = new JdbcExampleExecutor();
+
+        executorService.setExecutor("jdbc", databaseA, overrideA);
+        executorService.setExecutor("jdbc", databaseB, overrideB);
+
+        executorService.clearExecutor("jdbc", databaseA);
+
+        assertThat(executorService.getExecutor("jdbc", databaseB)).isSameAs(overrideB);
+        assertThat(executorService.getExecutor("jdbc", databaseA))
+                .isNotSameAs(overrideA)
+                .isInstanceOf(JdbcExecutor.class);
+    }
+
 }

--- a/liquibase-standard/src/test/java/liquibase/executor/ExecutorServiceTest.java
+++ b/liquibase-standard/src/test/java/liquibase/executor/ExecutorServiceTest.java
@@ -33,7 +33,7 @@ public class ExecutorServiceTest {
     }
 
     /**
-     * Regression test for https://github.com/liquibase/liquibase/issues/6927 (comment thread):
+     * Regression test for cross-module state corruption in parallel (-T) Maven reactor builds:
      * {@link ExecutorService#clearExecutor(String, liquibase.database.Database)} must only remove
      * the given database's override, unlike {@link ExecutorService#reset()} which (correctly, by
      * design) clears every database's entry. Command-step cleanUp() paths used to call the blanket


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!-- Suggested label: TypeBug -->

## Description

Running a multi-module Maven build with `-T` makes `liquibase-maven-plugin` goals fail intermittently, with modules picking up **another module's** database state. On a 20-module reactor this fails on essentially every run.

There is no open issue for this — #6927 had the same user-visible symptom but a different root cause and is already fixed (see *Additional Context*), so I've written this up issue-style below.

### Steps To Reproduce

Full reproduction: **https://github.com/pwielgolaski/liquibase-parallel-build-bug** — 20 trivial sibling modules, offline PostgreSQL connection (no real database required), `updateSQL` bound to `process-test-resources`.

```bash
# build the plugin from source, then:
mvn clean install -T 2C -Dliquibase.version=0-SNAPSHOT
```

### Expected Behavior

Each module runs `updateSQL` against its own database/changelog, independently of what sibling modules are doing concurrently.

### Actual Behavior

One of three failures, depending on interleaving:

```
[ERROR] Failed to execute goal org.liquibase:liquibase-maven-plugin:updateSQL (liquibase-updateSQL) on project module-l:
[ERROR] Error setting up or running Liquibase:
[ERROR] liquibase.exception.LiquibaseException: liquibase.exception.DatabaseException:
        java.nio.file.NoSuchFileException: /path/to/module-a/target/module-a-databasechangelog.csv
```
```
[ERROR] java.lang.ClassCastException: class liquibase.database.OfflineConnection cannot be cast to
        class liquibase.database.jvm.JdbcConnection
```
```
[ERROR] liquibase.exception.DatabaseException: Cannot execute commands against an offline database
```

The first is the clearest tell: `module-l` is reading `module-a`'s changelog CSV. In one captured run, five different modules all failed reaching for `module-a`'s file.

### Root cause

#7877 ("share a single root scope across threads", fixing #6880) made `Scope.rootScope` a single JVM-wide static. That is correct and this PR does not change it — but it changed what `Scope.getSingleton(...)` means:

```java
// Scope.java
public synchronized <T extends SingletonObject> T getSingleton(Class<T> type) {
    if (getParent() != null) {
        return getParent().getSingleton(type);   // always resolves at the root
    }
    ...
    values.put(key, singleton);                  // ...and is stored on the root
}
```

The Maven mojo gives each module its own chain of child scopes (`resourceAccessor`, `classLoader`, `mavenConfigurationProperties`, …), so *values* are isolated per module. But singletons cannot live in a child scope by design — they always resolve to the root. So since #7877, **every concurrently-building module shares one `ExecutorService` and one `ChangeLogHistoryServiceFactory` instance.**

Those registries are keyed by `Database`, so they remain correctly isolated *by construction* — module A's key is never module B's. Isolation is only broken by operations that ignore the key: the blanket `reset()` / `resetAll()`. Before #7877 those were harmless, because each thread had its own root and therefore its own private registries.

Three call sites still assumed that per-thread-private world:

1. **`OfflineConnection.attached()`** registered a database-bound `OfflineChangeLogHistoryService` through the generic priority-based `register()`/`getPlugin()` path. `AbstractPluginFactory.getPlugins()` breaks ties with a `TreeSet` ordered by `(priority, class name)` — identical for every module's instance — so it silently kept only the **first** registration and handed that one instance to every module. → *modules reading each other's CSV.*

2. **`AbstractUpdateCommandStep.cleanUp()` / `AbstractOutputWriterCommandStep.cleanUp()`** called the blanket `ExecutorService.reset()` (`executors.clear()`) on every command completion, erasing every *other* still-running module's `jdbc`/`logging` executor overrides. The next lookup re-resolved a real `JdbcExecutor` in place of the SQL-writing `LoggingExecutor`. → *"Cannot execute commands against an offline database".*

3. **`DatabaseChangelogCommandStep.cleanUp()`** had the same blanket `resetAll()` independently. Combined with fix 1, a wiped module fell back to `StandardChangeLogHistoryService` (whose `supports()` is unconditionally `true`), which has no offline awareness at all. → *the raw `ClassCastException`.*

### The change

Scope each cleanup to the database it belongs to, using the already-`Database`-keyed maps:

- **`ChangeLogHistoryServiceFactory.registerForDatabase(Database, ChangeLogHistoryService)`** — puts directly into the existing `services` map instead of the ambiguous priority resolver. `OfflineConnection.attached()` now uses it.
- **`ChangeLogHistoryServiceFactory.resetDatabase(Database)`** — invalidates one database's service, alongside the existing `resetAll()`.
- The three `cleanUp()` methods call the scoped variants (`ExecutorService.clearExecutor(name, database)` already existed).

No changes to `Scope.java`; #7877 is not reverted or weakened.

## Release note

Fixed multi-module Maven builds running in parallel (`-T`) corrupting each other's Liquibase state. Modules could read another module's changelog file, or fail with `Cannot execute commands against an offline database` or a `ClassCastException` about `OfflineConnection`.

## Things to be aware of

**`resetDatabase()` resets the service in place rather than evicting it.** Eviction is a stronger operation than a finishing command needs, and it destroys something the command doesn't own — the binding between a database and its service. `OfflineConnection` registers a service that `getPlugin()` cannot rebuild, so evicting it would leave the *next* command against that same database falling back to `StandardChangeLogHistoryService` — the same `ClassCastException`, reached by sequential reuse of one database rather than by concurrent modules. `reset()` clears exactly the stale ran-changeset/table-existence state, and is already how `UpdateTestingRollbackCommandStep` and `FastCheckService` invalidate.

**Why the fix isn't in `Scope`.** Making singletons resolve per-child-scope would undo #7877 and reopen #6880 (`ScopeTest` guards this). Since the registries are already `Database`-keyed, the isolation exists — the fix is to stop using the one operation that discards it.

**Validation.** 40/40 clean runs of the reproduction at `-T 2C`, from failing on essentially every run before. `ScopeTest` (added by #7877 for #6880) passes 14/14, confirming this doesn't reopen the split-brain-singleton problem. 1503 tests across `liquibase.command.**`, `liquibase.changelog.**`, `liquibase.lockservice.**`, `liquibase.executor.**` and `liquibase.database.**` pass. Each new test was verified to fail when its corresponding production change is reverted.

**Tests.** Each exercises the fixed call site directly with two distinct `Database` objects, simulating two concurrent modules sharing one JVM. A threaded/looping test was deliberately avoided — see the note on bug 3's rarity below.

| Test | Covers |
| --- | --- |
| `OfflineConnectionTest` | `attached()` registers an isolated service per database (bug 1, via the real production call site) |
| `ChangeLogHistoryServiceFactoryTest` | `registerForDatabase()` / `resetDatabase()` isolate and scope correctly; the binding survives a reset |
| `AbstractUpdateCommandStepTest` | `cleanUp()` touches only its own database's executor and history service (bug 2) |
| `DatabaseChangelogCommandStepTest` | `cleanUp()` invalidates only its own database's service (bug 3) |
| `ExecutorServiceTest` | `clearExecutor()` scoping — the primitive both fixes rely on |

## Things to worry about

1. **`OfflineChangeLogHistoryService` is no longer added to the generic plugin pool.** `registerForDatabase()` bypasses `register()`, so the service is reachable only via the database-keyed lookup. That's the point of the fix, but if any extension relies on discovering it through `getPlugin()`/`findAllInstances()`, that path is gone. I couldn't find such a caller in this repo — worth a maintainer's eye given Pro/extension code I can't see.

2. **The same anti-pattern remains at call sites this reproduction doesn't exercise.** I deliberately did not change them speculatively, but each looks suspect for the same reason:
   - `LockServiceCommandStep.cleanUp()`, `AbstractUpdateCommandStep.cleanUp()`, `StandardLockService.acquireLock()` → `LockServiceFactory.resetAll()`, which nulls the entire singleton. `LockServiceFactory` has the same JVM-wide + `Map<Database, …>` shape but no per-database reset.
   - `DropAllCommandStep.resetServices()`, `Liquibase.resetServices()` → the full `resetAll()`/`reset()` trio.
   - `MarkNextChangesetRanCommandStep` → `ExecutorService.reset()`.

   Happy to follow up in a separate PR, or file an issue tracking them.

3. **Bug 3 is rare enough to fool you.** After fixes 1 and 2, 20/20 runs passed and it looked done — bug 3 only misfires about 1 run in 15 and took a 30-run loop to surface. Anyone re-testing this should not trust a clean run of 10–20.

4. **`deploymentId` is now shared across concurrent modules.** It's generated once during root-scope bootstrap and resolved through the root, so all modules in a `-T` build write the same deployment ID into `DATABASECHANGELOG`. Same underlying cause, not fixed here, no failure reproduced from it — flagging in case it matters for deployment grouping.

## Additional Context

**Relationship to #6927.** This is *not* a reopening. #6927 ("[Regression] Multithread build on maven fails with goal `updateSQL`") had the same user-visible symptom but a different root cause — the shared static `COMMAND_DEFINITIONS` cache — and was correctly fixed by #7876. This reproduction was built while verifying that fix, and shows the "parallel builds corrupt each other" class of problem was not fully resolved.

**Bisect.** The reproduction points at a different commit:

| Build | Result over 5–10 runs |
| --- | --- |
| Released `5.0.3` (pre-#7877) | 0 failures |
| Commit before #7877 (`c0f504ed0`) | 0 failures (8/8 clean) |
| Commit at #7877 (`da65e0e4d`) | fails 2/5 |
| `main` tip (#7877 + #7876) | fails ~8/10 |

**Ruled out.** The original hypothesis was classloader identity across Maven `ClassRealm`s. Instrumentation showed this reproduction uses a *single shared* `ClassRealm` for the plugin across all 20 modules, so none of these failures are cross-realm `instanceof` mismatches — even the `ClassCastException` is a plain wrong-type cast within one loader.

**Related:** #7877 (root cause) · #6880 (what #7877 fixed) · #6927 / #7876 (earlier, separately-fixed instance of this symptom)
