### PR TITLE
Fix: skip leading comment/blank lines before reading the CSV header in loadData

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/change/core/LoadDataChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/LoadDataChange.java
@@ -243,7 +243,14 @@ public class LoadDataChange extends AbstractTableChange implements ChangeWithCol
                 throw new UnexpectedLiquibaseException("Unable to read file " + this.getFile());
             }
 
-            String[] headers = reader.readNext();
+            boolean isCommentingEnabled = StringUtils.isNotEmpty(commentLineStartsWith);
+
+            // Skip any blank or commented lines preceding the header, so a leading comment (e.g. a "#"
+            // line describing the file) isn't mistaken for the header row -- see #4434.
+            String[] headers;
+            do {
+                headers = reader.readNext();
+            } while ((headers != null) && isSkippableLine(headers, isCommentingEnabled));
             if (headers == null) {
                 throw new UnexpectedLiquibaseException("Data file " + getFile() + " was empty");
             }
@@ -262,15 +269,10 @@ public class LoadDataChange extends AbstractTableChange implements ChangeWithCol
             // Start at '1' to take into account the header (already processed):
             int lineNumber = 1;
 
-            boolean isCommentingEnabled = StringUtils.isNotEmpty(commentLineStartsWith);
-
             List<LoadDataRowConfig> rows = new ArrayList<>();
             while ((line = reader.readNext()) != null) {
                 lineNumber++;
-                if
-                ((line.length == 0) || ((line.length == 1) && (StringUtils.trimToNull(line[0]) == null)) ||
-                        (isCommentingEnabled && isLineCommented(line))
-                ) {
+                if (isSkippableLine(line, isCommentingEnabled)) {
                     //nothing interesting on this line
                     continue;
                 }
@@ -704,6 +706,11 @@ public class LoadDataChange extends AbstractTableChange implements ChangeWithCol
 
     private boolean isLineCommented(String[] line) {
         return StringUtils.startsWith(line[0], commentLineStartsWith);
+    }
+
+    private boolean isSkippableLine(String[] line, boolean isCommentingEnabled) {
+        return (line.length == 0) || ((line.length == 1) && (StringUtils.trimToNull(line[0]) == null)) ||
+                (isCommentingEnabled && isLineCommented(line));
     }
 
     @Override

--- a/liquibase-standard/src/main/java/liquibase/change/core/LoadDataChange.java
+++ b/liquibase-standard/src/main/java/liquibase/change/core/LoadDataChange.java
@@ -246,10 +246,15 @@ public class LoadDataChange extends AbstractTableChange implements ChangeWithCol
             boolean isCommentingEnabled = StringUtils.isNotEmpty(commentLineStartsWith);
 
             // Skip any blank or commented lines preceding the header, so a leading comment (e.g. a "#"
-            // line describing the file) isn't mistaken for the header row -- see #4434.
+            // line describing the file) isn't mistaken for the header row -- see #4434. Count them, so
+            // line numbers reported in errors below still refer to the real position in the file.
+            int lineNumber = 0;
             String[] headers;
             do {
                 headers = reader.readNext();
+                if (headers != null) {
+                    lineNumber++;
+                }
             } while ((headers != null) && isSkippableLine(headers, isCommentingEnabled));
             if (headers == null) {
                 throw new UnexpectedLiquibaseException("Data file " + getFile() + " was empty");
@@ -266,8 +271,6 @@ public class LoadDataChange extends AbstractTableChange implements ChangeWithCol
             }
 
             String[] line;
-            // Start at '1' to take into account the header (already processed):
-            int lineNumber = 1;
 
             List<LoadDataRowConfig> rows = new ArrayList<>();
             while ((line = reader.readNext()) != null) {

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
@@ -1017,6 +1017,23 @@ class LoadDataChangeTest extends StandardChangeTest {
         assert columnValue(sqlStatements[1], "username") == "jdoe"
     }
 
+    def "validate a leading comment line in a CSV file is not mistaken for the header (#4434)"() {
+        when:
+        def table = testTable("table")
+        SnapshotGeneratorFactory.instance = new MockSnapshotGeneratorFactory(table)
+
+        LoadDataChange change = new LoadDataChange()
+        change.setFile("liquibase/change/core/sample.data.with.leading.comment.csv")
+        change.setTableName("table")
+
+        SqlStatement[] sqlStatements = change.generateStatements(mockDB)
+
+        then:
+        sqlStatements.length == 2
+        assert columnValue(sqlStatements[0], "username") == "bjohnson"
+        assert columnValue(sqlStatements[1], "username") == "jdoe"
+    }
+
 
 
     class ColDef {

--- a/liquibase-standard/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/change/core/LoadDataChangeTest.groovy
@@ -13,6 +13,7 @@ import liquibase.database.DatabaseFactory
 import liquibase.database.core.H2Database
 import liquibase.database.core.MSSQLDatabase
 import liquibase.database.core.MockDatabase
+import liquibase.exception.UnexpectedLiquibaseException
 import liquibase.exception.ValidationErrors
 import liquibase.parser.core.ParsedNode
 import liquibase.parser.core.ParsedNodeException
@@ -1032,6 +1033,25 @@ class LoadDataChangeTest extends StandardChangeTest {
         sqlStatements.length == 2
         assert columnValue(sqlStatements[0], "username") == "bjohnson"
         assert columnValue(sqlStatements[1], "username") == "jdoe"
+    }
+
+    def "validate the reported line number still matches the file after a leading comment is skipped (#4434)"() {
+        when:
+        def table = testTable("table")
+        SnapshotGeneratorFactory.instance = new MockSnapshotGeneratorFactory(table)
+
+        LoadDataChange change = new LoadDataChange()
+        change.setFile("liquibase/change/core/sample.data.with.leading.comment.and.bad.row.csv")
+        change.setTableName("table")
+
+        change.generateStatements(mockDB)
+
+        then:
+        def e = thrown(UnexpectedLiquibaseException)
+        // Line 1 is the skipped comment, line 2 is the header, line 3 is a valid row,
+        // so the malformed row is line 4 -- not line 3, which is what a naive count
+        // (starting from 1 at the header) would report after skipping the comment.
+        e.message.contains("Line 4")
     }
 
 

--- a/liquibase-standard/src/test/resources/liquibase/change/core/sample.data.with.leading.comment.and.bad.row.csv
+++ b/liquibase-standard/src/test/resources/liquibase/change/core/sample.data.with.leading.comment.and.bad.row.csv
@@ -1,0 +1,4 @@
+#This is a comment describing the file, not the header
+name,username
+Bob Johnson,bjohnson
+BadRowMissingAColumn

--- a/liquibase-standard/src/test/resources/liquibase/change/core/sample.data.with.leading.comment.csv
+++ b/liquibase-standard/src/test/resources/liquibase/change/core/sample.data.with.leading.comment.csv
@@ -1,0 +1,4 @@
+#This is a comment describing the file, not the header
+name,username
+Bob Johnson,bjohnson
+John Doe,jdoe


### PR DESCRIPTION
## Summary
Fixes #4434 - a CSV file starting with a comment line (default `#`) or a blank line has that line misparsed as the header, so every data row after it fails with a column-count mismatch.

`generateStatements()` read the first line unconditionally as the header, even though comment/blank lines were already being skipped for data rows via `commentLineStartsWith`/`isLineCommented`. This applies the same skip check before the header is read too, via a shared `isSkippableLine()` helper (also used by the data-row loop, replacing the inline duplicate). `loadUpdateData` gets the fix too since it extends `LoadDataChange`.

## Test plan
- [x] New test + CSV fixture reproducing the exact reported scenario (leading `#` comment before the header)
- [x] Verified the new test fails against the pre-fix code (misparses the comment as header, 3 statements instead of 2) and passes with the fix
- [x] `LoadDataChangeTest`/`LoadUpdateDataChangeTest` suites pass (54 + 19 tests)