### PR TITLE
fix(security): build fork PRs with no secrets; keep credential jobs off untrusted checkout [TECHOPS-1102]

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -25,6 +25,11 @@ on:
 jobs:
 
   authorize:
+    # Trusted context only. The `build` job below deploys with a `packages: write`
+    # token by running fork-authored `./mvnw`; fork PRs must never reach it
+    # (GHSA-mqw2-j77g-6486, TECHOPS-1102). Allows push, workflow_dispatch and
+    # same-repo (internal) PRs; skips fork PRs.
+    if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository }}
     environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
     runs-on: ubuntu-latest
     steps:
@@ -44,7 +49,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.event.after}}
-          allow-unsafe-pr-checkout: true
 
       - name: Get Latest Merge Commit SHA
         id: get-sha
@@ -83,7 +87,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.event.after}}
-          allow-unsafe-pr-checkout: true
       - name: Set up Java for publishing to GitHub Repository
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.event.after}}
-          allow-unsafe-pr-checkout: true
       - name: Get Latest Merge Commit SHA
         id: get-sha
         run: |
@@ -67,30 +66,6 @@ jobs:
           echo "Modified Branch Name:" $modified_branch_name
           echo "Original Branch Name thisBranchName:" $branch_name
 
-      - name: Configure AWS credentials for vault access
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
-        with:
-          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
-          aws-region: us-east-1
-
-      - name: Get secrets from vault
-        id: vault-secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@2cb1a461cbd4865ac4299648312e4704c646cd53 # v3.0.1
-        with:
-          secret-ids: |
-            ,/vault/liquibase
-          parse-json-secrets: true
-
-      - name: Get GitHub App token
-        id: get-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ env.LIQUIBASE_GITHUB_APP_ID }}
-          private-key: ${{ env.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
-          owner: liquibase
-          permission-contents: read
-
-
   build_publish_branch:
     name: Artifacts - Build & Package
     runs-on: ubuntu-latest
@@ -99,7 +74,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.event.after}}
-          allow-unsafe-pr-checkout: true
       # this includes all the tar files included in the previous runs. So in the next step we deploy what was previously build
       - name: Download Artifacts for build.yml
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -22,6 +22,12 @@ permissions:
 jobs:
 
   authorize:
+    # Trusted context only. The run-test-harness-tests job reads /vault/liquibase
+    # and mints a GitHub App token; fork PRs must never reach this graph
+    # (GHSA-mqw2-j77g-6486, TECHOPS-1102). Allows the workflow_call path (invoked
+    # from build.yml in trusted context) and same-repo (internal) labeled PRs;
+    # skips fork PRs.
+    if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository }}
     environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
     runs-on: ubuntu-latest
     steps:
@@ -45,7 +51,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.event.after}} #sets the Git reference (commit or branch) to be checked out in the workflow
-          allow-unsafe-pr-checkout: true
 
   run-test-harness-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,6 +32,13 @@ on:
 
 jobs:
   authorize:
+    # Trusted context only. Fork PRs must never reach the credential-bearing jobs
+    # below (vault load, GPG signing, GPM/Maven deploy) — they are validated by
+    # test-pr.yml under the no-secrets `pull_request` event instead
+    # (GHSA-mqw2-j77g-6486, TECHOPS-1102). This condition allows push,
+    # workflow_dispatch, workflow_call and same-repo (internal) PRs, and skips the
+    # whole graph for fork PRs.
+    if: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository }}
     #concurrent runs for pull requests from forked repositories will be canceled, while runs for pull requests from the main repository won't be affected.
     #for a pull_request against main: the concurrency check will cancel commit A so that commit B check can run.
     concurrency:
@@ -56,7 +63,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
-          allow-unsafe-pr-checkout: true
 
       - name: Get current date
         id: get-date
@@ -105,7 +111,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.event.after}}
-          allow-unsafe-pr-checkout: true
 
       - name: Built Code Cache
         if: ${{ matrix.java == 17}}
