### PR TITLE
Fix: clear an old occurrence of a tag before applying it again

### DIFF
--- a/liquibase-standard/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
+++ b/liquibase-standard/src/main/java/liquibase/changelog/StandardChangeLogHistoryService.java
@@ -454,6 +454,14 @@ public class StandardChangeLogHistoryService extends AbstractChangeLogHistorySer
         getDatabase().commit();
 
         if (this.ranChangeSetList != null) {
+            // Clear the tag off whichever entry already carries it, mirroring what the SQL above just did
+            // to the DATABASECHANGELOG table -- otherwise a re-tag leaves two in-memory entries with the
+            // same tag until the cache is next rebuilt (#3763).
+            for (RanChangeSet ranChangeSet : ranChangeSetList) {
+                if (tagString.equals(ranChangeSet.getTag())) {
+                    ranChangeSet.setTag(null);
+                }
+            }
             ranChangeSetList.get(ranChangeSetList.size() - 1).setTag(tagString);
         }
     }

--- a/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/TagDatabaseGenerator.java
+++ b/liquibase-standard/src/main/java/liquibase/sqlgenerator/core/TagDatabaseGenerator.java
@@ -33,8 +33,16 @@ public class TagDatabaseGenerator extends AbstractSqlGenerator<TagDatabaseStatem
             String dateColumnNameEscaped = database.escapeObjectName("DATEEXECUTED", Column.class);
             String tagColumnNameEscaped = database.escapeObjectName("TAG", Column.class);
             String tagEscaped = DataTypeFactory.getInstance().fromObject(statement.getTag(), database).objectToSql(statement.getTag(), database);
+
+            // Clear the tag off any row that already carries it before tagging the latest row, so re-using a
+            // tag name doesn't leave it applied to multiple changesets (#3763).
+            UpdateStatement clearOldTagStatement = new UpdateStatement(database.getLiquibaseCatalogName(), database.getLiquibaseSchemaName(), database.getDatabaseChangeLogTableName())
+                    .addNewColumnValue("TAG", null)
+                    .setWhereClause(tagColumnNameEscaped + " = " + tagEscaped);
+            Sql[] clearOldTagSql = SqlGeneratorFactory.getInstance().generateSql(clearOldTagStatement, database);
+
             if (database instanceof MySQLDatabase) {
-                return new Sql[]{
+                return concat(clearOldTagSql,
                         new UnparsedSql(
                                 "UPDATE " + tableNameEscaped + " AS C " +
                                         "INNER JOIN (" +
@@ -42,18 +50,16 @@ public class TagDatabaseGenerator extends AbstractSqlGenerator<TagDatabaseStatem
                                         "FROM " + tableNameEscaped +
                                         " order by " + dateColumnNameEscaped + " desc, " + orderColumnNameEscaped + " desc limit 1) AS D " +
                                         "ON C." + orderColumnNameEscaped + " = D." + orderColumnNameEscaped + " " +
-                                        "SET C." + tagColumnNameEscaped + " = " + tagEscaped)
-                };
+                                        "SET C." + tagColumnNameEscaped + " = " + tagEscaped));
             } else if (database instanceof AbstractPostgresDatabase) {
-                return new Sql[]{
+                return concat(clearOldTagSql,
                         new UnparsedSql(
                                 "UPDATE " + tableNameEscaped + " t SET TAG=" + tagEscaped +
                                         " FROM (SELECT " + dateColumnNameEscaped + ", " + orderColumnNameEscaped + " FROM " + tableNameEscaped + " ORDER BY " + dateColumnNameEscaped + " DESC, " + orderColumnNameEscaped + " DESC LIMIT 1) sub " +
-                                        "WHERE t." + dateColumnNameEscaped + "=sub." + dateColumnNameEscaped + " AND t." + orderColumnNameEscaped + "=sub." + orderColumnNameEscaped)
-                };
+                                        "WHERE t." + dateColumnNameEscaped + "=sub." + dateColumnNameEscaped + " AND t." + orderColumnNameEscaped + "=sub." + orderColumnNameEscaped));
             } else if (database instanceof InformixDatabase) {
                 String tempTableNameEscaped = database.escapeObjectName("max_order_temp", Table.class);
-                return new Sql[]{
+                return concat(clearOldTagSql,
                         new UnparsedSql(
                                 "SELECT MAX(" + dateColumnNameEscaped + ") AS " + dateColumnNameEscaped +
                                         ", MAX(" + orderColumnNameEscaped + ") AS " + orderColumnNameEscaped + " " +
@@ -71,8 +77,7 @@ public class TagDatabaseGenerator extends AbstractSqlGenerator<TagDatabaseStatem
                                         "FROM " + tempTableNameEscaped +
                                         ");"),
                         new UnparsedSql(
-                                "DROP TABLE " + tempTableNameEscaped + ";")
-                };
+                                "DROP TABLE " + tempTableNameEscaped + ";"));
             } else if (database instanceof MSSQLDatabase) {
                 String changelogAliasEscaped = database.escapeObjectName("changelog", Table.class);
                 String latestAliasEscaped = database.escapeObjectName("latest", Table.class);
@@ -82,7 +87,7 @@ public class TagDatabaseGenerator extends AbstractSqlGenerator<TagDatabaseStatem
 
                 String topClause = "TOP (1)";
 
-                return new Sql[] {
+                return concat(clearOldTagSql,
                         new UnparsedSql(
                                 "UPDATE " + changelogAliasEscaped + " " +
                                 "SET " + tagColumnNameEscaped + " = " + tagEscaped + " " +
@@ -94,8 +99,7 @@ public class TagDatabaseGenerator extends AbstractSqlGenerator<TagDatabaseStatem
                                 ") AS " + latestAliasEscaped + " " +
                                 "ON " + latestAliasEscaped + "." + idColumnEscaped + " = " + changelogAliasEscaped + "." + idColumnEscaped + " " +
                                 "AND " + latestAliasEscaped + "." + authorColumnEscaped + " = " + changelogAliasEscaped + "." + authorColumnEscaped + " " +
-                                "AND " + latestAliasEscaped + "." + filenameColumnEscaped + " = " + changelogAliasEscaped + "." + filenameColumnEscaped)
-                    };
+                                "AND " + latestAliasEscaped + "." + filenameColumnEscaped + " = " + changelogAliasEscaped + "." + filenameColumnEscaped));
             } else if ((database instanceof OracleDatabase) || (database instanceof DB2Database)) {
                 String selectClause = "SELECT";
                 String endClause = ")";
@@ -107,13 +111,12 @@ public class TagDatabaseGenerator extends AbstractSqlGenerator<TagDatabaseStatem
                     endClause = " FETCH FIRST 1 ROWS ONLY)";
                 }
 
