### PR TITLE
Fix the SonarCloud quality gate: suppress false-positive S3077 on two safely-published volatile fields

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/Scope.java
+++ b/liquibase-standard/src/main/java/liquibase/Scope.java
@@ -103,7 +103,12 @@ public class Scope {
      * threads created before Liquibase initialized, or from another thread lineage) adopt this root
      * instead of bootstrapping a second one with their own context classloader, which produced
      * "not a subtype" ServiceLoader failures and split-brain singletons (#6880).
+     * <p>
+     * S3077: volatile is the right guarantee here rather than an insufficient one. The scope is fully
+     * populated as a local before this field is assigned, and its {@code values} map is never mutated
+     * afterwards, so the volatile write safely publishes an effectively immutable object.
      */
+    @SuppressWarnings("java:S3077")
     private static volatile Scope rootScope;
 
     /**

--- a/liquibase-standard/src/main/java/liquibase/configuration/LiquibaseConfiguration.java
+++ b/liquibase-standard/src/main/java/liquibase/configuration/LiquibaseConfiguration.java
@@ -46,7 +46,14 @@ public class LiquibaseConfiguration implements SingletonObject {
      */
     public static final String SCOPED_VALUE_PROVIDERS_KEY = "liquibase.scopedValueProviders";
 
-    // Immutable snapshot replaced on every mutation, so resolution never sees a half-updated set.
+    /**
+     * Immutable snapshot replaced on every mutation, so resolution never sees a half-updated set.
+     * <p>
+     * S3077: the published set is never mutated in place. {@link #registerProvider} and
+     * {@link #unregisterProvider} copy into a new {@code TreeSet} and reassign, so volatile on the
+     * reference is exactly the right guarantee rather than an insufficient one.
+     */
+    @SuppressWarnings("java:S3077")
     private volatile SortedSet<ConfigurationValueProvider> configurationValueProviders;
     private final static SortedSet<ConfigurationDefinition<?>> definitions = new TreeSet<>();
     public static final String REGISTERED_VALUE_PROVIDERS_KEY = "REGISTERED_VALUE_PROVIDERS";


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Fixes the failing SonarCloud quality gate on `main`. No logic changes — two `@SuppressWarnings("java:S3077")` annotations plus the reasoning behind them.

### What is actually failing

The gate fails exactly one condition:

| Condition | Actual | Required |
|---|---|---|
| `new_reliability_rating` | 2 (B) | 1 (A) |
| new_security_rating | 1 (A) | ✅ |
| new_maintainability_rating | 1 (A) | ✅ |
| new_coverage | 7.3 | ✅ |
| new_duplicated_lines_density | 0.1 | ✅ |
| new_security_hotspots_reviewed | 100% | ✅ |

There are 9 open bugs on `main`, but only two sit in the new-code period, and both are MINOR `java:S3077` ("non-primitive fields should not be `volatile`"):

- `liquibase/Scope.java:107` — `private static volatile Scope rootScope;`
- `liquibase/configuration/LiquibaseConfiguration.java:50` — `private volatile SortedSet<ConfigurationValueProvider> configurationValueProviders;`

The other seven are MAJOR and sit in old code. That they are not involved is provable from the rating itself: a MAJOR finding in new code forces reliability to C (3), and the gate reports B (2), so the worst new-code bug is MINOR — these two.

They arrived with the recent concurrency work (#7825 MDC-per-thread, #7848 service discovery), not with the recent Sonar cleanup in #7892.

### Why both are false positives

S3077's actual concern is that `volatile` publishes the *reference* safely but says nothing about the object's contents. That concern does not apply to either field, and the surrounding code already establishes why:

**`Scope.rootScope`** — the scope is fully populated on a local (`newRootScope`) before the volatile assignment, and `values` is a `private final SmartMap` that is never mutated after publication. A volatile write after full construction creates the happens-before edge that makes this a safe publication of an effectively immutable object.

**`LiquibaseConfiguration.configurationValueProviders`** — textbook copy-on-write. Every mutation builds a fresh `TreeSet` and reassigns (lines 82–84, 91–93, 102–104); nothing ever calls `add()`/`remove()` on the published set, and readers receive `Collections.unmodifiableSortedSet(...)` or a copy. `volatile` on the reference is precisely the right guarantee.

### Why suppression rather than a code change

`Scope.scopeManager`, nine lines above `rootScope` in the same file, already carries this exact annotation for the same reason:

```java
@SuppressWarnings("java:S3077")
private static volatile InheritableThreadLocal<ScopeManager> scopeManager;
```

That field is absent from Sonar's issue list while `rootScope` is present — which is what confirms the suppression is honoured and that this call has already been made in this file. This change follows the established precedent instead of inventing a new convention.

## Release note

<!-- Not customer-facing: CI/static-analysis only. skipReleaseNotes applied. -->

## Things to be aware of

- Comments were added alongside each annotation so the next reader does not have to re-derive why `volatile` is sufficient. A bare suppression would just move the question.
- The alternative that satisfies the rule structurally is `AtomicReference<…>` for both fields. I did not take it: it is a real change to correct concurrent code across all six read/write sites of `configurationValueProviders`, to appease a rule that is wrong about this code.

## Things to worry about

I inferred "these two and only these two are in new code" from the B rating rather than from a direct query — SonarCloud's `inNewCodePeriod` issue filter did not apply reliably for me, and the new-code period metadata came back empty from the API. The inference is sound (a MAJOR in new code would report C), but the definitive confirmation is the gate result on this branch's scan.

If the gate still reports B after this merges, the next step is to pull the new-code issue list from the UI rather than the API and re-triage — I would not expect that, but it is the fallback.

Separately, and not addressed here: the seven MAJOR findings on `main` are the documented false positives from #7892 and are still awaiting Won't Fix triage in the SonarCloud UI. They do not affect this gate, but main's bug count of 9 overstates reality until they are dismissed.

## Additional Context

Verified locally: `ScopeTest`, `LiquibaseConfigurationTest`, `GlobalConfigurationTest` (both packages) — 39 tests, all passing, plus a clean `liquibase-standard` compile.
