### PR TITLE
fix(ci): force bash for Build & Test so env vars expand on Windows (TECHOPS-526)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -135,6 +135,14 @@ jobs:
       # getting from build results page. If we remove 0-SNAPSHOT then we will need settings.xml
 
       - name: Build & Test Java 17+
+        # TECHOPS-526 follow-up: this job's matrix includes windows-latest, where the
+        # default shell is PowerShell and `$BRANCH_NAME` reads as an undefined
+        # PowerShell variable, not an env var. That silently passed -Dbuild.branch=
+        # and -Dbuild.commit= (empty), and the ant integration tests that short-SHA
+        # build.commit failed with StringIndexOutOfBoundsException. Forcing bash keeps
+        # the env: routing and expands identically on all three runners; mvnw handles
+        # MinGW natively (see its CYGWIN*|MINGW* branch).
+        shell: bash
         env:
           BRANCH_NAME: ${{ needs.setup.outputs.thisBranchName }}
           MERGE_SHA: ${{ needs.setup.outputs.latestMergeSha }}


### PR DESCRIPTION
## What

Adds `shell: bash` to `run-tests.yml`'s `Build & Test Java 17+` step.

## Why

#7931 moved `build.branch` / `build.commit` off inline `${{ }}` interpolation and into `env:` vars referenced as `$BRANCH_NAME` / `$MERGE_SHA`. That is the correct injection fix, but this job's matrix includes `windows-latest`, where the default shell is PowerShell. There `$BRANCH_NAME` is an undefined *PowerShell* variable, not an environment variable (that would be `$env:BRANCH_NAME`), so it expands to an empty string with no error.

From the failing job log on `main` @ `c17253f37`:

```
shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
env:
  BRANCH_NAME: main
  MERGE_SHA: c17253f372780290deadb92bf288f4664f1249d1
```

The env vars were set correctly; the script just could not read them. Maven received `-Dbuild.branch=` and `-Dbuild.commit=` empty, and the ant integration tests that short-SHA `build.commit` failed:

```
Expected build failure with message
  'Unable to initialize Liquibase: ... The file simple-changelog.xml was not found'
but was
  'Unable to initialize Liquibase: ... java.lang.StringIndexOutOfBoundsException: Range [0, 6) out of bounds for length 0'
```

`${{ }}` is interpolated by GitHub before any shell runs, so it worked on every runner. `$VAR` is shell-dependent, so the two forms are only equivalent on bash/sh.

## Regression, not pre-existing

`Run Test for (Java 21 / 25 windows-latest)` passed on the five preceding `main` runs and failed on exactly the #7931 merge commit.

It also cascades: `build_tests` gates `integration-test`, which gates `fossa`, `sonar` and `run-build-publish-file`, so two Windows jobs skipped the whole downstream pipeline. (The `main` SNAPSHOT still reached GPM because `build-main.yml` is an independent `push: main` workflow that #7931 did not touch.)

## Why `shell: bash` rather than reverting to `${{ }}`

Reverting would reopen the injection this ticket closed. `thisBranchName` derives from `GITHUB_HEAD_REF`, which is attacker-controlled on a fork PR, and the existing `tr '/_' '-'` does not strip `$`, backticks or parentheses. Keeping the `env:` routing holds zizmor at **0** high-severity `template-injection` findings across the four workflows.

`./mvnw` supports this directly: it has a `CYGWIN*|MINGW*` branch that `cygpath`s `JAVA_HOME` and converts paths back via `native_path`, so the JVM still runs as a native Windows process.

## Scope

Audited all 17 steps #7931 and liquibase-pro#4674 converted. **Exactly one** was exposed: every other step runs on a Linux-only runner, and liquibase-pro's `Set version` already declares `shell: bash`.

Considered and dismissed: `test-pr.yml` has the same unhardened step on the same Windows matrix, but it triggers on `pull_request`, so fork code is already compiled with a read-only token and no secrets. Template injection there is not a privilege escalation.

## Verification

Verified on a real Windows runner before opening this, via `workflow_dispatch --ref fix/techops-526-windows-shell` (dispatch uses the ref's own workflow copy, unlike `pull_request_target` which always uses base). Run [32940592930](https://github.com/liquibase/liquibase/actions/runs/32940592930):

```
shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
  BRANCH_NAME: fix-techops-526-windows-shell
  MERGE_SHA:   b7008fa3a534947135ba63d61a3b2165af68ce1a
```

- `Run Test for (Java 21 windows-latest)`: **success**
- `Run Test for (Java 25 windows-latest)`: **success**
- `DBDocVisitorTest`, `ChangeLogDirectoryTest`, `ChangeLogSyncTaskTest`, `DatabaseRollbackFutureTaskTest`: all 0 failures / 0 errors
- `StringIndexOutOfBoundsException`: 0 occurrences
- `BUILD SUCCESSFUL`

The run was cancelled after the Windows jobs concluded so it would not publish a snapshot from a scratch branch.

> [!NOTE]
> Because `run-tests.yml` runs on `pull_request_target`, **this PR's own checks will run `main`'s copy of the workflow, not this change.** That is exactly how the original regression slipped through a fully green board. The dispatch run linked above is the real evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)