### PR TITLE
[TECHOPS-1188] Harden kept workflows: deny-by-default permissions and persist-credentials

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -8,10 +8,16 @@ on:
     branches:
       - 'main'
 
+# Deny by default so a new job cannot silently pick up the org-wide write default.
+permissions: {}
+
 jobs:
   setup:
     name: Setup
     runs-on: ubuntu-22.04
+    permissions:
+      # Only what the checkout needs; this job publishes nothing, it just emits two outputs.
+      contents: read
     outputs:
       timeStamp: ${{ steps.get-timestamp.outputs.timeStamp }}
       latestMergeSha: ${{ steps.get-sha.outputs.latestMergeSha }}

--- a/.github/workflows/cleanup-main-builds.yml
+++ b/.github/workflows/cleanup-main-builds.yml
@@ -5,10 +5,16 @@ on:
   release:
     types: [ published ]
 
+# Deny by default so a new job cannot silently pick up the org-wide write default.
+permissions: {}
+
 jobs:
   delete-package:
     name: Delete Github Packages for Main
     runs-on: ubuntu-22.04
+    permissions:
+      # Only scope actions/delete-package-versions needs; it acts on packages owned by this repo.
+      packages: write
 
     strategy:
       matrix:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,9 @@ on:
   schedule:
     - cron: '16 14 * * 4'
 
+# Deny by default so a new job cannot silently pick up the org-wide write default.
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze
@@ -42,6 +45,9 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        # A pull_request run checks out the PR merge commit, so Autobuild builds fork-controlled code in this workspace.
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -79,6 +85,8 @@ jobs:
     # Replaced rsdmike/github-security-report-action@v3.0.4 (stuck on Node 16, unmaintained)
     # with actions/github-script@v8 (Node 24) to generate a security report from code scanning alerts
     - name: Generate Security Report
+      # A fork pull_request gets a read-only token with no code-scanning access, so this only ever logs a warning there.
+      if: github.event_name != 'pull_request'
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
@@ -156,6 +164,7 @@ jobs:
           core.info(`Security report generated with ${summary.total_open_alerts} open alerts`);
 
     - name: Upload Security Report
+      if: github.event_name != 'pull_request'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: security-report

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,13 +1,7 @@
 name: Attach Artifacts To Draft Release
 
-# Security: These write permissions are required for release creation
-# - contents: write - create release tags and upload assets
-# - actions: write - trigger downstream workflows
-# - id-token: write - AWS OIDC authentication
-permissions:
-  contents: write
-  actions: write
-  id-token: write
+# Deny by default; the two jobs that need scopes grant them for themselves below.
+permissions: {}
 
 on:
   workflow_dispatch:
@@ -89,8 +83,14 @@ jobs:
     needs: [setup]
     name: Re-version artifacts ${{ needs.setup.outputs.version }}
     runs-on: ubuntu-22.04
+    permissions:
+      # contents: push the release tag; actions: read the source run's artifacts; id-token: AWS OIDC for vault.
+      contents: write
+      actions: read
+      id-token: write
     steps:
 
+      # Credentials stay persisted here: "Set repository tags" below pushes the tag over this remote.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Configure AWS credentials for vault access
@@ -213,10 +213,17 @@ jobs:
     needs: [setup, reversion]
     name: Build Installers
     runs-on: ubuntu-22.04
+    permissions:
+      # contents: attach assets to the draft release; id-token: AWS OIDC for vault.
+      contents: write
+      id-token: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # This job runs no networked git command, so the token does not need to sit in .git/config.
+          persist-credentials: false
 
       - name: Configure AWS credentials for vault access
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -2,6 +2,10 @@ name: Pull Request Labels
 on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize, reopened]
+
+# Deny by default so a new job cannot silently pick up the org-wide write default.
+permissions: {}
+
 jobs:
   label:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,21 +6,16 @@ on:
     branches:
       - main
 
-permissions:
-  # write permission is required to create a github release
-  contents: write
-  # write permission is required for autolabeler
-  # otherwise, read permission is required at least
-  pull-requests: write
+# Deny by default so a new job cannot silently pick up the org-wide write default.
+permissions: {}
 
 jobs:
   create_draft_release_main_branch:
     permissions:
       # write permission is required to create a github release
       contents: write
-      # write permission is required for autolabeler
-      # otherwise, read permission is required at least
-      pull-requests: write
+      # read is enough: this calls the drafter, not the autolabeler, and release-drafter-main.yml declares no autolabeler rules.
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - name: Create Draft Release (Main)

--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -6,6 +6,14 @@ on:
         description: 'Liquibase Version'
         required: true
 
+# A called workflow can only reduce the caller's scopes, so this mirrors the set
+# extension-automated-release.yml declares for itself.
+permissions:
+  contents: write
+  packages: write
+  security-events: read
+  id-token: write
+
 jobs:
   automated-os-extensions-release:
     uses: liquibase/build-logic/.github/workflows/extension-automated-release.yml@main


