### PR TITLE
ci(scan): rescan every published tag on the daily run (TECHOPS-1253)

### DIFF
--- a/.github/workflows/trivy-scan-published-images.yml
+++ b/.github/workflows/trivy-scan-published-images.yml
@@ -2,6 +2,11 @@
 # This workflow scans published images on Docker Hub for vulnerabilities
 # using the reusable vulnerability scanning workflow from build-logic.
 #
+# Every active semver tag is scanned on every run (max_tags_to_scan defaults to
+# "all"). The job used to cover only the 10 newest tags, so anything older kept
+# whatever its last scan produced: for three months that was a June run with no
+# Grype output, which the CVE Library rendered as "Clean" (TECHOPS-1253).
+#
 # NOTE: SARIF results are NOT uploaded to GitHub Security tab to avoid stale alerts.
 # Published image vulnerabilities are tracked via workflow artifacts and GitHub Actions summary.
 # Only the main branch workflow (trivy.yml) populates the Security tab.
@@ -12,9 +17,9 @@ on:
   workflow_dispatch:
     inputs:
       max_tags_to_scan:
-        description: "Maximum number of published tags to scan"
+        description: "Number of newest published tags to scan, or \"all\""
         required: false
-        default: "20"
+        default: "all"
   schedule:
     # Run Monday-Friday at 10 AM UTC (published image monitoring)
     - cron: "0 10 * * 1-5"
@@ -37,7 +42,10 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     env:
-      MAX_TAGS: ${{ github.event.inputs.max_tags_to_scan || '10' }}
+      # Scheduled runs have no inputs, so they scan everything too. Needs the
+      # build-logic matrix script that understands "all" (build-logic PR noted
+      # in the TECHOPS-1253 PR that made this change).
+      MAX_TAGS: ${{ github.event.inputs.max_tags_to_scan || 'all' }}
     steps:
       - name: Checkout build-logic
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
Part of [TECHOPS-1253](https://datical.atlassian.net/browse/TECHOPS-1253). Requires the build-logic change that teaches `generate-dockerhub-matrix.sh` to accept `MAX_TAGS=all` (linked in the PR list below) to be merged **first**.

## Why

The weekday Published Images Vulnerability Scanning run scanned only the 10 newest semver tags (`max_tags_to_scan || '10'`). Anything older was never rescanned, so every `liquibase/liquibase` tag `<= 4.29.1` kept a 2026-06-10 scan with no Grype output (capture bug fixed upstream on 2026-08-05) for three months. The public CVE Library rendered those tags as "Clean"; the internal portal showed them as INCOMPLETE.

## What

- `max_tags_to_scan` defaults to `all` for both the schedule and `workflow_dispatch`, so every active semver tag on Docker Hub is rescanned on every run and no tag can sit on a stale or half-run scan.
- A number still works for an ad-hoc newest-N run.
- Header comment explains the scope and the incident behind it.

## Cost and behaviour

- Docker Hub currently has 60 active semver tags for `liquibase/liquibase` (back to 4.1), so a run is ~60 scan jobs instead of 10. The one-off dispatch with `max_tags_to_scan=60` (run 33831397692) is the reference for wall time.
- `scan-results` gets every tag rewritten each run (the persist step already handles N artifacts and a rejected push).
- Old tags pick up newly disclosed CVEs on every run, which is the point of a CVE library; the per-tag `Scanned` date stays visible on both portals.
- Very old images that cannot be pulled or scanned fail their job every run (`fail-fast: false`, so the rest persist). Today that is 4.7.0, 4.7.1, 4.16.0 and 4.18.0.

## Merge order

1. liquibase/build-logic: `MAX_TAGS=all` support.
2. This PR. If merged first, the matrix step fails with `head: illegal line count` until build-logic lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[TECHOPS-1253]: https://datical.atlassian.net/browse/TECHOPS-1253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