### PR TITLE
Fix concurrent updates leaving each other's changelog locks set by resetting only the finishing database's LockService

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/command/core/AbstractUpdateCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/AbstractUpdateCommandStep.java
@@ -208,8 +208,8 @@ public abstract class AbstractUpdateCommandStep extends AbstractCommandStep impl
     @Override
     public void cleanUp(CommandResultsBuilder resultsBuilder) {
         isDBLocked.remove();
-        LockServiceFactory.getInstance().resetAll();
         Database database = (Database) resultsBuilder.getCommandScope().getDependency(Database.class);
+        LockServiceFactory.getInstance().resetDatabase(database);
         Scope.getCurrentScope().getSingleton(ChangeLogHistoryServiceFactory.class).resetDatabase(database);
         ExecutorService executorService = Scope.getCurrentScope().getSingleton(ExecutorService.class);
         executorService.clearExecutor("jdbc", database);

--- a/liquibase-standard/src/main/java/liquibase/command/core/helpers/LockServiceCommandStep.java
+++ b/liquibase-standard/src/main/java/liquibase/command/core/helpers/LockServiceCommandStep.java
@@ -49,22 +49,24 @@ public class LockServiceCommandStep extends AbstractHelperCommandStep implements
     public void cleanUp(CommandResultsBuilder resultsBuilder) {
         try {
             if (isDBLocked.get()) {
+                Database database = (Database) resultsBuilder.getCommandScope().getDependency(Database.class);
                 try {
                     // Check hasChangeLogLock() rather than releasing unconditionally: some
                     // AbstractUpdateCommandStep subclasses (e.g. updateCount/updateSql/updateToTag) also
                     // release the lock themselves, from within run(), before this cleanUp() runs -- see
                     // #5438. Releasing again here without checking live state would fail against an
                     // already-unlocked row.
-                    LockService lockService = LockServiceFactory.getInstance().getLockService(
-                            (Database) resultsBuilder.getCommandScope().getDependency(Database.class)
-                    );
+                    LockService lockService = LockServiceFactory.getInstance().getLockService(database);
                     if (lockService.hasChangeLogLock()) {
                         lockService.releaseLock();
                     }
                 } catch (LockException e) {
                     Scope.getCurrentScope().getLog(getClass()).severe(Liquibase.MSG_COULD_NOT_RELEASE_LOCK, e);
                 }
-                LockServiceFactory.getInstance().resetAll();
+                // Drop only this database's lock service, not every database's: resetAll() would discard
+                // the singleton and with it the lock services of any execution running concurrently
+                // against another database, leaving them unable to release the lock they still hold.
+                LockServiceFactory.getInstance().resetDatabase(database);
             }
         } finally {
             isDBLocked.remove();

--- a/liquibase-standard/src/main/java/liquibase/lockservice/LockServiceFactory.java
+++ b/liquibase-standard/src/main/java/liquibase/lockservice/LockServiceFactory.java
@@ -75,10 +75,40 @@ public class LockServiceFactory {
         return openLockServices.get(database);
     }
 
+    /**
+     * Invalidates and drops the {@link LockService} cached for just the given database, as opposed to
+     * {@link #resetAll()} which drops every database's along with this factory's JVM-wide singleton.
+     * Cleanup paths belonging to a single execution should use this, so they don't discard other
+     * concurrently running executions' (different database's) lock services: a service dropped while
+     * its execution still holds the changelog lock reports {@link LockService#hasChangeLogLock()} as
+     * false, so that execution skips its release and leaves the DATABASECHANGELOGLOCK row set.
+     * <p>
+     * The entry is removed rather than reset in place: unlike
+     * {@link liquibase.changelog.ChangeLogHistoryServiceFactory}, every service this factory hands out
+     * is built on demand by {@link #getLockService(Database)}, so nothing is lost by dropping it, and
+     * keeping the map free of finished databases keeps it from growing for the life of the JVM.
+     */
+    public void resetDatabase(Database database) {
+        LockService lockService = openLockServices.remove(database);
+        if (lockService != null) {
+            lockService.reset();
+        }
+    }
+
+    /**
+     * Resets every {@link LockService} this factory knows about and drops the JVM-wide singleton. This
+     * is a full teardown; cleanup paths belonging to a single execution should use
+     * {@link #resetDatabase(Database)} instead.
+     */
     public void resetAll() {
         for (LockService lockService : registry) {
             lockService.reset();
         }
+        // registry holds only the prototypes discovered by the service locator, never the per-database
+        // instances getLockService() creates from them -- which are the ones that actually hold locks.
+        // reset() is idempotent, so any overlap between the two is harmless.
+        openLockServices.values().forEach(LockService::reset);
+        openLockServices.clear();
         reset();
     }
 }

--- a/liquibase-standard/src/test/groovy/liquibase/command/core/AbstractUpdateCommandStepTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/command/core/AbstractUpdateCommandStepTest.groovy
@@ -177,4 +177,30 @@ class AbstractUpdateCommandStepTest extends Specification {
         !executorService.getExecutor("jdbc", databaseA).is(overrideA)
         resets["A"] == 1
     }
+
+    def "cleanUp only drops the LockService for its own database"() {
+        // Same JVM-wide-singleton hazard as the test above, for LockServiceFactory: cleanUp() used to
+        // call the blanket LockServiceFactory.resetAll(), which nulls the singleton and with it every
+        // database's LockService. A concurrently running execution then looked its lock service up
+        // again, got a freshly built one whose hasChangeLogLock() is false, skipped its release without
+        // logging anything, and left its DATABASECHANGELOGLOCK row set.
+        given: "two independent executions, each with an open lock service"
+        def databaseA = new PostgresDatabase()
+        def databaseB = new PostgresDatabase()
+        def lockServiceA = LockServiceFactory.getInstance().getLockService(databaseA)
+        def lockServiceB = LockServiceFactory.getInstance().getLockService(databaseB)
+
+        def commandA = new CommandScope(UpdateSqlCommandStep.COMMAND_NAME)
+                .provideDependency(Database.class, databaseA)
+        def resultsBuilderA = new CommandResultsBuilder(commandA, new ByteArrayOutputStream())
+
+        when: "execution A finishes and cleans up while execution B is still in flight"
+        new UpdateSqlCommandStep().cleanUp(resultsBuilderA)
+
+        then: "B keeps the very lock service that knows it holds the changelog lock"
+        LockServiceFactory.getInstance().getLockService(databaseB).is(lockServiceB)
+
+        and: "A's own lock service is dropped, its execution being over"
+        !LockServiceFactory.getInstance().getLockService(databaseA).is(lockServiceA)
+    }
 }

--- a/liquibase-standard/src/test/groovy/liquibase/command/core/helpers/LockServiceCommandStepTest.groovy
+++ b/liquibase-standard/src/test/groovy/liquibase/command/core/helpers/LockServiceCommandStepTest.groovy
@@ -3,8 +3,10 @@ package liquibase.command.core.helpers
 import liquibase.command.CommandResultsBuilder
 import liquibase.command.CommandScope
 import liquibase.database.Database
+import liquibase.database.core.PostgresDatabase
 import liquibase.lockservice.LockService
 import liquibase.lockservice.LockServiceFactory
+import liquibase.lockservice.StandardLockService
 import spock.lang.Specification
 
 import java.util.concurrent.CyclicBarrier
@@ -223,5 +225,70 @@ class LockServiceCommandStepTest extends Specification {
         then: "cleanUp must not attempt a second release against an already-unlocked row"
         1 * mockLockService.waitForLock()
         0 * mockLockService.releaseLock()
+    }
+
+    def "cleanUp drops only its own database's lock service, leaving a concurrent execution able to release its own lock"() {
+        // cleanUp() used to end with the blanket LockServiceFactory.resetAll(). Since that factory is a
+        // JVM-wide singleton, one execution finishing discarded every other database's LockService too:
+        // the peer's release then ran against a freshly built service, saw hasChangeLogLock() == false,
+        // skipped the release, and left that database's DATABASECHANGELOGLOCK row set.
+        given: "a lock service implementation that needs no live database"
+        LockServiceFactory.getInstance().register(new FakeLockService())
+        def databaseA = new PostgresDatabase()
+        def databaseB = new PostgresDatabase()
+
+        and: "execution B has acquired its lock and is still in flight"
+        def serviceB = LockServiceFactory.getInstance().getLockService(databaseB)
+        serviceB.waitForLock()
+
+        and: "execution A has acquired its own lock through its own step"
+        def stepA = new LockServiceCommandStep()
+        def commandA = new CommandScope(LockServiceCommandStep.COMMAND_NAME)
+                .provideDependency(Database.class, databaseA)
+        def resultsBuilderA = new CommandResultsBuilder(commandA, new ByteArrayOutputStream())
+        stepA.run(resultsBuilderA)
+        def serviceA = LockServiceFactory.getInstance().getLockService(databaseA)
+
+        when: "A finishes and cleans up"
+        stepA.cleanUp(resultsBuilderA)
+
+        then: "A released its own lock and its service was dropped"
+        !serviceA.hasChangeLogLock()
+        !LockServiceFactory.getInstance().getLockService(databaseA).is(serviceA)
+
+        and: "B still holds its lock through the very same service, so its own release will find it"
+        LockServiceFactory.getInstance().getLockService(databaseB).is(serviceB)
+        serviceB.hasChangeLogLock()
+    }
+
+    /**
+     * A LockService that can be driven without a database, and that outranks StandardLockService in
+     * LockServiceFactory#getLockService's priority-based lookup. Instantiated reflectively by that
+     * lookup, so it needs a public no-arg constructor.
+     */
+    static class FakeLockService extends StandardLockService {
+
+        private boolean locked
+
+        @Override
+        int getPriority() { PRIORITY_DATABASE }
+
+        @Override
+        boolean supports(Database database) { true }
+
+        @Override
+        boolean hasChangeLogLock() { locked }
+
+        @Override
+        void waitForLock() { locked = true }
+
+        @Override
+        boolean acquireLock() { locked = true; true }
+
+        @Override
+        void releaseLock() { locked = false }
+
+        @Override
+        void reset() { locked = false }
     }
 }

