### PR TITLE
Allow sequence startValue and incrementBy on Firebird

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateSequenceGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/CreateSequenceGenerator.java
@@ -25,8 +25,10 @@ public class CreateSequenceGenerator extends AbstractSqlGenerator<CreateSequence
 
         validationErrors.checkRequiredField("sequenceName", statement.getSequenceName());
 
-        validationErrors.checkDisallowedField("startValue", statement.getStartValue(), database, FirebirdDatabase.class);
-        validationErrors.checkDisallowedField("incrementBy", statement.getIncrementBy(), database, FirebirdDatabase.class);
+        if (isFirebirdWithoutStartValueSupport(database)) {
+            validationErrors.checkDisallowedField("startValue", statement.getStartValue(), database, FirebirdDatabase.class);
+            validationErrors.checkDisallowedField("incrementBy", statement.getIncrementBy(), database, FirebirdDatabase.class);
+        }
 
         if (isH2WithMinMaxSupport(database)) {
 
@@ -151,6 +153,15 @@ public class CreateSequenceGenerator extends AbstractSqlGenerator<CreateSequence
             return database instanceof PostgresDatabase && database.getDatabaseMajorVersion() < 10;
         } catch (DatabaseException e) {
             // we can't determine the PostgreSQL version so we shouldn't throw validation error as it might work for this DB
+            return false;
+        }
+    }
+
+    private boolean isFirebirdWithoutStartValueSupport(Database database) {
+        try {
+            return database instanceof FirebirdDatabase && database.getDatabaseMajorVersion() < 4;
+        } catch (DatabaseException e) {
+            // we can't determine the Firebird version so we shouldn't throw validation error as it might work for this DB
             return false;
         }
     }

--- a/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/CreateSequenceGeneratorTest.java
+++ b/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/CreateSequenceGeneratorTest.java
@@ -2,6 +2,7 @@ package liquibase.sqlgenerator.core;
 
 import liquibase.database.Database;
 import liquibase.database.DatabaseConnection;
+import liquibase.database.core.FirebirdDatabase;
 import liquibase.database.core.H2Database;
 import liquibase.database.core.PostgresDatabase;
 import liquibase.database.core.SybaseASADatabase;
@@ -171,6 +172,34 @@ public class CreateSequenceGeneratorTest extends AbstractSqlGeneratorTest<Create
 
         sql = generatorUnderTest.generateSql(stmt, h2Database, new MockSqlGeneratorChain())[0].toSql();
         assertThat(sql).isEqualTo("CREATE SEQUENCE SCHEMA_NAME.SEQUENCE_NAME AS INT");
+    }
+
+    @Test
+    public void firebirdDatabaseSupportStartValueByVersion() throws Exception {
+        DatabaseConnection dbConnection = mock(DatabaseConnection.class);
+        FirebirdDatabase firebirdDatabase = spy(new FirebirdDatabase());
+        firebirdDatabase.setConnection(dbConnection);
+        doReturn(SEQUENCE_NAME).when(firebirdDatabase).escapeSequenceName(CATALOG_NAME, SCHEMA_NAME, SEQUENCE_NAME);
+
+        CreateSequenceStatement stmt = createSampleSqlStatement();
+        stmt.setStartValue(new BigInteger("1000"));
+        stmt.setIncrementBy(ONE);
+
+        // before 4.0 neither clause is supported
+        when(dbConnection.getDatabaseMajorVersion()).thenReturn(3);
+
+        ValidationErrors errors = generatorUnderTest.validate(stmt, firebirdDatabase, new MockSqlGeneratorChain());
+        assertThat(errors.getErrorMessages())
+                .contains("startValue is not allowed on firebird", "incrementBy is not allowed on firebird");
+
+        // since 4.0 both are supported and end up in the generated statement
+        when(dbConnection.getDatabaseMajorVersion()).thenReturn(4);
+
+        errors = generatorUnderTest.validate(stmt, firebirdDatabase, new MockSqlGeneratorChain());
+        assertThat(errors.getErrorMessages()).isEmpty();
+
+        String sql = generatorUnderTest.generateSql(stmt, firebirdDatabase, new MockSqlGeneratorChain())[0].toSql();
+        assertThat(sql).isEqualTo("CREATE SEQUENCE " + SEQUENCE_NAME + " START WITH 1000 INCREMENT BY 1");
     }
 
 //    @Before

--- a/liquibase-standard/src/test/resources/liquibase/change/ChangeDefinitionTest.yaml
+++ b/liquibase-standard/src/test/resources/liquibase/change/ChangeDefinitionTest.yaml
@@ -414,7 +414,7 @@ createSequence: |
     Supported: asany,cockroachdb,db2,db2z,derby,edb,h2,hsqldb,informix,mssql,postgresql
   incrementBy bigInteger 
     Description: Interval between sequence numbers
-    Supported: asany,cockroachdb,db2,db2z,derby,edb,h2,hsqldb,informix,mariadb,mssql,oracle,postgresql
+    Supported: all
   maxValue bigInteger 
     Description: Maximum value of the sequence
     Supported: asany,cockroachdb,db2,db2z,derby,edb,h2,informix,mariadb,mssql,oracle,postgresql
@@ -433,7 +433,7 @@ createSequence: |
     Required For: all
   startValue bigInteger 
     Description: First sequence number to be generated.
-    Supported: asany,cockroachdb,db2,db2z,derby,edb,h2,hsqldb,informix,mariadb,mssql,oracle,postgresql
+    Supported: all
 
 createTable: |
   catalogName string (since 3.0)


### PR DESCRIPTION
## Impact
- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
`CreateSequenceGenerator` rejected `startValue` and `incrementBy` on Firebird unconditionally,
so `<createSequence startValue="1000"/>` failed validation with
`startValue is not allowed on firebird` on every Firebird version.
Firebird only implements the SQL standard `START WITH` semantics since 4.0 (https://github.com/FirebirdSQL/firebird/issues/6615):
earlier versions stored the value as the current generator value, so the first generated
value was off by one increment. The restriction is now version-gated: kept below 4.0,
lifted from 4.0 on. When the version cannot be determined (no live connection), the fields
are allowed, matching how the Postgres and H2 checks in the same class behave.
Covered by a new unit test in `CreateSequenceGeneratorTest`.

## Release note
`createSequence` now accepts `startValue` and `incrementBy` on Firebird 4.0 and later,
instead of failing validation on every Firebird version.

## Things to be aware of
Implemented as `isFirebirdWithoutStartValueSupport(Database)`, mirroring the existing
`isPostgreWithoutAsDatatypeSupport` and `isH2WithoutAsDatatypeSupport` helpers, including
their lenient fallback when the version is unknown. `generateSql` needed no change, since it
already emits `START WITH` and `INCREMENT BY` without excluding Firebird.