### PR TITLE
fix: drop throwable from ChangeSet SEVERE log to prevent double-reporting

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/changelog/ChangeSet.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/ChangeSet.java
@@ -897,7 +897,13 @@ public class ChangeSet implements Conditional, ChangeLogChild {
             setStopTime();
             getCurrentScope().addMdcValue(MdcKey.CHANGESET_OPERATION_STOP_TIME, stopInstant.toString());
             getCurrentScope().addMdcValue(MdcKey.CHANGESET_OUTCOME, ExecType.FAILED.value.toLowerCase());
-            log.severe(String.format("ChangeSet %s encountered an exception.", toString(false)), e);
+            // Drop the throwable: (1) this catch block rethrows, so attaching the exception here
+            // would report the same failure twice (once here, once at the rethrow site);
+            // (2) Logback appends the full stack trace to any log record carrying a Throwable
+            // regardless of level — under quiet logging configurations this SEVERE record fires
+            // and the stack trace floods the console. Exception detail is surfaced by
+            // handleException at the appropriate verbosity level.
+            log.severe(String.format("ChangeSet %s encountered an exception.", toString(false)));
             setErrorMsg(e.getMessage());
 
             //


### PR DESCRIPTION
## Summary

- `ChangeSet.execute()` catches an exception, logs it as SEVERE, then rethrows. Attaching the `Throwable` to the `log.severe()` call causes the same failure to be reported twice: once here, once at the rethrow site.
- Additionally, Logback appends the full stack trace to any log record carrying a `Throwable` regardless of the configured log level. Under quiet logging configurations where this SEVERE record fires but lower-level records are suppressed, the stack trace floods the console.
- The exception detail is not lost: `setErrorMsg(e.getMessage())` retains the message, and `handleException` surfaces the full stack trace at the appropriate verbosity level.

## Test plan

- [ ] Reproduce with a changelog that triggers a changeset failure — verify the stack trace no longer appears twice in the output
- [ ] Verify stack traces still appear as expected under verbose/debug log levels
- [ ] Existing `ChangeSetTest` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)