--- a/liquibase-standard/src/test/java/liquibase/lockservice/LockServiceFactoryTest.java
+++ b/liquibase-standard/src/test/java/liquibase/lockservice/LockServiceFactoryTest.java
@@ -4,6 +4,7 @@ import liquibase.database.Database;
 import liquibase.database.DatabaseFactory;
 import liquibase.database.core.MySQLDatabase;
 import liquibase.database.core.OracleDatabase;
+import liquibase.database.core.PostgresDatabase;
 import liquibase.database.core.MockDatabase;
 import org.junit.After;
 import org.junit.Assert;
@@ -13,6 +14,8 @@ import org.junit.Test;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
@@ -131,6 +134,129 @@ public class LockServiceFactoryTest {
         } finally {
             executor.shutdownNow();
             executor.awaitTermination(10, TimeUnit.SECONDS);
+        }
+    }
+
+    /**
+     * Regression test: a finishing execution must not strip a concurrently running one of the
+     * {@link LockService} that knows it holds the changelog lock. {@link LockServiceFactory} is a
+     * JVM-wide singleton, so the blanket {@link LockServiceFactory#resetAll()} that command cleanup
+     * paths used to call discarded every database's lock service, not just the finishing one's. The
+     * peer then looked up a freshly built service, whose {@link LockService#hasChangeLogLock()} is
+     * false, silently skipped its release, and left its DATABASECHANGELOGLOCK row set until the next
+     * start had waited out the full changelog lock wait time.
+     */
+    @Test
+    public void resetDatabaseLeavesOtherDatabasesLockServicesIntact() throws Exception {
+        LockServiceFactory factory = LockServiceFactory.getInstance();
+        factory.register(new FakeLockService());
+        Database databaseA = new PostgresDatabase();
+        Database databaseB = new PostgresDatabase();
+
+        FakeLockService serviceA = (FakeLockService) factory.getLockService(databaseA);
+        FakeLockService serviceB = (FakeLockService) factory.getLockService(databaseB);
+        serviceA.acquireLock();
+        serviceB.acquireLock();
+
+        // execution A finishes while B is still between acquiring and releasing its lock
+        factory.resetDatabase(databaseA);
+
+        assertSame("B must keep the very service that holds its lock", serviceB,
+                factory.getLockService(databaseB));
+        assertTrue("B must still know it holds the changelog lock, so it can release it",
+                factory.getLockService(databaseB).hasChangeLogLock());
+        assertEquals("B's service must not be reset by A's cleanup", 0, serviceB.resetCount);
+    }
+
+    /**
+     * resetDatabase() is a teardown for the given database: its service is reset and dropped, so the
+     * next execution against that database builds a fresh one rather than inheriting stale state.
+     */
+    @Test
+    public void resetDatabaseResetsAndDropsTheGivenDatabasesLockService() throws Exception {
+        LockServiceFactory factory = LockServiceFactory.getInstance();
+        factory.register(new FakeLockService());
+        Database database = new PostgresDatabase();
+
+        FakeLockService service = (FakeLockService) factory.getLockService(database);
+        service.acquireLock();
+
+        factory.resetDatabase(database);
+
+        assertEquals(1, service.resetCount);
+        assertFalse(service.hasChangeLogLock());
+        assertNotSame(service, factory.getLockService(database));
+    }
+
+    /**
+     * resetDatabase() on a database this factory never handed a service out for is a no-op, not an NPE:
+     * cleanup paths run even when the pipeline failed before any lock was taken.
+     */
+    @Test
+    public void resetDatabaseOnAnUnknownDatabaseIsANoOp() {
+        LockServiceFactory.getInstance().resetDatabase(new PostgresDatabase());
+    }
+
+    /**
+     * resetAll() used to iterate only the registry - the prototypes the service locator discovered,
+     * which never hold a lock - and then null the singleton, orphaning the per-database services
+     * getLockService() actually hands out without ever resetting them. It must reset the open services
+     * too.
+     */
+    @Test
+    public void resetAllResetsTheServicesThatActuallyHoldLocks() throws Exception {
+        LockServiceFactory factory = LockServiceFactory.getInstance();
+        factory.register(new FakeLockService());
+
+        FakeLockService openService = (FakeLockService) factory.getLockService(new PostgresDatabase());
+        openService.acquireLock();
+
+        factory.resetAll();
+
+        assertEquals(1, openService.resetCount);
+        assertFalse(openService.hasChangeLogLock());
+    }
+
+    /**
+     * A LockService that can be driven without a database, and that outranks StandardLockService in
+     * {@link LockServiceFactory#getLockService(Database)}'s priority-based lookup. Public with a
+     * no-arg constructor because that lookup instantiates the winning candidate reflectively.
+     */
+    public static class FakeLockService extends StandardLockService {
+
+        private boolean locked;
+        private int resetCount;
+
+        @Override
+        public int getPriority() {
+            return PRIORITY_DATABASE;
+        }
+
+        @Override
+        public boolean supports(Database database) {
+            return true;
+        }
+
+        @Override
+        public boolean hasChangeLogLock() {
+            return locked;
+        }
+
+        @Override
+        public boolean acquireLock() {
+            locked = true;
+            return true;
+        }
+
+        @Override
+        public void releaseLock() {
+            locked = false;
+        }
+
+        @Override
+        public void reset() {
+            resetCount++;
+            locked = false;
         }
     }
 


