### PR TITLE
Fix ExceptionDetails.exception missing leading newline; close unclosed PrintWriter

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/logging/mdc/customobjects/ExceptionDetails.java
+++ b/liquibase-standard/src/main/java/liquibase/logging/mdc/customobjects/ExceptionDetails.java
@@ -38,8 +38,12 @@ public class ExceptionDetails implements CustomMdcObject {
             this.primaryExceptionReason = primaryException.getMessage();
             this.primaryExceptionSource = source;
             StringWriter stringWriter = new StringWriter();
-            PrintWriter printWriter = new PrintWriter(stringWriter);
-            exception.printStackTrace(printWriter);
+            try (PrintWriter printWriter = new PrintWriter(stringWriter)) {
+                // Leading newline matches StructuredLogFormatter / LogbackStructuredJsonEncoder.formatThrowable()
+                // so all "exception" fields in structured JSON output are consistent.
+                printWriter.println();
+                exception.printStackTrace(printWriter);
+            }
             this.exception = stringWriter.toString();
         }
     }


### PR DESCRIPTION
## Summary

- `ExceptionDetails(Throwable, String)` built the `exception` field via `printStackTrace()` with no preceding `println()`, so the stack trace started immediately on the first character with no leading newline.
- `StructuredLogFormatter.formatThrowable()` and `LogbackStructuredJsonEncoder.formatThrowable()` both call `println()` first, so all top-level `"exception"` fields in structured JSON output had a leading `\n` while `exceptionDetails.exception` (populated from this class via MDC) did not.
- The `PrintWriter` was also left unclosed.

**Fix:** wrap `PrintWriter` in try-with-resources and call `printWriter.println()` before `printStackTrace()`, matching the behaviour of the two formatters.

## Test plan

- [ ] Verify `ExceptionDetailsSpec` (new unit tests in liquibase-pro) passes
- [ ] Confirm structured JSON log output: `exceptionDetails.exception` begins with `\n` consistently with top-level `exception` field

Relates to liquibase/liquibase-pro#4692