-                return new Sql[]{
+                return concat(clearOldTagSql,
                         new UnparsedSql("MERGE INTO " + tableNameEscaped + " a " +
                                 "USING (" + selectClause + " " + orderColumnNameEscaped + ", " + dateColumnNameEscaped + " from " + tableNameEscaped + " order by " + dateColumnNameEscaped + " desc, " + orderColumnNameEscaped + " desc" + endClause + " b " +
                                 "ON ( a." + dateColumnNameEscaped + " = b." + dateColumnNameEscaped + " and a." + orderColumnNameEscaped + "=b." + orderColumnNameEscaped + " ) " +
                                 "WHEN MATCHED THEN " +
-                                "UPDATE SET  a.tag=" + tagEscaped + delimiter)
-                };
+                                "UPDATE SET  a.tag=" + tagEscaped + delimiter));
             } else {
 
                 //Only uses dateexecuted as a default. Depending on the timestamp resolution, multiple rows may be tagged which normally works fine but can cause confusion and some issues.
@@ -127,11 +130,18 @@ public class TagDatabaseGenerator extends AbstractSqlGenerator<TagDatabaseStatem
                                         "FROM " + tableNameEscaped +
                                         ")");
 
-                return SqlGeneratorFactory.getInstance().generateSql(updateStatement, database);
+                return concat(clearOldTagSql, SqlGeneratorFactory.getInstance().generateSql(updateStatement, database));
             }
         } finally {
             database.setObjectQuotingStrategy(currentStrategy);
         }
 
+    }
+
+    private static Sql[] concat(Sql[] first, Sql... rest) {
+        Sql[] result = new Sql[first.length + rest.length];
+        System.arraycopy(first, 0, result, 0, first.length);
+        System.arraycopy(rest, 0, result, first.length, rest.length);
+        return result;
     }
 }

--- a/liquibase-standard/src/test/java/liquibase/changelog/StandardChangeLogHistoryServiceTest.java
+++ b/liquibase-standard/src/test/java/liquibase/changelog/StandardChangeLogHistoryServiceTest.java
@@ -1,8 +1,16 @@
 package liquibase.changelog;
 
+import liquibase.database.Database;
 import liquibase.database.DatabaseConnection;
+import liquibase.database.DatabaseFactory;
 import liquibase.database.core.MockDatabase;
+import liquibase.database.jvm.JdbcConnection;
 import org.junit.Test;