### PR DESCRIPTION
Fixes #7956

<!-- Suggested label: TypeBug -->

## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

`LockServiceFactory` is a JVM-wide singleton, and two `cleanUp()` paths on the `update` pipeline ended by calling `LockServiceFactory.getInstance().resetAll()` — which nulls that singleton and with it **every** database's `LockService`, not just the one belonging to the execution that is finishing.

Two `update`s running concurrently in one JVM therefore corrupt each other's lock bookkeeping, even against entirely separate databases. Whichever finishes first wipes the factory; the still-running peer then looks its lock service up again, gets a *freshly built* one whose `hasChangeLogLock()` is `false`, and **skips** its release — not attempted-and-failed, skipped, so nothing is logged. That database's `DATABASECHANGELOGLOCK` row stays set, and the next start against it waits out the full `changeLogLockWaitTime` before throwing `LockException`. #7956 has a self-contained two-H2-database reproduction.

This is the same anti-pattern #7909 fixed for `ChangeLogHistoryServiceFactory` and `ExecutorService`; `LockServiceFactory.resetAll()` is unchanged context in that diff, and its review asked for exactly this follow-up.

The change is the same shape as #7909's:

1. **`LockServiceFactory#resetDatabase(Database)`** — resets and drops just that database's entry.
2. **Both call sites converted** to it: `AbstractUpdateCommandStep#cleanUp` (5.0.4 line 211) and `LockServiceCommandStep#cleanUp` (line 67). Converting only the first leaves the bug reachable — the second fires for every update subclass that takes its lock from the pipeline.
3. **`resetAll()` fixed too.** It iterated only `registry` — the prototypes the service locator discovered, which never hold a lock — called `reset()` on those and then nulled the singleton, never touching `openLockServices`, i.e. the per-database services `getLockService()` hands out and that actually hold the locks. So a full teardown reset the wrong objects and orphaned the right ones. This is a correctness improvement even single-threaded, and the same gap that was raised in review on #7909 for `services.values()`.

