### PR TITLE
[TECHOPS-1103] Gate the Claude assistant workflow on author association

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,10 +26,22 @@ permissions:
 
 jobs:
   claude:
+    # Trusted authors only. Every trigger below is public: issue_comment and
+    # issues fire for any GitHub account. This job calls build-logic's
+    # claude.yml, which assumes the vault OIDC role and reads /vault/liquibase
+    # before invoking the action, so without an author gate anyone who writes
+    # "@claude" causes a credential load. Bot senders are excluded so a bot
+    # echoing the mention cannot chain into a run.
+    #
+    # author_association hangs off a different object per event (comment,
+    # review, issue), which is why the check is repeated per branch rather than
+    # hoisted out of the expression.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.event.sender.type != 'Bot' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
+      )
     uses: liquibase/build-logic/.github/workflows/claude.yml@main
     secrets: inherit


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)

## Description

`issue_comment` and `issues` fire for any GitHub account, and this job calls build-logic's `claude.yml`, which assumes the vault OIDC role and reads `/vault/liquibase` before invoking the action ([build-logic claude.yml L37-L55](https://github.com/liquibase/build-logic/blob/04ea335beb37e0dfe952d34c0427b41660755f6d/.github/workflows/claude.yml#L37-L55)). Anyone who wrote `@claude` on a public issue or PR therefore caused a credential load.

This restricts the job to `OWNER`/`MEMBER`/`COLLABORATOR` authors and excludes bot senders. `author_association` hangs off a different object per event (comment, review, issue), so the check is repeated per branch rather than hoisted out of the expression.

Triggers, permissions, and the `secrets: inherit` call are untouched, so maintainer usage is unchanged. No other workflow is modified and no gating or required check is altered.

## Why this, and not the environment gate

TECHOPS-1103 originally called for moving `environment: external` onto every credential-bearing job, off the no-op `authorize` job it sits on today. **That approach is withdrawn**, for two reasons found during triage:

- It would add roughly five sequential reviewer approvals per fork-PR run, since jobs reach the environment at different stages and each requests review separately. Real approval-fatigue risk, and it does not shrink post-approval blast radius: once approved, fork code still runs with the full vault in scope.
- GitHub does not allow `environment:` on reusable-workflow caller (`uses:`) jobs, so `fossa`, `sonar` and `run-build-publish-file` in `run-tests.yml` could never have carried it directly.

The secret-free PR CI supersedes it ([#7944](https://github.com/liquibase/liquibase/pull/7944)): credential-bearing jobs come off PR events entirely, and at cutover the decoy `external` and `internal` environments are deleted rather than extended. No secrets are environment-scoped or repo-scoped, all are org-level, so those environments only ever provided a reviewer pause.

This PR is one of the two items that survive that change of plan, and it is independent of the cutover: the Claude assistant workflow is not one of the workflows being disabled, so the exposure persists after cutover unless gated here. The other survivor, replacing the release orchestrator's hardcoded approver list with a Terraform-managed `release` environment, is deliberately out of scope and stays queued behind cutover.

## How was this tested?

`actionlint` passes on the changed file.

This cannot be exercised from a PR branch: `issue_comment` and `issues` workflows always run from the default branch, so live behaviour is only observable after merge. After merge, the first maintainer `@claude` mention confirms the allow path, and a mention from a non-collaborator account is the deny path (job skipped, no vault step reached).

## Related

Part of the GHSA-mqw2-j77g-6486 remediation. The companion change disabling `claude-code-review.yml`, which loaded the vault on `pull_request`, is already applied. Cutover work is tracked in [#7944](https://github.com/liquibase/liquibase/pull/7944) and [#7945](https://github.com/liquibase/liquibase/pull/7945).

---

**After merge, check:** a maintainer `@claude` mention still starts a run (allow path), and a mention from a non-collaborator account leaves the job skipped with no vault step reached (deny path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
