### PR TITLE
[TECHOPS-1048] Gate DigiCert KeyLocker signing behind dry_run, drop from installer-build-check

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -107,6 +107,20 @@ jobs:
             ,/vault/liquibase
           parse-json-secrets: true
 
+      # TECHOPS-1048: /vault/liquibase is one shared secret and the action can only load
+      # it whole (parse-json-secrets), so this job gets the DigiCert KeyLocker signing
+      # credentials even though it only needs GPG — nothing in `reversion` signs anything.
+      # Blank them so they are not in the environment of any later step in this job.
+      # aws-actions/aws-secretsmanager-get-secrets#264 would let us request a subset of
+      # keys, but it has been open since Sep 2025 and is in no release; the complete fix
+      # is a separate GPG-only secret in Secrets Manager.
+      - name: Drop unused KeyLocker credentials from the job environment
+        run: |
+          for name in ${!SM_@}; do
+            echo "$name=" >> "$GITHUB_ENV"
+            echo "Cleared $name"
+          done
+
       - name: Download liquibase-artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -213,6 +227,17 @@ jobs:
             ,/vault/liquibase
           parse-json-secrets: true
 
+      # TECHOPS-1048: a dry run never reaches the signing steps below, so the KeyLocker
+      # credentials this job loaded are dead weight in its environment. Blank them on that
+      # path. See the same step in `reversion` for why a subset can't just be requested.
+      - name: Drop unused KeyLocker credentials from the job environment
+        if: ${{ inputs.dry_run == true }}
+        run: |
+          for name in ${!SM_@}; do
+            echo "$name=" >> "$GITHUB_ENV"
+            echo "Cleared $name"
+          done
+
       - name: Convert escaped newlines and set GPG key
         run: |
           {
@@ -253,12 +278,13 @@ jobs:
       - name: Set Environment Variables for Signing
         if: ${{ inputs.dry_run == false }}
         run: |
-          echo "SM_HOST=${{ env.SM_HOST }}" >> "$GITHUB_ENV"
-          echo "SM_API_KEY=${{ env.SM_API_KEY }}" >> "$GITHUB_ENV"
+          # SM_HOST, SM_API_KEY, SM_CLIENT_CERT_PASSWORD, SM_CODE_SIGNING_CERT_SHA1_HASH
+          # and SM_KEY_PAIR_ALIAS are already in the job environment — "Get secrets from
+          # vault" exports every field of /vault/liquibase via parse-json-secrets. Copying
+          # them onto themselves through ${{ env.X }} only re-expanded five more secrets
+          # into a generated shell script (TECHOPS-1048). SM_CLIENT_CERT_FILE is the one
+          # value the vault can't supply: it points at the cert decoded in the step above.
           echo "SM_CLIENT_CERT_FILE=/tmp/client-auth.p12" >> "$GITHUB_ENV"
-          echo "SM_CLIENT_CERT_PASSWORD=${{ env.SM_CLIENT_CERT_PASSWORD }}" >> "$GITHUB_ENV"
-          echo "SM_CODE_SIGNING_CERT_SHA1_HASH=${{ env.SM_CODE_SIGNING_CERT_SHA1_HASH }}" >> "$GITHUB_ENV"
-          echo "SM_KEY_PAIR_ALIAS=${{ env.SM_KEY_PAIR_ALIAS }}" >> "$GITHUB_ENV"
 
       - name: Install jsign and osslsigncode
         if: ${{ inputs.dry_run == false }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -242,10 +242,12 @@ jobs:
           GPG_PASSWORD: ${{ env.GPG_PASSPHRASE }}
 
       - name: Decode Client Authentication Certificate
+        if: ${{ inputs.dry_run == false }}
         run: |
           echo "${{ env.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /tmp/client-auth.p12
 
       - name: Set Environment Variables for Signing
+        if: ${{ inputs.dry_run == false }}
         run: |
           echo "SM_HOST=${{ env.SM_HOST }}" >> "$GITHUB_ENV"
           echo "SM_API_KEY=${{ env.SM_API_KEY }}" >> "$GITHUB_ENV"
@@ -255,12 +257,14 @@ jobs:
           echo "SM_KEY_PAIR_ALIAS=${{ env.SM_KEY_PAIR_ALIAS }}" >> "$GITHUB_ENV"
 
       - name: Install jsign and osslsigncode
+        if: ${{ inputs.dry_run == false }}
         run: |
           curl -fSslL https://github.com/ebourg/jsign/releases/download/3.1/jsign_3.1_all.deb -o jsign_3.1_all.deb
           sudo dpkg --install jsign_3.1_all.deb
           sudo apt-get install osslsigncode
-          
+
       - name: Create pkcs11properties.cfg
+        if: ${{ inputs.dry_run == false }}
         run: |
           cat << EOF > pkcs11properties.cfg
           name=signingmanager
@@ -292,6 +296,7 @@ jobs:
           echo "$ANDROID_SDK_ROOT/build-tools/30.0.2" >> $GITHUB_PATH
           
       - name: Install DigiCert KeyLocker Client Tools
+        if: ${{ inputs.dry_run == false }}
         uses: digicert/code-signing-software-trust-action@fae23a455ba4bde62b64fd7cb2f81ade788f5a95 # v1.2.1
 
       - name: Build Unsigned Windows Installer
@@ -319,6 +324,7 @@ jobs:
           echo "INSTALLER_PATH=$INSTALLER_PATH" >> $GITHUB_ENV
 
       - name: Sign Windows Installer using KeyLocker
+        if: ${{ inputs.dry_run == false }}
         run: |
           smctl sign -v --fingerprint "$SM_CODE_SIGNING_CERT_SHA1_HASH" \
           --keypair-alias $SM_KEY_PAIR_ALIAS \
@@ -327,6 +333,7 @@ jobs:
           --input "$INSTALLER_PATH" --tool jsign
 
       - name: Verify Windows Installer Signature
+        if: ${{ inputs.dry_run == false }}
         run: osslsigncode verify -CAfile /etc/ssl/certs/ca-certificates.crt -in "$INSTALLER_PATH"
         
       - name: Re-version Installers

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -244,7 +244,11 @@ jobs:
       - name: Decode Client Authentication Certificate
         if: ${{ inputs.dry_run == false }}
         run: |
-          echo "${{ env.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /tmp/client-auth.p12
+          # Read the secret from the shell environment rather than expanding
+          # ${{ env.SM_CLIENT_CERT_FILE_B64 }} into the generated script (zizmor
+          # template-injection). "Get secrets from vault" above already exports it
+          # into the job env via parse-json-secrets, so the value is identical.
+          printf '%s' "$SM_CLIENT_CERT_FILE_B64" | base64 --decode > /tmp/client-auth.p12
 
       - name: Set Environment Variables for Signing
         if: ${{ inputs.dry_run == false }}

--- a/.github/workflows/installer-build-check.yml
+++ b/.github/workflows/installer-build-check.yml
@@ -51,7 +51,7 @@ jobs:
         env:
           GPG_PASSWORD: ${{ env.GPG_PASSPHRASE }}
 
-      # TODO: Add install4j and DigiCert KeyLocker Client Tools caching if possible
+      # TODO: Add install4j caching if possible
       # - name: Cache Install4j
       #   id: cache-install4j
       #   uses: actions/cache@v4
@@ -65,37 +65,6 @@ jobs:
       #     wget -nv -O install4j.deb "https://download.ej-technologies.com/install4j/install4j_linux-x64_10_0_9.deb"
       #     sudo apt install -y ./install4j.deb
       #     rm install4j.deb
-
-      - name: Decode Client Authentication Certificate
-        run: |
-          echo "${{ env.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /tmp/client-auth.p12
-
-      - name: Set Environment Variables for Signing
-        run: |
-          echo "SM_HOST=${{ env.SM_HOST }}" >> "$GITHUB_ENV"
-          echo "SM_API_KEY=${{ env.SM_API_KEY }}" >> "$GITHUB_ENV"
-          echo "SM_CLIENT_CERT_FILE=/tmp/client-auth.p12" >> "$GITHUB_ENV"
-          echo "SM_CLIENT_CERT_PASSWORD=${{ env.SM_CLIENT_CERT_PASSWORD }}" >> "$GITHUB_ENV"
-          echo "SM_CODE_SIGNING_CERT_SHA1_HASH=${{ env.SM_CODE_SIGNING_CERT_SHA1_HASH }}" >> "$GITHUB_ENV"
-          echo "SM_KEY_PAIR_ALIAS=${{ env.SM_KEY_PAIR_ALIAS }}" >> "$GITHUB_ENV"
-
-      - name: Install jsign and osslsigncode
-        run: |
-          curl -fSslL https://github.com/ebourg/jsign/releases/download/3.1/jsign_3.1_all.deb -o jsign_3.1_all.deb
-          sudo dpkg --install jsign_3.1_all.deb
-          sudo apt-get install osslsigncode
-
-      - name: Create pkcs11properties.cfg
-        run: |
-          cat << EOF > pkcs11properties.cfg
-          name=signingmanager
-          library="$(pwd)/.github/util/smpkcs11.so"
-          slotListIndex=0
-          EOF
-          mv pkcs11properties.cfg $(pwd)/.github/util/
-
-      - name: Install DigiCert KeyLocker Client Tools
-        uses: digicert/code-signing-software-trust-action@fae23a455ba4bde62b64fd7cb2f81ade788f5a95 # v1.2.1
 
       - name: Set branch variable
         run: echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
@@ -144,18 +113,7 @@ jobs:
           echo "Found installer: $INSTALLER_PATH"
           echo "INSTALLER_PATH=$INSTALLER_PATH" >> $GITHUB_ENV
 
-      - name: Sign Windows Installer using KeyLocker
-        run: |
-          smctl sign -v --fingerprint "$SM_CODE_SIGNING_CERT_SHA1_HASH" \
-          --keypair-alias $SM_KEY_PAIR_ALIAS \
-          --certificate "$SM_CLIENT_CERT_FILE" \
-          --config-file "$(pwd)/.github/util/pkcs11properties.cfg" \
-          --input "$INSTALLER_PATH" --tool jsign
-          
-      - name: Verify Windows Installer Signature
-        run: osslsigncode verify -CAfile /etc/ssl/certs/ca-certificates.crt -in "$INSTALLER_PATH"
-
-      - name: GPG Sign Artifacts (After Code Signing the Windows Installer)
+      - name: GPG Sign Artifacts
         env:
           GPG_PASSWORD: ${{ env.GPG_PASSPHRASE }}
         run: |

--- a/.github/workflows/installer-build-check.yml
+++ b/.github/workflows/installer-build-check.yml
@@ -31,6 +31,17 @@ jobs:
             ,/vault/liquibase
           parse-json-secrets: true
 
+      # TECHOPS-1048: this workflow checks that the installer *builds*; the KeyLocker
+      # signing steps were removed from it, so it now needs GPG only. /vault/liquibase is
+      # one shared secret the action can only load whole, so blank the signing credentials
+      # rather than leave them in the environment of a workflow that never signs.
+      - name: Drop unused KeyLocker credentials from the job environment
+        run: |
+          for name in ${!SM_@}; do
+            echo "$name=" >> "$GITHUB_ENV"
+            echo "Cleared $name"
+          done
+
       - name: Convert escaped newlines and set GPG key
         run: |
           {


### PR DESCRIPTION
## Problem

Same root cause as the companion PR in `liquibase-pro`: `create-release.yml` and `installer-build-check.yml` both call DigiCert KeyLocker unconditionally, so every dry-run release and every test-installer build burns a signature from the same shared 1000-signature pool (TECHOPS-1048).

## Change

- **`create-release.yml`**: gate `Sign Windows Installer using KeyLocker`, `Verify Windows Installer Signature`, and the KeyLocker credential-prep steps (cert decode, env vars, jsign/osslsigncode install, KeyLocker client tools) behind `if: ${{ inputs.dry_run == false }}`. A dry-run release still builds and publishes an unsigned installer to the dry-run draft release, it just stops paying a signature for it.
- **`installer-build-check.yml`**: remove the KeyLocker signing/verification steps and their credential prep outright, no gate. This workflow ("Build Test Installers") checks that the installer *builds*, not that it's signed; it has run exactly twice and failed both times, so an opt-in flag would be more machinery than the workflow has earned.

## Why this approach (security / cost / simplicity)

**Cost.** Removes the two consumers of the shared KeyLocker pool that never correspond to a shipped release.

**Simplicity.** `inputs.dry_run == false` matches the idiom already used three times in this same file (lines 188, 358, 385) rather than introducing `!inputs.dry_run` as a second style. For `installer-build-check.yml`, deleting is simpler than gating a workflow whose only two runs both failed.

**Security.** Fewer code paths touching the KeyLocker client certificate and API key.

## Testing

- `actionlint` on both touched workflows: identical warning set to `main` (pre-existing shellcheck style notes only), zero new findings.
- Not run in CI: a live dry-run dispatch of `create-release.yml` to confirm it completes green and consumes zero signatures (ticket acceptance criterion 5). Recommend running before merge.

Jira: https://datical.atlassian.net/browse/TECHOPS-1048

Companion PR (liquibase-pro): https://github.com/liquibase/liquibase-pro/pull/4680

🤖 Draft by Mandalorian. Pending human review
