### PR TITLE
fix(security): mask GPG private key in Actions logs [TECHOPS-1093]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,12 +129,17 @@ jobs:
 
       - name: Convert escaped newlines and set GPG key
         run: |
+          GPG_KEY_CONTENT="$(printf '%b' "${{ env.GPG_SECRET }}")"
           {
             echo "GPG_KEY_CONTENT<<GPG_EOF"
-            printf '%b' "${{ env.GPG_SECRET }}"
+            echo "$GPG_KEY_CONTENT"
             echo
             echo "GPG_EOF"
           } >> $GITHUB_ENV
+          GPG_KEY_CONTENT="${GPG_KEY_CONTENT//%/%25}"
+          GPG_KEY_CONTENT="${GPG_KEY_CONTENT//$'\r'/%0D}"
+          GPG_KEY_CONTENT="${GPG_KEY_CONTENT//$'\n'/%0A}"
+          echo "::add-mask::${GPG_KEY_CONTENT}"
 
       - name: Set up JDK 21
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -137,12 +137,17 @@ jobs:
 
       - name: Convert escaped newlines and set GPG key
         run: |
+          GPG_KEY_CONTENT="$(printf '%b' "${{ env.GPG_SECRET }}")"
           {
             echo "GPG_KEY_CONTENT<<GPG_EOF"
-            printf '%b' "${{ env.GPG_SECRET }}"
+            echo "$GPG_KEY_CONTENT"
             echo
             echo "GPG_EOF"
           } >> $GITHUB_ENV
+          GPG_KEY_CONTENT="${GPG_KEY_CONTENT//%/%25}"
+          GPG_KEY_CONTENT="${GPG_KEY_CONTENT//$'\r'/%0D}"
+          GPG_KEY_CONTENT="${GPG_KEY_CONTENT//$'\n'/%0A}"
+          echo "::add-mask::${GPG_KEY_CONTENT}"
 
       - name: Set up JDK
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
@@ -240,12 +245,17 @@ jobs:
 
       - name: Convert escaped newlines and set GPG key
         run: |
+          GPG_KEY_CONTENT="$(printf '%b' "${{ env.GPG_SECRET }}")"
           {
             echo "GPG_KEY_CONTENT<<GPG_EOF"
-            printf '%b' "${{ env.GPG_SECRET }}"
+            echo "$GPG_KEY_CONTENT"
             echo
             echo "GPG_EOF"
           } >> $GITHUB_ENV
+          GPG_KEY_CONTENT="${GPG_KEY_CONTENT//%/%25}"
+          GPG_KEY_CONTENT="${GPG_KEY_CONTENT//$'\r'/%0D}"
+          GPG_KEY_CONTENT="${GPG_KEY_CONTENT//$'\n'/%0A}"
+          echo "::add-mask::${GPG_KEY_CONTENT}"
 
       - name: Download Completed Artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/installer-build-check.yml
+++ b/.github/workflows/installer-build-check.yml
@@ -44,12 +44,17 @@ jobs:
 
       - name: Convert escaped newlines and set GPG key
         run: |
+          GPG_KEY_CONTENT="$(printf '%b' "${{ env.GPG_SECRET }}")"
           {
             echo "GPG_KEY_CONTENT<<GPG_EOF"
-            printf '%b' "${{ env.GPG_SECRET }}"
+            echo "$GPG_KEY_CONTENT"
             echo
             echo "GPG_EOF"
           } >> $GITHUB_ENV
+          GPG_KEY_CONTENT="${GPG_KEY_CONTENT//%/%25}"
+          GPG_KEY_CONTENT="${GPG_KEY_CONTENT//$'\r'/%0D}"
+          GPG_KEY_CONTENT="${GPG_KEY_CONTENT//$'\n'/%0A}"
+          echo "::add-mask::${GPG_KEY_CONTENT}"
 
       - name: Set up JDK for GPG
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0

--- a/.github/workflows/release-deploy-maven.yml
+++ b/.github/workflows/release-deploy-maven.yml
@@ -91,12 +91,17 @@ jobs:
 
       - name: Convert escaped newlines and set GPG key
         run: |
+          GPG_KEY_CONTENT="$(printf '%b' "${{ env.GPG_SECRET }}")"
           {
             echo "GPG_KEY_CONTENT<<GPG_EOF"
-            printf '%b' "${{ env.GPG_SECRET }}"
+            echo "$GPG_KEY_CONTENT"
             echo
             echo "GPG_EOF"
           } >> $GITHUB_ENV
+          GPG_KEY_CONTENT="${GPG_KEY_CONTENT//%/%25}"
+          GPG_KEY_CONTENT="${GPG_KEY_CONTENT//$'\r'/%0D}"
+          GPG_KEY_CONTENT="${GPG_KEY_CONTENT//$'\n'/%0A}"
+          echo "::add-mask::${GPG_KEY_CONTENT}"
 
       - name: Set up Java for publishing to Maven Central Repository
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
@@ -222,12 +227,17 @@ jobs:
 
       - name: Convert escaped newlines and set GPG key
         run: |
+          GPG_KEY_CONTENT="$(printf '%b' "${{ env.GPG_SECRET }}")"
           {
             echo "GPG_KEY_CONTENT<<GPG_EOF"
-            printf '%b' "${{ env.GPG_SECRET }}"
+            echo "$GPG_KEY_CONTENT"
             echo
             echo "GPG_EOF"
           } >> $GITHUB_ENV
+          GPG_KEY_CONTENT="${GPG_KEY_CONTENT//%/%25}"
+          GPG_KEY_CONTENT="${GPG_KEY_CONTENT//$'\r'/%0D}"
+          GPG_KEY_CONTENT="${GPG_KEY_CONTENT//$'\n'/%0A}"
+          echo "::add-mask::${GPG_KEY_CONTENT}"
 
       - name: Set up Java for publishing to Maven Central Repository
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0


### PR DESCRIPTION
## Security fix — TECHOPS-1093

The release-signing **GPG private key** has been printed in plaintext in **public** GitHub Actions logs since PR #7090 (2025-07-17). This is a recurrence of **DAT-20612**, whose build-logic fix (PRs liquibase/build-logic#380, #381) was never propagated to this repo.

### Root cause
PR #7090 moved secrets to an AWS Secrets Manager JSON blob (`parse-json-secrets: true`), so `GPG_SECRET` arrives with literal `\n`. The "Convert escaped newlines and set GPG key" step un-escapes it into `GPG_KEY_CONTENT` and writes it to `$GITHUB_ENV` **without re-masking**. GitHub masks the original `GPG_SECRET` (`***`) but not the transformed twin, so the full key is emitted in the clear (setup-java input echo + env dumps).

### Fix
Replicates the proven build-logic pattern: URL-encode the converted key and register it with `::add-mask::` immediately, so every line is masked. 6 sites across:
- `.github/workflows/build.yml`
- `.github/workflows/create-release.yml` (×2)
- `.github/workflows/installer-build-check.yml`
- `.github/workflows/release-deploy-maven.yml` (×2)

### Note on scope
This is **Phase 3a** (stop the leak now). Companion PRs cover `liquibase-parent-pom` and `liquibase-pro`. **Key rotation is tracked separately in TECHOPS-1093** and is required regardless — code changes cannot un-expose the already-public key. Exploitation assessment (see ticket) indicates the key was very likely not abused: the passphrase was never leaked (key is passphrase-protected), Maven Central signatures are all ours, and the public key record shows no tampering or revocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)