### PR TITLE
[TECHOPS-1107] Scope the remaining vault reads in dry-run-release and auto-create-jira-on-merge

### DIFF
--- a/.github/workflows/auto-create-jira-on-merge.yml
+++ b/.github/workflows/auto-create-jira-on-merge.yml
@@ -63,11 +63,27 @@ jobs:
           aws-region: us-east-1
 
       - name: Get Jira service-account credentials from vault
-        uses: aws-actions/aws-secretsmanager-get-secrets@2cb1a461cbd4865ac4299648312e4704c646cd53 # v3
-        with:
-          secret-ids: |
-            ,/vault/liquibase
-          parse-json-secrets: true
+        # TECHOPS-1107: aws-secretsmanager-get-secrets can only load a secret whole, so
+        # parse-json-secrets: true put every credential in /vault/liquibase into this
+        # job's environment; read only the Jira service-account user and token.
+        run: |
+          set -euo pipefail
+          JSON=$(aws secretsmanager get-secret-value --secret-id /vault/liquibase --region us-east-1 --query SecretString --output text)
+          for k in JIRA_USER JIRA_API_TOKEN; do
+            # jq -j plus a sentinel: command substitution strips ALL trailing newlines,
+            # which would silently alter a value that legitimately ends in one.
+            v=$(printf '%s' "$JSON" | jq -j --arg k "$k" '.[$k] // ""'; printf 'X')
+            v=${v%X}
+            if [ -z "$v" ]; then echo "::error::$k missing from /vault/liquibase"; exit 1; fi
+            # The runner unescapes %0D, %0A and %25 in command data, so a value carrying
+            # those literals registers a mask that never matches it; % is escaped first
+            # so the escapes the next two produce are not escaped again.
+            e=$v; e=${e//'%'/%25}; e=${e//$'\r'/%0D}; e=${e//$'\n'/%0A}
+            printf '::add-mask::%s\n' "$e"
+            D="VAULT_EOF_${RANDOM}${RANDOM}"
+            { echo "$k<<$D"; printf '%s\n' "$v"; echo "$D"; } >> "$GITHUB_ENV"
+          done
+          unset JSON
 
       - name: Auto-create / update tickets
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9

--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -69,12 +69,27 @@ jobs:
           aws-region: us-east-1
 
       - name: Get secrets from vault
-        id: vault-secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@2cb1a461cbd4865ac4299648312e4704c646cd53 # v3.0.1
-        with:
-          secret-ids: |
-            ,/vault/liquibase
-          parse-json-secrets: true
+        # TECHOPS-1107: aws-secretsmanager-get-secrets can only load a secret whole, so
+        # parse-json-secrets: true put every credential in /vault/liquibase into this
+        # job's environment; read only the two App keys the token mint below needs.
+        run: |
+          set -euo pipefail
+          JSON=$(aws secretsmanager get-secret-value --secret-id /vault/liquibase --region us-east-1 --query SecretString --output text)
+          for k in LIQUIBASE_GITHUB_APP_ID LIQUIBASE_GITHUB_APP_PRIVATE_KEY; do
+            # jq -j plus a sentinel: command substitution strips ALL trailing newlines,
+            # which would silently alter a value that legitimately ends in one.
+            v=$(printf '%s' "$JSON" | jq -j --arg k "$k" '.[$k] // ""'; printf 'X')
+            v=${v%X}
+            if [ -z "$v" ]; then echo "::error::$k missing from /vault/liquibase"; exit 1; fi
+            # The runner unescapes %0D, %0A and %25 in command data, so a value carrying
+            # those literals registers a mask that never matches it; % is escaped first
+            # so the escapes the next two produce are not escaped again.
+            e=$v; e=${e//'%'/%25}; e=${e//$'\r'/%0D}; e=${e//$'\n'/%0A}
+            printf '::add-mask::%s\n' "$e"
+            D="VAULT_EOF_${RANDOM}${RANDOM}"
+            { echo "$k<<$D"; printf '%s\n' "$v"; echo "$D"; } >> "$GITHUB_ENV"
+          done
+          unset JSON
 
       - name: Get GitHub App token
         id: get-token
@@ -208,12 +223,27 @@ jobs:
           aws-region: us-east-1
 
       - name: Get secrets from vault
-        id: vault-secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@2cb1a461cbd4865ac4299648312e4704c646cd53 # v3.0.1
-        with:
-          secret-ids: |
-            ,/vault/liquibase
-          parse-json-secrets: true
+        # TECHOPS-1107: aws-secretsmanager-get-secrets can only load a secret whole, so
+        # parse-json-secrets: true put every credential in /vault/liquibase into this
+        # job's environment; read only the two App keys the token mint below needs.
+        run: |
+          set -euo pipefail
+          JSON=$(aws secretsmanager get-secret-value --secret-id /vault/liquibase --region us-east-1 --query SecretString --output text)
+          for k in LIQUIBASE_GITHUB_APP_ID LIQUIBASE_GITHUB_APP_PRIVATE_KEY; do
+            # jq -j plus a sentinel: command substitution strips ALL trailing newlines,
+            # which would silently alter a value that legitimately ends in one.
+            v=$(printf '%s' "$JSON" | jq -j --arg k "$k" '.[$k] // ""'; printf 'X')
+            v=${v%X}
+            if [ -z "$v" ]; then echo "::error::$k missing from /vault/liquibase"; exit 1; fi
+            # The runner unescapes %0D, %0A and %25 in command data, so a value carrying
+            # those literals registers a mask that never matches it; % is escaped first
+            # so the escapes the next two produce are not escaped again.
+            e=$v; e=${e//'%'/%25}; e=${e//$'\r'/%0D}; e=${e//$'\n'/%0A}
+            printf '::add-mask::%s\n' "$e"
+            D="VAULT_EOF_${RANDOM}${RANDOM}"
+            { echo "$k<<$D"; printf '%s\n' "$v"; echo "$D"; } >> "$GITHUB_ENV"
+          done
+          unset JSON
 
       - name: Get GitHub App token
         id: get-token
@@ -273,12 +303,27 @@ jobs:
           aws-region: us-east-1
 
       - name: Get secrets from vault
-        id: vault-secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@2cb1a461cbd4865ac4299648312e4704c646cd53 # v3.0.1
-        with:
-          secret-ids: |
-            ,/vault/liquibase
-          parse-json-secrets: true
+        # TECHOPS-1107: aws-secretsmanager-get-secrets can only load a secret whole, so
+        # parse-json-secrets: true put every credential in /vault/liquibase into this
+        # job's environment; read only the Slack bot token and channel id.
+        run: |
+          set -euo pipefail
+          JSON=$(aws secretsmanager get-secret-value --secret-id /vault/liquibase --region us-east-1 --query SecretString --output text)
+          for k in DRY_RUN_SLACK_BOT_TOKEN DRYRUN_RELEASES_SLACK_ID; do
+            # jq -j plus a sentinel: command substitution strips ALL trailing newlines,
+            # which would silently alter a value that legitimately ends in one.
+            v=$(printf '%s' "$JSON" | jq -j --arg k "$k" '.[$k] // ""'; printf 'X')
+            v=${v%X}
+            if [ -z "$v" ]; then echo "::error::$k missing from /vault/liquibase"; exit 1; fi
+            # The runner unescapes %0D, %0A and %25 in command data, so a value carrying
+            # those literals registers a mask that never matches it; % is escaped first
+            # so the escapes the next two produce are not escaped again.
+            e=$v; e=${e//'%'/%25}; e=${e//$'\r'/%0D}; e=${e//$'\n'/%0A}
+            printf '::add-mask::%s\n' "$e"
+            D="VAULT_EOF_${RANDOM}${RANDOM}"
+            { echo "$k<<$D"; printf '%s\n' "$v"; echo "$D"; } >> "$GITHUB_ENV"
+          done
+          unset JSON
 
       - name: Notify Slack on Build Failure
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0


### PR DESCRIPTION
## Problem

`aws-actions/aws-secretsmanager-get-secrets` can only load a secret whole, so `parse-json-secrets: true` against `/vault/liquibase` exports **every** credential in that shared secret into the job environment: GPG keys, DigiCert KeyLocker credentials, Sonatype tokens, SFTP passwords, the lot. Any job that only needs two of them still gets all of them.

Open PR #7962 closes 8 of the 12 remaining call sites on `main`. It leaves 4 untouched, in two files. This PR closes those 4.

## Scope

Four sites, in two files that #7962 does not touch:

| File | Job | Line on `main` | Keys now read |
|---|---|---|---|
| `.github/workflows/dry-run-release.yml` | `dry-run-create-release` | 77 | `LIQUIBASE_GITHUB_APP_ID`, `LIQUIBASE_GITHUB_APP_PRIVATE_KEY` |
| `.github/workflows/dry-run-release.yml` | `dry-run-release-published` | 216 | `LIQUIBASE_GITHUB_APP_ID`, `LIQUIBASE_GITHUB_APP_PRIVATE_KEY` |
| `.github/workflows/dry-run-release.yml` | `notify` | 281 | `DRY_RUN_SLACK_BOT_TOKEN`, `DRYRUN_RELEASES_SLACK_ID` |
| `.github/workflows/auto-create-jira-on-merge.yml` | `auto-create` | 70 | `JIRA_USER`, `JIRA_API_TOKEN` |

## Evidence for each key list

`secret-ids` is `,/vault/liquibase` (empty alias), so `parse-json-secrets` exports each JSON key under its own bare name. That makes every consumer of a vault key an `env.<KEY>` reference, and `grep -n 'env\.'` over each file returns the complete list of them:

`dry-run-release.yml` has exactly six `env.` references and no others:

```
83:          app-id: ${{ env.LIQUIBASE_GITHUB_APP_ID }}
84:          private-key: ${{ env.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
222:          app-id: ${{ env.LIQUIBASE_GITHUB_APP_ID }}
223:          private-key: ${{ env.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
287:          token: ${{ env.DRY_RUN_SLACK_BOT_TOKEN }}
289:            channel: ${{ env.DRYRUN_RELEASES_SLACK_ID }}
```

- **`dry-run-create-release`** (83, 84) and **`dry-run-release-published`** (222, 223): the only vault consumer in each job is the `actions/create-github-app-token` step. Everything after it uses `steps.get-token.outputs.token`, not a vault value. The `role-to-assume` on the preceding AWS step is `secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN`, a repo secret and not a vault key.
- **`notify`** (287, 289): the only vault consumer is the `slackapi/slack-github-action` step.
- I also checked the one non-trivial `uses:` passthrough in this file. `liquibase/build-logic/.github/actions/dispatch-and-wait` (pinned at `d12b3871`) is a composite whose single step declares an explicit `env:` block sourced entirely from its named `inputs` (`gh-token`, `workflow`, `repo`, `ref`, …). It reads no ambient vault variable, so it adds nothing to either job's key list.

`auto-create-jira-on-merge.yml`, `auto-create`: the `actions/github-script` step declares its own `env:` block, and that block is where the vault values enter:

```
JIRA_EMAIL: ${{ env.JIRA_USER }}
JIRA_TOKEN: ${{ env.JIRA_API_TOKEN }}
```

Nothing else in the job or the inline script reads a vault key: `JIRA_BASE_URL` is a hardcoded literal, and the script otherwise uses only `github`/`context` from the action. The file's own header comment already documents the requirement as "`/vault/liquibase` must contain `JIRA_USER` + `JIRA_API_TOKEN`", which agrees.

## Disjoint from #7962

`git diff --name-only main` here intersected with `gh api repos/liquibase/liquibase/pulls/7962/files` is empty. #7962 touches `create-release.yml`, `docker-release.yml`, `release-deploy-javadocs.yml`, `release-deploy-maven.yml`, `release-deploy-xsd.yml` and `release-publish-assets-s3.yml`; this PR touches `dry-run-release.yml` and `auto-create-jira-on-merge.yml`. No shared file, so the two can merge in either order with no conflict.

Together with #7952 (`build.yml`) and #7951 (`run-test-harness.yml`), already merged, and #7962, this leaves zero `parse-json-secrets: true` call sites in the repo.

## Implementation

The replacement block is the pattern from #7952 and #7962, verbatim: `aws secretsmanager get-secret-value` for the raw JSON, then per key a `jq -j` extract with a sentinel byte (command substitution strips trailing newlines), a hard fail if the key is absent, an escaped `::add-mask::` so a value containing literal `%`, `CR` or `LF` still masks, and a heredoc write to `$GITHUB_ENV`. Same idiom, same comments, no new approach.

## Verification

- `grep -rn 'parse-json-secrets: true' .github/workflows/` returns nothing in these two files; the 8 remaining hits are all in files #7962 rewrites.
- Both files round-trip through a YAML parser, and all 5 jobs in `dry-run-release.yml` plus the 1 in `auto-create-jira-on-merge.yml` still resolve.
- Each of the 4 extracted `run:` scripts passes `bash -n`.
- No `steps.vault-secrets.*` reference existed anywhere in either file, so dropping the now-meaningless `id: vault-secrets` from the three converted steps in `dry-run-release.yml` breaks no reference.
- No behavioural change is expected: the same variable names land in `$GITHUB_ENV` and every downstream `env.*` reference resolves as before. `dry-run-release.yml` runs weekly on a Wednesday cron and on demand, so the next scheduled run exercises all three of its sites end to end.
