### PR TITLE
Revert the fork PR authorize gate removal (#7902, #7906)

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -24,8 +24,15 @@ on:
 
 jobs:
 
+  authorize:
+    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+
   setup:
     name: Setup
+    needs: authorize
     runs-on: ubuntu-22.04
     outputs:
       timeStamp: ${{ steps.get-timestamp.outputs.timestamp }}

--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -21,7 +21,14 @@ permissions:
   
 jobs:
 
+  authorize:
+    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+
   test-harness-build:
+    needs: authorize
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'runFunctional&HarnessTests') || (github.event_name != 'pull_request' && github.event_name != 'pull_request_target')
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,13 +31,20 @@ on:
       - '**.md'
 
 jobs:
-  setup:
-    name: setup
+  authorize:
     #concurrent runs for pull requests from forked repositories will be canceled, while runs for pull requests from the main repository won't be affected.
     #for a pull_request against main: the concurrency check will cancel commit A so that commit B check can run.
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref == 'main' && (github.event_name == 'push' && 'push-to-main' || github.event_name == 'pull_request' && 'merge-to-main') || github.event_name == 'pull_request_target' && github.event.pull_request.number || github.run_id }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' && github.base_ref == 'main' }}
+    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+
+  setup:
+    name: setup
+    needs: [authorize]
     runs-on: ubuntu-24.04
     outputs:
       timestamp: ${{ steps.get-date.outputs.date }}


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)

Reverts #7902 and #7906.

## Description

The `authorize` job carried `environment: external` for fork PRs, and every other job hung off
it: `setup` -> `build_tests` -> `sonar` and `run-build-publish-file`. Those last two read
`/vault/liquibase` with `parse-json-secrets: true`, so the environment's required reviewers were
the only per-run gate between a fork PR and the whole secret bundle.

#7902 removed the environment and #7906 removed the now-empty job. A fork PR reached
`Artifacts - Build & Package` and `sonar` successfully the next day, which is the reachability
evidence in GHSA-mqw2-j77g-6486.

This restores the gate. The duplicate approval comes back, which is what #7902 set out to remove.

## Release note

## Things to be aware of

This is a stopgap, not the fix. Even with the gate, one approval click still runs untrusted fork
code in a job holding the vault, because these workflows build the PR head under
`pull_request_target` with `allow-unsafe-pr-checkout: true`.

The structural fix, and the one that also removes the approval fatigue: build fork code under
`pull_request` (read-only token, no secrets) and move `fossa`, `sonar` and the snapshot publish
to a trusted context that consumes the uploaded artifacts instead of checking out the fork head.
With no secrets in the PR build, the repo-level approval setting can go back to first-time
contributors only, so a returning contributor needs zero clicks.

## Things to worry about

`build.yml` and `build-branch.yml` still publish a SNAPSHOT built from fork code. Worth deciding
whether that should happen for fork PRs at all.

## Additional Context

GHSA-mqw2-j77g-6486
