### PR TITLE
fix: scope the setColumnRemarks view check to the target schema on Snowflake

### DIFF
--- a/liquibase-snowflake/src/main/java/liquibase/sqlgenerator/core/SetColumnRemarksGeneratorSnowflake.java
+++ b/liquibase-snowflake/src/main/java/liquibase/sqlgenerator/core/SetColumnRemarksGeneratorSnowflake.java
@@ -9,6 +9,8 @@ import liquibase.executor.ExecutorService;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.statement.core.RawParameterizedSqlStatement;
 import liquibase.statement.core.SetColumnRemarksStatement;
+import liquibase.structure.core.Catalog;
+import liquibase.structure.core.Schema;
 import liquibase.util.ColumnParentType;
 
 import java.util.List;
@@ -41,8 +43,7 @@ public class SetColumnRemarksGeneratorSnowflake extends SetColumnRemarksGenerato
                 // Check if we're trying to set the column remarks on a view, and if so, note that this is not supported.
                 try {
                     List<Map<String, ?>> viewList = Scope.getCurrentScope().getSingleton(ExecutorService.class).getExecutor("jdbc", database).queryForList(
-                            new RawParameterizedSqlStatement(String.format("SHOW VIEWS LIKE '%s'",
-                                database.escapeStringForDatabase(statement.getTableName()))));
+                            buildShowViewsStatement(statement, database));
                     if (!viewList.isEmpty()) {
                         validationErrors.addError(SET_COLUMN_REMARKS_NOT_SUPPORTED_ON_VIEW_MSG);
                     }
@@ -52,5 +53,32 @@ public class SetColumnRemarksGeneratorSnowflake extends SetColumnRemarksGenerato
             }
         }
         return validationErrors;
+    }
+
+    /**
+     * Builds the SHOW VIEWS used to tell a table apart from a view.
+     * <p>
+     * The table name is a LIKE pattern, so {@code %} and {@code _} have to be escaped or a table
+     * named MY_TABLE also matches a view named MYXTABLE. The statement is also scoped to the
+     * schema being changed: an unscoped SHOW VIEWS searches every database the role can see, so a
+     * same-named view in an unrelated schema would make this look like a view.
+     */
+    protected RawParameterizedSqlStatement buildShowViewsStatement(SetColumnRemarksStatement statement, Database database) {
+        String pattern = database.escapeStringForDatabase(statement.getTableName())
+                .replace("%", "\\%")
+                .replace("_", "\\_");
+        StringBuilder sql = new StringBuilder(String.format("SHOW VIEWS LIKE '%s'", pattern));
+
+        String schemaName = statement.getSchemaName() != null ? statement.getSchemaName() : database.getDefaultSchemaName();
+        if (schemaName != null) {
+            String catalogName = statement.getCatalogName() != null ? statement.getCatalogName() : database.getDefaultCatalogName();
+            sql.append(" IN SCHEMA ");
+            if (catalogName != null) {
+                sql.append(database.escapeObjectName(catalogName, Catalog.class)).append('.');
+            }
+            sql.append(database.escapeObjectName(schemaName, Schema.class));
+        }
+
+        return new RawParameterizedSqlStatement(sql.toString());
     }
 }

--- a/liquibase-snowflake/src/test/java/liquibase/sqlgenerator/core/SetColumnRemarksGeneratorSnowflakeTest.java
+++ b/liquibase-snowflake/src/test/java/liquibase/sqlgenerator/core/SetColumnRemarksGeneratorSnowflakeTest.java
@@ -1,0 +1,51 @@
+package liquibase.sqlgenerator.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import liquibase.database.core.SnowflakeDatabase;
+import liquibase.statement.core.SetColumnRemarksStatement;
+
+public class SetColumnRemarksGeneratorSnowflakeTest {
+
+    private final SetColumnRemarksGeneratorSnowflake generator = new SetColumnRemarksGeneratorSnowflake();
+
+    @Test
+    public void showViewsIsScopedToTheSchemaBeingChanged() {
+        SetColumnRemarksStatement statement =
+            new SetColumnRemarksStatement("mycatalog", "myschema", "mytable", "mycolumn", "a remark");
+
+        assertThat(generator.buildShowViewsStatement(statement, new SnowflakeDatabase()).getSql())
+            .isEqualTo("SHOW VIEWS LIKE 'mytable' IN SCHEMA mycatalog.myschema");
+    }
+
+    @Test
+    public void showViewsOmitsTheCatalogWhenOnlyTheSchemaIsKnown() {
+        SetColumnRemarksStatement statement =
+            new SetColumnRemarksStatement(null, "myschema", "mytable", "mycolumn", "a remark");
+
+        assertThat(generator.buildShowViewsStatement(statement, new SnowflakeDatabase()).getSql())
+            .isEqualTo("SHOW VIEWS LIKE 'mytable' IN SCHEMA myschema");
+    }
+
+    @Test
+    public void showViewsIsUnscopedWhenNoSchemaIsKnown() {
+        SetColumnRemarksStatement statement =
+            new SetColumnRemarksStatement(null, null, "mytable", "mycolumn", "a remark");
+
+        assertThat(generator.buildShowViewsStatement(statement, new SnowflakeDatabase()).getSql())
+            .isEqualTo("SHOW VIEWS LIKE 'mytable'");
+    }
+
+    @Test
+    public void likeWildcardsInTheTableNameAreEscaped() {
+        // snowflake treats _ and % in a SHOW ... LIKE pattern as wildcards, so an unescaped
+        // my_table would also match a view named myXtable
+        SetColumnRemarksStatement statement =
+            new SetColumnRemarksStatement(null, "myschema", "my_table%", "mycolumn", "a remark");
+
+        assertThat(generator.buildShowViewsStatement(statement, new SnowflakeDatabase()).getSql())
+            .isEqualTo("SHOW VIEWS LIKE 'my\\_table\\%' IN SCHEMA myschema");
+    }
+}


