### PR TITLE
fix: publish the branch-named artifacts at 0-SNAPSHOT too

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,8 +172,9 @@ jobs:
 
           # keep temp-artifact's 0-SNAPSHOT jars, the build below cleans these modules
           mkdir -p prebuilt
-          cp liquibase-maven-plugin/target/liquibase-maven-plugin-0-SNAPSHOT*.jar prebuilt/
-          cp liquibase-cli/target/liquibase-cli-0-SNAPSHOT*.jar prebuilt/
+          for i in 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-extension-testing'; do
+            cp $i/target/$i-0-SNAPSHOT*.jar prebuilt/
+          done
 
           ./mvnw -B -pl liquibase-dist,liquibase-maven-plugin,liquibase-extension-testing -am source:jar clean package failsafe:integration-test failsafe:verify \
           "-Dbuild.repository.owner=liquibase" \
@@ -220,11 +221,15 @@ jobs:
           mkdir artifacts-named
 
           cp liquibase-dist/target/liquibase-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT.tar.gz artifacts-named/liquibase-${{ needs.setup.outputs.thisBranchName }}.tar.gz
-          cp liquibase-extension-testing/target/liquibase-extension-testing-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT-deps.jar artifacts-named/liquibase-extension-testing-${{ needs.setup.outputs.thisBranchName }}-deps.jar
 
-          for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-extension-testing'; do
-            cp $i/target/$i-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT.jar artifacts-named/$i-${{ needs.setup.outputs.thisBranchName }}.jar
+          # liquibase-sdk:install-snapshot installs everything from here at 0-SNAPSHOT, so these
+          # carry that version inside even though the file name says the branch
+          cp prebuilt/liquibase-extension-testing-0-SNAPSHOT-deps.jar artifacts-named/liquibase-extension-testing-${{ needs.setup.outputs.thisBranchName }}-deps.jar
+          for i in 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-extension-testing'; do
+            cp prebuilt/$i-0-SNAPSHOT.jar artifacts-named/$i-${{ needs.setup.outputs.thisBranchName }}.jar
           done
+
+          cp liquibase-core/target/liquibase-core-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT.jar artifacts-named/liquibase-core-${{ needs.setup.outputs.thisBranchName }}.jar
 
       - name: Archive Packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,7 +172,7 @@ jobs:
 
           # keep temp-artifact's 0-SNAPSHOT jars, the build below cleans these modules
           mkdir -p prebuilt
-          for i in 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-extension-testing'; do
+          for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-extension-testing'; do
             cp $i/target/$i-0-SNAPSHOT*.jar prebuilt/
           done
 
@@ -222,14 +222,12 @@ jobs:
 
           cp liquibase-dist/target/liquibase-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT.tar.gz artifacts-named/liquibase-${{ needs.setup.outputs.thisBranchName }}.tar.gz
 
-          # liquibase-sdk:install-snapshot installs everything from here at 0-SNAPSHOT, so these
-          # carry that version inside even though the file name says the branch
+          # liquibase-sdk:install-snapshot runs install-file over these without coordinates, so maven
+          # reads the embedded pom: they need 0-SNAPSHOT inside even though the file name says the branch
           cp prebuilt/liquibase-extension-testing-0-SNAPSHOT-deps.jar artifacts-named/liquibase-extension-testing-${{ needs.setup.outputs.thisBranchName }}-deps.jar
-          for i in 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-extension-testing'; do
+          for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-extension-testing'; do
             cp prebuilt/$i-0-SNAPSHOT.jar artifacts-named/$i-${{ needs.setup.outputs.thisBranchName }}.jar
           done
-
-          cp liquibase-core/target/liquibase-core-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT.jar artifacts-named/liquibase-core-${{ needs.setup.outputs.thisBranchName }}.jar
 
       - name: Archive Packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)

Fixes #7903

## Description

#7908 fixed the `artifacts/` directory but not its sibling `artifacts-named/`, which is what
`liquibase-sdk:install-snapshot` actually consumes.

That mojo runs `install-file` with the file and nothing else, so Maven takes the coordinates
from the pom embedded in each jar. Two mismatches came out of that:

- the maven plugin's `plugin.xml` said `<branch>-SNAPSHOT` while `install-file` landed the jar at
  `0-SNAPSHOT` (its embedded `pom.xml` says `0-SNAPSHOT`), so Maven rejected the descriptor
- `liquibase-core`'s embedded pom says `<branch>-SNAPSHOT`, so core landed at `<branch>-SNAPSHOT`
  while the plugin pom asks for `liquibase-core:0-SNAPSHOT`, so the runtime realm did not resolve

Taking all four jars from `prebuilt/` gives them one consistent `0-SNAPSHOT` across `pom.xml`,
`pom.properties` and `plugin.xml`. The file name still carries the branch, which is what
`install-snapshot` looks up.

## Release note

## Things to be aware of

Verified against the real `liquibase-artifacts-main` from run `31736306343`, replaying the
workflow over that run's `temp-artifact`, installing with `install-file` the way the mojo does,
into an isolated local repository, then running the goal the harnesses actually use:

```
before   Invalid plugin descriptor for org.liquibase:liquibase-maven-plugin:0-SNAPSHOT,
         Plugin's descriptor contains the wrong version: main-SNAPSHOT
after    The database URL has not been specified
```

The second one is the mojo running, so the descriptor validated and the realm resolved.

Where each jar lands with `install-file`:

```
before   liquibase-core/main-SNAPSHOT      liquibase-maven-plugin/0-SNAPSHOT
after    liquibase-core/0-SNAPSHOT         liquibase-maven-plugin/0-SNAPSHOT
```

## Things to worry about

`build.yml` runs on push, so this cannot be exercised end to end from the PR itself.

The jars published today are internally inconsistent: the plugin's `pom.xml` says `0-SNAPSHOT`
while its `pom.properties` and `plugin.xml` say `<branch>-SNAPSHOT`. This PR sidesteps that by
publishing the untouched 0-SNAPSHOT build rather than reconciling the branch-versioned one.

## Additional Context
