### PR TITLE
ci: route branch/commit metadata through env: in fork-PR workflows (TECHOPS-525, TECHOPS-526)

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -66,12 +66,12 @@ jobs:
           # this logic checks if the branch is from a forked repository PR or not. Where -n is the inverse of -z (not empty)
           if [ -n "${GITHUB_HEAD_REF}" ];
           then
-            branch_name="${GITHUB_HEAD_REF}"
+            branch_name=${GITHUB_HEAD_REF}
           else
-            branch_name="$REF_NAME"
+            branch_name=$REF_NAME
           fi
 
-          modified_branch_name=`(echo "$branch_name" | tr '/' '_')`
+          modified_branch_name=$(echo $branch_name | tr '/' '_')
           echo "thisBranchName=$modified_branch_name" >> $GITHUB_OUTPUT          
 
   build:

--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -60,16 +60,18 @@ jobs:
 
       - name: Get Current BranchName
         id: get-branch-name
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           # this logic checks if the branch is from a forked repository PR or not. Where -n is the inverse of -z (not empty)
           if [ -n "${GITHUB_HEAD_REF}" ];
           then
-            branch_name=${GITHUB_HEAD_REF}
+            branch_name="${GITHUB_HEAD_REF}"
           else
-            branch_name=${{ github.ref_name }}
-          fi 
+            branch_name="$REF_NAME"
+          fi
 
-          modified_branch_name=`(echo $branch_name | tr '/' '_')`
+          modified_branch_name=`(echo "$branch_name" | tr '/' '_')`
           echo "thisBranchName=$modified_branch_name" >> $GITHUB_OUTPUT          
 
   build:
@@ -94,13 +96,17 @@ jobs:
 
       # Version artifact based off of branch and commit SHA.
       - name: Version Artifact
+        env:
+          BRANCH_NAME: ${{ needs.setup.outputs.thisBranchName }}
         run: |
-          ./mvnw versions:set "-DnewVersion=${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT"
-          #./mvnw versions:set "-DnewVersion=${{ inputs.branchName }}-SNAPSHOT"
+          ./mvnw versions:set "-DnewVersion=$BRANCH_NAME-SNAPSHOT"
 
       # Publish to GitHub Packages
       - name: Publish package
         run: |
