### PR TITLE
Fix includeAll search silently ignoring directory traversal failures

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/resource/AbstractPathResourceAccessor.java
+++ b/liquibase-standard/src/main/java/liquibase/resource/AbstractPathResourceAccessor.java
@@ -203,6 +203,9 @@ public abstract class AbstractPathResourceAccessor extends AbstractResourceAcces
 
             @Override
             public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                if (exc != null) {
+                    throw exc;
+                }
                 return FileVisitResult.CONTINUE;
             }
 

--- a/liquibase-standard/src/test/java/liquibase/resource/AbstractPathResourceAccessorTest.java
+++ b/liquibase-standard/src/test/java/liquibase/resource/AbstractPathResourceAccessorTest.java
@@ -1,0 +1,45 @@
+package liquibase.resource;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AbstractPathResourceAccessorTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void searchPropagatesDirectoryTraversalFailure() throws Exception {
+        IOException traversalFailure = new IOException("Unable to iterate directory");
+        DirectoryResourceAccessor accessor = new DirectoryResourceAccessor(tempDir);
+
+        try (MockedStatic<Files> files = Mockito.mockStatic(Files.class, Mockito.CALLS_REAL_METHODS)) {
+            files.when(() -> Files.walkFileTree(
+                            Mockito.any(Path.class),
+                            Mockito.anySet(),
+                            Mockito.anyInt(),
+                            Mockito.<FileVisitor<Path>>any()))
+                    .thenAnswer(invocation -> {
+                        FileVisitor<Path> visitor = invocation.getArgument(3);
+                        visitor.postVisitDirectory(tempDir, traversalFailure);
+                        return tempDir;
+                    });
+
+            IOException thrown = assertThrows(
+                    IOException.class,
+                    () -> accessor.search("", new ResourceAccessor.SearchOptions()));
+
+            assertSame(traversalFailure, thrown);
+        }
+    }
+}


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)

## Description

Fixes #7875.

`AbstractPathResourceAccessor.search()` previously continued when `Files.walkFileTree` reported an `IOException` after visiting a directory. That could make an `includeAll` operation appear successful while silently omitting changelog files from an unreadable directory.

The visitor now propagates the supplied exception. The behavior for successful directory visits is unchanged.

A regression test invokes the real `search()` entry point with a real temporary directory and simulates only the JDK walker callback. It verifies that the exact traversal exception reaches the caller.

## Release note

Fixed an issue where an `includeAll` search could silently omit changelog files after a directory traversal error. Liquibase now reports the traversal failure instead.

## Things to be aware of

This intentionally changes a failed directory iteration from a partial successful result to an `IOException`, preventing callers from treating an incomplete changelog set as complete.

## Things to worry about

No database-specific behavior is affected. The regression test isolates the otherwise difficult-to-trigger `postVisitDirectory` error callback without relying on filesystem permissions or platform behavior.

## Additional Context

Verification:

```text
./mvnw -pl liquibase-standard -Dtest=AbstractPathResourceAccessorTest,UrlDrivenResourceAccessorTest test
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
```