### PR TITLE
[TECHOPS-1119] Sign jars at deploy time and fail on a rejected Central publish

### DIFF
--- a/.github/workflows/release-deploy-maven.yml
+++ b/.github/workflows/release-deploy-maven.yml
@@ -140,13 +140,21 @@ jobs:
             sha1sum $i-${version}.pom | cut -d' ' -f1 > $i-${version}.pom.sha1
             sha256sum $i-${version}.pom | cut -d' ' -f1 > $i-${version}.pom.sha256
 
-            # Generate checksums for all JAR files (main, sources, javadoc).
-            # .sha256 is regenerated here (not just inherited from
-            # liquibase-additional-*.zip) because the sidecars produced by
+            # Sign and checksum every JAR here rather than reusing the sidecars
+            # from liquibase-additional-*.zip. Those are produced when artifacts
+            # are attached to the draft release, which can be days before the
+            # release is published. If the signing key rotates in that window the
+            # baked-in .asc files are signed by a key that no longer verifies and
+            # Central rejects the whole bundle. Signing at publish time always
+            # uses the key currently in the vault.
+            #
+            # .sha256 also has to be regenerated because the sidecars produced by
             # sign-artifacts.sh carry a trailing space that Sonatype Central
             # Portal rejects as "Invalid sha256 checksum".
             for jar_file in $i-${version}.jar $i-${version}-sources.jar $i-${version}-javadoc.jar; do
               if [ -f "$jar_file" ]; then
+                rm -f "$jar_file.asc"
+                gpg --batch --pinentry-mode=loopback --passphrase "$GPG_PASSWORD" -ab "$jar_file"
                 md5sum "$jar_file" | cut -d' ' -f1 > "$jar_file.md5"
                 sha1sum "$jar_file" | cut -d' ' -f1 > "$jar_file.sha1"
                 sha256sum "$jar_file" | cut -d' ' -f1 > "$jar_file.sha256"
@@ -192,9 +200,38 @@ jobs:
             exit 1
           fi
 
-          echo "Bundle uploaded successfully to Central Portal"
+          echo "Bundle accepted by Central Portal"
           echo "Deployment ID: $DEPLOYMENT_ID"
-          echo "Automatic publishing initiated for liquibase-${version}"
+
+          # A 201 only means Central accepted the bundle for processing. Validation
+          # runs asynchronously afterwards, so poll until it resolves. Without this
+          # the job goes green on a release that Central actually rejected.
+          echo "Waiting for Central Portal validation of ${DEPLOYMENT_ID}..."
+          STATE="UNKNOWN"
+          for attempt in $(seq 1 60); do
+            STATUS_JSON=$(curl -s -X POST \
+              -H "Authorization: Bearer ${AUTH_HEADER}" \
+              "https://central.sonatype.com/api/v1/publisher/status?id=${DEPLOYMENT_ID}")
+            STATE=$(echo "$STATUS_JSON" | jq -r '.deploymentState // "UNKNOWN"')
+            echo "  [${attempt}/60] ${STATE}"
+
+            case "$STATE" in
+              PUBLISHED)
+                echo "liquibase-${version} published to Maven Central"
+                exit 0
+                ;;
+              FAILED)
+                echo "Central Portal rejected the deployment:"
+                echo "$STATUS_JSON" | jq -r '.errors // .'
+                exit 1
+                ;;
+            esac
+            sleep 30
+          done
+
+          echo "Timed out after 30m waiting for ${DEPLOYMENT_ID} (last state: ${STATE})"
+          echo "Check https://central.sonatype.com/publishing/deployments"
+          exit 1
 
   deploy-maven-dryrun:
     name: Deploy to Maven Central (Dry Run)
@@ -276,13 +313,21 @@ jobs:
             sha1sum $i-${version}.pom | cut -d' ' -f1 > $i-${version}.pom.sha1
             sha256sum $i-${version}.pom | cut -d' ' -f1 > $i-${version}.pom.sha256
 
-            # Generate checksums for all JAR files (main, sources, javadoc).
-            # .sha256 is regenerated here (not just inherited from
-            # liquibase-additional-*.zip) because the sidecars produced by
+            # Sign and checksum every JAR here rather than reusing the sidecars
+            # from liquibase-additional-*.zip. Those are produced when artifacts
+            # are attached to the draft release, which can be days before the
+            # release is published. If the signing key rotates in that window the
+            # baked-in .asc files are signed by a key that no longer verifies and
+            # Central rejects the whole bundle. Signing at publish time always
+            # uses the key currently in the vault.
+            #
+            # .sha256 also has to be regenerated because the sidecars produced by
             # sign-artifacts.sh carry a trailing space that Sonatype Central
             # Portal rejects as "Invalid sha256 checksum".
             for jar_file in $i-${version}.jar $i-${version}-sources.jar $i-${version}-javadoc.jar; do
               if [ -f "$jar_file" ]; then
