### PR TITLE
[TECHOPS-1103] Gate the release on the release environment

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -327,7 +327,7 @@ To add a new step to the release process:
 
 **Issue**: Manual approval never arrives or is rejected
 - **Solution**: Check the run's deployment gate, not the issues list: approval happens on the run page under Review deployments
-- **Solution**: Check the reviewer list on the `release` environment. It is managed in liquibase-infrastructure (`github/liquibase/repos/public/liquibase-release-environment.tf`), so changing it takes a PR there
+- **Solution**: Check the reviewer list on the `release` environment. It is managed in [liquibase-release-environment.tf](https://github.com/liquibase/liquibase-infrastructure/blob/main/github/liquibase/repos/public/liquibase-release-environment.tf), so changing it takes a PR in liquibase-infrastructure
 - **Solution**: A reviewer cannot approve a run they started themselves. Someone else on the list has to
 
 **Issue**: Secrets not available in called workflows
@@ -392,7 +392,7 @@ dry_run_branch_name: (leave empty for production)
 **How approval works:** The job carries `environment: release`, so GitHub pauses it and shows
 **Review deployments** on the run page. Any reviewer on that environment can approve or reject,
 except the person who started the run. There is no tracking issue and no keyword replies. The
-reviewer list is Terraform-managed in liquibase-infrastructure.
+reviewer list is Terraform-managed in [liquibase-release-environment.tf](https://github.com/liquibase/liquibase-infrastructure/blob/main/github/liquibase/repos/public/liquibase-release-environment.tf).
 
 **Required inputs:**
 - `version`: Version to approve (e.g., `4.28.0`)

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -387,7 +387,9 @@ dry_run_branch_name: (leave empty for production)
 
 ### 2. Release Manual Approval (`release-manual-approval.yml`)
 
-**When to use:** If approval was skipped or needs to be re-requested.
+**When to use:** Normally never on its own. Approval is per-run: a paused orchestrator run is
+approved from **Review deployments** on that run's page, and dispatching this workflow standalone
+only gates its own, empty run. It exists as the reusable gate job the orchestrator calls.
 
 **How approval works:** The job carries `environment: release`, so GitHub pauses it and shows
 **Review deployments** on the run page. Any reviewer on that environment can approve or reject,
@@ -406,7 +408,8 @@ version: 4.28.0
 dry_run: false
 ```
 
-**Note:** Requires 2 approvers from the approved list.
+**Note:** One approval from the environment's reviewer list releases the gate, and the approver
+cannot be the person who started the run (`prevent_self_review`).
 
 ### 3. Deploy to Maven Central (`release-deploy-maven.yml`)
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -104,7 +104,7 @@ The main coordinator that triggers all release steps in the proper sequence. Sup
 | Workflow | Purpose | Can Run Independently |
 |----------|---------|----------------------|
 | `release-setup.yml` | Extract release metadata (version, tag, branch) | ✅ Yes |
-| `release-manual-approval.yml` | Request manual deployment approval | ✅ Yes |
+| `release-manual-approval.yml` | Hold the release for approval on the `release` environment | ✅ Yes |
 | `release-deploy-maven.yml` | Deploy artifacts to Maven Central | ✅ Yes |
 | `release-deploy-javadocs.yml` | Upload javadocs to S3 | ✅ Yes |
 | `release-publish-github-packages.yml` | Publish to GitHub Packages | ✅ Yes |
@@ -149,7 +149,7 @@ The pattern matches the orchestrator approach used in `liquibase-pro`:
 
 When a GitHub release is published, the orchestrator automatically:
 1. Extracts release metadata
-2. Requests manual approval (2 approvers required)
+2. Waits for approval on the `release` environment (one reviewer, and not the person who started the run)
 3. Deploys to all targets in parallel where possible
 4. Generates a comprehensive summary
 
@@ -199,7 +199,7 @@ If a specific step fails, you can re-run just that workflow:
                        │
                        ▼
               ┌────────────────┐
-              │Manual Approval │  2 approvers required (skipped if dry_run)
+              │Manual Approval │  `release` environment gate (skipped if dry_run)
               └────────┬───────┘
                        │
         ┌──────────────┴──────────────┐
@@ -325,9 +325,10 @@ To add a new step to the release process:
 - **Solution**: Check permissions in orchestrator file
 - **Solution**: Verify GitHub App has correct permissions
 
-**Issue**: Manual approval times out
-- **Solution**: Increase timeout in `release-manual-approval.yml`
-- **Solution**: Check approver list is correct
+**Issue**: Manual approval never arrives or is rejected
+- **Solution**: Check the run's deployment gate, not the issues list: approval happens on the run page under Review deployments
+- **Solution**: Check the reviewer list on the `release` environment. It is managed in liquibase-infrastructure (`github/liquibase/repos/public/liquibase-release-environment.tf`), so changing it takes a PR there
+- **Solution**: A reviewer cannot approve a run they started themselves. Someone else on the list has to
 
 **Issue**: Secrets not available in called workflows
 - **Solution**: Ensure `secrets: inherit` is present
@@ -387,6 +388,11 @@ dry_run_branch_name: (leave empty for production)
 ### 2. Release Manual Approval (`release-manual-approval.yml`)
 
 **When to use:** If approval was skipped or needs to be re-requested.
+
+**How approval works:** The job carries `environment: release`, so GitHub pauses it and shows
+**Review deployments** on the run page. Any reviewer on that environment can approve or reject,
+except the person who started the run. There is no tracking issue and no keyword replies. The
+reviewer list is Terraform-managed in liquibase-infrastructure.
 
 **Required inputs:**
 - `version`: Version to approve (e.g., `4.28.0`)

--- a/.github/workflows/release-manual-approval.yml
+++ b/.github/workflows/release-manual-approval.yml
@@ -28,22 +28,19 @@ on:
         default: false
 
 permissions:
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   manual-approval:
     name: Request Manual Approval
     runs-on: ubuntu-22.04
     if: ${{ inputs.dry_run == false }}
+    # The gate itself. GitHub holds the job here until a reviewer on the
+    # `release` environment approves the run, and every publishing job in the
+    # orchestrator depends on this job. The reviewer list lives in
+    # liquibase-infrastructure, not in this file, so it cannot be changed by
+    # editing a workflow.
+    environment: release
     steps:
-      - name: Get Version to deploy
-        uses: trstringer/manual-approval@fa642940caf8412403569b28b2db4a1df08a83a3 # v1
-        with:
-          secret: ${{ secrets.GITHUB_TOKEN }}
-          approvers: filipelautert,rberezen,jnewton03,jandroav,sayaliM0412
-          minimum-approvals: 2
-          issue-title: "Deploying ${{ inputs.version }} to Maven Central"
-          issue-body: "Please approve or deny the deployment of version ${{ inputs.version }} to Maven Central"
-          additional-approved-words: "lgtm,✅,👍,proceed,shipit,:shipit:"
-          additional-denied-words: "stop,error,failed,fail,broken,:x:,👎"
+      - name: Record approval
+        run: echo "Release ${{ inputs.version }} approved for deployment."

--- a/.github/workflows/release-manual-approval.yml
+++ b/.github/workflows/release-manual-approval.yml
@@ -37,9 +37,10 @@ jobs:
     if: ${{ inputs.dry_run == false }}
     # The gate itself. GitHub holds the job here until a reviewer on the
     # `release` environment approves the run, and every publishing job in the
-    # orchestrator depends on this job. The reviewer list lives in
-    # liquibase-infrastructure, not in this file, so it cannot be changed by
-    # editing a workflow.
+    # orchestrator depends on this job. The environment and its reviewer list are
+    # defined in liquibase-infrastructure, not in this file, so they cannot be
+    # changed by editing a workflow:
+    # https://github.com/liquibase/liquibase-infrastructure/blob/main/github/liquibase/repos/public/liquibase-release-environment.tf
     environment: release
     steps:
       - name: Record approval

--- a/.github/workflows/release-published-orchestrator.yml
+++ b/.github/workflows/release-published-orchestrator.yml
@@ -78,13 +78,9 @@ jobs:
     name: Manual Deployment Approval
     needs: [setup]
     uses: ./.github/workflows/release-manual-approval.yml
-    permissions:
-      issues: write
-      pull-requests: write
     with:
       version: ${{ needs.setup.outputs.version }}
       dry_run: ${{ inputs.dry_run || false }}
-    secrets: inherit
 
   deploy-javadocs:
     name: Deploy Javadocs


### PR DESCRIPTION
> 🚫 **Do not merge until [liquibase-infrastructure#4270](https://github.com/liquibase/liquibase-infrastructure/pull/4270) is merged AND applied.** Until the `release` environment exists, this blocks the next release on a gate that is not there.

Puts `environment: release` on the `manual-approval` job and deletes `trstringer/manual-approval`, so the reviewer list lives in Terraform-managed repository settings instead of workflow YAML and the release path drops a third-party action that held `GITHUB_TOKEN` and opened tracking issues. The caller no longer needs `issues`/`pull-requests` write or `secrets: inherit`, so both are removed, and `.github/workflows/README.md` is updated for whoever approves or debugs a release next.

⚠️ **Approval count changes from 2 to 1.** GitHub environments have no N-of-M setting, so `minimum-approvals: 2` has no equivalent; `prevent_self_review` on the environment keeps the approver distinct from whoever started the run, preserving "two different people" but not "two approvals". **This needs a release-owner decision before merge**: if two approvals are a hard requirement, this PR should be closed and the action kept.

Dry runs are unaffected (the job is still gated on `dry_run == false` and never reaches the environment). `actionlint` is clean on the approval workflow; the two findings it reports on the orchestrator are pre-existing on `main`.

---

**Merge order:** [liquibase-infrastructure#4270](https://github.com/liquibase/liquibase-infrastructure/pull/4270) merged **and applied** → this PR.

**Before marking ready:** confirm `release` exists under Settings → Environments with its reviewers and both deployment rules, defined in [liquibase-release-environment.tf](https://github.com/liquibase/liquibase-infrastructure/blob/main/github/liquibase/repos/public/liquibase-release-environment.tf).

**After merge, check:** the next dry run still skips `Manual Deployment Approval` entirely, and the next real release pauses there with a **Review deployments** prompt on the `release` environment rather than opening a tracking issue. After one reviewer approves, the publishing jobs (Maven Central, GitHub Packages, javadocs, XSD, Docker, S3) should run as before. If the job fails immediately with a deployment-rejected error, the environment's deployment rules do not match the run's ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