The `hasChangeLogLock()` guards in front of both releases are untouched — their comments cite #5438 and they are deliberate. The bug was the factory being wiped from under them, not the guards.

## Release note

Running two Liquibase updates at the same time in one JVM , each against its own database — no longer leaves a changelog lock behind. Previously, whichever update finished first could stop the other from releasing its lock, so that database's next update waited out the full changelog lock timeout and then failed.

## Things to be aware of

**`resetDatabase()` removes the entry rather than resetting it in place**, which is the opposite of the choice `ChangeLogHistoryServiceFactory#resetDatabase` made. The reason that one resets in place is that some of its services cannot be rebuilt — `OfflineConnection` registers a pre-configured one via `registerForDatabase`. `LockServiceFactory` has no such path: every service it hands out is built on demand by `getLockService()`, so nothing is lost by dropping it, and it keeps the map from accumulating an entry per `Database` for the life of the JVM (the concern noted in #7909's review, which does not arise here). Nothing outside the `lockservice` package configures a `LockService` instance that would need to survive.

**No new synchronization.** `openLockServices` is a `ConcurrentHashMap` and `remove` is atomic; adding `synchronized` to `resetDatabase` alone would not give mutual exclusion against the unsynchronized `getLockService`, so it would be misleading rather than safer.

**Two other `resetAll()` call sites are left alone**, both genuine full teardowns:
- `DropAllCommandStep:152` — named in #7909's review, but it runs after `lockService.destroy()` has dropped the lock table, and it lives in a `protected resetServices()` that Liquibase Pro subclasses, so changing that signature is a separate decision.
- `Liquibase.java:990` — `resetServices()` on the facade, arguably a legitimate full reset of a facade being torn down, and also `protected`.

Happy to fold either in if you'd prefer one PR.

## Things to worry about

Nothing outstanding. The one judgement call is remove-vs-reset-in-place above; if you'd rather have the two factories behave identically, resetting in place is a one-line change, at the cost of the map growing per `Database`.

## Additional Context

**Tests** — each one fails when its production change is reverted, verified individually:

| Test | Reverting… | Failure |
|---|---|---|
| `LockServiceFactoryTest#resetDatabaseLeavesOtherDatabasesLockServicesIntact` | `resetDatabase` → `resetAll` | `expected same: FakeLockService@… was not: FakeLockService@…` |
| `LockServiceFactoryTest#resetAllResetsTheServicesThatActuallyHoldLocks` | the `openLockServices` loop | `expected:<1> but was:<0>` |
| `AbstractUpdateCommandStepTest#"cleanUp only drops the LockService for its own database"` | that call site | `Condition not satisfied: …getLockService(databaseB).is(lockServiceB)` |
| `LockServiceCommandStepTest#"cleanUp drops only its own database's lock service…"` | that call site | `Condition not satisfied: …getLockService(databaseB).is(serviceB)` |

Plus `resetDatabaseResetsAndDropsTheGivenDatabasesLockService` and `resetDatabaseOnAnUnknownDatabaseIsANoOp` covering the new method's contract.

**Regressions ruled out** — the full `liquibase-standard` suite passes on this branch: 6492 tests, 0 failures, 12 skipped (unchanged from `main`).

**Verified end-to-end against a real downstream failure.** An application that initializes multiple databases, each on its own thread, hit exactly this and had to serialize its Liquibase invocations. With the serialization removed and this branch installed in place of 5.0.4, its deterministic H2 regression test — which parks one execution inside its update while a peer completes a whole migration — goes from failing on a leaked changelog lock to passing, and its full 1680-test module suite is green. The standalone reproduction in #7956 likewise flips from `*** LOCK LEAKED ***` to `ok, lock released`.

