### PR TITLE
fix(ci): use the asset API url for the dry-run tar.gz [TECHOPS-1205]

### DIFF
--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -133,9 +133,17 @@ jobs:
           echo "Assets API Response status code: $?"
           echo "Assets API Response: $assets_response"
 
-          # Get URLs for zip and tar.gz files - getting browser_download_url instead of url
+          # The zip keeps browser_download_url: nothing downloads it, it is only
+          # surfaced in the summary and passed to consumers that ignore it.
+          #
+          # The tar.gz must use the asset API url. The ansible role deploy is the
+          # only consumer that actually fetches it, and at this point the release is
+          # still a draft, so browser_download_url is an untagged-<hash> path that
+          # 404s for a token-authenticated client. The asset API url resolves with
+          # the Accept: application/octet-stream + bearer token the role already
+          # sends (TECHOPS-1205).
           dry_run_zip_url=$(echo "$assets_response" | jq -r '.[] | select(.name | test("^liquibase-dry-run-.*\\.zip$")) | .browser_download_url')
-          dry_run_tar_gz_url=$(echo "$assets_response" | jq -r '.[] | select(.name | test("^liquibase-dry-run-.*\\.tar\\.gz$")) | .browser_download_url')
+          dry_run_tar_gz_url=$(echo "$assets_response" | jq -r '.[] | select(.name | test("^liquibase-dry-run-.*\\.tar\\.gz$")) | .url')
 
           echo "Found zip URL: $dry_run_zip_url"
           echo "Found tar.gz URL: $dry_run_tar_gz_url"


### PR DESCRIPTION
## 🐛 Problem

Dry runs are still red after TECHOPS-1158. The semver gate is fixed and `Validate inputs` now passes, but the very next step in the same job cannot fetch the artifact:

```
--2026-08-28 10:40:04--  .../releases/download/untagged-75885c8c15942c9a98f4/liquibase-dry-run-33163869744.tar.gz
HTTP request sent, awaiting response... 404 Not Found
```

`dry-run-release.yml` published the tar.gz as the asset's `browser_download_url`. At that point the release is still a draft, so that value is an `untagged-<hash>` path, and GitHub does not serve it to a token-authenticated client.

Seen in run [33164188158](https://github.com/liquibase/liquibase/actions/runs/33164188158), job `Update Packages / upload_ansible_role / build_and_deploy_ansible`, step 9. This path had never actually run on a dry run before: Update Packages was skipped entirely until TECHOPS-1121 re-enabled it, which exposed both this and the TECHOPS-1158 gate.

## ✅ Fix

One field: the tar.gz now uses the asset API `url`. The ansible role deploy is the only consumer that downloads it, and it already sends `Accept: application/octet-stream` with a bearer token, which is what that endpoint expects, so nothing changes in `liquibase-ansible` and no SHA pin needs re-bumping.

The zip keeps `browser_download_url`: nothing downloads it, and it has other consumers.

## 🧪 Verification

* `jq` selector returns the API url and still matches exactly one asset, checked against a GitHub-shaped draft payload with a decoy `*.tar.gz` present.
* Against a real published asset, the asset API url returns `HTTP 206` with `content-type: application/octet-stream` and a correct `content-range`.
* Checked the redirect hop specifically, since the role uses `wget`, which forwards `--header` values across hosts and can trip "only one auth mechanism allowed". Both behaviours succeed: auth stripped at the redirect returns 206, and auth forwarded (`curl --location-trusted`, matching wget) also returns 206. So the existing `wget` call needs no change.
* `actionlint` + `shellcheck`: 7 findings before, 7 after, identical apart from shifted line numbers. No new findings.

## ⚠️ Remaining

The only real proof is another dry run, which I will dispatch once this merges. Scope is limited to `dry-run-release.yml`, which is only reachable via `workflow_dispatch` and the weekly Wednesday cron, so production releases are untouched.

Closes TECHOPS-1205. Unblocks the last acceptance criterion of TECHOPS-1158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)