### PR DESCRIPTION
## Impact

- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Adopts deny-by-default `GITHUB_TOKEN` permissions and `persist-credentials: false` on the workflows
that keep running after the PR-CI cut-over.

**Verified, not assumed:** the repository and organization both return
`{"default_workflow_permissions":"write","can_approve_pull_request_reviews":true}`, so a workflow with
no `permissions:` block today runs with a write-scoped token that can also approve pull requests. And
`persist-credentials` defaults to `true`, read from `actions/checkout`'s own `action.yml` at the single
SHA pinned across all 31 call sites in this repo.

| workflow | before | after |
|---|---|---|
| `codeql.yml` | no top-level block (write-all) | `permissions: {}`, analyze job keeps its existing grants, `persist-credentials: false` |
| `cleanup-main-builds.yml` | no top-level block (write-all) | `permissions: {}`, `packages: write` on the one job |
| `release-extensions.yml` | no top-level block (write-all) | explicit block mirroring what the callee declares |
| `release-drafter.yml` | duplicate top-level and job block | `permissions: {}`, `pull-requests` write to read |
| `create-release.yml` | `contents/actions/id-token: write` for every job | `permissions: {}`, per-job grants, `actions: write` dropped |

## Release note

<!-- CI-only change, not customer-facing. skipReleaseNotes applied. -->

## Things to be aware of

**Two scope removals argued from source, not taste.**

`create-release.yml`'s `actions: write` carried the in-file comment "trigger downstream workflows".
Reading all 437 lines, nothing in the file dispatches a workflow: no `createWorkflowDispatch`, no
`gh workflow run`, no `POST .../dispatches`. The direction is reversed, `dry-run-release.yml:93`
dispatches *this* workflow, which is why that file holds `actions: write`. The only Actions-API
consumer here is `reversion`'s artifact download from a different run, and `actions/download-artifact`
documents that as needing `actions: read`. Its `setup` job, whose only step is an `echo`, now inherits
`{}`.

`release-drafter.yml`'s `pull-requests: write` is documented by release-drafter's own README at the
pinned SHA as belonging to the separate `autolabeler` sub-action. This workflow uses the top-level
action, and `.github/release-drafter-main.yml` declares no `autolabeler` key, so `read` is sufficient.

**Credentials deliberately left persisted where a job pushes.** `create-release.yml`'s `reversion` job
pushes a tag over its checkout remote, so it keeps the default and says so in-file. The same applies to
the two scan-results pushers, `docker-scan.yml` and `trivy-scan-published-images.yml`, which are out of
scope here.

**`codeql.yml`'s security-report steps are now gated off `pull_request`.** A fork pull request gets a
read-only token, so `codeScanning.listAlertsForRepo` cannot succeed there. The script already caught
the failure and emitted an "INCOMPLETE" report, so this removes a step that could only ever warn rather
than granting a scope to make it work.

**actionlint: 133 findings on `origin/main`, 133 on this branch**, sets diffed identical after stripping
line numbers. All pre-existing.

## Things to worry about

**This touches the release path, so it wants a real run before merge.** Specifically one dry-run release
to exercise `create-release.yml` under the reduced scopes, and one push to `main` for
`release-drafter.yml`. Every reduced scope here is argued from the action's own manifest at its pinned
SHA plus a full read of the calling step, **not** from a green run.

Two I could not confirm without a run, stated plainly:

- Whether `packages: write` alone suffices to *delete* a package version with the repo-scoped
  `GITHUB_TOKEN`. There is no separate delete scope documented, and the workflow already effectively
  runs with `packages: write` via the write-all default, so the delete path is unchanged by this PR.
- `release-extensions.yml` is `workflow_dispatch`-only and release-gated. Its new block is set to
  exactly the four scopes the callee declares for itself, since a called workflow can only reduce, never
  elevate. Confirming it means an actual extension release.

## Additional Context

Part of the Vanta "P2 security issues resolved" remediation.

Two holes deliberately left out of scope, both arguably larger than what is in this PR:

- **`build.yml`** is `disabled_manually` but reachable, because `run-tests.yml:292` calls it by local
  path (`uses: ./.github/workflows/build.yml`), and `workflow_call` ignores the disabled state. It
  checks out `pull_request.head.sha` at lines 41 and 83 with credentials persisted, holds
  `packages: write` and `id-token: write`, and runs the fork's Maven build.
- **`build-logic/sonar-coverage-merge.yml`** has no top-level block, checks out the fork ref with
  credentials persisted at line 27, loads the whole vault at 38-42, then runs `mvn -B clean install`
  against that fork-controlled `pom.xml` at line 85.

Neither was on the remediation list. Both should be added to it.