@@ -212,7 +217,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.event.after}}
-          allow-unsafe-pr-checkout: true
 
       - name: Prepare
         id: prepare

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -1,0 +1,161 @@
+name: Test Fork PR
+
+# Fork-safe validation for pull requests from forked repositories.
+#
+# This runs under the plain `pull_request` event, which gives fork PRs a
+# read-only GITHUB_TOKEN and NO access to repository/organization secrets or the
+# `/vault/liquibase` bundle. It therefore never checks out fork code into a job
+# that holds release/signing/publishing credentials (GHSA-mqw2-j77g-6486,
+# TECHOPS-1102).
+#
+# Same-repo (internal) PRs are handled by run-tests.yml under
+# `pull_request_target`; the `if:` on `setup` skips this workflow for them to
+# avoid duplicate test runs. Keep the setup/build_tests/integration-test jobs in
+# sync with run-tests.yml.
+permissions:
+  contents: read
+  packages: read # read *-SNAPSHOT dependencies from GitHub Packages
+
+concurrency:
+  group: test-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  setup:
+    name: setup
+    # Fork PRs only. Internal PRs run the full pipeline in run-tests.yml.
+    if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+    runs-on: ubuntu-24.04
+    outputs:
+      timestamp: ${{ steps.get-date.outputs.date }}
+      latestMergeSha: ${{ steps.get-sha.outputs.latestMergeSha }}
+      thisBranchName: ${{ steps.get-branch-name.outputs.thisBranchName }}
+      thisSha: ${{ steps.get-sha.outputs.latestMergeSha }}
+      setupSuccessful: "true"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Get current date
+        id: get-date
+        run: |
+          echo "date=$(date +'%Y-%m-%d %H:%M:%S %Z')" >> $GITHUB_OUTPUT
+
+      - name: Get Latest Merge Commit SHA
+        id: get-sha
+        run: |
+          latest_merge_sha=`(git rev-parse HEAD)`
+          echo "latestMergeSha=${latest_merge_sha}" >> $GITHUB_OUTPUT
+
+      - name: Get Current BranchName
+        id: get-branch-name
+        run: |
+          # this logic checks if the branch is from a forked repository PR or not. Where -n is the inverse of -z (not empty)
+          if [ -n "${GITHUB_HEAD_REF}" ];
+          then
+            branch_name=${GITHUB_HEAD_REF}
+          else
+            branch_name=${{ github.ref_name }}
+          fi
+
+          modified_branch_name=`(echo $branch_name | tr '/_' '-')`
+          echo "thisBranchName=$modified_branch_name" >> $GITHUB_OUTPUT
+          echo $modified_branch_name
+
+  build_tests:
+    name: Run Test for (Java ${{ matrix.java }} ${{ matrix.os }})
+    needs: setup
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-24.04, macos-15-intel, windows-latest ]
+        java: [ 17, 21, 25 ]
+        exclude:
+          - os: windows-latest
+            java: 17
+          - os: macos-15-intel
+            java: 17
+    runs-on: ${{ matrix.os }}
+    env:
+      OS_TYPE: ${{ matrix.os }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # read-only for fork PRs
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+          cache: 'maven'
+
+      # look for dependencies in maven
+      - name: Configure Maven settings
+        shell: bash
+        run: |
+          mkdir -p ~/.m2
+          cp .github/maven/settings-snapshots.xml ~/.m2/settings.xml
+          echo "MAVEN_GPM_PASSWORD=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
+
+      - name: Build & Test Java 17+
+        run: |
+          ./mvnw -B "-Dbuild.repository.owner=liquibase" "-Dbuild.repository.name=liquibase" "-Dbuild.branch=${{ needs.setup.outputs.thisBranchName }}" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=${{ needs.setup.outputs.latestMergeSha }}" "-DtrimStackTrace=false" -P 'skip-integration-tests' clean test package surefire-report:report
+
+      - name: Remove Original Jars for *nix
+        if: env.OS_TYPE != 'windows-latest'
+        run: |
+          find . -name original-*.jar -exec rm {} \;
+
+  integration-test:
+    name: Integration Test
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        testSystem:
+          - db2
+          - h2
+          #- h2:1.4
+          - hsqldb
+          - mariadb
+          - mssql
+          - mysql
+          - oracle
+          - postgresql
+          - sqlite
+          - firebird
+    needs: build_tests
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Prepare
+        id: prepare
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            core.setOutput("testResultsArtifact", "liquibase-test-results-integration-${{ matrix.testSystem }}".replace(/[^a-zA-Z0-9\-_]/g, "_"));
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Run Tests
+        run: ./mvnw -B clean verify -DtrimStackTrace=false -Dliquibase.sdk.testSystem.test=${{ matrix.testSystem }} -Dliquibase.sdk.testSystem.acceptLicenses=${{ matrix.testSystem }} -Dtest=*IntegrationTest,*ExecutorTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dsurefire.failIfNoTests=false


### PR DESCRIPTION
## What & why

Core RCE fix for **[GHSA-mqw2-j77g-6486](https://github.com/liquibase/liquibase/security/advisories/GHSA-mqw2-j77g-6486)** (CVSS 9.9), ticket **TECHOPS-1102**.

Today a fork PR runs arbitrary code (`./mvnw`, `sign-artifacts.sh`) inside privileged jobs that have **already loaded the full `/vault/liquibase` bundle** — Maven Central token, GPG signing key, GitHub App key, install4j license, GPM PAT. The only thing holding a fork back is a manual environment approval. This PR removes the structural exposure so **no credential is ever in scope of fork-authored code**.

## Approach

Fork PRs become **test-only**; the credential-bearing pipeline runs **only in trusted context**.

- **New `test-pr.yml`** — validates fork PRs under the plain `pull_request` event: read-only `GITHUB_TOKEN`, no vault, no secrets, no publish. Mirrors `run-tests.yml`'s `setup` / `build_tests` / `integration-test` without the privileged tail.
- **Gated `authorize`** in `run-tests.yml`, `build-branch.yml`, `run-test-harness.yml` to trusted context only (`event != pull_request_target || head.repo == this repo`). Fork PRs skip the entire vault/GPG/deploy graph via `needs`.
- **Removed all 8 `allow-unsafe-pr-checkout: true` flags**, restoring `actions/checkout` v7's safe default. The flag is only needed to check out *fork* code under `pull_request_target`; the credentialed workflows now only ever check out same-repo refs.
- **Removed the dead AWS/vault/App-token steps** from `build.yml`'s `setup` job (outputs were never consumed).

## Acceptance criteria

- [x] Fork PRs run compile/test with a read-only token and no vault access
- [x] No vault/App-token job checks out fork-controlled refs
- [x] `allow-unsafe-pr-checkout` removed everywhere; `actionlint` shows no new findings vs `main`
- [ ] Canary fork PR (advisory PoC) reaches no secret-bearing job — to validate on this PR

## Reviewer notes

- **Behaviour for internal PRs / push / release is unchanged** — only the trigger gating and the (now-unnecessary) unsafe-checkout flags were touched.
- **Branch protection**: required status checks likely reference `run-tests.yml` job contexts. Fork PRs now report those as *skipped* and are validated by `test-pr.yml` instead — the required-check list needs a settings pass (TECHOPS-1105).
- **Out of scope**: build-logic `sonar-coverage-merge.yml` is a second, identical fork-checkout+vault path the flag-grep can't find — logged to **TECHOPS-1104**. Vault rotation is **TECHOPS-1101**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
