### PR TITLE
[TECHOPS-1111] Harden kept workflows: baseline permissions, persist-credentials, scoped vault read

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -25,6 +25,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # This job runs no networked git command, so the token does not need to
+          # sit in .git/config. [TECHOPS-1111]
+          persist-credentials: false
       - name: Get Latest Merge Commit SHA
         id: get-sha
         run: |
@@ -49,6 +53,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Set up Java for publishing to GitHub Repository
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # This job runs no networked git command, so the token does not need to
+          # sit in .git/config. [TECHOPS-1111]
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha || github.event.after}}
       - name: Get Latest Merge Commit SHA
         id: get-sha
@@ -83,6 +86,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha || github.event.after}}
       # this includes all the tar files included in the previous runs. So in the next step we deploy what was previously build
       - name: Download Artifacts for build.yml

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -92,6 +92,8 @@ jobs:
 
       # Credentials stay persisted here: "Set repository tags" below pushes the tag over this remote.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: true
 
       - name: Configure AWS credentials for vault access
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -13,5 +13,8 @@ permissions:
 
 jobs:
   dependabot-automerge:
+    # Only Dependabot's own PRs. Without this gate every pull_request event runs
+    # the reusable workflow with inherited secrets. [TECHOPS-1111]
+    if: github.actor == 'dependabot[bot]'
     uses: liquibase/build-logic/.github/workflows/dependabot-automerge.yml@main
     secrets: inherit

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -112,6 +112,9 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # The version-bump commit below is pushed with this App token.
+          # [TECHOPS-1111]
+          persist-credentials: true
           token: ${{ steps.get-token.outputs.token }}
           ref: main
 

--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -82,6 +82,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # persist-scan-results.sh pushes to the scan-results branch with this
+          # checkout's token. [TECHOPS-1111]
+          persist-credentials: true
           fetch-depth: 0
 
       - name: Download community scan artifact
@@ -113,6 +116,7 @@ jobs:
       - name: Checkout build-logic
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           repository: liquibase/build-logic
           path: build-logic
 

--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -271,6 +271,10 @@ jobs:
     steps:
       - name: Checkout liquibase
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The cleanup step below deletes the dry-run tag with this checkout's token.
+          # [TECHOPS-1111]
+          persist-credentials: true
 
       - name: Set up Git
         run: |

--- a/.github/workflows/release-deploy-xsd.yml
+++ b/.github/workflows/release-deploy-xsd.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Download liquibase xsd
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # This job runs no networked git command, so the token does not need to
+          # sit in .git/config. [TECHOPS-1111]
+          persist-credentials: false
           # Relative path under $GITHUB_WORKSPACE to place the repository
           path: liquibase-core-repo
           repository: "liquibase/liquibase"

--- a/.github/workflows/release-publish-github-packages.yml
+++ b/.github/workflows/release-publish-github-packages.yml
@@ -58,6 +58,10 @@ jobs:
     if: ${{ inputs.dry_run == false }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # This job runs no networked git command, so the token does not need to
+          # sit in .git/config. [TECHOPS-1111]
+          persist-credentials: false
       
       - name: Set up Java for publishing to GitHub Repository
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0

--- a/.github/workflows/release-setup.yml
+++ b/.github/workflows/release-setup.yml
@@ -108,6 +108,9 @@ jobs:
       - name: Checkout the determined branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # This job runs no networked git command, so the token does not need to
+          # sit in .git/config. [TECHOPS-1111]
+          persist-credentials: false
           ref: ${{ steps.ref-branch.outputs.branch }}
           fetch-depth: 0
 

--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -55,6 +55,9 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # This job runs no networked git command, so the token does not need to
+          # sit in .git/config. [TECHOPS-1111]
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha || github.event.after}} #sets the Git reference (commit or branch) to be checked out in the workflow
 
   run-test-harness-tests:
@@ -65,6 +68,8 @@ jobs:
     environment: ${{ github.event.pull_request && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set environment variables for PR branch and SHA
         env:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -58,6 +58,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # This job runs no networked git command, so the token does not need to
+          # sit in .git/config. [TECHOPS-1111]
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Get current date
@@ -108,6 +111,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha || github.event.after}}
 
       - name: Built Code Cache
@@ -225,6 +229,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha || github.event.after}}
 
       - name: Prepare

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -32,6 +32,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # This job runs no networked git command, so the token does not need to
+          # sit in .git/config. [TECHOPS-1111]
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Get Latest Merge Commit SHA
@@ -74,6 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up JDK ${{ matrix.java }}
@@ -118,6 +122,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up JDK 17

--- a/.github/workflows/trivy-scan-published-images.yml
+++ b/.github/workflows/trivy-scan-published-images.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Checkout build-logic
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # This job runs no networked git command, so the token does not need to
+          # sit in .git/config. [TECHOPS-1111]
+          persist-credentials: false
           repository: liquibase/build-logic
           path: build-logic
 
@@ -97,11 +100,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # persist-scan-results.sh pushes to the scan-results branch with this
+          # checkout's token. [TECHOPS-1111]
+          persist-credentials: true
           fetch-depth: 0
 
       - name: Checkout build-logic
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           repository: liquibase/build-logic
           path: build-logic
 


### PR DESCRIPTION
# Why

[TECHOPS-1111](https://datical.atlassian.net/browse/TECHOPS-1111). `actions/checkout` defaults to `persist-credentials: true`, which writes the token into `.git/config` as an `http.extraheader`. Anything that runs afterwards in the same workspace can read it, including a Maven build of a fork-controlled `pom.xml`.

**Rebuilt from scratch on today's `main`.** The PR previously carried three things; two of them landed elsewhere while it sat in review, so they are gone from here:

- **Top-level `permissions:`** was delivered by #7954. Verified: all workflows on `main` now carry a block, so there is nothing left to add.
- **The vault-read narrowing** went with #7962 and #7965 (TECHOPS-1107, now closed).
- **CodeQL** already has `persist-credentials: false` and its report steps gated off `pull_request` on `main`.

What is left is the half the ticket is actually named after, plus one behavioural gate.

# What

**All 25 `actions/checkout` call sites now state their intent explicitly** (was 2 of 25 on `main`):

- **20 set `persist-credentials: false`.** This includes the fork-head sites in `run-tests.yml`, `build.yml`, `run-test-harness.yml` and `test-pr.yml`, which are the ones the ticket lists first. I had skipped those in the first cut of this PR on the grounds that the cutover deletes them; that reasoning was wrong for the same reason it was wrong on TECHOPS-1107, so they are in now.
- **5 set `persist-credentials: true` with the reason in-file**, because a later step in the same job pushes with that credential: `create-release.yml` (release tag), `docker-release.yml` (version bump), `dry-run-release.yml` (dry-run tag cleanup), `docker-scan.yml` and `trivy-scan-published-images.yml` (both push to the `scan-results` branch via `persist-scan-results.sh`). Stating the default explicitly is the point: it stops a future bulk change from flipping them to `false` and breaking a release or the scan history silently.

**`dependabot-automerge.yml`** gains `if: github.actor == 'dependabot[bot]'`. It called the build-logic reusable workflow with `secrets: inherit` on every `pull_request` event, not just Dependabot's.

# Verification

- `actionlint` across all 14 changed files: finding profile **identical to `main`**, zero new. I checked this against a per-file baseline rather than eyeballing, because an earlier attempt at this change silently broke YAML in 7 files (the `- uses:` list form needs the key two columns right of the dash) and only the baseline comparison caught it.
- Every workflow parses as YAML.
- No `actions/checkout` is left without an explicit value.

# Not here

The `auto-create-jira-on-merge.yml` `push: main` retrigger. On `pull_request: closed` that workflow gets no secrets for merged fork PRs, so it silently skips the community PRs it exists for. That is a functional redesign, not a permissions change, and it stays on the ticket as its own follow-up.


[TECHOPS-1111]: https://datical.atlassian.net/browse/TECHOPS-1111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