### PR TITLE
[TECHOPS-1214] Fix the release pipeline diagram and document what guards it

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -101,16 +101,59 @@ The main coordinator that triggers all release steps in the proper sequence. Sup
 
 ### Extracted Reusable Workflows
 
-| Workflow | Purpose | Can Run Independently |
+| Workflow | Purpose | Can run independently |
 |----------|---------|----------------------|
 | `release-setup.yml` | Extract release metadata (version, tag, branch) | ✅ Yes |
 | `release-manual-approval.yml` | Hold the release for approval on the `release` environment | ✅ Yes |
-| `release-deploy-maven.yml` | Deploy artifacts to Maven Central | ✅ Yes |
-| `release-deploy-javadocs.yml` | Upload javadocs to S3 | ✅ Yes |
+| `release-deploy-maven.yml` | Deploy artifacts to Maven Central | ✅ Yes, with one approval |
+| `release-deploy-javadocs.yml` | Upload javadocs to S3 | ✅ Yes, with one approval |
 | `release-publish-github-packages.yml` | Publish to GitHub Packages | ✅ Yes |
-| `release-deploy-xsd.yml` | Deploy XSD files to S3 and SFTP | ✅ Yes |
+| `release-deploy-xsd.yml` | Deploy XSD files to S3 and SFTP | ✅ Yes, with one approval |
 | `release-docker.yml` | Trigger Docker image builds | ✅ Yes |
