### PR TITLE
[TECHOPS-1086] Persist the main-HEAD scan even when the CVE threshold trips

### DIFF
--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -55,7 +55,22 @@ jobs:
   persist-main-latest:
     name: Persist main HEAD scan to scan-results
     needs: scan-community
-    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    # `always()` on purpose. "Check scan results" in the reusable workflow is a
+    # THRESHOLD verdict, not a scan failure: the report artifacts are uploaded
+    # before it runs. Without always(), a HIGH/CRITICAL finding skips this job,
+    # so the very CVEs the dashboard exists to show are what stop it being
+    # updated. liquibase/liquibase:latest went stale for days that way.
+    #
+    # Mirrors trivy-scan-published-images.yml, whose persist job has always
+    # been gated this way and persists successfully on runs whose scans fail
+    # the threshold. `cancelled`/`skipped` are still excluded: those produce no
+    # artifacts to persist.
+    if: |
+      always()
+      && github.event_name != 'pull_request'
+      && github.ref == 'refs/heads/main'
+      && needs.scan-community.result != 'cancelled'
+      && needs.scan-community.result != 'skipped'
     runs-on: ubuntu-22.04
     permissions:
       contents: write


### PR DESCRIPTION
## Why

`liquibase/liquibase:latest` has not been updated on the `scan-results` branch since **2026-08-14**. The `persist-main-latest` job has been reported as *skipped* on every `docker-scan` run since:

| run date | persist |
|---|---|
| 2026-08-20 | skipped |
| 2026-08-19 | skipped |
| 2026-08-18 | skipped |
| 2026-08-17 | skipped |
| 2026-08-14 | success |

The same gap exists in `liquibase/liquibase-secure` (skipped since 2026-08-17), fixed in [[liquibase-pro#4771](https://github.com/liquibase/liquibase-pro/pull/4771).

## The mechanism

`persist-main-latest` depends on the scan job, so it inherits an implicit "only if it succeeded". But **`Check scan results` is a threshold verdict, not a scan failure** — it fails when the image has HIGH/CRITICAL findings, and it runs at line 817 of `reusable-vulnerability-scan.yml`, long after `Upload vulnerability report` at line 662.

So the report exists, is complete, and is thrown away. The CVEs the dashboard exists to show are precisely what stops the dashboard being updated, and it fails silently: a *skipped* job is not a red check.

## The fix

`always()` on the gate, matching `trivy-scan-published-images.yml` in this repo, whose persist job has always been written this way and persists successfully on runs whose scans fail the threshold.

`cancelled` and `skipped` stay excluded. An early scan failure that produced no artifact at all is safe: the download step filters by `pattern`, which succeeds with zero matches (unlike `name`, which throws), the wrap step tolerates a missing directory, and `persist-scan-results.sh` exits 0 when there is nothing to persist.

## Context

Found while verifying [TECHOPS-1086](https://datical.atlassian.net/browse/TECHOPS-1086) after merge. Pre-existing and unrelated to that work, but it means the Docker Security page has been showing a 6-day-old `:latest` for both image families.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECHOPS-1086]: https://datical.atlassian.net/browse/TECHOPS-1086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