### PR TITLE
Docker: Support LIQUIBASE_DEFAULTS_FILE environment variable

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -106,7 +106,7 @@ else
     fi
   fi
 
-  if [[ "$*" == *--defaultsFile* ]] || [[ "$*" == *--defaults-file* ]] || [[ "$*" == *--version* ]]; then
+  if [[ "$*" == *--defaultsFile* ]] || [[ "$*" == *--defaults-file* ]] || [[ "$*" == *--version* ]] || [[ -n "$LIQUIBASE_DEFAULTS_FILE" ]]; then
     ## Just run as-is, but add search path if needed
     if [ -n "$EXTRA_SEARCH_PATH" ]; then
       exec /liquibase/liquibase "$EXTRA_SEARCH_PATH" "$@"


### PR DESCRIPTION
## Impact

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
<!--  Maintainers only: Mandatory Labels to add to a PR

At least one of the labels must be added to the PR before it's merged. If no label is provided the workflow will fail and you will not be able to merge the PR. After the label is added it re-runs the `Pull Request Labels / label (pull_request)` and gives a green check. 

`skipReleaseNotes`   - Don't show up on the Draft Release Notes page
`notableChanges`     - Any notable changes
`TypeEnhancement`    - New features
`TypeTest`           - New Test features
`TypeBug`            - bug fixes
`breakingChanges`    - any breaking changes
`APIBreakingChanges` - any API breaking changes
`sdou`               - Security, Driver and Other Updates -dependabot PR's
`newContributors`    - New Contributors 

-->


## Description

Fixes #7926

The docker container respects the `LIQUIBASE_DEFAULTS_FILE` environment variable.

## Release note

The Docker container supports setting  the `LIQUIBASE_DEFAULTS_FILE` environment variable instead of an explicit `--default-file` command line argument.