-| `release-publish-assets-s3.yml` | Publish release assets to S3 | ✅ Yes |
+| `release-publish-assets-s3.yml` | Publish release assets to S3 | ✅ Yes, with one approval |
+
+## :closed_lock_with_key: What guards each release workflow
+
+The table above says what each workflow does. This one says what stands in front of it. Read it before changing any job that touches `/vault/liquibase`.
+
+| Job | Workflow | Gate | AWS role | Reads |
+|---|---|---|---|---|
+| `setup` | `release-setup.yml` | none | none | nothing |
+| `manual-approval` | `release-manual-approval.yml` | **`release`**, 5 reviewers | none | nothing; the gate makes no AWS call |
+| `deploy-javadocs` | `release-deploy-javadocs.yml` | via `needs` | release-scoped | `/vault/liquibase`, then assumes the build-logic prod role read out of it |
+| `publish-github-packages` | `release-publish-github-packages.yml` | via `needs` | none | `GITHUB_TOKEN` with `packages: write` |
+| `deploy-xsd` | `release-deploy-xsd.yml` | via `needs` | release-scoped | `/vault/liquibase`, then the build-logic role plus five WPEngine SFTP secrets |
+| `package` | `build-logic/package.yml@main` | via `needs` | **broad** | `/vault/liquibase`; shared workflow, so it cannot take this repo's environment |
+| `publish-assets-s3` | `release-publish-assets-s3.yml` | via `needs` | release-scoped | `/vault/liquibase`, then the build-logic prod role |
+| `deploy-maven-production` | `release-deploy-maven.yml` | via `needs` | release-scoped | `/vault/liquibase`; holds the Maven Central credentials |
+| `deploy-maven-dryrun` | `release-deploy-maven.yml` | none, by design | **broad** | `/vault/liquibase`; dry runs skip the gate deliberately |
+| `release-docker` | `release-docker.yml` | via `needs` | **broad** | delegates to `docker-release.yml`, whose `update-dockerfiles` reads the vault |
+| `reversion`, `build-installers` | `create-release.yml` | none | **broad** | `/vault/liquibase`; holds the GPG and DigiCert signing credentials |
+
+"release-scoped" is `liquibase-release-vault-oidc-role`, whose trust lists explicit subjects. "broad" is `liquibase-vault-oidc-role`, trusted as `repo:liquibase/*:*`.
+
+Three of the publishing jobs chain a second role: they read `AWS_PROD_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC` **out of the vault** and then assume it. The vault read is not the end of the blast radius.
+
+### :twisted_rightwards_arrows: Which environment a publishing job gets
+
+The four publishing jobs resolve their environment at run time:
+
+```yaml
+environment:
+  name: ${{ inputs.approved && 'release-publish' || 'release' }}
+```
+
+`approved` is declared only under `workflow_call`, never under `workflow_dispatch`, so no person can set it.
+
+| Path | `approved` | Environment | Cost |
+|---|---|---|---|
+| orchestrated release | `true`, passed by the orchestrator after `manual-approval` clears | `release-publish`, no reviewers | one approval for the whole release |
+| direct `workflow_dispatch` of a callee | never set | `release`, 5 reviewers | one approval, from someone other than the dispatcher |
+
+Both names emit an `environment:` OIDC subject, and the release-scoped role trusts both. `manual-approval` lives in the orchestrator, not in a callee's `needs` graph, which is why a direct dispatch needs its own gate rather than inheriting one.
+
+Both environments are defined in `liquibase-infrastructure`, not here, so they cannot be changed by editing a workflow:
+[`github/liquibase/repos/public/liquibase-release-environment.tf`](https://github.com/liquibase/liquibase-infrastructure/blob/main/github/liquibase/repos/public/liquibase-release-environment.tf)
 
 ## Key Benefits
 
@@ -184,58 +227,52 @@ If a specific step fails, you can re-run just that workflow:
    - `dry_run`: false (for production)
 5. Click **Run workflow**
 
+For the four publishing workflows, a direct dispatch runs in the `release` environment and waits for one reviewer before it starts. That is deliberate: `manual-approval` is a job in the orchestrator, so a workflow dispatched on its own never passes it.
+
 ## Deployment Pipeline
 
+```mermaid
+flowchart LR
+    trigger("release: published<br/>workflow_dispatch<br/>workflow_call"):::evt --> setup
+    setup("setup"):::plain --> approval
+    approval("manual-approval<br/>environment: release<br/>5 reviewers"):::gate
+
+    approval --> javadocs
+    approval --> ghpkg
+    approval --> xsd
+    approval --> package
+
+    javadocs("deploy-javadocs"):::scoped --> maven
+    ghpkg("publish-github-packages"):::plain --> maven
+    xsd("deploy-xsd"):::scoped --> maven
+    package("package<br/>build-logic@main"):::broad --> s3
+
+    maven("deploy-maven"):::scoped --> docker("release-docker"):::broad
+    s3("publish-assets-s3"):::scoped
+
+    docker --> summary
+    s3 --> summary
+    summary("generate-summary<br/>needs: all nine<br/>always()"):::plain
+
+    classDef evt    fill:#e9ecf1,stroke:#5b6573,stroke-width:1px,color:#14171c
+    classDef plain  fill:#ffffff,stroke:#5b6573,stroke-width:1px,color:#14171c
+    classDef gate   fill:#f6ead6,stroke:#9d5c00,stroke-width:2px,color:#14171c
+    classDef scoped fill:#dcefe7,stroke:#17654f,stroke-width:2px,color:#14171c
+    classDef broad  fill:#f6dedb,stroke:#9d2f26,stroke-width:2px,color:#14171c
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                  Release Published Event                         │
-│              (or workflow_dispatch trigger)                      │
-└──────────────────────┬──────────────────────────────────────────┘
-                       │
-                       ▼
-              ┌────────────────┐
-              │     Setup      │  Extract version, branch, SHA, timestamp
-              └────────┬───────┘
-                       │
-                       ▼
-              ┌────────────────┐
-              │Manual Approval │  `release` environment gate (skipped if dry_run)
-              └────────┬───────┘
-                       │
-        ┌──────────────┴──────────────┐
-        │                             │
-        ▼                             ▼
-┌───────────────┐            ┌────────────────┐
-│ Deploy        │            │ Publish to     │
-│ Javadocs      │            │ GitHub Packages│
-└───────┬───────┘            └───────┬────────┘
-        │                            │
-        │    ┌───────────────────────┤
-        │    │                       │
-        ▼    ▼                       ▼
-  ┌──────────────┐          ┌────────────┐
-  │ Deploy XSD   │          │  Docker    │
-  └──────┬───────┘          └──────┬─────┘
-         │                         │
-         └─────────────────────────┘
-                                   │
-                                   ▼
-                        ┌──────────────────┐
-                        │  Deploy to Maven │
-                        │     Central      │
-                        └──────────────────┘
-                                   
-         Parallel Execution:
-         ┌─────────────┐        ┌──────────────────┐
-         │   Package   │        │Publish Assets S3 │
-         └─────────────┘        └──────────────────┘
-                                   
-                                   │
-                                   ▼
-                        ┌──────────────────┐
-                        │Generate Summary  │
-                        └──────────────────┘
-```
+
+| | meaning |
+|---|---|
+| :large_orange_diamond: amber | the reviewer gate |
+| :green_square: green | reads `/vault/liquibase` through the release-scoped role |
+| :red_square: red | reads `/vault/liquibase` through the broad `repo:liquibase/*:*` role |
+| :white_large_square: white | no vault access |
+
+Three edges are easy to get backwards, so read them off the `needs:` keys rather than from memory:
+
+- `release-docker` runs **after** `deploy-maven`, not beside it.
+- `deploy-xsd` runs **beside** `deploy-javadocs`, not after it.
+- `publish-assets-s3` waits on `package`. That edge is load-bearing: when approval is denied `package` is skipped, and accepting a skipped `package` on its own would publish production assets past a rejected release.
 
 ## Testing Strategy
 
@@ -566,19 +603,22 @@ If manually running multiple workflows, follow this order:
 
 ```
 1. release-setup (must run first)
-   ↓
+   |
 2. release-manual-approval (if needed)
-   ↓
+   |
 3. Parallel (can run these together):
    - release-deploy-javadocs
    - release-publish-github-packages
    - release-deploy-xsd
-   - release-docker
-   ↓
-4. release-deploy-maven (waits for step 3)
-   ↓
-5. release-publish-assets-s3 (final step)
+   - package (build-logic)
+   |
+4. release-deploy-maven      (waits for javadocs + github-packages + xsd)
+   release-publish-assets-s3 (waits for package, not for maven)
+   |
+5. release-docker (waits for release-deploy-maven)
 ```
+
+`release-docker` is last, not part of step 3. It declares `needs: [setup, manual-approval, deploy-maven]`, so dispatching it before Maven has finished publishes images for artifacts that are not on Maven Central yet.
 
 ## Tips
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -290,7 +290,7 @@ flowchart LR
 |---|---|
 | :large_orange_diamond: amber | the reviewer gate |
 | :green_square: green | reads `/vault/liquibase` through the release-scoped role |
-| :red_square: red | reads `/vault/liquibase` through the broad `repo:liquibase/*:*` role |
+| :red_square: red | reads `/vault/liquibase` through the broad `liquibase-vault-oidc-role` |
 | :white_large_square: white | no vault access |
 
 Three edges are easy to get backwards, so read them off the `needs:` keys rather than from memory:
@@ -321,7 +321,7 @@ Three edges are easy to get backwards, so read them off the `needs:` keys rather
 
 3. **Test Manual Approval Logic**
    - Confirm approval is skipped in dry_run mode
-   - Verify 2 approvers are required in production mode
+   - Verify one approval from the `release` reviewer list is required in production mode, and that it cannot come from whoever started the run
 
 4. **Validate Summary Generation**
    - Check that all job statuses appear correctly

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -134,7 +134,7 @@ The main coordinator that triggers all release steps in the proper sequence. Sup
 | `release-deploy-javadocs.yml` | Upload javadocs to S3 | ✅ Yes, with one approval |
 | `release-publish-github-packages.yml` | Publish to GitHub Packages | ✅ Yes |
 | `release-deploy-xsd.yml` | Deploy XSD files to S3 and SFTP | ✅ Yes, with one approval |
-| `release-docker.yml` | Trigger Docker image builds | ✅ Yes |
+| `docker-release.yml` | Build and push release Docker images | ✅ Yes |
 | `release-publish-assets-s3.yml` | Publish release assets to S3 | ✅ Yes, with one approval |
 
 ## :closed_lock_with_key: What guards each release workflow
@@ -152,10 +152,10 @@ The table above says what each workflow does. This one says what stands in front
 | `publish-assets-s3` | `release-publish-assets-s3.yml` | via `needs` | release-scoped | `/vault/liquibase`, then the build-logic prod role |
 | `deploy-maven-production` | `release-deploy-maven.yml` | via `needs` | release-scoped | `/vault/liquibase`; holds the Maven Central credentials |
 | `deploy-maven-dryrun` | `release-deploy-maven.yml` | none, by design | **broad** | `/vault/liquibase`; dry runs skip the gate deliberately |
-| `release-docker` | `release-docker.yml` | via `needs` | **broad** | delegates to `docker-release.yml`, whose `update-dockerfiles` reads the vault |
+| `release-docker` | `docker-release.yml` | via `needs` | **broad** | its `update-dockerfiles` job reads the vault |
 | `reversion`, `build-installers` | `create-release.yml` | none | **broad** | `/vault/liquibase`; holds the GPG and DigiCert signing credentials |
 
-"release-scoped" is `liquibase-release-vault-oidc-role`, whose trust lists explicit subjects. "broad" is `liquibase-vault-oidc-role`, trusted as `repo:liquibase/*:*`.
+"release-scoped" is `liquibase-release-vault-oidc-role`, whose trust lists explicit subjects. "broad" is `liquibase-vault-oidc-role`, whose GitHub OIDC trust matches any repo in the `liquibase`, `Datical` and `datical` orgs, in both the classic and the immutable `owner@ownerId/repo@repoId` subject formats: six globs, not one. It carries a second statement besides, unrelated to GitHub: any principal inside the AWS org whose ARN matches the Spacelift role shapes can `sts:AssumeRole` into it.
 
 Three of the publishing jobs chain a second role: they read `AWS_PROD_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC` **out of the vault** and then assume it. The vault read is not the end of the blast radius.
 


### PR DESCRIPTION
## Impact

- [x] Bug fix (non-breaking change which fixes expected existing functionality)
- [ ] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Documentation only. No workflow file is touched.

> **Draft until [liquibase/liquibase#7964](https://github.com/liquibase/liquibase/pull/7964) merges.** The guards table below documents the `release-publish` environment, which does not exist until [liquibase/liquibase-infrastructure#4323](https://github.com/liquibase/liquibase-infrastructure/pull/4323) is applied. The diagram and dependency-order fixes are correct today and independent of that; they are here rather than in a separate PR because they are the same section of the same file.

## Description

### The diagram had three edges wrong

Read off the `needs:` keys in `release-published-orchestrator.yml`:

| README said | `needs:` actually says |
|---|---|
| Docker feeds **into** Maven, and is listed in parallel wave 3 | `release-docker` needs `deploy-maven`, so it runs **last** |
| XSD chained **below** javadocs | `deploy-xsd` needs only `[setup, manual-approval]`, so it runs **beside** it |
| `package` and `publish-assets-s3` under a loose "Parallel Execution" footnote, no edge | `publish-assets-s3` needs `package` |

The Docker one is the error that bites. **Dependency Order** is headed *"If manually running multiple workflows, follow this order"*, so it is the manual-recovery runbook, and it put `release-docker` in step 3 beside javadocs and XSD. Following it dispatches Docker before Maven has finished, publishing images for artifacts that are not on Maven Central yet.

The `package -> publish-assets-s3` edge is the one the orchestrator carries a comment about: when approval is denied `package` is skipped, and accepting a skipped `package` on its own would publish production assets past a rejected release. Drawing them as unrelated parallel boxes hides exactly that.

Redrawn in mermaid so it renders in the GitHub UI, and colour-coded by what guards each job.

### The README documented no guards at all

It said what each workflow does. It never said which of them reach `/vault/liquibase`, which role each assumes, or that four of them now resolve their environment at run time. That is the half a reader needs before changing one.

Adds a table covering all eleven jobs on the release path with gate, AWS role and what each can read, in the same shape as the existing CI overview's Secrets column, plus the two-environment behaviour and why a direct dispatch needs its own approval.

One thing worth recording because no single file shows it: **three of the publishing jobs read `AWS_PROD_GITHUB_OIDC_ROLE_ARN_BUILD_LOGIC` out of the vault and then assume it**, so the vault read is not the end of the blast radius. `deploy-xsd` pulls five WPEngine SFTP secrets on the same hop.

### Smaller corrections

- **"Can Run Independently"** is no longer an unqualified yes for the four publishing workflows. Now "Yes, with one approval", with a matching note where the re-run instructions are.
- The re-run section says plainly that a direct dispatch waits for a reviewer, and why: `manual-approval` is a job in the orchestrator, so a workflow dispatched on its own never passes it.

## How was it tested?

- Every edge in the new diagram derived from the `needs:` keys in `release-published-orchestrator.yml`, and every role from the `role-to-assume:` values on the release path, rather than from the prose being replaced.
- Mermaid audited for GitHub renderer hazards: no reserved node ids (`end`, `graph`, `class`, `o`, `x`), `<br/>` the only HTML tag used, code fences balanced.
- No workflow file modified, so no CI behaviour changes.

## Related

- [liquibase/liquibase#7964](https://github.com/liquibase/liquibase/pull/7964) (the environment split this documents)
- [liquibase/liquibase-infrastructure#4323](https://github.com/liquibase/liquibase-infrastructure/pull/4323) (creates `release-publish`)
- [TECHOPS-1214](https://datical.atlassian.net/browse/TECHOPS-1214)

## Release note

<!-- Docs-only change, not customer-facing. skipReleaseNotes applied. -->


[TECHOPS-1214]: https://datical.atlassian.net/browse/TECHOPS-1214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