+                rm -f "$jar_file.asc"
+                gpg --batch --pinentry-mode=loopback --passphrase "$GPG_PASSWORD" -ab "$jar_file"
                 md5sum "$jar_file" | cut -d' ' -f1 > "$jar_file.md5"
                 sha1sum "$jar_file" | cut -d' ' -f1 > "$jar_file.sha1"
                 sha256sum "$jar_file" | cut -d' ' -f1 > "$jar_file.sha256"
@@ -328,6 +373,35 @@ jobs:
             exit 1
           fi
 
-          echo "Bundle uploaded successfully to Central Portal for dry-run"
+          echo "Bundle accepted by Central Portal for dry-run"
           echo "Deployment ID: $DEPLOYMENT_ID"
-          echo "Manual publishing required - visit https://central.sonatype.com/publishing/deployments to review and publish"
+
+          # A 201 only means Central accepted the bundle for processing. Validation
+          # runs asynchronously afterwards, so poll until it resolves. Without this
+          # the job goes green on a release that Central actually rejected.
+          echo "Waiting for Central Portal validation of ${DEPLOYMENT_ID}..."
+          STATE="UNKNOWN"
+          for attempt in $(seq 1 60); do
+            STATUS_JSON=$(curl -s -X POST \
+              -H "Authorization: Bearer ${AUTH_HEADER}" \
+              "https://central.sonatype.com/api/v1/publisher/status?id=${DEPLOYMENT_ID}")
+            STATE=$(echo "$STATUS_JSON" | jq -r '.deploymentState // "UNKNOWN"')
+            echo "  [${attempt}/60] ${STATE}"
+
+            case "$STATE" in
+              VALIDATED|PUBLISHED)
+                echo "Dry-run bundle validated. Publishing is USER_MANAGED: review at https://central.sonatype.com/publishing/deployments"
+                exit 0
+                ;;
+              FAILED)
+                echo "Central Portal rejected the deployment:"
+                echo "$STATUS_JSON" | jq -r '.errors // .'
+                exit 1
+                ;;
+            esac
+            sleep 30
+          done
+
+          echo "Timed out after 30m waiting for ${DEPLOYMENT_ID} (last state: ${STATE})"
+          echo "Check https://central.sonatype.com/publishing/deployments"
+          exit 1


### PR DESCRIPTION
## 🐛 Problem

5.0.4 was rejected by Maven Central with all 9 jar signatures invalid, while the release workflow reported success. Two separate defects.

**1. Signatures are made too early.** `create-release.yml` signs the jars and bakes the `.asc` files into `liquibase-additional-VERSION.zip`, which is attached to a **draft** release. The deploy workflow unzips those days later and ships them as-is.

5.0.4 was signed 2026-08-18 12:30 UTC and published 2026-08-20 16:18 UTC. The signing key was revoked in between, at 2026-08-18 21:20 UTC, reason "Key has been compromised". Every jar shipped with a dead signature.

Only the three `.pom.asc` are signed at deploy time, which is exactly why Central flagged the 9 jars and none of the poms.

The control case: `liquibase-neo4j` 5.0.3 published fine the same day, because it signs at deploy time and picked up the rotated key automatically.

**2. CI cannot fail on a rejected publish.** The job treats `HTTP 201` as success and exits. 201 only means Central accepted the bundle for processing; validation runs asynchronously afterwards. The run was fully green while the release sat in `FAILED`. A developer noticed, not CI.

## 🔧 Changes

Applied to both the production and dry-run jobs.

**Sign jars in the publish job.** The GPG key is already imported there (the poms are signed the same way), so this is two lines inside the existing loop: drop the stale `.asc`, re-sign with whatever key is in the vault at publish time.

**Poll the Central Portal.** After upload, poll `/api/v1/publisher/status` until the deployment resolves, and fail on `FAILED` with the errors printed. Production waits for `PUBLISHED`; dry-run stops at `VALIDATED`, since it uploads `USER_MANAGED`.

## ✅ Verification

- YAML parses, both jobs intact
- `actionlint` reports the same 2 pre-existing SC2086 findings as `origin/main`, nothing new
- Status API shape confirmed against Sonatype's [Publish Portal API docs](https://central.sonatype.org/publish/publish-portal-api/): `POST /api/v1/publisher/status?id=`, states `PENDING`, `VALIDATING`, `VALIDATED`, `PUBLISHING`, `PUBLISHED`, `FAILED`

## 📌 Context

5.0.4 itself is already resolved: a developer re-signed the release artifacts and published to Central by hand. This PR is the prevention work, so the next draft that outlives a key rotation does not repeat it. That matters because 14 draft releases across 9 repos currently carry revoked-key signatures.

Not fixed here: the tag guard in `create-release.yml` ("Check OSS release tag existence") can never fire, because its checkout runs with `fetch-depth: 1` and `fetch-tags: false` so `git show-ref --tags` is always empty.

Ticket: https://datical.atlassian.net/browse/TECHOPS-1119

🤖 Generated with [Claude Code](https://claude.com/claude-code)