### PR TITLE
[TECHOPS-1214] Move the release publishing jobs onto environment: release

### DIFF
--- a/.github/workflows/release-deploy-javadocs.yml
+++ b/.github/workflows/release-deploy-javadocs.yml
@@ -44,6 +44,8 @@ jobs:
     if: ${{ inputs.dry_run == false }}
     # `approved` is `workflow_call`-only, so a direct dispatch cannot claim it and still meets the
     # reviewers on `release`. An orchestrated run cleared that gate once already.
+    # Keep it that way: on `workflow_dispatch` anyone who can dispatch could pick `release-publish`,
+    # and a non-`boolean` input would do it silently because the string "false" is truthy.
     environment:
       name: ${{ inputs.approved && 'release-publish' || 'release' }}
     steps:

--- a/.github/workflows/release-deploy-javadocs.yml
+++ b/.github/workflows/release-deploy-javadocs.yml
@@ -15,6 +15,12 @@ on:
         type: boolean
         default: false
   
+      approved:
+        description: "True only when release-published-orchestrator has already cleared the manual-approval gate for this run."
+        required: false
+        type: boolean
+        default: false
+
   workflow_dispatch:
     inputs:
       tag:
@@ -36,8 +42,11 @@ jobs:
     name: Upload Javadocs to S3
     runs-on: ubuntu-22.04
     if: ${{ inputs.dry_run == false }}
-    # Emits the `environment:release` OIDC subject, which is what the release-scoped vault role trusts.
-    environment: release
+    # Split so one release costs one approval: an orchestrated run has already cleared the
+    # `release` gate and passes `approved`, while a direct `workflow_dispatch` cannot set that input
+    # (it exists only under `workflow_call`) and so still lands on the reviewer-gated `release`.
+    environment:
+      name: ${{ inputs.approved && 'release-publish' || 'release' }}
     steps:
       - name: Download release javadocs
         env:

--- a/.github/workflows/release-deploy-javadocs.yml
+++ b/.github/workflows/release-deploy-javadocs.yml
@@ -42,9 +42,8 @@ jobs:
     name: Upload Javadocs to S3
     runs-on: ubuntu-22.04
     if: ${{ inputs.dry_run == false }}
-    # Split so one release costs one approval: an orchestrated run has already cleared the
-    # `release` gate and passes `approved`, while a direct `workflow_dispatch` cannot set that input
-    # (it exists only under `workflow_call`) and so still lands on the reviewer-gated `release`.
+    # `approved` is `workflow_call`-only, so a direct dispatch cannot claim it and still meets the
+    # reviewers on `release`. An orchestrated run cleared that gate once already.
     environment:
       name: ${{ inputs.approved && 'release-publish' || 'release' }}
     steps:

--- a/.github/workflows/release-deploy-javadocs.yml
+++ b/.github/workflows/release-deploy-javadocs.yml
@@ -36,6 +36,8 @@ jobs:
     name: Upload Javadocs to S3
     runs-on: ubuntu-22.04
     if: ${{ inputs.dry_run == false }}
+    # Emits the `environment:release` OIDC subject, which is what the release-scoped vault role trusts.
+    environment: release
     steps:
       - name: Download release javadocs
         env:
