### PR TITLE
[TECHOPS-1188] Narrow the harness vault read and scope its App token

### DIFF
--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -60,6 +60,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ test-harness-build ]
     name: Trigger Test Harness Tests
+    # Gated directly rather than only through needs, because the authorize job has been removed twice before (#7902, #7906).
+    environment: ${{ github.event.pull_request && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -92,22 +94,39 @@ jobs:
           role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
-      - name: Get secrets from vault
-        id: vault-secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@2cb1a461cbd4865ac4299648312e4704c646cd53 # v3.0.1
-        with:
-          secret-ids: |
-            ,/vault/liquibase
-          parse-json-secrets: true
+      - name: Get App credentials from vault
+        id: app-creds
+        # Read by hand because aws-secretsmanager-get-secrets cannot select individual JSON keys, and this job needs two of them.
+        run: |
+          set -euo pipefail
+          bundle=$(aws secretsmanager get-secret-value \
+            --secret-id /vault/liquibase \
+            --query SecretString --output text)
+          app_id=$(printf '%s' "$bundle" | jq -re '.LIQUIBASE_GITHUB_APP_ID')
+          app_key=$(printf '%s' "$bundle" | jq -re '.LIQUIBASE_GITHUB_APP_PRIVATE_KEY')
+          unset bundle
+          # add-mask matches line by line, so the PEM needs one mask per line.
+          echo "::add-mask::$app_id"
+          while IFS= read -r line; do
+            [ -n "$line" ] && echo "::add-mask::$line"
+          done <<< "$app_key"
+          {
+            echo "app_id=$app_id"
+            echo "app_key<<VAULT_PEM_EOF"
+            echo "$app_key"
+            echo "VAULT_PEM_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Get GitHub App token
         id: get-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ env.LIQUIBASE_GITHUB_APP_ID }}
-          private-key: ${{ env.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ steps.app-creds.outputs.app_id }}
+          private-key: ${{ steps.app-creds.outputs.app_key }}
           owner: ${{ github.repository_owner }}
-          permission-contents: write
+          # Without repositories: the token covers every repo the App is installed on.
+          repositories: liquibase-test-harness
+          # return-dispatch needs Actions write and nothing else.
           permission-actions: write
 
       - name: Build test-harness dispatch payload

--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -102,19 +102,30 @@ jobs:
           bundle=$(aws secretsmanager get-secret-value \
             --secret-id /vault/liquibase \
             --query SecretString --output text)
-          app_id=$(printf '%s' "$bundle" | jq -re '.LIQUIBASE_GITHUB_APP_ID')
-          app_key=$(printf '%s' "$bundle" | jq -re '.LIQUIBASE_GITHUB_APP_PRIVATE_KEY')
+          # jq -j plus a sentinel: command substitution strips ALL trailing newlines,
+          # which would silently alter a value that legitimately ends in one.
+          app_id=$(printf '%s' "$bundle" | jq -j '.LIQUIBASE_GITHUB_APP_ID // ""'; printf 'X')
+          app_id=${app_id%X}
+          app_key=$(printf '%s' "$bundle" | jq -j '.LIQUIBASE_GITHUB_APP_PRIVATE_KEY // ""'; printf 'X')
+          app_key=${app_key%X}
           unset bundle
-          # add-mask matches line by line, so the PEM needs one mask per line.
-          echo "::add-mask::$app_id"
-          while IFS= read -r line; do
-            [ -n "$line" ] && echo "::add-mask::$line"
-          done <<< "$app_key"
+          if [ -z "$app_id" ]; then echo "::error::LIQUIBASE_GITHUB_APP_ID missing from /vault/liquibase"; exit 1; fi
+          if [ -z "$app_key" ]; then echo "::error::LIQUIBASE_GITHUB_APP_PRIVATE_KEY missing from /vault/liquibase"; exit 1; fi
+          # add-mask matches line by line, so the PEM needs one mask per line. An `if`
+          # rather than `&&`: on a value ending in a newline the final empty line would
+          # make the loop exit non-zero and set -e would kill the step.
+          printf '%s\n' "$app_id" | while IFS= read -r line; do
+            if [ -n "$line" ]; then echo "::add-mask::$line"; fi
+          done
+          printf '%s\n' "$app_key" | while IFS= read -r line; do
+            if [ -n "$line" ]; then echo "::add-mask::$line"; fi
+          done
+          # Heredoc for both, not name=value: a preserved trailing newline would
+          # otherwise corrupt the output file.
+          D="VAULT_EOF_${RANDOM}${RANDOM}"
           {
-            echo "app_id=$app_id"
-            echo "app_key<<VAULT_PEM_EOF"
-            echo "$app_key"
-            echo "VAULT_PEM_EOF"
+            echo "app_id<<$D";  printf '%s\n' "$app_id";  echo "$D"
+            echo "app_key<<$D"; printf '%s\n' "$app_key"; echo "$D"
           } >> "$GITHUB_OUTPUT"
 
       - name: Get GitHub App token


### PR DESCRIPTION
## Impact

- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

`run-test-harness.yml` reads **all** of `/vault/liquibase` via `parse-json-secrets: true` and mints a
GitHub App token with `contents: write` scoped to every repository the App is installed on. The job
uses exactly two of those keys and needs Actions write on one repository.

**This is live, not dormant.** The workflow shows as `disabled_manually`, but `workflow_call` ignores
that state, so the chain still executes on every push to `main`:

```
run-tests.yml [ACTIVE]  push to main
  -> run-tests.yml:292   uses: ./.github/workflows/build.yml     [disabled_manually]
       -> build.yml:270  run-test-harness.yml@main               [disabled_manually]
```

Run [32948593018](https://github.com/liquibase/liquibase/actions/runs/32948593018) (2026-08-26): steps
`Configure AWS credentials for vault access`, `Get secrets from vault` and `Get GitHub App token` all
**succeeded**. Note a `git grep` for `workflows/build.yml@` finds nothing, because the caller uses a
local path.

Four changes:

1. **Narrow the vault read to the two keys the job uses.** The action has no way to select an
   individual JSON key, at our pinned version *or* on its `main` today (see Upstream below), so the
   read is hand-rolled. I confirmed `LIQUIBASE_GITHUB_APP_ID`
   and `LIQUIBASE_GITHUB_APP_PRIVATE_KEY` are the only vault keys referenced anywhere in the file, and
   that neither appears in any other workflow in this repo.
2. **Scope the App token to `liquibase-test-harness`.** Per `actions/create-github-app-token`'s own
   `action.yml`, `repositories` "defaults to current repository if owner is unset": with `owner` set
   and `repositories` unset, the token covers every repo the App is installed on.
3. **Drop `permission-contents: write`.** `codex-/return-dispatch`'s README at the pinned SHA states
   the requirement as "`Actions` repository permission, **write**" and nothing else.
4. **Put the `environment:` gate on the credentialed job itself**, not only inherited through `needs`.
   The `authorize` job was removed twice before (#7902, #7906) and restored by #7924, so a transitive
   gate is the fragile part.

## Release note

<!-- CI-only change, not customer-facing. skipReleaseNotes applied. -->

## Things to be aware of

**Gating is untouched and I want to be explicit about that.** Fork PRs were *already* blocked before
this PR, by the `authorize` job at `run-test-harness.yml:27` plus the equivalent gate in
`run-tests.yml`. Verified on fork run
[32751007888](https://github.com/liquibase/liquibase/actions/runs/32751007888), where `authorize` was
the only job and everything downstream skipped. This PR does not widen or narrow who can trigger
anything; it reduces what the job holds once it runs.

**Masking.** `parse-json-secrets: true` used to mask each JSON leaf for us. A hand-rolled read has to
do that itself, and `::add-mask::` matches line by line, so the PEM gets one mask per line. Losing
that would be a silent regression, which is why it is tested below.

**How it was verified.** I extracted the step body from the YAML with `yaml.safe_load` (so the real
text ran) and executed it under `bash -e` with a stub `aws` returning a fake bundle of the 2 needed
keys plus 6 sentinel keys named after real unused ones:

- exit 0; **29** `::add-mask::` directives emitted (1 for the id, 28 for the PEM lines)
- **zero** sentinel values in stdout, and none of the 6 unused keys reached `$GITHUB_OUTPUT`
- both values round-tripped byte-identical through the heredoc, and the recovered PEM passes
  `openssl rsa -check`
- `jq -re` makes a missing key exit non-zero, so the step fails closed rather than minting a token
  with an empty key

`actionlint`: 133 findings on `origin/main`, 133 on this branch, all pre-existing `SC2086` in steps
this PR does not touch.

## Things to worry about

- **No real CI run yet.** Everything above is local execution plus reading each action's manifest at
  its pinned SHA. The first real exercise is a push to `main`, since that is the only path that
  reaches this job today.
- `INSTALL4J_LICENSE` vs `INSTALL4J_LICENSE_KEY` diverge elsewhere in this repo. Not touched here,
  flagged because the same class of key-name assumption applies to narrow reads generally.
- This is 1 of 78 whole-vault read sites across this repo and `build-logic`. The rest are separate PRs.

## Upstream: the workaround is forced, not preferred

Worth stating plainly, because a reviewer will reasonably ask why we hand-roll a read instead of
asking the action to do it:

- Our pin `2cb1a461cbd4865ac4299648312e4704c646cd53` resolves **exactly** to tag `v3.0.1`, which is
  still the newest release (2026-04-03).
- `action.yml` on that repo's **`main` today** has the same four inputs: `secret-ids`,
  `parse-json-secrets`, `name-transformation`, `auto-select-family-attempt-timeout`. So this is not a
  stale-pin problem. The capability does not exist at HEAD either, and `json-secret-keys` appears
  nowhere in `src/index.ts` on `main`.
- **Liquibase already asked for it upstream, with a patch.**
  [aws-actions/aws-secretsmanager-get-secrets#263](https://github.com/aws-actions/aws-secretsmanager-get-secrets/issues/263)
  (issue) and
  [#264](https://github.com/aws-actions/aws-secretsmanager-get-secrets/pull/264) (PR, +204/-27 across
  11 files) were both opened by @jnewton03 on 2025-09-10. AWS parked the PR on 2025-09-12: "My
  preference would be to have a masking deny-list instead ... We're going to discuss this internally.
  No need to iterate on the associated PR in the meantime." Eleven months on it has **no reviews**, is
  now `mergeable_state=dirty`, and the last activity is an outside comment asking "What are we waiting
  for?"

So until either that PR lands or the secret itself is split, a CLI read is the only way to stop
loading the whole bundle.

**A second, independent reason from #263 that is easy to miss:** `parse-json-secrets: true` calls
`core.setSecret()` on *every* leaf, so innocuous values get redacted everywhere. Our own issue gives
the example of the literal string `liquibase` being masked throughout the logs. GitHub also refuses to
pass a masked value as a job output, so a vault value that happens to be a common string (a region
name, say) silently becomes an empty string downstream. Narrowing the read fixes that too.

## Additional Context

Part of the Vanta "P2 security issues resolved" remediation. Related in-flight work: #7944 (secret-free
PR CI) and #7945 (marking disabled workflows). Worth noting for #7945: the `DISABLED ... Do not
re-enable` header it adds to this file is not accurate today, for the `workflow_call` reason above.
