### PR TITLE
fix(ci): reference correct setup-job outputs for tar.gz GPM publish (TECHOPS-1126)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -265,7 +265,7 @@ jobs:
       #Publish to GitHub Packages.
       - name: Publish tar.gz package to GPM
         run: |
-          ./mvnw -B -pl liquibase-dist clean deploy -DskipTests=true "-Dbuild.timestamp=${{ needs.setup.outputs.timestamp }}" "-Dbuild.repository.owner=liquibase" "-Dbuild.repository.name=liquibase" "-Dbuild.branch=${{ needs.setup.outputs.thisBranchName }}" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=${{ needs.setup.outputs.thisSha }}"
+          ./mvnw -B -pl liquibase-dist clean deploy -DskipTests=true "-Dbuild.timestamp=${{ needs.setup.outputs.timeStamp }}" "-Dbuild.repository.owner=liquibase" "-Dbuild.repository.name=liquibase" "-Dbuild.branch=${{ needs.setup.outputs.thisBranchName }}" "-Dbuild.number=${{ github.run_number }}" "-Dbuild.commit=${{ needs.setup.outputs.latestMergeSha }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## What
`build.yml`'s "Publish tar.gz package to GPM" step references `needs.setup.outputs.thisSha` and `needs.setup.outputs.timestamp` (lowercase), neither of which the `setup` job actually declares — its real outputs are `latestMergeSha` and `timeStamp` (capital S).

## Why
GitHub Actions silently resolves an undefined property reference to an empty string instead of erroring, so `-Dbuild.commit=` and `-Dbuild.timestamp=` have been passed empty on every tar.gz GPM publish. This fixes the reference so published packages carry real commit/timestamp metadata.

Split out from #7931 (TECHOPS-525/526 security hardening) to keep that PR behavior-neutral — see [TECHOPS-1126](https://datical.atlassian.net/browse/TECHOPS-1126).

[TECHOPS-1126]: https://datical.atlassian.net/browse/TECHOPS-1126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