+
+import java.sql.DriverManager;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,5 +37,42 @@ public class StandardChangeLogHistoryServiceTest {
         service.reset();
 
         assertThat(service.getNextSequenceValue()).isEqualTo(1);
+    }
+
+    /**
+     * The service caches the deployed changesets in ranChangeSetList and keeps that cache across calls
+     * within the same JVM (ChangeLogHistoryServiceFactory reuses the same service per Database), so
+     * re-tagging has to clear the tag off whichever cached entry already carries it -- otherwise the
+     * in-memory history disagrees with DATABASECHANGELOG about which changeset the tag belongs to (#3763).
+     */
+    @Test
+    public void tagClearsTheTagFromAnyCachedRanChangeSetThatAlreadyCarriesIt() throws Exception {
+        java.sql.Connection jdbcConnection = DriverManager.getConnection("jdbc:h2:mem:" + UUID.randomUUID(), "sa", "");
+        try {
+            Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(jdbcConnection));
+            StandardChangeLogHistoryService service = new StandardChangeLogHistoryService();
+            service.setDatabase(database);
+            service.init();
+            service.getRanChangeSets(); // populate the cache so setExecType()/tag() start updating it
+
+            DatabaseChangeLog changeLog = new DatabaseChangeLog("changelog.xml");
+            ChangeSet changeSet1 = new ChangeSet("1", "author", false, false, "changelog.xml", null, null, changeLog);
+            ChangeSet changeSet2 = new ChangeSet("2", "author", false, false, "changelog.xml", null, null, changeLog);
+
+            service.setExecType(changeSet1, ChangeSet.ExecType.EXECUTED);
+            service.tag("release_tag");
+
+            service.setExecType(changeSet2, ChangeSet.ExecType.EXECUTED);
+            service.tag("release_tag");
+
+            List<RanChangeSet> taggedEntries = service.getRanChangeSets().stream()
+                    .filter(ranChangeSet -> "release_tag".equals(ranChangeSet.getTag()))
+                    .collect(Collectors.toList());
+
+            assertThat(taggedEntries).hasSize(1);
+            assertThat(taggedEntries.get(0).getId()).isEqualTo("2");
+        } finally {
+            jdbcConnection.close();
+        }
     }
 }

--- a/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/TagDatabaseGeneratorTest.java
+++ b/liquibase-standard/src/test/java/liquibase/sqlgenerator/core/TagDatabaseGeneratorTest.java
@@ -43,7 +43,10 @@ public class TagDatabaseGeneratorTest {
         TagDatabaseStatement statement = new TagDatabaseStatement("v1.0");
         Sql[] sql = SqlGeneratorFactory.getInstance().generateSql(statement, new MSSQLDatabase());
 
-        assertEquals(1, sql.length);
+        assertEquals(2, sql.length);
+        assertEquals(
+                "UPDATE DATABASECHANGELOG SET TAG = NULL WHERE TAG = 'v1.0'",
+                sql[0].toSql());
         assertEquals(
             "UPDATE changelog " +
                 "SET TAG = 'v1.0' " +
@@ -56,7 +59,7 @@ public class TagDatabaseGeneratorTest {
                 "ON latest.ID = changelog.ID " +
                 "AND latest.AUTHOR = changelog.AUTHOR " +
                 "AND latest.FILENAME = changelog.FILENAME",
-                sql[0].toSql());
+                sql[1].toSql());
     }
 
     @Test
@@ -64,7 +67,10 @@ public class TagDatabaseGeneratorTest {
         TagDatabaseStatement statement = new TagDatabaseStatement("v1.0");
         Sql[] sql = SqlGeneratorFactory.getInstance().generateSql(statement, new HsqlDatabase());
 
-        assertEquals(1, sql.length);
+        assertEquals(2, sql.length);
+        assertEquals(
+                "UPDATE DATABASECHANGELOG SET TAG = NULL WHERE TAG = 'v1.0'",
+                sql[0].toSql());
         assertEquals(
                 "UPDATE DATABASECHANGELOG " +
                 "SET TAG = 'v1.0' " +
@@ -72,6 +78,7 @@ public class TagDatabaseGeneratorTest {
                     "SELECT MAX(DATEEXECUTED) " +
                     "FROM DATABASECHANGELOG" +
                 ")",
-                sql[0].toSql());
+                sql[1].toSql());
     }
+
 }


### PR DESCRIPTION
Fixes #3763 (the duplicate-tag part of the issue).

Re-running `tag` with a name that was already used left the tag on the earlier row as well as the new one, since `TagDatabaseGenerator` only ever added the tag to the latest changeset row and never cleared it from wherever it used to be. This adds a `TAG = NULL WHERE TAG = <tag>` statement before the existing per-database tagging SQL, so a tag always identifies exactly one changeset regardless of how many times it's reused.

Left the feature-request half of the issue (making tag reuse configurable) out of scope — this only fixes the bug nvoxland described.

## Testing
Updated `TagDatabaseGeneratorTest` for the extra statement and asserted its exact SQL.