@@ -46,7 +48,7 @@ jobs:
       - name: Configure AWS credentials for vault access
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
-          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
+          role-to-assume: ${{ secrets.LIQUIBASE_RELEASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Get secrets from vault

--- a/.github/workflows/release-deploy-maven.yml
+++ b/.github/workflows/release-deploy-maven.yml
@@ -74,9 +74,8 @@ jobs:
     name: Deploy to Maven Central (Production)
     runs-on: ubuntu-22.04
     if: ${{ inputs.dry_run == false }}
-    # Split so one release costs one approval: an orchestrated run has already cleared the
-    # `release` gate and passes `approved`, while a direct `workflow_dispatch` cannot set that input
-    # (it exists only under `workflow_call`) and so still lands on the reviewer-gated `release`.
+    # `approved` is `workflow_call`-only, so a direct dispatch cannot claim it and still meets the
+    # reviewers on `release`. An orchestrated run cleared that gate once already.
     environment:
       name: ${{ inputs.approved && 'release-publish' || 'release' }}
     steps:

--- a/.github/workflows/release-deploy-maven.yml
+++ b/.github/workflows/release-deploy-maven.yml
@@ -76,6 +76,8 @@ jobs:
     if: ${{ inputs.dry_run == false }}
     # `approved` is `workflow_call`-only, so a direct dispatch cannot claim it and still meets the
     # reviewers on `release`. An orchestrated run cleared that gate once already.
+    # Keep it that way: on `workflow_dispatch` anyone who can dispatch could pick `release-publish`,
+    # and a non-`boolean` input would do it silently because the string "false" is truthy.
     environment:
       name: ${{ inputs.approved && 'release-publish' || 'release' }}
     steps:

--- a/.github/workflows/release-deploy-maven.yml
+++ b/.github/workflows/release-deploy-maven.yml
@@ -68,6 +68,8 @@ jobs:
     name: Deploy to Maven Central (Production)
     runs-on: ubuntu-22.04
     if: ${{ inputs.dry_run == false }}
+    # Emits the `environment:release` OIDC subject, which is what the release-scoped vault role trusts.
+    environment: release
     steps:
       - name: Download release assets
         env:
@@ -78,7 +80,7 @@ jobs:
       - name: Configure AWS credentials for vault access
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
-          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
+          role-to-assume: ${{ secrets.LIQUIBASE_RELEASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Get secrets from vault

--- a/.github/workflows/release-deploy-maven.yml
+++ b/.github/workflows/release-deploy-maven.yml
@@ -29,6 +29,12 @@ on:
         type: string
         default: ""
 
+      approved:
+        description: "True only when release-published-orchestrator has already cleared the manual-approval gate for this run."
+        required: false
+        type: boolean
+        default: false
+
   workflow_dispatch:
     inputs:
       version:
@@ -68,8 +74,11 @@ jobs:
     name: Deploy to Maven Central (Production)
     runs-on: ubuntu-22.04
     if: ${{ inputs.dry_run == false }}
-    # Emits the `environment:release` OIDC subject, which is what the release-scoped vault role trusts.
-    environment: release
+    # Split so one release costs one approval: an orchestrated run has already cleared the
+    # `release` gate and passes `approved`, while a direct `workflow_dispatch` cannot set that input
+    # (it exists only under `workflow_call`) and so still lands on the reviewer-gated `release`.
+    environment:
+      name: ${{ inputs.approved && 'release-publish' || 'release' }}
     steps:
       - name: Download release assets
         env:

--- a/.github/workflows/release-deploy-xsd.yml
+++ b/.github/workflows/release-deploy-xsd.yml
@@ -44,6 +44,8 @@ jobs:
     if: ${{ inputs.dry_run == false }}
     # `approved` is `workflow_call`-only, so a direct dispatch cannot claim it and still meets the
     # reviewers on `release`. An orchestrated run cleared that gate once already.
+    # Keep it that way: on `workflow_dispatch` anyone who can dispatch could pick `release-publish`,
+    # and a non-`boolean` input would do it silently because the string "false" is truthy.
     environment:
       name: ${{ inputs.approved && 'release-publish' || 'release' }}
     steps:

--- a/.github/workflows/release-deploy-xsd.yml
+++ b/.github/workflows/release-deploy-xsd.yml
@@ -42,9 +42,8 @@ jobs:
     name: Upload xsds
     runs-on: ubuntu-22.04
     if: ${{ inputs.dry_run == false }}
-    # Split so one release costs one approval: an orchestrated run has already cleared the
-    # `release` gate and passes `approved`, while a direct `workflow_dispatch` cannot set that input
-    # (it exists only under `workflow_call`) and so still lands on the reviewer-gated `release`.
+    # `approved` is `workflow_call`-only, so a direct dispatch cannot claim it and still meets the
+    # reviewers on `release`. An orchestrated run cleared that gate once already.
     environment:
       name: ${{ inputs.approved && 'release-publish' || 'release' }}
     steps:

--- a/.github/workflows/release-deploy-xsd.yml
+++ b/.github/workflows/release-deploy-xsd.yml
@@ -15,6 +15,12 @@ on:
         type: boolean
         default: false
   
+      approved:
+        description: "True only when release-published-orchestrator has already cleared the manual-approval gate for this run."
+        required: false
+        type: boolean
+        default: false
+
   workflow_dispatch:
     inputs:
       version:
@@ -36,8 +42,11 @@ jobs:
     name: Upload xsds
     runs-on: ubuntu-22.04
     if: ${{ inputs.dry_run == false }}
-    # Emits the `environment:release` OIDC subject, which is what the release-scoped vault role trusts.
-    environment: release
+    # Split so one release costs one approval: an orchestrated run has already cleared the
+    # `release` gate and passes `approved`, while a direct `workflow_dispatch` cannot set that input
+    # (it exists only under `workflow_call`) and so still lands on the reviewer-gated `release`.
+    environment:
+      name: ${{ inputs.approved && 'release-publish' || 'release' }}
     steps:
       - name: Download liquibase xsd
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release-deploy-xsd.yml
+++ b/.github/workflows/release-deploy-xsd.yml
@@ -36,6 +36,8 @@ jobs:
     name: Upload xsds
     runs-on: ubuntu-22.04
     if: ${{ inputs.dry_run == false }}
+    # Emits the `environment:release` OIDC subject, which is what the release-scoped vault role trusts.
+    environment: release
     steps:
       - name: Download liquibase xsd
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -47,7 +49,7 @@ jobs:
       - name: Configure AWS credentials for vault access
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
-          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
+          role-to-assume: ${{ secrets.LIQUIBASE_RELEASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Get secrets from vault

--- a/.github/workflows/release-publish-assets-s3.yml
+++ b/.github/workflows/release-publish-assets-s3.yml
@@ -44,6 +44,8 @@ jobs:
     if: ${{ inputs.dry_run == false }}
     # `approved` is `workflow_call`-only, so a direct dispatch cannot claim it and still meets the
     # reviewers on `release`. An orchestrated run cleared that gate once already.
+    # Keep it that way: on `workflow_dispatch` anyone who can dispatch could pick `release-publish`,
+    # and a non-`boolean` input would do it silently because the string "false" is truthy.
     environment:
       name: ${{ inputs.approved && 'release-publish' || 'release' }}
     steps:

--- a/.github/workflows/release-publish-assets-s3.yml
+++ b/.github/workflows/release-publish-assets-s3.yml
@@ -15,6 +15,12 @@ on:
         type: boolean
         default: false
   
+      approved:
+        description: "True only when release-published-orchestrator has already cleared the manual-approval gate for this run."
+        required: false
+        type: boolean
+        default: false
+
   workflow_dispatch:
     inputs:
       version:
@@ -36,8 +42,11 @@ jobs:
     name: Publish OSS released assets to s3 bucket liquibaseorg-origin
     runs-on: ubuntu-22.04
     if: ${{ inputs.dry_run == false }}
-    # Emits the `environment:release` OIDC subject, which is what the release-scoped vault role trusts.
-    environment: release
+    # Split so one release costs one approval: an orchestrated run has already cleared the
+    # `release` gate and passes `approved`, while a direct `workflow_dispatch` cannot set that input
+    # (it exists only under `workflow_call`) and so still lands on the reviewer-gated `release`.
+    environment:
+      name: ${{ inputs.approved && 'release-publish' || 'release' }}
     steps:
       - name: Download released assets
         env:

--- a/.github/workflows/release-publish-assets-s3.yml
+++ b/.github/workflows/release-publish-assets-s3.yml
@@ -36,6 +36,8 @@ jobs:
     name: Publish OSS released assets to s3 bucket liquibaseorg-origin
     runs-on: ubuntu-22.04
     if: ${{ inputs.dry_run == false }}
+    # Emits the `environment:release` OIDC subject, which is what the release-scoped vault role trusts.
+    environment: release
     steps:
       - name: Download released assets
         env:
@@ -52,7 +54,7 @@ jobs:
       - name: Configure AWS credentials for vault access
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
-          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
+          role-to-assume: ${{ secrets.LIQUIBASE_RELEASE_VAULT_OIDC_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Get secrets from vault

--- a/.github/workflows/release-publish-assets-s3.yml
+++ b/.github/workflows/release-publish-assets-s3.yml
@@ -42,9 +42,8 @@ jobs:
     name: Publish OSS released assets to s3 bucket liquibaseorg-origin
     runs-on: ubuntu-22.04
     if: ${{ inputs.dry_run == false }}
-    # Split so one release costs one approval: an orchestrated run has already cleared the
-    # `release` gate and passes `approved`, while a direct `workflow_dispatch` cannot set that input
-    # (it exists only under `workflow_call`) and so still lands on the reviewer-gated `release`.
+    # `approved` is `workflow_call`-only, so a direct dispatch cannot claim it and still meets the
+    # reviewers on `release`. An orchestrated run cleared that gate once already.
     environment:
       name: ${{ inputs.approved && 'release-publish' || 'release' }}
     steps:

--- a/.github/workflows/release-published-orchestrator.yml
+++ b/.github/workflows/release-published-orchestrator.yml
@@ -96,6 +96,7 @@ jobs:
       tag: ${{ needs.setup.outputs.tag }}
       dry_run: ${{ inputs.dry_run || false }}
       # Gate cleared above, so the callee uses `release-publish` and does not prompt again.
+      # That makes `needs: manual-approval` the only thing holding reviewers in front of this job.
       approved: true
     secrets: inherit
 
@@ -126,6 +127,7 @@ jobs:
       version: ${{ needs.setup.outputs.version }}
       dry_run: ${{ inputs.dry_run || false }}
       # Gate cleared above, so the callee uses `release-publish` and does not prompt again.
+      # That makes `needs: manual-approval` the only thing holding reviewers in front of this job.
       approved: true
     secrets: inherit
 
@@ -163,6 +165,7 @@ jobs:
       dry_run: ${{ inputs.dry_run || false }}
       dry_run_release_id: ${{ inputs.dry_run_release_id || '' }}
       # Gate cleared above, so the callee uses `release-publish` and does not prompt again.
+      # That makes `needs: manual-approval` the only thing holding reviewers in front of this job.
       approved: true
     secrets: inherit
 
@@ -206,6 +209,7 @@ jobs:
       version: ${{ needs.setup.outputs.version }}
       dry_run: ${{ inputs.dry_run || false }}
       # Gate cleared above, so the callee uses `release-publish` and does not prompt again.
+      # That makes `needs: manual-approval` the only thing holding reviewers in front of this job.
       approved: true
     secrets: inherit
 

--- a/.github/workflows/release-published-orchestrator.yml
+++ b/.github/workflows/release-published-orchestrator.yml
@@ -74,9 +74,8 @@ jobs:
       dry_run_branch_name: ${{ inputs.dry_run_branch_name || '' }}
     secrets: inherit
 
-  # The single approval for the whole release: GitHub approves per job, not per run, so the gate
-  # lives on one job that every publishing job depends on rather than on the publishing jobs
-  # themselves, which would stop the release once per wave of this graph.
+  # GitHub approves per job, not per run, so the gate sits on one job every publisher depends on.
+  # On the publishers themselves it would stop the release once per wave of this graph.
   manual-approval:
     name: Manual Deployment Approval
     needs: [setup]
@@ -96,8 +95,7 @@ jobs:
     with:
       tag: ${{ needs.setup.outputs.tag }}
       dry_run: ${{ inputs.dry_run || false }}
-      # This run already cleared the `release` gate on manual-approval above, so the callee
-      # uses the reviewer-less `release-publish` environment rather than gating a second time.
+      # Gate cleared above, so the callee uses `release-publish` and does not prompt again.
       approved: true
     secrets: inherit
 
@@ -127,8 +125,7 @@ jobs:
     with:
       version: ${{ needs.setup.outputs.version }}
       dry_run: ${{ inputs.dry_run || false }}
-      # This run already cleared the `release` gate on manual-approval above, so the callee
-      # uses the reviewer-less `release-publish` environment rather than gating a second time.
+      # Gate cleared above, so the callee uses `release-publish` and does not prompt again.
       approved: true
     secrets: inherit
 
@@ -165,8 +162,7 @@ jobs:
       tag: ${{ needs.setup.outputs.tag }}
       dry_run: ${{ inputs.dry_run || false }}
       dry_run_release_id: ${{ inputs.dry_run_release_id || '' }}
-      # This run already cleared the `release` gate on manual-approval above, so the callee
-      # uses the reviewer-less `release-publish` environment rather than gating a second time.
+      # Gate cleared above, so the callee uses `release-publish` and does not prompt again.
       approved: true
     secrets: inherit
 
@@ -209,8 +205,7 @@ jobs:
     with:
       version: ${{ needs.setup.outputs.version }}
       dry_run: ${{ inputs.dry_run || false }}
-      # This run already cleared the `release` gate on manual-approval above, so the callee
-      # uses the reviewer-less `release-publish` environment rather than gating a second time.
+      # Gate cleared above, so the callee uses `release-publish` and does not prompt again.
       approved: true
     secrets: inherit
 

--- a/.github/workflows/release-published-orchestrator.yml
+++ b/.github/workflows/release-published-orchestrator.yml
@@ -74,6 +74,9 @@ jobs:
       dry_run_branch_name: ${{ inputs.dry_run_branch_name || '' }}
     secrets: inherit
 
+  # The single approval for the whole release: GitHub approves per job, not per run, so the gate
+  # lives on one job that every publishing job depends on rather than on the publishing jobs
+  # themselves, which would stop the release once per wave of this graph.
   manual-approval:
     name: Manual Deployment Approval
     needs: [setup]
@@ -93,6 +96,9 @@ jobs:
     with:
       tag: ${{ needs.setup.outputs.tag }}
       dry_run: ${{ inputs.dry_run || false }}
+      # This run already cleared the `release` gate on manual-approval above, so the callee
+      # uses the reviewer-less `release-publish` environment rather than gating a second time.
+      approved: true
     secrets: inherit
 
   publish-github-packages:
@@ -121,6 +127,9 @@ jobs:
     with:
       version: ${{ needs.setup.outputs.version }}
       dry_run: ${{ inputs.dry_run || false }}
+      # This run already cleared the `release` gate on manual-approval above, so the callee
+      # uses the reviewer-less `release-publish` environment rather than gating a second time.
+      approved: true
     secrets: inherit
 
   release-docker:
@@ -156,6 +165,9 @@ jobs:
       tag: ${{ needs.setup.outputs.tag }}
       dry_run: ${{ inputs.dry_run || false }}
       dry_run_release_id: ${{ inputs.dry_run_release_id || '' }}
+      # This run already cleared the `release` gate on manual-approval above, so the callee
+      # uses the reviewer-less `release-publish` environment rather than gating a second time.
+      approved: true
     secrets: inherit
 
   package:
@@ -197,6 +209,9 @@ jobs:
     with:
       version: ${{ needs.setup.outputs.version }}
       dry_run: ${{ inputs.dry_run || false }}
+      # This run already cleared the `release` gate on manual-approval above, so the callee
+      # uses the reviewer-less `release-publish` environment rather than gating a second time.
+      approved: true
     secrets: inherit
 
   generate-summary:


### PR DESCRIPTION
## Impact

- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Step 3 of the release vault OIDC migration. `liquibase-release-vault-oidc-role` was created by [liquibase/liquibase-infrastructure#4279](https://github.com/liquibase/liquibase-infrastructure/pull/4279) but nothing assumed it: every publishing job still presented `LIQUIBASE_VAULT_OIDC_ROLE_ARN`, the broad `repo:liquibase/*:*` role, so the new role had zero traffic and the CloudTrail acceptance criterion could never have passed.

Two edits per job, both required for the role to be reachable:

- an `environment:`, so the OIDC subject becomes `environment:<name>`;
- `role-to-assume` switched to `LIQUIBASE_RELEASE_VAULT_OIDC_ROLE_ARN`.

## Decisions

### 1. The environment goes in the callees, not the orchestrator

The ticket originally called for adding `environment: release` to the orchestrator's publishing jobs. Not expressible: those jobs are reusable-workflow calls, and the workflow JSON schema's reusable-workflow-call job allows only `name`, `needs`, `permissions`, `if`, `uses`, `with`, `secrets`, `strategy`, `concurrency`, with `additionalProperties: false`. GitHub's prose docs never state this. So it sits on the jobs inside the callees.

### 2. Two environments, not one, because GitHub approves per job

The first version of this PR put `environment: release` on all four publishing jobs. That was wrong, and the review caught it. **Approval is granted per job, not per run**, so a single reviewer-gated environment stops the release once per wave of the orchestrator's `needs` graph:

```
manual-approval  ->  javadocs + xsd  ->  s3 (after package)  ->  maven (after javadocs/xsd/gh-packages)
```

Four prompts where there is one today. That is the approval fatigue [TECHOPS-1103](https://datical.atlassian.net/browse/TECHOPS-1103) rejected, and a release that stops four times in front of people not expecting it gets rubber-stamped.

The fix separates the two jobs one environment was doing. `release` keeps the five reviewers and stays the gate on `manual-approval`. `release-publish` ([liquibase/liquibase-infrastructure#4323](https://github.com/liquibase/liquibase-infrastructure/pull/4323)) has the same deployment policies and no reviewers, and exists only to emit an `environment:` OIDC subject, which a job emits with or without protection rules.

### 3. The environment is selected, not fixed, so direct dispatch stays gated

```yaml
environment:
  name: ${{ inputs.approved && 'release-publish' || 'release' }}
```

`approved` is declared **only under `workflow_call`**, never under `workflow_dispatch`, so it is not something a person can set. The orchestrator passes `approved: true` on the four calls it makes after `manual-approval` has cleared. Anything else falls back to `release` and its reviewers.

That fallback is the point. All four callees carry their own `workflow_dispatch`, and `manual-approval` lives in the orchestrator, not in the callee's `needs` graph, so a direct dispatch has never passed a gate. It is a live path, not a theoretical one: `release-deploy-maven.yml` has been dispatched directly 6 times, most recently 2026-08-23. Today it reaches the broad vault role with no approval at all.

| | orchestrated release | direct dispatch of a callee |
|---|---|---|
| today | 1 approval | **0** |
| first version of this PR | ~4 approvals | 1 approval |
| **this** | **1 approval** | **1 approval** |

## Scope

The four production jobs, all already gated on `dry_run == false`:

| file | job |
|---|---|
| `release-deploy-javadocs.yml` | `deploy-javadocs` |
| `release-deploy-maven.yml` | `deploy-maven-production` |
| `release-deploy-xsd.yml` | `deploy-xsd` |
| `release-publish-assets-s3.yml` | `publish-assets-s3` |

Plus `release-published-orchestrator.yml`, which passes `approved: true` on those four calls.

`deploy-maven-dryrun` is deliberately left on the old role with no environment: dry runs skip `manual-approval` and should not sit behind required reviewers. The second `configure-aws-credentials` step in three of these files uses `AWS_PROD_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC`, a different role with its own trust, and is untouched.

## Things to be aware of

**Merge order.** [liquibase/liquibase-infrastructure#4323](https://github.com/liquibase/liquibase-infrastructure/pull/4323) must be merged **and applied** first. `vault-manager` has no autodeploy, so its run needs confirming by hand. Until it does, the role does not trust `environment:release-publish` and a release fails with an STS `AccessDenied` that reads as unrelated.

**`create-release.yml` (2 sites) and `docker-release.yml` (1 site) still use the broad role.** Raised in review, verified on main. Outside this PR's scope, but it means [TECHOPS-1110](https://datical.atlassian.net/browse/TECHOPS-1110) does not close when this lands: the job holding the GPG and DigiCert signing credentials is still on `repo:liquibase/*:*`. Being raised separately.

**build-logic `package.yml` still uses the broad role.** Its `upload_packages` and `create-placeholder-branch` jobs assume `LIQUIBASE_VAULT_OIDC_ROLE_ARN`. It is shared by many repos, so scoping it to this environment would impose these reviewers on every other consumer. Needs its own change.

**Do not delete the tag subjects yet.** Step 5 removes `refs/tags/v*` from the role's trust. That waits until CloudTrail confirms the role is assumed on an `environment:` subject, on both a real release and a `workflow_dispatch` run.

**Any new release-path job that reads the vault needs two edits, not one.** The `environment:` block on the job inside the callee, never on the orchestrator, and `role-to-assume` pointed at the release role. Either edit without the other is a silent no-op.

## How was it tested?

- `actionlint` on all five files: **2 / 2 / 2 / 1 / 2 findings before and after**, byte-identical, all pre-existing shellcheck `SC2086` noise plus one pre-existing `required` + `default` warning on the orchestrator.
- YAML re-parsed to confirm `approved` is absent from every `workflow_dispatch` input list, that the environment expression resolves on exactly the four intended jobs, and that `deploy-maven-dryrun` still declares no environment.
- Expression support in `environment.name` confirmed against the workflow syntax reference: allowed contexts are `github`, `inputs`, `vars`, `needs`, `strategy`, `matrix`.
- Verified against the live `release` environment that the deployment policies admit both triggers, `branch main` and `tag v*`.

Not exercised end to end: the environment OIDC path has never been used anywhere in the org, so the first release is also its first test. A failure there surfaces as an STS `AccessDenied`.

## Release note

<!-- CI-only change, not customer-facing. skipReleaseNotes applied. -->



[TECHOPS-1103]: https://datical.atlassian.net/browse/TECHOPS-1103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