-          ./mvnw -B clean deploy -pl '!liquibase-dist' -DskipTests=true "-Dbuild.repository.owner=liquibase" "-Dbuild.repository.name=liquibase" "-Dbuild.branch=${{ needs.setup.outputs.thisBranchName }}" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=${{ needs.setup.outputs.latestMergeSha }}" "-Dbuild.timestamp=${{ needs.setup.outputs.timeStamp }}"
+          ./mvnw -B clean deploy -pl '!liquibase-dist' -DskipTests=true "-Dbuild.repository.owner=liquibase" "-Dbuild.repository.name=liquibase" "-Dbuild.branch=$BRANCH_NAME" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=$MERGE_SHA" "-Dbuild.timestamp=$BUILD_TIMESTAMP"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_NAME: ${{ needs.setup.outputs.thisBranchName }}
+          MERGE_SHA: ${{ needs.setup.outputs.latestMergeSha }}
+          BUILD_TIMESTAMP: ${{ needs.setup.outputs.timeStamp }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,7 +165,7 @@ jobs:
         env:
           BRANCH_NAME: ${{ needs.setup.outputs.thisBranchName }}
         run: |
-          version="$BRANCH_NAME-SNAPSHOT"
+          version=$BRANCH_NAME-SNAPSHOT
           ./mvnw versions:set -DnewVersion="$version"
 
       - name: Artifacts - Build & Sign
@@ -197,7 +197,7 @@ jobs:
           # Extract the tarball to allow us to upload the liquibase installation files to our
           # github actions workflow so that we don't double zip the archive
           mkdir -p branch-artifacts
-          tar -xzf "liquibase-dist/target/liquibase-$BRANCH_NAME-SNAPSHOT.tar.gz" -C branch-artifacts
+          tar -xzf liquibase-dist/target/liquibase-$BRANCH_NAME-SNAPSHOT.tar.gz -C branch-artifacts
 
           ##create installer - disabled here but run as nightly job and as part of release workflow
           # (cd liquibase-dist && ${{ github.workspace }}/.github/util/package-install4j.sh 0-SNAPSHOT)
@@ -208,13 +208,13 @@ jobs:
           # Copy artifacts
           mkdir -p artifacts
 
-          cp "liquibase-dist/target/liquibase-$BRANCH_NAME-SNAPSHOT.tar.gz" artifacts
-          cp "liquibase-dist/target/liquibase-$BRANCH_NAME-SNAPSHOT.zip" artifacts
-          cp "liquibase-core/target/liquibase-core-$BRANCH_NAME-SNAPSHOT.jar" artifacts/liquibase-core-0-SNAPSHOT.jar
+          cp liquibase-dist/target/liquibase-$BRANCH_NAME-SNAPSHOT.tar.gz artifacts
+          cp liquibase-dist/target/liquibase-$BRANCH_NAME-SNAPSHOT.zip artifacts
+          cp liquibase-core/target/liquibase-core-$BRANCH_NAME-SNAPSHOT.jar artifacts/liquibase-core-0-SNAPSHOT.jar
           #cp liquibase-dist/target/liquibase-$BRANCH_NAME-SNAPSHOT/internal/lib/liquibase-core.jar artifacts/liquibase-core-0-SNAPSHOT.jar
 
-          cp "liquibase-core/target/liquibase-core-$BRANCH_NAME-SNAPSHOT-sources.jar" artifacts/liquibase-core-0-SNAPSHOT-sources.jar
-          cp "target/liquibase-$BRANCH_NAME-SNAPSHOT-javadoc.jar" artifacts/liquibase-core-0-SNAPSHOT-javadoc.jar
+          cp liquibase-core/target/liquibase-core-$BRANCH_NAME-SNAPSHOT-sources.jar artifacts/liquibase-core-0-SNAPSHOT-sources.jar
+          cp target/liquibase-$BRANCH_NAME-SNAPSHOT-javadoc.jar artifacts/liquibase-core-0-SNAPSHOT-javadoc.jar
 
           ##create installer - disabled here but run as nightly job and as part of release workflow
           #cp liquibase-dist/target/liquibase-*-installer-* artifacts
@@ -230,13 +230,13 @@ jobs:
           ##prepare branch-named convenience artifacts directories
           mkdir artifacts-named
 
-          cp "liquibase-dist/target/liquibase-$BRANCH_NAME-SNAPSHOT.tar.gz" "artifacts-named/liquibase-$BRANCH_NAME.tar.gz"
+          cp liquibase-dist/target/liquibase-$BRANCH_NAME-SNAPSHOT.tar.gz artifacts-named/liquibase-$BRANCH_NAME.tar.gz
 
           # liquibase-sdk:install-snapshot runs install-file over these without coordinates, so maven
           # reads the embedded pom: they need 0-SNAPSHOT inside even though the file name says the branch
-          cp "prebuilt/liquibase-extension-testing-0-SNAPSHOT-deps.jar" "artifacts-named/liquibase-extension-testing-$BRANCH_NAME-deps.jar"
+          cp prebuilt/liquibase-extension-testing-0-SNAPSHOT-deps.jar artifacts-named/liquibase-extension-testing-$BRANCH_NAME-deps.jar
           for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-extension-testing'; do
-            cp "prebuilt/$i-0-SNAPSHOT.jar" "artifacts-named/$i-$BRANCH_NAME.jar"
+            cp prebuilt/$i-0-SNAPSHOT.jar artifacts-named/$i-$BRANCH_NAME.jar
           done
 
       - name: Archive Packages
@@ -279,8 +279,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_NAME: ${{ needs.setup.outputs.thisBranchName }}
-          MERGE_SHA: ${{ needs.setup.outputs.thisSha }}
-          BUILD_TIMESTAMP: ${{ needs.setup.outputs.timestamp }}
+          MERGE_SHA: ${{ needs.setup.outputs.latestMergeSha }}
+          BUILD_TIMESTAMP: ${{ needs.setup.outputs.timeStamp }}
 
   run-tests-harness:
     needs: [setup, build_publish_branch]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,15 +53,17 @@ jobs:
 
       - name: Get Current BranchName
         id: get-branch-name
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           # this logic checks if the branch is from a forked repository PR or not. Where -n is the inverse of -z (not empty)
           if [ -n "${GITHUB_HEAD_REF}" ];
           then
             branch_name=${GITHUB_HEAD_REF}
           else
-            branch_name=${{ github.ref_name }}
+            branch_name=$REF_NAME
           fi
-          modified_branch_name=`(echo $branch_name | tr '/' '_')`
+          modified_branch_name=$(echo $branch_name | tr '/' '_')
           echo "thisBranchName=$modified_branch_name" >> $GITHUB_OUTPUT
           echo "unmodifiedBranchName=$branch_name" >> $GITHUB_OUTPUT
           echo "Modified Branch Name:" $modified_branch_name
@@ -279,8 +281,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_NAME: ${{ needs.setup.outputs.thisBranchName }}
-          MERGE_SHA: ${{ needs.setup.outputs.latestMergeSha }}
-          BUILD_TIMESTAMP: ${{ needs.setup.outputs.timeStamp }}
+          MERGE_SHA: ${{ needs.setup.outputs.thisSha }}
+          BUILD_TIMESTAMP: ${{ needs.setup.outputs.timestamp }}
 
   run-tests-harness:
     needs: [setup, build_publish_branch]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,8 +162,10 @@ jobs:
 
       # Version artifact based off of branch
       - name: Version Artifact
+        env:
+          BRANCH_NAME: ${{ needs.setup.outputs.thisBranchName }}
         run: |
-          version=${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT
+          version="$BRANCH_NAME-SNAPSHOT"
           ./mvnw versions:set -DnewVersion="$version"
 
       - name: Artifacts - Build & Sign
@@ -171,6 +173,9 @@ jobs:
           INSTALL4J_LICENSE: ${{ env.INSTALL4J_LICENSE }}
           GPG_PASSWORD: ${{ env.GPG_PASSPHRASE }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_NAME: ${{ needs.setup.outputs.thisBranchName }}
+          MERGE_SHA: ${{ needs.setup.outputs.latestMergeSha }}
+          BUILD_TIMESTAMP: ${{ needs.setup.outputs.timeStamp }}
         run: |
           ## save install4j code signing keys
           mkdir -p liquibase-dist/target/keys
@@ -184,15 +189,15 @@ jobs:
           ./mvnw -B -pl liquibase-dist,liquibase-maven-plugin,liquibase-extension-testing -am source:jar clean package failsafe:integration-test failsafe:verify \
           "-Dbuild.repository.owner=liquibase" \
           "-Dbuild.repository.name=liquibase" \
-          "-Dbuild.branch=${{ needs.setup.outputs.thisBranchName }}" \
+          "-Dbuild.branch=$BRANCH_NAME" \
           "-Dbuild.number=${{ github.run_number }}" \
-          "-Dbuild.commit=${{ needs.setup.outputs.latestMergeSha }}" \
-          "-Dbuild.timestamp=${{ needs.setup.outputs.timeStamp }}"
+          "-Dbuild.commit=$MERGE_SHA" \
+          "-Dbuild.timestamp=$BUILD_TIMESTAMP"
 
           # Extract the tarball to allow us to upload the liquibase installation files to our
           # github actions workflow so that we don't double zip the archive
           mkdir -p branch-artifacts
-          tar -xzf liquibase-dist/target/liquibase-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT.tar.gz -C branch-artifacts
+          tar -xzf "liquibase-dist/target/liquibase-$BRANCH_NAME-SNAPSHOT.tar.gz" -C branch-artifacts
 
           ##create installer - disabled here but run as nightly job and as part of release workflow
           # (cd liquibase-dist && ${{ github.workspace }}/.github/util/package-install4j.sh 0-SNAPSHOT)
@@ -203,13 +208,13 @@ jobs:
           # Copy artifacts
           mkdir -p artifacts
 
-          cp liquibase-dist/target/liquibase-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT.tar.gz artifacts
-          cp liquibase-dist/target/liquibase-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT.zip artifacts
-          cp liquibase-core/target/liquibase-core-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT.jar artifacts/liquibase-core-0-SNAPSHOT.jar
-          #cp liquibase-dist/target/liquibase-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT/internal/lib/liquibase-core.jar artifacts/liquibase-core-0-SNAPSHOT.jar
+          cp "liquibase-dist/target/liquibase-$BRANCH_NAME-SNAPSHOT.tar.gz" artifacts
+          cp "liquibase-dist/target/liquibase-$BRANCH_NAME-SNAPSHOT.zip" artifacts
+          cp "liquibase-core/target/liquibase-core-$BRANCH_NAME-SNAPSHOT.jar" artifacts/liquibase-core-0-SNAPSHOT.jar
+          #cp liquibase-dist/target/liquibase-$BRANCH_NAME-SNAPSHOT/internal/lib/liquibase-core.jar artifacts/liquibase-core-0-SNAPSHOT.jar
 
-          cp liquibase-core/target/liquibase-core-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT-sources.jar artifacts/liquibase-core-0-SNAPSHOT-sources.jar
-          cp target/liquibase-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT-javadoc.jar artifacts/liquibase-core-0-SNAPSHOT-javadoc.jar
+          cp "liquibase-core/target/liquibase-core-$BRANCH_NAME-SNAPSHOT-sources.jar" artifacts/liquibase-core-0-SNAPSHOT-sources.jar
+          cp "target/liquibase-$BRANCH_NAME-SNAPSHOT-javadoc.jar" artifacts/liquibase-core-0-SNAPSHOT-javadoc.jar
 
           ##create installer - disabled here but run as nightly job and as part of release workflow
           #cp liquibase-dist/target/liquibase-*-installer-* artifacts
@@ -225,13 +230,13 @@ jobs:
           ##prepare branch-named convenience artifacts directories
           mkdir artifacts-named
 
-          cp liquibase-dist/target/liquibase-${{ needs.setup.outputs.thisBranchName }}-SNAPSHOT.tar.gz artifacts-named/liquibase-${{ needs.setup.outputs.thisBranchName }}.tar.gz
+          cp "liquibase-dist/target/liquibase-$BRANCH_NAME-SNAPSHOT.tar.gz" "artifacts-named/liquibase-$BRANCH_NAME.tar.gz"
 
           # liquibase-sdk:install-snapshot runs install-file over these without coordinates, so maven
           # reads the embedded pom: they need 0-SNAPSHOT inside even though the file name says the branch
-          cp prebuilt/liquibase-extension-testing-0-SNAPSHOT-deps.jar artifacts-named/liquibase-extension-testing-${{ needs.setup.outputs.thisBranchName }}-deps.jar
+          cp "prebuilt/liquibase-extension-testing-0-SNAPSHOT-deps.jar" "artifacts-named/liquibase-extension-testing-$BRANCH_NAME-deps.jar"
           for i in 'liquibase-core' 'liquibase-maven-plugin' 'liquibase-cli' 'liquibase-extension-testing'; do
-            cp prebuilt/$i-0-SNAPSHOT.jar artifacts-named/$i-${{ needs.setup.outputs.thisBranchName }}.jar
+            cp "prebuilt/$i-0-SNAPSHOT.jar" "artifacts-named/$i-$BRANCH_NAME.jar"
           done
 
       - name: Archive Packages
@@ -254,20 +259,28 @@ jobs:
 
       # Publish <commitsha>-SNAPSHOT version to GPM
       - name: Version Artifact Publish <commitsha>-SNAPSHOT version to GPM
+        env:
+          MERGE_SHA: ${{ needs.setup.outputs.latestMergeSha }}
         run: |
-          ./mvnw versions:set "-DnewVersion=${{ needs.setup.outputs.latestMergeSha }}-SNAPSHOT"
+          ./mvnw versions:set "-DnewVersion=$MERGE_SHA-SNAPSHOT"
       - name: Publish <commitsha>-SNAPSHOT package
         run: |
-          ./mvnw -B clean deploy -pl '!liquibase-dist' -DskipTests=true "-Dbuild.repository.owner=liquibase" "-Dbuild.repository.name=liquibase" "-Dbuild.branch=${{ needs.setup.outputs.thisBranchName }}" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=${{ needs.setup.outputs.latestMergeSha }}" "-Dbuild.timestamp=${{ needs.setup.outputs.timeStamp }}"
+          ./mvnw -B clean deploy -pl '!liquibase-dist' -DskipTests=true "-Dbuild.repository.owner=liquibase" "-Dbuild.repository.name=liquibase" "-Dbuild.branch=$BRANCH_NAME" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=$MERGE_SHA" "-Dbuild.timestamp=$BUILD_TIMESTAMP"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_NAME: ${{ needs.setup.outputs.thisBranchName }}
+          MERGE_SHA: ${{ needs.setup.outputs.latestMergeSha }}
+          BUILD_TIMESTAMP: ${{ needs.setup.outputs.timeStamp }}
 
       #Publish to GitHub Packages.
       - name: Publish tar.gz package to GPM
         run: |
-          ./mvnw -B -pl liquibase-dist clean deploy -DskipTests=true "-Dbuild.timestamp=${{ needs.setup.outputs.timestamp }}" "-Dbuild.repository.owner=liquibase" "-Dbuild.repository.name=liquibase" "-Dbuild.branch=${{ needs.setup.outputs.thisBranchName }}" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=${{ needs.setup.outputs.thisSha }}"
+          ./mvnw -B -pl liquibase-dist clean deploy -DskipTests=true "-Dbuild.timestamp=$BUILD_TIMESTAMP" "-Dbuild.repository.owner=liquibase" "-Dbuild.repository.name=liquibase" "-Dbuild.branch=$BRANCH_NAME" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=$MERGE_SHA"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_NAME: ${{ needs.setup.outputs.thisBranchName }}
+          MERGE_SHA: ${{ needs.setup.outputs.thisSha }}
+          BUILD_TIMESTAMP: ${{ needs.setup.outputs.timestamp }}
 
   run-tests-harness:
     needs: [setup, build_publish_branch]

--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -18,7 +18,7 @@ on:
 
 permissions:
   id-token: write # Required for OIDC authentication with AWS
-  
+
 jobs:
 
   authorize:
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'runFunctional&HarnessTests') || (github.event_name != 'pull_request' && github.event_name != 'pull_request_target')
     steps:
-      
+
       - name: Check variables
         run: |
           echo "github.event_name: ${{ github.event_name }}"
@@ -55,13 +55,19 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set environment variables for PR branch and SHA
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_BRANCH: ${{ inputs.thisBranchName }}
+          INPUT_SHA: ${{ inputs.latestMergeSha }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          if [ "${{ github.event_name }}" == "workflow_call" ]; then
-            echo "RUN_TESTS_BRANCH=${{ inputs.thisBranchName }}" >> $GITHUB_ENV
-            echo "RUN_TESTS_SHA=${{ inputs.latestMergeSha }}" >> $GITHUB_ENV
+          if [ "$EVENT_NAME" == "workflow_call" ]; then
+            echo "RUN_TESTS_BRANCH=$INPUT_BRANCH" >> $GITHUB_ENV
+            echo "RUN_TESTS_SHA=$INPUT_SHA" >> $GITHUB_ENV
           else
-            echo "RUN_TESTS_BRANCH=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
-            echo "RUN_TESTS_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+            echo "RUN_TESTS_BRANCH=$PR_HEAD_REF" >> $GITHUB_ENV
+            echo "RUN_TESTS_SHA=$PR_HEAD_SHA" >> $GITHUB_ENV
           fi
 
       - name: Get OSS Workflow Run URL
@@ -94,7 +100,21 @@ jobs:
           owner: ${{ github.repository_owner }}
           permission-contents: write
           permission-actions: write
-          
+
+      - name: Build test-harness dispatch payload
+        id: build-payload
+        env:
+          RUN_TESTS_SHA: ${{ env.RUN_TESTS_SHA }}
+          RUN_TESTS_BRANCH: ${{ env.RUN_TESTS_BRANCH }}
+          OSS_WORKFLOW_URL: ${{ env.ossWorkflowUrl }}
+        run: |
+          payload=$(jq -nc \
+            --arg commit "$RUN_TESTS_SHA" \
+            --arg desc "$OSS_WORKFLOW_URL" \
+            --arg branch "$RUN_TESTS_BRANCH" \
+            '{liquibaseCommit: $commit, runDescription: $desc, liquibaseBranch: $branch}')
+          echo "json=$payload" >> "$GITHUB_OUTPUT"
+
       - name: Dispatch an action and get the run ID
         uses: codex-/return-dispatch@85e564d60eaec3cc4aca885373d510cfe4bd5b19 # v3
         id: return_dispatch
@@ -104,11 +124,7 @@ jobs:
           repo: liquibase-test-harness
           owner: liquibase
           workflow: main.yml
-          workflow_inputs:
-            '{"liquibaseCommit": "${{ env.RUN_TESTS_SHA }}",
-              "runDescription": "${{ env.ossWorkflowUrl }}",
-              "liquibaseBranch": "${{ env.RUN_TESTS_BRANCH }}"
-            }'
+          workflow_inputs: ${{ steps.build-payload.outputs.json }}
 
       - name: Display run ID
         run: echo ${{ steps.return_dispatch.outputs.run_id }}

--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -103,17 +103,13 @@ jobs:
 
       - name: Build test-harness dispatch payload
         id: build-payload
-        env:
-          RUN_TESTS_SHA: ${{ env.RUN_TESTS_SHA }}
-          RUN_TESTS_BRANCH: ${{ env.RUN_TESTS_BRANCH }}
-          OSS_WORKFLOW_URL: ${{ env.ossWorkflowUrl }}
         run: |
           payload=$(jq -nc \
             --arg commit "$RUN_TESTS_SHA" \
-            --arg desc "$OSS_WORKFLOW_URL" \
+            --arg desc "$ossWorkflowUrl" \
             --arg branch "$RUN_TESTS_BRANCH" \
             '{liquibaseCommit: $commit, runDescription: $desc, liquibaseBranch: $branch}')
-          echo "json=$payload" >> "$GITHUB_OUTPUT"
+          echo "json=$payload" >> $GITHUB_OUTPUT
 
       - name: Dispatch an action and get the run ID
         uses: codex-/return-dispatch@85e564d60eaec3cc4aca885373d510cfe4bd5b19 # v3

--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -34,13 +34,20 @@ jobs:
     steps:
 
       - name: Check variables
+        # TECHOPS-526: routed through env: so the values stay data. Interpolating them
+        # straight into the script splices them in as code, even in a debug echo.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HAS_FUNCTIONAL_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'runFunctionalTests') }}
+          EVENT_AFTER: ${{ github.event.after }}
+          BASE_REF: ${{ github.base_ref }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
         run: |
-          echo "github.event_name: ${{ github.event_name }}"
-          echo "github.event.pull_request.labels.*.name: ${{ contains(github.event.pull_request.labels.*.name, 'runFunctionalTests') }}"
-          echo "github.event.after: ${{ github.event.after }}"
-          echo "github.base_ref: ${{ github.base_ref }}"
-          echo "github.event.pull_request.merged: ${{ github.event.pull_request.merged }}"
-          echo "github.event_name: ${{ github.event_name }}"
+          echo "github.event_name: $EVENT_NAME"
+          echo "github.event.pull_request.labels.*.name: $HAS_FUNCTIONAL_LABEL"
+          echo "github.event.after: $EVENT_AFTER"
+          echo "github.base_ref: $BASE_REF"
+          echo "github.event.pull_request.merged: $PR_MERGED"
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -71,18 +71,20 @@ jobs:
 
       - name: Get Current BranchName
         id: get-branch-name
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           # this logic checks if the branch is from a forked repository PR or not. Where -n is the inverse of -z (not empty)
           if [ -n "${GITHUB_HEAD_REF}" ];
           then
-            branch_name=${GITHUB_HEAD_REF}
+            branch_name="${GITHUB_HEAD_REF}"
           else
-            branch_name=${{ github.ref_name }}
+            branch_name="$REF_NAME"
           fi
 
-          modified_branch_name=`(echo $branch_name | tr '/_' '-')`
+          modified_branch_name=`(echo "$branch_name" | tr '/_' '-')`
           echo "thisBranchName=$modified_branch_name" >> $GITHUB_OUTPUT
-          echo $modified_branch_name
+          echo "$modified_branch_name"
 
   build_tests:
     name: Run Test for (Java ${{ matrix.java }} ${{ matrix.os }})
@@ -132,8 +134,11 @@ jobs:
       # getting from build results page. If we remove 0-SNAPSHOT then we will need settings.xml
 
       - name: Build & Test Java 17+
+        env:
+          BRANCH_NAME: ${{ needs.setup.outputs.thisBranchName }}
+          MERGE_SHA: ${{ needs.setup.outputs.latestMergeSha }}
         run: |
-          ./mvnw -B "-Dbuild.repository.owner=liquibase" "-Dbuild.repository.name=liquibase" "-Dbuild.branch=${{ needs.setup.outputs.thisBranchName }}" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=${{ needs.setup.outputs.latestMergeSha }}" "-DtrimStackTrace=false" -P 'skip-integration-tests' clean test package surefire-report:report
+          ./mvnw -B "-Dbuild.repository.owner=liquibase" "-Dbuild.repository.name=liquibase" "-Dbuild.branch=$BRANCH_NAME" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=$MERGE_SHA" "-DtrimStackTrace=false" -P 'skip-integration-tests' clean test package surefire-report:report
 
       - name: Remove Original Jars for *nix
         if: env.OS_TYPE != 'windows-latest'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -77,14 +77,14 @@ jobs:
           # this logic checks if the branch is from a forked repository PR or not. Where -n is the inverse of -z (not empty)
           if [ -n "${GITHUB_HEAD_REF}" ];
           then
-            branch_name="${GITHUB_HEAD_REF}"
+            branch_name=${GITHUB_HEAD_REF}
           else
-            branch_name="$REF_NAME"
+            branch_name=$REF_NAME
           fi
 
-          modified_branch_name=`(echo "$branch_name" | tr '/_' '-')`
+          modified_branch_name=$(echo $branch_name | tr '/_' '-')
           echo "thisBranchName=$modified_branch_name" >> $GITHUB_OUTPUT
-          echo "$modified_branch_name"
+          echo $modified_branch_name
 
   build_tests:
     name: Run Test for (Java ${{ matrix.java }} ${{ matrix.os }})


### PR DESCRIPTION
## What

Continues the workflow-hardening work from [TECHOPS-526]/[TECHOPS-525]. `build.yml`, `build-branch.yml`, `run-tests.yml`, and `run-test-harness.yml` all derive a branch name, commit SHA, and build timestamp from the triggering PR and pass them between jobs as outputs. Several places spliced those job outputs directly into `run:` script text via `${{ }}`. This PR routes them through `env:` and references them as shell variables instead, matching the pattern already used for the direct `github.event.*/inputs.*` cases fixed earlier. `run-test-harness.yml`'s test-harness dispatch payload is also now built with jq instead of hand-concatenated JSON.

## Why

GitHub's own security guidance recommends passing untrusted or PR-derived values through `env:` rather than interpolating them directly into script bodies - the existing fixes covered direct references to PR-controlled context, but the same values also flow through job outputs into a few remaining spots. This closes that gap and keeps the whole fork-PR build/test path consistent.

[TECHOPS-526]: https://datical.atlassian.net/browse/TECHOPS-526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TECHOPS-525]: https://datical.atlassian.net/browse/TECHOPS-525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