### PR TITLE
[TECHOPS-1188] Narrow the build.yml vault read to the four keys it uses

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,13 +116,12 @@ jobs:
             v=$(printf '%s' "$JSON" | jq -j --arg k "$k" '.[$k] // ""'; printf 'X')
             v=${v%X}
             if [ -z "$v" ]; then echo "::error::$k missing from /vault/liquibase"; exit 1; fi
-            # One mask per line: the runner matches masks line by line, so a multi-line
-            # value masked whole still prints its individual lines in cleartext.
-            # An `if` rather than `&&`: on a value ending in a newline the final empty
-            # line would make the loop exit non-zero and set -e would kill the step.
-            printf '%s\n' "$v" | while IFS= read -r line; do
-              if [ -n "$line" ]; then echo "::add-mask::$line"; fi
-            done
+            # The runner unescapes %0D, %0A and %25 in command data, so a value carrying
+            # those literals registers a mask that never matches it; % is escaped first
+            # so the escapes the next two produce are not escaped again.
+            e=$v; e=${e//'%'/%25}; e=${e//$'\r'/%0D}; e=${e//$'\n'/%0A}
+            # Escaped, one command masks the whole value and every line within it.
+            printf '::add-mask::%s\n' "$e"
             D="VAULT_EOF_${RANDOM}${RANDOM}"
             { echo "$k<<$D"; printf '%s\n' "$v"; echo "$D"; } >> "$GITHUB_ENV"
           done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,11 +104,25 @@ jobs:
 
       - name: Get secrets from vault
         id: vault-secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@2cb1a461cbd4865ac4299648312e4704c646cd53 # v3.0.1
-        with:
-          secret-ids: |
-            ,/vault/liquibase
-          parse-json-secrets: true
+        # TECHOPS-1188: aws-secretsmanager-get-secrets can only load a secret whole, so
+        # parse-json-secrets: true put every credential in /vault/liquibase into this
+        # job's environment; read only the four keys this job uses instead.
+        run: |
+          set -euo pipefail
+          JSON=$(aws secretsmanager get-secret-value --secret-id /vault/liquibase --region us-east-1 --query SecretString --output text)
+          for k in GPG_SECRET GPG_PASSPHRASE LIQUIBOT_PAT_GPM_ACCESS INSTALL4J_LICENSE; do
+            v=$(printf '%s' "$JSON" | jq -r --arg k "$k" '.[$k] // ""')
+            if [ -z "$v" ]; then echo "::error::$k missing from /vault/liquibase"; exit 1; fi
+            # One mask per line: the runner matches masks line by line, so a multi-line
+            # value masked whole still prints its individual lines in cleartext.
+            printf '%s\n' "$v" | while IFS= read -r line; do
+              [ -n "$line" ] && echo "::add-mask::$line"
+            done
+            D="VAULT_EOF_${RANDOM}${RANDOM}"
+            { echo "$k<<$D"; printf '%s\n' "$v"; echo "$D"; } >> "$GITHUB_ENV"
+          done
+          unset JSON
+          echo "Loaded GPG_SECRET, GPG_PASSPHRASE, LIQUIBOT_PAT_GPM_ACCESS and INSTALL4J_LICENSE from /vault/liquibase."
 
       - name: Convert escaped newlines and set GPG key
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,12 +111,17 @@ jobs:
           set -euo pipefail
           JSON=$(aws secretsmanager get-secret-value --secret-id /vault/liquibase --region us-east-1 --query SecretString --output text)
           for k in GPG_SECRET GPG_PASSPHRASE LIQUIBOT_PAT_GPM_ACCESS INSTALL4J_LICENSE; do
-            v=$(printf '%s' "$JSON" | jq -r --arg k "$k" '.[$k] // ""')
+            # jq -j plus a sentinel: command substitution strips ALL trailing newlines,
+            # which would silently alter a value that legitimately ends in one.
+            v=$(printf '%s' "$JSON" | jq -j --arg k "$k" '.[$k] // ""'; printf 'X')
+            v=${v%X}
             if [ -z "$v" ]; then echo "::error::$k missing from /vault/liquibase"; exit 1; fi
             # One mask per line: the runner matches masks line by line, so a multi-line
             # value masked whole still prints its individual lines in cleartext.
+            # An `if` rather than `&&`: on a value ending in a newline the final empty
+            # line would make the loop exit non-zero and set -e would kill the step.
             printf '%s\n' "$v" | while IFS= read -r line; do
-              [ -n "$line" ] && echo "::add-mask::$line"
+              if [ -n "$line" ]; then echo "::add-mask::$line"; fi
             done
             D="VAULT_EOF_${RANDOM}${RANDOM}"
             { echo "$k<<$D"; printf '%s\n' "$v"; echo "$D"; } >> "$GITHUB_ENV"


### PR DESCRIPTION
## Impact

- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

`build.yml` loads **every** key in `/vault/liquibase` into the job environment via
`parse-json-secrets: true`. The job consumes four: `GPG_SECRET`, `GPG_PASSPHRASE`,
`LIQUIBOT_PAT_GPM_ACCESS` and `INSTALL4J_LICENSE`. This narrows the read to those four.

**Reached on every internal PR and every push to `main`**, through `run-tests.yml:292`, which calls
this file by local path (`uses: ./.github/workflows/build.yml`). The `disabled_manually` state on
`build.yml` does not apply to `workflow_call`. Evidence: run
[32948593018](https://github.com/liquibase/liquibase/actions/runs/32948593018), job
`run-build-publish-file / Artifacts - Build & Package`, **success**. For scale, `build.yml` has 2 runs
ever under its own name, both failures in July 2025, so run count is not a useful signal here: the
caller owns the runs.

`aws-actions/aws-secretsmanager-get-secrets` cannot select an individual JSON key, at our pinned
version or on its `main` today, so a narrow read has to be hand-rolled until the secret itself is
split. See Upstream below: we already asked for this feature and AWS parked our patch.

## Release note

<!-- CI-only change, not customer-facing. skipReleaseNotes applied. -->

## Things to be aware of

**This follows the pattern already in this org**, at `package.yml:150-167`,
`reusable-docker-build-qa.yml:100-113` and `reusable-preview-distribute.yml:150-164`: CLI read,
explicit key allowlist, fail closed on a missing key, `::add-mask::` before `$GITHUB_ENV`. Two
deliberate hardenings over that precedent:

1. **One mask per line.** The precedent masks a multi-line value whole. The runner matches masks line
   by line, so a PGP key masked as one string still prints its individual lines in cleartext.
2. **A random heredoc delimiter** instead of `echo "$k=$v" >> $GITHUB_ENV`, which is an env-injection
   vector on a multi-line value. `${RANDOM}` matches the existing idiom at
   `build-logic/reusable-docker-build.yml:631` and avoids adding an `openssl` dependency.

**Gating is untouched.** The job's fork guard at `build.yml:79` is unchanged, and this PR does not
alter any trigger, `if:`, or permission. It only reduces what is in the environment once the job runs.

**How it was verified.** Step body extracted from the YAML with `yaml.safe_load` and executed with a
stub `aws` returning the 4 real keys plus 6 `MUSTNOTLEAK-*` sentinels named after real unused vault
keys:

- exit 0; zero sentinel strings in step output; none of the 6 unused key names reached `$GITHUB_ENV`
- exactly 4 heredoc headers exported, all 4 values byte-identical to the source
- missing key gives exit 1 with `::error::<KEY> missing from /vault/liquibase`
- a multi-line PGP value survives intact, including cases with an internal blank line and with a
  trailing newline (both added specifically to rule out a `set -e` trap in the masking loop)

`actionlint`: 133 findings on `origin/main`, 133 on this branch. All pre-existing.

## Things to worry about

- **`INSTALL4J_LICENSE` is assumed to be the real key name.** `build.yml:170` reads
  `${{ env.INSTALL4J_LICENSE }}` today, so the exploding action must be supplying it under that name,
  and this PR preserves the name exactly. But `create-release.yml:344` reads
  `INSTALL4J_LICENSE_KEY`. Whether both exist in the vault is unverified. **One real run confirms it**,
  and the step fails closed rather than silently proceeding if the name is wrong.
- No real CI run yet, for the same reason as above: the reaching path is a push to `main`.

## Upstream: the workaround is forced, not preferred

Worth stating plainly, because a reviewer will reasonably ask why we hand-roll a read instead of
asking the action to do it:

- Our pin `2cb1a461cbd4865ac4299648312e4704c646cd53` resolves **exactly** to tag `v3.0.1`, which is
  still the newest release (2026-04-03).
- `action.yml` on that repo's **`main` today** has the same four inputs: `secret-ids`,
  `parse-json-secrets`, `name-transformation`, `auto-select-family-attempt-timeout`. So this is not a
  stale-pin problem. The capability does not exist at HEAD either, and `json-secret-keys` appears
  nowhere in `src/index.ts` on `main`.
- **Liquibase already asked for it upstream, with a patch.**
  [aws-actions/aws-secretsmanager-get-secrets#263](https://github.com/aws-actions/aws-secretsmanager-get-secrets/issues/263)
  (issue) and
  [#264](https://github.com/aws-actions/aws-secretsmanager-get-secrets/pull/264) (PR, +204/-27 across
  11 files) were both opened by @jnewton03 on 2025-09-10. AWS parked the PR on 2025-09-12: "My
  preference would be to have a masking deny-list instead ... We're going to discuss this internally.
  No need to iterate on the associated PR in the meantime." Eleven months on it has **no reviews**, is
  now `mergeable_state=dirty`, and the last activity is an outside comment asking "What are we waiting
  for?"

So until either that PR lands or the secret itself is split, a CLI read is the only way to stop
loading the whole bundle.

**A second, independent reason from #263 that is easy to miss:** `parse-json-secrets: true` calls
`core.setSecret()` on *every* leaf, so innocuous values get redacted everywhere. Our own issue gives
the example of the literal string `liquibase` being masked throughout the logs. GitHub also refuses to
pass a masked value as a job output, so a vault value that happens to be a common string (a region
name, say) silently becomes an empty string downstream. Narrowing the read fixes that too.

## Additional Context

Part of the Vanta "P2 security issues resolved" remediation. 78 whole-vault read sites exist across
this repo (18) and `build-logic` (60); `parse-json-secrets: false` appears zero times in either. This
is one of them, chosen because it is the highest-frequency credentialed consumer that is proven to
execute. Splitting the secret itself is separate and needs Terraform plus a manual value migration.
