### PR TITLE
[TECHOPS-1099] Mark disabled workflows as superseded

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -1,3 +1,4 @@
+# DISABLED 2026-08-25 (TECHOPS-1104): superseded by snapshot-branch.yml for on-demand branch snapshots (PR #7944); per-PR publishing is dropped. Do not re-enable; the file is kept for history until the post-Phase-3 deletion PR.
 name: Build Branch SNAPSHOT
 
 # concurrent runs for pull requests (both internal and forked) will be canceled when a new run is triggered.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,4 @@
+# DISABLED 2026-08-25 (TECHOPS-1104): superseded by main.yml and snapshot-branch.yml (PR #7944). Do not re-enable; the file is kept for history until the post-Phase-3 deletion PR.
 
 name: Build and Publish
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,3 +1,4 @@
+# DISABLED 2026-08-25 (TECHOPS-1103): superseded by @claude review via the gated claude.yml; automatic review loaded vault credentials on a PR event. Do not re-enable; the file is kept for history until the post-Phase-3 deletion PR.
 name: Claude Code Review
 
 on:

--- a/.github/workflows/cleanup-branch-builds.yml
+++ b/.github/workflows/cleanup-branch-builds.yml
@@ -1,3 +1,4 @@
+# DISABLED 2026-08-25 (TECHOPS-1099): superseded by cleanup-packages.yml (PR #7944); the delete trigger ignored its branch filters and 29 of the last 30 runs failed. Do not re-enable; the file is kept for history until the post-Phase-3 deletion PR.
 # │ Purpose : Reactive cleanup when a branch is removed 
 name: Cleanup on Branch Delete
 

--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -1,3 +1,4 @@
+# DISABLED 2026-08-25 (TECHOPS-1099): superseded by the release-published-orchestrator dry_run input; a workflow_call dry run will replace this in Phase 3. Do not re-enable; the file is kept for history until the post-Phase-3 deletion PR.
 name: Dry run release
 
 # Security: These write permissions are required for dry-run release testing

--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -1,4 +1,3 @@
-# DISABLED 2026-08-25 (TECHOPS-1099): superseded by the release-published-orchestrator dry_run input; a workflow_call dry run will replace this in Phase 3. Do not re-enable; the file is kept for history until the post-Phase-3 deletion PR.
 name: Dry run release
 
 # Security: These write permissions are required for dry-run release testing

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -1,3 +1,4 @@
+# DISABLED 2026-08-25 (TECHOPS-1099): superseded by fossa_ai.yml and the FOSSA job in main.yml. Do not re-enable; the file is kept for history until the post-Phase-3 deletion PR.
 # Name of the GitHub Action workflow
 name: FOSSA License Compliance and Security Check
 

--- a/.github/workflows/installer-build-check.yml
+++ b/.github/workflows/installer-build-check.yml
@@ -1,3 +1,4 @@
+# DISABLED 2026-08-25 (TECHOPS-1099): superseded by the release pipeline, which builds the installer at release time. Do not re-enable; the file is kept for history until the post-Phase-3 deletion PR.
 name: Build Test Installers
 
 on:

--- a/.github/workflows/owasp-scanner.yml
+++ b/.github/workflows/owasp-scanner.yml
@@ -1,3 +1,4 @@
+# DISABLED 2026-08-25 (TECHOPS-1112): superseded by CodeQL, Trivy scans and Dependabot; last run 2025-10. Do not re-enable; the file is kept for history until the post-Phase-3 deletion PR.
 name: OWASP Dependency Scanner
 
 on:

--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -1,3 +1,4 @@
+# DISABLED 2026-08-25 (TECHOPS-1106): superseded by dispatching liquibase-test-harness/main.yml directly from that repo. Do not re-enable; the file is kept for history until the post-Phase-3 deletion PR.
 name: Run Test Harness Tests
 
 on:

--- a/.github/workflows/weekly-integration-tests.yml
+++ b/.github/workflows/weekly-integration-tests.yml
@@ -1,3 +1,4 @@
+# DISABLED 2026-08-25 (TECHOPS-1112): superseded by nothing; disabled since 2025-11. Do not re-enable; the file is kept for history until the post-Phase-3 deletion PR.
 name: Weekly Integration Tests
 
 permissions:


### PR DESCRIPTION
## Summary

Header comment on the nine workflows disabled in the Actions UI today (`gh workflow disable`), so nobody re-enables one by accident. **No behavior change**; the disable state lives in the repo settings, this only documents it.

| Workflow | Superseded by | Ticket |
|---|---|---|
| `build.yml`, `build-branch.yml` | `main.yml` / `snapshot-branch.yml` (#7944) | TECHOPS-1104 |
| `run-test-harness.yml` | dispatching the harness from its own repo | TECHOPS-1106 |
| `claude-code-review.yml` | `@claude review` via gated `claude.yml` | TECHOPS-1103 |
| `cleanup-branch-builds.yml` | `cleanup-packages.yml` (#7944) | TECHOPS-1099 |
| `installer-build-check.yml`, `fossa.yml` | release pipeline / `fossa_ai.yml` | TECHOPS-1099 |
| `owasp-scanner.yml`, `weekly-integration-tests.yml` | CodeQL/Trivy/Dependabot; nothing | TECHOPS-1112 |

Still active until cutover (they carry today's CI): `run-tests.yml`, `test-pr.yml`, `build-main.yml`, `nightly-release.yml`, `label-pr.yml`, `docker-test.yml`, `docker-scan.yml`. `dry-run-release.yml` stays active too: it is the weekly release rehearsal (green 8 weeks running) and has no replacement until Phase 3.

Note: disabling a workflow does **not** stop it being invoked via `workflow_call`. `build.yml` (disabled since 2025) still runs on every internal PR through `run-tests.yml`, and calls `run-test-harness.yml`. Those paths end when `run-tests.yml` is disabled at cutover.

Deletion of the files is deferred until after the release pipeline rebuild (Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