### PR DESCRIPTION
`SetColumnRemarksGeneratorSnowflake.validate` decides whether the target is a view by running

```java
new RawParameterizedSqlStatement(String.format("SHOW VIEWS LIKE '%s'",
    database.escapeStringForDatabase(statement.getTableName())))
```

Two things go wrong with that on Snowflake.

**The SHOW isn't scoped, so it finds views in other databases.** Without an `IN` clause, `SHOW VIEWS` searches everything the role can see. Against a real Snowflake account:

```
> SHOW TERSE VIEWS LIKE 'APPLICABLE_ROLES'
APPLICABLE_ROLES  VIEW  CORTEX           INFORMATION_SCHEMA
APPLICABLE_ROLES  VIEW  INFERENCEDATA    INFORMATION_SCHEMA
APPLICABLE_ROLES  VIEW  ML_PLATFORM_DEV  INFORMATION_SCHEMA
APPLICABLE_ROLES  VIEW  RAWDATA          INFORMATION_SCHEMA
APPLICABLE_ROLES  VIEW  SNOWFLAKE        INFORMATION_SCHEMA
APPLICABLE_ROLES  VIEW  TRANSDATA        INFORMATION_SCHEMA

> SHOW TERSE VIEWS LIKE 'APPLICABLE_ROLES' IN SCHEMA CORTEX.INFORMATION_SCHEMA
APPLICABLE_ROLES  VIEW  CORTEX           INFORMATION_SCHEMA
```

`viewList` is non-empty as long as *some* database has a view of that name, so `setColumnRemarks` on a table gets rejected with "isn't supported on Snowflake for a 'view'" because an unrelated schema happens to have a same-named view. Sharing a name between a table in one schema and a view in another is pretty ordinary in a warehouse.

**The table name is used as a LIKE pattern.** `_` and `%` are wildcards there, so `MY_TABLE` also matches a view named `MYXTABLE`. Escaping with a backslash is honoured:

```
> SHOW TERSE VIEWS LIKE 'APPLICABLE_ROLE_'    IN SCHEMA CORTEX.INFORMATION_SCHEMA
APPLICABLE_ROLES        <- trailing _ matched the S

> SHOW TERSE VIEWS LIKE 'APPLICABLE\_ROLE\_' IN SCHEMA CORTEX.INFORMATION_SCHEMA
(no rows)

> SHOW TERSE VIEWS LIKE 'APPLICABLE\_ROLES'  IN SCHEMA CORTEX.INFORMATION_SCHEMA
APPLICABLE_ROLES
```

So this scopes the statement with `IN SCHEMA`, falling back to the database's default catalog/schema and leaving it unscoped when neither is known, and escapes `%`/`_` in the name. Backslashes in the name are left alone so `escapeStringForDatabase`'s `\'` isn't disturbed — Snowflake identifiers don't really contain them, and the old code didn't handle that either.

The escaping is deliberately applied after `escapeStringForDatabase` rather than before, because that method uses a `(?<!\\)'` lookbehind and would skip a quote that already had a backslash in front of it.

Pulled the query construction into `buildShowViewsStatement` so it can be asserted directly. New tests cover the catalog+schema, schema-only, unscoped, and wildcard cases; 3 of the 4 fail before the change:

```
expected: "SHOW VIEWS LIKE 'mytable' IN SCHEMA mycatalog.myschema"
 but was: "SHOW VIEWS LIKE 'mytable'"
expected: "SHOW VIEWS LIKE 'my\_table\%' IN SCHEMA myschema"
 but was: "SHOW VIEWS LIKE 'my_table%'"
```

`mvn -pl liquibase-snowflake test` is green (81 tests). The SHOW output above is from a live Snowflake account, not a mock.
